### PR TITLE
Dive mode to planner

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -827,7 +827,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 
 	/* Print the settings for the diveplan next. */
 	if (decoMode() == BUEHLMANN){
-		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Bühlmann ZHL-16C with GFLow = %d and GFHigh = %d"),
+		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Bühlmann ZHL-16C with GFLow = %d%% and GFHigh = %d%%"),
 			diveplan->gflow, diveplan->gfhigh);
 	} else if (decoMode() == VPMB){
 		int temp_len;
@@ -840,7 +840,7 @@ static void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool
 					     , diveplan->eff_gfhigh);
 
 	} else if (decoMode() == RECREATIONAL){
-		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d and GFHigh = %d"),
+		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d%% and GFHigh = %d%%"),
 			diveplan->gflow, diveplan->gfhigh);
 	}
 	len += snprintf(buffer + len, sz_buffer - len, "<div>%s<br>",temp);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -186,6 +186,11 @@ void DivePlannerWidget::setSurfacePressure(int surface_pressure)
 	ui.ATMPressure->setValue(surface_pressure);
 }
 
+void PlannerSettingsWidget::setDiveMode(int mode)
+{
+	ui.rebreathermode->setCurrentIndex(mode);
+}
+
 void DivePlannerWidget::setSalinity(int salinity)
 {
 	ui.salinity->setValue(salinity / 10000.0);

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -85,6 +85,7 @@ slots:
 	void setBestmixEND(int depth);
 	void setBackgasBreaks(bool dobreaks);
 	void disableDecoElements(int mode);
+	void setDiveMode(int mode);
 
 private:
 	Ui::plannerSettingsWidget ui;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -953,7 +953,8 @@ void MainWindow::on_actionDivePlanner_triggered()
 	DivePlannerPointsModel::instance()->setupStartTime();
 	DivePlannerPointsModel::instance()->createSimpleDive();
 	// plan the dive in the same mode as the currently selected one
-	divePlannerSettingsWidget()->setDiveMode(current_dive->dc.divemode);
+	if (current_dive)
+		divePlannerSettingsWidget()->setDiveMode(current_dive->dc.divemode);
 	DivePictureModel::instance()->updateDivePictures();
 	divePlannerWidget()->setReplanButton(false);
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -908,6 +908,7 @@ void MainWindow::setupForAddAndPlan(const char *model)
 	// setup the dive cylinders
 	DivePlannerPointsModel::instance()->clear();
 	DivePlannerPointsModel::instance()->setupCylinders();
+
 }
 
 void MainWindow::on_actionReplanDive_triggered()
@@ -951,6 +952,8 @@ void MainWindow::on_actionDivePlanner_triggered()
 	setupForAddAndPlan("planned dive"); // don't translate, stored in XML file
 	DivePlannerPointsModel::instance()->setupStartTime();
 	DivePlannerPointsModel::instance()->createSimpleDive();
+	// plan the dive in the same mode as the currently selected one
+	divePlannerSettingsWidget()->setDiveMode(current_dive->dc.divemode);
 	DivePictureModel::instance()->updateDivePictures();
 	divePlannerWidget()->setReplanButton(false);
 }


### PR DESCRIPTION
3 commits:
1) a trivial strings change (notice that this is a translated string). 
2) Preserve dive mode when planning a dive. Like it says, when an OC dive is selected and "plan a dive" is chosen, the user want to plan an OC dive. Same for CCR and pSCR dives.  It is just inconsistent to copy over cylinders and used gasses, but ignoring the fact that this is (strongly) related to the type of dive.
3) Handle CCR setpoint when replanning a dive. This is just a bug in the current master. When replanning a CCR dive, do not reset the setpoint data back to 0 (making it OC). 