### PR TITLE
Changes in duration formats in dive list table and info tab

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -927,17 +927,17 @@ int parseGasMixHE(const QString &text)
 QString get_dive_duration_string(timestamp_t when, QString hourText, QString minutesText, QString secondsText, bool isFreeDive)
 {
 	int hrs, mins, fullmins, secs;
-	mins = (when + 59) / 60;
+	mins = (when + 30) / 60;
 	fullmins = when / 60;
 	secs = when - 60 * fullmins;
 	hrs = mins / 60;
 
 	QString displayTime;
-	if (prefs.units.duration_units == units::ALWAYS_HOURS || (prefs.units.duration_units == units::MIXED && hrs)) {
+	if (isFreeDive) {
+		displayTime = QString("%1%2%3%4").arg(fullmins).arg(minutesText).arg(secs, 2, 10, QChar('0')).arg(secondsText);
+	} else if (prefs.units.duration_units == units::ALWAYS_HOURS || (prefs.units.duration_units == units::MIXED && hrs)) {
 		mins -= hrs * 60;
 		displayTime = QString("%1%2%3%4").arg(hrs).arg(hourText).arg(mins, 2, 10, QChar('0')).arg(hourText == ":" ? "" : minutesText);
-	} else if (isFreeDive) {
-		displayTime = QString("%1%2%3%4").arg(fullmins).arg(minutesText).arg(secs, 2, 10, QChar('0')).arg(secondsText);
 	} else {
 		displayTime = QString("%1%2").arg(mins).arg(hourText == ":" ? "" : minutesText);
 	}

--- a/desktop-widgets/preferences/preferences_units.ui
+++ b/desktop-widgets/preferences/preferences_units.ui
@@ -234,7 +234,7 @@
    <item>
     <widget class="QGroupBox">
      <property name="title">
-      <string>Duration units</string>
+      <string>Duration units in dive list table</string>
      </property>
      <layout class="QGridLayout">
       <item row="0" column="0">

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -75,7 +75,7 @@ void TabDiveInformation::updateData()
 	ui->oxygenHeliumText->setText(gaslist);
 
 	int sum = displayed_dive.dc.divemode != FREEDIVE ? 30 : 0;
-	ui->diveTimeText->setText(get_time_string_s(displayed_dive.duration.seconds + sum, 0, false));
+	ui->diveTimeText->setText(get_time_string_s(displayed_dive.duration.seconds + sum, 0, displayed_dive.dc.divemode == FREEDIVE));
 
 	struct dive *prevd;
 	process_all_dives(&displayed_dive, &prevd);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -343,7 +343,7 @@ int DiveItem::countPhotos(dive *dive) const
 QString DiveItem::displayDuration() const
 {
 	struct dive *dive = get_dive_by_uniq_id(diveId);
-	return get_dive_duration_string(dive->duration.seconds, ":", "m", "s", dive->dc.divemode == FREEDIVE);
+	return get_dive_duration_string(dive->duration.seconds, ":", tr("min"), tr("s"), dive->dc.divemode == FREEDIVE);
 }
 
 QString DiveItem::displayTemperature() const


### PR DESCRIPTION
- "Rounding" of minutes changed - do it the same way as in info and stats tab
- For decission about format give "isFreeDive" the highest prio in if-else clause
- In preferences dialog make it more clear that prefs are for dive list table
- In info tab do decission about format for freedive in same way as in table
- Change unit for minutes to "min" because "m" is reserved for meters
- Translate "min" for minutes and "s" for seconds