### PR TITLE
Ignore empty cylinders on Cobalt import

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -2869,7 +2869,7 @@ extern int cobalt_dive(void *param, int columns, char **data, char **column)
 	sqlite3 *handle = (sqlite3 *)param;
 	char *err = NULL;
 	char get_profile_template[] = "select runtime*60,(DepthPressure*10000/SurfacePressure)-10000,p.Temperature from Dive AS d JOIN TrackPoints AS p ON d.Id=p.DiveId where d.Id=%d";
-	char get_cylinder_template[] = "select FO2,FHe,StartingPressure,EndingPressure,TankSize,TankPressure,TotalConsumption from GasMixes where DiveID=%d and StartingPressure>0 group by FO2,FHe";
+	char get_cylinder_template[] = "select FO2,FHe,StartingPressure,EndingPressure,TankSize,TankPressure,TotalConsumption from GasMixes where DiveID=%d and StartingPressure>0 and EndingPressure > 0 group by FO2,FHe";
 	char get_buddy_template[] = "select l.Data from Items AS i, List AS l ON i.Value1=l.Id where i.DiveId=%d and l.Type=4";
 	char get_visibility_template[] = "select l.Data from Items AS i, List AS l ON i.Value1=l.Id where i.DiveId=%d and l.Type=3";
 	char get_location_template[] = "select l.Data from Items AS i, List AS l ON i.Value1=l.Id where i.DiveId=%d and l.Type=0";


### PR DESCRIPTION
It appears that Cobalt might include additional gas mixes, and only way
to determine what is used appears to be to ensure that start and end
pressures are greater than 0. One would assume there to be something
else available in the database, but I was not able to spot it.

Fixes #297

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>