### PR TITLE
Last added dive planner point for correct lenght not always added

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -119,7 +119,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 		}
 	}
 	// make sure we get the last point right so the duration is correct
-	addStop(0, d->dc.duration.seconds,cylinderid, 0, true);
+	if (!hasMarkedSamples) addStop(0, d->dc.duration.seconds,cylinderid, 0, true);
 	recalc = oldRec;
 	emitDataChanged();
 }


### PR DESCRIPTION
Don't add the last stop with addstop for correcting the lenght
of the dive if planner generated points can be removed when replanning.
Otherwise this will not be deleted when replanning a dive.

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>