### PR TITLE
Image import: Make Exif handling more tolerant, better info,...

### DIFF
--- a/core/exif.cpp
+++ b/core/exif.cpp
@@ -420,23 +420,6 @@ int easyexif::EXIFInfo::parseFrom(const unsigned char *buf, unsigned len) {
   if (!buf || len < 4) return PARSE_EXIF_ERROR_NO_JPEG;
   if (buf[0] != 0xFF || buf[1] != 0xD8) return PARSE_EXIF_ERROR_NO_JPEG;
 
-  // Sanity check: some cameras pad the JPEG image with null bytes at the end.
-  // Normally, we should able to find the JPEG end marker 0xFFD9 at the end
-  // of the image, but not always. As long as there are null/0xFF bytes at the
-  // end of the image buffer, keep decrementing len until an 0xFFD9 is found,
-  // or some other bytes are. If the first non-zero/0xFF bytes from the end are
-  // not 0xFFD9, then we can be reasonably sure that the buffer is not a JPEG.
-  while (len > 2) {
-    if (buf[len - 1] == 0 || buf[len - 1] == 0xFF) {
-      len--;
-    } else {
-      if (buf[len - 1] != 0xD9 || buf[len - 2] != 0xFF) {
-        return PARSE_EXIF_ERROR_NO_JPEG;
-      } else {
-        break;
-      }
-    }
-  }
   clear();
 
   // Scan for EXIF header (bytes 0xFF 0xE1) and do a sanity check by

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -309,7 +309,7 @@ void ShiftImageTimesDialog::syncCameraClicked()
 	QStringList fileNames = QFileDialog::getOpenFileNames(this,
 							      tr("Open image file"),
 							      DiveListView::lastUsedImageDir(),
-							      tr("Image files (*.jpg *.jpeg *.pnm *.tif *.tiff)"));
+							      tr("Image files (*.jpg *.jpeg)"));
 	if (fileNames.isEmpty())
 		return;
 
@@ -401,7 +401,10 @@ void ShiftImageTimesDialog::updateInvalid()
 		// We've found invalid image
 		timestamp = picture_get_timestamp(fileName.toUtf8().data());
 		time_first.setTime_t(timestamp + m_amount);
-		ui.invalidFilesText->append(fileName + " " + time_first.toString());
+		if (timestamp == 0)
+			ui.invalidFilesText->append(fileName + " - " + tr("No Exif date/time found"));
+		else
+			ui.invalidFilesText->append(fileName + " - " + time_first.toString());
 		allValid = false;
 	}
 


### PR DESCRIPTION
This is for the moment the most lightweigth fix for #370 and it is imho even good enought to keep it for a long time until s.o. want's to improve this further. This statement is for sure based on my assumption that most users will have JPG pictures. For TIFF with Exif info this for sure doesn't realy improve the situation but it also doesn't make it worse.

Regarding the exif.cpp change: A think the sanity check for the JPG EOI has no added value because later in the processing there is also the check for correct Exif data.
