### PR TITLE
Translate names of additional dive events and nicer format info box text

### DIFF
--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -107,15 +107,15 @@ static struct sample *dtrak_profile(struct dive *dt_dive, FILE *archivo)
 		else
 			sample->in_deco = false;
 		if (byte[1] != 0)
-			add_event(dc, sample->time.seconds, 0, 0, 0, "rbt");
+			add_event(dc, sample->time.seconds, 0, 0, 0, QT_TRANSLATE_NOOP("gettextFromC", "rbt"));
 		if (byte[2] != 0)
-			add_event(dc, sample->time.seconds, 0, 0, 0, "ascent");
+			add_event(dc, sample->time.seconds, 0, 0, 0, QT_TRANSLATE_NOOP("gettextFromC", "ascent"));
 		if (byte[3] != 0)
-			add_event(dc, sample->time.seconds, 0, 0, 0, "ceiling");
+			add_event(dc, sample->time.seconds, 0, 0, 0, QT_TRANSLATE_NOOP("gettextFromC", "ceiling"));
 		if (byte[4] != 0)
-			add_event(dc, sample->time.seconds, 0, 0, 0, "workload");
+			add_event(dc, sample->time.seconds, 0, 0, 0, QT_TRANSLATE_NOOP("gettextFromC", "workload"));
 		if (byte[5] != 0)
-			add_event(dc, sample->time.seconds, 0, 0, 0, "transmitter");
+			add_event(dc, sample->time.seconds, 0, 0, 0, QT_TRANSLATE_NOOP("gettextFromC", "transmitter"));
 		if (j == 3) {
 			read_bytes(1);
 			if (is_O2) {

--- a/core/planner.c
+++ b/core/planner.c
@@ -317,7 +317,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, bool track_gas)
 			/* this is a bad idea - we should get a different SAMPLE_EVENT type
 			 * reserved for this in libdivecomputer... overloading SMAPLE_EVENT_PO2
 			 * with a different meaning will only cause confusion elsewhere in the code */
-			add_event(dc, lasttime, SAMPLE_EVENT_PO2, 0, po2, "SP change");
+			add_event(dc, lasttime, SAMPLE_EVENT_PO2, 0, po2, QT_TRANSLATE_NOOP("gettextFromC", "SP change"));
 			oldpo2 = po2;
 		}
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -198,7 +198,8 @@ void SetpointDialog::setpointData(struct divecomputer *divecomputer, int second)
 void SetpointDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole && dc) {
-		add_event(dc, time, SAMPLE_EVENT_PO2, 0, (int)(1000.0 * ui.spinbox->value()), "SP change");
+		add_event(dc, time, SAMPLE_EVENT_PO2, 0, (int)(1000.0 * ui.spinbox->value()), 
+			QT_TRANSLATE_NOOP("gettextFromC", "SP change"));
 		invalidate_dive_cache(current_dive);
 	}
 	mark_divelist_changed(true);

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -156,6 +156,10 @@ void DiveEventItem::setupToolTipString()
 	} else if (value) {
 		if (type == SAMPLE_EVENT_PO2 && same_string(internalEvent->name, "SP change")) {
 			name += QString(": %1bar").arg((double)value / 1000, 0, 'f', 1);
+		} else if (type == SAMPLE_EVENT_CEILING && same_string(internalEvent->name, "planned waypoint above ceiling")) {
+			const char *depth_unit;
+			double depth_value = get_depth_units(value*1000, NULL, &depth_unit);
+			name += QString(": %1%2").arg((int) round(depth_value)).arg(depth_unit);
 		} else {
 			name += QString(": %1").arg(value);
 		}

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -152,17 +152,17 @@ void DiveEventItem::setupToolTipString()
 
 		/* Do we have an explicit cylinder index?  Show it. */
 		if (internalEvent->gas.index >= 0)
-			name += QString(" (cyl %1)").arg(internalEvent->gas.index+1);
+			name += tr(" (cyl. %1)").arg(internalEvent->gas.index + 1);
 	} else if (value) {
-		if (type == SAMPLE_EVENT_PO2 && name == "SP change") {
-			name += QString(":%1").arg((double)value / 1000);
+		if (type == SAMPLE_EVENT_PO2 && same_string(internalEvent->name, "SP change")) {
+			name += QString(": %1bar").arg((double)value / 1000, 0, 'f', 1);
 		} else {
-			name += QString(":%1").arg(value);
+			name += QString(": %1").arg(value);
 		}
-	} else if (type == SAMPLE_EVENT_PO2 && name == "SP change") {
+	} else if (type == SAMPLE_EVENT_PO2 && same_string(internalEvent->name, "SP change")) {
 		// this is a bad idea - we are abusing an existing event type that is supposed to
 		// warn of high or low pO₂ and are turning it into a set point change event
-		name += "\n" + tr("Manual switch to OC");
+		name += ":\n" + tr("Manual switch to OC");
 	} else {
 		name += internalEvent->flags & SAMPLE_FLAGS_BEGIN ? tr(" begin", "Starts with space!") :
 								    internalEvent->flags & SAMPLE_FLAGS_END ? tr(" end", "Starts with space!") : "";

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -192,7 +192,8 @@ void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelI
 			if (entry->depth < max - 100 && entry->sec > 0) {
 				profileColor = QColor(Qt::red);
 				if (!eventAdded) {
-					add_event(&displayed_dive.dc, entry->sec, SAMPLE_EVENT_CEILING, -1, max / 1000, "planned waypoint above ceiling");
+					add_event(&displayed_dive.dc, entry->sec, SAMPLE_EVENT_CEILING, -1, max / 1000, 
+						QT_TRANSLATE_NOOP("gettextFromC", "planned waypoint above ceiling"));
 					eventAdded = true;
 				}
 			}


### PR DESCRIPTION
Enable translation for a few additional internal dive events.
Ensure that all event names in datatrak.c are collected for translation.
Ensure that for gaschange in profile info box the "cyl." string is also translated.
"SP change" info format in info box: Added/changed formating and "bar".
"waypoint above ceiling" event in info box: Added formating and depth unit.

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>