### PR TITLE
Allow weight system name to be edited

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -377,7 +377,7 @@ void WSInfoDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, co
 	mymodel->passInData(IDX(WeightModel::WEIGHT), grams);
 }
 
-WSInfoDelegate::WSInfoDelegate(QObject *parent) : ComboBoxDelegate(WSInfoModel::instance(), parent, false)
+WSInfoDelegate::WSInfoDelegate(QObject *parent) : ComboBoxDelegate(WSInfoModel::instance(), parent, true)
 {
 }
 


### PR DESCRIPTION
Issue #272 lead to the introduction of a new private property of the ComboBoxDelegate class (editable). This new property was not correctly set when creating the weight system delegate. This corrects the (trivial) error, and now allows edit of the weight system name.

Fixes: #392

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>