### PR TITLE
Support for new DM5 blob format

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -2466,6 +2466,9 @@ extern int dm5_dive(void *param, int columns, char **data, char **column)
 			case 3:
 				block_size = 23;
 				break;
+			case 4:
+				block_size = 26;
+				break;
 			default:
 				block_size = 16;
 				break;


### PR DESCRIPTION
Currently we do not know what the extra data in the sampleBlob is, but
the block size must be adjusted nevertheless.

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>