### PR TITLE
Update SupportedDivecomputers to 4.6 Beta 2 list

### DIFF
--- a/SupportedDivecomputers.html
+++ b/SupportedDivecomputers.html
@@ -1,65 +1,77 @@
 <dl><dt>Aeris</dt><dd><ul>
-	    <li>A300, A300 AI, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, Manta, XR-1 NX, XR-2</li></ul>
+	    <li>500AI, A300, A300 AI, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Epic, F10, Manta, XR-1 NX, XR-2</li></ul>
     </dd>
     <dt>Apeks</dt><dd><ul>
 	    <li>Quantum X</li></ul>
+    </dd>
+    <dt>AquaLung</dt><dd><ul>
+	<li>i300, i450T, i550T</li></ul>
     </dd>
     <dt>Atomic Aquatics</dt><dd><ul>
 	    <li>Cobalt, Cobalt 2</li></ul>
     </dd>
     <dt>Beuchat</dt><dd><ul>
-	    <li>Voyager 2G</li></ul>
+	    <li>Mundial 2, Mundial 3, Voyager 2G</li></ul>
+    </dd>
+    <dt>Citizen</dt><dd><ul>
+	    <li>Hyper Aqualand</li></ul>
+    </dd>
+    <dt>Cochran</dt><dd><ul>
+	    <li>Commander, EMC-14, EMC-16, EMC-20H</li></ul>
     </dd>
     <dt>Cressi</dt><dd><ul>
-	    <li>Edy, Giotto, Leonardo</li></ul>
+	    <li>Edy, Giotto, Leonardo, Newton</li></ul>
     </dd>
     <dt>Dive Rite</dt><dd><ul>
 	    <li>NiTek Q, NiTek Trio</li></ul>
+    </dd>
+    <dt>Dive System</dt><dd><ul>
+	    <li>Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec</li></ul>
     </dd>
     <dt>Genesis</dt><dd><ul>
 	    <li>React Pro, React Pro White</li></ul>
     </dd>
     <dt>Heinrichs Weikamp</dt><dd><ul>
-	    <li>Frog, OSTC, OSTC 2C, OSTC 2N, OSTC 3, OSTC Mk2</li></ul>
+	    <li>Frog, OSTC, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3+, OSTC 4, OSTC Mk2</li></ul>
     </dd>
     <dt>Hollis</dt><dd><ul>
 	    <li>DG03, TX1</li></ul>
     </dd>
     <dt>Mares</dt><dd><ul>
-	    <li>Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro</li></ul>
+	    <li>Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea</li></ul>
     </dd>
     <dt>Oceanic</dt><dd><ul>
-	    <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
+	    <li>Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro</li></ul>
     </dd>
     <dt>Reefnet</dt><dd><ul>
 	    <li>Sensus, Sensus Pro, Sensus Ultra</li></ul>
     </dd>
     <dt>Scubapro</dt><dd><ul>
-	    <li>Meridian, XTender 5</li></ul>
+	    <li>Chromis, Mantis, Mantis 2, Meridian, XTender 5</li></ul>
     </dd>
     <dt>Seemann</dt><dd><ul>
 	    <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-	    <li>Petrel, Predator, Nerd</li></ul>
+	    <li>Nerd, Petrel, Predator</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
-	    <li>Amphos, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3</li></ul>
+	    <li>Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3</li></ul>
     </dd>
     <dt>Subgear</dt><dd><ul>
-	    <li>XP Air, XP-10</li></ul>
+	    <li>XP Air</li></ul>
     </dd>
     <dt>Suunto</dt><dd><ul>
-	    <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop</li></ul>
+	    <li>Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo</li></ul>
     </dd>
     <dt>Tusa</dt><dd><ul>
-	    <li>Element II (IQ-750), Zen (IQ-900), Zen Air (IQ-950)</li></ul>
+	    <li>Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)</li></ul>
     </dd>
     <dt>Uemis</dt><dd><ul>
 	    <li>Zürich SDA</li></ul>
     </dd>
     <dt>Uwatec</dt><dd><ul>
-	    <li>Aladin 2G, Aladin 2G, Aladin Air Twin, Aladin Air Z, Aladin Air Z Nitrox, Aladin Air Z O2, Aladin Prime, Aladin Pro, Aladin Pro Ultra, Aladin Sport Plus, Aladin Tec, Aladin Tec 2G, Galileo Luna, Galileo Sol, Galileo Terra, Galileo Trimix, Memomouse, Smart Com, Smart Pro, Smart Tec, Smart Z</li></ul>
+	    <li>Aladin Air Twin, Aladin Air Z, Aladin Air Z Nitrox, Aladin Air Z O2, Aladin Pro, Aladin Pro Ultra, Aladin Sport Plus, Memomouse</li></ul>
     </dd>
     <dt>Zeagle</dt><dd><ul>
 	    <li>N2iTiON3</li>

