### PR TITLE
Add plan creation date and Subsurface version to planner output

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -15,6 +15,7 @@
 #include "gettext.h"
 #include "libdivecomputer/parser.h"
 #include "qthelperfromc.h"
+#include "version.h"
 
 #define TIMESTEP 2 /* second */
 #define DECOTIMESTEP 60 /* seconds. Unit of deco stop times */
@@ -66,6 +67,9 @@ void dump_plan(struct diveplan *diveplan)
 	}
 }
 #endif
+
+/* this is in qthelper.cpp, so including the .h file is a pain */
+extern const char *get_current_date();
 
 bool diveplan_empty(struct diveplan *diveplan)
 {
@@ -837,10 +841,13 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 	const char *depth_unit;
 	int altitude = (int) get_depth_units((int) (log(1013.0 / diveplan->surface_pressure) * 7800000), NULL, &depth_unit);
 
-	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "ATM pressure: %dmbar (%d%s)<br></div>"),
+	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "ATM pressure: %dmbar (%d%s)<br>"),
 			diveplan->surface_pressure,
 			altitude,
 			depth_unit);
+
+	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Plan creation date and version: %s, %s<br></div>"),
+			get_current_date(), subsurface_canonical_version());
 
 	/* Get SAC values and units for printing it in gas consumption */
 	double bottomsacvalue, decosacvalue;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -959,6 +959,16 @@ const char *get_dive_date_c_string(timestamp_t when)
 	return strdup(text.toUtf8().data());
 }
 
+extern "C" const char *get_current_date()
+{
+	QDateTime ts(QDateTime::currentDateTime());;
+	QString current_date;
+	
+	current_date = loc.toString(ts, QString(prefs.date_format_short));
+
+	return strdup(current_date.toUtf8().data());
+}
+
 bool is_same_day(timestamp_t trip_when, timestamp_t dive_when)
 {
 	static timestamp_t twhen = (timestamp_t) 0;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -16,6 +16,7 @@ QString weight_string(int weight_in_grams);
 QString distance_string(int distanceInMeters);
 bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_text, bool *parsed_out = 0);
 extern "C" const char *printGPSCoords(int lat, int lon);
+extern "C" const char *get_current_date();
 QList<int> getDivesInTrip(dive_trip_t *trip);
 QString get_gas_string(struct gasmix gas);
 QString get_divepoint_gas_string(struct dive *d, const divedatapoint& dp);


### PR DESCRIPTION
This has to be discussed first. @atdotde has some doubts that we sooner or later have to much info in the planner output. So maybe we take this for master, maybe not. As I started to code it I just wanted to finish it... :-)