### PR TITLE
OSTC3 incorrect notice to upgrade firmware

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -385,9 +385,11 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	// You can enter "OSTC 3" and download just fine from a "OSTC Sport", but
 	// this check will compair apples and oranges, firmware wise, then.
 	QString product(ui.product->currentText());
-	if (product == "OSTC 3" || product == "OSTC 3+" ||
+	//
+	// We shouldn't do this for memory dumps.
+	if ((product == "OSTC 3" || product == "OSTC 3+" ||
 			product == "OSTC Cr" || product == "OSTC Sport" ||
-			product == "OSTC 4")
+			product == "OSTC 4") && !data.libdc_dump)
 		ostcFirmwareCheck = new OstcFirmwareCheck(product);
 }
 


### PR DESCRIPTION
See https://github.com/Subsurface-divelog/subsurface/issues/342. The reason is that we never get a DC_EVENT_DEVINFO when doing a memory dump. Just do not offer to update firmware when we are creating a libdc dump.

Full credits of this fix go to Anton.

Fixed-by: Anton Lundin <glance@acc.umu.se>
Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>