### PR TITLE
Merge furtger BLE updates

### DIFF
--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -635,11 +635,11 @@ QString ConfigureDiveComputer::dc_open(device_data_t *data)
 #if defined(SSRF_CUSTOM_IO)
 	if (data->bluetooth_mode) {
 #if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
-		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops());
+		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops(), data);
 #endif
 #ifdef SERIAL_FTDI
 	} else if (!strcmp(data->devname, "ftdi")) {
-		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops);
+		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops, data);
 #endif
 	}
 

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -605,7 +605,7 @@ static void parse_string_field(struct dive *dive, dc_field_string_t *str)
 }
 #endif
 
-static dc_status_t libdc_header_parser(dc_parser_t *parser, struct device_data_t *devdata, struct dive *dive)
+static dc_status_t libdc_header_parser(dc_parser_t *parser, dc_user_device_t *devdata, struct dive *dive)
 {
 	dc_status_t rc = 0;
 	dc_datetime_t dt = { 0 };
@@ -1091,11 +1091,11 @@ const char *do_libdivecomputer_import(device_data_t *data)
 #if defined(SSRF_CUSTOM_IO)
 	if (data->bluetooth_mode) {
 #if defined(BT_SUPPORT) && defined(SSRF_CUSTOM_IO)
-		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops());
+		rc = dc_context_set_custom_io(data->context, get_qt_serial_ops(), data);
 #endif
 #ifdef SERIAL_FTDI
 	} else if (!strcmp(data->devname, "ftdi")) {
-		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops);
+		rc = dc_context_set_custom_io(data->context, &serial_ftdi_ops, data);
 		INFO(0, "setting up ftdi ops");
 #else
 		INFO(0, "FTDI disabled");

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /* don't forget to include the UI toolkit specific display-XXX.h first
    to get the definition of progressbar_t */
