### PR TITLE
mobile ui layout improvements

### DIFF
--- a/qt-mobile/DiveList.qml
+++ b/qt-mobile/DiveList.qml
@@ -40,23 +40,84 @@ Rectangle {
 
 			//Layout of the page: (mini profile, dive no, date at the top
 			//And other details at the bottom.
-			Column {
+			Item {
 				x: units.spacing
 				width: parent.width - units.spacing * 2
 				height: childrenRect.height + units.spacing * 2
-				spacing: units.spacing / 2
+				//spacing: units.spacing / 2
 				anchors.margins: units.spacing
 
 				Text {
-					text: diveNumber + ' (' + date + ')'
+					id: locationText
+					text: location
+					color: theme.textColor
+					scale: 1.1 // Let's see how this works, otherwise, we'll need the default point size somewhere
+					transformOrigin: Item.TopLeft
+					anchors {
+						left: parent.left
+						top: parent.top
+					}
 				}
-				Text { text: location; width: parent.width }
-				Text { text: '<b>Depth:</b> ' + depth + ' <b>Duration:</b> ' + duration; width: parent.width }
+				Text {
+					text: date
+					opacity: 0.6
+					color: theme.textColor
+					anchors {
+						right: parent.right
+						top: parent.top
+						bottomMargin: units.spacing / 2
+					}
+				}
+				Row {
+					id: descriptionText
+					anchors {
+						left: parent.left
+						right: parent.right
+						bottom: numberText.bottom
+					}
+					Text {
+						text: 'Depth: '
+						opacity: 0.6
+						color: theme.textColor
+					}
+					Text {
+						text: depth
+						width: Math.max(units.gridUnit * 3, paintedWidth) // helps vertical alignment throughout listview
+						color: theme.textColor
+					}
+					Text {
+						text: 'Duration: '
+						opacity: 0.6
+						color: theme.textColor
+					}
+					Text {
+						text: duration
+						color: theme.textColor
+					}
+				}
+				Text {
+					id: numberText
+					text: "#" + diveNumber
+					color: theme.textColor
+					scale: 1.2
+					transformOrigin: Item.BottomRight
+					opacity: 0.4
+					anchors {
+						right: parent.right
+						topMargin: units.spacing
+						top: locationText.bottom
+					}
+				}
+				//Text { text: location; width: parent.width }
 				Rectangle {
 					color: theme.textColor
 					opacity: .2
-					width: parent.width
 					height: Math.max(1, units.gridUnit / 24) // we really want a thin line
+					anchors {
+						left: parent.left
+						right: parent.right
+						top: numberText.bottom
+					}
 				}
 			}
 		}

--- a/qt-mobile/DiveList.qml
+++ b/qt-mobile/DiveList.qml
@@ -16,17 +16,8 @@ Rectangle {
 
 			property real detailsOpacity : 0
 
-			width: diveListView.width
+			width: diveListView.width - units.spacing
 			height: childrenRect.height
-
-			//Bounded rect for the background
-			Rectangle {
-				id: background
-				x: 2; y: 2; width: parent.width - x*2; height: parent.height - y*2;
-				color: "ivory"
-				border.color: "lightblue"
-				radius: 5
-			}
 
 			//Mouse region: When clicked, the mode changes to details view
 			MouseArea {
@@ -49,19 +40,23 @@ Rectangle {
 
 			//Layout of the page: (mini profile, dive no, date at the top
 			//And other details at the bottom.
-			Row {
-				id: topLayout
-				x: 10; y: 10; height: childrenRect.height; width: parent.width
+			Column {
+				x: units.spacing
+				width: parent.width - units.spacing * 2
+				height: childrenRect.height + units.spacing * 2
+				spacing: units.spacing / 2
+				anchors.margins: units.spacing
 
-				Column {
-					width: background.width; height: childrenRect.height * 1.1
-					spacing: 5
-
-					Text {
-						text: diveNumber + ' (' + date + ')'
-					}
-					Text { text: location; width: parent.width }
-					Text { text: '<b>Depth:</b> ' + depth + ' <b>Duration:</b> ' + duration; width: parent.width }
+				Text {
+					text: diveNumber + ' (' + date + ')'
+				}
+				Text { text: location; width: parent.width }
+				Text { text: '<b>Depth:</b> ' + depth + ' <b>Duration:</b> ' + duration; width: parent.width }
+				Rectangle {
+					color: theme.textColor
+					opacity: .2
+					width: parent.width
+					height: Math.max(1, units.gridUnit / 24) // we really want a thin line
 				}
 			}
 		}
@@ -69,15 +64,31 @@ Rectangle {
 
 	Component {
 		id: tripHeading
-		Rectangle {
-			width: page.width
-			height: childrenRect.height
-			color: "lightsteelblue"
+		Item {
+			width: page.width - units.spacing * 2
+			height: childrenRect.height + units.spacing * 2
 
 			Text {
+				id: sectionText
 				text: section
-				font.bold: true
+				anchors {
+					top: parent.top
+					left: parent.left
+					leftMargin: units.spacing
+					right: parent.right
+				}
+				color: theme.textColor
 				font.pointSize: 16
+			}
+			Rectangle {
+				height: Math.max(2, units.gridUnit / 12) // we want a thicker line
+				anchors {
+					top: sectionText.bottom
+					left: parent.left
+					leftMargin: units.spacing
+					right: parent.right
+				}
+				color: theme.accentColor
 			}
 		}
 	}
@@ -87,8 +98,10 @@ Rectangle {
 		anchors.fill: parent
 		model: diveModel
 		delegate: diveDelegate
+		boundsBehavior: Flickable.StopAtBounds
+		//highlight: Rectangle { color: theme.highlightColor; width: units.spacing }
 		focus: true
-
+		clip: true
 		section.property: "trip"
 		section.criteria: ViewSection.FullString
 		section.delegate: tripHeading

--- a/qt-mobile/TopBar.qml
+++ b/qt-mobile/TopBar.qml
@@ -9,31 +9,31 @@ import org.subsurfacedivelog.mobile 1.0
 
 Rectangle {
 	id: topBar
-	color: "#2C4882"
+	color: theme.accentColor
 	Layout.fillWidth: true
 	Layout.margins: 0
-	Layout.minimumHeight: prefsButton.height * 1.2
+	Layout.minimumHeight: prefsButton.height + units.spacing * 2
 	RowLayout {
 		anchors.bottom: topBar.bottom
-		anchors.bottomMargin: prefsButton.height * 0.1
+		anchors.bottomMargin: units.spacing
 		anchors.left: topBar.left
-		anchors.leftMargin: prefsButton.height * 0.1
+		anchors.leftMargin: units.spacing
 		anchors.right: topBar.right
-		anchors.rightMargin: prefsButton.height * 0.1
+		anchors.rightMargin: units.spacing
 		Button {
 			id: backButton
 			Layout.maximumHeight: prefsButton.height
 			Layout.minimumHeight: prefsButton.height
-			Layout.preferredWidth: Screen.width * 0.1
+			Layout.preferredWidth: units.gridUnit * 2
 			text: "\u2190"
 			style: ButtonStyle {
 				background: Rectangle {
-					color: "#2C4882"
-					implicitWidth: 50
+					color: theme.accentColor
+					implicitWidth: units.gridUnit * 2
 				}
 				label: Text {
 					id: txt
-					color: "white"
+					color: theme.accentTextColor
 					font.pointSize: 18
 					font.bold: true
 					text: control.text
@@ -58,10 +58,10 @@ Rectangle {
 		Text {
 			text: qsTr("Subsurface mobile")
 			font.pointSize: 18
-			font.bold: true
-			color: "white"
-			anchors.horizontalCenter: parent.horizontalCenter
-			horizontalAlignment: Text.AlignHCenter
+			color: theme.accentTextColor
+			anchors.left: backButton.right
+			anchors.leftMargin: units.spacing
+			//horizontalAlignment: Text.AlignHCenter
 		}
 	}
 }

--- a/qt-mobile/main.qml
+++ b/qt-mobile/main.qml
@@ -189,8 +189,6 @@ ApplicationWindow {
 	}
 
 	Component.onCompleted: {
-		print("main.qml laoded.");
-		print("gridUnit is: " + units.gridUnit);
-		print("hightlight : " + theme.highlightColor);
+		print("units.gridUnit is: " + units.gridUnit);
 	}
 }

--- a/qt-mobile/main.qml
+++ b/qt-mobile/main.qml
@@ -86,43 +86,39 @@ ApplicationWindow {
 			ColumnLayout {
 				id: awLayout
 				anchors.fill: parent
-				spacing: 8
+				spacing: units.gridUnit / 2
 				Rectangle {
 					id: topPart
-					color: "#2C4882"
-					Layout.minimumHeight: prefsButton.height * 1.2
+					color: theme.accentColor
+					Layout.minimumHeight: units.gridUnit * 2 + units.spacing * 2
 					Layout.fillWidth: true
-					anchors.bottom: detailsPage.top
-					anchors.bottomMargin: prefsButton.height * 0.1
 					Layout.margins: 0
 					RowLayout {
 						anchors.bottom: topPart.bottom
-						anchors.bottomMargin: prefsButton.height * 0.1
+						anchors.bottomMargin: units.spacing
 						anchors.left: topPart.left
-						anchors.leftMargin: prefsButton.height * 0.1
+						anchors.leftMargin: units.spacing
 						anchors.right: topPart.right
-						anchors.rightMargin: prefsButton.height * 0.1
+						anchors.rightMargin: units.spacing
 						Text {
 							text: qsTr("Subsurface mobile")
 							font.pointSize: 18
-							font.bold: true
-							color: "white"
-							anchors.horizontalCenter: parent.horizontalCenter
-							horizontalAlignment: Text.AlignHCenter
+							color: theme.accentTextColor
 						}
 						Button {
 							id: prefsButton
 							text: "\u22ee"
 							anchors.right: parent.right
-							Layout.preferredWidth: Screen.width * 0.1
+							Layout.preferredWidth: units.gridUnit * 2
+							Layout.preferredHeight: units.gridUnit * 2
 							style: ButtonStyle {
 								background: Rectangle {
-									implicitWidth: 50
-									color: "#2C4882"
+									implicitWidth: units.gridUnit * 2
+									color: theme.accentColor
 								}
 								label: Text {
 									id: txt
-									color: "white"
+									color: theme.accentTextColor
 									font.pointSize: 18
 									font.bold: true
 									text: control.text
@@ -146,7 +142,7 @@ ApplicationWindow {
 					DiveList {
 						anchors.fill: detailsPage
 						id: diveDetails
-						color: "#2C4882"
+						color: theme.backgroundColor
 					}
 				}
 
@@ -157,9 +153,9 @@ ApplicationWindow {
 
 					Text {
 						id: message
-						color: "#000000"
+						color: theme.textColor
 						text: ""
-						styleColor: "#ff0000"
+						styleColor: theme.textColor
 						font.pointSize: 10
 					}
 				}

--- a/qt-mobile/main.qml
+++ b/qt-mobile/main.qml
@@ -6,12 +6,22 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
 import org.subsurfacedivelog.mobile 1.0
+import "qrc:/qml/theme" as Theme
+
 
 ApplicationWindow {
 	title: qsTr("Subsurface mobile")
 	property bool fullscreen: true
 	property alias messageText: message.text
 	visible: true
+
+	Theme.Units {
+		id: units
+	}
+
+	Theme.Theme {
+		id: theme
+	}
 
 	Menu {
 		id: prefsMenu
@@ -180,5 +190,11 @@ ApplicationWindow {
 	Log {
 		id: logWindow
 		visible: false
+	}
+
+	Component.onCompleted: {
+		print("main.qml laoded.");
+		print("gridUnit is: " + units.gridUnit);
+		print("hightlight : " + theme.highlightColor);
 	}
 }

--- a/qt-mobile/main.qml
+++ b/qt-mobile/main.qml
@@ -100,10 +100,20 @@ ApplicationWindow {
 						anchors.leftMargin: units.spacing
 						anchors.right: topPart.right
 						anchors.rightMargin: units.spacing
+						Image {
+							source: "qrc:/qml/subsurface-mobile-icon.png"
+							Layout.maximumWidth: units.gridUnit * 2
+							Layout.preferredWidth: units.gridUnit * 2
+							Layout.preferredHeight: units.gridUnit * 2
+						}
 						Text {
 							text: qsTr("Subsurface mobile")
 							font.pointSize: 18
+							Layout.fillWidth: false
 							color: theme.accentTextColor
+						}
+						Item {
+							Layout.fillWidth: true
 						}
 						Button {
 							id: prefsButton

--- a/qt-mobile/mobile-resources.qrc
+++ b/qt-mobile/mobile-resources.qrc
@@ -9,4 +9,8 @@
         <file>Log.qml</file>
         <file>TopBar.qml</file>
     </qresource>
+    <qresource prefix="/qml/theme">
+        <file alias="Theme.qml">theme/Theme.qml</file>
+        <file alias="Units.qml" >theme/Units.qml</file>
+    </qresource>
 </RCC>

--- a/qt-mobile/mobile-resources.qrc
+++ b/qt-mobile/mobile-resources.qrc
@@ -8,6 +8,7 @@
         <file>DownloadFromDiveComputer.qml</file>
         <file>Log.qml</file>
         <file>TopBar.qml</file>
+        <file alias="subsurface-mobile-icon.png">../icons/subsurface-mobile-icon.png</file>
     </qresource>
     <qresource prefix="/qml/theme">
         <file alias="Theme.qml">theme/Theme.qml</file>

--- a/qt-mobile/theme/Theme.qml
+++ b/qt-mobile/theme/Theme.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.3
 
 QtObject {
-	property color accentColor: "#114d6f"
+	property color accentColor: "#2d5b9a"
 	property color accentTextColor: "#ececec"
 	property color textColor: "#333333"
 	property color backgroundColor: "#ececec"

--- a/qt-mobile/theme/Theme.qml
+++ b/qt-mobile/theme/Theme.qml
@@ -1,7 +1,10 @@
 import QtQuick 2.3
 
 QtObject {
+	property color accentColor: "#114d6f"
+	property color accentTextColor: "#ececec"
 	property color textColor: "#333333"
 	property color backgroundColor: "#ececec"
 	property color highlightColor: "#91c4e1"
+	property color highlightTextColor: "#333333"
 }

--- a/qt-mobile/theme/Theme.qml
+++ b/qt-mobile/theme/Theme.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.3
+
+QtObject {
+	property color textColor: "#333333"
+	property color backgroundColor: "#ececec"
+	property color highlightColor: "#91c4e1"
+}

--- a/qt-mobile/theme/Units.qml
+++ b/qt-mobile/theme/Units.qml
@@ -2,4 +2,5 @@ import QtQuick 2.3
 
 QtObject {
 	property int gridUnit: 24
+	property int spacing: gridUnit / 3
 }

--- a/qt-mobile/theme/Units.qml
+++ b/qt-mobile/theme/Units.qml
@@ -1,6 +1,11 @@
 import QtQuick 2.3
 
-QtObject {
-	property int gridUnit: 24
+Item {
+	property int gridUnit: unitsM.paintedHeight
 	property int spacing: gridUnit / 3
+
+	Text {
+		id: unitsM
+		text: "M"
+	}
 }

--- a/qt-mobile/theme/Units.qml
+++ b/qt-mobile/theme/Units.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.3
+
+QtObject {
+	property int gridUnit: 24
+}


### PR DESCRIPTION
Various layout, alignment and dpi-corrections, basically. Comments welcome.
- add a units object to base sizing on, this object uses the rendered font size to provide a base units for sizing. units.gridUnit provides a dpi-corrected base-value for all UI elements.
- add a theme object which provides a color theme, I've filled this in with the blue from the subsurface icon and chose a matching light grey as background and a darker grey for text, looks pretty smooth, and can be further adjusted to taste
- port a whole bunch of hard-coded sizes to units.gridUnit, and colors to theme
- some layouting changes to what seems more convenient (Row, vs. RowLayout vs. anchors)
- various cleanups in object dependencies

I've only tested this on my desktop machine (180dpi), I'd be interested in screenshots of other dpi screens, especially Android devices. I'll be away for a week starting this weekend, so my next response may take a while.

Here's a screenshot: http://imgur.com/n0DnAjp
