### PR TITLE
Fixes cylinder table headers not translated

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -23,7 +23,6 @@
 #define UNIT_FACTOR ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
 
 static DivePlannerPointsModel* plannerModel = DivePlannerPointsModel::instance();
-static CylindersModel* cylinderModel = CylindersModel::instance();
 
 DiveHandler::DiveHandler() : QGraphicsEllipseItem()
 {
@@ -354,8 +353,8 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.min_switch_duration, SIGNAL(valueChanged(int)), plannerModel, SLOT(setMinSwitchDuration(int)));
 	connect(ui.rebreathermode, SIGNAL(currentIndexChanged(int)), plannerModel, SLOT(setRebreatherMode(int)));
 
-	connect(ui.bottompo2, SIGNAL(valueChanged(double)), cylinderModel, SLOT(updateBestMixes()));
-	connect(ui.bestmixEND, SIGNAL(valueChanged(int)), cylinderModel, SLOT(updateBestMixes()));
+	connect(ui.bottompo2, SIGNAL(valueChanged(double)), CylindersModel::instance(), SLOT(updateBestMixes()));
+	connect(ui.bestmixEND, SIGNAL(valueChanged(int)), CylindersModel::instance(), SLOT(updateBestMixes()));
 
 	connect(modeMapper, SIGNAL(mapped(int)), this, SLOT(disableDecoElements(int)));
 	connect(ui.ascRate75, SIGNAL(valueChanged(int)), this, SLOT(setAscRate75(int)));

--- a/desktop-widgets/maintab.cpp
+++ b/desktop-widgets/maintab.cpp
@@ -34,7 +34,7 @@
 
 MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	weightModel(new WeightModel(this)),
-	cylindersModel(CylindersModel::instance()),
+	cylindersModel(new CylindersModel(this)),
 	extraDataModel(new ExtraDataModel(this)),
 	editMode(NONE),
 	divePictureModel(DivePictureModel::instance()),


### PR DESCRIPTION
The cylinder table was constructed very early from the constructor of the
planner, so early that the tr() functions are not registered. This fix
instantiates the cylinderModel from the maintab (as it is done
with, for example, the weightsModel) and lets the planner user
this instantiated (and proper translating) cylinderModel.

Fixes: #206

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>