### PR TITLE
Use real gas compressibility in planner

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -136,6 +136,7 @@ extern int units_to_sac(double volume);
 /* Volume in mliter of a cylinder at pressure 'p' */
 extern int gas_volume(cylinder_t *cyl, pressure_t p);
 extern double gas_compressibility_factor(struct gasmix *gas, double bar);
+extern double isothermal_pressure(struct gasmix *gas, double p1, int volume1, int volume2);
 
 
 static inline int get_o2(const struct gasmix *mix)

--- a/core/gas-model.c
+++ b/core/gas-model.c
@@ -62,3 +62,13 @@ double gas_compressibility_factor(struct gasmix *gas, double bar)
 	 */
 	return Z * 0.001 + 1.0;
 }
+
+/* Compute the new pressure when compressing (expanding) volome v1 at pressure p1 bar to volume v2
+ * taking into account the compressebility (to first order) */
+
+double isothermal_pressure(struct gasmix *gas, double p1, int volume1, int volume2)
+{
+	double p_ideal = p1 * volume1 / volume2 / gas_compressibility_factor(gas, p1);
+
+	return p_ideal * gas_compressibility_factor(gas, p_ideal);
+}


### PR DESCRIPTION
Now, that I am convinced that Linus' calculation makes sense, we should take it into account also in the planner.

I tested this a little bit but I am not sure if this should still go into the upcoming release.

-- 

Modify formluas for gas use to take into account the
compressibility correction for real gases. This introduces
also the inverse formula to compute the pressure for a given
amount of gas.

Signed-off-by: Robert C. Helling <helling@atdotde.de>