### PR TITLE
Enable bottom pO2 option also for recreational dives in planner

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -247,7 +247,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(true);
 		ui.backgasBreaks->setDisabled(true);
-		ui.bottompo2->setDisabled(true);
+		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(true);
 		ui.reserve_gas->setDisabled(false);
 		ui.vpmb_conservatism->setDisabled(true);


### PR DESCRIPTION
Bottom pO2 gas option in planner should be always enabled because also recreational dives can use nitrox and produce "high pO2" warnings.

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>