### PR TITLE
Make compile with Qt developer builds

### DIFF
--- a/core/divesitehelpers.cpp
+++ b/core/divesitehelpers.cpp
@@ -8,6 +8,7 @@
 #include "divesite.h"
 #include "helpers.h"
 #include "membuffer.h"
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>


### PR DESCRIPTION
subsurface/core/divesitehelpers.cpp: In member function 'virtual void ReverseGeoLookupThread::run()':
subsurface/core/divesitehelpers.cpp:128:12: error: invalid use of incomplete type 'class QDebug'
     qDebug() << "no reverse geo lookup; geonames returned\n" << fullReply;
            ^

Signed-off-by: Alex Blasche <alexander.blasche@qt.io>