### PR TITLE
Fix double to int truncation in C++ code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	# in currently used cmake version.
 	if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9.0")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wfloat-conversion")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wfloat-conversion")
 	endif()
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")

--- a/core/configuredivecomputerthreads.cpp
+++ b/core/configuredivecomputerthreads.cpp
@@ -1566,7 +1566,7 @@ void DeviceThread::event_cb(dc_device_t *device, dc_event_type_t event, const vo
 
 	switch (event) {
 	case DC_EVENT_PROGRESS:
-		dt->progressCB(100.0 * (double)progress->current / (double)progress->maximum);
+		dt->progressCB(lrint(100.0 * (double)progress->current / (double)progress->maximum));
 		break;
 	default:
 		emit dt->error("Unexpected event recived");

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -157,8 +157,8 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 		gpsTracker gt;
 		gt.when = pos.timestamp().toTime_t();
 		gt.when += gettimezoneoffset(gt.when);
-		gt.latitude.udeg = lrint(pos.coordinate().latitude() * 1000000);
-		gt.longitude.udeg = lrint(pos.coordinate().longitude() * 1000000);
+		gt.latitude.udeg = (int)(pos.coordinate().latitude() * 1000000);
+		gt.longitude.udeg = (int)(pos.coordinate().longitude() * 1000000);
 		addFixToStorage(gt);
 	}
 }
@@ -612,8 +612,8 @@ void GpsLocation::downloadFromServer()
 
 				struct gpsTracker gt;
 				gt.when = timestamp.toMSecsSinceEpoch() / 1000;
-				gt.latitude.udeg = latitude.toDouble() * 1000000;
-				gt.longitude.udeg = longitude.toDouble() * 1000000;
+				gt.latitude.udeg = (int)(latitude.toDouble() * 1000000);
+				gt.longitude.udeg = (int)(longitude.toDouble() * 1000000);
 				gt.name = name;
 				// add this GPS fix to the QMap and the settings (remove existing fix at the same timestamp first)
 				if (m_trackers.keys().contains(gt.when)) {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -775,7 +775,7 @@ int parseDurationToSeconds(const QString &text)
 		hours = "0";
 		minutes = numOnly;
 	}
-	secs = hours.toDouble() * 3600 + minutes.toDouble() * 60 + seconds.toDouble();
+	secs = lrint(hours.toDouble() * 3600 + minutes.toDouble() * 60 + seconds.toDouble());
 	return secs;
 }
 
@@ -788,7 +788,7 @@ int parseLengthToMm(const QString &text)
 		return 0;
 	double number = numOnly.toDouble();
 	if (text.contains(QObject::tr("m"), Qt::CaseInsensitive)) {
-		mm = number * 1000;
+		mm = lrint(number * 1000);
 	} else if (text.contains(QObject::tr("ft"), Qt::CaseInsensitive)) {
 		mm = feet_to_mm(number);
 	} else {
@@ -797,7 +797,7 @@ int parseLengthToMm(const QString &text)
 			mm = feet_to_mm(number);
 			break;
 		case units::METERS:
-			mm = number * 1000;
+			mm = lrint(number * 1000);
 			break;
 		default:
 			mm = 0;

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -494,11 +494,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 	deviceDetails->dynamicAscendRate = ui.dynamicAscendRate->isChecked();
 	deviceDetails->graphicalSpeedIndicator = ui.graphicalSpeedIndicator->isChecked();
 	deviceDetails->alwaysShowppO2 = ui.alwaysShowppO2->isChecked();
-	deviceDetails->tempSensorOffset = ui.tempSensorOffsetDoubleSpinBox->value() * 10;
+	deviceDetails->tempSensorOffset = lrint(ui.tempSensorOffsetDoubleSpinBox->value() * 10);
 	deviceDetails->safetyStopLength = ui.safetyStopLengthSpinBox->value();
-	deviceDetails->safetyStopStartDepth = ui.safetyStopStartDepthDoubleSpinBox->value() * 10;
-	deviceDetails->safetyStopEndDepth = ui.safetyStopEndDepthDoubleSpinBox->value() * 10;
-	deviceDetails->safetyStopResetDepth = ui.safetyStopResetDepthDoubleSpinBox->value() * 10;
+	deviceDetails->safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox->value() * 10);
+	deviceDetails->safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox->value() * 10);
+	deviceDetails->safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox->value() * 10);
 
 	//set gas values
 	gas gas1;
