### PR TITLE
Let user pick first dive computer

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -374,7 +374,7 @@ static void free_pic(struct picture *picture);
 
 /* this is very different from the copy_divecomputer later in this file;
  * this function actually makes full copies of the content */
-static void copy_dc(struct divecomputer *sdc, struct divecomputer *ddc)
+void copy_dc(struct divecomputer *sdc, struct divecomputer *ddc)
 {
 	*ddc = *sdc;
 	ddc->model = copy_string(sdc->model);

--- a/core/dive.h
+++ b/core/dive.h
@@ -550,6 +550,8 @@ extern int selected_dive;
 extern unsigned int dc_number;
 #define current_dive (get_dive(selected_dive))
 #define current_dc (get_dive_dc(current_dive, dc_number))
+void copy_dc(struct divecomputer *sdc, struct divecomputer *ddc);
+
 
 static inline struct dive *get_dive(int nr)
 {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1192,6 +1192,36 @@ void MainWindow::on_actionNextDC_triggered()
 	information()->updateDiveInfo();
 }
 
+void MainWindow::on_actionFirstDC_triggered()
+{
+	struct divecomputer *next = current_dc->next;
+	struct divecomputer computer;
+	struct divecomputer *dc;
+	struct divecomputer *new_first = current_dc;
+
+	if (!current_dive || !dc_number)
+		return;
+
+
+	computer = current_dive->dc;
+	current_dive->dc = *new_first;
+	current_dive->dc.next = new_first;
+	*new_first = computer;
+	dc = new_first;
+	while(dc) {
+		if (dc->next == new_first)
+			dc->next = next;
+		dc = dc->next;
+	}
+
+	dc_number = 0;
+	copy_dive(current_dive, &displayed_dive);
+	mark_divelist_changed(true);
+	configureToolbar();
+	graphics()->plotDive();
+	information()->updateDiveInfo();
+}
+
 void MainWindow::on_actionFullScreen_triggered(bool checked)
 {
 	if (checked) {

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -125,6 +125,7 @@ slots:
 	void on_actionViewAll_triggered();
 	void on_actionPreviousDC_triggered();
 	void on_actionNextDC_triggered();
+	void on_actionFirstDC_triggered();
 	void on_actionFullScreen_triggered(bool checked);
 
 	/* other menu actions */

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -112,6 +112,7 @@
     <addaction name="actionYearlyStatistics"/>
     <addaction name="actionPreviousDC"/>
     <addaction name="actionNextDC"/>
+    <addaction name="actionFirstDC"/>
     <addaction name="separator"/>
     <addaction name="actionFullScreen"/>
    </widget>
@@ -357,6 +358,11 @@
    </property>
    <property name="shortcut">
     <string notr="true">Right</string>
+   </property>
+  </action>
+  <action name="actionFirstDC">
+   <property name="text">
+    <string>&amp;Make DC first</string>
    </property>
   </action>
   <action name="actionAboutSubsurface">


### PR DESCRIPTION
For a dive with several dive computers the order of
the computers is a historical accident. But the first is special
as this is the one whose profile is displayed by default (and
in the mobile version, currently, only the first dive computer
is displayed).

This adds an entry to the View menu to make the current dive computer
the first one.

Please double check before pushing: It took me a while to get this to work (in my test case), thanks to the special nature of the dc linked list: The first entry is actually in struct dive, while the later ones come from the heap. So changing the first actually involves copying data rather than jumbling with the pointers.

Signed-off-by: Robert C. Helling <helling@atdotde.de>