### PR TITLE
Smtk import rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,6 @@ option(USE_WEBENGINE "Use QWebEngine instead of QWebKit" OFF)
 # Options regarding What should we build on subsurface
 option(MAKE_TESTS "Make the tests" ON)
 
-#Extra features
-option(SMARTTRAK_IMPORT "enable building SmartTrak divelogs import tool (requires glib2 and libmdb)" OFF)
-
 SET(SUBSURFACE_TARGET_EXECUTABLE "DesktopExecutable" CACHE STRING "The type of application, DesktopExecutable or MobileExecutable")
 LIST(APPEND SUBSURFACE_ACCEPTED_EXECUTABLES  "DesktopExecutable" "MobileExecutable")
 SET_PROPERTY(CACHE SUBSURFACE_TARGET_EXECUTABLE PROPERTY STRINGS ${SUBSURFACE_ACCEPTED_EXECUTABLES})
@@ -128,11 +125,6 @@ pkg_config_library(LIBSQLITE3 sqlite3 REQUIRED)
 pkg_config_library(LIBXSLT libxslt REQUIRED)
 pkg_config_library(LIBZIP libzip REQUIRED)
 pkg_config_library(LIBUSB libusb-1.0 QUIET)
-
-if(SMARTTRAK_IMPORT)
-	pkg_config_library(GLIB2 glib-2.0 REQUIRED)
-	pkg_config_library(LIBMDB libmdb REQUIRED)
-endif()
 
 include_directories(.
 	${CMAKE_CURRENT_BINARY_DIR}
@@ -238,10 +230,6 @@ add_subdirectory(core)
 add_subdirectory(qt-models)
 add_subdirectory(profile-widget)
 
-if(SMARTTRAK_IMPORT)
-	add_subdirectory(smtk-import)
-endif()
-
 if (${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
 	add_subdirectory(desktop-widgets)
 endif()
@@ -287,12 +275,6 @@ elseif(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
         else()
                 add_executable(${SUBSURFACE_TARGET} MACOSX_BUNDLE WIN32 ${SUBSURFACE_PKG} ${SUBSURFACE_APP} ${SUBSURFACE_RESOURCES})
         endif()
-
-        if(SMARTTRAK_IMPORT)
-		set(SMTK_IMPORT_TARGET smtk2ssrf)
-		add_executable(smtk2ssrf smtk-import/smtk_standalone.cpp ${SUBSURFACE_RESOURCES})
-		target_link_libraries(smtk2ssrf smtk_import)
-	endif()
 
 	if(FBSUPPORT)
 		set(FACEBOOK_INTEGRATION facebook_integration)
@@ -475,9 +457,6 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	install(DIRECTORY printing_templates DESTINATION share/subsurface)
 	install(FILES ${TRANSLATIONS} DESTINATION share/subsurface/translations)
         install(TARGETS ${SUBSURFACE_TARGET} DESTINATION bin)
-        if (SMARTTRAK_IMPORT)
-                install(TARGETS ${SMTK_IMPORT_TARGET} DESTINATION bin)
-        endif()
 	if(DEFINED LIBMARBLEDEVEL)
 		install(
 			CODE "file(GLOB SSRFMARBLE_SHLIBS \"${LIBMARBLEDEVEL}/lib/libssrfmarblewidget.so*\")"

--- a/packaging/windows/smtk-import.nsi.in
+++ b/packaging/windows/smtk-import.nsi.in
@@ -1,0 +1,234 @@
+#
+# Smrtk2ssrf NSIS installer script
+#
+# This installer creator needs to be run with:
+# makensis smtk-import.nsi
+#
+
+#--------------------------------
+# Include Modern UI
+
+    !include "MUI2.nsh"
+
+#--------------------------------
+# General
+
+    # Program version
+    !define SUBSURFACE_VERSION "VERSIONTOKEN"
+
+    # VIProductVersion requires version in x.x.x.x format
+    !define SUBSURFACE_VIPRODUCTVERSION "PRODVTOKEN"
+
+    # Installer name and filename
+    Name "Smtk2ssrf"
+    Caption "Smtk2ssrf ${SUBSURFACE_VERSION} Setup"
+    OutFile "..\smtk2ssrf-${SUBSURFACE_VERSION}.exe"
+
+    # Icon to use for the installer
+    !define MUI_ICON "subsurface.ico"
+
+    # Default installation folder
+    InstallDir "$PROGRAMFILES\Smtk2ssrf"
+
+    # Get installation folder from registry if available
+    InstallDirRegKey HKCU "Software\Smtk2ssrf" ""
+
+    # Request application privileges
+    RequestExecutionLevel admin
+
+#--------------------------------
+# Version information
+
+    VIProductVersion "${SUBSURFACE_VIPRODUCTVERSION}"
+    VIAddVersionKey "ProductName" "Smtk2ssrf"
+    VIAddVersionKey "FileDescription" "Smtk2ssrf - Import SmartTrak divelogs to Subsurface XML format."
+    VIAddVersionKey "FileVersion" "${SUBSURFACE_VERSION}"
+    VIAddVersionKey "LegalCopyright" "GPL v.2"
+    VIAddVersionKey "ProductVersion" "${SUBSURFACE_VERSION}"
+
+#--------------------------------
+# Settings
+
+    # Show a warn on aborting installation
+    !define MUI_ABORTWARNING
+
+    # Defines the target start menu folder
+    !define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKCU"
+    !define MUI_STARTMENUPAGE_REGISTRY_KEY "Software\Smtk2ssrf"
+    !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "Start Menu Folder"
+
+#--------------------------------
+# Variables
+
+    Var StartMenuFolder
+
+#--------------------------------
+# Custom pages
+#
+# Maintain some checkboxes in the uninstall dialog
+#Var UninstallDialog
+#Var Checkbox_Reg
+#Var Checkbox_Reg_State
+#Var Checkbox_UserDir
+#Var Checkbox_UserDir_State
+#Var UserDir
+#
+#Function un.UninstallOptions
+#    nsDialogs::Create 1018
+#    Pop $UninstallDialog
+#    ${If} $UninstallDialog == error
+#        Abort
+#    ${EndIf}
+#
+#    StrCpy $Checkbox_Reg_State 0
+#    StrCpy $Checkbox_UserDir 0
+#
+#    # if this key exists Subsurface was run at least once
+#    ReadRegStr $UserDir HKCU "Software\Subsurface\Subsurface\GeneralSettings" "default_directory"
+#    ${If} $UserDir != ""
+#        # checkbox for removing registry entries
+#        ${NSD_CreateCheckbox} 0 0u 100% 20u "Registry entries (HKEY_CURRENT_USER\Software\Subsurface)"
+#        Pop $Checkbox_Reg
+#        GetFunctionAddress $0 un.OnCheckbox_Reg
+#        nsDialogs::OnClick $Checkbox_Reg $0
+#
+#        ${If} ${FileExists} "$UserDir\*.*"
+#            # checkbox for removing the user directory
+#            ${NSD_CreateCheckbox} 0 20u 100% 20u "User directory ($UserDir)"
+#            Pop $Checkbox_UserDir
+#            GetFunctionAddress $0 un.OnCheckbox_UserDir
+#            nsDialogs::OnClick $Checkbox_UserDir $0
+#       ${EndIf}
+#    ${EndIf}
+#
+#    nsDialogs::Show
+#FunctionEnd
+#
+#Function un.OnCheckbox_Reg
+#    ${NSD_GetState} $Checkbox_Reg $Checkbox_Reg_State
+#FunctionEnd
+#Function un.OnCheckbox_UserDir
+#    ${NSD_GetState} $Checkbox_UserDir $Checkbox_UserDir_State
+#    ${If} $Checkbox_UserDir_State == 1
+#       MessageBox MB_OK "WARNING!$\nMake sure you don't have important files in the user directory!"
+#    ${EndIf}
+#FunctionEnd
+
+#--------------------------------
+# Pages
+
+    # Installer pages
+    !insertmacro MUI_PAGE_LICENSE "gpl-2.0.txt"
+    !insertmacro MUI_PAGE_DIRECTORY
+    !insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+    !insertmacro MUI_PAGE_INSTFILES
+
+    # Uninstaller pages
+    !insertmacro MUI_UNPAGE_CONFIRM
+#    UninstPage custom un.UninstallOptions
+    !insertmacro MUI_UNPAGE_INSTFILES
+
+#--------------------------------
+# Languages
+
+    !insertmacro MUI_LANGUAGE "English"
+
+Section
+    SetShellVarContext all
+
+    # Installation path
+    SetOutPath "$INSTDIR"
+
+    # Delete any already installed DLLs to avoid buildup of various
+    # versions of the same library when upgrading
+    Delete "$INSTDIR\*.dll"
+
+    # Files to include in installer
+    # now that we install into the staging directory and try to only have
+    # the DLLs there that we depend on, this is much easier
+    File smtk2ssrf.exe
+#    File /r data
+#    File /r theme
+#    File /r images
+    File /r plugins
+#    File /r Documentation
+#    File /r translations
+#    File /r printing_templates
+#    File /r grantlee
+    File *.dll
+    File subsurface.ico
+    File qt.conf
+
+    # Store installation folder in registry
+    WriteRegStr HKCU "Software\Smtk2ssrf" "" $INSTDIR
+
+    # Create shortcuts
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+        CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+        CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Smtk2ssrf.lnk" "$INSTDIR\smtk2ssrf.exe" "" "$INSTDIR\subsurface.ico" 0
+        CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall Smtk2ssrf.lnk" "$INSTDIR\Uninstall_smtk2ssrf.exe"
+        CreateShortCut "$DESKTOP\Smtk2ssrf.lnk" "$INSTDIR\smtk2ssrf.exe" "" "$INSTDIR\subsurface.ico" 0
+    !insertmacro MUI_STARTMENU_WRITE_END
+
+    # Create the uninstaller
+    WriteUninstaller "$INSTDIR\Uninstall_smtk2ssrf.exe"
+
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Smtk2ssrf" \
+        "DisplayName" "Smtk2ssrf"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Smtk2ssrf" \
+        "DisplayIcon" "$INSTDIR\subsurface.ico"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Smtk2ssrf" \
+        "UninstallString" "$INSTDIR\Uninstall_smtk2ssrf.exe"
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Smtk2ssrf" \
+        "DisplayVersion" ${SUBSURFACE_VERSION}
+
+SectionEnd
+
+#--------------------------------
+# Uninstaller section
+
+Section "Uninstall"
+    SetShellVarContext all
+
+    # Delete installed files
+    Delete "$INSTDIR\*.dll"
+    Delete "$INSTDIR\freetype-config"
+    Delete "$INSTDIR\smtk2ssrf.exe"
+    Delete "$INSTDIR\subsurface.ico"
+    Delete "$INSTDIR\Uninstall_smtk2ssrf.exe"
+    Delete "$INSTDIR\qt.conf"
+#    RMDir /r "$INSTDIR\share"
+#    RMDir /r "$INSTDIR\data"
+#    RMDir /r "$INSTDIR\theme"
+#    RMDir /r "$INSTDIR\images"
+#    RMDir /r "$INSTDIR\translations"
+#    RMDir /r "$INSTDIR\oldshare"
+    RMDir /r "$INSTDIR\plugins"
+#    RMDir /r "$INSTDIR\Documentation"
+#    RMDir /r "$INSTDIR\printing_templates"
+#    RMDir /r "$INSTDIR\grantlee"
+    RMDir "$INSTDIR"
+
+    # Remove shortcuts
+    !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
+    Delete "$SMPROGRAMS\$StartMenuFolder\Smtk2ssrf.lnk"
+    Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall Smtk2ssrf.lnk"
+    RMDir "$SMPROGRAMS\$StartMenuFolder"
+    Delete "$DESKTOP\Smtk2ssrf.lnk"
+
+    # remove the registry entires
+    ${If} $Checkbox_Reg_State == 1
+        DeleteRegKey HKCU "Software\Smtk2ssrf"
+    ${EndIf}
+
+    # remove the user directory
+    ${If} $Checkbox_UserDir_State == 1
+    ${AndIf} $UserDir != ""
+    ${AndIf} ${FileExists} "$UserDir\*.*"
+        RMDir /r $UserDir
+    ${EndIf}
+
+    # remove the uninstaller entry
+    DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Smtk2ssrf"
+
+SectionEnd

--- a/packaging/windows/smtk2ssrf-mxe-build.sh
+++ b/packaging/windows/smtk2ssrf-mxe-build.sh
@@ -1,0 +1,229 @@
+#!/bin/bash -e
+
+# This script is based in subsurface's packaging/windows/mxe-based-build.sh and
+# works in the same fashion. Building needs to be done in a directory out of
+# the source tree and, please, refer to said script for instructions on how to
+# build.
+#
+# Subsurface *MUST* have been built before running that script, as the importer
+# links against libsubsurface_corelib.a library.
+# Although is possible to build the latest git version of the importer against
+# whichever other version of subsurface, this should be avoided, and both
+# versions, subsurface and smtk-import should be the same.
+#
+# Flags and options:
+# -i (--installer): Packs a windows installer. This should always be used.
+# -t (--tag):       Defines which git version we want to build. Defaults to
+#                   latest. E.g. -t v4.6.4
+# -b (--build):     Values: debug or release. Defines the build we want to do.
+# -d (--dir):	    Specify a directory where a copy of the installer will be
+#                   placed. This is a *must* if the script runs in a VM, and
+#		    refers -usually- to a local dir mounted on the VM.
+#
+# Examples: (provided Subsurface has been previously cross built)
+#
+# smtk2ssrf-mxe-build.sh -i -t master
+# This will build an release installer of smtk2ssrf placed in a directory under
+# the win-build directory where it has been launched, named smtk-import. It will
+# build git latest master regardless of subsurface's cross built version.
+#
+# smtk2ssrf-mxe-build.sh -b debug
+# This will build *just* a windows binary (no packing) of the latest master.
+#
+# smtk2ssrf-mxe-build.sh -i -t v4.6.4 -b relase -d /mnt/data
+# As I'm building in a fedora-25 docker VM, this should bring up a release
+# installer of the v4.6.4 tag, and put a copy in my local mounted dir. In
+# fact this *should* fail to build because of portability issues in v4.6.4.
+#
+
+exec 1> >(tee ./winbuild_smtk2ssrf.log) 2>&1
+# for debugging
+# trap "set +x; sleep 1; set -x" DEBUG
+
+# Set some colors for pretty output
+#
+BLUE="\033[0;34m"
+RED="\033[0;31m"
+LIGHT_GRAY="\033[0;37m"
+DEFAULT="\033[0m"
+
+SSRF_TAG=""
+RELEASE="Release"
+
+# this is important, if we are building in a VM or if we want to get a copy
+# of the installer elsewhere out of the building tree.
+# In my case this is a mount point on the docker VM.
+DATADIR=""
+
+# Adjust desired build parallelism
+JOBS="-j1"
+
+EXECDIR=$(pwd)
+BASEDIR=$(cd "$EXECDIR/.."; pwd)
+BUILDDIR=$(cd "$EXECDIR"; pwd)
+
+echo -e "$BLUE-> $BUILDDIR$DEFAULT"
+
+if [[ ! -d "$BASEDIR"/mxe ]] ; then
+	echo -e "$RED--> Please start this from the right directory"
+	echo -e "usually a winbuild directory parallel to the mxe directory $DEFAULT"
+	exit 1
+fi
+
+echo -e "$BLUE---> Building in$LIGHT_GRAY $BUILDDIR ...$DEFAULT"
+
+# check for arguments and set options
+if [ $# -eq 0 ]; then
+	echo -e "$BLUE---> No arguments given."
+	echo -e "---> Building actual git commit and Release type without installer $DEFAULT"
+else
+	while [ $# -gt 0 ]; do
+		case $1 in
+			-t|--tag)	SSRF_TAG="$2"
+					shift;;
+			-i|--installer)	INSTALLER="installer"
+					;;
+			-b|--build)	RELEASE="$2"
+					shift;;
+			-d|--dir)	DATADIR="$2"
+					shift;;
+		esac
+		shift
+	done
+	echo -e "$BLUE---> Subsurface tagged to:$LIGHT_GRAY $SSRF_TAG"
+	echo -e "$BLUE---> Building type:$LIGHT_GRAY $RELEASE"
+	echo -e "$BLUE---> Installer set to:$LIGHT_GRAY $INSTALLER $DEFAULT"
+fi
+case "$RELEASE" in
+	debug|Debug)		RELEASE=Debug
+				DLL_SUFFIX="d"
+				[[ -f Release ]] && rm -rf ./*
+				touch Debug
+				;;
+	release|Release)	RELEASE=Release
+				DLL_SUFFIX=""
+				[[ -f Debug ]] && rm -rf ./*
+				touch Release
+				;;
+esac
+
+export PATH="$BASEDIR"/mxe/usr/bin:$PATH:"$BASEDIR"/mxe/usr/i686-w64-mingw32.shared/qt5/bin/
+export CXXFLAGS=-std=c++11
+export PKG_CONFIG_PATH_i686_w64_mingw32_static="$BASEDIR/mxe/usr/i686-w64-mingw32.static/lib/pkgconfig"
+export PKG_CONFIG_PATH_i686_w64_mingw32_shared="$BASEDIR/mxe/usr/i686-w64-mingw32.shared/lib/pkgconfig"
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH_i686_w64_mingw32_static":"$PKG_CONFIG_PATH_i686_w64_mingw32_shared"
+
+#
+# mdbtools
+#
+if [ ! -f "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib/libmdb.a ]; then
+	echo -e "$BLUE---> Building mdbtools ... $DEFAULT "
+	mkdir -p --verbose "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/include
+	mkdir -p --verbose "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib
+	cd "$BUILDDIR"
+	[[ -d mdbtools ]] && rm -rf mdbtools
+	mkdir -p mdbtools
+	cd mdbtools
+	if [ ! -f "$BASEDIR"/mdbtools/configure ] ; then
+		( cd "$BASEDIR"/mdbtools
+		autoreconf -v -f -i )
+	fi
+	"$BASEDIR"/mdbtools/configure  --host=i686-w64-mingw32.static \
+			     --srcdir="$BASEDIR"/mdbtools \
+			     --prefix="$BASEDIR"/mxe/usr/i686-w64-mingw32.static \
+			     --enable-shared \
+			     --disable-man \
+			     --disable-gmdb2
+	make $JOBS >/dev/null
+	if [ $? -ne 0 ]; then
+		echo -e "$RED---> Building mdbtools failed. Aborting ...$DEFAULT "
+		exit 1
+	fi
+	make install
+else
+	echo -e "$BLUE---> Prebuilt mxe mdbtools ... $DEFAULT"
+fi
+
+# Subsurface
+#
+cd "$BASEDIR/subsurface"
+git reset --hard master && echo -e "$BLUE---> Uncommited changes to Subsurface (if any) dropped$DEFAULT"
+git pull "$(git remote -v |grep fetch |awk '{print $1}')" master
+if [ $? -ne 0 ]; then
+	echo -e "$RED---> git pull failed, Subsurface not updated$DEFAULT"
+else
+	echo -e "$BLUE---> Subsurface updated$DEFAULT"
+fi
+
+if [ "$SSRF_TAG" != "" ]; then
+	git checkout "$SSRF_TAG"
+	if [ $? -ne 0 ]; then
+		echo -e "$RED---> Failed to checkout Subsurface's $SSRF_TAG. Abort building. $DEFAULT"
+		exit 1
+	fi
+fi
+
+# Every thing is ok. Go on.
+cd "$BUILDDIR"
+
+# Blow up smtk-import binary dir and make it again, just to be extra-clean
+rm -rf smtk-import && echo -e "$BLUE---> Deleted$LIGHT_GRAY $BUILDDIR/smtk-import folder$DEFAULT"
+mkdir -p smtk-import && echo -e "$BLUE---> Created new$LIGHT_GRAY $BUILDDIR/smtk-import folder$DEFAULT"
+
+# first copy the Qt plugins in place
+QT_PLUGIN_DIRECTORIES="$BASEDIR/mxe/usr/i686-w64-mingw32.shared/qt5/plugins/iconengines \
+$BASEDIR/mxe/usr/i686-w64-mingw32.shared/qt5/plugins/imageformats \
+$BASEDIR/mxe/usr/i686-w64-mingw32.shared/qt5/plugins/platforms"
+
+# This comes from subsurface's mxe-based-build.sh. I'm not sure it is necessary
+# but, well, it doesn't hurt.
+EXTRA_MANUAL_DEPENDENCIES="$BASEDIR/mxe/usr/i686-w64-mingw32.shared/qt5/bin/Qt5Xml$DLL_SUFFIX.dll"
+
+STAGING_DIR=$BUILDDIR/smtk-import/staging
+
+mkdir -p "$STAGING_DIR"/plugins
+
+for d in $QT_PLUGIN_DIRECTORIES
+do
+    cp -a "$d" "$STAGING_DIR"/plugins
+done
+
+for f in $EXTRA_MANUAL_DEPENDENCIES
+do
+    cp "$f" "$STAGING_DIR"
+done
+
+# this is absolutely hackish, but necessary. Libmdb (built or prebuilt) is linked against
+# shared glib-2.0, but once and again we are trying to link against static lib.
+mv -vf "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib/libglib-2.0.a "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib/libglib-2.0.a.bak || \
+	echo -e "$BLUE------> libglib-2.0.a had been moved in a previous run$DEFAULT"
+
+cd "$BUILDDIR"/smtk-import
+mkdir -p staging
+
+echo -e "$BLUE---> Building CMakeCache.txt$DEFAULT"
+cmake	-DCMAKE_TOOLCHAIN_FILE="$BASEDIR"/mxe/usr/i686-w64-mingw32.shared/share/cmake/mxe-conf.cmake \
+	-DPKG_CONFIG_EXECUTABLE="/usr/bin/pkg-config" \
+	-DCMAKE_PREFIX_PATH="$BASEDIR"/mxe/usr/i686-w64-mingw32.shared/qt5 \
+	-DCMAKE_BUILD_TYPE=$RELEASE \
+	-DMAKENSIS=i686-w64-mingw32.shared-makensis \
+	-DSSRF_CORELIB="$BUILDDIR"/subsurface/core/libsubsurface_corelib.a \
+	"$BASEDIR"/subsurface/smtk-import
+
+echo -e "$BLUE---> Building ...$DEFAULT"
+if [ ! -z "$INSTALLER" ]; then
+	make "$JOBS" "$INSTALLER"
+else
+	make "$JOBS"
+fi
+
+# Undo previous hackery
+echo -e "$BLUE---> Restoring system to initial state$DEFAULT"
+mv -vf "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib/libglib-2.0.a.bak "$BASEDIR"/mxe/usr/i686-w64-mingw32.static/lib/libglib-2.0.a
+
+if [ ! -z "$DATADIR" ]; then
+	echo -e "$BLUE---> Copying Smtk2ssrf installer to data folder$DEFAULT"
+	cp -vf "$BUILDDIR"/smtk-import/smtk2ssrf-*.exe "$DATADIR"
+fi
+
+echo -e "$RED---> Building smtk2ssrf done$DEFAULT"

--- a/scripts/smtk2ssrf-build.sh
+++ b/scripts/smtk2ssrf-build.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# This script is meant to run from src directory in the same fashion than
+# subsurface/scripts/build.sh
+#
+# Flags:	-t (--tag) A git valid tag, commit, etc in subsurface tree
+#		-j (--jobs) Desired build parallelism, integer.
+#		-b (--build) Cmake build type, valid values Debug or Release
+# Examples:
+#     $	./subsurface/scripts/build-smtk2ssrf.sh
+#	No flags, will build a Release version, with -j4 parallelism in the
+#	last set git tree position. This should be the usual use form.
+#     $	./subsurface/scripts/build-smtk2ssrf.sh -j 2 -t v4.6.5 -b Debug
+#	Will build a Debug version of smtk2ssrf from the tag v4.6.5 (proved it
+#	exists) with -j2 parallelism.
+#
+
+# Default build parallelism
+#
+JOBS="-j4"
+
+# Default subsurface git tag: none, assume last manually selected
+# or set in build.sh
+#
+SSRF_TAG=""
+
+# Default build type Release
+#
+RELEASE=Release
+
+BASEDIR="$(pwd)"
+INSTALL_ROOT="$BASEDIR"/install-root
+SSRF_PATH="$BASEDIR"/subsurface
+
+# Display an error message if we need to bail out
+#
+function aborting() {
+	echo "----> $1. Aborting."
+	exit 1
+}
+
+# check for arguments and set options if any
+#
+while [ $# -gt 0 ]; do
+	case $1 in
+		-t|--tag)	SSRF_TAG="$2"
+				shift;;
+		-j|--jobs)	JOBS=-j"$2"
+				shift;;
+		-b|--build)	RELEASE="$2"
+				shift;;
+	esac
+	shift
+done
+
+echo ">> Building smtk2ssrf <<"
+
+# Check if we are in a sane environment
+#
+[[ ! -d "$SSRF_PATH" ]] && aborting "Please start from the source root directory" || echo "--> Building from $BASEDIR"
+
+
+# Ensure cmake and pkg-config have the corrects paths set
+#
+export CMAKE_PREFIX_PATH="$BASEDIR/install-root:$CMAKE_PREFIX_PATH"
+export PKG_CONFIG_PATH="$BASEDIR/install-root/lib/pkgconfig"
+
+# Check if we have glib-2.0 installed. This is a dependency for
+# mdbtools.
+#
+pkg-config --exists glib-2.0
+[[ $? -ne 0 ]] && aborting "Glib-2.0 not installed" || \
+	echo "----> Glib-2.0 exists: $(pkg-config --print-provides glib-2.0)"
+
+# Mdbtools
+#
+# Check if mdbtools devel package is avaliable, if it is not, download
+# and build it.
+#
+pkg-config --exists libmdb
+if [ $? -ne 0 ]; then
+	echo "----> Downloading/Updating mdbtools "
+	if [ -d "$BASEDIR"/mdbtools ]; then
+		cd "$BASEDIR"/mdbtools || aborting "Couldn't cd into $BASEDIR/mdbtools"
+		git pull --rebase
+	else
+		git clone https://github.com/brianb/mdbtools.git "$BASEDIR"/mdbtools
+	fi
+	[[ $? -ne 0 ]] && aborting "Problem downloading/updating mdbtools"
+
+	echo "----> Building mdbtools ..."
+	echo "----> This will display a lot of errors and warnings"
+	cd "$BASEDIR"/mdbtools || aborting "Couldn't cd into $BASEDIR/mdbtools"
+	autoreconf -i -f
+	./configure --prefix "$INSTALL_ROOT" --disable-man --disable-gmdb2 >/dev/null
+	make "$JOBS">/dev/null || aborting "Building mdbtools failed"
+	make install
+else
+	echo "----> Mdbtools already installed: $(pkg-config --print-provides libmdb)"
+fi
+
+# We are done. Move on
+# No need to update subsurface sources, as it has been previously
+# done by build.sh
+#
+# Do we want to build a branch or commit other than the one used
+# for build.sh?
+#
+if [ ! "$SSRF_TAG" == "" ]; then
+	cd "$SSRF_PATH" || aborting "Couldn't cd into $SSRF_PATH"
+	git checkout "$SSRF_TAG" || aborting "Couldn't checkout $SSRF_TAG. Is it correct?"
+fi
+
+echo "----> Building smtk2ssrf SmartTrak divelogs importer"
+
+cd "$SSRF_PATH"/smtk-import || aborting "Couldnt cd into $SSRF_PATH/smtk-import"
+mkdir -p build
+cd build || aborting "Couldn't cd into $SSRF_PATH/smtk-import/build"
+
+cmake -DCMAKE_BUILD_TYPE="$RELEASE" .. || aborting "Cmake incomplete"
+
+make "$JOBS" || aborting "Failed to build smtk2ssrf"
+
+echo ">> Building smtk2ssrf completed <<"
+echo ">> Executable placed in  $SSRF_PATH/smtk-import/build <<"
+echo ">> To install system-wide, move there and run sudo make install <<"

--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -1,12 +1,152 @@
+# Modified from Subsurface's CMakeLists.txt
+
+project(smtk2ssrf)
+cmake_minimum_required(VERSION 2.8.11)
+
+set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_BUILD_TYPE "Release")
+
+set(SSRF_PATH ../)
+set(CMAKE_MODULE_PATH ${SSRF_PATH}cmake/Modules)
+include(${CMAKE_MODULE_PATH}/MacroOutOfSourceBuild.cmake)
+include(${CMAKE_MODULE_PATH}/cmake_variables_helper.cmake)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	include(${CMAKE_MODULE_PATH}/HandleVersionGeneration.cmake)
+endif()
+
+MACRO_ENSURE_OUT_OF_SOURCE_BUILD(
+    "We don't support building in source, please create a build folder elsewhere and remember to run git clean -xdf to remove temporary files created by CMake."
+)
+
+# Find needed packages and Qt5 components. Most of them needed by Subsurface
+find_package(PkgConfig)
+include(${SSRF_PATH}cmake/Modules/pkgconfig_helper.cmake)
+pkg_config_library(LIBXML libxml-2.0 REQUIRED)
+pkg_config_library(LIBSQLITE3 sqlite3 REQUIRED)
+pkg_config_library(LIBXSLT libxslt REQUIRED)
+pkg_config_library(LIBZIP libzip REQUIRED)
+pkg_config_library(LIBUSB libusb-1.0 QUIET)
+pkg_config_library(GLIB2 glib-2.0 REQUIRED)
+pkg_config_library(LIBGIT2 libgit2 REQUIRED)
+pkg_config_library(LIBMDB libmdb REQUIRED)
+pkg_config_library(LIBDC libdivecomputer REQUIRED)
+
+find_package(Qt5 REQUIRED COMPONENTS Core
+				     Concurrent
+				     Widgets
+				     Network
+				     Svg
+				     Test
+				     LinguistTools
+				     Positioning
+				     Bluetooth)
+
+set(QT_LIBRARIES Qt5::Core
+		 Qt5::Concurrent
+		 Qt5::Widgets
+		 Qt5::Network
+		 Qt5::Svg
+		 Qt5::Positioning
+		 Qt5::Bluetooth)
+
+set(QT5_INCLUDE_PATH ${Qt5_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS} ${Qt5Core_INCLUDE_DIRS})
+qt5_add_resources(SUBSURFACE_RESOURCES ${SSRF_PATH}subsurface.qrc)
+
+include_directories(${SSRF_PATH} ${QT5_INCLUDE_PATH} ${LIBMDB_INCLUDEDIR} ${LIBDIVECOMPUTER_INCLUDEDIR})
+
+# Check for libsubsurface_corelib.a
+# A previous build of subsurface is needed (windows and linux)
+message(STATUS "Checking for Subsurface core library")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	find_library(SSRF_CORELIB
+		NAMES subsurface_corelib
+		PATHS ${CMAKE_BINARY_DIR}/../subsurface/core
+		)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	find_library(SSRF_CORELIB
+		NAMES subsurface_corelib
+		PATHS ${SSRF_PATH}build/core
+		)
+endif()
+
+if(NOT DEFINED SSRF_CORELIB OR SSRF_CORELIB STREQUAL "SSRF_CORELIB-NOTFOUND")
+	message(FATAL_ERROR "  libsubsurface_corelib.a not found. Did you build Subsurface previously?")
+else()
+	message(STATUS "  Found ${SSRF_CORELIB}")
+endif()
+
+# Set compiler flags and definitions
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(SMTK_LINK_LIBRARIES ${SMTK_LINK_LIBRARIES} -lssh2 -lz -lpthread)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(SMTK_LINK_LIBRARIES ${SMTK_LINK_LIBRARIES} -lwsock32 -lws2_32 -lole32 -limm32 -lwinmm)
+	remove_definitions(-DUNICODE)
+        add_definitions(-mwindows -D_WIN32)
+endif()
+
+set(SMTK_LINK_LIBRARIES ${SMTK_LINK_LIBRARIES} ${LIBMDB_LIBRARIES} ${LIBDIVECOMPUTER_LIBRARIES})
+
 set(SMTK_IMPORT_SRCS
 	smartrak.c
 	smrtk2ssrfc_window.ui
 	smrtk2ssrfc_window.h
 	smrtk2ssrfc_window.cpp
 )
-
+set(SMTK_LINK_LIBRARIES ${SMTK_LINK_LIBRARIES} ${SUBSURFACE_LINK_LIBRARIES} ${SSRF_CORELIB} ${QT_LIBRARIES})
 source_group("SmartTrak Import libs" FILES ${SMTK_IMPORT_SRCS})
+set(SMTK_IMPORT_TARGET smtk2ssrf)
 add_library(smtk_import STATIC ${SMTK_IMPORT_SRCS})
-target_link_libraries(smtk_import subsurface_corelib ${SUBSURFACE_LINK_LIBRARIES})
+add_executable(${SMTK_IMPORT_TARGET} smtk_standalone.cpp ${SUBSURFACE_RESOURCES})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	add_custom_command(
+		OUTPUT ${CMAKE_BINARY_DIR}/qt.conf
+		COMMAND echo \"[Paths]\" > ${CMAKE_BINARY_DIR}/qt.conf \; echo \"Prefix=.\" >> ${CMAKE_BINARY_DIR}/qt.conf
+	)
+	add_custom_target(
+		generate_qtconf
+		DEPENDS ${CMAKE_BINARY_DIR}/qt.conf
+	)
+	add_dependencies(${SMTK_IMPORT_TARGET} generate_qtconf)
+endif()
+
+target_link_libraries(${SMTK_IMPORT_TARGET} smtk_import ${SMTK_LINK_LIBRARIES})
+
+# Install instructions
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	install(TARGETS ${SMTK_IMPORT_TARGET} DESTINATION bin)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	set(WINDOWSSTAGING ${CMAKE_BINARY_DIR}/staging)
+	install(FILES ${SSRF_PATH}gpl-2.0.txt ${SSRF_PATH}packaging/windows/subsurface.ico DESTINATION ${WINDOWSSTAGING})
+	install(TARGETS ${SMTK_IMPORT_TARGET} DESTINATION ${WINDOWSSTAGING})
+	install(FILES ${CMAKE_BINARY_DIR}/qt.conf DESTINATION ${WINDOWSSTAGING})
+	if(NOT DEFINED MAKENSIS)
+		set(MAKENSIS makensis)
+	endif()
+
+	# this ensures that smtk2ssrf.exe has been built before this is run
+	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DSMTK_IMPORT_TARGET=${SMTK_IMPORT_TARGET} -DSMTK_IMPORT_SRCS=${SMTK_IMPORT_SRCS} -DSTAGING=${WINDOWSSTAGING} -P ${CMAKE_SOURCE_DIR}/cmake/Modules/dlllist.cmake)")
+
+	# create the smtk2ssrf-x.y.z.exe installer - this needs to depend
+	# on the install target but cmake doesn't allow that, so we depend
+	# on the fake target instead
+	add_custom_target(
+		fake_install
+		COMMAND "${CMAKE_COMMAND}" --build . --target install
+		DEPENDS ${SMTK_IMPORT_TARGET}
+	)
+
+	add_custom_target(
+		installer
+		COMMAND ${MAKENSIS} ${WINDOWSSTAGING}/smtk-import.nsi
+		DEPENDS fake_install
+	)
+endif()
+
+# useful for debugging CMake issues
+# printll_variables()

--- a/smtk-import/cmake/Modules/dlllist.cmake
+++ b/smtk-import/cmake/Modules/dlllist.cmake
@@ -1,0 +1,42 @@
+message(STATUS "processing dlllist.cmake")
+
+# figure out which command to use for objdump
+execute_process(
+	COMMAND ${CMAKE_C_COMPILER} -dumpmachine
+	OUTPUT_VARIABLE OBJDUMP
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# figure out where we should search for libraries
+execute_process(
+	COMMAND ${CMAKE_C_COMPILER} -print-search-dirs
+	COMMAND sed -nE "/^libraries: =/{s///;s,/lib/?\(:|\$\$\),/bin\\1,g;p;q;}"
+	OUTPUT_VARIABLE ADDPATH
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "addpath is ${ADDPATH}")
+# since cmake doesn't appear to give us a variable with
+# all libraries we link against, grab the link.txt script
+# instead and drop the command name from it (before the
+# first space) -- this will fail if the full path for the
+# linker used contains a space...
+execute_process(
+	COMMAND tail -1 CMakeFiles/${SMTK_IMPORT_TARGET}.dir/link.txt
+	COMMAND cut -d\  -f 2-
+	OUTPUT_VARIABLE LINKER_LINE
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# finally run our win-ldd.pl script against that to
+# collect all the required dlls
+execute_process(
+	COMMAND sh -c "OBJDUMP=${OBJDUMP}-objdump PATH=$ENV{PATH}:${ADDPATH} perl '../../subsurface/scripts/win-ldd.pl' ${SMTK_IMPORT_TARGET}.exe ${LINKER_LINE}"
+	WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	OUTPUT_VARIABLE DLLS
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+# replace newlines with semicolons so this is a cmake list
+string(REPLACE "\n" ";" DLLLIST ${DLLS})
+# executing 'install' as a command seems hacky, but you
+# can't use the install() cmake function in a script
+foreach(DLL ${DLLLIST})
+	execute_process(COMMAND install ${DLL} ${STAGING})
+endforeach()

--- a/smtk-import/cmake/Modules/version.cmake
+++ b/smtk-import/cmake/Modules/version.cmake
@@ -1,0 +1,24 @@
+message(STATUS "processing version.cmake")
+execute_process(
+	COMMAND sh ${CMAKE_TOP_SRC_DIR}/../scripts/get-version linux
+	WORKING_DIRECTORY ${CMAKE_TOP_SRC_DIR}
+	OUTPUT_VARIABLE GIT_VERSION_STRING
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+	COMMAND sh ${CMAKE_TOP_SRC_DIR}/../scripts/get-version full
+	WORKING_DIRECTORY ${CMAKE_TOP_SRC_DIR}
+	OUTPUT_VARIABLE CANONICAL_VERSION_STRING
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+set(MOBILE_VERSION_STRING "1.2.1")
+
+configure_file(${SRC} ${DST} @ONLY)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	execute_process(
+		COMMAND cat ${CMAKE_TOP_SRC_DIR}/../packaging/windows/smtk-import.nsi.in
+		COMMAND sed -e "s/VERSIONTOKEN/${GIT_VERSION_STRING}/"
+		COMMAND sed -e "s/PRODVTOKEN/${CANONICAL_VERSION_STRING}/"
+		OUTPUT_FILE ${CMAKE_BINARY_DIR}/staging/smtk-import.nsi
+	)
+endif()


### PR DESCRIPTION
Reworks SmartTrak importing tool, so it is now fully independent (well, almost fully as building first subsurface is a must) from subsurface build.
The importer should build using provided scripts smtk2ssrf-build.sh for linux version and smtk2ssrf-mxe-build.sh for windows cross-build.
This needs to apply previously the PR "smtk2ssrf portability". Kept separated branches as a recent change in CMakeLists.txt would require a merge or rebase of said PR.
BTW, I like to have coloured messages while building, so the mxe script includes some, but if this is a problem, they can be removed.
BTW, BTW :-)  see line  198 and its comment in smtk2ssrf-mxe-build.sh. It's absolutely ugly, so any idea to avoid/improve it is welcome.

Regards.

Salva.