### PR TITLE
Test profile export

### DIFF
--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -370,6 +370,53 @@ void TestParse::exportCSVDiveDetails()
 	clear_dive_file_data();
 }
 
+int TestParse::parseCSVprofile(int units, std::string file)
+{
+	verbose = 1;
+	char *params[55];
+	int pnr = 0;
+
+	params[pnr++] = strdup("dateField");
+	params[pnr++] = intdup(1);
+	params[pnr++] = strdup("datefmt");
+	params[pnr++] = intdup(2);
+	params[pnr++] = strdup("starttimeField");
+	params[pnr++] = intdup(2);
+	params[pnr++] = strdup("numberField");
+	params[pnr++] = intdup(0);
+	params[pnr++] = strdup("timeField");
+	params[pnr++] = intdup(3);
+	params[pnr++] = strdup("depthField");
+	params[pnr++] = intdup(4);
+	params[pnr++] = strdup("tempField");
+	params[pnr++] = intdup(5);
+	params[pnr++] = strdup("pressureField");
+	params[pnr++] = intdup(6);
+	params[pnr++] = strdup("units");
+	params[pnr++] = intdup(units);
+	params[pnr++] = NULL;
+
+	return parse_csv_file(file.c_str(), params, pnr - 1, "csv");
+}
+
+void TestParse::exportCSVDiveProfile()
+{
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
+
+	export_dives_xslt("testcsvexportprofile.csv", 0, 0, "xml2csv.xslt");
+	export_dives_xslt("testcsvexportprofileimperial.csv", 0, 1, "xml2csv.xslt");
+
+	clear_dive_file_data();
+
+	parseCSVprofile(1, "testcsvexportprofileimperial.csv");
+	export_dives_xslt("testcsvexportprofile2.csv", 0, 0, "xml2csv.xslt");
+
+	FILE_COMPARE("testcsvexportprofile2.csv",
+		"testcsvexportprofile.csv");
+
+	clear_dive_file_data();
+}
+
 void TestParse::exportUDDF()
 {
 	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
@@ -390,6 +437,7 @@ void TestParse::exportUDDF()
 void TestParse::testExport()
 {
 	exportCSVDiveDetails();
+	exportCSVDiveProfile();
 	exportUDDF();
 }
 

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -26,6 +26,8 @@ private slots:
 
 	int parseCSVmanual(int, std::string);
 	void exportCSVDiveDetails();
+	int parseCSVprofile(int, std::string);
+	void exportCSVDiveProfile();
 	void exportUDDF();
 	void testExport();
 

--- a/xslt/csv2xml.xslt
+++ b/xslt/csv2xml.xslt
@@ -327,7 +327,7 @@
               <xsl:value-of select="translate($depth, ',', '.')"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:value-of select="translate(translate($depth, translate($depth, '0123456789,.', ''), ''), ',', '.') * 0.3048"/>
+              <xsl:value-of select="round(translate(translate($depth, translate($depth, '0123456789,.', ''), ''), ',', '.') * 0.3048 * 1000) div 1000"/>
             </xsl:otherwise>
           </xsl:choose>
         </xsl:attribute>

--- a/xslt/xml2csv.xslt
+++ b/xslt/xml2csv.xslt
@@ -34,10 +34,10 @@
       <xsl:value-of select="$fs"/>
       <xsl:choose>
         <xsl:when test="$units = 1">
-          <xsl:value-of select="concat('&quot;', format-number((substring-before(@depth, ' ') div 0.3048), '#.#'), ' ft&quot;')"/>
+          <xsl:value-of select="concat('&quot;', round((substring-before(@depth, ' ') div 0.3048) * 1000) div 1000, ' ft&quot;')"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="concat('&quot;', substring-before(@depth, ' '), '&quot;')"/>
+          <xsl:value-of select="concat('&quot;', round(substring-before(@depth, ' ') * 1000) div 1000, '&quot;')"/>
         </xsl:otherwise>
       </xsl:choose>
 


### PR DESCRIPTION
This test case exports dive profile to CSV. The comparison test case is first exported to imperial, then read back and exported finally to CSV. This ensures imperial conversion makes some sense in import-export cycle.