### PR TITLE
Handle notes from planner

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -588,10 +588,10 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		return;
 	}
 
-	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div><b>%s</b><br></div>", disclaimer) : 0;
+	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div>*!* <b>%s</b><br></div>", disclaimer) : 0;
 
 	if (diveplan->surface_interval > 60) {
-		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
+		len += snprintf(buffer + len, sz_buffer - len, "<div>*** <b>%s (%s) %s %d:%02d) %s %s<br>",
 				translate("gettextFromC", "Subsurface"),
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> (surface interval "),
@@ -599,7 +599,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 				translate("gettextFromC", "created on"),
 				get_current_date());
 	} else {
-		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %s</b><br>",
+		len += snprintf(buffer + len, sz_buffer - len, "<div>*** <b>%s (%s) %s %s</b><br>",
 				translate("gettextFromC", "Subsurface"),
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> created on"),

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -884,6 +884,19 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		displayed_dive.maxdepth.mm = 0;
 		displayed_dive.dc.maxdepth.mm = 0;
 		fixup_dive(&displayed_dive);
+		// Try to identify old planner output and remove only this part
+		// If we don't manage to identify old plan start but there is a 
+		// table, delete everything
+		QString oldnotes(current_dive->notes);
+		if (oldnotes.indexOf(QString("*!*")) >= 0)
+			oldnotes.truncate(oldnotes.indexOf(QString("*!*")));
+		else if (oldnotes.indexOf(QString("***")) >= 0)
+			oldnotes.truncate(oldnotes.indexOf(QString("***")));
+		else if (oldnotes.indexOf(QString("<table")) >= 0)
+			oldnotes.truncate(0);
+		oldnotes.append(displayed_dive.notes);
+		displayed_dive.notes = strdup(oldnotes.toUtf8().data());
+		// If we save as new create a copy of the dive here
 		if (replanCopy) {
 			struct dive *copy = alloc_dive();
 			copy_dive(current_dive, copy);
@@ -893,11 +906,6 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 			if (current_dive->divetrip)
 				add_dive_to_trip(copy, current_dive->divetrip);
 			record_dive(copy);
-			QString oldnotes(current_dive->notes);
-			if (oldnotes.indexOf(QString(disclaimer).left(40)) >= 0)
-				oldnotes.truncate(oldnotes.indexOf(QString(displayed_dive.notes).left(40)));
-			oldnotes.append(displayed_dive.notes);
-			displayed_dive.notes = strdup(oldnotes.toUtf8().data());
 		}
 		copy_dive(&displayed_dive, current_dive);
 	}


### PR DESCRIPTION
I start this pull request for discussion.

Both @atdotde and I know that the current implementation of identifying the old planner output in the dive notes doesn't work. This is an alternative, very simply (one could call it stupid!) implementation which I'm testing since a few days and which should work pretty stable. I'm personally also ok with the look of it but for sure someone maybe doesn't like it.