### PR TITLE
Mobile: Enable download from paired devices

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -45,7 +45,7 @@ BTDiscovery::BTDiscovery(QObject *parent)
 	    localBtDevice.hostMode() == QBluetoothLocalDevice::HostConnectable) {
 		btPairedDevices.clear();
 		qDebug() <<  "localDevice " + localBtDevice.name() + " is valid, starting discovery";
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
 		discoveryAgent = new QBluetoothDeviceDiscoveryAgent(this);
 		connect(discoveryAgent, &QBluetoothDeviceDiscoveryAgent::deviceDiscovered, this, &BTDiscovery::btDeviceDiscovered);
 		discoveryAgent->start();
@@ -56,7 +56,7 @@ BTDiscovery::BTDiscovery(QObject *parent)
 		for (int i = 0; i < btPairedDevices.length(); i++) {
 			qDebug() << "Paired =" << btPairedDevices[i].name << btPairedDevices[i].address.toString();
 		}
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
 		discoveryAgent->stop();
 #endif
 	} else {

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -2,9 +2,35 @@
 
 #include "btdiscovery.h"
 #include "downloadfromdcthread.h"
+#include "core/libdivecomputer.h"
 #include <QDebug>
 
+extern QMap<QString, dc_descriptor_t *> descriptorLookup;
+
 BTDiscovery *BTDiscovery::m_instance = NULL;
+
+static dc_descriptor_t *getDeviceType(QString btName)
+// central function to convert a BT name to a Subsurface known vendor/model pair
+{
+	QString vendor, product;
+
+	if (btName.startsWith("OSTC")) {
+		vendor = "Heinrichs Weikamp";
+		if (btName.mid(4,2) == "3#") product = "OSTC 3";
+		else if (btName.mid(4,2) == "3+") product = "OSTC 3+";
+		else if (btName.mid(4,2) == "s#") product = "OSTC Sport";
+		else if (btName.mid(4,2) == "4-") product = "OSTC 4";
+		else if (btName.mid(4,2) == "2-") product = "OSTC 2N";
+		// all OSTCs are HW_FAMILY_OSTC_3, so when we do not know,
+		// just try this
+		else product = "OSTC 3"; // all OSTCs are HW_FAMILY_OSTC_3
+	}
+
+	if (!vendor.isEmpty() && !product.isEmpty())
+		return(descriptorLookup[vendor + product]);
+
+	return(NULL);
+}
 
 BTDiscovery::BTDiscovery(QObject *parent)
 {
@@ -68,11 +94,13 @@ void BTDiscovery::btDeviceDiscovered(const QBluetoothDeviceInfo &device)
 	btPairedDevices.append(this_d);
 	struct btVendorProduct btVP;
 
-	QString newDevice = device.name();
+	QString newDevice;
+	dc_descriptor_t *newDC = getDeviceType(device.name());
+	if (newDC)
+		newDevice = dc_descriptor_get_product(newDC);
+	 else
+		newDevice = device.name();
 
-	// all the HW OSTC BT computers show up as "OSTC" + some other text, depending on model
-	if (newDevice.startsWith("OSTC"))
-		newDevice = "OSTC 3";
 	QList<QBluetoothUuid> serviceUuids = device.serviceUuids();
 	foreach (QBluetoothUuid id, serviceUuids) {
 		addBtUuid(id);
@@ -80,11 +108,12 @@ void BTDiscovery::btDeviceDiscovered(const QBluetoothDeviceInfo &device)
 	}
 	qDebug() << "Found new device:" << newDevice << device.address();
 	QString vendor;
-	foreach (vendor, productList.keys()) {
+	if (newDC) foreach (vendor, productList.keys()) {
 		if (productList[vendor].contains(newDevice)) {
 			qDebug() << "this could be a " + vendor + " " +
 					(newDevice == "OSTC 3" ? "OSTC family" : newDevice);
 			btVP.btdi = device;
+			btVP.dcDescriptor = newDC;
 			btVP.vendorIdx = vendorList.indexOf(vendor);
 			btVP.productIdx = productList[vendor].indexOf(newDevice);
 			qDebug() << "adding new btDCs entry (detected DC)" << newDevice << btVP.vendorIdx << btVP.productIdx << btVP.btdi.address();;
@@ -95,6 +124,7 @@ void BTDiscovery::btDeviceDiscovered(const QBluetoothDeviceInfo &device)
 	productList[QObject::tr("Paired Bluetooth Devices")].append(this_d.name);
 
 	btVP.btdi = device;
+	btVP.dcDescriptor = newDC;
 	btVP.vendorIdx = vendorList.indexOf(QObject::tr("Paired Bluetooth Devices"));
 	btVP.productIdx = productList[QObject::tr("Paired Bluetooth Devices")].indexOf(this_d.name);
 	qDebug() << "adding new btDCs entry (all paired)" << newDevice << btVP.vendorIdx << btVP.productIdx <<  btVP.btdi.address();
@@ -174,4 +204,5 @@ bool BTDiscovery::checkException(const char* method, const QAndroidJniObject *ob
 	return result;
 }
 #endif // Q_OS_ANDROID
+
 #endif // BT_SUPPORT

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -9,12 +9,16 @@
 #include <QBluetoothLocalDevice>
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothUuid>
+#include "core/libdivecomputer.h"
 
 struct btVendorProduct {
 	QBluetoothDeviceInfo btdi;
+	dc_descriptor_t *dcDescriptor;
 	int vendorIdx;
 	int productIdx;
 };
+
+static dc_descriptor_t *getDeviceType(QString btName);
 
 #endif
 #if defined(Q_OS_ANDROID)

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -11,12 +11,7 @@
 #include <QBluetoothUuid>
 #include "core/libdivecomputer.h"
 
-struct btVendorProduct {
-	QBluetoothDeviceInfo btdi;
-	dc_descriptor_t *dcDescriptor;
-	int vendorIdx;
-	int productIdx;
-};
+
 
 static dc_descriptor_t *getDeviceType(QString btName);
 
@@ -39,12 +34,21 @@ public:
 		QBluetoothAddress address;
 		QString name;
 	};
+
+	struct btVendorProduct {
+		btPairedDevice btpdi;
+		dc_descriptor_t *dcDescriptor;
+		int vendorIdx;
+		int productIdx;
+	};
+
 	void btDeviceDiscovered(const QBluetoothDeviceInfo &device);
+	void btDeviceDiscoveredMain(const btPairedDevice &device);
 #if defined(Q_OS_ANDROID)
 	void getBluetoothDevices();
 #endif
-	QList<struct btVendorProduct> getBtDcs();
-	QList<struct btVendorProduct> getBtAllDevices();
+	QList<btVendorProduct> getBtDcs();
+	QList<btVendorProduct> getBtAllDevices();
 #endif
 private:
 	static BTDiscovery *m_instance;

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -40,11 +40,13 @@ public:
 	void getBluetoothDevices();
 #endif
 	QList<struct btVendorProduct> getBtDcs();
+	QList<struct btVendorProduct> getBtAllDevices();
 #endif
 private:
 	static BTDiscovery *m_instance;
 #if defined(BT_SUPPORT)
-	QList<struct btVendorProduct> btDCs;
+	QList<struct btVendorProduct> btDCs;		// recognized DCs
+	QList<struct btVendorProduct> btAllDevices;	// all paired BT stuff
 #endif
 #if defined(Q_OS_ANDROID)
 	bool checkException(const char* method, const QAndroidJniObject* obj);

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -247,8 +247,8 @@ device_data_t* DCDeviceData::internalData()
 int DCDeviceData::getDetectedVendorIndex(const QString &currentText)
 {
 #if defined(BT_SUPPORT)
-	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
-	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<BTDiscovery::btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
 
 	// Pick the vendor of the first confirmed find of a DC (if any), but
 	// only return a true vendor, and not our virtual one
@@ -270,7 +270,7 @@ int DCDeviceData::getDetectedProductIndex(const QString &currentVendorText,
 					  const QString &currentProductText)
 {
 #if defined(BT_SUPPORT)
-	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 
 	// Display in the QML UI, the first found dive computer that is been
 	// detected as a possible real dive computer (and not some other paired
@@ -293,14 +293,14 @@ QString DCDeviceData::getDetectedDeviceAddress(const QString &currentVendorText,
 					       const QString &currentProductText)
 {
 #if defined(BT_SUPPORT)
-	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
-	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<BTDiscovery::btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
 
 	// Pull the BT address from the first found dive computer that is been
 	// detected as a possible real dive computer (and not some other paired
 	// BT device
 	if (currentVendorText != QObject::tr("Paired Bluetooth Devices") && !btDCs.isEmpty()) {
-		QString btAddr = btDCs.first().btdi.address().toString();
+		QString btAddr = btDCs.first().btpdi.address.toString();
 		qDebug() << "getDetectedDeviceAddress" << btAddr;
 		return btAddr;
 	}
@@ -309,7 +309,7 @@ QString DCDeviceData::getDetectedDeviceAddress(const QString &currentVendorText,
 	// unsure being a dive computer
 	if (currentVendorText == QObject::tr("Paired Bluetooth Devices")) {
 		int i =  productList[currentVendorText].indexOf(currentProductText);
-		QString btAddr = btAllDevices[i].btdi.address().toString();
+		QString btAddr = btAllDevices[i].btpdi.address.toString();
 		qDebug() << "getDetectedDeviceAddress" << btAddr;
 		return btAddr;
 	}
@@ -321,8 +321,8 @@ QString DCDeviceData::getDeviceDescriptorVendor(const QString &currentVendorText
 						const QString &currentProductText)
 {
 #if defined(BT_SUPPORT)
-	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
-	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<BTDiscovery::btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
 
 	// Pull the vendor from the first found dive computer that is been
 	// detected as a possible real dive computer (and not some other paired
@@ -349,8 +349,8 @@ QString DCDeviceData::getDeviceDescriptorProduct(const QString &currentVendorTex
 						 const QString &currentProductText)
 {
 #if defined(BT_SUPPORT)
-	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
-	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<BTDiscovery::btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
 
 	// Pull the product from the first found dive computer that is been
 	// detected as a possible real dive computer (and not some other paired

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -251,7 +251,7 @@ int DCDeviceData::getDetectedVendorIndex(const QString &currentText)
 	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
 
 	// Pick the vendor of the first confirmed find of a DC (if any), but
-	// only return a true vendow, and not our virtual one
+	// only return a true vendor, and not our virtual one
 	if (!btDCs.isEmpty() && currentText != QObject::tr("Paired Bluetooth Devices")) {
 		qDebug() << "getDetectedVendorIndex" << currentText << btDCs.first().vendorIdx;
 		return btDCs.first().vendorIdx;
@@ -313,7 +313,62 @@ QString DCDeviceData::getDetectedDeviceAddress(const QString &currentVendorText,
 		qDebug() << "getDetectedDeviceAddress" << btAddr;
 		return btAddr;
 	}
-
-	return QString();
 #endif
+	return QString();
+}
+
+QString DCDeviceData::getDeviceDescriptorVendor(const QString &currentVendorText,
+						const QString &currentProductText)
+{
+#if defined(BT_SUPPORT)
+	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+
+	// Pull the vendor from the first found dive computer that is been
+	// detected as a possible real dive computer (and not some other paired
+	// BT device
+	if (currentVendorText != QObject::tr("Paired Bluetooth Devices") && !btDCs.isEmpty()) {
+		QString dcVendor =  dc_descriptor_get_vendor(btDCs.first().dcDescriptor);
+		qDebug() << "getDeviceDescriptorVendor" << dcVendor;
+		return dcVendor;
+	}
+
+	// if the above fails, pull vendor from the selected paired device
+	// unsure being a dive computer
+	if (currentVendorText == QObject::tr("Paired Bluetooth Devices")) {
+		int i =  productList[currentVendorText].indexOf(currentProductText);
+		QString dcVendor = dc_descriptor_get_vendor(btAllDevices[i].dcDescriptor);
+		qDebug() << "getDeviceDescriptorVendor" << dcVendor;
+		return dcVendor;
+	}
+#endif
+	return NULL;
+}
+
+QString DCDeviceData::getDeviceDescriptorProduct(const QString &currentVendorText,
+						 const QString &currentProductText)
+{
+#if defined(BT_SUPPORT)
+	QList<btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
+	QList<btVendorProduct> btAllDevices = BTDiscovery::instance()->getBtAllDevices();
+
+	// Pull the product from the first found dive computer that is been
+	// detected as a possible real dive computer (and not some other paired
+	// BT device
+	if (currentVendorText != QObject::tr("Paired Bluetooth Devices") && !btDCs.isEmpty()) {
+		QString dcProduct =  dc_descriptor_get_product(btDCs.first().dcDescriptor);
+		qDebug() << "getDeviceDescriptorProduct" << dcProduct;
+		return dcProduct;
+	}
+
+	// if the above fails, pull product from the selected paired device
+	// unsure being a dive computer
+	if (currentVendorText == QObject::tr("Paired Bluetooth Devices")) {
+		int i =  productList[currentVendorText].indexOf(currentProductText);
+		QString dcProduct = dc_descriptor_get_product(btAllDevices[i].dcDescriptor);
+		qDebug() << "getDeviceDescriptorProduct" << dcProduct;
+		return dcProduct;
+	}
+#endif
+	return NULL;
 }

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -50,6 +50,10 @@ public:
 						const QString &currentProductText);
 	Q_INVOKABLE QString getDetectedDeviceAddress(const QString &currentVendorText,
 						     const QString &currentProductText);
+	Q_INVOKABLE QString getDeviceDescriptorVendor(const QString &currentVendorText,
+						      const QString &currentProductText);
+	Q_INVOKABLE QString getDeviceDescriptorProduct(const QString &currentVendorText,
+						       const QString &currentProductText);
 
 public slots:
 	void setVendor(const QString& vendor);

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -45,9 +45,11 @@ public:
 	device_data_t* internalData();
 
 	Q_INVOKABLE QStringList getProductListFromVendor(const QString& vendor);
-	Q_INVOKABLE int getDetectedVendorIndex();
-	Q_INVOKABLE int getDetectedProductIndex();
-	Q_INVOKABLE QString getDetectedDeviceAddress();
+	Q_INVOKABLE int getDetectedVendorIndex(const QString &currentText);
+	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText,
+						const QString &currentProductText);
+	Q_INVOKABLE QString getDetectedDeviceAddress(const QString &currentVendorText,
+						     const QString &currentProductText);
 
 public slots:
 	void setVendor(const QString& vendor);

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -53,24 +53,27 @@ Kirigami.Page {
 		GridLayout {
 			columns: 2
 			Kirigami.Label { text: qsTr(" Vendor name: ") }
+			property var vendoridx: downloadThread.data().getDetectedVendorIndex("")
 			ComboBox {
 				id: comboVendor
 				Layout.fillWidth: true
 				model: vendorList
-				currentIndex: downloadThread.data().getDetectedVendorIndex(currentText)
+				currentIndex: parent.vendoridx
 				onCurrentTextChanged: {
 					console.log("vendor changed to " + currentText + " -- data pointer is " + downloadThread.data())
-					comboProduct.model = downloadThread.data().getProductListFromVendor(comboVendor.currentText)
-					if (currentIndex == downloadThread.data().getDetectedVendorIndex(currentText))
-						comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex(currentText, comboProduct.currentText)
+					comboProduct.model = downloadThread.data().getProductListFromVendor(currentText)
 				}
 			}
 			Kirigami.Label { text: qsTr(" Dive Computer:") }
 			ComboBox {
 				id: comboProduct
+				property var productidx: downloadThread.data().getDetectedProductIndex(comboVendor.currentText, currentText)
 				Layout.fillWidth: true
 				model: null
-				currentIndex: -1
+				currentIndex: productidx
+				onModelChanged: {
+					currentIndex = productidx
+				}
 			}
 			Kirigami.Label { text: qsTr("Bluetooth download:") }
 			CheckBox {

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -94,6 +94,13 @@ Kirigami.Page {
 																				  comboProduct.currentText)
 						if (addr !== "")
 						downloadThread.deviceData.devName = addr
+						var vendor = downloadThread.deviceData.getDeviceDescriptorVendor(comboVendor.currentText,
+																						 comboProduct.currentText)
+						downloadThread.deviceData.vendor = vendor;
+
+						var product = downloadThread.deviceData.getDeviceDescriptorProduct(comboVendor.currentText,
+																						 comboProduct.currentText)
+						downloadThread.deviceData.product = product;
 					}
 					manager.appendTextToLog("DCDownloadThread started for " + downloadThread.deviceData.devName)
 					downloadThread.start()

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -57,12 +57,12 @@ Kirigami.Page {
 				id: comboVendor
 				Layout.fillWidth: true
 				model: vendorList
-				currentIndex: downloadThread.data().getDetectedVendorIndex()
+				currentIndex: downloadThread.data().getDetectedVendorIndex(currentText)
 				onCurrentTextChanged: {
 					console.log("vendor changed to " + currentText + " -- data pointer is " + downloadThread.data())
 					comboProduct.model = downloadThread.data().getProductListFromVendor(comboVendor.currentText)
-					if (currentIndex == downloadThread.data().getDetectedVendorIndex())
-						comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex()
+					if (currentIndex == downloadThread.data().getDetectedVendorIndex(currentText))
+						comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex(currentText, comboProduct.currentText)
 				}
 			}
 			Kirigami.Label { text: qsTr(" Dive Computer:") }
@@ -75,7 +75,7 @@ Kirigami.Page {
 			Kirigami.Label { text: qsTr("Bluetooth download:") }
 			CheckBox {
 				id: isBluetooth
-				checked: downloadThread.data().getDetectedVendorIndex() != -1
+				checked: downloadThread.data().getDetectedVendorIndex(ComboBox.currentText) != -1
 			}
 		}
 
@@ -90,7 +90,8 @@ Kirigami.Page {
 				onClicked: {
 					text: qsTr("Retry")
 					if (downloadThread.deviceData.bluetoothMode) {
-						var addr = downloadThread.data().getDetectedDeviceAddress()
+						var addr = downloadThread.data().getDetectedDeviceAddress(comboVendor.currentText,
+																				  comboProduct.currentText)
 						if (addr !== "")
 						downloadThread.deviceData.devName = addr
 					}


### PR DESCRIPTION
Combined, this PR enables downloading from a BT dive computer on Android, and for testing, on mobile-for-desktop on identical way. This requires translation from BT name to internal vendor/product type, and this is currently only implemented for most HW devices (based on the email from Christian Weikamp regarding BT naming).

Please read the messages of the individual commits for more detail, and remaining work to be done.