### PR TITLE
QML UI: Parse multiple buddies when editing a dive

### DIFF
--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -177,7 +177,7 @@ Item {
 			}
 			ComboBox {
 				id: buddyBox
-				editable: currentText != qsTr("Multiple Buddies")
+				editable: true
 				model: diveDetailsListView.currentItem.modelData.dive.buddyList
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -869,13 +869,10 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		d->suit = strdup(qPrintable(suit));
 	}
 	if (myDive->buddy() != buddy) {
-		if (myDive->buddy().contains(",")) {
-			if (!buddy.contains(tr("Multiple Buddies"))) {
-				diveChanged = true;
-				free(d->buddy);
-				d->buddy = strdup(qPrintable(buddy));
-			}
-		} else {
+		if (buddy.contains(",")){
+			buddy = buddy.replace(QRegExp("\\s*,\\s*"), ", ");
+		}
+		if (!buddy.contains("Multiple Buddies")) {
 			diveChanged = true;
 			free(d->buddy);
 			d->buddy = strdup(qPrintable(buddy));


### PR DESCRIPTION
This allows the user to enter multiple buddies as a comma separated list,
the "Multiple Buddies" entry is still a special case as we can only populate
the combobox with a single name for each entry.

fixes #168

Signed-off-by: Joakim Bygdell <j.bygdell@gmail.com>