### PR TITLE
Correct divesite geocoding translation

### DIFF
--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -3,13 +3,13 @@
 #include <stdlib.h>
 
 char *taxonomy_category_names[TC_NR_CATEGORIES] = {
-	QT_TRANSLATE_NOOP("getTextFromC", "None"),
-	QT_TRANSLATE_NOOP("getTextFromC", "Ocean"),
-	QT_TRANSLATE_NOOP("getTextFromC", "Country"),
-	QT_TRANSLATE_NOOP("getTextFromC", "State"),
-	QT_TRANSLATE_NOOP("getTextFromC", "County"),
-	QT_TRANSLATE_NOOP("getTextFromC", "Town"),
-	QT_TRANSLATE_NOOP("getTextFromC", "City")
+	QT_TRANSLATE_NOOP("gettextFromC", "None"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Ocean"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Country"),
+	QT_TRANSLATE_NOOP("gettextFromC", "State"),
+	QT_TRANSLATE_NOOP("gettextFromC", "County"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Town"),
+	QT_TRANSLATE_NOOP("gettextFromC", "City")
 };
 
 // these are the names for geoname.org

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 #include <QLineEdit>
 #include <QIcon>
+#include <core/gettextfromc.h>
 
 bool dive_site_less_than(dive_site *a, dive_site *b)
 {
@@ -184,7 +185,7 @@ GeoReferencingOptionsModel::GeoReferencingOptionsModel(QObject *parent) : QStrin
 	QStringList list;
 	int i;
 	for (i = 0; i < TC_NR_CATEGORIES; i++)
-		list << taxonomy_category_names[i];
+		list << gettextFromC::instance()->trGettext(taxonomy_category_names[i]);
 	setStringList(list);
 }
 


### PR DESCRIPTION
See https://github.com/Subsurface-divelog/subsurface/issues/345. The menus where not translated. The basis of this error is a simple typo in core/taxonomy.c where the classname was mis-spelled in the QT_TRANSLATE_NOOP. In addition, to pull and translate the strings from C code, the normal tr() does not work, and the functionality from the gettextfromc class is used.

Fixes: #345

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>