### PR TITLE
Fix float to int rounding errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+	# Warn about possible float conversion errors
+	# Use NOT VERSION_LESS since VERSION_GREATER_EQUAL is not available
+	# in currently used cmake version.
+	if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9.0")
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wfloat-conversion")
+	endif()
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   # using Intel C++
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/core/cochran.c
+++ b/core/cochran.c
@@ -578,14 +578,14 @@ static void cochran_parse_samples(struct dive *dive, const unsigned char *log,
 		if (temp < *min_temp) *min_temp = temp;
 		*avg_depth = (*avg_depth * seconds + depth) / (seconds + 1);
 
-		sample->depth.mm = depth * FEET * 1000;
+		sample->depth.mm = lrint(depth * FEET * 1000);
 		sample->ndl.seconds = ndl;
 		sample->in_deco = in_deco;
 		sample->stoptime.seconds = deco_time;
-		sample->stopdepth.mm = deco_ceiling * FEET * 1000;
+		sample->stopdepth.mm = lrint(deco_ceiling * FEET * 1000);
 		sample->temperature.mkelvin = C_to_mkelvin((temp - 32) / 1.8);
 		sample->sensor = 0;
-		sample->cylinderpressure.mbar = psi * PSI / 100;
+		sample->cylinderpressure.mbar = lrint(psi * PSI / 100);
 
 		finish_sample(dc);
 
@@ -693,13 +693,13 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		dive->number = log[CMD_NUMBER] + log[CMD_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[CMD_BT] + log[CMD_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[CMD_SIT] + log[CMD_SIT + 1] * 256) * 60;
-		dc->maxdepth.mm = (log[CMD_MAX_DEPTH] +
-			log[CMD_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000;
-		dc->meandepth.mm = (log[CMD_AVG_DEPTH] +
-			log[CMD_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000;
+		dc->maxdepth.mm = lrint((log[CMD_MAX_DEPTH] +
+			log[CMD_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000);
+		dc->meandepth.mm = lrint((log[CMD_AVG_DEPTH] +
+			log[CMD_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000);
 		dc->watertemp.mkelvin = C_to_mkelvin((log[CMD_MIN_TEMP] / 32) - 1.8);
-		dc->surface_pressure.mbar = ATM / BAR * pow(1 - 0.0000225577
-			* (double) log[CMD_ALTITUDE] * 250 * FEET, 5.25588) * 1000;
+		dc->surface_pressure.mbar = lrint(ATM / BAR * pow(1 - 0.0000225577
+			* (double) log[CMD_ALTITUDE] * 250 * FEET, 5.25588) * 1000);
 		dc->salinity = 10000 + 150 * log[CMD_WATER_CONDUCTIVITY];
 
 		SHA1(log + CMD_NUMBER, 2, (unsigned char *)csum);
@@ -734,13 +734,13 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		dive->number = log[EMC_NUMBER] + log[EMC_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[EMC_BT] + log[EMC_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[EMC_SIT] + log[EMC_SIT + 1] * 256) * 60;
-		dc->maxdepth.mm = (log[EMC_MAX_DEPTH] +
-			log[EMC_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000;
-		dc->meandepth.mm = (log[EMC_AVG_DEPTH] +
-			log[EMC_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000;
+		dc->maxdepth.mm = lrint((log[EMC_MAX_DEPTH] +
+			log[EMC_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000);
+		dc->meandepth.mm = lrint((log[EMC_AVG_DEPTH] +
+ 			log[EMC_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000);
 		dc->watertemp.mkelvin = C_to_mkelvin((log[EMC_MIN_TEMP] - 32) / 1.8);
-		dc->surface_pressure.mbar = ATM / BAR * pow(1 - 0.0000225577
-			* (double) log[EMC_ALTITUDE] * 250 * FEET, 5.25588) * 1000;
+		dc->surface_pressure.mbar = lrint(ATM / BAR * pow(1 - 0.0000225577
+			* (double) log[EMC_ALTITUDE] * 250 * FEET, 5.25588) * 1000);
 		dc->salinity = 10000 + 150 * (log[EMC_WATER_CONDUCTIVITY] & 0x3);
 
 		SHA1(log + EMC_NUMBER, 2, (unsigned char *)csum);
@@ -758,8 +758,8 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 
 	// Check for corrupt dive
 	if (corrupt_dive) {
-		dc->maxdepth.mm = max_depth * FEET * 1000;
-		dc->meandepth.mm = avg_depth * FEET * 1000;
+		dc->maxdepth.mm = lrint(max_depth * FEET * 1000);
+		dc->meandepth.mm = lrint(avg_depth * FEET * 1000);
 		dc->watertemp.mkelvin = C_to_mkelvin((min_temp - 32) / 1.8);
 		dc->duration.seconds = duration;
 	}

--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -384,7 +384,7 @@ bool dt_dive_parser(FILE *archivo, struct dive *dt_dive)
 	 */
 	read_bytes(2);
 	if (tmp_2bytes != 0x7FFF && dt_dive->cylinder[0].type.size.mliter)
-		dt_dive->cylinder[0].gas_used.mliter = dt_dive->cylinder[0].type.size.mliter * (tmp_2bytes / 100.0);
+		dt_dive->cylinder[0].gas_used.mliter = lrint(dt_dive->cylinder[0].type.size.mliter * (tmp_2bytes / 100.0));
 
 	/*
 	 * Dive Type 1 -  Bit table. Subsurface don't have this record, but
@@ -625,7 +625,7 @@ bool dt_dive_parser(FILE *archivo, struct dive *dt_dive)
 			read_bytes(1);
 			if (is_nitrox) {
 				dt_dive->cylinder[0].gasmix.o2.permille =
-					(tmp_1byte & 0x0F ? 20.0 + 2 * (tmp_1byte & 0x0F) : 21.0) * 10;
+					lrint((tmp_1byte & 0x0F ? 20.0 + 2 * (tmp_1byte & 0x0F) : 21.0) * 10);
 			} else {
 				dt_dive->cylinder[0].gasmix.o2.permille = tmp_1byte * 10;
 				read_bytes(1)  // Jump over one byte, unknown use

--- a/core/deco.c
+++ b/core/deco.c
@@ -622,10 +622,10 @@ int deco_allowed_depth(double tissues_tolerance, double surface_pressure, struct
 	/* Avoid negative depths */
 	pressure_delta = tissues_tolerance > surface_pressure ? tissues_tolerance - surface_pressure : 0.0;
 
-	depth = rel_mbar_to_depth(pressure_delta * 1000, dive);
+	depth = rel_mbar_to_depth(lrint(pressure_delta * 1000), dive);
 
 	if (!smooth)
-		depth = ceil(depth / DECO_STOPS_MULTIPLIER_MM) * DECO_STOPS_MULTIPLIER_MM;
+		depth = lrint(ceil(depth / DECO_STOPS_MULTIPLIER_MM) * DECO_STOPS_MULTIPLIER_MM);
 
 	if (depth > 0 && depth < buehlmann_config.last_deco_stop_in_mtr * 1000)
 		depth = buehlmann_config.last_deco_stop_in_mtr * 1000;

--- a/core/device.c
+++ b/core/device.c
@@ -64,10 +64,10 @@
 static int fill_samples(struct sample *s, int max_d, int avg_d, int max_t, double slope, double d_frac)
 {
 	double t_frac = max_t * (1 - avg_d / (double)max_d);
-	int t1 = max_d / slope;
-	int t4 = max_t - t1 * d_frac;
-	int t3 = t4 - (t_frac - t1) / (1 - d_frac);
-	int t2 = t3 - t1 * (1 - d_frac);
+	int t1 = lrint(max_d / slope);
+	int t4 = lrint(max_t - t1 * d_frac);
+	int t3 = lrint(t4 - (t_frac - t1) / (1 - d_frac));
+	int t2 = lrint(t3 - t1 * (1 - d_frac));
 
 	if (t1 < 0 || t1 > t2 || t2 > t3 || t3 > t4 || t4 > max_t)
 		return 0;
@@ -77,9 +77,9 @@ static int fill_samples(struct sample *s, int max_d, int avg_d, int max_t, doubl
 	s[2].time.seconds = t2;
 	s[2].depth.mm = max_d;
 	s[3].time.seconds = t3;
-	s[3].depth.mm = max_d * d_frac;
+	s[3].depth.mm = lrint(max_d * d_frac);
 	s[4].time.seconds = t4;
-	s[4].depth.mm = max_d * d_frac;
+	s[4].depth.mm = lrint(max_d * d_frac);
 
 	return 1;
 }
@@ -92,18 +92,18 @@ static void fill_samples_no_avg(struct sample *s, int max_d, int max_t, double s
 {
 	// shallow or short dives are just trapecoids based on the given slope
 	if (max_d < 10000 || max_t < 600) {
-		s[1].time.seconds = max_d / slope;
+		s[1].time.seconds = lrint(max_d / slope);
 		s[1].depth.mm = max_d;
-		s[2].time.seconds = max_t - max_d / slope;
+		s[2].time.seconds = max_t - lrint(max_d / slope);
 		s[2].depth.mm = max_d;
 	} else {
-		s[1].time.seconds = max_d / slope;
+		s[1].time.seconds = lrint(max_d / slope);
 		s[1].depth.mm = max_d;
-		s[2].time.seconds = max_t - max_d / slope - 180;
+		s[2].time.seconds = max_t - lrint(max_d / slope) - 180;
 		s[2].depth.mm = max_d;
-		s[3].time.seconds = max_t - 5000 / slope - 180;
+		s[3].time.seconds = max_t - lrint(5000 / slope) - 180;
 		s[3].depth.mm = 5000;
-		s[4].time.seconds = max_t - 5000 / slope;
+		s[4].time.seconds = max_t - lrint(5000 / slope);
 		s[4].depth.mm = 5000;
 	}
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -243,15 +243,15 @@ double get_volume_units(unsigned int ml, int *frac, const char **units)
 int units_to_sac(double volume)
 {
 	if (get_units()->volume == CUFT)
-		return rint(cuft_to_l(volume) * 1000.0);
+		return lrint(cuft_to_l(volume) * 1000.0);
 	else
-		return rint(volume * 1000);
+		return lrint(volume * 1000);
 }
 
 unsigned int units_to_depth(double depth)
 {
 	if (get_units()->length == METERS)
-		return rint(depth * 1000);
+		return lrint(depth * 1000);
 	return feet_to_mm(depth);
 }
 
@@ -872,7 +872,7 @@ int gas_volume(cylinder_t *cyl, pressure_t p)
 {
 	double bar = p.mbar / 1000.0;
 	double z_factor = gas_compressibility_factor(&cyl->gasmix, bar);
-	return rint(cyl->type.size.mliter * bar_to_atm(bar) / z_factor);
+	return lrint(cyl->type.size.mliter * bar_to_atm(bar) / z_factor);
 }
 
 /*
@@ -1019,7 +1019,7 @@ static void match_standard_cylinder(cylinder_type_t *type)
 	default:
 		return;
 	}
-	len = snprintf(buffer, sizeof(buffer), fmt, (int)rint(cuft));
+	len = snprintf(buffer, sizeof(buffer), fmt, (int)lrint(cuft));
 	p = malloc(len + 1);
 	if (!p)
 		return;
@@ -1056,7 +1056,7 @@ static void sanitize_cylinder_type(cylinder_type_t *type)
 		volume_of_air = cuft_to_l(type->size.mliter);
 		/* milliliters at 1 atm: not corrected for compressibility! */
 		volume = volume_of_air / bar_to_atm(bar);
-		type->size.mliter = rint(volume);
+		type->size.mliter = lrint(volume);
 	}
 
 	/* Ok, we have both size and pressure: try to match a description */

--- a/core/dive.h
+++ b/core/dive.h
@@ -173,7 +173,7 @@ static inline int interpolate(int a, int b, int part, int whole)
 	/* It is doubtful that we actually need floating point for this, but whatever */
 	if (whole) {
 		double x = (double)a * (whole - part) + (double)b * part;
-		return rint(x / whole);
+		return lrint(x / whole);
 	}
 	return (a+b)/2;
 }
@@ -440,7 +440,7 @@ static inline int calculate_depth_to_mbar(int depth, pressure_t surface_pressure
 	if (salinity < 500)
 		salinity += FRESHWATER_SALINITY;
 	specific_weight = salinity / 10000.0 * 0.981;
-	mbar += rint(depth / 10.0 * specific_weight);
+	mbar += lrint(depth / 10.0 * specific_weight);
 	return mbar;
 }
 
@@ -470,7 +470,7 @@ static inline int rel_mbar_to_depth(int mbar, struct dive *dive)
 	if (dive->dc.salinity)
 		specific_weight = dive->dc.salinity / 10000.0 * 0.981;
 	/* whole mbar gives us cm precision */
-	cm = rint(mbar / specific_weight);
+	cm = lrint(mbar / specific_weight);
 	return cm * 10;
 }
 
@@ -489,7 +489,7 @@ static inline depth_t gas_mod(struct gasmix *mix, pressure_t po2_limit, struct d
 	depth_t rounded_depth;
 
 	double depth = (double) mbar_to_depth(po2_limit.mbar * 1000 / get_o2(mix), dive);
-	rounded_depth.mm = rint(depth / roundto) * roundto;
+	rounded_depth.mm = lrint(depth / roundto) * roundto;
 	return rounded_depth;
 }
 
@@ -500,7 +500,7 @@ static inline depth_t gas_mnd(struct gasmix *mix, depth_t end, struct dive *dive
 	ppo2n2.mbar = depth_to_mbar(end.mm, dive);
 
 	double maxambient = ppo2n2.mbar / (1 - get_he(mix) / 1000.0);
-	rounded_depth.mm = rint(mbar_to_depth(maxambient, dive) / roundto) * roundto;
+	rounded_depth.mm = lrint(((double)mbar_to_depth(maxambient, dive)) / roundto) * roundto;
 	return rounded_depth;
 }
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -499,7 +499,7 @@ static inline depth_t gas_mnd(struct gasmix *mix, depth_t end, struct dive *dive
 	pressure_t ppo2n2;
 	ppo2n2.mbar = depth_to_mbar(end.mm, dive);
 
-	double maxambient = ppo2n2.mbar / (1 - get_he(mix) / 1000.0);
+	int maxambient = lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0));
 	rounded_depth.mm = lrint(((double)mbar_to_depth(maxambient, dive)) / roundto) * roundto;
 	return rounded_depth;
 }

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -183,7 +183,7 @@ static int calculate_otu(struct dive *dive)
 		if (po2 >= 500)
 			otu += pow((po2 - 500) / 1000.0, 0.83) * t / 30.0;
 	}
-	return rint(otu);
+	return lrint(otu);
 }
 /* calculate CNS for a dive - this only takes the first divecomputer into account */
 int const cns_table[][3] = {

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -178,7 +178,7 @@ static int calculate_otu(struct dive *dive)
 			po2 = sample->setpoint.mbar;
 		} else {
 			int o2 = active_o2(dive, dc, sample->time);
-			po2 = o2 * depth_to_atm(sample->depth.mm, dive);
+			po2 = lrint(o2 * depth_to_atm(sample->depth.mm, dive));
 		}
 		if (po2 >= 500)
 			otu += pow((po2 - 500) / 1000.0, 0.83) * t / 30.0;
@@ -243,7 +243,7 @@ static int calculate_cns(struct dive *dive)
 			po2 = sample->setpoint.mbar;
 		} else {
 			int o2 = active_o2(dive, dc, sample->time);
-			po2 = o2 * depth_to_atm(sample->depth.mm, dive);
+			po2 = lrint(o2 * depth_to_atm(sample->depth.mm, dive));
 		}
 		/* CNS don't increse when below 500 matm */
 		if (po2 < 500)
@@ -256,7 +256,7 @@ static int calculate_cns(struct dive *dive)
 		cns += ((double)t) / ((double)cns_table[j][1]) * 100;
 	}
 	/* save calculated cns in dive struct */
-	dive->cns = cns;
+	dive->cns = lrint(cns);
 	return dive->cns;
 }
 /*
@@ -305,7 +305,7 @@ static int calculate_sac(struct dive *dive)
 	sac = airuse / pressure * 60 / duration;
 
 	/* milliliters per minute.. */
-	return sac * 1000;
+	return lrint(sac * 1000);
 }
 
 /* for now we do this based on the first divecomputer */

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -65,7 +65,7 @@ unsigned int get_distance(degrees_t lat1, degrees_t lon1, degrees_t lat2, degree
 	double c = 2 * atan2(sqrt(a), sqrt(1.0 - a));
 
 	// Earth radious in metres
-	return 6371000 * c;
+	return lrint(6371000 * c);
 }
 
 /* find the closest one, no more than distance meters away - if more than one at same distance, pick the first */

--- a/core/file.c
+++ b/core/file.c
@@ -293,31 +293,31 @@ static void add_sample_data(struct sample *sample, enum csv_format type, double 
 		sample->cylinderpressure.mbar = psi_to_mbar(val * 4);
 		break;
 	case POSEIDON_DEPTH:
-		sample->depth.mm = val * 0.5 *1000;
+		sample->depth.mm = lrint(val * 0.5 * 1000);
 		break;
 	case POSEIDON_TEMP:
 		sample->temperature.mkelvin = C_to_mkelvin(val * 0.2);
 		break;
 	case POSEIDON_SETPOINT:
-		sample->setpoint.mbar = val * 10;
+		sample->setpoint.mbar = lrint(val * 10);
 		break;
 	case POSEIDON_SENSOR1:
-		sample->o2sensor[0].mbar = val * 10;
+		sample->o2sensor[0].mbar = lrint(val * 10);
 		break;
 	case POSEIDON_SENSOR2:
-		sample->o2sensor[1].mbar = val * 10;
+		sample->o2sensor[1].mbar = lrint(val * 10);
 		break;
 	case POSEIDON_PRESSURE:
-		sample->cylinderpressure.mbar = val * 1000;
+		sample->cylinderpressure.mbar = lrint(val * 1000);
 		break;
 	case POSEIDON_O2CYLINDER:
-		sample->o2cylinderpressure.mbar = val * 1000;
+		sample->o2cylinderpressure.mbar = lrint(val * 1000);
 		break;
 	case POSEIDON_NDL:
-		sample->ndl.seconds = val * 60;
+		sample->ndl.seconds = lrint(val * 60);
 		break;
 	case POSEIDON_CEILING:
-		sample->stopdepth.mm = val * 1000;
+		sample->stopdepth.mm = lrint(val * 1000);
 		break;
 	}
 }

--- a/core/gaspressures.c
+++ b/core/gaspressures.c
@@ -137,7 +137,7 @@ static void fill_missing_segment_pressures(pr_track_t *list, enum interpolation_
 				pt += list->pressure_time;
 				pressure = start;
 				if (pt_sum)
-					pressure -= (start - end) * (double)pt / pt_sum;
+					pressure -= lrint((start - end) * (double)pt / pt_sum);
 				list->end = pressure;
 				if (list == tmp)
 					break;

--- a/core/gaspressures.c
+++ b/core/gaspressures.c
@@ -148,7 +148,7 @@ static void fill_missing_segment_pressures(pr_track_t *list, enum interpolation_
 		case TIME:
 			if (list->t_end && (tmp->t_start - tmp->t_end)) {
 				magic = (list->t_start - tmp->t_end) / (tmp->t_start - tmp->t_end);
-				list->end = rint(start - (start - end) * magic);
+				list->end = lrint(start - (start - end) * magic);
 			} else {
 				list->end = start;
 			}
@@ -290,11 +290,11 @@ static void fill_missing_tank_pressures(struct dive *dive, struct plot_info *pi,
 				magic = (interpolate.end - interpolate.start) / (double)interpolate.pressure_time;
 
 				/* Use that overall pressure change to update the current pressure */
-				cur_pr[cyl] = rint(interpolate.start + magic * interpolate.acc_pressure_time);
+				cur_pr[cyl] = lrint(interpolate.start + magic * interpolate.acc_pressure_time);
 			}
 		} else {
 			magic = (interpolate.end - interpolate.start) /  (segment->t_end - segment->t_start);
-			cur_pr[cyl] = rint(segment->start + magic * (entry->sec - segment->t_start));
+			cur_pr[cyl] = lrint(segment->start + magic * (entry->sec - segment->t_start));
 		}
 		*save_interpolated = cur_pr[cyl]; // and store the interpolated data in plot_info
 	}

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -157,8 +157,8 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 		gpsTracker gt;
 		gt.when = pos.timestamp().toTime_t();
 		gt.when += gettimezoneoffset(gt.when);
-		gt.latitude.udeg = rint(pos.coordinate().latitude() * 1000000);
-		gt.longitude.udeg = rint(pos.coordinate().longitude() * 1000000);
+		gt.latitude.udeg = lrint(pos.coordinate().latitude() * 1000000);
+		gt.longitude.udeg = lrint(pos.coordinate().longitude() * 1000000);
 		addFixToStorage(gt);
 	}
 }

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -117,8 +117,8 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 			if (i >= MAX_CYLINDERS)
 				continue;
 
-			 o2 = rint(gasmix.oxygen * 1000);
-			he = rint(gasmix.helium * 1000);
+			 o2 = lrint(gasmix.oxygen * 1000);
+			he = lrint(gasmix.helium * 1000);
 
 			/* Ignore bogus data - libdivecomputer does some crazy stuff */
 			if (o2 + he <= O2_IN_AIR || o2 > 1000) {
@@ -149,8 +149,8 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 			if (rc == DC_STATUS_SUCCESS) {
 				cylinder_t *cyl = dive->cylinder + i;
 
-				cyl->type.size.mliter = rint(tank.volume * 1000);
-				cyl->type.workingpressure.mbar = rint(tank.workpressure * 1000);
+				cyl->type.size.mliter = lrint(tank.volume * 1000);
+				cyl->type.workingpressure.mbar = lrint(tank.workpressure * 1000);
 
 				cyl->cylinder_use = OC_GAS;
 				if (tank.type & DC_TANKINFO_CC_O2)
@@ -330,7 +330,7 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 		finish_sample(dc);
 		break;
 	case DC_SAMPLE_DEPTH:
-		sample->depth.mm = rint(value.depth * 1000);
+		sample->depth.mm = lrint(value.depth * 1000);
 		break;
 	case DC_SAMPLE_PRESSURE:
 		/* Do we already have a pressure reading? */
@@ -341,7 +341,7 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 				break;
 		}
 		sample->sensor = value.pressure.tank;
-		sample->cylinderpressure.mbar = rint(value.pressure.value * 1000);
+		sample->cylinderpressure.mbar = lrint(value.pressure.value * 1000);
 		break;
 	case DC_SAMPLE_GASMIX:
 		handle_gasmix(dc, sample, value.gasmix);
@@ -373,11 +373,11 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 #if DC_VERSION_CHECK(0, 3, 0)
 	case DC_SAMPLE_SETPOINT:
 		/* for us a setpoint means constant pO2 from here */
-		sample->setpoint.mbar = po2 = rint(value.setpoint * 1000);
+		sample->setpoint.mbar = po2 = lrint(value.setpoint * 1000);
 		break;
 	case DC_SAMPLE_PPO2:
 		if (nsensor < 3)
-			sample->o2sensor[nsensor].mbar = rint(value.ppo2 * 1000);
+			sample->o2sensor[nsensor].mbar = lrint(value.ppo2 * 1000);
 		else
 			report_error("%d is more o2 sensors than we can handle", nsensor);
 		nsensor++;
@@ -386,22 +386,22 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 			dc->no_o2sensors = nsensor;
 		break;
 	case DC_SAMPLE_CNS:
-		sample->cns = cns = rint(value.cns * 100);
+		sample->cns = cns = lrint(value.cns * 100);
 		break;
 	case DC_SAMPLE_DECO:
 		if (value.deco.type == DC_DECO_NDL) {
 			sample->ndl.seconds = ndl = value.deco.time;
-			sample->stopdepth.mm = stopdepth = rint(value.deco.depth * 1000.0);
+			sample->stopdepth.mm = stopdepth = lrint(value.deco.depth * 1000.0);
 			sample->in_deco = in_deco = false;
 		} else if (value.deco.type == DC_DECO_DECOSTOP ||
 			   value.deco.type == DC_DECO_DEEPSTOP) {
 			sample->in_deco = in_deco = true;
-			sample->stopdepth.mm = stopdepth = rint(value.deco.depth * 1000.0);
+			sample->stopdepth.mm = stopdepth = lrint(value.deco.depth * 1000.0);
 			sample->stoptime.seconds = stoptime = value.deco.time;
 			ndl = 0;
 		} else if (value.deco.type == DC_DECO_SAFETYSTOP) {
 			sample->in_deco = in_deco = false;
-			sample->stopdepth.mm = stopdepth = rint(value.deco.depth * 1000.0);
+			sample->stopdepth.mm = stopdepth = lrint(value.deco.depth * 1000.0);
 			sample->stoptime.seconds = stoptime = value.deco.time;
 		}
 #endif
@@ -627,7 +627,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, struct device_data_t
 		return rc;
 	}
 	if (rc == DC_STATUS_SUCCESS)
-		dive->dc.maxdepth.mm = rint(maxdepth * 1000);
+		dive->dc.maxdepth.mm = lrint(maxdepth * 1000);
 
 #if DC_VERSION_CHECK(0, 5, 0) && defined(DC_GASMIX_UNKNOWN)
 	// if this is defined then we have a fairly late version of libdivecomputer
@@ -678,7 +678,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, struct device_data_t
 		return rc;
 	}
 	if (rc == DC_STATUS_SUCCESS)
-		dive->dc.salinity = rint(salinity.density * 10.0);
+		dive->dc.salinity = lrint(salinity.density * 10.0);
 
 	double surface_pressure = 0;
 	rc = dc_parser_get_field(parser, DC_FIELD_ATMOSPHERIC, 0, &surface_pressure);
@@ -687,7 +687,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, struct device_data_t
 		return rc;
 	}
 	if (rc == DC_STATUS_SUCCESS)
-		dive->dc.surface_pressure.mbar = rint(surface_pressure * 1000.0);
+		dive->dc.surface_pressure.mbar = lrint(surface_pressure * 1000.0);
 #endif
 
 #ifdef DC_FIELD_STRING

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -166,10 +166,11 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 						 * First, the pressures are off by a constant factor. WTF?
 						 * Then we can round the wet sizes so we get to multiples of 10
 						 * for cuft sizes (as that's all that you can enter) */
-						dive->cylinder[i].type.workingpressure.mbar *= 206.843 / 206.7;
+						dive->cylinder[i].type.workingpressure.mbar = lrint(
+							dive->cylinder[i].type.workingpressure.mbar * 206.843 / 206.7 );
 						char name_buffer[9];
-						int rounded_size = ml_to_cuft(gas_volume(&dive->cylinder[i],
-											 dive->cylinder[i].type.workingpressure));
+						int rounded_size = lrint(ml_to_cuft(gas_volume(&dive->cylinder[i],
+							dive->cylinder[i].type.workingpressure)));
 						rounded_size = (int)((rounded_size + 5) / 10) * 10;
 						switch (dive->cylinder[i].type.workingpressure.mbar) {
 						case 206843:
@@ -189,8 +190,8 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 							break;
 						}
 						dive->cylinder[i].type.description = copy_string(name_buffer);
-						dive->cylinder[i].type.size.mliter = cuft_to_l(rounded_size) * 1000 /
-										     mbar_to_atm(dive->cylinder[i].type.workingpressure.mbar);
+						dive->cylinder[i].type.size.mliter = lrint(cuft_to_l(rounded_size) * 1000 /
+											mbar_to_atm(dive->cylinder[i].type.workingpressure.mbar));
 					}
 				}
 				if (tank.gasmix != i) { // we don't handle this, yet
@@ -203,8 +204,8 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 
 			// this new API also gives us the beginning and end pressure for the tank
 			if (!IS_FP_SAME(tank.beginpressure, 0.0) && !IS_FP_SAME(tank.endpressure, 0.0)) {
-				dive->cylinder[i].start.mbar = tank.beginpressure * 1000;
-				dive->cylinder[i].end.mbar = tank.endpressure * 1000;
+				dive->cylinder[i].start.mbar = lrint(tank.beginpressure * 1000);
+				dive->cylinder[i].end.mbar = lrint(tank.endpressure * 1000);
 			}
 		}
 #endif

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -234,9 +234,9 @@ static void parse_dives (int log_version, const unsigned char *buf, unsigned int
 			// Xeo, with CNS and OTU
 			start_cns = *(float *) (buf + ptr);
 			ptr += 4;
-			dive->cns = *(float *) (buf + ptr);	// end cns
+			dive->cns = lrintf(*(float *) (buf + ptr));	// end cns
 			ptr += 4;
-			dive->otu = *(float *) (buf + ptr);
+			dive->otu = lrintf(*(float *) (buf + ptr));
 			ptr += 4;
 			dive_mode = *(buf + ptr++);	// 0=Deco, 1=Gauge, 2=None
 			algorithm = *(buf + ptr++);	// 0=ZH-L16C+GF

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -81,40 +81,40 @@ static temperature_t get_temperature(const char *line)
 static depth_t get_depth(const char *line)
 {
 	depth_t d;
-	d.mm = rint(1000*ascii_strtod(line, NULL));
+	d.mm = lrint(1000*ascii_strtod(line, NULL));
 	return d;
 }
 
 static volume_t get_volume(const char *line)
 {
 	volume_t v;
-	v.mliter = rint(1000*ascii_strtod(line, NULL));
+	v.mliter = lrint(1000*ascii_strtod(line, NULL));
 	return v;
 }
 
 static weight_t get_weight(const char *line)
 {
 	weight_t w;
-	w.grams = rint(1000*ascii_strtod(line, NULL));
+	w.grams = lrint(1000*ascii_strtod(line, NULL));
 	return w;
 }
 
 static pressure_t get_pressure(const char *line)
 {
 	pressure_t p;
-	p.mbar = rint(1000*ascii_strtod(line, NULL));
+	p.mbar = lrint(1000*ascii_strtod(line, NULL));
 	return p;
 }
 
 static int get_salinity(const char *line)
 {
-	return rint(10*ascii_strtod(line, NULL));
+	return lrint(10*ascii_strtod(line, NULL));
 }
 
 static fraction_t get_fraction(const char *line)
 {
 	fraction_t f;
-	f.permille = rint(10*ascii_strtod(line, NULL));
+	f.permille = lrint(10*ascii_strtod(line, NULL));
 	return f;
 }
 
@@ -568,10 +568,10 @@ static char *parse_sample_unit(struct sample *sample, double val, char *unit)
 	/* The units are "°C", "m" or "bar", so let's just look at the first character */
 	switch (*unit) {
 	case 'm':
-		sample->depth.mm = rint(1000*val);
+		sample->depth.mm = lrint(1000*val);
 		break;
 	case 'b':
-		sample->cylinderpressure.mbar = rint(1000*val);
+		sample->cylinderpressure.mbar = lrint(1000*val);
 		break;
 	default:
 		sample->temperature.mkelvin = C_to_mkelvin(val);

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -425,7 +425,7 @@ static void temperature(char *buffer, temperature_t *temperature)
 	case FLOAT:
 		switch (xml_parsing_units.temperature) {
 		case KELVIN:
-			temperature->mkelvin = val.fp * 1000;
+			temperature->mkelvin = lrint(val.fp * 1000);
 			break;
 		case CELSIUS:
 			temperature->mkelvin = C_to_mkelvin(val.fp);
@@ -2219,7 +2219,7 @@ extern int dm5_cylinders(void *handle, int columns, char **data, char **column)
 		if (atof(data[6]) == 0.0 && cur_dive->cylinder[cur_cylinder_index].start.mbar)
 			cur_dive->cylinder[cur_cylinder_index].type.size.mliter = 12000;
 		else
-			cur_dive->cylinder[cur_cylinder_index].type.size.mliter = (atof(data[6])) * 1000;
+			cur_dive->cylinder[cur_cylinder_index].type.size.mliter = lrint((atof(data[6])) * 1000);
 	}
 	if (data[2])
 		cur_dive->cylinder[cur_cylinder_index].gasmix.o2.permille = atoi(data[2]) * 10;
@@ -2240,7 +2240,7 @@ extern int dm5_gaschange(void *handle, int columns, char **data, char **column)
 		cur_event.time.seconds = atoi(data[0]);
 	if (data[1]) {
 		strcpy(cur_event.name, "gaschange");
-		cur_event.value = atof(data[1]);
+		cur_event.value = lrint(atof(data[1]));
 	}
 	event_end();
 
@@ -2308,7 +2308,7 @@ extern int dm4_dive(void *param, int columns, char **data, char **column)
 	settings_end();
 
 	if (data[6])
-		cur_dive->dc.maxdepth.mm = atof(data[6]) * 1000;
+		cur_dive->dc.maxdepth.mm = lrint(atof(data[6]) * 1000);
 	if (data[8])
 		cur_dive->dc.airtemp.mkelvin = C_to_mkelvin(atoi(data[8]));
 	if (data[9])
@@ -2327,7 +2327,7 @@ extern int dm4_dive(void *param, int columns, char **data, char **column)
 	if (data[11] && atoi(data[11]) > 0)
 		cur_dive->cylinder[cur_cylinder_index].end.mbar = (atoi(data[11]));
 	if (data[12])
-		cur_dive->cylinder[cur_cylinder_index].type.size.mliter = (atof(data[12])) * 1000;
+		cur_dive->cylinder[cur_cylinder_index].type.size.mliter = lrint((atof(data[12])) * 1000);
 	if (data[13])
 		cur_dive->cylinder[cur_cylinder_index].type.workingpressure.mbar = (atoi(data[13]));
 	if (data[20])
@@ -2347,7 +2347,7 @@ extern int dm4_dive(void *param, int columns, char **data, char **column)
 		sample_start();
 		cur_sample->time.seconds = i * interval;
 		if (profileBlob)
-			cur_sample->depth.mm = profileBlob[i] * 1000;
+			cur_sample->depth.mm = lrintf(profileBlob[i] * 1000.0f);
 		else
 			cur_sample->depth.mm = cur_dive->dc.maxdepth.mm;
 
@@ -2431,7 +2431,7 @@ extern int dm5_dive(void *param, int columns, char **data, char **column)
 	settings_end();
 
 	if (data[6])
-		cur_dive->dc.maxdepth.mm = atof(data[6]) * 1000;
+		cur_dive->dc.maxdepth.mm = lrint(atof(data[6]) * 1000);
 	if (data[8])
 		cur_dive->dc.airtemp.mkelvin = C_to_mkelvin(atoi(data[8]));
 	if (data[9])
@@ -2477,7 +2477,7 @@ extern int dm5_dive(void *param, int columns, char **data, char **column)
 
 		sample_start();
 		cur_sample->time.seconds = i * interval;
-		cur_sample->depth.mm = depth[0] * 1000;
+		cur_sample->depth.mm = lrintf(depth[0] * 1000.0f);
 		/*
 		 * Limit temperatures and cylinder pressures to somewhat
 		 * sensible values
@@ -2506,7 +2506,7 @@ extern int dm5_dive(void *param, int columns, char **data, char **column)
 			sample_start();
 			cur_sample->time.seconds = i * interval;
 			if (profileBlob)
-				cur_sample->depth.mm = profileBlob[i] * 1000;
+				cur_sample->depth.mm = lrintf(profileBlob[i] * 1000.0f);
 			else
 				cur_sample->depth.mm = cur_dive->dc.maxdepth.mm;
 
@@ -2601,9 +2601,9 @@ extern int shearwater_cylinders(void *handle, int columns, char **data, char **c
 
 	cylinder_start();
 	if (data[0])
-		cur_dive->cylinder[cur_cylinder_index].gasmix.o2.permille = atof(data[0]) * 1000;
+		cur_dive->cylinder[cur_cylinder_index].gasmix.o2.permille = lrint(atof(data[0]) * 1000);
 	if (data[1])
-		cur_dive->cylinder[cur_cylinder_index].gasmix.he.permille = atof(data[1]) * 1000;
+		cur_dive->cylinder[cur_cylinder_index].gasmix.he.permille = lrint(atof(data[1]) * 1000);
 	cylinder_end();
 
 	return 0;
@@ -2620,7 +2620,7 @@ extern int shearwater_changes(void *handle, int columns, char **data, char **col
 		cur_event.time.seconds = atoi(data[0]);
 	if (data[1]) {
 		strcpy(cur_event.name, "gaschange");
-		cur_event.value = atof(data[1]) * 100;
+		cur_event.value = lrint(atof(data[1]) * 100);
 	}
 	event_end();
 
@@ -2657,11 +2657,11 @@ extern int shearwater_profile_sample(void *handle, int columns, char **data, cha
 	if (data[0])
 		cur_sample->time.seconds = atoi(data[0]);
 	if (data[1])
-		cur_sample->depth.mm = metric ? atof(data[1]) * 1000 : feet_to_mm(atof(data[1]));
+		cur_sample->depth.mm = metric ? lrint(atof(data[1]) * 1000) : feet_to_mm(atof(data[1]));
 	if (data[2])
 		cur_sample->temperature.mkelvin = metric ? C_to_mkelvin(atof(data[2])) : F_to_mkelvin(atof(data[2]));
 	if (data[3]) {
-		cur_sample->setpoint.mbar = atof(data[3]) * 1000;
+		cur_sample->setpoint.mbar = lrint(atof(data[3]) * 1000);
 		cur_dive->dc.divemode = CCR;
 	}
 	if (data[4])
@@ -2710,7 +2710,7 @@ extern int shearwater_dive(void *param, int columns, char **data, char **column)
 
 	/* TODO: verify that metric calculation is correct */
 	if (data[6])
-		cur_dive->dc.maxdepth.mm = metric ? atof(data[6]) * 1000 : feet_to_mm(atof(data[6]));
+		cur_dive->dc.maxdepth.mm = metric ? lrint(atof(data[6]) * 1000) : feet_to_mm(atof(data[6]));
 
 	if (data[7])
 		cur_dive->dc.duration.seconds = atoi(data[7]) * 60;
@@ -3294,7 +3294,7 @@ extern int divinglog_dive(void *param, int columns, char **data, char **column)
 		utf8_string(data[4], &cur_dive->notes);
 
 	if (data[5])
-		cur_dive->dc.maxdepth.mm = atof(data[5]) * 1000;
+		cur_dive->dc.maxdepth.mm = lrint(atof(data[5]) * 1000);
 
 	if (data[6])
 		cur_dive->dc.duration.seconds = atoi(data[6]) * 60;

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -286,7 +286,7 @@ static enum number_type parse_float(const char *buffer, double *res, const char 
 	if (errno || *endp == buffer)
 		return NEITHER;
 	if (**endp == ',') {
-		if (IS_FP_SAME(val, rint(val))) {
+		if (IS_FP_SAME(val, lrint(val))) {
 			/* we really want to send an error if this is a Subsurface native file
 			 * as this is likely indication of a bug - but right now we don't have
 			 * that information available */
@@ -338,7 +338,7 @@ static void pressure(char *buffer, pressure_t *pressure)
 			break;
 		}
 		if (fabs(mbar) > 5 && fabs(mbar) < 5000000) {
-			pressure->mbar = rint(mbar);
+			pressure->mbar = lrint(mbar);
 			break;
 		}
 	/* fallthrough */
@@ -358,7 +358,7 @@ static void salinity(char *buffer, int *salinity)
 	union int_or_float val;
 	switch (integer_or_float(buffer, &val)) {
 	case FLOAT:
-		*salinity = rint(val.fp * 10.0);
+		*salinity = lrint(val.fp * 10.0);
 		break;
 	default:
 		printf("Strange salinity reading %s\n", buffer);
@@ -373,7 +373,7 @@ static void depth(char *buffer, depth_t *depth)
 	case FLOAT:
 		switch (xml_parsing_units.length) {
 		case METERS:
-			depth->mm = rint(val.fp * 1000);
+			depth->mm = lrint(val.fp * 1000);
 			break;
 		case FEET:
 			depth->mm = feet_to_mm(val.fp);
@@ -405,7 +405,7 @@ static void weight(char *buffer, weight_t *weight)
 	case FLOAT:
 		switch (xml_parsing_units.weight) {
 		case KG:
-			weight->grams = rint(val.fp * 1000);
+			weight->grams = lrint(val.fp * 1000);
 			break;
 		case LBS:
 			weight->grams = lbs_to_grams(val.fp);
@@ -510,7 +510,7 @@ static void percent(char *buffer, fraction_t *fraction)
 
 		/* Then turn percent into our integer permille format */
 		if (val >= 0 && val <= 100.0) {
-			fraction->permille = rint(val * 10);
+			fraction->permille = lrint(val * 10);
 			break;
 		}
 	default:
@@ -541,7 +541,7 @@ static void cylindersize(char *buffer, volume_t *volume)
 
 	switch (integer_or_float(buffer, &val)) {
 	case FLOAT:
-		volume->mliter = rint(val.fp * 1000);
+		volume->mliter = lrint(val.fp * 1000);
 		break;
 
 	default:
@@ -614,7 +614,7 @@ static void get_rating(char *buffer, int *i)
 
 static void double_to_o2pressure(char *buffer, o2pressure_t *i)
 {
-	i->mbar = rint(ascii_strtod(buffer, NULL) * 1000.0);
+	i->mbar = lrint(ascii_strtod(buffer, NULL) * 1000.0);
 }
 
 static void hex_value(char *buffer, uint32_t *i)
@@ -697,7 +697,7 @@ static void psi_or_bar(char *buffer, pressure_t *pressure)
 		if (val.fp > 400)
 			pressure->mbar = psi_to_mbar(val.fp);
 		else
-			pressure->mbar = rint(val.fp * 1000);
+			pressure->mbar = lrint(val.fp * 1000);
 		break;
 	default:
 		fprintf(stderr, "Crazy Diving Log PSI reading %s\n", buffer);
@@ -3182,7 +3182,7 @@ extern int divinglog_profile(void *handle, int columns, char **data, char **colu
 			if (atoi(ppo2_3) > 0)
 				cur_sample->o2sensor[2].mbar = atoi(ppo2_3) * 100;
 			if (atoi(cns) > 0)
-				cur_sample->cns = rint(atoi(cns) / 10);
+				cur_sample->cns = lrintf(atoi(cns) / 10.0f);
 			if (atoi(setpoint) > 0)
 				cur_sample->setpoint.mbar = atoi(setpoint) * 100;
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -220,7 +220,7 @@ void fill_default_cylinder(cylinder_t *cyl)
 	} else {
 		cyl->type.workingpressure.mbar = psi_to_mbar(ti->psi);
 		if (ti->psi)
-			cyl->type.size.mliter = cuft_to_l(ti->cuft) * 1000 / bar_to_atm(psi_to_bar(ti->psi));
+			cyl->type.size.mliter = lrint(cuft_to_l(ti->cuft) * 1000 / bar_to_atm(psi_to_bar(ti->psi)));
 	}
 	// MOD of air
 	cyl->depth = gas_mod(&cyl->gasmix, pO2, &displayed_dive, 1);
@@ -241,12 +241,12 @@ static void update_cylinder_pressure(struct dive *d, int old_depth, int new_dept
 	if (!cyl)
 		return;
 	mean_depth.mm = (old_depth + new_depth) / 2;
-	gas_used.mliter = depth_to_atm(mean_depth.mm, d) * sac / 60 * duration * factor / 1000;
+	gas_used.mliter = lrint(depth_to_atm(mean_depth.mm, d) * sac / 60 * duration * factor / 1000);
 	cyl->gas_used.mliter += gas_used.mliter;
 	if (in_deco)
 		cyl->deco_gas_used.mliter += gas_used.mliter;
 	if (cyl->type.size.mliter) {
-		delta_p.mbar = gas_used.mliter * 1000.0 / cyl->type.size.mliter * gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0);
+		delta_p.mbar = lrint(gas_used.mliter * 1000.0 / cyl->type.size.mliter * gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0));
 		cyl->end.mbar -= delta_p.mbar;
 	}
 }
@@ -830,7 +830,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 			depth_unit);
 
 	/* Get SAC values and units for printing it in gas consumption */
-	float bottomsacvalue, decosacvalue;
+	double bottomsacvalue, decosacvalue;
 	int sacdecimals;
 	const char* sacunit;
 
@@ -858,10 +858,10 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		volume = get_volume_units(cyl->gas_used.mliter, NULL, &unit);
 		deco_volume = get_volume_units(cyl->deco_gas_used.mliter, NULL, &unit);
 		if (cyl->type.size.mliter) {
-			int remaining_gas = (double)cyl->end.mbar * cyl->type.size.mliter / 1000.0 / gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0);
+			int remaining_gas = lrint((double)cyl->end.mbar * cyl->type.size.mliter / 1000.0 / gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0));
 			double deco_pressure_bar = isothermal_pressure(&cyl->gasmix, 1.0, remaining_gas + cyl->deco_gas_used.mliter, cyl->type.size.mliter)
 					- cyl->end.mbar / 1000.0;
-			deco_pressure = get_pressure_units(1000.0 * deco_pressure_bar, &pressure_unit);
+			deco_pressure = get_pressure_units(lrint(1000.0 * deco_pressure_bar), &pressure_unit);
 			pressure = get_pressure_units(cyl->start.mbar - cyl->end.mbar, &pressure_unit);
 			/* Warn if the plan uses more gas than is available in a cylinder
 			 * This only works if we have working pressure for the cylinder

--- a/core/planner.c
+++ b/core/planner.c
@@ -1406,8 +1406,8 @@ bool plan(struct diveplan *diveplan, char **cached_datap, bool is_planner, bool 
 
 	plan_add_segment(diveplan, clock - previous_point_time, 0, current_cylinder, po2, false);
 	if (decoMode() == VPMB) {
-		diveplan->eff_gfhigh = rint(100.0 * regressionb());
-		diveplan->eff_gflow = rint(100.0 * (regressiona() * first_stop_depth + regressionb()));
+		diveplan->eff_gfhigh = lrint(100.0 * regressionb());
+		diveplan->eff_gflow = lrint(100.0 * (regressiona() * first_stop_depth + regressionb()));
 	}
 
 	create_dive_from_plan(diveplan, is_planner);

--- a/core/profile.c
+++ b/core/profile.c
@@ -112,7 +112,7 @@ int get_maxdepth(struct plot_info *pi)
 		/* Minimum 30m, rounded up to 10m, with at least 3m to spare */
 		md = MAX((unsigned)30000, ROUND_UP(mm + 3000, 10000));
 	}
-	md += pi->maxpp * 9000;
+	md += lrint(pi->maxpp * 9000);
 	return md;
 }
 
@@ -194,7 +194,7 @@ static int get_local_sac(struct plot_data *entry1, struct plot_data *entry2, str
 	airuse = gas_volume(cyl, a) - gas_volume(cyl, b);
 
 	/* milliliters per minute */
-	return airuse / atm * 60 / duration;
+	return lrint(airuse / atm * 60 / duration);
 }
 
 #define HALF_INTERVAL 9 * 30
@@ -1020,8 +1020,8 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 				double m_value = buehlmann_inertgas_a[j] + entry->ambpressure / buehlmann_inertgas_b[j];
 				entry->ceilings[j] = deco_allowed_depth(tolerated_by_tissue[j], surface_pressure, dive, 1);
 				entry->percentages[j] = tissue_inertgas_saturation[j] < entry->ambpressure ?
-								tissue_inertgas_saturation[j] / entry->ambpressure * AMB_PERCENTAGE :
-								AMB_PERCENTAGE + (tissue_inertgas_saturation[j] - entry->ambpressure) / (m_value - entry->ambpressure) * (100.0 - AMB_PERCENTAGE);
+					lrint(tissue_inertgas_saturation[j] / entry->ambpressure * AMB_PERCENTAGE) :
+					lrint(AMB_PERCENTAGE + (tissue_inertgas_saturation[j] - entry->ambpressure) / (m_value - entry->ambpressure) * (100.0 - AMB_PERCENTAGE));
 			}
 
 			/* should we do more calculations?
@@ -1322,18 +1322,18 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 	if (prefs.pp_graphs.phe)
 		put_format(b, translate("gettextFromC", "pHe: %.2fbar\n"), entry->pressures.he);
 	if (prefs.mod) {
-		mod = (int)get_depth_units(entry->mod, NULL, &depth_unit);
+		mod = lrint(get_depth_units(lrint(entry->mod), NULL, &depth_unit));
 		put_format(b, translate("gettextFromC", "MOD: %d%s\n"), mod, depth_unit);
 	}
-	eadd = (int)get_depth_units(entry->eadd, NULL, &depth_unit);
+	eadd = lrint(get_depth_units(lrint(entry->eadd), NULL, &depth_unit));
 	if (prefs.ead) {
 		switch (pi->dive_type) {
 		case NITROX:
-			ead = (int)get_depth_units(entry->ead, NULL, &depth_unit);
+			ead = lrint(get_depth_units(lrint(entry->ead), NULL, &depth_unit));
 			put_format(b, translate("gettextFromC", "EAD: %d%s\nEADD: %d%s\n"), ead, depth_unit, eadd, depth_unit);
 			break;
 		case TRIMIX:
-			end = (int)get_depth_units(entry->end, NULL, &depth_unit);
+			end = lrint(get_depth_units(lrint(entry->end), NULL, &depth_unit));
 			put_format(b, translate("gettextFromC", "END: %d%s\nEADD: %d%s\n"), end, depth_unit, eadd, depth_unit);
 			break;
 		case AIR:
@@ -1570,7 +1570,7 @@ void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int 
 			double atm = depth_to_atm(avg_depth, &displayed_dive);
 
 			/* milliliters per minute */
-			int sac = volume_used / atm * 60 / delta_time;
+			int sac = lrint(volume_used / atm * 60 / delta_time);
 			memcpy(buf2, buf, bufsize);
 			volume_value = get_volume_units(sac, &volume_precision, &volume_unit);
 			snprintf(buf, bufsize, translate("gettextFromC", "%s SAC:%.*f %s"), buf2, volume_precision, volume_value, volume_unit);

--- a/core/profile.c
+++ b/core/profile.c
@@ -760,7 +760,7 @@ static int sac_between(struct dive *dive, struct plot_data *first, struct plot_d
 	pressuretime /= 60;
 
 	/* SAC = mliter per minute */
-	return rint(airuse / pressuretime);
+	return lrint(airuse / pressuretime);
 }
 
 /*

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -51,9 +51,9 @@ QString weight_string(int weight_in_grams)
 	} else {
 		double lbs = grams_to_lbs(weight_in_grams);
 		if (lbs >= 40.0)
-			lbs = rint(lbs + 0.5);
+			lbs = lrint(lbs + 0.5);
 		else
-			lbs = rint(lbs + 0.05);
+			lbs = lrint(lbs + 0.05);
 		str = QString("%1").arg(lbs, 0, 'f', lbs >= 40.0 ? 0 : 1);
 	}
 	return (str);
@@ -264,8 +264,8 @@ bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_te
 	if (!(*parsed = parseGpsText(gps_text, &latitude, &longitude)))
 		return false;
 
-	latudeg = rint(1000000 * latitude);
-	longudeg = rint(1000000 * longitude);
+	latudeg = lrint(1000000 * latitude);
+	longudeg = lrint(1000000 * longitude);
 
 	/* if dive gps didn't change, nothing changed */
 	if (dive->latitude.udeg == latudeg && dive->longitude.udeg == longudeg)
@@ -843,13 +843,13 @@ int parseWeightToGrams(const QString &text)
 		return 0;
 	double number = numOnly.toDouble();
 	if (text.contains(QObject::tr("kg"), Qt::CaseInsensitive)) {
-		grams = rint(number * 1000);
+		grams = lrint(number * 1000);
 	} else if (text.contains(QObject::tr("lbs"), Qt::CaseInsensitive)) {
 		grams = lbs_to_grams(number);
 	} else {
 		switch (prefs.units.weight) {
 		case units::KG:
-			grams = rint(number * 1000);
+			grams = lrint(number * 1000);
 			break;
 		case units::LBS:
 			grams = lbs_to_grams(number);
@@ -870,13 +870,13 @@ int parsePressureToMbar(const QString &text)
 		return 0;
 	double number = numOnly.toDouble();
 	if (text.contains(QObject::tr("bar"), Qt::CaseInsensitive)) {
-		mbar = rint(number * 1000);
+		mbar = lrint(number * 1000);
 	} else if (text.contains(QObject::tr("psi"), Qt::CaseInsensitive)) {
 		mbar = psi_to_mbar(number);
 	} else {
 		switch (prefs.units.pressure) {
 		case units::BAR:
-			mbar = rint(number * 1000);
+			mbar = lrint(number * 1000);
 			break;
 		case units::PSI:
 			mbar = psi_to_mbar(number);
@@ -1242,8 +1242,8 @@ extern "C" void picture_load_exif_data(struct picture *p)
 		goto picture_load_exit;
 	if (exif.parseFrom((const unsigned char *)mem.buffer, (unsigned)mem.size) != PARSE_EXIF_SUCCESS)
 		goto picture_load_exit;
-	p->longitude.udeg= lrint(1000000.0 * exif.GeoLocation.Longitude);
-	p->latitude.udeg  = lrint(1000000.0 * exif.GeoLocation.Latitude);
+	p->longitude.udeg= llrint(1000000.0 * exif.GeoLocation.Longitude);
+	p->latitude.udeg  = llrint(1000000.0 * exif.GeoLocation.Latitude);
 
 picture_load_exit:
 	free(mem.buffer);
@@ -1280,7 +1280,7 @@ weight_t string_to_weight(const char *str)
 	if (prefs.units.weight == prefs.units.LBS)
 		goto lbs;
 kg:
-	weight.grams = rint(value * 1000);
+	weight.grams = lrint(value * 1000);
 	return weight;
 lbs:
 	weight.grams = lbs_to_grams(value);
@@ -1305,7 +1305,7 @@ depth_t string_to_depth(const char *str)
 	if (prefs.units.length == prefs.units.FEET)
 		goto ft;
 m:
-	depth.mm = rint(value * 1000);
+	depth.mm = lrint(value * 1000);
 	return depth;
 ft:
 	depth.mm = feet_to_mm(value);
@@ -1328,7 +1328,7 @@ pressure_t string_to_pressure(const char *str)
 	if (prefs.units.pressure == prefs.units.PSI)
 		goto psi;
 bar:
-	pressure.mbar = rint(value * 1000);
+	pressure.mbar = lrint(value * 1000);
 	return pressure;
 psi:
 	pressure.mbar = psi_to_mbar(value);
@@ -1362,7 +1362,7 @@ cuft:
 		value /= bar_to_atm(workp.mbar / 1000.0);
 	value = cuft_to_l(value);
 l:
-	volume.mliter = rint(value * 1000);
+	volume.mliter = lrint(value * 1000);
 	return volume;
 }
 
@@ -1372,7 +1372,7 @@ fraction_t string_to_fraction(const char *str)
 	double value = strtod_flags(str, &end, 0);
 	fraction_t fraction;
 
-	fraction.permille = rint(value * 10);
+	fraction.permille = lrint(value * 10);
 	/*
 	 * Don't permit values less than zero or greater than 100%
 	 */

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -127,7 +127,7 @@ static void put_cylinder_HTML(struct membuffer *b, struct dive *dive)
 		if (cylinder->type.size.mliter) {
 			int volume = cylinder->type.size.mliter;
 			if (prefs.units.volume == CUFT && cylinder->type.workingpressure.mbar)
-				volume *= bar_to_atm(cylinder->type.workingpressure.mbar / 1000.0);
+				volume = lrint(volume * bar_to_atm(cylinder->type.workingpressure.mbar / 1000.0));
 			put_HTML_volume_units(b, volume, "\"Size\":\"", " \", ");
 		} else {
 			write_attribute(b, "Size", "--", ", ");

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -68,15 +68,15 @@ static void process_dive(struct dive *dp, stats_t *stats)
 		return;
 	if (dp->meandepth.mm) {
 		stats->total_average_depth_time.seconds += duration;
-		stats->avg_depth.mm = (1.0 * old_tadt * stats->avg_depth.mm +
-				       duration * dp->meandepth.mm) /
-				stats->total_average_depth_time.seconds;
+		stats->avg_depth.mm = lrint((1.0 * old_tadt * stats->avg_depth.mm +
+					duration * dp->meandepth.mm) /
+					stats->total_average_depth_time.seconds);
 	}
 	if (dp->sac > 100) { /* less than .1 l/min is bogus, even with a pSCR */
 		sac_time = stats->total_sac_time + duration;
-		stats->avg_sac.mliter = (1.0 * stats->total_sac_time * stats->avg_sac.mliter +
+		stats->avg_sac.mliter = lrint((1.0 * stats->total_sac_time * stats->avg_sac.mliter +
 					 duration * dp->sac) /
-					sac_time;
+					 sac_time);
 		if (dp->sac > stats->max_sac.mliter)
 			stats->max_sac.mliter = dp->sac;
 		if (stats->min_sac.mliter == 0 || dp->sac < stats->min_sac.mliter)

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -396,8 +396,8 @@ static void get_gas_parts(struct gasmix mix, volume_t vol, int o2_in_topup, volu
 		return;
 	}
 
-	air.mliter = rint(((double)vol.mliter * (1000 - get_he(&mix) - get_o2(&mix))) / (1000 - o2_in_topup));
-	he->mliter = rint(((double)vol.mliter * get_he(&mix)) / 1000.0);
+	air.mliter = lrint(((double)vol.mliter * (1000 - get_he(&mix) - get_o2(&mix))) / (1000 - o2_in_topup));
+	he->mliter = lrint(((double)vol.mliter * get_he(&mix)) / 1000.0);
 	o2->mliter += vol.mliter - he->mliter - air.mliter;
 }
 

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -92,7 +92,7 @@ static void uemis_ts(char *buffer, void *_when)
 /* float minutes */
 static void uemis_duration(char *buffer, duration_t *duration)
 {
-	duration->seconds = rint(ascii_strtod(buffer, NULL) * 60);
+	duration->seconds = lrint(ascii_strtod(buffer, NULL) * 60);
 }
 
 /* int cm */

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -129,8 +129,8 @@ static void uemis_add_string(const char *buffer, char **text, const char *delimi
 static void uemis_get_weight(char *buffer, weightsystem_t *weight, int diveid)
 {
 	weight->weight.grams = uemis_get_weight_unit(diveid) ?
-				       lbs_to_grams(ascii_strtod(buffer, NULL)) :
-				       ascii_strtod(buffer, NULL) * 1000;
+		lbs_to_grams(ascii_strtod(buffer, NULL)) :
+		lrint(ascii_strtod(buffer, NULL) * 1000);
 	weight->description = strdup(translate("gettextFromC", "unknown"));
 }
 

--- a/core/uemis.c
+++ b/core/uemis.c
@@ -337,7 +337,7 @@ void uemis_parse_divelog_binary(char *base64, void *datap)
 		 * we store the incorrect working pressure to get the SAC calculations "close"
 		 * but the user will have to correct this manually
 		 */
-		dive->cylinder[i].type.size.mliter = rint(volume);
+		dive->cylinder[i].type.size.mliter = lrintf(volume);
 		dive->cylinder[i].type.workingpressure.mbar = 202600;
 		dive->cylinder[i].gasmix.o2.permille = *(uint8_t *)(data + 120 + 25 * (gasoffset + i)) * 10;
 		dive->cylinder[i].gasmix.he.permille = 0;

--- a/core/uemis.c
+++ b/core/uemis.c
@@ -173,8 +173,8 @@ void uemis_set_divelocation(int divespot, char *text, double longitude, double l
 			struct dive_site *ds = get_dive_site_by_uuid(hp->dive_site_uuid);
 			if (ds) {
 				ds->name = strdup(text);
-				ds->longitude.udeg = round(longitude * 1000000);
-				ds->latitude.udeg = round(latitude * 1000000);
+				ds->longitude.udeg = lrint(longitude * 1000000);
+				ds->latitude.udeg = lrint(latitude * 1000000);
 			}
 		}
 		hp = hp->next;
@@ -329,7 +329,7 @@ void uemis_parse_divelog_binary(char *base64, void *datap)
 	if (template == 0)
 		template = 1;
 	for (i = 0; i < template; i++) {
-		float volume = *(float *)(data + 116 + 25 * (gasoffset + i)) * 1000.0;
+		float volume = *(float *)(data + 116 + 25 * (gasoffset + i)) * 1000.0f;
 		/* uemis always assumes a working pressure of 202.6bar (!?!?) - I first thought
 		 * it was 3000psi, but testing against all my dives gets me that strange number.
 		 * Still, that's of course completely bogus and shows they don't get how

--- a/core/units.h
+++ b/core/units.h
@@ -134,7 +134,7 @@ static inline double grams_to_lbs(int grams)
 
 static inline int lbs_to_grams(double lbs)
 {
-	return rint(lbs * 453.6);
+	return lrint(lbs * 453.6);
 }
 
 static inline double ml_to_cuft(int ml)
@@ -159,12 +159,12 @@ static inline double m_to_mile(int m)
 
 static inline unsigned long feet_to_mm(double feet)
 {
-	return rint(feet * 304.8);
+	return lrint(feet * 304.8);
 }
 
 static inline int to_feet(depth_t depth)
 {
-	return rint(mm_to_feet(depth.mm));
+	return lrint(mm_to_feet(depth.mm));
 }
 
 static inline double mkelvin_to_C(int mkelvin)
@@ -179,12 +179,12 @@ static inline double mkelvin_to_F(int mkelvin)
 
 static inline unsigned long F_to_mkelvin(double f)
 {
-	return rint((f - 32) * 1000 / 1.8 + ZERO_C_IN_MKELVIN);
+	return lrint((f - 32) * 1000 / 1.8 + ZERO_C_IN_MKELVIN);
 }
 
 static inline unsigned long C_to_mkelvin(double c)
 {
-	return rint(c * 1000 + ZERO_C_IN_MKELVIN);
+	return lrint(c * 1000 + ZERO_C_IN_MKELVIN);
 }
 
 static inline double psi_to_bar(double psi)
@@ -194,12 +194,12 @@ static inline double psi_to_bar(double psi)
 
 static inline long psi_to_mbar(double psi)
 {
-	return rint(psi_to_bar(psi) * 1000);
+	return lrint(psi_to_bar(psi) * 1000);
 }
 
 static inline int to_PSI(pressure_t pressure)
 {
-	return rint(pressure.mbar * 0.0145037738);
+	return lrint(pressure.mbar * 0.0145037738);
 }
 
 static inline double bar_to_atm(double bar)

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -379,12 +379,12 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 
 void PlannerSettingsWidget::updateUnitsUI()
 {
-	ui.ascRate75->setValue(rint(prefs.ascrate75 / UNIT_FACTOR));
-	ui.ascRate50->setValue(rint(prefs.ascrate50 / UNIT_FACTOR));
-	ui.ascRateStops->setValue(rint(prefs.ascratestops / UNIT_FACTOR));
-	ui.ascRateLast6m->setValue(rint(prefs.ascratelast6m / UNIT_FACTOR));
-	ui.descRate->setValue(rint(prefs.descrate / UNIT_FACTOR));
-	ui.bestmixEND->setValue(rint(get_depth_units(prefs.bestmixend.mm, NULL, NULL)));
+	ui.ascRate75->setValue(lrint(prefs.ascrate75 / UNIT_FACTOR));
+	ui.ascRate50->setValue(lrint(prefs.ascrate50 / UNIT_FACTOR));
+	ui.ascRateStops->setValue(lrint(prefs.ascratestops / UNIT_FACTOR));
+	ui.ascRateLast6m->setValue(lrint(prefs.ascratelast6m / UNIT_FACTOR));
+	ui.descRate->setValue(lrint(prefs.descrate / UNIT_FACTOR));
+	ui.bestmixEND->setValue(lrint(get_depth_units(prefs.bestmixend.mm, NULL, NULL)));
 }
 
 PlannerSettingsWidget::~PlannerSettingsWidget()

--- a/desktop-widgets/globe.cpp
+++ b/desktop-widgets/globe.cpp
@@ -140,8 +140,8 @@ void GlobeGPS::mouseClicked(qreal lon, qreal lat, GeoDataCoordinates::Unit unit)
 		return;
 
 	GeoDataCoordinates here(lon, lat, unit);
-	long lon_udeg = rint(1000000 * here.longitude(GeoDataCoordinates::Degree));
-	long lat_udeg = rint(1000000 * here.latitude(GeoDataCoordinates::Degree));
+	long lon_udeg = lrint(1000000 * here.longitude(GeoDataCoordinates::Degree));
+	long lat_udeg = lrint(1000000 * here.latitude(GeoDataCoordinates::Degree));
 
 	// distance() is in km above the map.
 	// We're going to use that to decide how
@@ -155,7 +155,7 @@ void GlobeGPS::mouseClicked(qreal lon, qreal lat, GeoDataCoordinates::Unit unit)
 	// Trigonometry is hard, but sin x == x
 	// for small x, so let's just do this as
 	// a linear thing.
-	long resolve = rint(distance() * 1000);
+	long resolve = lrint(distance() * 1000);
 
 	int idx;
 	struct dive *dive;
@@ -347,8 +347,8 @@ void GlobeGPS::changeDiveGeoPosition(qreal lon, qreal lat, GeoDataCoordinates::U
 	centerOn(lon, lat, true);
 
 	// change the location of the displayed_dive and put the UI in edit mode
-	displayed_dive_site.latitude.udeg = lrint(lat * 1000000.0);
-	displayed_dive_site.longitude.udeg = lrint(lon * 1000000.0);
+	displayed_dive_site.latitude.udeg = llrint(lat * 1000000.0);
+	displayed_dive_site.longitude.udeg = llrint(lon * 1000000.0);
 	emit coordinatesChanged();
 	repopulateLabels();
 }

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -41,7 +41,7 @@ void PreferencesGraph::refreshSettings()
 	ui->show_ccr_sensors->setChecked(prefs.show_ccr_sensors);
 	ui->defaultSetpoint->setValue((double)prefs.defaultsetpoint / 1000.0);
 	ui->psro2rate->setValue(prefs.o2consumption / 1000.0);
-	ui->pscrfactor->setValue(rint(1000.0 / prefs.pscr_ratio));
+	ui->pscrfactor->setValue(lrint(1000.0 / prefs.pscr_ratio));
 
 	ui->display_unused_tanks->setChecked(prefs.display_unused_tanks);
 	ui->show_average_depth->setChecked(prefs.show_average_depth);
@@ -50,9 +50,9 @@ void PreferencesGraph::refreshSettings()
 void PreferencesGraph::syncSettings()
 {
 	auto general = SettingsObjectWrapper::instance()->general_settings;
-	general->setDefaultSetPoint(rint(ui->defaultSetpoint->value() * 1000.0));
-	general->setO2Consumption(rint(ui->psro2rate->value() *1000.0));
-	general->setPscrRatio(rint(1000.0 / ui->pscrfactor->value()));
+	general->setDefaultSetPoint(lrint(ui->defaultSetpoint->value() * 1000.0));
+	general->setO2Consumption(lrint(ui->psro2rate->value() *1000.0));
+	general->setPscrRatio(lrint(1000.0 / ui->pscrfactor->value()));
 
 	auto pp_gas = SettingsObjectWrapper::instance()->pp_gas;
 	pp_gas->setPheThreshold(ui->pheThreshold->value());

--- a/dives/TestDiveDM4.xml
+++ b/dives/TestDiveDM4.xml
@@ -141,7 +141,7 @@
   <sample time='42:00 min' depth='16.07 m' pressure='91.15 bar' />
   <sample time='42:20 min' depth='15.95 m' pressure='90.42 bar' />
   <sample time='42:40 min' depth='16.24 m' pressure='89.9 bar' />
-  <sample time='43:00 min' depth='16.379 m' pressure='88.92 bar' />
+  <sample time='43:00 min' depth='16.38 m' pressure='88.92 bar' />
   <sample time='43:20 min' depth='16.67 m' pressure='88.2 bar' />
   <sample time='43:40 min' depth='16.61 m' pressure='87.41 bar' />
   <sample time='44:00 min' depth='17.17 m' pressure='86.42 bar' />

--- a/mobile-widgets/qmlprofile.cpp
+++ b/mobile-widgets/qmlprofile.cpp
@@ -37,7 +37,7 @@ void QMLProfile::paint(QPainter *painter)
 	qreal sy = painterRect.height() / sceneSize / dprComp;
 
 	// next figure out the weird magic by which we need to shift the painter so the profile is shown
-	int dpr = rint(devicePixelRatio());
+	int dpr = lrint(devicePixelRatio());
 	qreal magicShiftFactor = (dpr == 2 ? 0.25 : (dpr == 3 ? 0.33 : 0.0));
 
 	// now set up the transformations scale the profile and

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -949,8 +949,8 @@ void ProfileWidget2::mouseDoubleClickEvent(QMouseEvent *event)
 		if (isPointOutOfBoundaries(mappedPos))
 			return;
 
-		int minutes = rint(timeAxis->valueAt(mappedPos) / 60);
-		int milimeters = rint(profileYAxis->valueAt(mappedPos) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
+		int minutes = lrint(timeAxis->valueAt(mappedPos) / 60);
+		int milimeters = lrint(profileYAxis->valueAt(mappedPos) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
 		plannerModel->addStop(milimeters, minutes * 60, -1, 0, true);
 	}
 }
@@ -1789,13 +1789,13 @@ void ProfileWidget2::recreatePlannedDive()
 	if (index < plannerModel->size() - 1)
 		maxtime = plannerModel->at(index + 1).time;
 
-	int minutes = rint(timeAxis->valueAt(activeHandler->pos()) / 60);
+	int minutes = lrint(timeAxis->valueAt(activeHandler->pos()) / 60);
 	if (minutes * 60 <= mintime || minutes * 60 >= maxtime)
 		return;
 
 	divedatapoint data = plannerModel->at(index);
-	data.depth = rint(profileYAxis->valueAt(activeHandler->pos()) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
-	data.time = rint(timeAxis->valueAt(activeHandler->pos()));
+	data.depth = lrint(profileYAxis->valueAt(activeHandler->pos()) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
+	data.time = lrint(timeAxis->valueAt(activeHandler->pos()));
 
 	plannerModel->editStop(index, data);
 }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -241,7 +241,7 @@ QVariant DivePlannerPointsModel::data(const QModelIndex &index, int role) const
 		case CCSETPOINT:
 			return (double)p.setpoint / 1000;
 		case DEPTH:
-			return (int) rint(get_depth_units(p.depth, NULL, NULL));
+			return (int) lrint(get_depth_units(p.depth, NULL, NULL));
 		case RUNTIME:
 			return p.time / 60;
 		case DURATION:


### PR DESCRIPTION
I have identified several other potential similar rounding issues.
The exact same one in dm5_dive code, in maxdepth computation for both dm4_dive and dm5_dive and many other places in parse-xml.c code and some as well (but in lesser amount) in other parts of the code.

The one fixed here is the only one that was highlighted by a test failure (when running TestParse on windows). How should I/we proceed forward?
1. My original goal was more to get all tests passing under windows so it could get integrated in CI, TestPreference is still failing... So we could simply pull this change and get back to this issue later, focusing first on test execution for windows CI
2. Fix "blindly" all potential rounding errors, but I'm not really clear on what could be the side effect(s) of this.
3. Spend time creating test cases that would highlight each rounding errors but the task is huge, not always straight forward (blob data), and current test philosophy seem to be closer to quick functional testing rather than deep regression testing.

What is your point of view here? Should I post in the mailing to get more inputs too?