### PR TITLE
SmartTrak import change tanks import logic and others

### DIFF
--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -424,14 +424,15 @@ static void smtk_build_tank_info(MdbHandle *mdb, cylinder_t *tank, char *idx)
 bool is_same_cylinder(cylinder_t *cyl_a, cylinder_t *cyl_b)
 {
 	// different gasmixes (non zero)
-	if (gasmix_distance(&cyl_a->gasmix, &cyl_b->gasmix) != 0 &&
+	if (cyl_a->gasmix.o2.permille - cyl_b->gasmix.o2.permille != 0 &&
 	    cyl_a->gasmix.o2.permille != 0 &&
 	    cyl_b->gasmix.o2.permille != 0)
+		return false;
 	// different start pressures (possible error 0.1 bar)
-	if (!abs(cyl_a->start.mbar - cyl_b->start.mbar) <= 100)
+	if (!(abs(cyl_a->start.mbar - cyl_b->start.mbar) <= 100))
 		return false;
 	// different end pressures (possible error 0.1 bar)
-	if (!abs(cyl_a->end.mbar - cyl_b->end.mbar) <= 100)
+	if (!(abs(cyl_a->end.mbar - cyl_b->end.mbar) <= 100))
 		return false;
 	// different names (none of them null)
 	if (!same_string(cyl_a->type.description, "---") &&

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -858,7 +858,6 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 		 * Revisit data under some circunstances, e.g. a start pressure = 0 may mean
 		 * that dc doesn't support gas control, in this situation let's look into mdb data
 		 */
-		int numtanks = (tanks == 10) ? 8 : 3; // Subsurface supports up to 8 tanks
 		int pstartcol = coln(PSTART);
 		int o2fraccol = coln(O2FRAC);
 		int hefraccol = coln(HEFRAC);

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -396,7 +396,7 @@ static void smtk_build_location(MdbHandle *mdb, char *idx, timestamp_t when, uin
 	free(str);
 }
 
-static void smtk_build_tank_info(MdbHandle *mdb, struct dive *dive, int tanknum, char *idx)
+static void smtk_build_tank_info(MdbHandle *mdb, cylinder_t *tank, char *idx)
 {
 	MdbTableDef *table;
 	MdbColumn *col[MDB_MAX_COLS];
@@ -409,9 +409,9 @@ static void smtk_build_tank_info(MdbHandle *mdb, struct dive *dive, int tanknum,
 
 	for (i = 1; i <= atoi(idx); i++)
 		mdb_fetch_row(table);
-	dive->cylinder[tanknum].type.description = copy_string(col[1]->bind_ptr);
-	dive->cylinder[tanknum].type.size.mliter = strtod(col[2]->bind_ptr, NULL) * 1000;
-	dive->cylinder[tanknum].type.workingpressure.mbar = strtod(col[4]->bind_ptr, NULL) * 1000;
+	tank->type.description = copy_string(col[1]->bind_ptr);
+	tank->type.size.mliter = lrint(strtod(col[2]->bind_ptr, NULL) * 1000);
+	tank->type.workingpressure.mbar = lrint(strtod(col[4]->bind_ptr, NULL) * 1000);
 
 	smtk_free(bound_values, table->num_cols);
 	mdb_free_tabledef(table);


### PR DESCRIPTION
This set of patches does:
- Fix memory leaks (mostly copy_string() abuse)
- Add smartTrak bookmarks import capability
- Applies lrint() rounding policy as discussed in mailing list
- Modify cylinder import logic
Please, read comments on commits for more info.