### PR TITLE
FTDI: slower backoff

### DIFF
--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -404,7 +404,7 @@ static dc_status_t serial_ftdi_read (void **userdata, void *data, size_t size, s
 			slept += backoff;
 			backoff *= 2;
 			if (backoff + slept > timeout)
-				backoff = timeout - slept;
+				backoff = timeout - backoff;
 		} else {
 			// Reset backoff to 1 on success.
 			backoff = 1;


### PR DESCRIPTION
The current exponential backoff for ftdi communication is a bit to fast,
as it effectively causes a timeout after 20 ms.
Slowing this will give us slightly more time to initiate communication.

Signed-off-by: Joakim Bygdell <j.bygdell@gmail.com>