### PR TITLE
Several updates to bring testing under windows forward

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ endif()
 include(cmake/Modules/HandleFtdiSupport.cmake)
 include(cmake/Modules/HandleVersionGeneration.cmake)
 include(cmake/Modules/RunOnBuildDir.cmake)
+include(cmake/Modules/cmake_variables_helper.cmake)
 
 pkg_config_library(LIBXML libxml-2.0 REQUIRED)
 pkg_config_library(LIBSQLITE3 sqlite3 REQUIRED)
@@ -467,9 +468,4 @@ if (MAKE_TESTS)
 endif()
 
 # useful for debugging CMake issues
-#
-# message(STATUS "print variables")
-# get_cmake_property(_variableNames VARIABLES)
-# foreach(_variableName ${_variableNames})
-#	message(STATUS "${_variableName}=${${_variableName}}")
-# endforeach()
+# print_all_variables()

--- a/cmake/Modules/cmake_variables_helper.cmake
+++ b/cmake/Modules/cmake_variables_helper.cmake
@@ -1,0 +1,44 @@
+# This file contains helper macro to print env variables as status messages
+
+# print_variable
+#
+# Prints a status message with the value of the variable
+#
+# Parameters:
+#  variableName - A string containing the name of the variable to be printed
+#
+# Usage:
+#  print_variable(CMAKE_CURRENT_BINARY_DIR)
+#
+# Output:
+#  -- CMAKE_CURRENT_BINARY_DIR=/home/xxx/xxx
+#
+macro(print_variable _variableName)
+  message(STATUS "${_variableName}=${${_variableName}}")
+endmacro()
+
+# print_all_variables
+#
+# Prints a status message for all currently defined variables.
+#
+# Parameters:
+#  none
+#
+# Usage:
+#  print_all_variable()
+#
+# Output:
+#  -- ------------------------------ print variables ------------------------------
+#  -- CMAKE_CURRENT_BINARY_DIR=/home/xxx/xxx
+#  -- ....
+#  -- -----------------------------------------------------------------------------
+#
+macro(print_all_variables)
+  message(STATUS "------------------------------ print variables ------------------------------")
+  get_cmake_property(_variableNames VARIABLES)
+
+  foreach(_variableName ${_variableNames})
+    print_variable(${_variableName})
+  endforeach()
+  message(STATUS "-----------------------------------------------------------------------------")
+endmacro()

--- a/cmake/Modules/dlllist.cmake
+++ b/cmake/Modules/dlllist.cmake
@@ -20,7 +20,7 @@ message(STATUS "addpath is ${ADDPATH}")
 # first space) -- this will fail if the full path for the
 # linker used contains a space...
 execute_process(
-	COMMAND tail -1 CMakeFiles/subsurface.dir/link.txt
+	COMMAND tail -1 CMakeFiles/${SUBSURFACE_TARGET}.dir/link.txt
 	COMMAND cut -d\  -f 2-
 	OUTPUT_VARIABLE LINKER_LINE
 	OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,20 +5,78 @@ qt5_add_resources(SUBSURFACE_TEST_RESOURCES ../subsurface.qrc)
 # In cross compilation cases or when test will not be executed at build time
 # a differnt value can be set via cmake -DSUBSURFACE_TEST_DATA.
 if(NOT SUBSURFACE_TEST_DATA)
-  set(SUBSURFACE_TEST_DATA ${SUBSURFACE_SOURCE})
+	if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+		# For windows case we expect tests to be executed
+		# with WORKING_DIRECTORY pointing to folder where test data can be found
+		set(SUBSURFACE_TEST_DATA .)
+	else()
+		set(SUBSURFACE_TEST_DATA ${SUBSURFACE_SOURCE})
+	endif()
 endif()
 
 add_library(RESOURCE_LIBRARY STATIC ${SUBSURFACE_TEST_RESOURCES})
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+
+	# Prepare a staging_tests folder
+	# Test can run accessing data and dependecies for build time testing
+	# or can be deployed for target testing
+	# It inludes:
+	#  - test data
+	#  - test binaries (see TEST macro)
+	#  - test binaries dependencies (see TEST macro)
+	set(WINDOWS_STAGING_TESTS ${CMAKE_BINARY_DIR}/staging_tests)
+	install(DIRECTORY ${SUBSURFACE_SOURCE}/dives DESTINATION ${WINDOWS_STAGING_TESTS})
+	install(FILES ${SUBSURFACE_SOURCE}/wreck.jpg DESTINATION ${WINDOWS_STAGING_TESTS})
+
+	# Check if we can run tests locally using wine
+	# Add a fake test used to ensure data is deployed to WINDOWS_STAGING_TESTS before running
+	find_program(WINE_PROGRAM wine)
+	if(WINE_PROGRAM)
+		add_test(
+			NAME InstallTestsDataAndDependencies
+			COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_BINARY_DIR} --target install
+			)
+	endif()
+endif()
+
+# Helper macro TEST used to created rules to build, link, install and run tests
 macro(TEST NAME FILE)
 	add_executable(${NAME} ${FILE} )
