### PR TITLE
Correct "set-point" -> "setpoint" and window title setpoint change

### DIFF
--- a/desktop-widgets/setpoint.ui
+++ b/desktop-widgets/setpoint.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Renumber</string>
+   <string>Add setpoint change</string>
   </property>
   <property name="windowIcon">
    <iconset>
@@ -40,7 +40,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>New set-point (0 for OC)</string>
+      <string>New setpoint (0 for OC)</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="leftMargin">

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1383,7 +1383,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 			gasChange->addAction(action);
 		}
 	}
-	QAction *setpointAction = m.addAction(tr("Add set-point change"), this, SLOT(addSetpointChange()));
+	QAction *setpointAction = m.addAction(tr("Add setpoint change"), this, SLOT(addSetpointChange()));
 	setpointAction->setData(event->globalPos());
 	QAction *action = m.addAction(tr("Add bookmark"), this, SLOT(addBookmark()));
 	action->setData(event->globalPos());


### PR DESCRIPTION
This is also for post 4.6.3 because it changes strings. Main trigger for this change is correcting the window title of the small pop up window for "Add setpoint change" in the profil.

Change 2x "set-point" to "setpoint".
Correct window title for "Add setpoint change" window.

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>