### PR TITLE
Don't do strcmp on NIL pointer

### DIFF
--- a/core/macos.c
+++ b/core/macos.c
@@ -204,7 +204,7 @@ int subsurface_zip_close(struct zip *zip)
 void subsurface_console_init(bool dedicated, bool logfile)
 {
 	(void)dedicated;
-	(void)logifle;
+	(void)logfile;
 	/* NOP */
 }
 

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -369,7 +369,7 @@ void get_gas_used(struct dive *dive, volume_t gases[MAX_CYLINDERS])
 		pressure_t start, end;
 
 		for_each_dc(dive, dc) {
-			if (!strcmp(dc->model, "planned dive"))
+			if (same_string(dc->model, "planned dive"))
 				continue;
 			if (has_gaschange_event(dive, dc, idx))
 				used = true;


### PR DESCRIPTION
This is what we have same_string() for...

This prevents a crash when saving a dive in the planner.

And fix a typo.

Signed-off-by: Robert C. Helling <helling@atdotde.de>