### PR TITLE
Fix Windows issue with Load/Save to cloudstorage for non-ASCII user n…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,9 @@ if (${_index} EQUAL -1)
     Example: -DSUBSURFACE_TARGET_EXECUTABLE=DesktopExecutable")
 endif()
 
-add_definitions(-DSUBSURFACE_SOURCE="${CMAKE_SOURCE_DIR}")
+# SUBSURFACE_SOURCE may be used in subdirectories (tests)
+set(SUBSURFACE_SOURCE ${CMAKE_SOURCE_DIR})
+add_definitions(-DSUBSURFACE_SOURCE="${SUBSURFACE_SOURCE}")
 
 #evenrything's correct, moving on.
 set(CMAKE_MODULE_PATH
@@ -421,7 +423,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	# the script we created above is now added as a command to run at
 	# install time - so this ensures that subsurface.exe has been
 	# built before this is run
-	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DSUBSURFACE_TARGET=${SUBSURFACE_TARGET} -DSUBSURFACE_SOURCE=${CMAKE_SOURCE_DIR} -DSTAGING=${WINDOWSSTAGING} -P ${CMAKE_SOURCE_DIR}/cmake/Modules/dlllist.cmake)")
+	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DSUBSURFACE_TARGET=${SUBSURFACE_TARGET} -DSUBSURFACE_SOURCE=${SUBSURFACE_SOURCE} -DSTAGING=${WINDOWSSTAGING} -P ${CMAKE_SOURCE_DIR}/cmake/Modules/dlllist.cmake)")
 
 	# create the subsurface-x.y.z.exe installer - this needs to depend
 	# on the install target but cmake doesn't allow that, so we depend

--- a/core/android.cpp
+++ b/core/android.cpp
@@ -176,6 +176,11 @@ int subsurface_access(const char *path, int mode)
 	return access(path, mode);
 }
 
