### PR TITLE
Android BT: pull the pairing data from a device

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -94,8 +94,8 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	alreadySaving(false)
 {
 #if defined(BT_SUPPORT)
-	if (localBtDevice.isValid()) {
-		localBtDevice.powerOn();
+	if (localBtDevice.isValid() &&
+	    localBtDevice.hostMode() == QBluetoothLocalDevice::HostConnectable) {
 		QStringList pairedBT = getBluetoothDevices();
 
 		for (int i = 0; i < pairedBT.length(); i++) {

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -12,6 +12,9 @@
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothUuid>
 #endif
+#if defined(Q_OS_ANDROID)
+#include <QAndroidJniObject>
+#endif
 
 #include "core/gpslocation.h"
 #include "qt-models/divelistmodel.h"
@@ -125,6 +128,7 @@ public:
 #if defined(BT_SUPPORT)
 	void btDeviceDiscovered(const QBluetoothDeviceInfo &device);
 #endif
+	QStringList getBluetoothDevices();
 
 public slots:
 	void applicationStateChanged(Qt::ApplicationState state);
@@ -207,6 +211,11 @@ private:
 	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
 	bool m_showPin;
+
+#if defined(Q_OS_ANDROID)
+	bool checkException(const char* method, const QAndroidJniObject* obj);
+#endif
+
 #if defined(BT_SUPPORT)
 	QBluetoothLocalDevice localBtDevice;
 	QBluetoothDeviceDiscoveryAgent *discoveryAgent;


### PR DESCRIPTION
As Qt is not able to pull the pairing data from a device, a lengthy discovery process is needed to see what devices are paired. On https://forum.qt.io/topic/46075/solved-bluetooth-list-paired-devices user s.frings74 does, however, present a solution to this using JNI. Currently, this code is taken "as is".

Currently, only for Android (so not mobile-on-desktop, or even desktop). And only generating logging data in the logcat.

And added a commit to not forcefully switch BT on. Very impolite to the user.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>