-	target_link_libraries(${NAME} subsurface_corelib RESOURCE_LIBRARY ${QT_TEST_LIBRARIES} ${SUBSURFACE_LINK_LIBRARIES} )
-	add_test(NAME ${NAME} COMMAND  $<TARGET_FILE:${NAME}>)
+	target_link_libraries(
+		${NAME}
+		subsurface_corelib
+		RESOURCE_LIBRARY
+		${QT_TEST_LIBRARIES}
+		${SUBSURFACE_LINK_LIBRARIES}
+		)
+
+	if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+		# Re-install dependencies in WINDOWS_STAGING_TESTS (and not in WINDOWSSTAGING)
+		# to avoid packing testing related dlls in the installer
+		install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DSUBSURFACE_TARGET=${NAME} -DSUBSURFACE_SOURCE=${SUBSURFACE_SOURCE} -DSTAGING=${WINDOWS_STAGING_TESTS} -P ${CMAKE_SOURCE_DIR}/cmake/Modules/dlllist.cmake)")
+
+		# Run test using wine
+		if(WINE_PROGRAM)
+			add_test(
+				NAME ${NAME}
+				COMMAND "$<TARGET_FILE:${NAME}>"
+				WORKING_DIRECTORY ${WINDOWS_STAGING_TESTS}
+				)
+			# Set WINEPATH (%PATH%) to WINDOWS_STAGING_TESTS allowing wine to find dlls
+			# WINEDEBUG=-all is used to avoid anoying winde debug outputs
+			set_tests_properties(${NAME} PROPERTIES ENVIRONMENT "WINEPATH=${WINDOWS_STAGING_TESTS};WINEDEBUG=-all")
+			set_tests_properties(${NAME} PROPERTIES DEPENDS PrepareTests)
+		endif()
+	else()
+		add_test(NAME ${NAME} COMMAND  $<TARGET_FILE:${NAME}>)
+	endif()
 endmacro()
 
 enable_testing()
 add_definitions(-g)
 add_definitions(-DSUBSURFACE_TEST_DATA="${SUBSURFACE_TEST_DATA}")
+
 TEST(TestUnitConversion testunitconversion.cpp)
 TEST(TestProfile testprofile.cpp)
 TEST(TestGpsCoords testgpscoords.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,3 +46,6 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestPicture
 	TestMerge
 )
+
+# useful for debugging CMake issues
+# print_all_variables()

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -29,7 +29,7 @@ void TestMerge::testMergeEmpty()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -53,7 +53,7 @@ void TestMerge::testMergeBackwards()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -122,7 +122,7 @@ void TestParse::testParseCompareOutput()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -149,7 +149,7 @@ void TestParse::testParseCompareDM4Output()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -222,7 +222,7 @@ void TestParse::testParseCompareHUDCOutput()
 	QStringList written = outS.readAll().split("\n");
 
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 
 	clear_dive_file_data();
@@ -379,7 +379,7 @@ void TestParse::testParseCompareNewFormatOutput()
 
 // currently the CSV parse fails
 //	while(readin.size() && written.size()){
-//		QCOMPARE(readin.takeFirst(), written.takeFirst());
+//		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 //	}
 
 	clear_dive_file_data();
@@ -414,7 +414,7 @@ void TestParse::testParseCompareDLDOutput()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -436,7 +436,7 @@ void TestParse::testParseMerge()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst(), written.takeFirst());
+		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }


### PR DESCRIPTION
The major improvement here is that we can now run tests (ctest and make check rule) directly from build machine if wine is available.

Not all tests are passing yet, but it is going forward
TestMerge is now passing completely
TestParse still has some failures but (I only made short analysis) they do not seem to be simple test code issues.
TestPreferences still not passing under wine (and crashes when running on target) but this was already the case before.
See current test failures here: [LastTest.txt](https://github.com/Subsurface-divelog/subsurface/files/801319/LastTest.txt)