### PR TITLE
Do not import pre existing dives (and a litte more)

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -29,6 +29,7 @@ void DownloadThread::run()
 
 	downloadTable.nr = 0;
 	qDebug() << "Starting the thread" << downloadTable.nr;
+	dive_table.preexisting = dive_table.nr;
 
 	Q_ASSERT(internalData->download_table != nullptr);
 	const char *errorText;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -481,7 +481,7 @@ static int find_dive(struct divecomputer *match)
 {
 	int i;
 
-	for (i = 0; i < dive_table.preexisting; i++) {
+	for (i = dive_table.preexisting - 1; i >= 0; i--) {
 		struct dive *old = dive_table.dives[i];
 
 		if (match_one_dive(match, old))

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -140,7 +140,10 @@ void DiveImportedModel::setImportedDivesIndexes(int first, int last)
 
 void DiveImportedModel::repopulate()
 {
-	setImportedDivesIndexes(0, diveTable->nr-1);
+	if (diveTable->nr)
+		setImportedDivesIndexes(0, diveTable->nr-1);
+	else
+		setImportedDivesIndexes(0, 0);
 }
 
 void DiveImportedModel::recordDives()


### PR DESCRIPTION
3 (small) commits, of which the 2nd is most relevant. It appears that in the mobile app, the preexisting attribute is 0, where it should be the number of dives before the download. This causes the check for existing dive to conclude that any dive is a new one when importing. 