### PR TITLE
Fix right boundary when moving last handle in planner

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1808,7 +1808,8 @@ void ProfileWidget2::recreatePlannedDive()
 	DiveHandler *activeHandler = qobject_cast<DiveHandler *>(sender());
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
 	int index = fixHandlerIndex(activeHandler);
-	int mintime = 0, maxtime = lrint((timeAxis->maximum() + 10) * 60);
+	int mintime = 0;
+	int maxtime = plannerModel->at(plannerModel->size() - 1).time * 3 / 2;
 	if (index > 0)
 		mintime = plannerModel->at(index - 1).time;
 	if (index < plannerModel->size() - 1)


### PR DESCRIPTION
There was a bug in the old code due to confusion between minutes
and seconds as the unit of the time axis. But rather than limiting
the time for the last handle in terms of the time axis (which
potentially includes long deco and allowing that for bottom time
quickly leads to dives many many hours long) limit it to 150%
of the previous bottom time.

Signed-off-by: Robert C. Helling <helling@atdotde.de>