### PR TITLE
User manual EN update batch

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -264,7 +264,8 @@ line segments demarcated by waypoints (white dots on the profile, as shown
 above). The default dive depth is 15 m.
 If the dive depth was 20 m then you need to drag the appropriate waypoints
 downward to 20 m. To add a waypoint, double-click on
-any line segment. To move an additional waypoint, drag it.
+any line segment. To move an additional waypoint, drag it. Moving can also
+be done by selecting the waypoint and using the arrow keys.
 To remove a waypoint, right-click on it and choose "Remove this point" from the
 context menu. Drag the waypoints to represent an
 accurate
@@ -3637,7 +3638,7 @@ of that table corresponds to one of the gas mixtures specified in the _Available
 Add new waypoints until the main features of the dive have been completed, e.g. the
 bottom time segment and deep stops (if these are implemented). In most cases _Subsurface_
 computes additional way points in order to fulfill decompression requirements for that
-dive. A waypoint can be moved by selecting it and by using the arrow keys.
+dive. A waypoint can also be moved by selecting it and by using the arrow keys.
 The waypoints listed in the _Dive Planner Points_ dialogue can be edited by hand in
 order to get a precise presentation of the dive plan. In fact, it is sometimes more easy to create the
 whole dive profile by editing the _Dive Planner Points_ dialog.

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3337,7 +3337,7 @@ to list similar languages. For instance there are several system variants of Eng
 or French. *This particular preference requires a restart of _Subsurface_ to take
 effect*.
 
-In this section also specify appropriate date an time formats for showing dive details.
+In this section also specify appropriate date and time formats for showing dive details.
 
 === Network
 This panel facilitates communication between _Subsurface_ and data sources on the Internet.

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3646,10 +3646,8 @@ whole dive profile by editing the _Dive Planner Points_ dialog.
 Show any changes in gas cylinder used by indicating gas changes as explained
 in the section <<S_CreateProfile,hand-creating a dive profile>>. These changes should
 reflect the cylinders and gas compositions defined in the table with _Available Gases_.
-If two or more gases are used, automatic gas switches will be suggested during the ascent to
-the surface. These changes can be deleted by right-clicking the gas change and
-manually creating a gas change by right-clicking on the appropriate
-waypoint.
+If two or more gases are used, automatic gas switches will be planned during the ascent to
+the surface.
 
 A non-zero value in the "CC setpoint" column of the table of dive planner points
 indicates a valid setpoint for oxygen partial pressure and that the segment

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -2039,7 +2039,7 @@ The mean pO~2~ of the sensors is indicated with a green line,
 The oxygen setpoint values as well as the readings from the individual
 oxygen sensors can be shown. The display of additional CCR information is turned on by
 checking the appropriate boxes in the _Preferences_ panel (accessible by
-selecting xref:S_CCR_options[_File ->  Preferences ->  Graph_]). This part of
+selecting xref:S_CCR_options[_File ->  Preferences ->  Profile_]). This part of
 the _Preferences_ panel is shown in the image below, representing two checkboxes that modify
 the display of pO~2~ when the appropriate toolbar button on the Dive Profile
 has been checked.
@@ -2098,7 +2098,7 @@ by clicking the appropriate button to the left of the dive profile:
 image::images/icons/cceiling.jpg["DC ceiling icon"]
 
 The default color of the computer-generated deco ceiling is white. This can be set to red
-by checking the appropriate check box after selecting _File  ->  Preferences  ->  Graph_.
+by checking the appropriate check box after selecting _File  ->  Preferences  ->  Profile_.
 Below is a dive profile indicating the dive computer-generated deco ceiling:
 
 image::images/CCR_dive_ceilingF22.jpg["FIGURE: CCR computer-generated deco ceiling",align="center"]
@@ -2214,7 +2214,7 @@ buttons on the left of the profile panel. These are:
 Show the *Maximum Operating Depth (MOD)* of the dive, given the
 gas mixture used. MOD is dependent on the oxygen concentration in the breathing gas.
 For air (21% oxygen) it is around 57 m if a maximum pO~2~ of 1.4 is specified in the *Preferences* section