-typedef struct device_data_t
+typedef struct dc_user_device_t
 {
 	dc_descriptor_t *descriptor;
 	const char *vendor, *product, *devname;

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -42,13 +42,14 @@ void BLEObject::writeCompleted(const QLowEnergyDescriptor &d, const QByteArray &
 
 void BLEObject::addService(const QBluetoothUuid &newService)
 {
-	const char *uuid = newService.toString().toUtf8().data();
-
-	qDebug() << "Found service" << uuid;
-	if (uuid[1] == '0') {
-		qDebug () << " .. ignoring since first digit is '0'";
+	qDebug() << "Found service" << newService;
+	bool isStandardUuid = false;
+	newService.toUInt16(&isStandardUuid);
+	if (isStandardUuid) {
+		qDebug () << " .. ignoring standard service";
 		return;
 	}
+
 	service = controller->createServiceObject(newService, this);
 	qDebug() << " .. created service object" << service;
 	if (service) {

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -11,7 +11,7 @@ class BLEObject : public QObject
 	Q_OBJECT
 
 public:
-	BLEObject(QLowEnergyController *c);
+	BLEObject(QLowEnergyController *c, dc_user_device_t *);
 	~BLEObject();
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
@@ -32,6 +32,7 @@ private:
 	QLowEnergyController *controller = nullptr;
 	QList<QByteArray> receivedPackets;
 	QEventLoop waitForPacket;
+	dc_user_device_t *device;
 };
 
 

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -2,6 +2,7 @@
 #ifndef QT_BLE_H
 #define QT_BLE_H
 
+#include <QVector>
 #include <QLowEnergyController>
 #include <QEventLoop>
 
@@ -14,7 +15,10 @@ public:
 	~BLEObject();
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
-	QLowEnergyService *service;
+
+	//TODO: need better mode of selecting the desired service than below
+	inline QLowEnergyService *preferredService()
+				{ return services.isEmpty() ? nullptr : services[0]; }
 
 public slots:
 	void addService(const QBluetoothUuid &newService);
@@ -23,7 +27,9 @@ public slots:
 	void writeCompleted(const QLowEnergyDescriptor &d, const QByteArray &value);
 
 private:
-	QLowEnergyController *controller;
+	QVector<QLowEnergyService *> services;
+
+	QLowEnergyController *controller = nullptr;
 	QList<QByteArray> receivedPackets;
 	QEventLoop waitForPacket;
 };

--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -71,9 +71,9 @@ typedef struct ftdi_serial_t {
 	unsigned int nbits;
 } ftdi_serial_t;
 
-static dc_status_t serial_ftdi_get_received (void **userdata, size_t *value)
+static dc_status_t serial_ftdi_get_received (dc_custom_io_t *io, size_t *value)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -145,7 +145,7 @@ static int serial_ftdi_open_device (struct ftdi_context *ftdi_ctx)
 //
 // Open the serial port.
 // Initialise ftdi_context and use it to open the device
-static dc_status_t serial_ftdi_open (void **userdata, const char* name)
+static dc_status_t serial_ftdi_open (dc_custom_io_t *io, dc_context_t *context, const char* name)
 {
 	INFO(0, "serial_ftdi_open called");
 	// Allocate memory.
@@ -203,7 +203,7 @@ static dc_status_t serial_ftdi_open (void **userdata, const char* name)
 
 	device->ftdi_ctx = ftdi_ctx;
 
-	*userdata = device;
+	io->userdata = device;
 
 	return DC_STATUS_SUCCESS;
 }
@@ -211,9 +211,9 @@ static dc_status_t serial_ftdi_open (void **userdata, const char* name)
 //
 // Close the serial port.
 //
-static dc_status_t serial_ftdi_close (void **userdata)
+static dc_status_t serial_ftdi_close (dc_custom_io_t *io)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_SUCCESS;
@@ -233,7 +233,7 @@ static dc_status_t serial_ftdi_close (void **userdata)
 	// Free memory.
 	free (device);
 
-	*userdata = NULL;
+	io->userdata = NULL;
 
 	return DC_STATUS_SUCCESS;
 }
@@ -241,9 +241,9 @@ static dc_status_t serial_ftdi_close (void **userdata)
 //
 // Configure the serial port (baudrate, databits, parity, stopbits and flowcontrol).
 //
-static dc_status_t serial_ftdi_configure (void **userdata, unsigned int baudrate, unsigned int databits, dc_parity_t parity, dc_stopbits_t stopbits, dc_flowcontrol_t flowcontrol)
+static dc_status_t serial_ftdi_configure (dc_custom_io_t *io, unsigned int baudrate, unsigned int databits, dc_parity_t parity, dc_stopbits_t stopbits, dc_flowcontrol_t flowcontrol)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -341,9 +341,9 @@ static dc_status_t serial_ftdi_configure (void **userdata, unsigned int baudrate
 //
 // Configure the serial port (timeouts).
 //
-static dc_status_t serial_ftdi_set_timeout (void **userdata, long timeout)
+static dc_status_t serial_ftdi_set_timeout (dc_custom_io_t *io, long timeout)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -355,9 +355,9 @@ static dc_status_t serial_ftdi_set_timeout (void **userdata, long timeout)
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_set_halfduplex (void **userdata, unsigned int value)
+static dc_status_t serial_ftdi_set_halfduplex (dc_custom_io_t *io, unsigned int value)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -370,9 +370,9 @@ static dc_status_t serial_ftdi_set_halfduplex (void **userdata, unsigned int val
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_read (void **userdata, void *data, size_t size, size_t *actual)
+static dc_status_t serial_ftdi_read (dc_custom_io_t *io, void *data, size_t size, size_t *actual)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -421,9 +421,9 @@ static dc_status_t serial_ftdi_read (void **userdata, void *data, size_t size, s
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_write (void **userdata, const void *data, size_t size, size_t *actual)
+static dc_status_t serial_ftdi_write (dc_custom_io_t *io, const void *data, size_t size, size_t *actual)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -488,9 +488,9 @@ static dc_status_t serial_ftdi_write (void **userdata, const void *data, size_t 
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_flush (void **userdata, dc_direction_t queue)
+static dc_status_t serial_ftdi_flush (dc_custom_io_t *io, dc_direction_t queue)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -525,9 +525,9 @@ static dc_status_t serial_ftdi_flush (void **userdata, dc_direction_t queue)
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_send_break (void **userdata)
+static dc_status_t serial_ftdi_send_break (dc_custom_io_t *io)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -542,9 +542,9 @@ static dc_status_t serial_ftdi_send_break (void **userdata)
 	return DC_STATUS_UNSUPPORTED;
 }
 
-static dc_status_t serial_ftdi_set_break (void **userdata, int level)
+static dc_status_t serial_ftdi_set_break (dc_custom_io_t *io, int level)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -556,9 +556,9 @@ static dc_status_t serial_ftdi_set_break (void **userdata, int level)
 	return DC_STATUS_UNSUPPORTED;
 }
 
-static dc_status_t serial_ftdi_set_dtr (void **userdata, int level)
+static dc_status_t serial_ftdi_set_dtr (dc_custom_io_t *io, int level)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
@@ -573,9 +573,9 @@ static dc_status_t serial_ftdi_set_dtr (void **userdata, int level)
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t serial_ftdi_set_rts (void **userdata, int level)
+static dc_status_t serial_ftdi_set_rts (dc_custom_io_t *io, int level)
 {
-	ftdi_serial_t *device = (ftdi_serial_t*) *userdata;
+	ftdi_serial_t *device = (ftdi_serial_t*) io->userdata;
 
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1120,7 +1120,7 @@ static void get_uemis_divespot(const char *mountpath, int divespot_id, struct di
 	}
 }
 
-static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, struct device_data_t *data, const char *mountpath, const char deviceidnr)
+static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, dc_user_device_t *data, const char *mountpath, const char deviceidnr)
 {
 	struct dive *dive = data->download_table->dives[idx];
 	char log_file_no_to_find[20];


### PR DESCRIPTION
This branch has five commits: three cleanups from Alex, and the new code from me to switch to the updated SSRF_CUSTOM_IO v2, and use that to implement device-specific quirks for BLE downloading.

Note that this obviously needs to be pulled together with the libdivecomputer pull request I did separately.

With this, the hardcoded hacks I had to make my Perdix AI work are no longer hardcoded, and only trigger when downloading from a Shearwater dive computer. Thus downloading now works for me over BLE both with the Suunto EON Steel and the Shearwater Perdix AI.