### PR TITLE
Convert to new libdivecomputer custom IO model

### DIFF
--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -632,14 +632,14 @@ QString ConfigureDiveComputer::dc_open(device_data_t *data)
 		dc_context_set_logfunc(data->context, logfunc, fp);
 	}
 
-#if defined(SSRF_CUSTOM_SERIAL)
+#if defined(SSRF_CUSTOM_IO)
 	if (data->bluetooth_mode) {
-#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_SERIAL)
-		rc = dc_context_set_custom_serial(data->context, get_qt_serial_ops());
+#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
+		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops());
 #endif
 #ifdef SERIAL_FTDI
 	} else if (!strcmp(data->devname, "ftdi")) {
-		rc = dc_context_set_custom_serial(data->context, &serial_ftdi_ops);
+		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops);
 #endif
 	}
 

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1078,14 +1078,14 @@ const char *do_libdivecomputer_import(device_data_t *data)
 
 	err = translate("gettextFromC", "Unable to open %s %s (%s)");
 
-#if defined(SSRF_CUSTOM_SERIAL)
+#if defined(SSRF_CUSTOM_IO)
 	if (data->bluetooth_mode) {
-#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_SERIAL)
-		rc = dc_context_set_custom_serial(data->context, get_qt_serial_ops());
+#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
+		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops());
 #endif
 #ifdef SERIAL_FTDI
 	} else if (!strcmp(data->devname, "ftdi")) {
-		rc = dc_context_set_custom_serial(data->context, &serial_ftdi_ops);
+		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops);
 		INFO(0, "setting up ftdi ops");
 #else
 		INFO(0, "FTDI disabled");

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -11,8 +11,8 @@
 #include <libdivecomputer/version.h>
 #include <libdivecomputer/device.h>
 #include <libdivecomputer/parser.h>
-#ifdef SSRF_CUSTOM_SERIAL
-#include <libdivecomputer/custom_serial.h>
+#ifdef SSRF_CUSTOM_IO
+#include <libdivecomputer/custom_io.h>
 #endif
 
 #include "dive.h"
@@ -56,12 +56,12 @@ extern double progress_bar_fraction;
 extern char *logfile_name;
 extern char *dumpfile_name;
 
-#if SSRF_CUSTOM_SERIAL
+#if SSRF_CUSTOM_IO
 // WTF. this symbol never shows up at link time
-//extern dc_custom_serial_t qt_serial_ops;
+//extern dc_custom_io_t qt_serial_ops;
 // Thats why I've worked around it with a stupid helper returning it.
-dc_custom_serial_t* get_qt_serial_ops();
-extern dc_custom_serial_t serial_ftdi_ops;
+dc_custom_io_t* get_qt_serial_ops();
+extern dc_custom_io_t serial_ftdi_ops;
 #endif
 
 #ifdef __cplusplus

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -9,7 +9,7 @@
 
 #include <libdivecomputer/version.h>
 
-#if defined(SSRF_CUSTOM_SERIAL)
+#if defined(SSRF_CUSTOM_IO)
 
 #if defined(Q_OS_WIN)
 	#include <winsock2.h>
@@ -17,7 +17,7 @@
 	#include <ws2bth.h>
 #endif
 
-#include <libdivecomputer/custom_serial.h>
+#include <libdivecomputer/custom_io.h>
 
 QList<QBluetoothUuid> registeredUuids;
 
@@ -399,26 +399,26 @@ static dc_status_t qt_serial_set_timeout(void **userdata, long timeout)
 	return DC_STATUS_SUCCESS;
 }
 
