### PR TITLE
QML UI: Allow cancel of ongoing download

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -201,14 +201,16 @@ Kirigami.Page {
 					antialiasing: true
 					radius: Kirigami.Units.smallSpacing * 2
 				}
-				text: qsTr("Quit")
+				text: progressBar.visible ? qsTr("Cancel") : qsTr("Quit")
 				contentItem: Text {
 					text: quitbutton.text
 					color: subsurfaceTheme.darkerPrimaryTextColor
 				}
 				onClicked: {
+					manager.cancelDownloadDC()
+					if (!progressBar.visible)
+						stackView.pop();
 					manager.appendTextToLog("exit DCDownload screen")
-					stackView.pop();
 				}
 			}
 		}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1121,6 +1121,11 @@ void QMLManager::deleteDive(int id)
 	changesNeedSaving();
 }
 
+void QMLManager::cancelDownloadDC()
+{
+	import_thread_cancelled = true;
+}
+
 QString QMLManager::addDive()
 {
 	appendTextToLog("Adding new dive.");

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -162,6 +162,7 @@ public slots:
 	void sendGpsData();
 	void downloadGpsData();
 	void populateGpsData();
+	void cancelDownloadDC();
 	void clearGpsData();
 	void finishSetup();
 	void openLocalThenRemote(QString url);


### PR DESCRIPTION
This commit adds the capability to cancel a running download from DC. The actual cancel is fully handled in the underlying libdivecomputer code. As the user may be interested in the dives downloaded up to the moment of cancel, do not just close the download screen (as it was before this commit). Now, the  `<quit>` button changes to `<cancel>` when the download is started, and pressing cancel, only cancels the download and does not close the download screen, but presents the so far downloaded data. When no download is running, the `<quit>` button just quits the screen as before.

Fixes: #485

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>