### PR TITLE
Add double imperial tanks to defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_AUTOMOC ON)
 include(cmake/Modules/MacroOutOfSourceBuild.cmake)
 MACRO_ENSURE_OUT_OF_SOURCE_BUILD(
-    "We don't support building in source, please create a build folder elsewhere and remember to run git clean -xdf to remoev temporary files created by CMake."
+    "We don't support building in source, please create a build folder elsewhere and remember to run git clean -xdf to remove temporary files created by CMake."
 )
 
 #Options regarding usage of pkgconfig

--- a/README
+++ b/README
@@ -80,7 +80,7 @@ to subscribe.
 If you want to contribute code, please open a pull request with signed-off
 commits at https://github.com/Subsurface-divelog/subsurface/pulls
 (alternatively, you can also send your patches as emails to the developer
-mailing lsit).
+mailing list).
 
 Either way, if you don't sign off your patches, we will not accept them.
 This means adding a line that says "Signed-off-by: Name <email>" at the

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -153,6 +153,9 @@ struct tank_info_t tank_info[100] = {
 	{ "AL80", .cuft = 80, .psi = 3000 },
 	{ "AL100", .cuft = 100, .psi = 3300 },
 
+	/* Double AL cylinders */
+	{ "D80 AL", .cuft = 160, .psi = 3000 },
+
 	/* Metric AL cylinders */
 	{ "ALU7", .ml = 7000, .bar = 200 },
 
@@ -164,6 +167,7 @@ struct tank_info_t tank_info[100] = {
 
 	/* Somewhat common double LP steel cylinders */
 	{ "D85 LP", .cuft = 170, .psi = 2640 },
+	{ "D95 LP", .cuft = 190, .psi = 2640 },
 
 	/* Somewhat common HP steel cylinders */
 	{ "HP65", .cuft = 65, .psi = 3442 },
@@ -188,14 +192,9 @@ struct tank_info_t tank_info[100] = {
 	{ "12ℓ 300 bar", .ml = 12000, .bar = 300 },
 	{ "15ℓ 200 bar", .ml = 15000, .bar = 200 },
 	{ "15ℓ 232 bar", .ml = 15000, .bar = 232 },
-	{ "D7 300 bar", .ml = 14000, .bar = 300 },
-	{ "D8.5 232 bar", .ml = 17000, .bar = 232 },
 	{ "D12 232 bar", .ml = 24000, .bar = 232 },
-	{ "D13 232 bar", .ml = 26000, .bar = 232 },
 	{ "D15 232 bar", .ml = 30000, .bar = 232 },
-	{ "D16 232 bar", .ml = 32000, .bar = 232 },
 	{ "D18 232 bar", .ml = 36000, .bar = 232 },
-	{ "D20 232 bar", .ml = 40000, .bar = 232 },
 
 	/* We'll fill in more from the dive log dynamically */
 	{ NULL, }

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -162,13 +162,27 @@ struct tank_info_t tank_info[100] = {
 	{ "LP108", .cuft = 108, .psi = 2640 },
 	{ "LP121", .cuft = 121, .psi = 2640 },
 
+    /* Somewhat common double LP steel cylinders */
+    { "D85 LP", .cuft = 170, .psi = 2640 },
+    { "D95 LP", .cuft = 190, .psi = 2640 },
+    { "D108 LP", .cuft = 216, .psi = 2640 },
+
 	/* Somewhat common HP steel cylinders */
 	{ "HP65", .cuft = 65, .psi = 3442 },
 	{ "HP80", .cuft = 80, .psi = 3442 },
 	{ "HP100", .cuft = 100, .psi = 3442 },
 	{ "HP117", .cuft = 117, .psi = 3442 },
+	{ "HP120", .cuft = 120, .psi = 3442 },
 	{ "HP119", .cuft = 119, .psi = 3442 },
 	{ "HP130", .cuft = 130, .psi = 3442 },
+
+    /* Somewhat common double HP steel cylinders */
+    { "D100 HP", .cuft = 200, .psi = 3442 },
+    { "D117 HP", .cuft = 234, .psi = 3442 },
+    { "D119 HP", .cuft = 238, .psi = 3442 },
+    { "D120 HP", .cuft = 240, .psi = 3442 },
+    { "D130 HP", .cuft = 260, .psi = 3442 },
+
 
 	/* Common European steel cylinders */
 	{ "3ℓ 232 bar", .ml = 3000, .bar = 232 },

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -162,10 +162,10 @@ struct tank_info_t tank_info[100] = {
 	{ "LP108", .cuft = 108, .psi = 2640 },
 	{ "LP121", .cuft = 121, .psi = 2640 },
 
-    /* Somewhat common double LP steel cylinders */
-    { "D85 LP", .cuft = 170, .psi = 2640 },
-    { "D95 LP", .cuft = 190, .psi = 2640 },
-    { "D108 LP", .cuft = 216, .psi = 2640 },
+	/* Somewhat common double LP steel cylinders */
+	{ "D85 LP", .cuft = 170, .psi = 2640 },
+	{ "D95 LP", .cuft = 190, .psi = 2640 },
+	{ "D108 LP", .cuft = 216, .psi = 2640 },
 
 	/* Somewhat common HP steel cylinders */
 	{ "HP65", .cuft = 65, .psi = 3442 },
@@ -176,13 +176,12 @@ struct tank_info_t tank_info[100] = {
 	{ "HP119", .cuft = 119, .psi = 3442 },
 	{ "HP130", .cuft = 130, .psi = 3442 },
 
-    /* Somewhat common double HP steel cylinders */
-    { "D100 HP", .cuft = 200, .psi = 3442 },
-    { "D117 HP", .cuft = 234, .psi = 3442 },
-    { "D119 HP", .cuft = 238, .psi = 3442 },
-    { "D120 HP", .cuft = 240, .psi = 3442 },
-    { "D130 HP", .cuft = 260, .psi = 3442 },
-
+	/* Somewhat common double HP steel cylinders */
+	{ "D100 HP", .cuft = 200, .psi = 3442 },
+	{ "D117 HP", .cuft = 234, .psi = 3442 },
+	{ "D119 HP", .cuft = 238, .psi = 3442 },
+	{ "D120 HP", .cuft = 240, .psi = 3442 },
+	{ "D130 HP", .cuft = 260, .psi = 3442 },
 
 	/* Common European steel cylinders */
 	{ "3ℓ 232 bar", .ml = 3000, .bar = 232 },

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -164,23 +164,17 @@ struct tank_info_t tank_info[100] = {
 
 	/* Somewhat common double LP steel cylinders */
 	{ "D85 LP", .cuft = 170, .psi = 2640 },
-	{ "D95 LP", .cuft = 190, .psi = 2640 },
-	{ "D108 LP", .cuft = 216, .psi = 2640 },
 
 	/* Somewhat common HP steel cylinders */
 	{ "HP65", .cuft = 65, .psi = 3442 },
 	{ "HP80", .cuft = 80, .psi = 3442 },
 	{ "HP100", .cuft = 100, .psi = 3442 },
 	{ "HP117", .cuft = 117, .psi = 3442 },
-	{ "HP120", .cuft = 120, .psi = 3442 },
 	{ "HP119", .cuft = 119, .psi = 3442 },
 	{ "HP130", .cuft = 130, .psi = 3442 },
 
 	/* Somewhat common double HP steel cylinders */
 	{ "D100 HP", .cuft = 200, .psi = 3442 },
-	{ "D117 HP", .cuft = 234, .psi = 3442 },
-	{ "D119 HP", .cuft = 238, .psi = 3442 },
-	{ "D120 HP", .cuft = 240, .psi = 3442 },
 	{ "D130 HP", .cuft = 260, .psi = 3442 },
 
 	/* Common European steel cylinders */


### PR DESCRIPTION
When not using a dive computer that is air integrated, resetting the tank
size and nomenclature on each dive is tedious for imperial double tanks.
This change sets a standard for their nomenclature that works with the
XML export, and adds the typical tanks doubled by imperial divers to the
default list.

Signed-off-by: Mark Fox <mark.p.fox@gmail.com>