-dc_custom_serial_t qt_serial_ops = {
+dc_custom_io_t qt_serial_ops = {
 	.userdata = NULL,
-	.open = qt_serial_open,
-	.close = qt_serial_close,
-	.read = qt_serial_read,
-	.write = qt_serial_write,
-	.purge = qt_serial_flush,
-	.get_available = qt_serial_get_received,
-	.set_timeout = qt_serial_set_timeout,
+	.serial_open = qt_serial_open,
+	.serial_close = qt_serial_close,
+	.serial_read = qt_serial_read,
+	.serial_write = qt_serial_write,
+	.serial_purge = qt_serial_flush,
+	.serial_get_available = qt_serial_get_received,
+	.serial_set_timeout = qt_serial_set_timeout,
 // These doesn't make sense over bluetooth
 // NULL means NOP
-	.configure = NULL,
-	.set_dtr = NULL,
-	.set_rts = NULL,
-	.set_halfduplex = NULL,
-	.set_break = NULL
+	.serial_configure = NULL,
+	.serial_set_dtr = NULL,
+	.serial_set_rts = NULL,
+	.serial_set_halfduplex = NULL,
+	.serial_set_break = NULL
 };
 
-dc_custom_serial_t* get_qt_serial_ops() {
-	return (dc_custom_serial_t*) &qt_serial_ops;
+dc_custom_io_t* get_qt_serial_ops() {
+	return (dc_custom_io_t*) &qt_serial_ops;
 }
 
 }

--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -43,7 +43,7 @@
 //#define SYSERROR(context, errcode)	ERROR(__FILE__ ":" __LINE__ ": %s", strerror(errcode))
 #define SYSERROR(context, errcode)	;
 
-#include <libdivecomputer/custom_serial.h>
+#include <libdivecomputer/custom_io.h>
 #include <libdivecomputer/context.h>
 
 #define VID 0x0403 // Vendor ID of FTDI
@@ -590,21 +590,21 @@ static dc_status_t serial_ftdi_set_rts (void **userdata, int level)
 	return DC_STATUS_SUCCESS;
 }
 
-dc_custom_serial_t serial_ftdi_ops = {
+dc_custom_io_t serial_ftdi_ops = {
 	.userdata = NULL,
-	.open = serial_ftdi_open,
-	.close = serial_ftdi_close,
-	.read = serial_ftdi_read,
-	.write = serial_ftdi_write,
-	.purge = serial_ftdi_flush,
-	.get_available = serial_ftdi_get_received,
-	.set_timeout = serial_ftdi_set_timeout,
-	.configure = serial_ftdi_configure,
-	.set_dtr = serial_ftdi_set_dtr,
-	.set_rts = serial_ftdi_set_rts,
-	.set_halfduplex = serial_ftdi_set_halfduplex,
+	.serial_open = serial_ftdi_open,
+	.serial_close = serial_ftdi_close,
+	.serial_read = serial_ftdi_read,
+	.serial_write = serial_ftdi_write,
+	.serial_purge = serial_ftdi_flush,
+	.serial_get_available = serial_ftdi_get_received,
+	.serial_set_timeout = serial_ftdi_set_timeout,
+	.serial_configure = serial_ftdi_configure,
+	.serial_set_dtr = serial_ftdi_set_dtr,
+	.serial_set_rts = serial_ftdi_set_rts,
+	.serial_set_halfduplex = serial_ftdi_set_halfduplex,
 // Can't be done in ftdi?
 // only used in vyper2
 // NULL means NOP
-	.set_break = NULL
+	.serial_set_break = NULL
 };

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -87,7 +87,7 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	ui.downloadCancelRetryButton->setEnabled(true);
 	ui.downloadCancelRetryButton->setText(tr("Download"));
 
-#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_SERIAL)
+#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
 	ui.bluetoothMode->setText(tr("Choose Bluetooth download mode"));
 	ui.bluetoothMode->setChecked(dc->downloadMode() == DC_TRANSPORT_BLUETOOTH);
 	btDeviceSelectionDialog = 0;
@@ -293,7 +293,7 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	dc->setProduct(data->product());
 	dc->setDevice(data->devName());
 
-#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_SERIAL)
+#if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
 	dc->setDownloadMode(ui.bluetoothMode->isChecked() ? DC_TRANSPORT_BLUETOOTH : DC_TRANSPORT_SERIAL);
 #endif
 


### PR DESCRIPTION
Instead of being "custom serial", it's a IO model that allows serial or
packet modes, independently of each other (ie you can have a bluetooth
device that does serial over BT rfcomm and packet-based communication
over BLE GATT with the same serial operations that describe both cases).

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>