### PR TITLE
Subsurface-mobile: do send decimal GPS to Google

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -109,6 +109,18 @@ QString DiveObjectHelper::gps() const
 	struct dive_site *ds = get_dive_site_by_uuid(m_dive->dive_site_uuid);
 	return ds ? QString(printGPSCoords(ds->latitude.udeg, ds->longitude.udeg)) : QString();
 }
+
+QString DiveObjectHelper::gps_decimal() const
+{
+	bool savep = prefs.coordinates_traditional;
+	QString val;
+
+	prefs.coordinates_traditional = false;
+	val = gps();
+	prefs.coordinates_traditional = savep;
+	return(val);
+}
+
 QString DiveObjectHelper::duration() const
 {
 	return get_dive_duration_string(m_dive->duration.seconds, QObject::tr("h:"), QObject::tr("min"));

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -18,6 +18,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(int timestamp READ timestamp CONSTANT)
 	Q_PROPERTY(QString location READ location CONSTANT)
 	Q_PROPERTY(QString gps READ gps CONSTANT)
+	Q_PROPERTY(QString gps_decimal READ gps_decimal CONSTANT)
 	Q_PROPERTY(QString duration READ duration CONSTANT)
 	Q_PROPERTY(bool noDive READ noDive CONSTANT)
 	Q_PROPERTY(QString depth READ depth CONSTANT)
@@ -60,6 +61,7 @@ public:
 	QString time() const;
 	QString location() const;
 	QString gps() const;
+	QString gps_decimal() const;
 	QString duration() const;
 	bool noDive() const;
 	QString depth() const;

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -89,7 +89,7 @@ Kirigami.Page {
 		text: qsTr("Show on map")
 		iconName: "gps"
 		onTriggered: {
-			showMap(diveDetailsListView.currentItem.modelData.dive.gps)
+			showMap(diveDetailsListView.currentItem.modelData.dive.gps_decimal)
 		}
 	}
 

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -53,8 +53,8 @@ Item {
 			MouseArea {
 				anchors.fill: parent
 				onClicked: {
-					if (dive.gps !== "")
-						showMap(dive.gps)
+					if (dive.gps_decimal !== "")
+						showMap(dive.gps_decimal)
 				}
 			}
 		}


### PR DESCRIPTION
Sending nicely readable formatted coordinates to Google Maps does not result in a correctly positioned map. Google likes unreadable decimal format.

Little hacky solution. Added a gps_decimal attribute, populate that with the standard function for format a coordinate to string, but reset the preferences value temporary so that it always converts it to decimal style.

fixes #268 

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>