### PR TITLE
Fix dive site string merging

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -275,6 +275,9 @@ static void merge_string(char **a, char **b)
 {
 	char *s1 = *a, *s2 = *b;
 
+	if (!s2)
+		return;
+
 	if (same_string(s1, s2))
 		return;
 


### PR DESCRIPTION
If the second dive site doesn't have a particular string, but the first
one does, we did the wrong thing and created a result string like

   (first dive site string) or ((null))

which is not useful.  We should just use the first dive site string
as-is.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>