### PR TITLE
SmarTrak import: Some fixes

### DIFF
--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -687,15 +687,15 @@ static void smtk_parse_bookmarks(MdbHandle *mdb, struct dive *d, char *dive_idx)
 			time = lrint(strtod(col[4]->bind_ptr, NULL) * 60);
 			tmp = strdup(col[2]->bind_ptr);
 			ev = find_bookmark(d->dc.events, time);
-			if (ev != NULL) {
-				memset(&ev->name, 0, strlen(tmp) + 1);
-				memcpy(ev->name, tmp, strlen(tmp));
-			} else
+			if (ev)
+				update_event_name(d, ev, tmp);
+			else
 				if (!add_event(&d->dc, time, SAMPLE_EVENT_BOOKMARK, 0, 0, tmp))
 					report_error("[smtk-import] Error - Couldn't add bookmark, dive %d, Name = %s",
 						     d->number, tmp);
 		}
 	}
+	free(tmp);
 	smtk_free(bound_values, table->num_cols);
 	mdb_free_tabledef(table);
 }

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -904,11 +904,12 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 					smtkdive->cylinder[i].end.mbar = lrint(strtod(col[(i * 2) + 1 + pstartcol]->bind_ptr, NULL) * 1000 ? : 1000);
 			if (smtkdive->cylinder[i].gasmix.o2.permille == 0)
 				smtkdive->cylinder[i].gasmix.o2.permille = lrint(strtod(col[i + o2fraccol]->bind_ptr, NULL) * 10);
-			if (smtk_version == 10213)
+			if (smtk_version == 10213) {
 				if (smtkdive->cylinder[i].gasmix.he.permille == 0)
 					smtkdive->cylinder[i].gasmix.he.permille = lrint(strtod(col[i + hefraccol]->bind_ptr, NULL) * 10);
-			else
+			} else {
 				smtkdive->cylinder[i].gasmix.he.permille = 0;
+			}
 			smtk_build_tank_info(mdb_clon, &smtkdive->cylinder[i], col[i + tankidxcol]->bind_ptr);
 		}
 		/* Check for duplicated cylinders and clean them */

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -678,8 +678,10 @@ static void smtk_parse_bookmarks(MdbHandle *mdb, struct dive *d, char *dive_idx)
 	struct event *ev;
 
 	table = smtk_open_table(mdb, "Marker", col, bound_values);
-	if (!table)
+	if (!table) {
 		report_error("[smtk-import] Error - Couldn't open table 'Marker', dive %d", d->number);
+		return;
+	}
 	while (mdb_fetch_row(table)) {
 		if (same_string(col[0]->bind_ptr, dive_idx)) {
 			time = lrint(strtod(col[4]->bind_ptr, NULL) * 60);


### PR DESCRIPTION
0001 - Fix potential crash if Marker table doesn't open
0002 - Fix (more than) potential crash while merging bookmarks names. Makes good use of update_event_name().
0003 - Parsing tanks logic failed with trimix dives because nested conditionals require (sometimes) curly braces.