### PR TITLE
Picture feature: Improve UI and translation of shift image times dialog

### DIFF
--- a/desktop-widgets/shiftimagetimes.ui
+++ b/desktop-widgets/shiftimagetimes.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>693</width>
-    <height>606</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -139,11 +139,17 @@ Not all images have timestamps in the range between
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="invalidLabel">
+       <widget class="QTextEdit" name="invalidFilesText">
         <property name="styleSheet">
          <string notr="true">color: red; </string>
         </property>
-        <property name="text">
+        <property name="lineWrapMode">
+         <enum>QTextEdit::NoWrap</enum>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="text" stdset="0">
          <string/>
         </property>
        </widget>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -380,9 +380,10 @@ void ShiftImageTimesDialog::updateInvalid()
 	timestamp_t timestamp;
 	bool allValid = true;
 	ui.warningLabel->hide();
-	ui.invalidLabel->hide();
+	ui.invalidFilesText->hide();
 	QDateTime time = QDateTime::fromTime_t(displayed_dive.when, Qt::UTC);
-	ui.invalidLabel->setText("Dive:" + time.toString() + "\n");
+	ui.invalidFilesText->setPlainText(tr("Dive date/time") + ": " + time.toString() + "\n");
+	ui.invalidFilesText->append(tr("Files with inappropriate date/time") + ":");
 
 	Q_FOREACH (const QString &fileName, fileNames) {
 		if (picture_check_valid(fileName.toUtf8().data(), m_amount))
@@ -391,13 +392,13 @@ void ShiftImageTimesDialog::updateInvalid()
 		// We've found invalid image
 		timestamp = picture_get_timestamp(fileName.toUtf8().data());
 		time.setTime_t(timestamp + m_amount);
-		ui.invalidLabel->setText(ui.invalidLabel->text() + fileName + " " + time.toString() + "\n");
+		ui.invalidFilesText->append(fileName + " " + time.toString());
 		allValid = false;
 	}
 
 	if (!allValid){
 		ui.warningLabel->show();
-		ui.invalidLabel->show();
+		ui.invalidFilesText->show();
 	}
 }
 


### PR DESCRIPTION
For the list of pictures with inappropriate date/time not fitting with
the dive time use a QTextEdit in read only mode with scroll bars
enabled instead of a QLabel.
This helps to fit the text in the UI even if there are many files and long paths/file names.

Also update and translate some strings used there.

Fixes three items of #368 
I would simply remove these items then from the issue, ok?

One question:
- Is "inappropriate" the right word or is there s.th. better?