### PR TITLE
Reedit fixes

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -426,8 +426,9 @@ static struct gaschanges *analyze_gaslist(struct diveplan *diveplan, int *gascha
 	struct gaschanges *gaschanges = NULL;
 	struct divedatapoint *dp = diveplan->dp;
 	int best_depth = displayed_dive.cylinder[*asc_cylinder].depth.mm;
+	bool total_time_zero = true;
 	while (dp) {
-		if (dp->time == 0) {
+		if (dp->time == 0 && total_time_zero) {
 			if (dp->depth <= depth) {
 				int i = 0;
 				nr++;
@@ -449,6 +450,8 @@ static struct gaschanges *analyze_gaslist(struct diveplan *diveplan, int *gascha
 					*asc_cylinder = dp->cylinderid;
 				}
 			}
+		} else {
+			total_time_zero = false;
 		}
 		dp = dp->next;
 	}

--- a/core/planner.c
+++ b/core/planner.c
@@ -734,7 +734,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 				/* Normally a gas change is displayed on the stopping segment, so only display a gas change at the end of
 				 * an ascent segment if it is not followed by a stop
 				 */
-				if (isascent && gaschange_after && dp->next && nextdp && dp->depth != nextdp->depth) {
+				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth != nextdp->depth || nextdp->entered)) {
 					if (dp->setpoint) {
 						snprintf(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) nextdp->setpoint / 1000.0);
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasname(&newgasmix),

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -56,10 +56,10 @@ void setupPlan(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(79, 260) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, droptime, M_OR_FT(79, 260), 0, 0, 1);
-	plan_add_segment(dp, 30*60 - droptime, M_OR_FT(79, 260), 0, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&ean36, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3,10)).mm, 2, 0, 1);
+	plan_add_segment(dp, droptime, M_OR_FT(79, 260), 0, 0, 1);
+	plan_add_segment(dp, 30*60 - droptime, M_OR_FT(79, 260), 0, 0, 1);
 }
 
 void setupPlanVpmb60m30minAir(struct diveplan *dp)
@@ -97,9 +97,9 @@ void setupPlanVpmb60m30minEan50(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
+	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1);
 	plan_add_segment(dp, 30*60 - droptime, M_OR_FT(60, 200), 0, 0, 1);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 }
 
 void setupPlanVpmb60m30minTx(struct diveplan *dp)
@@ -119,9 +119,9 @@ void setupPlanVpmb60m30minTx(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
+	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1);
 	plan_add_segment(dp, 30*60 - droptime, M_OR_FT(60, 200), 0, 0, 1);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 }
 
 void setupPlanVpmbMultiLevelAir(struct diveplan *dp)
@@ -163,10 +163,10 @@ void setupPlanVpmb100m60min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1);
-	plan_add_segment(dp, 60*60 - droptime, M_OR_FT(100, 330), 0, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3,10)).mm, 2, 0, 1);
+	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1);
+	plan_add_segment(dp, 60*60 - droptime, M_OR_FT(100, 330), 0, 0, 1);
 }
 
 void setupPlanVpmb100m10min(struct diveplan *dp)
@@ -188,10 +188,10 @@ void setupPlanVpmb100m10min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1);
-	plan_add_segment(dp, 10*60 - droptime, M_OR_FT(100, 330), 0, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
 	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3,10)).mm, 2, 0, 1);
+	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1);
+	plan_add_segment(dp, 10*60 - droptime, M_OR_FT(100, 330), 0, 0, 1);
 }
 
 void setupPlanVpmb30m20min(struct diveplan *dp)
@@ -233,13 +233,13 @@ void setupPlanVpmb100mTo70m30min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(18, 60);
+	plan_add_segment(dp, 0, gas_mod(&tx21_35, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
+	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 2, 0, 1);
+	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3,10)).mm, 3, 0, 1);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1);
 	plan_add_segment(dp, 20*60 - droptime, M_OR_FT(100, 330), 0, 0, 1);
 	plan_add_segment(dp, 3*60, M_OR_FT(70, 230), 0, 0, 1);
 	plan_add_segment(dp, (30 - 20 - 3) * 60, M_OR_FT(70, 230), 0, 0, 1);
-	plan_add_segment(dp, 0, gas_mod(&tx21_35, po2, &displayed_dive, M_OR_FT(3,10)).mm, 1, 0, 1);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3,10)).mm, 2, 0, 1);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3,10)).mm, 3, 0, 1);
 }
 
 /* We compare the calculated runtimes against two values:


### PR DESCRIPTION
Fixes two bugs in the reediting of a planned dive: One is to show all gas changes in the manually entered part of the dive immediately  (as opposed to at the next stop in the computed part), the other is to interpret only samples at the beginning of the dive as stating the gas list and gas change depths.