### PR TITLE
Do not carry po2 setpoint data over dive boundaries

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -749,8 +749,8 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 	device_data_t *devdata = userdata;
 	struct dive *dive = NULL;
 
-	/* reset the deco / ndl data */
-	ndl = stoptime = stopdepth = 0;
+	/* reset static data, that is only valid per dive */
+	ndl = stoptime = stopdepth = po2 = 0;
 	in_deco = false;
 	current_gas_index = -1;
 


### PR DESCRIPTION
The file static po2 value, used to set the setpoint data, was not re-initialized at the parsing of a dive during import from the divecomputer. So, in one import session, the po2 was transferred from one dive to the next, obviously resulting in weird bugs, due to possible wrong po2 settings.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>