### PR TITLE
Download dialog showed hour indicator weirdly

### DIFF
--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -77,7 +77,7 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 		case 0:
 			return QVariant(get_short_dive_date_string(d->when));
 		case 1:
-			return QVariant(get_dive_duration_string(d->duration.seconds, tr("h:"), tr("min")));
+			return QVariant(get_dive_duration_string(d->duration.seconds, tr("h"), tr("min")));
 		case 2:
 			return QVariant(get_depth_string(d->maxdepth.mm, true, false));
 		case 3:


### PR DESCRIPTION
The used time format was h:mh: i.e. 1:16h:
This patch gets rid of the colon after the hour indicator.

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>