### PR TITLE
mobile: the infamous enumerate problem

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -171,7 +171,7 @@ Kirigami.Page {
 		diveDetailsPage.state = "edit"
 	}
 
-	onWidthChanged: diveDetailsListView.positionViewAtIndex(diveDetailsListView.currentIndex, ListView.Beginning);
+	//onWidthChanged: diveDetailsListView.positionViewAtIndex(diveDetailsListView.currentIndex, ListView.Beginning);
 
 	Item {
 		anchors.fill: parent
@@ -189,8 +189,9 @@ Kirigami.Page {
 				highlightFollowsCurrentItem: true
 				focus: true
 				clip: false
-				cacheBuffer: parent.width * 3 // cache one item on either side (this is in pixels)
+				//cacheBuffer: parent.width * 3 // cache one item on either side (this is in pixels)
 				snapMode: ListView.SnapOneItem
+				highlightRangeMode: ListView.StrictlyEnforceRange
 				onMovementEnded: {
 					currentIndex = indexAt(contentX+1, 1);
 				}


### PR DESCRIPTION
This fix seems to fix the enumerate problem: the problem that on a seemingly non-deterministic way, all the profiles get enumerated and rendered, causing freeze of the app, or even crash due to out of memory.

Only 3 lines of code change, but this fix did not come easy. The enumerate problem seems some kind of race condition between QML, Kiragami and most definitely, the Subsurface QML code itself. The breakthrough in my debugging was the setting of highlightRangeMode: ListView.StrictlyEnforceRange based on the QML documentation on snapMode: enumeration.

This fix deserves proper testing in multiple environments. As could be seen on the developpers mailing list, I was (easily) able to reproduce the enumerate problem, but Rick was not. So I definitely do not claim to understand why this fix solves the issue for me.

And as a side note: fixes #263 for me as well.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>