### PR TITLE
After DC import don't do RemoveRows if there is nothing to remove

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -733,8 +733,10 @@ void DiveImportedModel::clearTable()
 void DiveImportedModel::setImportedDivesIndexes(int first, int last)
 {
 	Q_ASSERT(last >= first);
-	beginRemoveRows(QModelIndex(), 0, lastIndex - firstIndex);
-	endRemoveRows();
+	if (lastIndex >= firstIndex) {
+		beginRemoveRows(QModelIndex(), 0, lastIndex - firstIndex);
+		endRemoveRows();
+	}
 	beginInsertRows(QModelIndex(), 0, last - first);
 	lastIndex = last;
 	firstIndex = first;


### PR DESCRIPTION
This fixes an issue where beginRemoveRows is called with argument -1
in DiveImportedModel::setImportedDivesIndexes.

Fixes crash part of #332

Signed-off-by: Stefan Fuchs <sfuchs@gmx.de>