+int subsurface_stat(const char* path, struct stat* buf)
+{
+	return stat(path, buf);
+}
+
 struct zip *subsurface_zip_open_readonly(const char *path, int flags, int *errorp)
 {
 	return zip_open(path, flags, errorp);

--- a/core/dive.h
+++ b/core/dive.h
@@ -8,6 +8,7 @@
 #include <zip.h>
 #include <sqlite3.h>
 #include <string.h>
+#include <sys/stat.h>
 #include "divesite.h"
 
 /* Windows has no MIN/MAX macros - so let's just roll our own */
@@ -728,6 +729,7 @@ extern int subsurface_open(const char *path, int oflags, mode_t mode);
 extern FILE *subsurface_fopen(const char *path, const char *mode);
 extern void *subsurface_opendir(const char *path);
 extern int subsurface_access(const char *path, int mode);
+extern int subsurface_stat(const char* path, struct stat* buf);
 extern struct zip *subsurface_zip_open_readonly(const char *path, int flags, int *errorp);
 extern int subsurface_zip_close(struct zip *zip);
 extern void subsurface_console_init(bool dedicated, bool logfile);

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -768,7 +768,7 @@ static struct git_repository *get_remote_repo(const char *localdir, const char *
 	}
 	git_storage_update_progress(false, "start git interaction");
 	/* Do we already have a local cache? */
-	if (!stat(localdir, &st)) {
+	if (!subsurface_stat(localdir, &st)) {
 		if (!S_ISDIR(st.st_mode)) {
 			if (is_subsurface_cloud)
 				(void)cleanup_local_cache(remote, branch);
@@ -934,7 +934,7 @@ struct git_repository *is_git_repository(const char *filename, const char **bran
 		return repo;
 	}
 
-	if (stat(loc, &st) < 0 || !S_ISDIR(st.st_mode)) {
+	if (subsurface_stat(loc, &st) < 0 || !S_ISDIR(st.st_mode)) {
 		free(loc);
 		free(branch);
 		return dummy_git_repository;

--- a/core/linux.c
+++ b/core/linux.c
@@ -204,6 +204,11 @@ int subsurface_access(const char *path, int mode)
 	return access(path, mode);
 }
 
+int subsurface_stat(const char* path, struct stat* buf)
+{
+	return stat(path, buf);
+}
+
 struct zip *subsurface_zip_open_readonly(const char *path, int flags, int *errorp)
 {
 	return zip_open(path, flags, errorp);

--- a/core/windows.c
+++ b/core/windows.c
@@ -346,6 +346,18 @@ int subsurface_access(const char *path, int mode)
 	return ret;
 }
 
+int subsurface_stat(const char* path, struct stat* buf)
+{
+	int ret = -1;
+	if (!path)
+		return ret;
+	wchar_t *wpath = utf8_to_utf16(path);
+	if (wpath)
+		ret = wstat(wpath, buf);
+	free((void *)wpath);
+	return ret;
+}
+
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 # QTest based tests
 qt5_add_resources(SUBSURFACE_TEST_RESOURCES ../subsurface.qrc)
 
+# Access test data (dive folder) from SUBSURFACE_SOURCE by default.
+# In cross compilation cases or when test will not be executed at build time
+# a differnt value can be set via cmake -DSUBSURFACE_TEST_DATA.
+if(NOT SUBSURFACE_TEST_DATA)
+  set(SUBSURFACE_TEST_DATA ${SUBSURFACE_SOURCE})
+endif()
+
 add_library(RESOURCE_LIBRARY STATIC ${SUBSURFACE_TEST_RESOURCES})
 
 macro(TEST NAME FILE)
@@ -11,6 +18,7 @@ endmacro()
 
 enable_testing()
 add_definitions(-g)
+add_definitions(-DSUBSURFACE_TEST_DATA="${SUBSURFACE_TEST_DATA}")
 TEST(TestUnitConversion testunitconversion.cpp)
 TEST(TestProfile testprofile.cpp)
 TEST(TestGpsCoords testgpscoords.cpp)

--- a/tests/testdivesiteduplication.cpp
+++ b/tests/testdivesiteduplication.cpp
@@ -4,7 +4,7 @@
 
 void TestDiveSiteDuplication::testReadV2()
 {
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/TwoTimesTwo.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf"), 0);
 	QCOMPARE(dive_site_table.nr, 2);
 }
 

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -64,6 +64,7 @@ void TestGitStorage::testGitStorageLocal_data()
 	// test different path we may encounter (since storage depends on user name)
 	QTest::addColumn<QString>("testDirName");
 	QTest::newRow("ASCII path") << "./gittest";
+	QTest::newRow("Non ASCII path") << "./gittest_éèêôàüäößíñóúäåöø";
 }
 
 void TestGitStorage::testGitStorageLocal()

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -38,7 +38,7 @@ void TestGitStorage::testSetup()
 	QString gitUrl(prefs.cloud_base_url);
 	if (gitUrl.right(1) != "/")
 		gitUrl += "/";
-	prefs.cloud_git_url = strdup(qPrintable(gitUrl + "git"));
+	prefs.cloud_git_url = strdup(qUtf8Printable(gitUrl + "git"));
 	s.endGroup();
 	prefs.cloud_storage_email_encoded = strdup("ssrftest@hohndel.org");
 	prefs.cloud_storage_password = strdup("geheim");
@@ -69,11 +69,11 @@ void TestGitStorage::testGitStorageLocal()
 	QDir testDir(testDirName);
 	QCOMPARE(testDir.removeRecursively(), true);
 	QCOMPARE(QDir().mkdir(testDirName), true);
-	QCOMPARE(git_repository_init(&repo, qPrintable(testDirName), false), 0);
-	QCOMPARE(save_dives(qPrintable(testDirName + "[test]")), 0);
+	QCOMPARE(git_repository_init(&repo, qUtf8Printable(testDirName), false), 0);
+	QCOMPARE(save_dives(qUtf8Printable(testDirName + "[test]")), 0);
 	QCOMPARE(save_dives("./SampleDivesV3.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(testDirName + "[test]")), 0);
+	QCOMPARE(parse_file(qUtf8Printable(testDirName + "[test]")), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viagit.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -94,9 +94,9 @@ void TestGitStorage::testGitStorageCloud()
 	// and repeat the same test as before with the local git storage
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -118,17 +118,17 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	// read the local repo from the previous test and add dive 10
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml"), 0);
 	// calling process_dive() sorts the table, but calling it with
 	// is_imported == true causes it to try to update the window title... let's not do that
 	process_dives(false, false);
 	// now save only to the local cache but not to the remote server
-	QCOMPARE(save_dives(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10local.ssrf"), 0);
 	clear_dive_file_data();
 	// open the cloud storage and compare
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10local.ssrf");
 	org.open(QFile::ReadOnly);
@@ -140,13 +140,13 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
 	// write back out to cloud storage, move away the local cache, open again and compare
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 	QDir localCacheDirectory(localCacheDir);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectorySave.removeRecursively(), true);
 	QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10fromcloud.ssrf"), 0);
 	org.close();
 	org.open(QFile::ReadOnly);
@@ -168,17 +168,17 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepoSave = localCacheDir + "save[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(localCacheRepoSave)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(localCacheRepoSave)), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives(qPrintable(localCacheRepoSave)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(localCacheRepoSave)), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -187,7 +187,7 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectory.rename(localCacheDir + "save", localCacheDir), true);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SapleDivesV3plus10-11-12-merged.ssrf"), 0);
 	clear_dive_file_data();
 	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf"), 0);
@@ -216,12 +216,12 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
 	QCOMPARE(save_dives("./SampleDivesMinus1.ssrf"), 0);
-	QCOMPARE(save_dives(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -232,13 +232,13 @@ void TestGitStorage::testGitStorageCloudMerge2()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify that first dive
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	process_dives(false, false);
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
 	free(dive->notes);
 	dive->notes = strdup("These notes have been modified by TestGitStorage");
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -248,9 +248,9 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesMinus1-merged.ssrf"), 0);
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	QFile org("./SampleDivesMinus1-merged.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesMinus1.ssrf");
@@ -273,7 +273,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(0);
 	QVERIFY(dive != 0);
@@ -282,10 +282,10 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
 	dive = get_dive(2);
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Create multi line dive notes\nDifferent line 2 and removed 3-5\n\nThat should be enough");
@@ -293,7 +293,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
 	dive = get_dive(2);
 	dive->notes = strdup("single line dive notes");
-	QCOMPARE(save_dives(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -304,7 +304,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify those first dive notes differently
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Completely different dive notes\nBut also multi line");
@@ -312,7 +312,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("single line dive notes");
 	dive = get_dive(2);
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
-	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -322,7 +322,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -59,13 +59,20 @@ void TestGitStorage::testSetup()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 }
 
+void TestGitStorage::testGitStorageLocal_data()
+{
+	// test different path we may encounter (since storage depends on user name)
+	QTest::addColumn<QString>("testDirName");
+	QTest::newRow("ASCII path") << "./gittest";
+}
+
 void TestGitStorage::testGitStorageLocal()
 {
 	// test writing and reading back from local git storage
 	git_repository *repo;
 	git_libgit2_init();
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
-	QString testDirName("./gittest");
+	QFETCH(QString, testDirName);
 	QDir testDir(testDirName);
 	QCOMPARE(testDir.removeRecursively(), true);
 	QCOMPARE(QDir().mkdir(testDirName), true);

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -64,7 +64,7 @@ void TestGitStorage::testGitStorageLocal()
 	// test writing and reading back from local git storage
 	git_repository *repo;
 	git_libgit2_init();
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/SampleDivesV2.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
 	QString testDirName("./gittest");
 	QDir testDir(testDirName);
 	QCOMPARE(testDir.removeRecursively(), true);
@@ -93,7 +93,7 @@ void TestGitStorage::testGitStorageCloud()
 	// connect to the ssrftest repository on the cloud server
 	// and repeat the same test as before with the local git storage
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/SampleDivesV2.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
@@ -119,7 +119,7 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	// read the local repo from the previous test and add dive 10
 	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test10.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml"), 0);
 	// calling process_dive() sorts the table, but calling it with
 	// is_imported == true causes it to try to update the window title... let's not do that
 	process_dives(false, false);
@@ -169,14 +169,14 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepoSave = localCacheDir + "save[ssrftest@hohndel.org]";
 	QCOMPARE(parse_file(qPrintable(localCacheRepoSave)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test11.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives(qPrintable(localCacheRepoSave)), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test12.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
@@ -191,9 +191,9 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QCOMPARE(save_dives("./SapleDivesV3plus10-11-12-merged.ssrf"), 0);
 	clear_dive_file_data();
 	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf"), 0);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test11.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test12.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives("./SapleDivesV3plus10-11-12.ssrf"), 0);
 	QFile org("./SapleDivesV3plus10-11-12-merged.ssrf");

--- a/tests/testgitstorage.h
+++ b/tests/testgitstorage.h
@@ -8,6 +8,7 @@ class TestGitStorage : public QObject
 	Q_OBJECT
 private slots:
 	void testSetup();
+	void testGitStorageLocal_data();
 	void testGitStorageLocal();
 	void testGitStorageCloud();
 	void testGitStorageCloudOfflineSync();

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -15,12 +15,12 @@ void TestMerge::testMergeEmpty()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
 	process_dives(true, false);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test48.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml"), 0);
 	process_dives(true, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/test47+48.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testmerge47+48.ssrf");
 	out.open(QFile::ReadOnly);
@@ -39,12 +39,12 @@ void TestMerge::testMergeBackwards()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test48.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml"), 0);
 	process_dives(true, false);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
 	process_dives(true, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/test47+48.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testmerge47+48.ssrf");
 	out.open(QFile::ReadOnly);

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -80,7 +80,7 @@ void TestParse::testParseCSV()
 	params[pnr++] = intdup(-1);
 	params[pnr++] = NULL;
 
-	QCOMPARE(parse_manual_file(SUBSURFACE_SOURCE "/dives/test41.csv", params, pnr - 1), 0);
+	QCOMPARE(parse_manual_file(SUBSURFACE_TEST_DATA "/dives/test41.csv", params, pnr - 1), 0);
 	fprintf(stderr, "number of dives %d \n", dive_table.nr);
 }
 
@@ -92,7 +92,7 @@ void TestParse::testParseDivingLog()
 	struct dive_site *ds = alloc_or_get_dive_site(0xdeadbeef);
 	ds->name = copy_string("Suomi -  - Hälvälä");
 
-	QCOMPARE(sqlite3_open(SUBSURFACE_SOURCE "/dives/TestDivingLog4.1.1.sql", &handle), 0);
+	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql", &handle), 0);
 	QCOMPARE(parse_divinglog_buffer(handle, 0, 0, 0, &dive_table), 0);
 
 	sqlite3_close(handle);
@@ -101,19 +101,19 @@ void TestParse::testParseDivingLog()
 void TestParse::testParseV2NoQuestion()
 {
 	// parsing of a V2 file should work
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test40.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml"), 0);
 }
 
 void TestParse::testParseV3()
 {
 	// parsing of a V3 files should succeed
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test42.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml"), 0);
 }
 
 void TestParse::testParseCompareOutput()
 {
 	QCOMPARE(save_dives("./testout.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/test40-42.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testout.ssrf");
 	out.open(QFile::ReadOnly);
@@ -131,7 +131,7 @@ void TestParse::testParseDM4()
 {
 	sqlite3 *handle;
 
-	QCOMPARE(sqlite3_open(SUBSURFACE_SOURCE "/dives/TestDiveDM4.db", &handle), 0);
+	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &handle), 0);
 	QCOMPARE(parse_dm4_buffer(handle, 0, 0, 0, &dive_table), 0);
 
 	sqlite3_close(handle);
@@ -140,7 +140,7 @@ void TestParse::testParseDM4()
 void TestParse::testParseCompareDM4Output()
 {
 	QCOMPARE(save_dives("./testdm4out.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/TestDiveDM4.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testdm4out.ssrf");
 	out.open(QFile::ReadOnly);
@@ -193,7 +193,7 @@ void TestParse::testParseHUDC()
 	params[pnr++] = strdup("\"DC text\"");
 	params[pnr++] = NULL;
 
-	QCOMPARE(parse_csv_file(SUBSURFACE_SOURCE "/dives/TestDiveSeabearHUDC.csv",
+	QCOMPARE(parse_csv_file(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.csv",
 				params, pnr - 1, "csv"), 0);
 
 	QCOMPARE(dive_table.nr, 1);
@@ -212,7 +212,7 @@ void TestParse::testParseHUDC()
 void TestParse::testParseCompareHUDCOutput()
 {
 	QCOMPARE(save_dives("./testhudcout.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/TestDiveSeabearHUDC.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testhudcout.ssrf");
 	out.open(QFile::ReadOnly);
@@ -240,7 +240,7 @@ void TestParse::testParseNewFormat()
 	 * Set the directory location and file filter for H3 CSV files.
 	 */
 
-	dir = QString::fromLatin1(SUBSURFACE_SOURCE "/dives");
+	dir = QString::fromLatin1(SUBSURFACE_TEST_DATA "/dives");
 	filter << "TestDiveSeabearH3*.csv";
 	filter << "TestDiveSeabearT1*.csv";
 	files = dir.entryList(filter, QDir::Files);
@@ -253,7 +253,7 @@ void TestParse::testParseNewFormat()
 		QString delta;
 		QStringList currColumns;
 		QStringList headers;
-		QString file = QString::fromLatin1(SUBSURFACE_SOURCE "/dives/").append(files.at(i));
+		QString file = QString::fromLatin1(SUBSURFACE_TEST_DATA "/dives/").append(files.at(i));
 		QFile f(file);
 
 		/*
@@ -368,7 +368,7 @@ void TestParse::testParseNewFormat()
 void TestParse::testParseCompareNewFormatOutput()
 {
 	QCOMPARE(save_dives("./testsbnewout.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/TestDiveSeabearNewFormat.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearNewFormat.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testsbnewout.ssrf");
 	out.open(QFile::ReadOnly);
@@ -388,7 +388,7 @@ void TestParse::testParseCompareNewFormatOutput()
 void TestParse::testParseDLD()
 {
 	struct memblock mem;
-	QString filename = SUBSURFACE_SOURCE "/dives/TestDiveDivelogsDE.DLD";
+	QString filename = SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.DLD";
 
 	QVERIFY(readfile(filename.toLatin1().data(), &mem) > 0);
 	QVERIFY(try_to_open_zip(filename.toLatin1().data()) > 0);
@@ -405,7 +405,7 @@ void TestParse::testParseCompareDLDOutput()
 	 */
 
 	QCOMPARE(save_dives("./testdldout.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/TestDiveDivelogsDE.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testdldout.ssrf");
 	out.open(QFile::ReadOnly);
@@ -424,10 +424,10 @@ void TestParse::testParseMerge()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/ostc.xml"), 0);
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/vyper.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml"), 0);
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
-	QFile org(SUBSURFACE_SOURCE "/dives/mergedVyperOstc.xml");
+	QFile org(SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testmerge.ssrf");
 	out.open(QFile::ReadOnly);

--- a/tests/testpicture.cpp
+++ b/tests/testpicture.cpp
@@ -17,14 +17,14 @@ void TestPicture::addPicture()
 	struct picture *pic;
 	verbose = 1;
 
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test44.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml"), 0);
 	dive = get_dive(0);
 	QVERIFY(dive != NULL);
 	pic = dive->picture_list;
 	// So far no picture in dive
 	QVERIFY(pic == NULL);
 
-	dive_create_picture(dive, SUBSURFACE_SOURCE "/wreck.jpg", 0, false);
+	dive_create_picture(dive, SUBSURFACE_TEST_DATA "/wreck.jpg", 0, false);
 	pic = dive->picture_list;
 	// Now there is a picture
 	QVERIFY(pic != NULL);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -6,14 +6,14 @@
 
 void TestRenumber::setup()
 {
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
 	process_dives(false, false);
 	dive_table.preexisting = dive_table.nr;
 }
 
 void TestRenumber::testMerge()
 {
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test47b.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml"), 0);
 	process_dives(true, false);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
@@ -23,7 +23,7 @@ void TestRenumber::testMerge()
 
 void TestRenumber::testMergeAndAppend()
 {
-	QCOMPARE(parse_file(SUBSURFACE_SOURCE "/dives/test47c.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml"), 0);
 	process_dives(true, false);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);


### PR DESCRIPTION
…ames.

Added new subsurface_stat() portability function to replace stat().
Added Windows implementation of subsurface_stat() using wstat(),
with conversion to ut16 of the inputed path.
Other platform implementations (linux, android) make use of the normal stat().

Update tests with a (compile time) option SUBSURFACE_TEST_DATA,
pointing to test data base path. It is needed for cross compilation cases.
SUBSURFACE_TEST_DATA is set to SUBSURFACE_SOURCE by default,
or configurable via cmake option -DSUBSURFACE_TEST_DATA="...".

Update TestGitStorage to use qUtf8Printable instead of pPrintable.
This ensures that non-ASCII chars are utf8 encoded before calling internal functions.
In windows case pPrintable returns other codepoints that depend on system settings.

Signed-off-by: Jeremie Guichard <djebrest@gmail.com>