### PR TITLE
QML UI: only drag a pull down sync, and not flick it

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -313,7 +313,7 @@ Kirigami.ScrollablePage {
 		model: diveModel
 		currentIndex: -1
 		delegate: diveDelegate
-		//boundsBehavior: Flickable.StopAtBounds
+		boundsBehavior: Flickable.DragOverBounds
 		maximumFlickVelocity: parent.height * 5
 		bottomMargin: Kirigami.Units.iconSizes.medium + Kirigami.Units.gridUnit
 		cacheBuffer: 0 // seems to avoid empty rendered profiles


### PR DESCRIPTION
When the user has selected offline mode, it was still possible to activate a cloud sync when pulling down the divelist. This is confusing and not logical as the pull down sync gets triggered very easily when scrolling fast to the top of the dive list.

This (simple) commit just disables the pull down sync when offline. Obviously, manual sync from the menu is still possible.

Version 2 of this commit (force pushed):

 QML UI: only drag a pull down sync, and not flick it

Fast flicking to the top of the divelist triggers almost certainly a pull down sync, as the default boundBehavior is DragAndOvershootBounds. Despite being the default QML action, this leads to unwanted pull down syncs (even in offline mode).

Setting the boundBehavior to DragOverBounds solves this issue. Now, the user has to explicitly drag the top down to force a pull down sync, and a accidental fast flick is stopped at the upper bound.

See also issue #454. Fixes item 1.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>