### PR TITLE
Android BT: fix compile bug

### DIFF
--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -19,6 +19,7 @@ struct btVendorProduct {
 #endif
 #if defined(Q_OS_ANDROID)
 #include <QAndroidJniObject>
+#include <QAndroidJniEnvironment>
 #endif
 
 class BTDiscovery : public QObject {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -11,10 +11,6 @@
 #include <QApplication>
 #include <QElapsedTimer>
 #include <QTimer>
-#if defined(Q_OS_ANDROID)
-#include <QAndroidJniObject>
-#include <QAndroidJniEnvironment>
-#endif
 
 #include "qt-models/divelistmodel.h"
 #include "qt-models/gpslistmodel.h"


### PR DESCRIPTION
One Andorid JNI include was missing. And removed the unused ones from QMLManager.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>