### PR TITLE
Add cylinder equipment tooltips with gas volume

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -872,7 +872,7 @@ int gas_volume(cylinder_t *cyl, pressure_t p)
 {
 	double bar = p.mbar / 1000.0;
 	double z_factor = gas_compressibility_factor(&cyl->gasmix, bar);
-	return cyl->type.size.mliter * bar_to_atm(bar) / z_factor;
+	return rint(cyl->type.size.mliter * bar_to_atm(bar) / z_factor);
 }
 
 /*


### PR DESCRIPTION
This adds tooltips for the equipment tab for each cylinder, showing the
amount of gas used.

When you mouse over the size and working pressure fields, the tooltip will
show the amount of gas used (along with start and end gas volumes). And
when you mouse over the start and end pressures, it will show the start
and end gas volumes, and the Z factor used.

I started doing this because of the gas volume questions in the last day
or two (and a few from a few weeks ago). When even Robert Helling starts
wondering about the effects of compressibility on the SAC calculation, our
numbers are clearly too opaque.

With these tooltips, at least you can see what went into the used gas
calculations, instead of having to add debugging options to print out Z
factors.

[ This patch also adds a "rint()" to get the rounding right in the
  gas_volume() function.  Although rounding to the nearst milliliter
  really doesn't matter, it's the right thing to do after doing FP
  calculations ;^]

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>