### PR TITLE
Bugfix cylindermodel add units and correct trash icon

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -207,14 +207,14 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 			} else {
 				pressure_t modpO2;
 				modpO2.mbar = prefs.bottompo2;
-				ret = get_depth_string(gas_mod(&cyl->gasmix, modpO2, &displayed_dive, M_OR_FT(1,1)));
+				ret = get_depth_string(gas_mod(&cyl->gasmix, modpO2, &displayed_dive, M_OR_FT(1,1)), true);
 			}
 			break;
 		case MND:
 			if (cyl->bestmix_he)
 				ret = QString("*");
 			else
-				ret = get_depth_string(gas_mnd(&cyl->gasmix, prefs.bestmixend, &displayed_dive, M_OR_FT(1,1)));
+				ret = get_depth_string(gas_mnd(&cyl->gasmix, prefs.bestmixend, &displayed_dive, M_OR_FT(1,1)), true);
 			break;
 		case USE:
 			ret = gettextFromC::instance()->trGettext(cylinderuse_text[cyl->cylinder_use]);


### PR DESCRIPTION
Two more fixes for the cylinder table:
1. Add the units (m or ft) for MOD and MND in cylinder table in planner
2. Correctly diplay a trash or trashforbidden icon for each cylinder in the table plus the correct tooltip

Both changes needs careful review!

For second change the following is open:
What is the best way to update the trash/trashforbidden icon in the planner when used gasses are added/removed in the planner points? Help needed! :-)
