### PR TITLE
smtk-import: Fix freeing unallocated memory

### DIFF
--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -724,6 +724,7 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 				smtkdive->dc.duration.seconds = smtkdive->duration.seconds = smtk_time_to_secs(col[coln(DURATION)]->bind_ptr);
 				smtkdive->dc.maxdepth.mm = smtkdive->maxdepth.mm = strtod(col[coln(MAXDEPTH)]->bind_ptr, NULL) * 1000;
 			}
+			free(hdr_buffer);
 			free(prf_buffer);
 		} else {
 			/* Manual dives or unknown DCs */
@@ -731,7 +732,6 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 			smtkdive->dc.duration.seconds = smtkdive->duration.seconds = smtk_time_to_secs(col[coln(DURATION)]->bind_ptr);
 			smtkdive->dc.maxdepth.mm = smtkdive->maxdepth.mm = strtod(col[coln(MAXDEPTH)]->bind_ptr, NULL) * 1000;
 		}
-		free(hdr_buffer);
 		/*
 		 * Cylinder and gasmixes completion.
 		 * Revisit data under some circunstances, e.g. a start pressure = 0 may mean


### PR DESCRIPTION
hdr_buffer pointer was not always allocated (just on dc dives), but was
always freed.
This should cause a crash while processing a manually added dive (or a dive
whose dc model couldn't be stablished), but not always does, crashes only
if the pointed memory hasn't been previously allocated. In most cases causes
memory corruption, which goes easily unnoticed as it is correctly freed in
next parse run.
This means, obviously, I have some work TODO fixing leaks with valgrind.

Signed-off-by: Salvador Cuñat <salvador.cunat@gmail.com>