### PR TITLE
Updates for mxe-build script 

### DIFF
--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -113,9 +113,17 @@ if [[ "$1" == "debug" ]] ; then
 	RELEASE="Debug"
 	DLL_SUFFIX="d"
 	shift
+	if [[ -f Release ]] ; then
+		rm -rf *
+	fi
+	touch Debug
 else
 	RELEASE="Release"
 	DLL_SUFFIX=""
+	if [[ -f Debug ]] ; then
+		rm -rf *
+	fi
+	touch Release
 fi
 
 # grantlee

--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -291,8 +291,18 @@ mkdir -p $STAGING_TESTS_DIR
 
 for d in $QT_PLUGIN_DIRECTORIES
 do
-    cp -a $d $STAGING_DIR/plugins
-    cp -a $d $STAGING_TESTS_DIR
+	mkdir -p $STAGING_DIR/plugins/$(basename $d)
+	mkdir -p $STAGING_TESTS_DIR/$(basename $d)
+	for f in $d/*
+	do
+		if [[ "$RELEASE" == "Release" ]] && ([[ ! -f ${f//d.dll/.dll} || "$f" == "${f//d.dll/.dll}" ]]) ; then
+			cp $f $STAGING_DIR/plugins/$(basename $d)
+			cp $f $STAGING_TESTS_DIR/$(basename $d)
+		elif [[ "$RELEASE" == "Debug" && ! -f ${f//.dll/d.dll} ]] ; then
+			cp $f $STAGING_DIR/plugins/$(basename $d)
+			cp $f $STAGING_TESTS_DIR/$(basename $d)
+		fi
+	done
 done
 
 for f in $EXTRA_MANUAL_DEPENDENCIES


### PR DESCRIPTION
Two updates for the MXE build script:

1. Copy the correct Qt plugin DLLs
For the plugin DDLs:
Debug: Only copy *d.DLLs
Release: Only copy *.DLLs

2. Rebuild everything when switching between debug and release build