### PR TITLE
Picture feature: Improve UI and translation of shift image times dial…

### DIFF
--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -111,6 +111,7 @@ slots:
 	void syncCameraClicked();
 	void dcDateTimeChanged(const QDateTime &);
 	void timeEditChanged(const QTime &time);
+	void timeEditChanged();
 	void updateInvalid();
 	void matchAllImagesToggled(bool);
 


### PR DESCRIPTION
…og P2

@dirkhh 
Sorry, I was too quick pushing the button. I have a second part...

Show date/time of first/last selected dive instead of displayed_dive.
Thats more useful to identify the right time offset for the images.

Trigger first update of image info already in constructor of the dialog.