### PR TITLE
Identify user provided notes in plain text in replan

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -588,10 +588,10 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 		return;
 	}
 
-	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div>*!* <b>%s</b><br></div>", disclaimer) : 0;
+	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div><b>%s</b><br></div>", disclaimer) : 0;
 
 	if (diveplan->surface_interval > 60) {
-		len += snprintf(buffer + len, sz_buffer - len, "<div>*** <b>%s (%s) %s %d:%02d) %s %s<br>",
+		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
 				translate("gettextFromC", "Subsurface"),
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> (surface interval "),
@@ -599,7 +599,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 				translate("gettextFromC", "created on"),
 				get_current_date());
 	} else {
-		len += snprintf(buffer + len, sz_buffer - len, "<div>*** <b>%s (%s) %s %s</b><br>",
+		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %s</b><br>",
 				translate("gettextFromC", "Subsurface"),
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> created on"),

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -7,6 +7,7 @@
 #include "core/device.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QApplication>
+#include <QTextDocument>
 
 /* TODO: Port this to CleanerTableModel to remove a bit of boilerplate and
  * use the signal warningMessage() to communicate errors to the MainWindow.
@@ -885,15 +886,16 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		displayed_dive.dc.maxdepth.mm = 0;
 		fixup_dive(&displayed_dive);
 		// Try to identify old planner output and remove only this part
-		// If we don't manage to identify old plan start but there is a 
-		// table, delete everything
-		QString oldnotes(current_dive->notes);
-		if (oldnotes.indexOf(QString("*!*")) >= 0)
-			oldnotes.truncate(oldnotes.indexOf(QString("*!*")));
-		else if (oldnotes.indexOf(QString("***")) >= 0)
-			oldnotes.truncate(oldnotes.indexOf(QString("***")));
-		else if (oldnotes.indexOf(QString("<table")) >= 0)
-			oldnotes.truncate(0);
+		// Treat user provided text as plain text.
+		QTextDocument notesDocument;
+		notesDocument.setHtml(current_dive->notes);
+		QString oldnotes(notesDocument.toPlainText());
+		int disclaimerPosition = oldnotes.indexOf(disclaimer);
+		if (disclaimerPosition >= 0)
+			oldnotes.truncate(disclaimerPosition);
+		// Deal with line breaks
+		notesDocument.setPlainText(oldnotes);
+		oldnotes = notesDocument.toHtml();
 		oldnotes.append(displayed_dive.notes);
 		displayed_dive.notes = strdup(oldnotes.toUtf8().data());
 		// If we save as new create a copy of the dive here


### PR DESCRIPTION
This is another attept at the problem if identifying a potentially
user supplied text in the dive notes upon replannig a dive.

It gets rid of the user visable position markers (*!* and ***) and
cirumvents problems with mark-up by first converting the old notes
to plan text (assuming that user only enters plain text in the notes
field as we do in other places as well). Then the automatically added
part is identified by locating the disclaimer in the text (if the user
edited/delted the disclaimer or changed langue in between it is her
problem to manually delete the old plan).

Everything from the disclaimer on is deleted and replaced by the new plan.

If the disclaimer is not found, the new plan is appended to the old notes.
This way we make sure no information gets automatically deleted.

Signed-off-by: Robert C. Helling <helling@atdotde.de>