### PR TITLE
Small planner improvements

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -30,7 +30,7 @@ static const char *default_tags[] = {
 };
 
 const char *cylinderuse_text[] = {
-	QT_TRANSLATE_NOOP("gettextFromC", "OC-gas"), QT_TRANSLATE_NOOP("gettextFromC", "diluent"), QT_TRANSLATE_NOOP("gettextFromC", "oxygen")
+	QT_TRANSLATE_NOOP("gettextFromC", "OC-gas"), QT_TRANSLATE_NOOP("gettextFromC", "diluent"), QT_TRANSLATE_NOOP("gettextFromC", "oxygen"), QT_TRANSLATE_NOOP("gettextFromC", "not used")
 };
 const char *divemode_text[] = { "OC", "CCR", "PSCR", "Freedive" };
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -56,7 +56,7 @@ extern "C" {
 extern int last_xml_version;
 
 enum dive_comp_type {OC, CCR, PSCR, FREEDIVE, NUM_DC_TYPE};	// Flags (Open-circuit and Closed-circuit-rebreather) for setting dive computer type
-enum cylinderuse {OC_GAS, DILUENT, OXYGEN, NUM_GAS_USE}; // The different uses for cylinders
+enum cylinderuse {OC_GAS, DILUENT, OXYGEN, NOT_USED, NUM_GAS_USE}; // The different uses for cylinders
 
 extern const char *cylinderuse_text[];
 extern const char *divemode_text[];

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -480,7 +480,7 @@ void CylindersModel::copyFromDive(dive *d)
 
 Qt::ItemFlags CylindersModel::flags(const QModelIndex &index) const
 {
-	if (index.column() == REMOVE)
+	if (index.column() == REMOVE || index.column() == USE)
 		return Qt::ItemIsEnabled;
 	return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
 }
@@ -488,6 +488,17 @@ Qt::ItemFlags CylindersModel::flags(const QModelIndex &index) const
 void CylindersModel::remove(const QModelIndex &index)
 {
 	int mapping[MAX_CYLINDERS];
+
+	if (index.column() == USE) {
+		cylinder_t *cyl = cylinderAt(index);
+		if (cyl->cylinder_use == OC_GAS)
+			cyl->cylinder_use = NOT_USED;
+		else if (cyl->cylinder_use == NOT_USED)
+			cyl->cylinder_use = OC_GAS;
+		changed = true;
+		dataChanged(index, index);
+		return;
+	}
 	if (index.column() != REMOVE) {
 		return;
 	}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -6,6 +6,7 @@
 #include "qt-models/models.h"
 #include "core/device.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include <QApplication>
 
 /* TODO: Port this to CleanerTableModel to remove a bit of boilerplate and
  * use the signal warningMessage() to communicate errors to the MainWindow.
@@ -700,16 +701,16 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
  * remove method that will pass the first and last index of the
  * removed rows, and remove those in a go.
  */
-//	int i;
-//	int rows = rowCount();
-//	if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
-//		beginRemoveRows(QModelIndex(), index.row(), rows - 1);
-//		for (i = rows - 1; i >= index.row(); i--)
-//			divepoints.remove(i);
-//	} else {
+	int i;
+	int rows = rowCount();
+	if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+		beginRemoveRows(QModelIndex(), index.row(), rows - 1);
+		for (i = rows - 1; i >= index.row(); i--)
+			divepoints.remove(i);
+	} else {
 		beginRemoveRows(QModelIndex(), index.row(), index.row());
 		divepoints.remove(index.row());
-//	}
+	}
 	endRemoveRows();
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -72,6 +72,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	recalc = false;
 	CylindersModel::instance()->updateDive();
 	duration_t lasttime = {};
+	duration_t lastrecordedtime = {};
 	duration_t newtime = {};
 	free_dps(&diveplan);
 	diveplan.when = d->when;
@@ -103,7 +104,10 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 		}
 		if (samplecount) {
 			int cylinderid = get_cylinderid_at_time(d, dc, lasttime);
-			addStop(depthsum / samplecount, newtime.seconds, cylinderid, 0, true);
+			if (newtime.seconds - lastrecordedtime.seconds > 10) {
+				addStop(depthsum / samplecount, newtime.seconds, cylinderid, 0, true);
+				lastrecordedtime = newtime;
+			}
 			lasttime = newtime;
 			depthsum = 0;
 			samplecount = 0;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -798,7 +798,7 @@ void DivePlannerPointsModel::createTemporaryPlan()
 	struct divedatapoint *dp = NULL;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		cylinder_t *cyl = &displayed_dive.cylinder[i];
-		if (cyl->depth.mm) {
+		if (cyl->depth.mm && cyl->cylinder_use != NOT_USED) {
 			dp = create_dp(0, cyl->depth.mm, i, 0);
 			if (diveplan.dp) {
 				dp->next = diveplan.dp;


### PR DESCRIPTION
This branch contains two patches that add features to the planner recently requested:

1) Don't show zero length segments at gas changes when re-planning a dive

2) Allow the user to disable a cylinder in the planner for easier contingency planning