### PR TITLE
Make depth conversion work for negative depths

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -248,11 +248,15 @@ int units_to_sac(double volume)
 		return rint(volume * 1000);
 }
 
-unsigned int units_to_depth(double depth)
+depth_t units_to_depth(double depth)
 {
-	if (get_units()->length == METERS)
-		return rint(depth * 1000);
-	return feet_to_mm(depth);
+	depth_t internaldepth;
+	if (get_units()->length == METERS) {
+		internaldepth.mm = rint(depth * 1000);
+	} else {
+		internaldepth.mm = feet_to_mm(depth);
+	}
+	return internaldepth;
 }
 
 double get_depth_units(int mm, int *frac, const char **units)

--- a/core/dive.c
+++ b/core/dive.c
@@ -3588,11 +3588,11 @@ void average_max_depth(struct diveplan *dive, int *avg_depth, int *max_depth)
 	while (dp) {
 		if (dp->time) {
 			/* Ignore gas indication samples */
-			integral += (dp->depth + last_depth) * (dp->time - last_time) / 2;
+			integral += (dp->depth.mm + last_depth) * (dp->time - last_time) / 2;
 			last_time = dp->time;
-			last_depth = dp->depth;
-			if (dp->depth > *max_depth)
-				*max_depth = dp->depth;
+			last_depth = dp->depth.mm;
+			if (dp->depth.mm > *max_depth)
+				*max_depth = dp->depth.mm;
 		}
 		dp = dp->next;
 	}

--- a/core/dive.h
+++ b/core/dive.h
@@ -845,7 +845,7 @@ extern double tissue_tolerance_calc(const struct dive *dive, double pressure);
 /* this should be converted to use our types */
 struct divedatapoint {
 	int time;
-	int depth;
+	depth_t depth;
 	int cylinderid;
 	int setpoint;
 	bool entered;

--- a/core/dive.h
+++ b/core/dive.h
@@ -131,7 +131,7 @@ extern double get_temp_units(unsigned int mk, const char **units);
 extern double get_weight_units(unsigned int grams, int *frac, const char **units);
 extern double get_vertical_speed_units(unsigned int mms, int *frac, const char **units);
 
-extern unsigned int units_to_depth(double depth);
+extern depth_t units_to_depth(double depth);
 extern int units_to_sac(double volume);
 
 /* Volume in mliter of a cylinder at pressure 'p' */

--- a/core/planner.c
+++ b/core/planner.c
@@ -262,7 +262,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, bool track_gas)
 	cylinder_t *cyl;
 	int oldpo2 = 0;
 	int lasttime = 0;
-	int lastdepth = 0;
+	depth_t lastdepth = {.mm = 0};
 	int lastcylid = 0;
 	enum dive_comp_type type = displayed_dive.dc.divemode;
 
@@ -303,7 +303,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, bool track_gas)
 		if (dp->setpoint)
 			type = CCR;
 		int time = dp->time;
