### PR TITLE
Correct BT detect for OSTC Sport

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -19,6 +19,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		if (btName.mid(4,2) == "3#") product = "OSTC 3";
 		else if (btName.mid(4,2) == "3+") product = "OSTC 3+";
 		else if (btName.mid(4,2) == "s#") product = "OSTC Sport";
+		else if (btName.mid(4,2) == "s ") product = "OSTC Sport";
 		else if (btName.mid(4,2) == "4-") product = "OSTC 4";
 		else if (btName.mid(4,2) == "2-") product = "OSTC 2N";
 		// all OSTCs are HW_FAMILY_OSTC_3, so when we do not know,


### PR DESCRIPTION
Apparently, OSTC Sport has a BT name like `OSTCs<space><serial>`.

Small code addition to detect this properly. As long as we do not have an improved way of detection. Notice that most of the HWs use the same BT hardware, so simple detection on offered services will not work.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>