### PR TITLE
Handle negative dates (before the epoch) better

### DIFF
--- a/core/time.c
+++ b/core/time.c
@@ -108,7 +108,7 @@ timestamp_t utc_mktime(struct tm *tm)
 	/* First normalize relative to 1900 */
 	if (year < 50)
 		year += 100;
-	else if (year > 1900)
+	else if (year >= 1900)
 		year -= 1900;
 
 	if (year < 0 || year > 129) /* algo only works for 1900-2099 */

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -94,10 +94,10 @@ QVariant DiveItem::data(int column, int role) const
 		Q_ASSERT(dive != NULL);
 		switch (column) {
 		case NR:
-			retVal = (qulonglong)dive->when;
+			retVal = (qlonglong)dive->when;
 			break;
 		case DATE:
-			retVal = (qulonglong)dive->when;
+			retVal = (qlonglong)dive->when;
 			break;
 		case RATING:
 			retVal = dive->rating;


### PR DESCRIPTION
The Qt model sorting for the dive date was using a unsigned number,
which doesn't work for dates before 1970.

Also, the dive date parsing got the year 1900 wrong.  Not that we really
care, because other parts of date handling will screw up with any date
before the year 1904.  So if you claim to be diving before 1904, you get
basically random behavior.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>