@@ -612,7 +612,7 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 	deviceDetails->desaturation = ui.desaturationSpinBox_3->value();
 	deviceDetails->lastDeco = ui.lastDecoSpinBox_3->value();
 	deviceDetails->samplingRate = ui.samplingRateSpinBox_3->value();
-	deviceDetails->salinity = ui.salinityDoubleSpinBox_3->value() * 100;
+	deviceDetails->salinity = lrint(ui.salinityDoubleSpinBox_3->value() * 100);
 	deviceDetails->dateFormat = ui.dateFormatComboBox_3->currentIndex();
 	deviceDetails->syncTime = ui.dateTimeSyncCheckBox_3->isChecked();
 	deviceDetails->safetyStop = ui.safetyStopCheckBox_3->isChecked();
@@ -629,9 +629,9 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 	deviceDetails->decoGasConsumption = ui.decoGasConsumption_3->value();
 	deviceDetails->graphicalSpeedIndicator = ui.graphicalSpeedIndicator_3->isChecked();
 	deviceDetails->safetyStopLength = ui.safetyStopLengthSpinBox_3->value();
-	deviceDetails->safetyStopStartDepth = ui.safetyStopStartDepthDoubleSpinBox_3->value() * 10;
-	deviceDetails->safetyStopEndDepth = ui.safetyStopEndDepthDoubleSpinBox_3->value() * 10;
-	deviceDetails->safetyStopResetDepth = ui.safetyStopResetDepthDoubleSpinBox_3->value() * 10;
+	deviceDetails->safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox_3->value() * 10);
+	deviceDetails->safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox_3->value() * 10);
+	deviceDetails->safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox_3->value() * 10);
 
 	//set gas values
 	gas gas1;

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -228,7 +228,7 @@ void DivePlannerWidget::heightChanged(const int height)
 void DivePlannerWidget::salinityChanged(const double salinity)
 {
 	/* Salinity is expressed in weight in grams per 10l */
-	plannerModel->setSalinity(10000 * salinity);
+	plannerModel->setSalinity(lrint(10000 * salinity));
 }
 
 void PlannerSettingsWidget::bottomSacChanged(const double bottomSac)
@@ -478,27 +478,27 @@ void PlannerSettingsWidget::printDecoPlan()
 
 void PlannerSettingsWidget::setAscRate75(int rate)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setAscrate75(rate * UNIT_FACTOR);
+	SettingsObjectWrapper::instance()->planner_settings->setAscrate75(lrint(rate * UNIT_FACTOR));
 }
 
 void PlannerSettingsWidget::setAscRate50(int rate)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setAscrate50(rate * UNIT_FACTOR);
+	SettingsObjectWrapper::instance()->planner_settings->setAscrate50(lrint(rate * UNIT_FACTOR));
 }
 
 void PlannerSettingsWidget::setAscRateStops(int rate)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setAscratestops(rate * UNIT_FACTOR);
+	SettingsObjectWrapper::instance()->planner_settings->setAscratestops(lrint(rate * UNIT_FACTOR));
 }
 
 void PlannerSettingsWidget::setAscRateLast6m(int rate)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setAscratelast6m(rate * UNIT_FACTOR);
