### PR TITLE
Update stats layout and some strings

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>388</width>
-        <height>409</height>
+        <width>382</width>
+        <height>403</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="diveInfoScrollAreaLayout">
@@ -47,8 +47,11 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <property name="spacing">
-        <number>2</number>
+       <property name="horizontalSpacing">
+        <number>6</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>0</number>
        </property>
        <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox_5">

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -119,12 +119,16 @@ void TabDiveStatistics::updateData()
 		*/
 	if (he_tot.mliter || o2_tot.mliter) {
 		gasUsedString.append(tr("These gases could be\nmixed from Air and using:\n"));
-		if (he_tot.mliter)
-			gasUsedString.append(QString("He: %1").arg(get_volume_string(he_tot, true)));
+		if (he_tot.mliter) {
+			gasUsedString.append(tr("He"));
+			gasUsedString.append(QString(": %1").arg(get_volume_string(he_tot, true)));
+		}
 		if (he_tot.mliter && o2_tot.mliter)
-			gasUsedString.append(tr(" and "));
-		if (o2_tot.mliter)
-			gasUsedString.append(QString("O2: %2\n").arg(get_volume_string(o2_tot, true)));
+			gasUsedString.append(" ").append(tr("and")).append(" ");
+		if (o2_tot.mliter) {
+			gasUsedString.append(tr("O₂"));
+			gasUsedString.append(QString(": %2\n").arg(get_volume_string(o2_tot, true)));
+		}
 	}
 	ui->gasConsumption->setText(gasUsedString);
 }

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -45,7 +45,10 @@ void TabDiveStatistics::updateData()
 {
 	clear();
 	ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true));
-	ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true));
+	if (amount_selected > 1)
+		ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true));
+	else
+		ui->depthLimits->setMinimum("");
 	// the overall average depth is really confusing when listed between the
 	// deepest and shallowest dive - let's just not set it
 	// ui->depthLimits->setAverage(get_depth_string(stats_selection.avg_depth, true));
@@ -54,11 +57,11 @@ void TabDiveStatistics::updateData()
 	ui->depthLimits->overrideAvgToolTipText("");
 	ui->depthLimits->setAvgVisibility(false);
 
-	if (stats_selection.max_sac.mliter)
+	if (stats_selection.max_sac.mliter && (stats_selection.max_sac.mliter != stats_selection.avg_sac.mliter))
 		ui->sacLimits->setMaximum(get_volume_string(stats_selection.max_sac, true).append(tr("/min")));
 	else
 		ui->sacLimits->setMaximum("");
-	if (stats_selection.min_sac.mliter)
+	if (stats_selection.min_sac.mliter && (stats_selection.min_sac.mliter != stats_selection.avg_sac.mliter))
 		ui->sacLimits->setMinimum(get_volume_string(stats_selection.min_sac, true).append(tr("/min")));
 	else
 		ui->sacLimits->setMinimum("");

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.ui
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.ui
@@ -7,15 +7,24 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>304</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Statistics</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="verticalSpacing">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -30,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>388</width>
-        <height>288</height>
+        <width>382</width>
+        <height>286</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -49,8 +58,14 @@
        </property>
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
          <property name="horizontalSpacing">
           <number>6</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>0</number>
          </property>
          <item row="1" column="0">
           <widget class="QGroupBox" name="groupBoxb">
@@ -156,6 +171,19 @@
             </item>
            </layout>
           </widget>
+         </item>
+         <item row="3" column="0">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
One commit brings some translation fixes. I guess there is not much to discuss about this one.

For the other two commits I really want to get some feedback again first mainly from @glance- 
Layout: Anton did a nice change before me but I then saw that now info and stats look too different from layout point of view. I guess regarding the spacings - thats clear. For the height of the boxes: I looked at the two options (expand or not expand in height) yesterday some time and I have the feeling that the readability is better if the boxes don't expand to max height.
SAC min/max: I first thought I exactly did revert Antons change and was really ashamed that I did propose this to him. But it's not exactly the case. I only want to disable SAC min/max if it's equal to mean value.

If someone whants some changes I for sure can update this.
