### PR TITLE
Ignore double clicks on the divelist

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -1034,3 +1034,8 @@ void DiveListView::updateLastImageTimeOffset(const int offset)
 	s.beginGroup("MainWindow");
 	s.setValue("LastImageTimeOffset", offset);
 }
+
+void DiveListView::mouseDoubleClickEvent(QMouseEvent * event)
+{
+	return;
+}

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -21,6 +21,7 @@ class DiveListView : public QTreeView {
 public:
 	DiveListView(QWidget *parent = 0);
 	~DiveListView();
+	void mouseDoubleClickEvent(QMouseEvent * event);
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 	void currentChanged(const QModelIndex &current, const QModelIndex &previous);
 	void reload(DiveTripModel::Layout layout, bool forceSort = true);


### PR DESCRIPTION
Fixes #170 on GitHub

Simple catch function for double click events in the divelist,
prevents users from trying to edit the divenumber ithe wrong way.

Signed-off-by: Joakim Bygdell <j.bygdell@gmail.com>