### PR TITLE
UI: typo fix

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -2343,7 +2343,7 @@
               </item>
               <item>
                <property name="text">
-                <string>Apnoea</string>
+                <string>Apnea</string>
                </property>
               </item>
               <item>


### PR DESCRIPTION
Trivial typo fix, suggested in issue #274. Apnea is more common than Apnoea, and Apnea is also used in the code already, so, more common and more consistent. Hmm. A lot of text for a one letter fix.

Close of issue suggested #274.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>