+	SettingsObjectWrapper::instance()->planner_settings->setAscratelast6m(lrint(rate * UNIT_FACTOR));
 }
 
 void PlannerSettingsWidget::setDescRate(int rate)
 {
-	SettingsObjectWrapper::instance()->planner_settings->setDescrate(rate * UNIT_FACTOR);
+	SettingsObjectWrapper::instance()->planner_settings->setDescrate(lrint(rate * UNIT_FACTOR));
 }
 
 void PlannerSettingsWidget::sacFactorChanged(const double factor)

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -126,7 +126,7 @@ void DownloadFromDCWidget::updateProgressBar()
 	} else {
 		ui.progressBar->setFormat("%p%");
 	}
-	ui.progressBar->setValue(progress_bar_fraction * 100);
+	ui.progressBar->setValue(lrint(progress_bar_fraction * 100));
 }
 
 void DownloadFromDCWidget::updateState(states state)

--- a/desktop-widgets/globe.cpp
+++ b/desktop-widgets/globe.cpp
@@ -267,7 +267,7 @@ void GlobeGPS::centerOnDiveSite(struct dive_site *ds)
 	// otherwise check to make sure we aren't still running an animation and then remember
 	// the current zoom level
 	if (currentZoomLevel == -1) {
-		currentZoomLevel = zoomFromDistance(3.0);
+		currentZoomLevel = lrint(zoomFromDistance(3.0));
 		centerOn(longitude, latitude);
 		fixZoom(true);
 		return;

--- a/desktop-widgets/groupedlineedit.cpp
+++ b/desktop-widgets/groupedlineedit.cpp
@@ -139,9 +139,9 @@ QSize GroupedLineEdit::sizeHint() const
 {
 	QSize rs(
 		40,
-		document()->findBlock(0).layout()->lineAt(0).height() +
+		lrint(document()->findBlock(0).layout()->lineAt(0).height() +
 			document()->documentMargin() * 2 +
-			frameWidth() * 2);
+			frameWidth() * 2));
 	return rs;
 }
 

--- a/desktop-widgets/kmessagewidget.cpp
+++ b/desktop-widgets/kmessagewidget.cpp
@@ -177,8 +177,8 @@ void KMessageWidgetPrivate::updateSnapShot()
 
 void KMessageWidgetPrivate::slotTimeLineChanged(qreal value)
 {
-    q->setFixedHeight(qMin(value * 2, qreal(1.0)) * content->height());
-    q->update();
+	q->setFixedHeight(lrint(qMin(value * 2, qreal(1.0)) * content->height()));
+	q->update();
 }
 
 void KMessageWidgetPrivate::slotTimeLineFinished()

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -156,8 +156,8 @@ void LocationInformationWidget::acceptChanges()
 	if (!ui.diveSiteCoordinates->text().isEmpty()) {
 		double lat, lon;
 		parseGpsText(ui.diveSiteCoordinates->text(), &lat, &lon);
-		currentDs->latitude.udeg = lat * 1000000.0;
-		currentDs->longitude.udeg = lon * 1000000.0;
+		currentDs->latitude.udeg = (int)(lat * 1000000.0);
+		currentDs->longitude.udeg = (int)(lon * 1000000.0);
 	}
 	if (dive_site_is_empty(currentDs)) {
 		LocationInformationModel::instance()->removeRow(get_divesite_idx(currentDs));
@@ -232,8 +232,8 @@ void LocationInformationWidget::on_diveSiteCoordinates_textChanged(const QString
 	if (!same_string(qPrintable(text), coords)) {
 		double latitude, longitude;
 		if (parseGpsText(text, &latitude, &longitude)) {
-			displayed_dive_site.latitude.udeg = latitude * 1000000;
-			displayed_dive_site.longitude.udeg = longitude * 1000000;
+			displayed_dive_site.latitude.udeg = (int)(latitude * 1000000);
+			displayed_dive_site.longitude.udeg = (int)(longitude * 1000000);
 			markChangedWidget(ui.diveSiteCoordinates);
 			emit coordinatesChanged();
 			ui.geoCodeButton->setEnabled(latitude != 0 && longitude != 0);

--- a/desktop-widgets/maintab.cpp
+++ b/desktop-widgets/maintab.cpp
@@ -629,7 +629,7 @@ void MainTab::updateDiveInfo(bool clear)
 				continue;
 			volumes.append(get_volume_string(gases[i], true));
 			if (duration[i]) {
-				sac.mliter = gases[i].mliter / (depth_to_atm(mean[i], &displayed_dive) * duration[i] / 60);
+				sac.mliter = lrint(gases[i].mliter / (depth_to_atm(mean[i], &displayed_dive) * duration[i] / 60));
 				SACs.append(get_volume_string(sac, true).append(tr("/min")));
 			}
 		}

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1041,8 +1041,8 @@ void MainWindow::on_actionYearlyStatistics_triggered()
 	QTreeView *view = new QTreeView();
 	view->setModel(m);
 	l->addWidget(view);
-	d.resize(width() * .8, height() / 2);
-	d.move(width() * .1, height() / 4);
+	d.resize(lrint(width() * .8), height() / 2);
+	d.move(lrint(width() * .1), height() / 4);
 	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), &d);
 	connect(close, SIGNAL(activated()), &d, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), &d);
