### PR TITLE
OSTC over BLE (2)

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -69,7 +69,7 @@ void BLEObject::characteristcStateChanged(const QLowEnergyCharacteristic &c, con
 			hw_credit--;
 			receivedPackets.append(value);
 			if (hw_credit == MINIMAL_HW_CREDIT)
-				setHwCredit(MAXIMAL_HW_CREDIT - hw_credit);
+				setHwCredit(MAXIMAL_HW_CREDIT - MINIMAL_HW_CREDIT);
 		} else {
 			qDebug() << "ignore packet from" << c.uuid() << value.toHex();
 		}
@@ -94,7 +94,9 @@ void BLEObject::characteristicWritten(const QLowEnergyCharacteristic &c, const Q
 
 void BLEObject::writeCompleted(const QLowEnergyDescriptor &d, const QByteArray &value)
 {
-	qDebug() << "BLE write completed on" << d.name() <<  d.value();
+	Q_UNUSED(value)
+	Q_UNUSED(d)
+	qDebug() << "BLE write completed";
 }
 
 void BLEObject::addService(const QBluetoothUuid &newService)

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -32,6 +32,7 @@ public slots:
 	void characteristicWritten(const QLowEnergyCharacteristic &c, const QByteArray &value);
 	void writeCompleted(const QLowEnergyDescriptor &d, const QByteArray &value);
 	dc_status_t setupHwTerminalIo(QList<QLowEnergyCharacteristic>);
+	dc_status_t setHwCredit(unsigned int c);
 private:
 	QVector<QLowEnergyService *> services;
 
@@ -39,6 +40,7 @@ private:
 	QList<QByteArray> receivedPackets;
 	bool isCharacteristicWritten;
 	dc_user_device_t *device;
+	unsigned int hw_credit = 0;
 
 	QList<QUuid> hwAllCharacteristics = {
 		"{00000001-0000-1000-8000-008025000000}", // HW_OSTC_BLE_DATA_RX

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -126,19 +126,34 @@ static dc_status_t ble_serial_read(dc_custom_io_t *io, void* data, size_t size, 
 {
 	Q_UNUSED(io)
 	size_t len;
+	size_t received = 0;
 
 	if (buffer.in_pos >= buffer.in_bytes) {
-		dc_status_t rc;
-		size_t received;
-
 		ble_serial_flush_write();
-		rc = ble_serial_ops.packet_read(&ble_serial_ops, buffer.in, sizeof(buffer.in), &received);
+	}
+
+	/* There is still unused/unread data in the input steam.
+	 * So preseve it at the start of a new read.
+	 */
+	if (buffer.in_pos > 0) {
+		len = buffer.in_bytes - buffer.in_pos;
+		memcpy(buffer.in, buffer.in + buffer.in_pos, len);
+		buffer.in_pos = 0;
+		buffer.in_bytes = len;
+	}
+
+	/* Read a long as requested in the size parameter */
+	while ((buffer.in_bytes - buffer.in_pos) < size) {
+		dc_status_t rc;
+
+		rc = ble_serial_ops.packet_read(&ble_serial_ops, buffer.in + buffer.in_bytes,
+						sizeof(buffer.in) - buffer.in_bytes, &received);
 		if (rc != DC_STATUS_SUCCESS)
 			return rc;
 		if (!received)
 			return DC_STATUS_IO;
-		buffer.in_pos = 0;
-		buffer.in_bytes = received;
+
+		buffer.in_bytes += received;
 	}
 
 	len = buffer.in_bytes - buffer.in_pos;


### PR DESCRIPTION
Did the following functionally (for code details see the included commits):

1) Undid the the aggressive "read until there is no more data coming" in the BLEObject::read(). Not only because it breaks non-OSTC usage, but simply because it is wrong.
2) As suggested by Anton, implemented a more friendly read one level above. ble_serial_read() now reads not only one packet, but reads up to the requested size parameter. For example, the OSTC libdc parser code reads from individual bytes, up to 1K blocks for the larger data parts (profile data). I cannot test this adapted behavior of the serial BLE read for other than OSTC, but I have good hopes that this will work for any serial over BLE libdb interface (assuming that these call this function with the proper size parameter).
3) Implemented "credit management". Despite a simple concept, and seemingly good documentation in the earlier mentioned TIO document, it is a tricky process. Asking for to much or to little credit will stall the download at some point, tripping a timeout. I spend (too) much time understanding why my download stopped in a deterministic way after correctly downloading 14 dives (and almost 13K of 20-byte BLE packets). 

 Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>