### PR TITLE
smtk-import: partially revert and complete 6963b52d

### DIFF
--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -3,7 +3,7 @@
 project(smtk2ssrf)
 cmake_minimum_required(VERSION 2.8.11)
 
-option(COMMANDLINE "Build command line version")
+option(COMMANDLINE "Build command line version" OFF)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -104,6 +104,12 @@ source_group("SmartTrak Import libs" FILES ${SMTK_IMPORT_SRCS})
 set(SMTK_IMPORT_TARGET smtk2ssrf)
 add_library(smtk_import STATIC ${SMTK_IMPORT_SRCS})
 add_executable(${SMTK_IMPORT_TARGET} smtk_standalone.cpp ${SUBSURFACE_RESOURCES})
+
+# We just want CLI mode on Linux. Silently drop it if cross building to Windows.
+if (COMMANDLINE AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	message(WARNING "Building Command Line mode.")
+	target_compile_definitions(${SMTK_IMPORT_TARGET} PRIVATE COMMANDLINE=1)
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	add_custom_command(

--- a/smtk-import/smtk_standalone.cpp
+++ b/smtk-import/smtk_standalone.cpp
@@ -5,7 +5,6 @@
 #include "smrtk2ssrfc_window.h"
 #include <QApplication>
 #include <QDebug>
-#define COMMANDLINE 1
 
 extern "C" void smartrak_import(const char *file, struct dive_table *table);
 


### PR DESCRIPTION
6963b52d introduced a cmake option, COMMANDLINE to enable building a
pure command line version of smtk2ssrf importer, but then the
 #define COMMANDLINE=1 forces building CLI mode.

This patch allows building GUI or CLI versions depending on selection of
the COMMANDLINE option.

Signed-off-by: Salvador Cuñat <salvador.cunat@gmail.com>