### PR TITLE
QML UI: fix crash and correct default download from dc

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -16,10 +16,10 @@ static QString str_error(const char *fmt, ...)
 	return str;
 }
 
-DownloadThread::DownloadThread() : m_data(new DCDeviceData())
+DownloadThread::DownloadThread()
 {
+	m_data = DCDeviceData::instance();
 }
-
 
 void DownloadThread::run()
 {

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -249,7 +249,7 @@ int DCDeviceData::getDetectedVendorIndex()
 #if defined(BT_SUPPORT)
 	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 	if (!btDCs.isEmpty()) {
-		qDebug() << "getVendorIdx" << btDCs.first().vendorIdx;
+		qDebug() << "getDetectedVendorIndex" << btDCs.first().vendorIdx;
 		return btDCs.first().vendorIdx;
 	}
 #endif
@@ -261,7 +261,7 @@ int DCDeviceData::getDetectedProductIndex()
 #if defined(BT_SUPPORT)
 	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 	if (!btDCs.isEmpty()) {
-		qDebug() << "getProductIdx" << btDCs.first().productIdx;
+		qDebug() << "getDetectedProductIndex" << btDCs.first().productIdx;
 		return btDCs.first().productIdx;
 	}
 #endif
@@ -274,7 +274,7 @@ QString DCDeviceData::getDetectedDeviceAddress()
 	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 	if (!btDCs.isEmpty()) {
 		QString btAddr = btDCs.first().btdi.address().toString();
-		qDebug() << "getBtAddress" << btAddr;
+		qDebug() << "getDetectedDeviceAddress" << btAddr;
 		return btAddr;
 	}
 	return QString();

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -90,11 +90,11 @@ Kirigami.Page {
 				onClicked: {
 					text: qsTr("Retry")
 					if (downloadThread.deviceData.bluetoothMode) {
-						var addr = manager.getBtAddress()
+						var addr = downloadThread.data().getDetectedDeviceAddress()
 						if (addr !== "")
 						downloadThread.deviceData.devName = addr
 					}
-					manager.appendTextToLog("DCDownloadThread started from " + downloadThread.deviceData.devName)
+					manager.appendTextToLog("DCDownloadThread started for " + downloadThread.deviceData.devName)
 					downloadThread.start()
 				}
 			}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -91,7 +91,8 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_updateSelectedDive(-1),
 	m_selectedDiveTimestamp(0),
 	m_credentialStatus(UNKNOWN),
-	alreadySaving(false)
+	alreadySaving(false),
+	m_device_data(new DCDeviceData(this))
 {
 #if defined(BT_SUPPORT)
 	// ensure that we start the BTDiscovery - this should be triggered by the export of the class

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -18,6 +18,7 @@
 
 #include "core/btdiscovery.h"
 #include "core/gpslocation.h"
+#include "core/downloadfromdcthread.h"
 #include "qt-models/divelistmodel.h"
 
 class QMLManager : public QObject {
@@ -204,6 +205,7 @@ private:
 	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
 	bool m_showPin;
+	DCDeviceData *m_device_data;
 
 signals:
 	void cloudUserNameChanged();


### PR DESCRIPTION
Two commits.

1) For reasons unknown to me, the DCDeviceData instance was freed way too early, and used afterwards, obviously resulting in a SIGSEGV. This commit creates the DCDeviceData as a direct child of the QMLManager instance, ensuring it does not get freed prematurely.

2) After the recent refactoring of QMLManager to btdiscovery, the manager.getBtAddress() got superseded by downloadThread.data().getDetectedDeviceAddress(). Corrected this here.

Further some debug output is modified, so that it report the proper function names.

This corrects the download from an automatically detected OSTC 3. Manual selection of the same device from the fake vendor "Paired BT Devices" does not work, however. Still work to be done in that area.
