### PR TITLE
Add a messageHandler to take care of qDebug & friends on QML

### DIFF
--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -4,6 +4,7 @@ import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
+import QtQuick.Controls 2.1
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.0 as Kirigami
 
@@ -21,14 +22,16 @@ Kirigami.ScrollablePage {
 		Kirigami.Heading {
 			text: qsTr("Application Log")
 		}
-		Kirigami.Label {
-			id: logContent
-			width: parent.width
-			Layout.preferredWidth: parent.width
-			Layout.maximumWidth: parent.width
-			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
-			text: manager.logText
+
+		ListView {
+			width: parent.width;
+			height: 500
+			model: logModel
+			delegate : Text {
+				text : message
+			}
 		}
+
 		Rectangle {
 			color: "transparent"
 			height: Kirigami.Units.gridUnit * 2

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SUBSURFACE_MODELS_LIB_SRCS
 	divelistmodel.cpp
 	gpslistmodel.cpp
 	diveimportedmodel.cpp
+	messagehandlermodel.cpp
 )
 
 source_group("Subsurface Models" FILES ${SUBSURFACE_MODELS})

--- a/qt-models/messagehandlermodel.cpp
+++ b/qt-models/messagehandlermodel.cpp
@@ -1,0 +1,60 @@
+#include "messagehandlermodel.h"
+
+void logMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+	MessageHandlerModel::self()->addLog(type, msg);
+}
+
+MessageHandlerModel * MessageHandlerModel::self()
+{
+	static MessageHandlerModel *self = new MessageHandlerModel();
+	return self;
+}
+
+MessageHandlerModel::MessageHandlerModel(QObject *parent)
+{
+	// no more than one message handler.
+	qInstallMessageHandler(logMessageHandler);
+}
+
+int MessageHandlerModel::rowCount(const QModelIndex& parent) const
+{
+	Q_UNUSED(parent);
+	return m_data.size();
+}
+
+#include <iostream>
+
+void MessageHandlerModel::addLog(QtMsgType type, const QString& message)
+{
+	beginInsertRows(QModelIndex(), rowCount(), rowCount());
+	m_data.append({message, type});
+	endInsertRows();
+	std::cout << "adding" << message.toStdString() << " to the model" << std::endl;
+}
+
+QVariant MessageHandlerModel::data(const QModelIndex& idx, int role) const
+{
+	switch(role) {
+		case Message:
+		case Qt::DisplayRole:
+			return m_data.at(idx.row()).message;
+	}
+	return QVariant(QString("Role: %1").arg(role));
+};
+
+QHash<int, QByteArray> MessageHandlerModel::roleNames() const {
+	static QHash<int, QByteArray> roles = {
+		{Message, "message"},
+		{Severity, "severity"}
+	};
+	return roles;
+};
+
+void MessageHandlerModel::reset()
+{
+	beginRemoveRows(QModelIndex(), 0, m_data.size()-1);
+	m_data.clear();
+	endRemoveRows();
+
+}

--- a/qt-models/messagehandlermodel.h
+++ b/qt-models/messagehandlermodel.h
@@ -1,0 +1,29 @@
+#ifndef MESSAGEHANDLERMODEL_H
+#define MESSAGEHANDLERMODEL_H
+
+#include <QAbstractListModel>
+
+
+class MessageHandlerModel : public QAbstractListModel {
+	Q_OBJECT
+public:
+	static MessageHandlerModel *self();
+	enum MsgTypes {Message = Qt::UserRole + 1, Severity};
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex& idx, int role) const override;
+	QHash<int, QByteArray> roleNames() const override;
+	void addLog(QtMsgType type, const QString& message);
+
+	/* call this to clear the debug data */
+	Q_INVOKABLE void reset();
+
+private:
+	MessageHandlerModel(QObject *parent = 0);
+	struct MessageData {
+		QString message;
+		QtMsgType type;
+	};
+	QVector<MessageData> m_data;
+};
+
+#endif

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -23,6 +23,7 @@
 #include "mobile-widgets/qmlprofile.h"
 #include "core/downloadfromdcthread.h"
 #include "qt-models/diveimportedmodel.h"
+#include "qt-models/messagehandlermodel.h"
 
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 
@@ -74,6 +75,7 @@ void run_ui()
 	ctxt->setContextProperty("diveModel", sortModel);
 	ctxt->setContextProperty("gpsModel", gpsSortModel);
 	ctxt->setContextProperty("vendorList", vendorList);
+	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
 
 	engine.load(QUrl(QStringLiteral("qrc:///qml/main.qml")));
 	qqWindowObject = engine.rootObjects().value(0);


### PR DESCRIPTION
all qDebug / qCDebug and friends now will be properly
logged into developer -> log, on QML.

Signed-off-by: Tomaz Canabrava <tcanabrava@kde.org>