### PR TITLE
TestPreferences: Fix update manager test date

### DIFF
--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -553,7 +553,7 @@ void TestPreferences::testPreferences()
 	TEST(update->lastVersionUsed(), QStringLiteral("tomaz-1"));
 	TEST(update->nextCheck(), date);
 
-	date.addDays(3);
+	date = date.addDays(3);
 	update->setDontCheckForUpdates(false);
 	update->setLastVersionUsed("tomaz-2");
 	update->setNextCheck(date);


### PR DESCRIPTION
QDate::addDays() returns a copy with the changed date, calling it and
ignoring the return value does nothing.

Signed-off-by: Seamus Boyle <seamus@beantrader.com.au>