@@ -1105,19 +1105,19 @@ void MainWindow::on_actionViewAll_triggered()
 	const int appH = qApp->desktop()->size().height();
 	const int appW = qApp->desktop()->size().width();
 	if (mainSizes.empty()) {
-		mainSizes.append(appH * 0.7);
-		mainSizes.append(appH * 0.3);
+		mainSizes.append(lrint(appH * 0.7));
+		mainSizes.append(lrint(appH * 0.3));
 	}
 	static QList<int> infoProfileSizes;
 	if (infoProfileSizes.empty()) {
-		infoProfileSizes.append(appW * 0.3);
-		infoProfileSizes.append(appW * 0.7);
+		infoProfileSizes.append(lrint(appW * 0.3));
+		infoProfileSizes.append(lrint(appW * 0.7));
 	}
 
 	static QList<int> listGlobeSizes;
 	if (listGlobeSizes.empty()) {
-		listGlobeSizes.append(appW * 0.7);
-		listGlobeSizes.append(appW * 0.3);
+		listGlobeSizes.append(lrint(appW * 0.7));
+		listGlobeSizes.append(lrint(appW * 0.3));
 	}
 
 	QSettings settings;

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -526,18 +526,18 @@ print_part:
 	if (option.state & QStyle::State_Selected) {
 		painter->setPen(QPen(opt.palette.highlight().color().darker()));
 		painter->setBrush(opt.palette.highlight());
-		const qreal pad = 1.0;
-		const qreal pad2 = pad * 2.0;
-		const qreal rounding = 5.0;
+		const int pad = 1;
+		const int pad2 = pad * 2;
+		const int rounding = 5;
 		painter->drawRoundedRect(option.rect.x() + pad,
-			option.rect.y() + pad,
-			option.rect.width() - pad2,
-			option.rect.height() - pad2,
-			rounding, rounding);
+					option.rect.y() + pad,
+					option.rect.width() - pad2,
+					option.rect.height() - pad2,
+					rounding, rounding);
 	}
 	painter->setPen(textPen);
 	painter->setFont(fontBigger);
-	const qreal textPad = 5.0;
+	const int textPad = 5;
 	painter->drawText(option.rect.x() + textPad, option.rect.y() + fmBigger.boundingRect("YH").height(), diveSiteName);
 	double pointSize = fontSmaller.pointSizeF();
 	fontSmaller.setPointSizeF(0.9 * pointSize);

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -104,7 +104,7 @@ void Printer::flowRender()
 			webView->page()->mainFrame()->scroll(0, dontbreakElement.geometry().y() - start);
 
 			// rendering progress is 4/5 of total work
