### PR TITLE
Don't try to dereference empty product/vendor list

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -378,6 +378,8 @@ QString DCDeviceData::getDeviceDescriptorVendor(const QString &currentVendorText
 	// unsure being a dive computer
 	if (currentVendorText == QObject::tr("Paired Bluetooth Devices")) {
 		int i =  productList[currentVendorText].indexOf(currentProductText);
+		if (i < 0 || btAllDevices.length() <= i)
+			return QString();
 		QString dcVendor = dc_descriptor_get_vendor(btAllDevices[i].dcDescriptor);
 		qDebug() << "getDeviceDescriptorVendor" << dcVendor;
 		return dcVendor;
@@ -406,6 +408,8 @@ QString DCDeviceData::getDeviceDescriptorProduct(const QString &currentVendorTex
 	// unsure being a dive computer
 	if (currentVendorText == QObject::tr("Paired Bluetooth Devices")) {
 		int i =  productList[currentVendorText].indexOf(currentProductText);
+		if (i >= btAllDevices.length() || i < 0)
+			return QString();
 		QString dcProduct = dc_descriptor_get_product(btAllDevices[i].dcDescriptor);
 		qDebug() << "getDeviceDescriptorProduct" << dcProduct;
 		return dcProduct;


### PR DESCRIPTION
Now it only hangs, we still need to set some timeout...

Signed-off-by: Robert C. Helling <helling@atdotde.de>