### PR TITLE
Don't erroneously mark the cylinder pressure red - second try

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -147,8 +147,11 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 		// seem implausible
 		case START:
 		case END:
-			if ((cyl->start.mbar && !cyl->end.mbar && !cyl->sample_end.mbar) ||
-					(cyl->end.mbar && cyl->start.mbar <= cyl->end.mbar))
+			pressure_t startp, endp;
+			startp = cyl->start.mbar ? cyl->start : cyl->sample_start;
+			endp = cyl->end.mbar ? cyl->end : cyl->sample_end;
+			if ((startp.mbar && !endp.mbar) ||
+					(endp.mbar && startp.mbar <= endp.mbar))
 				ret = REDORANGE1_HIGH_TRANS;
 			break;
 		}
@@ -157,11 +160,12 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 	case Qt::FontRole: {
 		QFont font = defaultModelFont();
 		switch (index.column()) {
+		// if we don't have manually set pressure data use italic font
 		case START:
 			font.setItalic(!cyl->start.mbar);
 			break;
 		case END:
-			font.setItalic(!cyl->end.mbar && !cyl->sample_end.mbar);
+			font.setItalic(!cyl->end.mbar);
 			break;
 		}
 		ret = font;


### PR DESCRIPTION
Second attempt to do the thing with the red background color for cylinder
start and end pressure correctly. This now should cover all scenarios.

This rewrites and partitially reverts commit b8e044d

This for the moment leaves one question open:
What shall the italic font tell the user? Maybe we can find the answer to this question before merging this to:
a) Describe the idea in the code
b) Double check if this part is now correct or not