### PR TITLE
Smtk2ssrf portability

### DIFF
--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -30,6 +30,10 @@
 #include <stdarg.h>
 #include <locale.h>
 
+#if defined(WIN32) || defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include "core/dive.h"
 #include "core/gettext.h"
 #include "core/divelist.h"

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -62,7 +62,7 @@ static void smtk_free(char **array, int count)
  * a smarttrak db, and a tiny function which returns the number of the column where
  * a field is expected to be, taking into account the different db formats .
  */
-enum field_pos {IDX = 0, DIVENUM, DATE, INTIME, INTVAL, DURATION, OUTTIME, DESATBEFORE, DESATAFTER, NOFLYBEFORE,
+enum field_pos {IDX = 0, DIVENUM, _DATE, INTIME, INTVAL, DURATION, OUTTIME, DESATBEFORE, DESATAFTER, NOFLYBEFORE,
 		NOFLYAFTER, NOSTOPDECO, MAXDEPTH, VISIBILITY, WEIGHT, O2FRAC, HEFRAC, PSTART, PEND, AIRTEMP,
 		MINWATERTEMP, MAXWATERTEMP, SECFACT, ALARMS, MODE, REMARKS, DCNUMBER, DCMODEL, DIVETIMECOUNT, LOG,
 		PROFILE, SITEIDX, ALTIDX, SUITIDX, WEATHERIDX, SURFACEIDX, UNDERWATERIDX, TANKIDX};
@@ -921,7 +921,7 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 		smtk_clean_cylinders(smtkdive);
 
 		/* Date issues with libdc parser - Take date time from mdb */
-		smtk_date_to_tm(col[coln(DATE)]->bind_ptr, tm_date);
+		smtk_date_to_tm(col[coln(_DATE)]->bind_ptr, tm_date);
 		smtk_time_to_tm(col[coln(INTIME)]->bind_ptr, tm_date);
 		smtkdive->dc.when = smtkdive->when = timegm(tm_date);
 		free(tm_date);

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -116,10 +116,10 @@ static void smtk_date_to_tm(char *d_buffer, struct tm *tm_date)
  */
 static void smtk_time_to_tm(char *t_buffer, struct tm *tm_date)
 {
-	unsigned int n, hr, min, sec;
+	int n, hr, min, sec;
 
 	if ((t_buffer) && (!same_string(t_buffer, ""))) {
-		n = sscanf(t_buffer, "%*m[/0-9] %d:%d:%d ", &hr, &min, &sec);
+		n = sscanf(t_buffer, "%*[0-9/] %d:%d:%d ", &hr, &min, &sec);
 		if (n == 3) {
 			tm_date->tm_hour = hr;
 			tm_date->tm_min = min;
@@ -141,10 +141,10 @@ static void smtk_time_to_tm(char *t_buffer, struct tm *tm_date)
  */
 static unsigned int smtk_time_to_secs(char *t_buffer)
 {
-	unsigned int n, hr, min, sec;
+	int n, hr, min, sec;
 
 	if (!same_string(t_buffer, "")) {
-		n = sscanf(t_buffer, "%*m[/0-9] %d:%d:%d ", &hr, &min, &sec);
+		n = sscanf(t_buffer, "%*[0-9/] %d:%d:%d ", &hr, &min, &sec);
 		return((n == 3) ? (((hr*60)+min)*60)+sec : 0);
 	} else {
 		return 0;


### PR DESCRIPTION
I've finally managed to cross build the SmartTrak importer to windows. These patches are needed to build under mxe (some used functions weren't portable, others aren't included in mingw, etc).

Now I've a serious doubt about next step.
I mean:
ATM we are building -in linux- smtk2ssrf together with subsurface, simply setting -DSMTK_IMPORT=ON on cmake (provided installed the needed dependencies).
This approach means that we will need to bloat CMakeLists.txt with "if (SMTK_IMPORT)" conditionals to handle the windows build, and accordingly have some of the cmake modules. And I'm not even sure it will work.
The other approach -the one I've really used, and tested- is to absolutely isolate the smtk2ssrf building.  Here, scripts, much like build.sh and mxe-based-build.sh, are used to build the importer regardless of subsurface.  The only condition is that subsurface has to be built in first place, as smtk2ssrf needs to link  corelib; and the cost is the need of a new build directory, as building in the same that subsurface would blow up subsurface's CMakeCache.txt, and semi-clone some of the cmake modules in smtk-import source tree.

I feel this second option is better and cleaner, but would like your views before sending the final round of patches.

Best regards.