-(select _File -> Preferences -> Graph_ and edit the text box _pO~2~ in calculating MOD_.
+(select _File -> Preferences -> Profile_ and edit the text box _pO~2~ in calculating MOD_.
 When diving below the MOD there is a markedly increased risk of exposure to the dangers of oxygen toxicity.
 
 [icon="images/icons/NDL.jpg"]
@@ -3686,7 +3686,7 @@ the transitions are shown separately from the segment durations at a particular 
 
 To plan a dive using a passive semi-closed rebreather (pSCR), select _pSCR_ rather than
 _Open circuit_ in the dropdown list.
-The parameters of the pSCR dive can be set by selecting  _File ->   Preferences ->   Graph_
+The parameters of the pSCR dive can be set by selecting  _File ->   Preferences ->   Profile_
 from the main menu, where the gas consumption calculation takes into account the pSCR dump
 ratio (default 1:10) as well as the metabolic rate. The calculation also takes the oxygen drop
 accross the mouthpiece of the rebreather into account. If the
@@ -3712,7 +3712,7 @@ list, circled in blue in the image below.
 diluent cylinder and for any bail-out cylinders. Do NOT enter the information for the oxygen
 cylinder since it is implied when the _CCR_ dropdown selection is made.
 
-*Entering setpoints*: Specify a default setpoint in the Preferences tab, by selecting _File ->  Preferences ->  Graph_ from
+*Entering setpoints*: Specify a default setpoint in the Preferences tab, by selecting _File ->  Preferences ->  Profile_ from
 the main menu. All user-entered segments in the _Dive planner points_ table
 use the default setpoint value. Then, different setpoints can be specified for dive segments
 in the _Dive planner points_ table. A zero setpoint

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3616,7 +3616,7 @@ At the same moment the combined SAC of both divers is increased by a estimated f
 The result of the minimum gas calculation for the bottom gas is printed to the planner output as an
 additional information. No automatic checks are performed based on this result.
 Please take care that the feature only gives valid results for simple, rectengular shaped single
-level dive profiles. For multi level dives one would need to check every leg of the profile independantly.
+level dive profiles. For multi level dives one would need to check every leg of the profile independently.
 
 
 Now you can start the detailed time-depth planning of the dive. _Subsurface_ offers an unique
@@ -3635,8 +3635,7 @@ Each waypoint on the dive profile creates a _Dive Planner Point_ in the table on
 left of the dive planner panel. Ensure the _Used Gas_ value in each row
 of that table corresponds to one of the gas mixtures specified in the _Available Gases_ table.
 Add new waypoints until the main features of the dive have been completed, e.g. the
-bottom time segment and deep stops (if these are implemented). Leave the remaining
-waypoints on the ascent to _Subsurface_. In most cases _Subsurface_
+bottom time segment and deep stops (if these are implemented). In most cases _Subsurface_
 computes additional way points in order to fulfill decompression requirements for that
 dive. A waypoint can be moved by selecting it and by using the arrow keys.
 The waypoints listed in the _Dive Planner Points_ dialogue can be edited by hand in

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1286,7 +1286,7 @@ after _Dive date_). If the field names in the first line are long, the alignment
 cannot be maintained. Here is a highly simplified and shortened TAB-delimited example of a _CSV_ dive log
 from an APD closed-circuit rebreather (CCR) dive computer:
 
-	Dive Time (s)	Depth (m)	pO₂ - Setpoint (Bar) 	pO₂ - C1 Cell 1 (Bar)	Ambient temp. (Celsius)
+	Dive Time (s)	Depth (m)	pO~2~ - Setpoint (Bar) 	pO~2~ - C1 Cell 1 (Bar)	Ambient temp. (Celsius)
 	0       0.0     0.70    0.81    13.1
 	0       1.2     0.70    0.71    13.1
 	0       0.0     0.70    0.71    13.1
@@ -3387,7 +3387,7 @@ image::images/Pref7_f23.jpg["FIGURE: Georeference panel",align="center"]
 Dive planning is an advanced feature of _Subsurface_, accessed by selecting
 _Log ->  Plan Dive_ from the main menu. It allows calculation of
 inert gas load during a dive by using the Bühlmann ZH-L16 algorithm with the addition
-of gradient factors as implemented by Erik Baker.
+of gradient factors as implemented by Erik Baker, or using the VPM-B model.
 
 ****
 [icon="images/icons/warning2.png"]
@@ -3412,7 +3412,7 @@ user interface. It is explicitly used under the following conditions:
 === The _Subsurface_ dive planner screen
 
 Like the _Subsurface_ dive log, the planner screen is divided into several sections (see image below). The *setup*
-parameters for a dive are entered into the sections on the left hand side of the screen.
+parameters for a dive are entered into the sections on the left hand and bottom side of the screen.
 They are: Available Gases, Rates, Planning, Gas Options and Notes.
 
 At the top right hand is a green *design panel* on which the profile of the dive can be
@@ -3442,18 +3442,18 @@ image::images/PlannerWindow1_f20.jpg["FIGURE: Dive planner startup window",align
 - In the table labelled _Available Gases_, add the information of the cylinders to be used
   as well as the gas composition within that cylinder. This is done in a similar way as for
   <<cylinder_definitions,providing cylinder data for dive logs>>. Choose the cylinder type by
-  double clicking the cylinder type and using the dropdown list, then specify the work
-  pressure of this cylinder. By leaving the oxygen concentration (O2%) field empty,
+  double clicking the cylinder type and using the dropdown list, then specify the start
+  pressure of this cylinder. By leaving the oxygen concentration (O~2~%) field empty,
   the cylinder is assumed to contain air. Otherwise enter the oxygen and/or helium
   concentration in the boxes provided in this dialogue. Add additional cylinders by using the
   "+" icon to the top right-hand of the dialogue.
 
 - The _Available Gases_ table includes three gas depth fields, labelled:
  ** Deco switch at: the switch depth for deco gases. Unless overridden by the user, this will be
-    automatically calculated based on the Deco pO₂ preference (default 1.6 bar)
+    automatically calculated based on the Deco pO~2~ preference (default 1.6 bar)
  ** Bot. MOD: the gas Maximum Operating Depth (MOD) if it is used as a bottom mix. Automatically
-    calculated based on the Bottom pO₂ preference (default 1.4 bar). Editing this field will modify the
-    O₂% according to the depth set. Set to ''*'' to calculate the best O₂% for the dive maximum depth.
+    calculated based on the Bottom pO~2~ preference (default 1.4 bar). Editing this field will modify the
+    O~2~% according to the depth set. Set to ''*'' to calculate the best O~2~% for the dive maximum depth.
  ** MND: the gas Maximum Narcotic Depth (MND). Automatically calculated based on the Best Mix END
     preference (default 30m / 98 ft). Editing this field will modify the He% according to the depth set.
     Set to ''*'' to calculate the best He% for the dive maximum depth.
@@ -3498,7 +3498,7 @@ the nitrogen load incurred during previous dives.
   Check these two boxes.
 
 - Then define the cylinder size,
-  the gas mixture (air or % oxygen) and the starting cylinder pressure in the top left-hand
+  the gas mixture (air or % oxygen) and the working cylinder pressure in the top left-hand
   section of the planner under _Available gases_.
 
 - The planner calculates whether the specified cylinder contains enough air/gas to complete
@@ -3582,7 +3582,7 @@ in the _Rates_ section of the dive setup.
 pressure for oxygen needs to be specified for the
 bottom part of the dive (_bottom po2_) as well as for the decompression part of the dive (_deco po2_).
 Commonly used values are 1.4 bar for the bottom part of the dive and 1.6 bar for any decompression
-stages. Normally, a partial pressure of 1.6 bar is not exceeded. pO₂ settings and the depth at which switching to a gas takes place can also be edited in the
+stages. Normally, a partial pressure of 1.6 bar is not exceeded. pO~2~ settings and the depth at which switching to a gas takes place can also be edited in the
 _Available Gases_ dialog. Normally the planner decides on switching to a new gas when, during
 ascent, the partial pressure of the new gas has decreased to 1.6 bar.
 
@@ -4097,7 +4097,7 @@ and select 'Add new device'. The dive computer should appear. If asked for a pas
 Write down or copy the MAC address of your dive computer - this needed later and should be in the form 	00:11:22:33:44:55.
 
 If the graphical method doesn't work, pair the device from the command line. Open a terminal
-and use +hciconfig+ to check the Bluetooth controller status
+and use +hciconfig+ to check the Bluetooth controller status.
 
 	$ hciconfig
 	hci0:	Type: BR/EDR  Bus: USB
@@ -4121,7 +4121,7 @@ Now power on the controller and enable authentication:
 
 Check that the status now includes +'UP', 'RUNNING' AND 'AUTH'+.
 
-If there are multiple controllers running, it's easiest to off the unused controller(s). For example, for +hci1+:
+If there are multiple controllers running, it's easiest to turn off the unused controller(s). For example, for +hci1+:
 
 	sudo hciconfig hci1 down
 
@@ -4160,7 +4160,7 @@ If the system has Bluez version 4 (e.g. Ubuntu 12.04 through to 15.04), there is
 		00:11:22:33:44:55       Petrel
 		bluez-simple-agent hci0 00:11:22:33:44:55
 
-Once ther dive computer is pired, set up the RFCOMM connection
+Once the dive computer is paired, set up the RFCOMM connection.
 
 ===== Establishing the RFCOMM connection
 

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1473,7 +1473,7 @@ On first use the app has three options:
 [IMPORTANT]
 In the _Subsurface_ main program, the *DIVERID* should also be entered on the
 Default Preferences
-panel, by selecting _File ->  Preferences ->  Defaults_ from the main menu
+panel, by selecting _File ->  Preferences ->  General_ from the main menu
 in _Subsurface_ itself.
 This helps synchronization between _Subsurface_ and the Companion App.
 

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3582,8 +3582,9 @@ in the _Rates_ section of the dive setup.
 pressure for oxygen needs to be specified for the
 bottom part of the dive (_bottom po2_) as well as for the decompression part of the dive (_deco po2_).
 Commonly used values are 1.4 bar for the bottom part of the dive and 1.6 bar for any decompression
-stages. Normally, a partial pressure of 1.6 bar is not exceeded. pO~2~ settings and the depth at which switching to a gas takes place can also be edited in the
-_Available Gases_ dialog. Normally the planner decides on switching to a new gas when, during
+stages. Normally, a partial pressure of 1.6 bar is not exceeded. The depth at which switching to a gas
+takes place can be edited in the
+_Available Gases_ dialog. Normally, the planner decides on switching to a new gas when, during
 ascent, the partial pressure of the new gas has decreased to 1.6 bar.
 
 *c) Gas management*: With open-circuit dives this is a primary

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -2051,7 +2051,7 @@ The first checkbox allows the display of setpoint information. This is a red lin
 superimposed on the green oxygen partial pressure graph and allows a comparison of the
 mean measured oxygen partial pressure and the setpoint values, as shown below.
 
-image::images/CCR_setpoint_f20.jpg["FIGURE: CCR setpoint and po2 graph",align="center"]
+image::images/CCR_setpoint_f20.jpg["FIGURE: CCR setpoint and pO~2~ graph",align="center"]
 
 The second checkbox allows the display of the data from each individual oxygen sensor
 of the CCR equipment. The data for each sensor is colour-coded as follows:
@@ -3261,7 +3261,7 @@ image::images/Pref4_f23.jpg["FIGURE: Preferences Graph page",align="center"]
     during a particular dive. Setpoint changes during the dive can be added via the
     profile context menu.
 
-*** _CCR: Show setpoints when viewing pO2:_ With this checkbox activated, the pO~2~
+*** _CCR: Show setpoints when viewing pO~2~:_ With this checkbox activated, the pO~2~
     graph on the dive profile has an overlay in red which indicates the CCR setpoint
     values. See the section on xref:S_CCR_dives[Closed Circuit Rebreather dives].
 

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3342,10 +3342,9 @@ In this section also specify appropriate date and time formats for showing dive 
 === Network
 This panel facilitates communication between _Subsurface_ and data sources on the Internet.
 This is important, for instance, when _Subsurface_ needs to communicate with web
-services such as Cloud storage or the <<S_Companion,_Subsurface
-Companion app_>>. These Internet requirements are determined by your type of
-connection to the Internet and by the Internet Service Provider (ISP) used.
-Your ISP should provide the appropriate information.
+services such as Cloud storage, the <<S_Companion,_Subsurface
+Companion app_>> or when you want to communicate through a proxy.
+
 
 image::images/Pref5_f23.jpg["FIGURE: Preferences Network page",align="center"]
 

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3350,7 +3350,7 @@ image::images/Pref5_f23.jpg["FIGURE: Preferences Network page",align="center"]
 
 This dialogue has three sections:
 
-** _Proxy type_:
+** _Proxy_:
 If a proxy server is used for Internet access, the type of proxy needs to be selected from the dropdown list,
 after which the IP address of the host and the appropriate port number should
 be provided. If the proxy server uses authentication, the appropriate userID and

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3691,9 +3691,11 @@ from the main menu, where the gas consumption calculation takes into account the
 ratio (default 1:10) as well as the metabolic rate. The calculation also takes the oxygen drop
 accross the mouthpiece of the rebreather into account. If the
 pO~2~ drops below what is considered safe, a warning appears in the _Dive plan
-details_. A typical pSCR configuration is with a single cylinder and one or more bail-out
-cylinders. Therefore the setup of the _Available gases_ and the _Dive planner points_ tables
-are very similar to that of a CCR dive plan, described below. However, no oxygen setpoints
+details_. A typical pSCR cylinder setup is very similar to an open circuit dive;
+one or more drive cilinders, possibly with different bottom and decompression
+gasses, including gas switches during the dive like in open circuit diving.
+Therefore, the setup of the _Available gases_ and the _Dive planner points_ tables
+are very similar to that of a open circuit dive plan, described above. However, no oxygen setpoints
 are specified for pSCR dives. Below is a dive plan for a pSCR dive. The dive is comparable
 to that of the CCR dive below, but note the longer ascent duration due to the lower oxygen
 in the loop due to the oxygen drop across the mouthpiece of the pSCR equipment.


### PR DESCRIPTION
And another small batch of user manual updates. From simple spelling stuff to changes due to UI changes.

One "major" thing is pSCR (also in the previous batch) handling/planning/cylinder choices. Not sure why the manual thinks that pSCR is single tank, single gas diving (well, probably exposed to a Drager Dolphin). For me, recreational rebreather (pSCR, MCCR, eCCR, ...) does not exist. It is something technical, and accelerated deco using the proper gas for that is done by 99% of pSCR divers I know. 