### PR TITLE
QML UI: fix some obvious UI errors

### DIFF
--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -127,7 +127,7 @@ Item {
 					x: checkboxGPS.leftPadding
 					y: parent.height / 2 - height / 2
 					radius: 4
-					border.color: checkboxGPS.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+					border.color: checkboxGPS.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 					color: subsurfaceTheme.backgroundColor
 
 					Rectangle {
@@ -136,7 +136,7 @@ Item {
 					    x: 4
 					    y: 4
 					    radius: 3
-					    color: checkboxGPS.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+						color: checkboxGPS.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 					    visible: checkboxGPS.checked
 					}
 				}

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -231,8 +231,6 @@ Kirigami.Page {
 				depth: model.depth ? model.depth : ""
 				selected: model.selected ? model.selected : false
 
-				backgroundColor: selectAll ? subsurfaceTheme.darkPrimaryColor : subsurfaceTheme.backgroundColor
-
 				onClicked : {
 					console.log("Selecting index" + index);
 					importModel.selectRow(index)

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -34,16 +34,16 @@ Kirigami.AbstractListItem {
 		CheckBox {
 			id: diveIsSelected
 			checked: innerListItem.selected;
-			width: childrenRect.heigh - Kirigami.Units.smallSpacing;
+			width: childrenRect.width - Kirigami.Units.smallSpacing;
 			height: childrenRect.heigh - Kirigami.Units.smallSpacing;
 			indicator: Rectangle {
 				visible: diveIsSelected
 				implicitWidth: 20
 				implicitHeight: 20
-				x: isBluetooth.leftPadding
+				//x: isBluetooth.leftPadding
 				y: parent.height / 2 - height / 2
 				radius: 4
-				border.color: diveIsSelected.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+				border.color: diveIsSelected.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 				color: subsurfaceTheme.backgroundColor
 
 				Rectangle {
@@ -52,7 +52,7 @@ Kirigami.AbstractListItem {
 					x: 4
 					y: 4
 					radius: 3
-					color: diveIsSelected.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+					color: diveIsSelected.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 					visible: diveIsSelected && diveIsSelected.checked
 				}
 			}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -294,7 +294,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					x: locationCheckbox.leftPadding
 					y: parent.height / 2 - height / 2
 					radius: 4
-					border.color: locationCheckbox.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+					border.color: locationCheckbox.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 					color: subsurfaceTheme.drawerColor
 
 					Rectangle {
@@ -303,7 +303,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 						x: 4
 						y: 4
 						radius: 3
-						color: locationCheckbox.down ? subsurfaceTheme.PrimaryColor : subsurfaceTheme.darkerPrimaryColor
+						color: locationCheckbox.down ? subsurfaceTheme.primaryColor : subsurfaceTheme.darkerPrimaryColor
 						visible: locationCheckbox && locationCheckbox.checked
 					}
 				}


### PR DESCRIPTION
Fixes: #490 items 1) and 2).

1) Reference to `isBluetooth.leftPadding` is removed as the `isBluetooth` checkbox is gone.

2) Do not set background color of downloaded dives. The checkbox is used to denote "selected or not".

In addition, incorrect references to `subsurfaceTheme.PrimaryColor` (which does not exist) are replaced by the correct `subsurfaceTheme.primaryColor`.

Finally, an obvious copy/paste error `width: childrenRect.height`. that is supposed to be `width: childrenRect.width`.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>