### PR TITLE
Remove default stylesheet from planner output

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -892,7 +892,7 @@ void MainWindow::printPlan()
 
 	plannerDetails()->divePlanOutput()->setHtml(withDisclaimer);
 	plannerDetails()->divePlanOutput()->print(&printer);
-	plannerDetails()->divePlanOutput()->setHtml(diveplan);
+	plannerDetails()->divePlanOutput()->setHtml(displayed_dive.notes);
 #endif
 }
 

--- a/desktop-widgets/plannerDetails.ui
+++ b/desktop-widgets/plannerDetails.ui
@@ -83,17 +83,13 @@
       </sizepolicy>
      </property>
      <property name="styleSheet">
-      <string notr="true">font: 13pt &quot;Courier&quot;;</string>
+      <string notr="true"/>
      </property>
      <property name="readOnly">
       <bool>true</bool>
      </property>
      <property name="html">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Courier'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'.Curier New';&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string/>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Remove the default stylesheet ("Courier" 13pt) from the planner output QTextEdit.

Fix for #203
S.o. with experience should please review this. But I think this goes into the right direction.

Advantages:
Display is according to font settings.
ctrl - mousewheel for zoom works.
Drawbacks:
Printing font is same as display font but can be adjusted by zooming before.

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>