### PR TITLE
BT Discovery: add Shearwater Petrel and Perdix

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -26,6 +26,12 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		else product = "OSTC 3"; // all OSTCs are HW_FAMILY_OSTC_3
 	}
 
+	if (btName.startsWith("Petrel") || btName.startsWith("Perdix")) {
+		vendor = "Shearwater";
+		if (btName.startsWith("Petrel")) product = "Petrel"; // or petrel 2?
+		if (btName.startsWith("Perdix")) product = "Perdix";
+	}
+
 	if (!vendor.isEmpty() && !product.isEmpty())
 		return(descriptorLookup[vendor + product]);
 


### PR DESCRIPTION
Add Shearwater Petrel and Perdix to automatic detection

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>