-			emit(progessUpdated((end * 80.0 / fullPageResolution) + done));
+			emit(progessUpdated(lrint((end * 80.0 / fullPageResolution) + done)));
 
 			// add new pages only in print mode, while previewing we don't add new pages
 			if (printMode == Printer::PRINT)
@@ -183,7 +183,7 @@ void Printer::render(int Pages = 0)
 		viewPort.adjust(0, pageSize.height(), 0, pageSize.height());
 
 		// rendering progress is 4/5 of total work
-		emit(progessUpdated((i * 80.0 / Pages) + done));
+		emit(progessUpdated(lrint((i * 80.0 / Pages) + done)));
 		if (i < Pages - 1 && printMode == Printer::PRINT)
 			static_cast<QPrinter*>(paintDevice)->newPage();
 	}

--- a/desktop-widgets/templateedit.cpp
+++ b/desktop-widgets/templateedit.cpp
@@ -17,7 +17,7 @@ TemplateEdit::TemplateEdit(QWidget *parent, struct print_options *printOptions, 
 
 	// restore the settings and init the UI
 	ui->fontSelection->setCurrentIndex(templateOptions->font_index);
-	ui->fontsize->setValue(templateOptions->font_size);
+	ui->fontsize->setValue(lrint(templateOptions->font_size));
 	ui->colorpalette->setCurrentIndex(templateOptions->color_palette_index);
 	ui->linespacing->setValue(templateOptions->line_spacing);
 	ui->borderwidth->setValue(templateOptions->border_width);

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -105,7 +105,7 @@ QString TemplateLayout::generate()
 		DiveObjectHelper *d = new DiveObjectHelper(dive);
 		diveList.append(QVariant::fromValue(d));
 		progress++;
-		emit progressUpdated(progress * 100.0 / totalWork);
+		emit progressUpdated(lrint(progress * 100.0 / totalWork));
 	}
 	Grantlee::Context c;
 	c.insert("dives", diveList);

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -369,7 +369,7 @@ QString DepthAxis::textForValue(double value)
 {
 	if (value == 0)
 		return QString();
-	return get_depth_string(value, false, false);
+	return get_depth_string(lrint(value), false, false);
 }
 
 QColor DepthAxis::colorForValue(double value)
