### PR TITLE
Several improvements in test code

### DIFF
--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -59,6 +59,11 @@ void TestGitStorage::initTestCase()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 }
 
+void TestGitStorage::cleanup()
+{
+	clear_dive_file_data();
+}
+
 void TestGitStorage::testGitStorageLocal_data()
 {
 	// test different path we may encounter (since storage depends on user name)
@@ -92,7 +97,6 @@ void TestGitStorage::testGitStorageLocal()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
-	clear_dive_file_data();
 }
 
 void TestGitStorage::testGitStorageCloud()
@@ -115,7 +119,6 @@ void TestGitStorage::testGitStorageCloud()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
-	clear_dive_file_data();
 }
 
 void TestGitStorage::testGitStorageCloudOfflineSync()
@@ -165,7 +168,6 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	readin = orgS2.readAll();
 	written = outS2.readAll();
 	QCOMPARE(readin, written);
-	clear_dive_file_data();
 }
 
 void TestGitStorage::testGitStorageCloudMerge()
@@ -213,7 +215,6 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
-	clear_dive_file_data();
 }
 
 void TestGitStorage::testGitStorageCloudMerge2()
@@ -268,7 +269,6 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
-	clear_dive_file_data();
 }
 
 void TestGitStorage::testGitStorageCloudMerge3()