-		int depth = dp->depth;
+		depth_t depth = dp->depth;
 
 		if (time == 0) {
 			/* special entries that just inform the algorithm about
@@ -329,7 +329,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, bool track_gas)
 			sample = prepare_sample(dc);
 			sample[-1].setpoint.mbar = po2;
 			sample->time.seconds = lasttime + 1;
-			sample->depth.mm = lastdepth;
+			sample->depth = lastdepth;
 			sample->manually_entered = dp->entered;
 			sample->sac.mliter = dp->entered ? prefs.bottomsac : prefs.decosac;
 			if (track_gas && cyl->type.workingpressure.mbar)
@@ -344,11 +344,11 @@ static void create_dive_from_plan(struct diveplan *diveplan, bool track_gas)
 		sample[-1].setpoint.mbar = po2;
 		sample->setpoint.mbar = po2;
 		sample->time.seconds = lasttime = time;
-		sample->depth.mm = lastdepth = depth;
+		sample->depth = lastdepth = depth;
 		sample->manually_entered = dp->entered;
 		sample->sac.mliter = dp->entered ? prefs.bottomsac : prefs.decosac;
 		if (track_gas && !sample[-1].setpoint.mbar) {    /* Don't track gas usage for CCR legs of dive */
-			update_cylinder_pressure(&displayed_dive, sample[-1].depth.mm, depth, time - sample[-1].time.seconds,
+			update_cylinder_pressure(&displayed_dive, sample[-1].depth.mm, depth.mm, time - sample[-1].time.seconds,
 					dp->entered ? diveplan->bottomsac : diveplan->decosac, cyl, !dp->entered);
 			if (cyl->type.workingpressure.mbar)
 				sample->cylinderpressure.mbar = cyl->end.mbar;
@@ -382,7 +382,7 @@ struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po
 
 	dp = malloc(sizeof(struct divedatapoint));
 	dp->time = time_incr;
-	dp->depth = depth;
+	dp->depth.mm = depth;
 	dp->cylinderid = cylinderid;
 	dp->setpoint = po2;
 	dp->entered = false;
@@ -429,24 +429,24 @@ static struct gaschanges *analyze_gaslist(struct diveplan *diveplan, int *gascha
 	bool total_time_zero = true;
 	while (dp) {
 		if (dp->time == 0 && total_time_zero) {
-			if (dp->depth <= depth) {
+			if (dp->depth.mm <= depth) {
 				int i = 0;
 				nr++;
 				gaschanges = realloc(gaschanges, nr * sizeof(struct gaschanges));
 				while (i < nr - 1) {
-					if (dp->depth < gaschanges[i].depth) {
+					if (dp->depth.mm < gaschanges[i].depth) {
 						memmove(gaschanges + i + 1, gaschanges + i, (nr - i - 1) * sizeof(struct gaschanges));
 						break;
 					}
 					i++;
 				}
-				gaschanges[i].depth = dp->depth;
+				gaschanges[i].depth = dp->depth.mm;
 				gaschanges[i].gasidx = dp->cylinderid;
 				assert(gaschanges[i].gasidx != -1);
 			} else {
 				/* is there a better mix to start deco? */
-				if (dp->depth < best_depth) {
-					best_depth = dp->depth;
+				if (dp->depth.mm < best_depth) {
+					best_depth = dp->depth.mm;
 					*asc_cylinder = dp->cylinderid;
 				}
 			}
@@ -614,13 +614,13 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		const char *depth_unit;
 		double depthvalue;
 		int decimals;
-		bool isascent = (dp->depth < lastdepth);
+		bool isascent = (dp->depth.mm < lastdepth);
 
 		nextdp = dp->next;
 		if (dp->time == 0)
 			continue;
 		gasmix = dive->cylinder[dp->cylinderid].gasmix;
-		depthvalue = get_depth_units(dp->depth, &decimals, &depth_unit);
+		depthvalue = get_depth_units(dp->depth.mm, &decimals, &depth_unit);
 		/* analyze the dive points ahead */
 		while (nextdp && nextdp->time == 0)
 			nextdp = nextdp->next;
@@ -631,12 +631,12 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		/* do we want to skip this leg as it is devoid of anything useful? */
 		if (!dp->entered &&
 		    nextdp &&
-		    dp->depth != lastdepth &&
-		    nextdp->depth != dp->depth &&
+		    dp->depth.mm != lastdepth &&
+		    nextdp->depth.mm != dp->depth.mm &&
 		    !gaschange_before &&
 		    !gaschange_after)
 			continue;
-		if (dp->time - lasttime < 10 && !(gaschange_after && dp->next && dp->depth != dp->next->depth))
+		if (dp->time - lasttime < 10 && !(gaschange_after && dp->next && dp->depth.mm != dp->next->depth.mm))
 			continue;
 
 		len = strlen(buffer);
@@ -647,8 +647,8 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 			 * to determine whether or not to print a segment much simpler than  with the
 			 * non-verbatim plan.
 			 */
-			if (dp->depth != lastprintdepth) {
-				if (plan_display_transitions || dp->entered || !dp->next || (gaschange_after && dp->next && dp->depth != nextdp->depth)) {
+			if (dp->depth.mm != lastprintdepth) {
+				if (plan_display_transitions || dp->entered || !dp->next || (gaschange_after && dp->next && dp->depth.mm != nextdp->depth.mm)) {
 					if (dp->setpoint)
 						snprintf(temp, sz_temp, translate("gettextFromC", "Transition to %.*f %s in %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
 							 decimals, depthvalue, depth_unit,
@@ -666,10 +666,10 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 
 					len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
 				}
-				newdepth = dp->depth;
+				newdepth = dp->depth.mm;
 				lasttime = dp->time;
 			} else {
-				if ((nextdp && dp->depth != nextdp->depth) || gaschange_after) {
+				if ((nextdp && dp->depth.mm != nextdp->depth.mm) || gaschange_after) {
 					if (dp->setpoint)
 						snprintf(temp, sz_temp, translate("gettextFromC", "Stay at %.*f %s for %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
 								decimals, depthvalue, depth_unit,
@@ -685,7 +685,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 								gasname(&gasmix));
 
 						len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
-					newdepth = dp->depth;
+					newdepth = dp->depth.mm;
 					lasttime = dp->time;
 				}
 			}
@@ -707,14 +707,14 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 			 *    time has been allowed for a gas switch.
 			 */
 			if (plan_display_transitions || dp->entered || !dp->next ||
-			    (nextdp && dp->depth != nextdp->depth) ||
-			    (!isascent && gaschange_before && nextdp && dp->depth != nextdp->depth) ||
+			    (nextdp && dp->depth.mm != nextdp->depth.mm) ||
+			    (!isascent && gaschange_before && nextdp && dp->depth.mm != nextdp->depth.mm) ||
 			    (gaschange_after && lastentered) || (gaschange_after && !isascent) ||
-			    (isascent && gaschange_after && nextdp && dp->depth != nextdp->depth )) {
+			    (isascent && gaschange_after && nextdp && dp->depth.mm != nextdp->depth.mm )) {
 				// Print a symbol to indicate whether segment is an ascent, descent, constant depth (user entered) or deco stop
 				if (isascent)
 					segmentsymbol = "&#10138;"; // up-right arrow for ascent
-				else if (dp->depth > lastdepth)
+				else if (dp->depth.mm > lastdepth)
 					segmentsymbol = "&#10136;"; // down-right arrow for descent
 				else if (dp->entered)
 					segmentsymbol = "&#10137;"; // right arrow for entered entered segment at constant depth
@@ -737,7 +737,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 				/* Normally a gas change is displayed on the stopping segment, so only display a gas change at the end of
 				 * an ascent segment if it is not followed by a stop
 				 */
-				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth != nextdp->depth || nextdp->entered)) {
+				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth.mm != nextdp->depth.mm || nextdp->entered)) {
 					if (dp->setpoint) {
 						snprintf(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) nextdp->setpoint / 1000.0);
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasname(&newgasmix),
@@ -765,7 +765,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 					len += snprintf(buffer + len, sz_buffer - len, "<td>&nbsp;</td>");
 				}
 				len += snprintf(buffer + len, sz_buffer - len, "</tr>");
-				newdepth = dp->depth;
+				newdepth = dp->depth.mm;
 				lasttime = dp->time;
 			}
 		}
@@ -785,7 +785,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 			}
 		}
 		lastprintdepth = newdepth;
-		lastdepth = dp->depth;
+		lastdepth = dp->depth.mm;
 		lastsetpoint = dp->setpoint;
 		lastentered = dp->entered;
 	} while ((dp = nextdp) != NULL);
@@ -889,12 +889,12 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 			if (dp->time != 0) {
 				struct gas_pressures pressures;
 				struct gasmix *gasmix = &dive->cylinder[dp->cylinderid].gasmix;
-				fill_pressures(&pressures, depth_to_atm(dp->depth, dive), gasmix, 0.0, dive->dc.divemode);
+				fill_pressures(&pressures, depth_to_atm(dp->depth.mm, dive), gasmix, 0.0, dive->dc.divemode);
 
 				if (pressures.o2 > (dp->entered ? prefs.bottompo2 : prefs.decopo2) / 1000.0) {
 					const char *depth_unit;
 					int decimals;
-					double depth_value = get_depth_units(dp->depth, &decimals, &depth_unit);
+					double depth_value = get_depth_units(dp->depth.mm, &decimals, &depth_unit);
 					len = strlen(buffer);
 					snprintf(temp, sz_temp,
 						 translate("gettextFromC", "high pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),
@@ -904,7 +904,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 				} else if (pressures.o2 < 0.16) {
 					const char *depth_unit;
 					int decimals;
-					double depth_value = get_depth_units(dp->depth, &decimals, &depth_unit);
+					double depth_value = get_depth_units(dp->depth.mm, &decimals, &depth_unit);
 					len = strlen(buffer);
 					snprintf(temp, sz_temp,
 						 translate("gettextFromC", "low pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -750,7 +750,7 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsSuuntoVyper()
 	deviceDetails->lightEnabled = ui.lightCheckBox->isChecked();
 	deviceDetails->light = ui.lightSpinBox->value();
 	deviceDetails->alarmDepthEnabled = ui.alarmDepthCheckBox->isChecked();
-	deviceDetails->alarmDepth = units_to_depth(ui.alarmDepthDoubleSpinBox->value());
+	deviceDetails->alarmDepth = units_to_depth(ui.alarmDepthDoubleSpinBox->value()).mm;
 	deviceDetails->alarmTimeEnabled = ui.alarmTimeCheckBox->isChecked();
 	deviceDetails->alarmTime = ui.alarmTimeSpinBox->value();
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -217,7 +217,7 @@ void DivePlannerWidget::atmPressureChanged(const int pressure)
 
 void DivePlannerWidget::heightChanged(const int height)
 {
-	int pressure = (int) (1013.0 * exp(- (double) units_to_depth((double) height) / 7800000.0));
+	int pressure = (int) (1013.0 * exp(- (double) units_to_depth((double) height).mm / 7800000.0));
 	ui.ATMPressure->blockSignals(true);
 	ui.ATMPressure->setValue(pressure);
 	ui.ATMPressure->blockSignals(false);
@@ -495,7 +495,7 @@ void PlannerSettingsWidget::setDecoPo2(double po2)
 
 void PlannerSettingsWidget::setBestmixEND(int depth)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setBestmixend(units_to_depth(depth));
+	SettingsObjectWrapper::instance()->planner_settings->setBestmixend(units_to_depth(depth).mm);
 }
 
 void PlannerSettingsWidget::setBackgasBreaks(bool dobreaks)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1736,13 +1736,13 @@ void ProfileWidget2::repositionDiveHandlers()
 			continue;
 		DiveHandler *h = handles.at(i);
 		h->setVisible(datapoint.entered);
-		h->setPos(timeAxis->posAtValue(datapoint.time), profileYAxis->posAtValue(datapoint.depth));
+		h->setPos(timeAxis->posAtValue(datapoint.time), profileYAxis->posAtValue(datapoint.depth.mm));
 		QPointF p1;
 		if (i == 0) {
 			if (prefs.drop_stone_mode)
 				// place the text on the straight line from the drop to stone position
-				p1 = QPointF(timeAxis->posAtValue(datapoint.depth / prefs.descrate),
-					     profileYAxis->posAtValue(datapoint.depth));
+				p1 = QPointF(timeAxis->posAtValue(datapoint.depth.mm / prefs.descrate),
+					     profileYAxis->posAtValue(datapoint.depth.mm));
 			else
 				// place the text on the straight line from the origin to the first position
 				p1 = QPointF(timeAxis->posAtValue(0), profileYAxis->posAtValue(0));
@@ -1794,7 +1794,7 @@ void ProfileWidget2::recreatePlannedDive()
 		return;
 
 	divedatapoint data = plannerModel->at(index);
-	data.depth = rint(profileYAxis->valueAt(activeHandler->pos()) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
+	data.depth.mm = rint(profileYAxis->valueAt(activeHandler->pos()) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
 	data.time = rint(timeAxis->valueAt(activeHandler->pos()));
 
 	plannerModel->editStop(index, data);
@@ -1810,10 +1810,10 @@ void ProfileWidget2::keyDownAction()
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handles.indexOf(handler);
 			divedatapoint dp = plannerModel->at(row);
-			if (dp.depth >= profileYAxis->maximum())
+			if (dp.depth.mm >= profileYAxis->maximum())
 				continue;
 
-			dp.depth += M_OR_FT(1, 5);
+			dp.depth.mm += M_OR_FT(1, 5);
 			plannerModel->editStop(row, dp);
 		}
 	}
@@ -1830,10 +1830,10 @@ void ProfileWidget2::keyUpAction()
 			int row = handles.indexOf(handler);
 			divedatapoint dp = plannerModel->at(row);
 
-			if (dp.depth <= 0)
+			if (dp.depth.mm <= 0)
 				continue;
 
-			dp.depth -= M_OR_FT(1, 5);
+			dp.depth.mm -= M_OR_FT(1, 5);
 			plannerModel->editStop(row, dp);
 		}
 	}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -288,7 +288,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 		switch (index.column()) {
 		case DEPTH:
 			if (value.toInt() >= 0) {
-				p.depth = units_to_depth(value.toInt());
+				p.depth = units_to_depth(value.toInt()).mm;
 				if (updateMaxDepth())
 					CylindersModel::instance()->updateBestMixes();
 			}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -159,8 +159,8 @@ bool DivePlannerPointsModel::updateMaxDepth()
 	displayed_dive.maxdepth.mm = 0;
 	for (int i = 0; i < rowCount(); i++) {
 		divedatapoint p = at(i);
-		if (p.depth > displayed_dive.maxdepth.mm)
-			displayed_dive.maxdepth.mm = p.depth;
+		if (p.depth.mm > displayed_dive.maxdepth.mm)
+			displayed_dive.maxdepth.mm = p.depth.mm;
 	}
 	return (displayed_dive.maxdepth.mm != prevMaxDepth);
 }
@@ -241,7 +241,7 @@ QVariant DivePlannerPointsModel::data(const QModelIndex &index, int role) const
 		case CCSETPOINT:
 			return (double)p.setpoint / 1000;
 		case DEPTH:
-			return (int) rint(get_depth_units(p.depth, NULL, NULL));
+			return (int) rint(get_depth_units(p.depth.mm, NULL, NULL));
 		case RUNTIME:
 			return p.time / 60;
 		case DURATION:
@@ -288,7 +288,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 		switch (index.column()) {
 		case DEPTH:
 			if (value.toInt() >= 0) {
-				p.depth = units_to_depth(value.toInt()).mm;
+				p.depth = units_to_depth(value.toInt());
 				if (updateMaxDepth())
 					CylindersModel::instance()->updateBestMixes();
 			}
@@ -542,7 +542,7 @@ void DivePlannerPointsModel::setDropStoneMode(bool value)
 		beginInsertRows(QModelIndex(), 0, 0);
 		/* Copy the first current point */
 		divedatapoint p = divepoints.at(0);
-		p.time = p.depth / prefs.descrate;
+		p.time = p.depth.mm / prefs.descrate;
 		divepoints.push_front(p);
 		endInsertRows();
 	}
@@ -609,7 +609,7 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 	if (seconds == 0 && milimeters == 0 && row != 0) {
 		/* this is only possible if the user clicked on the 'plus' sign on the DivePoints Table */
 		const divedatapoint t = divepoints.at(lastEnteredPoint());
-		milimeters = t.depth;
+		milimeters = t.depth.mm;
 		seconds = t.time + 600; // 10 minutes.
 		cylinderid = t.cylinderid;
 		ccpoint = t.setpoint;
@@ -648,7 +648,7 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 	// add the new stop
 	beginInsertRows(QModelIndex(), row, row);
 	divedatapoint point;
-	point.depth = milimeters;
+	point.depth.mm = milimeters;
 	point.time = seconds;
 	point.cylinderid = cylinderid;
 	point.setpoint = ccpoint;
@@ -793,11 +793,11 @@ void DivePlannerPointsModel::createTemporaryPlan()
 		lastIndex = i;
 		if (i == 0 && mode == PLAN && prefs.drop_stone_mode) {
 			/* Okay, we add a first segment where we go down to depth */
-			plan_add_segment(&diveplan, p.depth / prefs.descrate, p.depth, p.cylinderid, p.setpoint, true);
-			deltaT -= p.depth / prefs.descrate;
+			plan_add_segment(&diveplan, p.depth.mm / prefs.descrate, p.depth.mm, p.cylinderid, p.setpoint, true);
+			deltaT -= p.depth.mm / prefs.descrate;
 		}
 		if (p.entered)
-			plan_add_segment(&diveplan, deltaT, p.depth, p.cylinderid, p.setpoint, true);
+			plan_add_segment(&diveplan, deltaT, p.depth.mm, p.cylinderid, p.setpoint, true);
 	}
 
 	// what does the cache do???


### PR DESCRIPTION
This is needed in the altitude pressure conversion as there
negative altitudes are possible (for diving in the netherlands
or the Dead Sea).

Signed-off-by: Robert C. Helling <helling@atdotde.de>


Have I complained about the use of unsigned before that caused weird computational bugs when stuff unexpectedly goes negative....?