@@ -409,7 +409,7 @@ QColor TimeAxis::colorForValue(double value)
 
 QString TimeAxis::textForValue(double value)
 {
-	int nr = value / 60;
+	int nr = lrint(value) / 60;
 	if (maximum() < 600)
 		return QString("%1:%2").arg(nr).arg((int)value % 60, 2, 10, QChar('0'));
 	return QString::number(nr);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -667,7 +667,7 @@ void DiveMeanDepthItem::createTextItem() {
 	texts.clear();
 	int decimals;
 	const char *unitText;
-	double d = get_depth_units(lastRunningSum, &decimals, &unitText);
+	double d = get_depth_units(lrint(lastRunningSum), &decimals, &unitText);
 	DiveTextItem *text = new DiveTextItem(this);
 	text->setAlignment(Qt::AlignRight | Qt::AlignTop);
 	text->setBrush(getColor(TEMP_TEXT));

--- a/profile-widget/divetextitem.cpp
+++ b/profile-widget/divetextitem.cpp
@@ -88,7 +88,7 @@ void DiveTextItem::updateText()
 	if ((size = fnt.pixelSize()) > 0) {
 		// set in pixels - so the scale factor may not make a difference if it's too close to 1
 		size *= scale * printScale;
-		fnt.setPixelSize(size);
+		fnt.setPixelSize(lrint(size));
 	} else {
 		size = fnt.pointSizeF();
 		size *= scale * printScale;

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -108,7 +108,7 @@ void ToolTipItem::expand()
 		width = title->boundingRect().width() + sp2;
 	// clip the height
 	if (entryToolTip.first) {
-		const int minH = entryToolTip.first->y() + entryToolTip.first->pixmap().height() + sp2;
+		const int minH = lrint(entryToolTip.first->y() + entryToolTip.first->pixmap().height() + sp2);
 		if (height < minH)
 			height = minH;
 	} else if (height < iconMetrics.sz_small) {
@@ -245,7 +245,7 @@ void ToolTipItem::refresh(const QPointF &pos)
 		return;
 	refreshTime.start();
 
-	int time = timeAxis->valueAt(pos);
+	int time = lrint(timeAxis->valueAt(pos));
 	if (time == lastTime)
 		return;
 
@@ -269,9 +269,9 @@ void ToolTipItem::refresh(const QPointF &pos)
 
 		painter.setPen(QColor(0, 0, 0, 255));
 		if (decoMode() == BUEHLMANN)
-			painter.drawLine(0, 60 - entry->gfline / 2, 16, 60 - entry->gfline / 2);
-		painter.drawLine(0, 60 - AMB_PERCENTAGE * (entry->pressures.n2 + entry->pressures.he) / entry->ambpressure / 2,
-				16, 60 - AMB_PERCENTAGE * (entry->pressures.n2 + entry->pressures.he) / entry->ambpressure /2);
+			painter.drawLine(0, lrint(60 - entry->gfline / 2), 16, lrint(60 - entry->gfline / 2));
+		painter.drawLine(0, lrint(60 - AMB_PERCENTAGE * (entry->pressures.n2 + entry->pressures.he) / entry->ambpressure / 2),
+				16, lrint(60 - AMB_PERCENTAGE * (entry->pressures.n2 + entry->pressures.he) / entry->ambpressure /2));
 		painter.setPen(QColor(0, 0, 0, 127));
 		for (int i=0; i<16; i++) {
 			painter.drawLine(i, 60, i, 60 - entry->percentages[i] / 2);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -975,8 +975,8 @@ void ProfileWidget2::scrollViewTo(const QPoint &pos)
 	QScrollBar *hs = horizontalScrollBar();
 	const qreal yRat = (qreal)pos.y() / viewport()->height();
 	const qreal xRat = (qreal)pos.x() / viewport()->width();
-	vs->setValue(yRat * vs->maximum());
-	hs->setValue(xRat * hs->maximum());
+	vs->setValue(lrint(yRat * vs->maximum()));
+	hs->setValue(lrint(xRat * hs->maximum()));
 }
 
 void ProfileWidget2::mouseMoveEvent(QMouseEvent *event)
@@ -1312,7 +1312,7 @@ bool ProfileWidget2::isAddOrPlanner()
 struct plot_data *ProfileWidget2::getEntryFromPos(QPointF pos)
 {
 	// find the time stamp corresponding to the mouse position
-	int seconds = timeAxis->valueAt(pos);
+	int seconds = lrint(timeAxis->valueAt(pos));
 	struct plot_data *entry = NULL;
 
 	for (int i = 0; i < plotInfo.nr; i++) {
@@ -1540,7 +1540,7 @@ void ProfileWidget2::addBookmark()
 {
 	QAction *action = qobject_cast<QAction *>(sender());
 	QPointF scenePos = mapToScene(mapFromGlobal(action->data().toPoint()));
-	add_event(current_dc, timeAxis->valueAt(scenePos), SAMPLE_EVENT_BOOKMARK, 0, 0, "bookmark");
+	add_event(current_dc, lrint(timeAxis->valueAt(scenePos)), SAMPLE_EVENT_BOOKMARK, 0, 0, "bookmark");
 	invalidate_dive_cache(current_dive);
 	mark_divelist_changed(true);
 	replot();
@@ -1550,7 +1550,7 @@ void ProfileWidget2::addSetpointChange()
 {
 	QAction *action = qobject_cast<QAction *>(sender());
 	QPointF scenePos = mapToScene(mapFromGlobal(action->data().toPoint()));
-	SetpointDialog::instance()->setpointData(current_dc, timeAxis->valueAt(scenePos));
+	SetpointDialog::instance()->setpointData(current_dc, lrint(timeAxis->valueAt(scenePos)));
 	SetpointDialog::instance()->show();
 }
 
@@ -1783,7 +1783,7 @@ void ProfileWidget2::recreatePlannedDive()
 	DiveHandler *activeHandler = qobject_cast<DiveHandler *>(sender());
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
 	int index = fixHandlerIndex(activeHandler);
-	int mintime = 0, maxtime = (timeAxis->maximum() + 10) * 60;
+	int mintime = 0, maxtime = lrint((timeAxis->maximum() + 10) * 60);
 	if (index > 0)
 		mintime = plannerModel->at(index - 1).time;
 	if (index < plannerModel->size() - 1)
@@ -1992,7 +1992,7 @@ void ProfileWidget2::dropEvent(QDropEvent *event)
 
 		FOR_EACH_PICTURE(current_dive) {
 			if (QString(picture->filename) == filename) {
-				picture->offset.seconds = timeAxis->valueAt(mappedPos);
+				picture->offset.seconds = lrint(timeAxis->valueAt(mappedPos));
 				mark_divelist_changed(true);
 				break;
 			}

--- a/profile-widget/ruleritem.cpp
+++ b/profile-widget/ruleritem.cpp
@@ -127,7 +127,7 @@ void RulerItem2::recalculate()
 	const qreal diff = begin.x() + textItem->boundingRect().width();
 	// clamp so that the text doesn't go out of the screen to the right
 	if (diff > view->width()) {
-		begin.setX(begin.x() - (diff - view->width()));
+		begin.setX(lrint(begin.x() - (diff - view->width())));
 		tgtX = mapFromScene(view->mapToScene(begin)).x();
 	}
 	// always show the text bellow the lowest of the start and end points

--- a/qt-models/tankinfomodel.cpp
+++ b/qt-models/tankinfomodel.cpp
@@ -62,7 +62,7 @@ QVariant TankInfoModel::data(const QModelIndex &index, int role) const
 		double bar = (info->psi) ? psi_to_bar(info->psi) : info->bar;
 
 		if (info->cuft && info->psi)
-			ml = cuft_to_l(info->cuft) * 1000 / bar_to_atm(bar);
+			ml = lrint(cuft_to_l(info->cuft) * 1000 / bar_to_atm(bar));
 
 		switch (index.column()) {
 		case BAR:

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -332,7 +332,7 @@ bool compareDecoTime(int actualRunTimeSeconds, int benchmarkRunTimeSeconds, int 
 		* 1% of total run time + 1 minute */
 		int permilDifferenceAllowed = 1 * 10;
 		int absoluteDifferenceAllowedSeconds = 60;
-		int totalDifferenceAllowed = 0.001 * permilDifferenceAllowed * benchmarkRunTimeSeconds + absoluteDifferenceAllowedSeconds;
+		int totalDifferenceAllowed = lrint(0.001 * permilDifferenceAllowed * benchmarkRunTimeSeconds + absoluteDifferenceAllowedSeconds);
 		int totalDifference = abs(actualRunTimeSeconds - benchmarkRunTimeSeconds);
 
 		qDebug("Calculated run time = %d seconds", actualRunTimeSeconds);


### PR DESCRIPTION
Wfloat-conversion enabled for C++ part of the code
Fix warnings raised by the flag using lrint

Original issue reported on the mailing list:
The ascent/descent rates are sometimes not what is expected.
E.g. setting the ascent rate to 10m/min results in an actual
ascent rate of 9m/min.
This is due to truncating the ascent rate preference,
then effectively rounding up the time to reach each stop to 2s intervals.
The result being that setting the ascent rate to 10m/min
results in 20s to ascend 3m (9m/min), when it should be exactly 18s.

Reported-by: John Smith <noseygit@hotmail.com>
Reported-by: Rick Walsh <rickmwalsh@gmail.com>
Signed-off-by: Jeremie Guichard <djebrest@gmail.com>