@@ -334,7 +334,6 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(save_dives("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge
-	clear_dive_file_data();
 }
 
 QTEST_GUILESS_MAIN(TestGitStorage)

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -16,7 +16,7 @@
 // this is a local helper function in git-access.c
 extern "C" char *get_local_dir(const char *remote, const char *branch);
 
-void TestGitStorage::testSetup()
+void TestGitStorage::initTestCase()
 {
 	// first, setup the preferences an proxy information
 	copy_prefs(&default_prefs, &prefs);

--- a/tests/testgitstorage.h
+++ b/tests/testgitstorage.h
@@ -7,7 +7,7 @@ class TestGitStorage : public QObject
 {
 	Q_OBJECT
 private slots:
-	void testSetup();
+	void initTestCase();
 	void testGitStorageLocal_data();
 	void testGitStorageLocal();
 	void testGitStorageCloud();

--- a/tests/testgitstorage.h
+++ b/tests/testgitstorage.h
@@ -8,6 +8,8 @@ class TestGitStorage : public QObject
 	Q_OBJECT
 private slots:
 	void initTestCase();
+	void cleanup();
+
 	void testGitStorageLocal_data();
 	void testGitStorageLocal();
 	void testGitStorageCloud();

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -29,7 +29,7 @@ void TestMerge::testMergeEmpty()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -53,7 +53,7 @@ void TestMerge::testMergeBackwards()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -10,6 +10,11 @@ void TestMerge::initTestCase()
 	Q_INIT_RESOURCE(subsurface);
 }
 
+void TestMerge::cleanup()
+{
+	clear_dive_file_data();
+}
+
 void TestMerge::testMergeEmpty()
 {
 	/*
@@ -31,7 +36,6 @@ void TestMerge::testMergeEmpty()
 	while(readin.size() && written.size()){
 		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
-	clear_dive_file_data();
 }
 
 void TestMerge::testMergeBackwards()
@@ -55,7 +59,6 @@ void TestMerge::testMergeBackwards()
 	while(readin.size() && written.size()){
 		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
-	clear_dive_file_data();
 }
 
 QTEST_GUILESS_MAIN(TestMerge)

--- a/tests/testmerge.h
+++ b/tests/testmerge.h
@@ -7,6 +7,8 @@ class TestMerge : public QObject{
 	Q_OBJECT
 private slots:
 	void initTestCase();
+	void cleanup();
+
 	void testMergeEmpty();
 	void testMergeBackwards();
 };

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -4,10 +4,41 @@
 #include "core/divelist.h"
 #include <QTextStream>
 
+/* We have to use a macro since QCOMPARE
+ * can only be called from a test method
+ * invoked by the QTest framework
+ */
+#define FILE_COMPARE(actual, expected)				\
+	QFile org(expected);					\
+	org.open(QFile::ReadOnly);				\
+	QFile out(actual);					\
+	out.open(QFile::ReadOnly);				\
+	QTextStream orgS(&org);					\
+	QTextStream outS(&out);					\
+	QStringList readin = orgS.readAll().split("\n");	\
+	QStringList written = outS.readAll().split("\n");	\
+	while(readin.size() && written.size()){			\
+		QCOMPARE(written.takeFirst().trimmed(),		\
+			readin.takeFirst().trimmed());		\
+	}							\
+
 void TestParse::initTestCase()
 {
 	/* we need to manually tell that the resource exists, because we are using it as library. */
 	Q_INIT_RESOURCE(subsurface);
+}
+
+void TestParse::init()
+{
+	_sqlite3_handle = NULL;
+}
+
+void TestParse::cleanup()
+{
+	clear_dive_file_data();
+
+	// Some test use sqlite3, ensure db is closed
+	sqlite3_close(_sqlite3_handle);
 }
 
 char *intdup(int index)
@@ -19,7 +50,7 @@ char *intdup(int index)
 	return strdup(tmpbuf);
 }
 
-void TestParse::testParseCSV()
+int TestParse::parseCSV()
 {
 	// some basic file parsing tests
 	//
@@ -80,78 +111,63 @@ void TestParse::testParseCSV()
 	params[pnr++] = intdup(-1);
 	params[pnr++] = NULL;
 
-	QCOMPARE(parse_manual_file(SUBSURFACE_TEST_DATA "/dives/test41.csv", params, pnr - 1), 0);
-	fprintf(stderr, "number of dives %d \n", dive_table.nr);
+	return parse_manual_file(SUBSURFACE_TEST_DATA "/dives/test41.csv", params, pnr - 1);
 }
 
-void TestParse::testParseDivingLog()
+int TestParse::parseDivingLog()
 {
 	// Parsing of DivingLog import from SQLite database
-	sqlite3 *handle;
-
 	struct dive_site *ds = alloc_or_get_dive_site(0xdeadbeef);
 	ds->name = copy_string("Suomi -  - Hälvälä");
 
-	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql", &handle), 0);
-	QCOMPARE(parse_divinglog_buffer(handle, 0, 0, 0, &dive_table), 0);
+	int ret = sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql", &_sqlite3_handle);
+	if ( ret == 0 )
+		ret = parse_divinglog_buffer(_sqlite3_handle, 0, 0, 0, &dive_table);
+	else
+		fprintf(stderr, "Can't open sqlite3 db: " SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql");
 
-	sqlite3_close(handle);
+	return ret;
 }
 
-void TestParse::testParseV2NoQuestion()
+int TestParse::parseV2NoQuestion()
 {
 	// parsing of a V2 file should work
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml"), 0);
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
 }
 
-void TestParse::testParseV3()
+int TestParse::parseV3()
 {
 	// parsing of a V3 files should succeed
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml"), 0);
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml");
 }
 
-void TestParse::testParseCompareOutput()
+void TestParse::testParse()
 {
+	QCOMPARE(parseCSV(), 0);
+	fprintf(stderr, "number of dives %d \n", dive_table.nr);
+	
+	QCOMPARE(parseDivingLog(), 0);
+	fprintf(stderr, "number of dives %d \n", dive_table.nr);
+
+	QCOMPARE(parseV2NoQuestion(), 0);
+	fprintf(stderr, "number of dives %d \n", dive_table.nr);
+
+	QCOMPARE(parseV3(), 0);
+	fprintf(stderr, "number of dives %d \n", dive_table.nr);
+
 	QCOMPARE(save_dives("./testout.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testout.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
-	while(readin.size() && written.size()){
-		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-	}
-	clear_dive_file_data();
+	FILE_COMPARE("./testout.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
 }
 
 void TestParse::testParseDM4()
 {
-	sqlite3 *handle;
-
-	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &handle), 0);
-	QCOMPARE(parse_dm4_buffer(handle, 0, 0, 0, &dive_table), 0);
-
-	sqlite3_close(handle);
-}
-
-void TestParse::testParseCompareDM4Output()
-{
+	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &_sqlite3_handle), 0);
+	QCOMPARE(parse_dm4_buffer(_sqlite3_handle, 0, 0, 0, &dive_table), 0);
+	
 	QCOMPARE(save_dives("./testdm4out.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testdm4out.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
-	while(readin.size() && written.size()){
-		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-	}
-	clear_dive_file_data();
+	FILE_COMPARE("./testdm4out.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.xml");
 }
 
 void TestParse::testParseHUDC()
@@ -207,25 +223,10 @@ void TestParse::testParseHUDC()
 		dive->when = 1255152761;
 		dive->dc.when = 1255152761;
 	}
-}
 
-void TestParse::testParseCompareHUDCOutput()
-{
 	QCOMPARE(save_dives("./testhudcout.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testhudcout.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
-
-	while(readin.size() && written.size()){
-		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-	}
-
-	clear_dive_file_data();
+	FILE_COMPARE("./testhudcout.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.xml");
 }
 
 void TestParse::testParseNewFormat()
@@ -363,26 +364,11 @@ void TestParse::testParseNewFormat()
 	}
 
 	fprintf(stderr, "number of dives %d \n", dive_table.nr);
-}
-
-void TestParse::testParseCompareNewFormatOutput()
-{
 	QCOMPARE(save_dives("./testsbnewout.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearNewFormat.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testsbnewout.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
 
-// currently the CSV parse fails
-//	while(readin.size() && written.size()){
-//		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-//	}
-
-	clear_dive_file_data();
+	// Currently the CSV parse fails
+	FILE_COMPARE("./testsbnewout.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearNewFormat.xml");
 }
 
 void TestParse::testParseDLD()
@@ -394,29 +380,16 @@ void TestParse::testParseDLD()
 	QVERIFY(try_to_open_zip(filename.toLatin1().data()) > 0);
 
 	fprintf(stderr, "number of dives from DLD: %d \n", dive_table.nr);
-}
 
-void TestParse::testParseCompareDLDOutput()
-{
+	// Compare output
 	/*
 	 * DC is not cleared from previous tests with the
 	 * clear_dive_file_data(), so we do have an additional DC nick
 	 * name field on the log.
 	 */
-
 	QCOMPARE(save_dives("./testdldout.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testdldout.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
-	while(readin.size() && written.size()){
-		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-	}
-	clear_dive_file_data();
+	FILE_COMPARE("./testdldout.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.xml")
 }
 
 void TestParse::testParseMerge()
@@ -427,18 +400,8 @@ void TestParse::testParseMerge()
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml"), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml"), 0);
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
-	QFile org(SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
-	org.open(QFile::ReadOnly);
-	QFile out("./testmerge.ssrf");
-	out.open(QFile::ReadOnly);
-	QTextStream orgS(&org);
-	QTextStream outS(&out);
-	QStringList readin = orgS.readAll().split("\n");
-	QStringList written = outS.readAll().split("\n");
-	while(readin.size() && written.size()){
-		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
-	}
-	clear_dive_file_data();
+	FILE_COMPARE("./testmerge.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
 }
 
 QTEST_GUILESS_MAIN(TestParse)

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -122,7 +122,7 @@ void TestParse::testParseCompareOutput()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -149,7 +149,7 @@ void TestParse::testParseCompareDM4Output()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -222,7 +222,7 @@ void TestParse::testParseCompareHUDCOutput()
 	QStringList written = outS.readAll().split("\n");
 
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 
 	clear_dive_file_data();
@@ -379,7 +379,7 @@ void TestParse::testParseCompareNewFormatOutput()
 
 // currently the CSV parse fails
 //	while(readin.size() && written.size()){
-//		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+//		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 //	}
 
 	clear_dive_file_data();
@@ -414,7 +414,7 @@ void TestParse::testParseCompareDLDOutput()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }
@@ -436,7 +436,7 @@ void TestParse::testParseMerge()
 	QStringList readin = orgS.readAll().split("\n");
 	QStringList written = outS.readAll().split("\n");
 	while(readin.size() && written.size()){
-		QCOMPARE(readin.takeFirst().trimmed(), written.takeFirst().trimmed());
+		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
 	}
 	clear_dive_file_data();
 }

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -2,25 +2,29 @@
 #define TESTPARSE_H
 
 #include <QtTest>
+#include <sqlite3.h>
 
 class TestParse : public QObject{
 	Q_OBJECT
 private slots:
 	void initTestCase();
-	void testParseCSV();
-	void testParseDivingLog();
-	void testParseV2NoQuestion();
-	void testParseV3();
-	void testParseCompareOutput();
+	void init();
+	void cleanup();
+
+	int parseCSV();
+	int parseDivingLog();
+	int parseV2NoQuestion();
+	int parseV3();
+	void testParse();
+
 	void testParseDM4();
-	void testParseCompareDM4Output();
 	void testParseHUDC();
-	void testParseCompareHUDCOutput();
 	void testParseNewFormat();
-	void testParseCompareNewFormatOutput();
 	void testParseDLD();
-	void testParseCompareDLDOutput();
 	void testParseMerge();
+
+private:
+	sqlite3 *_sqlite3_handle = NULL;
 };
 
 #endif


### PR DESCRIPTION
Three first changes are quite straight forward, read commit message for details.

Last one is the reason for my question about lambdas on the IRC. Here my goal (like for the use of cleanup method in previous commit) is to avoid several/all tests to fail when only one is actually raising an issue.
 
There is here two advantages in using the ScopedShutdownHelper approach
1. Tests are interdependent so QTest::cleanup method cannot be used. A solution I would have preferred would be to bring parse and compare output tests in the same test method to avoid the interdependence between tests. (Tell me if you think I should rather go this direction)
2. For non C++ resources allocated during a test (e.g. sqlite* handle) use of cleanup method would requisite to have handles/pointers as member of the test class. ScopedShutdownHelper allows to be a bit more concise.

I know that currently pull requests are stalled by the 4.6.3 release, but I'd like to get comments/needed changes early so that I can update and go forward with the work on my windows test failure fixes :)