--- a/SupportedDivecomputers.txt
+++ b/SupportedDivecomputers.txt
@@ -1,24 +1,26 @@
-Aeris: A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2
+Aeris: 500AI, A300, A300 AI, A300CS, Atmos 2, Atmos AI, Atmos AI 2, Compumask, Elite, Elite T3, Epic, Epic, F10, F11, Manta, XR-1 NX, XR-2
 Apeks: Quantum X
+Aqualung: i300, i450T, i550T
 Atomic Aquatics: Cobalt, Cobalt 2
-Beuchat: Voyager 2G
+Beuchat: Mundial 2, Mundial 3, Voyager 2G
 Citizen: Hyper Aqualand
-Cressi: Edy, Giotto, Leonardo
+Cochran: Commander, EMC-14, EMC-16, EMC-20H
+Cressi: Edy, Giotto, Leonardo, Newton
 Dive Rite: NiTek Q, NiTek Trio
-DiveSystem: Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M
+DiveSystem: Orca, iDive DAN, iDive Deep, iDive Easy, iDive Free, iDive Pro, iDive Reb, iDive Stealth, iDive Tech, iDive X3M, iX3M Deep, iX3M Easy, iX3M Reb, iX3M Tec
 Genesis: React Pro, React Pro White
-Heinrichs Weikamp: Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3, OSTC Mk2, OSTC Sport, OSTC cR
+Heinrichs Weikamp: Frog, OSTC, OSTC 2, OSTC 2C, OSTC 2N, OSTC 3, OSTC 3 +, OSTC 4, OSTC Mk2, OSTC Sport, OSTC cR
 Hollis: DG03, TX1
 Mares: Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, Nemo, Nemo Air, Nemo Apneist, Nemo Excel, Nemo Steel, Nemo Titanium, Nemo Wide, Nemo Wide 2, Puck, Puck 2, Puck Air, Puck Pro, Smart, Smart Apnea
-Oceanic: Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, Geo, Geo 2.0, OC1, OC1, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro
+Oceanic: Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F11, Geo, Geo 2.0, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro
 Reefnet: Sensus, Sensus Pro, Sensus Ultra
-Scubapro: Chromis, Meridian, XTender 5
+Scubapro: Chromis, Mantis, Mantis 2, Meridian, XTender 5
 Seemann: XP5
-Shearwater: Petrel, Petrel 2, Predator, Nerd
-Sherwood: Amphos, Amphos Air, Insight, Insight 2, Wisdom, Wisdom 2, Wisdom 3
-Subgear: XP Air, XP-10, XP-3G
-Suunto: Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vytec, Zoop
+Shearwater: Nerd, Petrel, Petrel 2, Predator
+Sherwood: Amphos, Amphos Air, Insight, Insight 2, Vision, Wisdom, Wisdom 2, Wisdom 3
+Subgear: XP Air
+Suunto: Cobra, Cobra 2, Cobra 3, D3, D4, D4i, D6, D6i, D9, D9tx, DX, EON Steel, Eon, Gekko, HelO2, Mosquito, Solution, Solution Alpha, Solution Nitrox, Spyder, Stinger, Vyper, Vyper 2, Vyper Air, Vyper Novo, Vytec, Zoop, Zoop Novo
 Tusa: Element II (IQ-750), IQ-700, Zen (IQ-900), Zen Air (IQ-950)
 Uemis: Zürich SDA
-Uwatec: Aladin 2G, Aladin 2G, Aladin Air Twin, Aladin Air Z, Aladin Air Z Nitrox, Aladin Air Z O2, Aladin Prime, Aladin Pro, Aladin Pro Ultra, Aladin Sport Plus, Aladin Tec, Aladin Tec 2G, Galileo Luna, Galileo Sol, Galileo Terra, Galileo Trimix, Memomouse, Smart Com, Smart Pro, Smart Tec, Smart Z
+Uwatec: Aladin Air Twin, Aladin Air Z, Aladin Air Z Nitrox, Aladin Air Z O2, Aladin Pro, Aladin Pro Ultra, Aladin Sport Plus, Memomouse
 Zeagle: N2iTiON3


### PR DESCRIPTION
The dive computers were taken from the "Download
from dive computer" menu within Subsurface. Some 
previously listed computers were no longer listed, and
some new computers were added based off that list.

Signed-off-by: Federico Masias `<fedemasias@yahoo.com>`