### PR TITLE
Fix a crash when git init fails

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -648,6 +648,11 @@ static int repository_create_cb(git_repository **out, const char *path, int bare
 	git_config *conf;
 
 	int ret = git_repository_init(out, path, bare);
+	if (ret != 0) {
+		if (verbose)
+			fprintf(stderr, "Initializing git repository failed\n");
+		return ret;
+	}
 
 	git_repository_config(&conf, *out);
 	if (getProxyString(&proxy_string)) {


### PR DESCRIPTION
This can occur e.g. if directory permissions prevent one from writing to
the local cloud storage directory. (Such a crash was discussed on
mailing list.) The error message on GUI is misleading, claiming that
cloud connection failed...

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>
---
We probably should check the return value of other git operations as
well, but going for bare minimum for now.