### PR TITLE
Bugfix cylindermodel

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -143,7 +143,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 		// seem implausible
 		case START:
 		case END:
-			if ((cyl->start.mbar && !cyl->end.mbar) ||
+			if ((cyl->start.mbar && !cyl->end.mbar && !cyl->sample_end.mbar) ||
 					(cyl->end.mbar && cyl->start.mbar <= cyl->end.mbar))
 				ret = REDORANGE1_HIGH_TRANS;
 			break;
@@ -157,7 +157,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 			font.setItalic(!cyl->start.mbar);
 			break;
 		case END:
-			font.setItalic(!cyl->end.mbar);
+			font.setItalic(!cyl->end.mbar && !cyl->sample_end.mbar);
 			break;
 		}
 		ret = font;

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -20,7 +20,7 @@ CylindersModel::CylindersModel(QObject *parent) :
 
 QVariant CylindersModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-	if (role == Qt::DisplayRole && in_planner() && section == WORKINGPRESS)
+	if (role == Qt::DisplayRole && orientation == Qt::Horizontal && in_planner() && section == WORKINGPRESS)
 		return tr("Start press.");
 	else
 		return CleanerTableModel::headerData(section, orientation, role);


### PR DESCRIPTION
Two bugfixes for the cylinder table:
- Fix cyclinder table issue "workingpressure" in planner
- Don't erroneously mark the cylinder pressure red and set font italic