### PR TITLE
BT discovery Android: Allow BT/LE devices connect both ways

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -229,6 +229,11 @@ void BTDiscovery::getBluetoothDevices()
 			result.name = dev.callObjectMethod("getName", "()Ljava/lang/String;").toString();
 			qDebug() << "paired Device type" << btType << "with address" << result.address;
 			btPairedDevices.append(result);
+			if (btType == 3) { // DEVICE_TYPE_DUAL
+				result.address = QString("LE:%1").arg(result.address);
+				qDebug() << "paired Device type" << btType << "with address" << result.address;
+				btPairedDevices.append(result);
+			}
 		}
 	}
 }


### PR DESCRIPTION
For DCs that support both BT and LE, allow the user to connect to both interface layers. Maybe not useful in the end (as BT is faster than LE), but as long as BT on Android is WIP is it very useful to be able to connect to the interface layer we like.

Just add it to the Paired Devices list twice. The normal way, and the LE: prepend way.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>