### PR TITLE
Use libdc from github now

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -129,7 +129,7 @@ if [ ! -d libdivecomputer ] ; then
 	if [[ $1 = local ]] ; then
 		git clone $SRC/../libdivecomputer libdivecomputer
 	else
-		git clone -b Subsurface-branch git://subsurface-divelog.org/libdc libdivecomputer
+		git clone -b Subsurface-branch git://github.com/Subsurface-divelog/libdc.git libdivecomputer
 	fi
 fi
 cd libdivecomputer


### PR DESCRIPTION
The build script was cloning the Sursurface branch of libdivecomputer from the "old" location. Use the new github based location from now on.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>