### PR TITLE
Fix calculation of how many samples profile are in datatrack dive log file

### DIFF
--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -639,7 +639,9 @@ bool dt_dive_parser(FILE *archivo, struct dive *dt_dive)
 		 * 2bytes per sample plus another one each three samples. Also includes the
 		 * bytes jumped over (22) and the nitrox (2) or O2 (3).
 		 */
-		int samplenum = is_O2 ? (profile_length - 25) * 3 / 8 : (profile_length - 24) * 3 / 7;
+		int numerator = is_O2 ? (profile_length - 25) * 3 : (profile_length - 24) * 3;
+		int denominator = is_O2 ? 8 : 7;
+		int samplenum = (numerator / denominator) + (((numerator % denominator) != 0) ? 1 : 0);
 
 		dc->events = calloc(samplenum, sizeof(struct event));
 		dc->alloc_samples = samplenum;


### PR DESCRIPTION
Fix issue #354 : Importing Datatrack/WLog corruped.
The number of samples was badly calculated in samplenum variable. 
Sample length is 2 bytes and there is an extra byte (2 bytes for O2 computers) every 3 samples.
So, when the remainder of the division is not zero, samplenum must be rouded up, avoiding missing last sample when reading the file, possibly causing desynchronisation.

Signed-off-by: olivstdev <oliverst@free.fr>