### PR TITLE
Fix crash when merging dives with a missing dive computer model

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3139,7 +3139,7 @@ struct dive *merge_dives(struct dive *a, struct dive *b, int offset, bool prefer
 			dl = b;
 	}
 
-	if (!strcmp(a->dc.model, "planneed dive")) {
+	if (same_string(a->dc.model, "planned dive")) {
 		struct dive *tmp = a;
 		a = b;
 		b = tmp;


### PR DESCRIPTION
The test for the dive being a planned dive was completely bogus:

 - it should use "same_string()" which correctly checks for NULL

 - the string it checks for is obviously spelled wrong anyway.

Reported-by: Alessandro Volpi <volpial@gmail.com>
Fixes: a031dbbbd ("When merging planned dives keep all cylinders")
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>