### PR TITLE
Add support for libdivecomputer using DC_SAMPLE_GASMIX

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -251,6 +251,14 @@ static void handle_event(struct divecomputer *dc, struct sample *sample, dc_samp
 		current_gas_index = ev->gas.index;
 }
 
+static void handle_gasmix(struct divecomputer *dc, struct sample *sample, int idx)
+{
+	if (idx < 0 || idx >= MAX_CYLINDERS)
+		return;
+	add_event(dc, sample->time.seconds, SAMPLE_EVENT_GASCHANGE2, idx+1, 0, "gaschange");
+	current_gas_index = idx;
+}
+
 void
 sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 {
@@ -306,6 +314,9 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 		}
 		sample->sensor = value.pressure.tank;
 		sample->cylinderpressure.mbar = rint(value.pressure.value * 1000);
+		break;
+	case DC_SAMPLE_GASMIX:
+		handle_gasmix(dc, sample, value.gasmix);
 		break;
 	case DC_SAMPLE_TEMPERATURE:
 		sample->temperature.mkelvin = C_to_mkelvin(value.temperature);


### PR DESCRIPTION
New libdivecomputer versions use DC_SAMPLE_GASMIX to indicate a gas
change (which contains the cylinder index we're changing to) rather than
SAMPLE_EVENT_GASCHANGE*.

Unlike the old GASCHANGE model, and despite the name, DC_SAMPLE_GASMIX
does not actually say what the mix is, it only specifies a cylinder
index.  We had already extended SAMPLE_EVENT_GASCHANGE2 to have the
cylinder index in the otherwise unused "flags" field, so this is not all
that different from what we used to do.

And subsurface internally already had the logic that "if we know what
the cylinder index is, take the gas mix from the cylinder data", so
we've already been able to transparently use _either_ the actual gas mix
or the cylinder index to show the event.

But we do want to make it an event rather than some sample data, because
we want to show it as such in the profile.  But because we are happy
with just the cylinder index, we'll just translate the DC_SAMPLE_GASMIX
thing to the SAMPLE_EVENT_GASCHANGE2 event, and nothing really changes
for subsurface.

libdivecomputer has made other changes, like indicating the initial
cylinder index with an early DC_SAMPLE_GASMIX report, but we've seen
that before too (in the form of early SAMPLE_EVENT_GASCHANGE events), so
that doesn't really end up changing anything for us either.

HOWEVER, one thing that is worth noticing: do *not* apply this patch and
then use an old libdivecomputer library that sends both the
DC_SAMPLE_GASMIX samples _and_ the deprecated SAMPLE_EVENT_GASCHANGE
events.  It will all *work*, but since subsurface will take either,
you'll then get duplicate gas mix events.

It's not like that is in any way fatal, but it might be a bit confusing.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>