### PR TITLE
Handle notes in replan

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -538,7 +538,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 	const unsigned int sz_temp = 100000;
 	char *buffer = (char *)malloc(sz_buffer);
 	char *temp = (char *)malloc(sz_temp);
-	char *deco, *segmentsymbol;
+	const char *deco, *segmentsymbol;
 	static char buf[1000];
 	int len, lastdepth = 0, lasttime = 0, lastsetpoint = -1, newdepth = 0, lastprintdepth = 0, lastprintsetpoint = -1;
 	struct gasmix lastprintgasmix = {{ -1 }, { -1 }};

--- a/core/planner.c
+++ b/core/planner.c
@@ -41,7 +41,7 @@ extern void reset_regression();
 
 pressure_t first_ceiling_pressure, max_bottom_ceiling_pressure = {};
 
-const char *disclaimer;
+char *disclaimer;
 int plot_depth = 0;
 #if DEBUG_PLAN
 void dump_plan(struct diveplan *diveplan)
@@ -555,9 +555,9 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 	plan_display_transitions = prefs.display_transitions;
 
 	if (decoMode() == VPMB) {
-		deco = "VPM-B";
+		deco = translate("gettextFromC", "VPM-B");
 	} else {
-		deco = "BUHLMANN";
+		deco = translate("gettextFromC", "BUHLMANN");
 	}
 
 	snprintf(buf, sizeof(buf), translate("gettextFromC", "DISCLAIMER / WARNING: THIS IS A NEW IMPLEMENTATION OF THE %s "

--- a/core/planner.c
+++ b/core/planner.c
@@ -584,7 +584,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		return;
 	}
 
-	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div><b>%s<b><br></div>", disclaimer) : 0;
+	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div><b>%s</b><br></div>", disclaimer) : 0;
 
 	if (diveplan->surface_interval > 60) {
 		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s %d:%02d)</b><br>",

--- a/core/planner.h
+++ b/core/planner.h
@@ -24,7 +24,7 @@ extern bool diveplan_empty(struct diveplan *diveplan);
 extern void free_dps(struct diveplan *diveplan);
 extern struct dive *planned_dive;
 extern char *cache_data;
-extern const char *disclaimer;
+extern char *disclaimer;
 extern double plangflow, plangfhigh;
 
 #ifdef __cplusplus

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -873,7 +873,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	setRecalc(oldRecalc);
 
 	//TODO: C-based function here?
-	bool did_deco = plan(&diveplan, &cache, isPlanner(), true);
+	plan(&diveplan, &cache, isPlanner(), true);
 	free(cache);
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing on
@@ -896,8 +896,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 			QString oldnotes(current_dive->notes);
 			if (oldnotes.indexOf(QString(disclaimer).left(40)) >= 0)
 				oldnotes.truncate(oldnotes.indexOf(QString(displayed_dive.notes).left(40)));
-			if (did_deco)
-				oldnotes.append(displayed_dive.notes);
+			oldnotes.append(displayed_dive.notes);
 			displayed_dive.notes = strdup(oldnotes.toUtf8().data());
 		}
 		copy_dive(&displayed_dive, current_dive);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -894,8 +894,8 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 				add_dive_to_trip(copy, current_dive->divetrip);
 			record_dive(copy);
 			QString oldnotes(current_dive->notes);
-			if (oldnotes.indexOf(QString(disclaimer)) >= 0)
-				oldnotes.truncate(oldnotes.indexOf(QString(disclaimer)));
+			if (oldnotes.indexOf(QString(disclaimer).left(40)) >= 0)
+				oldnotes.truncate(oldnotes.indexOf(QString(displayed_dive.notes).left(40)));
 			if (did_deco)
 				oldnotes.append(displayed_dive.notes);
 			displayed_dive.notes = strdup(oldnotes.toUtf8().data());


### PR DESCRIPTION
Upon replanning a dive, we want to delete the old
dive plan in the notes and replace it with the actual.

This fixes a problem when we failed to detect the old plan due
to the deco model name appearing in the disclaimer that was used
as a marker for the notes.

This patch also adds translation markers for the deco model name strings..

Fixes #285

Signed-off-by: Robert C. Helling <helling@atdotde.de>