### PR TITLE
Deal with additional line break in dive notes from planner

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -894,11 +894,12 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		notesDocument.setHtml(current_dive->notes);
 		QString oldnotes(notesDocument.toPlainText());
 		int disclaimerPosition = oldnotes.indexOf(disclaimer);
-		if (disclaimerPosition >= 0)
-			oldnotes.truncate(disclaimerPosition);
+		if (disclaimerPosition == 0)
+			oldnotes.clear();
+		else if (disclaimerPosition >= 1)
+			oldnotes.truncate(disclaimerPosition-1);
 		// Deal with line breaks
-		notesDocument.setPlainText(oldnotes);
-		oldnotes = notesDocument.toHtml();
+		oldnotes.replace("\n", "<br>");
 		oldnotes.append(displayed_dive.notes);
 		displayed_dive.notes = strdup(oldnotes.toUtf8().data());
 		// If we save as new create a copy of the dive here


### PR DESCRIPTION
This again fixes a marginality around dealing with the planner notes.
With current code for each replanning the planner output moves down by one line. This change should fix this.

@atdotde please should check this before merging. If there are any doubts this is for sure not important for 4.6.4. So then @dirkhh  leave it as it is now!