### PR TITLE
Attempt latin1 parsing on import

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -2042,6 +2042,9 @@ int parse_xml_buffer(const char *url, const char *buffer, int size,
 
 	target_table = table;
 	doc = xmlReadMemory(res, strlen(res), url, NULL, 0);
+	if (!doc)
+		doc = xmlReadMemory(res, strlen(res), url, "latin1", 0);
+
 	if (res != buffer)
 		free((char *)res);
 


### PR DESCRIPTION
We parse input XML using UTF-8 encoding by default. If this fails, try
latin1 instead.

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>