### PR TITLE
Fix issue 280: Facebook without a dive selected

### DIFF
--- a/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
+++ b/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
@@ -296,6 +296,10 @@ void SocialNetworkDialog::selectionChanged()
 {
 	struct dive *d = current_dive;
 	QString fullText;
+
+	if (!d)
+		return;
+
 	if (ui->date->isChecked()) {
 		fullText += tr("Dive date: %1 \n").arg(get_short_dive_date_string(d->when));
 	}


### PR DESCRIPTION
Accessing Facebook stuff without a dive selected (as in an empty logbook) just SIGSEGVs. Just be more careful.

After this fix, it is still possible to upload an "empty dive" to FB. Ok, a little pointless, but a nice picture of the Subsurface logo is uploaded to FB. Consider it an easter egg :-)

Fixes: #280

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>