### PR TITLE
In TextHyperlinkEventFilter::eventFilter remove event QEvent::ToolTip...

### DIFF
--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -641,8 +641,7 @@ bool TextHyperlinkEventFilter::eventFilter(QObject *target, QEvent *evt)
 	if (target != scrollView)
 		return false;
 
-	if (evt->type() != QEvent::MouseButtonPress &&
-	    evt->type() != QEvent::ToolTip)
+	if (evt->type() != QEvent::MouseButtonPress)
 		return false;
 
 	// --------------------
@@ -652,24 +651,12 @@ bool TextHyperlinkEventFilter::eventFilter(QObject *target, QEvent *evt)
 				 static_cast<QMouseEvent *>(evt)->modifiers() & Qt::ControlModifier &&
 				 static_cast<QMouseEvent *>(evt)->button() == Qt::LeftButton;
 
-	const bool isTooltip = evt->type() == QEvent::ToolTip;
-
-	QString urlUnderCursor;
-
-	if (isCtrlClick || isTooltip) {
-		QTextCursor cursor = isCtrlClick ?
-					     textEdit->cursorForPosition(static_cast<QMouseEvent *>(evt)->pos()) :
-					     textEdit->cursorForPosition(static_cast<QHelpEvent *>(evt)->pos());
+	if (isCtrlClick) {
+		QString urlUnderCursor;
+		QTextCursor cursor = textEdit->cursorForPosition(static_cast<QMouseEvent *>(evt)->pos());
 
 		urlUnderCursor = tryToFormulateUrl(&cursor);
-	}
-
-	if (isCtrlClick) {
 		handleUrlClick(urlUnderCursor);
-	}
-
-	if (isTooltip) {
-		handleUrlTooltip(urlUnderCursor, static_cast<QHelpEvent *>(evt)->globalPos());
 	}
 
 	// 'return true' would mean that all event handling stops for this event.


### PR DESCRIPTION
from trigger condition for the URL identify and start function.

This may be the correct fix for #315. More details can be found there.

But this time I really must not forget to mention for @dirkhh:
Please wait with merging either until we have feedback from @pestophagous or you can for sure confirm that I'm doing the right thing here. Because this may REMOVE a feature we still like to have but I don't understand. Sorry, I'm still a beginner but I'm totaly motivated to haunt any strange bug I find somewhere.