### PR TITLE
Fix comparison data for TestParse

### DIFF
--- a/dives/TestDiveSeabearNewFormat.xml
+++ b/dives/TestDiveSeabearNewFormat.xml
@@ -25,187 +25,187 @@
   <sample time='0:55 min' depth='15.1 m' />
   <sample time='1:00 min' depth='16.3 m' />
   <sample time='1:05 min' depth='17.6 m' tts='3:00 min' />
-  <sample time='1:10 min' depth='18.8 m' tts='0:00 min' />
+  <sample time='1:10 min' depth='18.8 m' />
   <sample time='1:15 min' depth='20.1 m' />
   <sample time='1:20 min' depth='20.9 m' />
   <sample time='1:25 min' depth='21.7 m' />
   <sample time='1:30 min' depth='22.6 m' />
-  <sample time='1:35 min' depth='23.4 m' temp='27.0 C' ndl='0:34 min' tts='3:00 min' />
-  <sample time='1:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='1:35 min' depth='23.4 m' temp='27.0 C' ndl='0:34 min' />
+  <sample time='1:40 min' depth='24.2 m' />
   <sample time='1:45 min' depth='25.1 m' />
   <sample time='1:50 min' depth='25.9 m' />
   <sample time='1:55 min' depth='26.7 m' />
   <sample time='2:00 min' depth='27.6 m' />
-  <sample time='2:05 min' depth='28.4 m' ndl='0:14 min' tts='3:00 min' />
-  <sample time='2:10 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='2:05 min' depth='28.4 m' ndl='0:14 min' />
+  <sample time='2:10 min' depth='29.2 m' />
   <sample time='2:15 min' depth='30.1 m' />
   <sample time='2:20 min' depth='30.9 m' />
   <sample time='2:25 min' depth='31.7 m' />
   <sample time='2:30 min' depth='32.6 m' />
-  <sample time='2:35 min' depth='33.4 m' ndl='0:07 min' tts='3:00 min' />
-  <sample time='2:40 min' depth='34.2 m' tts='0:00 min' />
+  <sample time='2:35 min' depth='33.4 m' ndl='0:07 min' />
+  <sample time='2:40 min' depth='34.2 m' />
   <sample time='2:45 min' depth='35.1 m' />
   <sample time='2:50 min' depth='35.9 m' />
   <sample time='2:55 min' depth='36.7 m' />
   <sample time='3:00 min' depth='37.6 m' />
-  <sample time='3:05 min' depth='38.4 m' temp='26.0 C' ndl='0:04 min' tts='3:00 min' />
-  <sample time='3:10 min' depth='39.2 m' tts='0:00 min' />
+  <sample time='3:05 min' depth='38.4 m' temp='26.0 C' ndl='0:04 min' />
+  <sample time='3:10 min' depth='39.2 m' />
   <sample time='3:15 min' depth='40.1 m' />
   <sample time='3:20 min' depth='40.9 m' />
   <sample time='3:25 min' depth='41.7 m' />
   <sample time='3:30 min' depth='42.5 m' />
-  <sample time='3:35 min' depth='43.4 m' ndl='0:03 min' tts='3:00 min' />
-  <sample time='3:40 min' depth='44.2 m' tts='0:00 min' />
+  <sample time='3:35 min' depth='43.4 m' ndl='0:03 min' />
+  <sample time='3:40 min' depth='44.2 m' />
   <sample time='3:45 min' depth='45.0 m' />
   <sample time='3:50 min' depth='45.9 m' />
   <sample time='3:55 min' depth='46.7 m' />
   <sample time='4:00 min' depth='47.5 m' />
-  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' tts='3:00 min' />
-  <sample time='4:10 min' depth='49.2 m' tts='0:00 min' />
+  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' />
+  <sample time='4:10 min' depth='49.2 m' />
   <sample time='4:15 min' depth='50.0 m' />
   <sample time='4:20 min' depth='50.6 m' />
   <sample time='4:25 min' depth='51.2 m' />
   <sample time='4:30 min' depth='51.8 m' />
-  <sample time='4:35 min' depth='52.4 m' tts='3:00 min' />
-  <sample time='4:40 min' depth='53.0 m' tts='0:00 min' />
+  <sample time='4:35 min' depth='52.4 m' />
+  <sample time='4:40 min' depth='53.0 m' />
   <sample time='4:45 min' depth='53.5 m' />
   <sample time='4:50 min' depth='54.1 m' />
   <sample time='4:55 min' depth='54.7 m' />
   <sample time='5:00 min' depth='55.3 m' />
-  <sample time='5:05 min' depth='55.9 m' ndl='0:00 min' tts='3:00 min' />
-  <sample time='5:10 min' depth='56.5 m' tts='0:00 min' />
+  <sample time='5:05 min' depth='55.9 m' ndl='0:00 min' />
+  <sample time='5:10 min' depth='56.5 m' />
   <sample time='5:15 min' depth='57.0 m' />
   <sample time='5:20 min' depth='57.6 m' />
   <sample time='5:25 min' depth='58.2 m' />
   <sample time='5:30 min' depth='58.8 m' />
-  <sample time='5:35 min' depth='59.4 m' tts='3:00 min' />
-  <sample time='5:40 min' depth='60.0 m' tts='0:00 min' />
+  <sample time='5:35 min' depth='59.4 m' />
+  <sample time='5:40 min' depth='60.0 m' />
   <sample time='5:45 min' depth='60.5 m' />
   <sample time='5:50 min' depth='61.1 m' />
   <sample time='5:55 min' depth='61.7 m' />
   <sample time='6:00 min' depth='62.3 m' />
   <sample time='6:05 min' depth='62.9 m' tts='10:30 min' />
-  <sample time='6:10 min' depth='63.5 m' tts='0:00 min' />
+  <sample time='6:10 min' depth='63.5 m' />
   <sample time='6:15 min' depth='64.0 m' />
   <sample time='6:20 min' depth='64.6 m' />
   <sample time='6:25 min' depth='65.2 m' />
   <sample time='6:30 min' depth='65.8 m' />
   <sample time='6:35 min' depth='66.4 m' tts='12:30 min' />
-  <sample time='6:40 min' depth='67.0 m' tts='0:00 min' />
+  <sample time='6:40 min' depth='67.0 m' />
   <sample time='6:45 min' depth='67.5 m' />
   <sample time='6:50 min' depth='68.1 m' />
   <sample time='6:55 min' depth='68.7 m' />
   <sample time='7:00 min' depth='69.3 m' />
   <sample time='7:05 min' depth='69.9 m' tts='14:10 min' />
-  <sample time='7:10 min' depth='68.8 m' tts='0:00 min' />
+  <sample time='7:10 min' depth='68.8 m' />
   <sample time='7:15 min' depth='66.7 m' />
   <sample time='7:20 min' depth='64.6 m' />
   <sample time='7:25 min' depth='62.6 m' />
   <sample time='7:30 min' depth='60.5 m' />
   <sample time='7:35 min' depth='59.3 m' tts='11:30 min' />
-  <sample time='7:40 min' depth='58.4 m' tts='0:00 min' />
+  <sample time='7:40 min' depth='58.4 m' />
   <sample time='7:45 min' depth='57.6 m' />
   <sample time='7:50 min' depth='56.8 m' />
   <sample time='7:55 min' depth='55.9 m' />
   <sample time='8:00 min' depth='55.1 m' />
-  <sample time='8:05 min' depth='54.3 m' tts='11:30 min' />
-  <sample time='8:10 min' depth='53.4 m' tts='0:00 min' />
+  <sample time='8:05 min' depth='54.3 m' />
+  <sample time='8:10 min' depth='53.4 m' />
   <sample time='8:15 min' depth='52.6 m' />
   <sample time='8:20 min' depth='51.8 m' />
   <sample time='8:25 min' depth='50.9 m' />
   <sample time='8:30 min' depth='50.1 m' />
   <sample time='8:35 min' depth='49.3 m' tts='10:50 min' />
-  <sample time='8:40 min' depth='48.4 m' tts='0:00 min' />
+  <sample time='8:40 min' depth='48.4 m' />
   <sample time='8:45 min' depth='47.6 m' />
   <sample time='8:50 min' depth='46.8 m' />
   <sample time='8:55 min' depth='45.9 m' />
   <sample time='9:00 min' depth='45.1 m' />
   <sample time='9:05 min' depth='44.3 m' temp='25.0 C' tts='10:10 min' />
-  <sample time='9:10 min' depth='43.4 m' tts='0:00 min' />
+  <sample time='9:10 min' depth='43.4 m' />
   <sample time='9:15 min' depth='42.6 m' />
   <sample time='9:20 min' depth='41.8 m' />
   <sample time='9:25 min' depth='40.9 m' />
   <sample time='9:30 min' depth='40.1 m' />
   <sample time='9:35 min' depth='39.3 m' tts='9:50 min' />
-  <sample time='9:40 min' depth='38.4 m' tts='0:00 min' />
+  <sample time='9:40 min' depth='38.4 m' />
   <sample time='9:45 min' depth='37.6 m' />
   <sample time='9:50 min' depth='36.8 m' />
   <sample time='9:55 min' depth='35.9 m' />
   <sample time='10:00 min' depth='35.1 m' />
   <sample time='10:05 min' depth='34.3 m' tts='9:10 min' />
-  <sample time='10:10 min' depth='33.4 m' tts='0:00 min' />
+  <sample time='10:10 min' depth='33.4 m' />
   <sample time='10:15 min' depth='32.6 m' />
   <sample time='10:20 min' depth='31.8 m' />
   <sample time='10:25 min' depth='30.9 m' />
   <sample time='10:30 min' depth='30.1 m' />
   <sample time='10:35 min' depth='29.6 m' tts='8:30 min' />
-  <sample time='10:40 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='10:40 min' depth='29.2 m' />
   <sample time='10:45 min' depth='28.8 m' />
   <sample time='10:50 min' depth='28.3 m' />
   <sample time='10:55 min' depth='27.9 m' />
   <sample time='11:00 min' depth='27.5 m' />
-  <sample time='11:05 min' depth='27.1 m' tts='8:30 min' />
-  <sample time='11:10 min' depth='26.7 m' tts='0:00 min' />
+  <sample time='11:05 min' depth='27.1 m' />
+  <sample time='11:10 min' depth='26.7 m' />
   <sample time='11:15 min' depth='26.3 m' />
   <sample time='11:20 min' depth='25.8 m' />
   <sample time='11:25 min' depth='25.4 m' />
   <sample time='11:30 min' depth='25.0 m' />
   <sample time='11:35 min' depth='24.6 m' tts='8:10 min' />
-  <sample time='11:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='11:40 min' depth='24.2 m' />
   <sample time='11:45 min' depth='23.8 m' />
   <sample time='11:50 min' depth='23.3 m' />
   <sample time='11:55 min' depth='22.9 m' />
   <sample time='12:00 min' depth='22.5 m' />
-  <sample time='12:05 min' depth='22.1 m' tts='8:10 min' />
-  <sample time='12:10 min' depth='21.7 m' tts='0:00 min' />
+  <sample time='12:05 min' depth='22.1 m' />
+  <sample time='12:10 min' depth='21.7 m' />
   <sample time='12:15 min' depth='21.3 m' />
   <sample time='12:20 min' depth='20.8 m' />
   <sample time='12:25 min' depth='20.4 m' />
   <sample time='12:30 min' depth='20.0 m' />
   <sample time='12:35 min' depth='19.6 m' tts='7:50 min' />
-  <sample time='12:40 min' depth='19.2 m' tts='0:00 min' />
+  <sample time='12:40 min' depth='19.2 m' />
   <sample time='12:45 min' depth='18.8 m' />
   <sample time='12:50 min' depth='18.3 m' />
   <sample time='12:55 min' depth='17.9 m' />
   <sample time='13:00 min' depth='17.5 m' />
   <sample time='13:05 min' depth='17.1 m' tts='7:30 min' />
-  <sample time='13:10 min' depth='16.7 m' tts='0:00 min' />
+  <sample time='13:10 min' depth='16.7 m' />
   <sample time='13:15 min' depth='16.3 m' />
   <sample time='13:20 min' depth='15.8 m' />
   <sample time='13:25 min' depth='15.4 m' />
   <sample time='13:30 min' depth='15.0 m' />
   <sample time='13:35 min' depth='14.6 m' temp='26.0 C' tts='6:50 min' />
-  <sample time='13:40 min' depth='14.2 m' tts='0:00 min' />
+  <sample time='13:40 min' depth='14.2 m' />
   <sample time='13:45 min' depth='13.8 m' />
   <sample time='13:50 min' depth='13.3 m' />
   <sample time='13:55 min' depth='12.9 m' />
   <sample time='14:00 min' depth='12.5 m' />
   <sample time='14:05 min' depth='12.1 m' temp='25.0 C' tts='6:30 min' />
-  <sample time='14:10 min' depth='11.7 m' tts='0:00 min' />
+  <sample time='14:10 min' depth='11.7 m' />
   <sample time='14:15 min' depth='11.3 m' />
   <sample time='14:20 min' depth='10.8 m' />
   <sample time='14:25 min' depth='10.4 m' />
   <sample time='14:30 min' depth='10.0 m' />
   <sample time='14:35 min' depth='9.6 m' temp='26.0 C' tts='6:00 min' />
-  <sample time='14:40 min' depth='9.2 m' tts='0:00 min' />
+  <sample time='14:40 min' depth='9.2 m' />
   <sample time='14:45 min' depth='8.8 m' />
   <sample time='14:50 min' depth='8.3 m' />
   <sample time='14:55 min' depth='7.9 m' />
   <sample time='15:00 min' depth='7.5 m' />
   <sample time='15:05 min' depth='7.1 m' temp='25.0 C' tts='5:40 min' />
-  <sample time='15:10 min' depth='6.7 m' tts='0:00 min' />
+  <sample time='15:10 min' depth='6.7 m' />
   <sample time='15:15 min' depth='6.3 m' />
   <sample time='15:20 min' depth='5.8 m' />
   <sample time='15:25 min' depth='5.4 m' />
   <sample time='15:30 min' depth='5.0 m' />
   <sample time='15:35 min' depth='4.6 m' tts='5:20 min' />
-  <sample time='15:40 min' depth='4.2 m' tts='0:00 min' />
+  <sample time='15:40 min' depth='4.2 m' />
   <sample time='15:45 min' depth='3.8 m' />
   <sample time='15:50 min' depth='3.3 m' />
   <sample time='15:55 min' depth='2.9 m' />
   <sample time='16:00 min' depth='2.5 m' />
   <sample time='16:05 min' depth='2.1 m' tts='4:40 min' />
-  <sample time='16:10 min' depth='1.7 m' tts='0:00 min' />
+  <sample time='16:10 min' depth='1.7 m' />
   <sample time='16:15 min' depth='1.3 m' />
   <sample time='16:20 min' depth='0.8 m' />
   <sample time='16:25 min' depth='0.4 m' />
@@ -232,187 +232,187 @@
   <sample time='0:55 min' depth='15.1 m' />
   <sample time='1:00 min' depth='16.3 m' />
   <sample time='1:05 min' depth='17.6 m' ndl='0:30 min' tts='3:00 min' />
-  <sample time='1:10 min' depth='18.8 m' tts='0:00 min' />
+  <sample time='1:10 min' depth='18.8 m' />
   <sample time='1:15 min' depth='20.1 m' />
   <sample time='1:20 min' depth='20.9 m' />
   <sample time='1:25 min' depth='21.7 m' />
   <sample time='1:30 min' depth='22.6 m' />
-  <sample time='1:35 min' depth='23.4 m' ndl='0:13 min' tts='3:00 min' />
-  <sample time='1:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='1:35 min' depth='23.4 m' ndl='0:13 min' />
+  <sample time='1:40 min' depth='24.2 m' />
   <sample time='1:45 min' depth='25.1 m' />
   <sample time='1:50 min' depth='25.9 m' />
   <sample time='1:55 min' depth='26.7 m' />
   <sample time='2:00 min' depth='27.6 m' />
-  <sample time='2:05 min' depth='28.4 m' ndl='0:08 min' tts='3:00 min' />
-  <sample time='2:10 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='2:05 min' depth='28.4 m' ndl='0:08 min' />
+  <sample time='2:10 min' depth='29.2 m' />
   <sample time='2:15 min' depth='30.1 m' />
   <sample time='2:20 min' depth='30.9 m' />
   <sample time='2:25 min' depth='31.7 m' />
   <sample time='2:30 min' depth='32.6 m' />
-  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' tts='3:00 min' />
-  <sample time='2:40 min' depth='34.2 m' tts='0:00 min' />
+  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' />
+  <sample time='2:40 min' depth='34.2 m' />
   <sample time='2:45 min' depth='35.1 m' />
   <sample time='2:50 min' depth='35.9 m' />
   <sample time='2:55 min' depth='36.7 m' />
   <sample time='3:00 min' depth='37.6 m' />
-  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' tts='3:00 min' />
-  <sample time='3:10 min' depth='39.2 m' tts='0:00 min' />
+  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' />
+  <sample time='3:10 min' depth='39.2 m' />
   <sample time='3:15 min' depth='40.1 m' />
   <sample time='3:20 min' depth='40.9 m' />
   <sample time='3:25 min' depth='41.7 m' />
   <sample time='3:30 min' depth='42.5 m' />
-  <sample time='3:35 min' depth='43.4 m' ndl='0:02 min' tts='3:00 min' />
-  <sample time='3:40 min' depth='44.2 m' tts='0:00 min' />
+  <sample time='3:35 min' depth='43.4 m' ndl='0:02 min' />
+  <sample time='3:40 min' depth='44.2 m' />
   <sample time='3:45 min' depth='45.0 m' />
   <sample time='3:50 min' depth='45.9 m' />
   <sample time='3:55 min' depth='46.7 m' />
   <sample time='4:00 min' depth='47.5 m' />
-  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' tts='3:00 min' />
-  <sample time='4:10 min' depth='49.2 m' tts='0:00 min' />
+  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' />
+  <sample time='4:10 min' depth='49.2 m' />
   <sample time='4:15 min' depth='50.0 m' />
   <sample time='4:20 min' depth='50.6 m' />
   <sample time='4:25 min' depth='51.2 m' />
   <sample time='4:30 min' depth='51.8 m' />
-  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' tts='3:00 min' />
-  <sample time='4:40 min' depth='53.0 m' tts='0:00 min' />
+  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' />
+  <sample time='4:40 min' depth='53.0 m' />
   <sample time='4:45 min' depth='53.5 m' />
   <sample time='4:50 min' depth='54.1 m' />
   <sample time='4:55 min' depth='54.7 m' />
   <sample time='5:00 min' depth='55.3 m' />
-  <sample time='5:05 min' depth='55.9 m' tts='3:00 min' />
-  <sample time='5:10 min' depth='56.5 m' tts='0:00 min' />
+  <sample time='5:05 min' depth='55.9 m' />
+  <sample time='5:10 min' depth='56.5 m' />
   <sample time='5:15 min' depth='57.0 m' />
   <sample time='5:20 min' depth='57.6 m' />
   <sample time='5:25 min' depth='58.2 m' />
   <sample time='5:30 min' depth='58.8 m' />
   <sample time='5:35 min' depth='59.4 m' temp='25.0 C' tts='11:10 min' />
-  <sample time='5:40 min' depth='60.0 m' tts='0:00 min' />
+  <sample time='5:40 min' depth='60.0 m' />
   <sample time='5:45 min' depth='60.5 m' />
   <sample time='5:50 min' depth='61.1 m' />
   <sample time='5:55 min' depth='61.7 m' />
   <sample time='6:00 min' depth='62.3 m' />
   <sample time='6:05 min' depth='62.9 m' tts='13:10 min' />
-  <sample time='6:10 min' depth='63.5 m' tts='0:00 min' />
+  <sample time='6:10 min' depth='63.5 m' />
   <sample time='6:15 min' depth='64.0 m' />
   <sample time='6:20 min' depth='64.6 m' />
   <sample time='6:25 min' depth='65.2 m' />
   <sample time='6:30 min' depth='65.8 m' />
   <sample time='6:35 min' depth='66.4 m' tts='16:50 min' />
-  <sample time='6:40 min' depth='67.0 m' tts='0:00 min' />
+  <sample time='6:40 min' depth='67.0 m' />
   <sample time='6:45 min' depth='67.5 m' />
   <sample time='6:50 min' depth='68.1 m' />
   <sample time='6:55 min' depth='68.7 m' />
   <sample time='7:00 min' depth='69.3 m' />
   <sample time='7:05 min' depth='69.9 m' tts='20:30 min' />
-  <sample time='7:10 min' depth='68.8 m' tts='0:00 min' />
+  <sample time='7:10 min' depth='68.8 m' />
   <sample time='7:15 min' depth='66.7 m' />
   <sample time='7:20 min' depth='64.6 m' />
   <sample time='7:25 min' depth='62.6 m' />
   <sample time='7:30 min' depth='60.5 m' />
   <sample time='7:35 min' depth='59.3 m' temp='26.0 C' tts='16:10 min' />
-  <sample time='7:40 min' depth='58.4 m' tts='0:00 min' />
+  <sample time='7:40 min' depth='58.4 m' />
   <sample time='7:45 min' depth='57.6 m' />
   <sample time='7:50 min' depth='56.8 m' />
   <sample time='7:55 min' depth='55.9 m' />
   <sample time='8:00 min' depth='55.1 m' />
   <sample time='8:05 min' depth='54.3 m' tts='16:50 min' />
-  <sample time='8:10 min' depth='53.4 m' tts='0:00 min' />
+  <sample time='8:10 min' depth='53.4 m' />
   <sample time='8:15 min' depth='52.6 m' />
   <sample time='8:20 min' depth='51.8 m' />
   <sample time='8:25 min' depth='50.9 m' />
   <sample time='8:30 min' depth='50.1 m' />
   <sample time='8:35 min' depth='49.3 m' temp='25.0 C' tts='16:10 min' />
-  <sample time='8:40 min' depth='48.4 m' tts='0:00 min' />
+  <sample time='8:40 min' depth='48.4 m' />
   <sample time='8:45 min' depth='47.6 m' />
   <sample time='8:50 min' depth='46.8 m' />
   <sample time='8:55 min' depth='45.9 m' />
   <sample time='9:00 min' depth='45.1 m' />
   <sample time='9:05 min' depth='44.3 m' tts='15:30 min' />
-  <sample time='9:10 min' depth='43.4 m' tts='0:00 min' />
+  <sample time='9:10 min' depth='43.4 m' />
   <sample time='9:15 min' depth='42.6 m' />
   <sample time='9:20 min' depth='41.8 m' />
   <sample time='9:25 min' depth='40.9 m' />
   <sample time='9:30 min' depth='40.1 m' />
   <sample time='9:35 min' depth='39.3 m' tts='15:10 min' />
-  <sample time='9:40 min' depth='38.4 m' tts='0:00 min' />
+  <sample time='9:40 min' depth='38.4 m' />
   <sample time='9:45 min' depth='37.6 m' />
   <sample time='9:50 min' depth='36.8 m' />
   <sample time='9:55 min' depth='35.9 m' />
   <sample time='10:00 min' depth='35.1 m' />
   <sample time='10:05 min' depth='34.3 m' tts='14:30 min' />
-  <sample time='10:10 min' depth='33.4 m' tts='0:00 min' />
+  <sample time='10:10 min' depth='33.4 m' />
   <sample time='10:15 min' depth='32.6 m' />
   <sample time='10:20 min' depth='31.8 m' />
   <sample time='10:25 min' depth='30.9 m' />
   <sample time='10:30 min' depth='30.1 m' />
   <sample time='10:35 min' depth='29.6 m' tts='14:10 min' />
-  <sample time='10:40 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='10:40 min' depth='29.2 m' />
   <sample time='10:45 min' depth='28.8 m' />
   <sample time='10:50 min' depth='28.3 m' />
   <sample time='10:55 min' depth='27.9 m' />
   <sample time='11:00 min' depth='27.5 m' />
-  <sample time='11:05 min' depth='27.1 m' tts='14:10 min' />
-  <sample time='11:10 min' depth='26.7 m' tts='0:00 min' />
+  <sample time='11:05 min' depth='27.1 m' />
+  <sample time='11:10 min' depth='26.7 m' />
   <sample time='11:15 min' depth='26.3 m' />
   <sample time='11:20 min' depth='25.8 m' />
   <sample time='11:25 min' depth='25.4 m' />
   <sample time='11:30 min' depth='25.0 m' />
   <sample time='11:35 min' depth='24.6 m' tts='13:50 min' />
-  <sample time='11:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='11:40 min' depth='24.2 m' />
   <sample time='11:45 min' depth='23.8 m' />
   <sample time='11:50 min' depth='23.3 m' />
   <sample time='11:55 min' depth='22.9 m' />
   <sample time='12:00 min' depth='22.5 m' />
   <sample time='12:05 min' depth='22.1 m' tts='13:30 min' />
-  <sample time='12:10 min' depth='21.7 m' tts='0:00 min' />
+  <sample time='12:10 min' depth='21.7 m' />
   <sample time='12:15 min' depth='21.3 m' />
   <sample time='12:20 min' depth='20.8 m' />
   <sample time='12:25 min' depth='20.4 m' />
   <sample time='12:30 min' depth='20.0 m' />
   <sample time='12:35 min' depth='19.6 m' tts='13:10 min' />
-  <sample time='12:40 min' depth='19.2 m' tts='0:00 min' />
+  <sample time='12:40 min' depth='19.2 m' />
   <sample time='12:45 min' depth='18.8 m' />
   <sample time='12:50 min' depth='18.3 m' />
   <sample time='12:55 min' depth='17.9 m' />
   <sample time='13:00 min' depth='17.5 m' />
   <sample time='13:05 min' depth='17.1 m' tts='12:50 min' />
-  <sample time='13:10 min' depth='16.7 m' tts='0:00 min' />
+  <sample time='13:10 min' depth='16.7 m' />
   <sample time='13:15 min' depth='16.3 m' />
   <sample time='13:20 min' depth='15.8 m' />
   <sample time='13:25 min' depth='15.4 m' />
   <sample time='13:30 min' depth='15.0 m' />
   <sample time='13:35 min' depth='14.6 m' tts='12:30 min' />
-  <sample time='13:40 min' depth='14.2 m' tts='0:00 min' />
+  <sample time='13:40 min' depth='14.2 m' />
   <sample time='13:45 min' depth='13.8 m' />
   <sample time='13:50 min' depth='13.3 m' />
   <sample time='13:55 min' depth='12.9 m' />
   <sample time='14:00 min' depth='12.5 m' />
   <sample time='14:05 min' depth='12.1 m' tts='12:00 min' />
-  <sample time='14:10 min' depth='11.7 m' tts='0:00 min' />
+  <sample time='14:10 min' depth='11.7 m' />
   <sample time='14:15 min' depth='11.3 m' />
   <sample time='14:20 min' depth='10.8 m' />
   <sample time='14:25 min' depth='10.4 m' />
   <sample time='14:30 min' depth='10.0 m' />
   <sample time='14:35 min' depth='9.6 m' tts='11:40 min' />
-  <sample time='14:40 min' depth='9.2 m' tts='0:00 min' />
+  <sample time='14:40 min' depth='9.2 m' />
   <sample time='14:45 min' depth='8.8 m' />
   <sample time='14:50 min' depth='8.3 m' />
   <sample time='14:55 min' depth='7.9 m' />
   <sample time='15:00 min' depth='7.5 m' />
   <sample time='15:05 min' depth='7.1 m' tts='11:00 min' />
-  <sample time='15:10 min' depth='6.7 m' tts='0:00 min' />
+  <sample time='15:10 min' depth='6.7 m' />
   <sample time='15:15 min' depth='6.3 m' />
   <sample time='15:20 min' depth='5.8 m' />
   <sample time='15:25 min' depth='5.4 m' />
   <sample time='15:30 min' depth='5.0 m' />
   <sample time='15:35 min' depth='4.6 m' tts='10:20 min' />
-  <sample time='15:40 min' depth='4.2 m' tts='0:00 min' />
+  <sample time='15:40 min' depth='4.2 m' />
   <sample time='15:45 min' depth='3.8 m' />
   <sample time='15:50 min' depth='3.3 m' />
   <sample time='15:55 min' depth='2.9 m' />
   <sample time='16:00 min' depth='2.5 m' />
   <sample time='16:05 min' depth='2.1 m' tts='10:00 min' />
-  <sample time='16:10 min' depth='1.7 m' tts='0:00 min' />
+  <sample time='16:10 min' depth='1.7 m' />
   <sample time='16:15 min' depth='1.3 m' />
   <sample time='16:20 min' depth='0.8 m' />
   <sample time='16:25 min' depth='0.4 m' />
@@ -1580,187 +1580,187 @@
   <sample time='0:55 min' depth='15.1 m' />
   <sample time='1:00 min' depth='16.3 m' />
   <sample time='1:05 min' depth='17.6 m' ndl='1:19 min' tts='3:00 min' sensor3='0.93 bar' />
-  <sample time='1:10 min' depth='18.8 m' tts='0:00 min' />
+  <sample time='1:10 min' depth='18.8 m' />
   <sample time='1:15 min' depth='20.1 m' />
   <sample time='1:20 min' depth='20.9 m' />
   <sample time='1:25 min' depth='21.7 m' />
   <sample time='1:30 min' depth='22.6 m' />
-  <sample time='1:35 min' depth='23.4 m' ndl='0:21 min' tts='3:00 min' sensor3='0.96 bar' />
-  <sample time='1:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='1:35 min' depth='23.4 m' ndl='0:21 min' sensor3='0.96 bar' />
+  <sample time='1:40 min' depth='24.2 m' />
   <sample time='1:45 min' depth='25.1 m' />
   <sample time='1:50 min' depth='25.9 m' />
   <sample time='1:55 min' depth='26.7 m' />
   <sample time='2:00 min' depth='27.6 m' />
-  <sample time='2:05 min' depth='28.4 m' ndl='0:10 min' tts='3:00 min' />
-  <sample time='2:10 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='2:05 min' depth='28.4 m' ndl='0:10 min' />
+  <sample time='2:10 min' depth='29.2 m' />
   <sample time='2:15 min' depth='30.1 m' />
   <sample time='2:20 min' depth='30.9 m' />
   <sample time='2:25 min' depth='31.7 m' />
   <sample time='2:30 min' depth='32.6 m' />
-  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' tts='3:00 min' sensor2='0.99 bar' />
-  <sample time='2:40 min' depth='34.2 m' tts='0:00 min' />
+  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' sensor2='0.99 bar' />
+  <sample time='2:40 min' depth='34.2 m' />
   <sample time='2:45 min' depth='35.1 m' />
   <sample time='2:50 min' depth='35.9 m' />
   <sample time='2:55 min' depth='36.7 m' />
   <sample time='3:00 min' depth='37.6 m' />
-  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' tts='3:00 min' sensor2='0.96 bar' />
-  <sample time='3:10 min' depth='39.2 m' tts='0:00 min' />
+  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' sensor2='0.96 bar' />
+  <sample time='3:10 min' depth='39.2 m' />
   <sample time='3:15 min' depth='40.1 m' />
   <sample time='3:20 min' depth='40.9 m' />
   <sample time='3:25 min' depth='41.7 m' />
   <sample time='3:30 min' depth='42.5 m' />
-  <sample time='3:35 min' depth='43.4 m' temp='25.0 C' ndl='0:02 min' tts='3:00 min' sensor2='0.99 bar' />
-  <sample time='3:40 min' depth='44.2 m' tts='0:00 min' />
+  <sample time='3:35 min' depth='43.4 m' temp='25.0 C' ndl='0:02 min' sensor2='0.99 bar' />
+  <sample time='3:40 min' depth='44.2 m' />
   <sample time='3:45 min' depth='45.0 m' />
   <sample time='3:50 min' depth='45.9 m' />
   <sample time='3:55 min' depth='46.7 m' />
   <sample time='4:00 min' depth='47.5 m' />
-  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' tts='3:00 min' />
-  <sample time='4:10 min' depth='49.2 m' tts='0:00 min' />
+  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' />
+  <sample time='4:10 min' depth='49.2 m' />
   <sample time='4:15 min' depth='50.0 m' />
   <sample time='4:20 min' depth='50.6 m' />
   <sample time='4:25 min' depth='51.2 m' />
   <sample time='4:30 min' depth='51.8 m' />
-  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' tts='3:00 min' sensor2='0.96 bar' />
-  <sample time='4:40 min' depth='53.0 m' tts='0:00 min' />
+  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' sensor2='0.96 bar' />
+  <sample time='4:40 min' depth='53.0 m' />
   <sample time='4:45 min' depth='53.5 m' />
   <sample time='4:50 min' depth='54.1 m' />
   <sample time='4:55 min' depth='54.7 m' />
   <sample time='5:00 min' depth='55.3 m' />
-  <sample time='5:05 min' depth='55.9 m' tts='3:00 min' />
-  <sample time='5:10 min' depth='56.5 m' tts='0:00 min' />
+  <sample time='5:05 min' depth='55.9 m' />
+  <sample time='5:10 min' depth='56.5 m' />
   <sample time='5:15 min' depth='57.0 m' />
   <sample time='5:20 min' depth='57.6 m' />
   <sample time='5:25 min' depth='58.2 m' />
   <sample time='5:30 min' depth='58.8 m' />
   <sample time='5:35 min' depth='59.4 m' tts='10:10 min' />
-  <sample time='5:40 min' depth='60.0 m' tts='0:00 min' />
+  <sample time='5:40 min' depth='60.0 m' />
   <sample time='5:45 min' depth='60.5 m' />
   <sample time='5:50 min' depth='61.1 m' />
   <sample time='5:55 min' depth='61.7 m' />
   <sample time='6:00 min' depth='62.3 m' />
   <sample time='6:05 min' depth='62.9 m' tts='11:30 min' sensor2='0.99 bar' />
-  <sample time='6:10 min' depth='63.5 m' tts='0:00 min' />
+  <sample time='6:10 min' depth='63.5 m' />
   <sample time='6:15 min' depth='64.0 m' />
   <sample time='6:20 min' depth='64.6 m' />
   <sample time='6:25 min' depth='65.2 m' />
   <sample time='6:30 min' depth='65.8 m' />
   <sample time='6:35 min' depth='66.4 m' tts='14:10 min' sensor2='0.96 bar' />
-  <sample time='6:40 min' depth='67.0 m' tts='0:00 min' />
+  <sample time='6:40 min' depth='67.0 m' />
   <sample time='6:45 min' depth='67.5 m' />
   <sample time='6:50 min' depth='68.1 m' />
   <sample time='6:55 min' depth='68.7 m' />
   <sample time='7:00 min' depth='69.3 m' />
   <sample time='7:05 min' depth='69.9 m' tts='16:10 min' sensor2='0.99 bar' />
-  <sample time='7:10 min' depth='68.8 m' tts='0:00 min' />
+  <sample time='7:10 min' depth='68.8 m' />
   <sample time='7:15 min' depth='66.7 m' />
   <sample time='7:20 min' depth='64.6 m' />
   <sample time='7:25 min' depth='62.6 m' />
   <sample time='7:30 min' depth='60.5 m' />
   <sample time='7:35 min' depth='59.3 m' tts='13:30 min' sensor2='0.96 bar' />
-  <sample time='7:40 min' depth='58.4 m' tts='0:00 min' />
+  <sample time='7:40 min' depth='58.4 m' />
   <sample time='7:45 min' depth='57.6 m' />
   <sample time='7:50 min' depth='56.8 m' />
   <sample time='7:55 min' depth='55.9 m' />
   <sample time='8:00 min' depth='55.1 m' />
-  <sample time='8:05 min' depth='54.3 m' tts='13:30 min' />
-  <sample time='8:10 min' depth='53.4 m' tts='0:00 min' />
+  <sample time='8:05 min' depth='54.3 m' />
+  <sample time='8:10 min' depth='53.4 m' />
   <sample time='8:15 min' depth='52.6 m' />
   <sample time='8:20 min' depth='51.8 m' />
   <sample time='8:25 min' depth='50.9 m' />
   <sample time='8:30 min' depth='50.1 m' />
   <sample time='8:35 min' depth='49.3 m' tts='12:50 min' sensor2='0.99 bar' />
-  <sample time='8:40 min' depth='48.4 m' tts='0:00 min' />
+  <sample time='8:40 min' depth='48.4 m' />
   <sample time='8:45 min' depth='47.6 m' />
   <sample time='8:50 min' depth='46.8 m' />
   <sample time='8:55 min' depth='45.9 m' />
   <sample time='9:00 min' depth='45.1 m' />
   <sample time='9:05 min' depth='44.3 m' tts='11:50 min' sensor2='0.96 bar' />
-  <sample time='9:10 min' depth='43.4 m' tts='0:00 min' />
+  <sample time='9:10 min' depth='43.4 m' />
   <sample time='9:15 min' depth='42.6 m' />
   <sample time='9:20 min' depth='41.8 m' />
   <sample time='9:25 min' depth='40.9 m' />
   <sample time='9:30 min' depth='40.1 m' />
-  <sample time='9:35 min' depth='39.3 m' tts='11:50 min' />
-  <sample time='9:40 min' depth='38.4 m' tts='0:00 min' />
+  <sample time='9:35 min' depth='39.3 m' />
+  <sample time='9:40 min' depth='38.4 m' />
   <sample time='9:45 min' depth='37.6 m' />
   <sample time='9:50 min' depth='36.8 m' />
   <sample time='9:55 min' depth='35.9 m' />
   <sample time='10:00 min' depth='35.1 m' />
   <sample time='10:05 min' depth='34.3 m' tts='11:10 min' />
-  <sample time='10:10 min' depth='33.4 m' tts='0:00 min' />
+  <sample time='10:10 min' depth='33.4 m' />
   <sample time='10:15 min' depth='32.6 m' />
   <sample time='10:20 min' depth='31.8 m' />
   <sample time='10:25 min' depth='30.9 m' />
   <sample time='10:30 min' depth='30.1 m' />
   <sample time='10:35 min' depth='29.6 m' tts='10:30 min' sensor2='0.99 bar' />
-  <sample time='10:40 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='10:40 min' depth='29.2 m' />
   <sample time='10:45 min' depth='28.8 m' />
   <sample time='10:50 min' depth='28.3 m' />
   <sample time='10:55 min' depth='27.9 m' />
   <sample time='11:00 min' depth='27.5 m' />
-  <sample time='11:05 min' depth='27.1 m' tts='10:30 min' />
-  <sample time='11:10 min' depth='26.7 m' tts='0:00 min' />
+  <sample time='11:05 min' depth='27.1 m' />
+  <sample time='11:10 min' depth='26.7 m' />
   <sample time='11:15 min' depth='26.3 m' />
   <sample time='11:20 min' depth='25.8 m' />
   <sample time='11:25 min' depth='25.4 m' />
   <sample time='11:30 min' depth='25.0 m' />
   <sample time='11:35 min' depth='24.6 m' tts='10:10 min' sensor2='0.96 bar' />
-  <sample time='11:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='11:40 min' depth='24.2 m' />
   <sample time='11:45 min' depth='23.8 m' />
   <sample time='11:50 min' depth='23.3 m' />
   <sample time='11:55 min' depth='22.9 m' />
   <sample time='12:00 min' depth='22.5 m' />
   <sample time='12:05 min' depth='22.1 m' tts='9:50 min' sensor2='0.99 bar' />
-  <sample time='12:10 min' depth='21.7 m' tts='0:00 min' />
+  <sample time='12:10 min' depth='21.7 m' />
   <sample time='12:15 min' depth='21.3 m' />
   <sample time='12:20 min' depth='20.8 m' />
   <sample time='12:25 min' depth='20.4 m' />
   <sample time='12:30 min' depth='20.0 m' />
   <sample time='12:35 min' depth='19.6 m' tts='9:30 min' />
-  <sample time='12:40 min' depth='19.2 m' tts='0:00 min' />
+  <sample time='12:40 min' depth='19.2 m' />
   <sample time='12:45 min' depth='18.8 m' />
   <sample time='12:50 min' depth='18.3 m' />
   <sample time='12:55 min' depth='17.9 m' />
   <sample time='13:00 min' depth='17.5 m' />
   <sample time='13:05 min' depth='17.1 m' tts='9:10 min' sensor2='0.96 bar' />
-  <sample time='13:10 min' depth='16.7 m' tts='0:00 min' />
+  <sample time='13:10 min' depth='16.7 m' />
   <sample time='13:15 min' depth='16.3 m' />
   <sample time='13:20 min' depth='15.8 m' />
   <sample time='13:25 min' depth='15.4 m' />
   <sample time='13:30 min' depth='15.0 m' />
   <sample time='13:35 min' depth='14.6 m' tts='9:00 min' />
-  <sample time='13:40 min' depth='14.2 m' tts='0:00 min' />
+  <sample time='13:40 min' depth='14.2 m' />
   <sample time='13:45 min' depth='13.8 m' />
   <sample time='13:50 min' depth='13.3 m' />
   <sample time='13:55 min' depth='12.9 m' />
   <sample time='14:00 min' depth='12.5 m' />
   <sample time='14:05 min' depth='12.1 m' tts='8:40 min' />
-  <sample time='14:10 min' depth='11.7 m' tts='0:00 min' />
+  <sample time='14:10 min' depth='11.7 m' />
   <sample time='14:15 min' depth='11.3 m' />
   <sample time='14:20 min' depth='10.8 m' />
   <sample time='14:25 min' depth='10.4 m' />
   <sample time='14:30 min' depth='10.0 m' />
   <sample time='14:35 min' depth='9.6 m' tts='8:00 min' />
-  <sample time='14:40 min' depth='9.2 m' tts='0:00 min' />
+  <sample time='14:40 min' depth='9.2 m' />
   <sample time='14:45 min' depth='8.8 m' />
   <sample time='14:50 min' depth='8.3 m' />
   <sample time='14:55 min' depth='7.9 m' />
   <sample time='15:00 min' depth='7.5 m' />
   <sample time='15:05 min' depth='7.1 m' tts='7:40 min' sensor2='0.99 bar' />
-  <sample time='15:10 min' depth='6.7 m' tts='0:00 min' />
+  <sample time='15:10 min' depth='6.7 m' />
   <sample time='15:15 min' depth='6.3 m' />
   <sample time='15:20 min' depth='5.8 m' />
   <sample time='15:25 min' depth='5.4 m' />
   <sample time='15:30 min' depth='5.0 m' />
   <sample time='15:35 min' depth='4.6 m' tts='7:00 min' sensor2='0.96 bar' />
-  <sample time='15:40 min' depth='4.2 m' tts='0:00 min' />
+  <sample time='15:40 min' depth='4.2 m' />
   <sample time='15:45 min' depth='3.8 m' />
   <sample time='15:50 min' depth='3.3 m' />
   <sample time='15:55 min' depth='2.9 m' />
   <sample time='16:00 min' depth='2.5 m' />
   <sample time='16:05 min' depth='2.1 m' tts='6:40 min' />
-  <sample time='16:10 min' depth='1.7 m' tts='0:00 min' />
+  <sample time='16:10 min' depth='1.7 m' />
   <sample time='16:15 min' depth='1.3 m' />
   <sample time='16:20 min' depth='0.8 m' />
   <sample time='16:25 min' depth='0.4 m' />
@@ -1787,187 +1787,187 @@
   <sample time='0:55 min' depth='15.1 m' />
   <sample time='1:00 min' depth='16.3 m' />
   <sample time='1:05 min' depth='17.6 m' tts='3:00 min' />
-  <sample time='1:10 min' depth='18.8 m' tts='0:00 min' />
+  <sample time='1:10 min' depth='18.8 m' />
   <sample time='1:15 min' depth='20.1 m' />
   <sample time='1:20 min' depth='20.9 m' />
   <sample time='1:25 min' depth='21.7 m' />
   <sample time='1:30 min' depth='22.6 m' />
-  <sample time='1:35 min' depth='23.4 m' temp='27.0 C' ndl='0:34 min' tts='3:00 min' />
-  <sample time='1:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='1:35 min' depth='23.4 m' temp='27.0 C' ndl='0:34 min' />
+  <sample time='1:40 min' depth='24.2 m' />
   <sample time='1:45 min' depth='25.1 m' />
   <sample time='1:50 min' depth='25.9 m' />
   <sample time='1:55 min' depth='26.7 m' />
   <sample time='2:00 min' depth='27.6 m' />
-  <sample time='2:05 min' depth='28.4 m' ndl='0:14 min' tts='3:00 min' />
-  <sample time='2:10 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='2:05 min' depth='28.4 m' ndl='0:14 min' />
+  <sample time='2:10 min' depth='29.2 m' />
   <sample time='2:15 min' depth='30.1 m' />
   <sample time='2:20 min' depth='30.9 m' />
   <sample time='2:25 min' depth='31.7 m' />
   <sample time='2:30 min' depth='32.6 m' />
-  <sample time='2:35 min' depth='33.4 m' ndl='0:07 min' tts='3:00 min' />
-  <sample time='2:40 min' depth='34.2 m' tts='0:00 min' />
+  <sample time='2:35 min' depth='33.4 m' ndl='0:07 min' />
+  <sample time='2:40 min' depth='34.2 m' />
   <sample time='2:45 min' depth='35.1 m' />
   <sample time='2:50 min' depth='35.9 m' />
   <sample time='2:55 min' depth='36.7 m' />
   <sample time='3:00 min' depth='37.6 m' />
-  <sample time='3:05 min' depth='38.4 m' temp='26.0 C' ndl='0:04 min' tts='3:00 min' />
-  <sample time='3:10 min' depth='39.2 m' tts='0:00 min' />
+  <sample time='3:05 min' depth='38.4 m' temp='26.0 C' ndl='0:04 min' />
+  <sample time='3:10 min' depth='39.2 m' />
   <sample time='3:15 min' depth='40.1 m' />
   <sample time='3:20 min' depth='40.9 m' />
   <sample time='3:25 min' depth='41.7 m' />
   <sample time='3:30 min' depth='42.5 m' />
-  <sample time='3:35 min' depth='43.4 m' ndl='0:03 min' tts='3:00 min' />
-  <sample time='3:40 min' depth='44.2 m' tts='0:00 min' />
+  <sample time='3:35 min' depth='43.4 m' ndl='0:03 min' />
+  <sample time='3:40 min' depth='44.2 m' />
   <sample time='3:45 min' depth='45.0 m' />
   <sample time='3:50 min' depth='45.9 m' />
   <sample time='3:55 min' depth='46.7 m' />
   <sample time='4:00 min' depth='47.5 m' />
-  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' tts='3:00 min' />
-  <sample time='4:10 min' depth='49.2 m' tts='0:00 min' />
+  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' />
+  <sample time='4:10 min' depth='49.2 m' />
   <sample time='4:15 min' depth='50.0 m' />
   <sample time='4:20 min' depth='50.6 m' />
   <sample time='4:25 min' depth='51.2 m' />
   <sample time='4:30 min' depth='51.8 m' />
-  <sample time='4:35 min' depth='52.4 m' tts='3:00 min' />
-  <sample time='4:40 min' depth='53.0 m' tts='0:00 min' />
+  <sample time='4:35 min' depth='52.4 m' />
+  <sample time='4:40 min' depth='53.0 m' />
   <sample time='4:45 min' depth='53.5 m' />
   <sample time='4:50 min' depth='54.1 m' />
   <sample time='4:55 min' depth='54.7 m' />
   <sample time='5:00 min' depth='55.3 m' />
-  <sample time='5:05 min' depth='55.9 m' ndl='0:00 min' tts='3:00 min' />
-  <sample time='5:10 min' depth='56.5 m' tts='0:00 min' />
+  <sample time='5:05 min' depth='55.9 m' ndl='0:00 min' />
+  <sample time='5:10 min' depth='56.5 m' />
   <sample time='5:15 min' depth='57.0 m' />
   <sample time='5:20 min' depth='57.6 m' />
   <sample time='5:25 min' depth='58.2 m' />
   <sample time='5:30 min' depth='58.8 m' />
-  <sample time='5:35 min' depth='59.4 m' tts='3:00 min' />
-  <sample time='5:40 min' depth='60.0 m' tts='0:00 min' />
+  <sample time='5:35 min' depth='59.4 m' />
+  <sample time='5:40 min' depth='60.0 m' />
   <sample time='5:45 min' depth='60.5 m' />
   <sample time='5:50 min' depth='61.1 m' />
   <sample time='5:55 min' depth='61.7 m' />
   <sample time='6:00 min' depth='62.3 m' />
   <sample time='6:05 min' depth='62.9 m' tts='10:30 min' />
-  <sample time='6:10 min' depth='63.5 m' tts='0:00 min' />
+  <sample time='6:10 min' depth='63.5 m' />
   <sample time='6:15 min' depth='64.0 m' />
   <sample time='6:20 min' depth='64.6 m' />
   <sample time='6:25 min' depth='65.2 m' />
   <sample time='6:30 min' depth='65.8 m' />
   <sample time='6:35 min' depth='66.4 m' tts='12:30 min' />
-  <sample time='6:40 min' depth='67.0 m' tts='0:00 min' />
+  <sample time='6:40 min' depth='67.0 m' />
   <sample time='6:45 min' depth='67.5 m' />
   <sample time='6:50 min' depth='68.1 m' />
   <sample time='6:55 min' depth='68.7 m' />
   <sample time='7:00 min' depth='69.3 m' />
   <sample time='7:05 min' depth='69.9 m' tts='14:10 min' />
-  <sample time='7:10 min' depth='68.8 m' tts='0:00 min' />
+  <sample time='7:10 min' depth='68.8 m' />
   <sample time='7:15 min' depth='66.7 m' />
   <sample time='7:20 min' depth='64.6 m' />
   <sample time='7:25 min' depth='62.6 m' />
   <sample time='7:30 min' depth='60.5 m' />
   <sample time='7:35 min' depth='59.3 m' tts='11:30 min' />
-  <sample time='7:40 min' depth='58.4 m' tts='0:00 min' />
+  <sample time='7:40 min' depth='58.4 m' />
   <sample time='7:45 min' depth='57.6 m' />
   <sample time='7:50 min' depth='56.8 m' />
   <sample time='7:55 min' depth='55.9 m' />
   <sample time='8:00 min' depth='55.1 m' />
-  <sample time='8:05 min' depth='54.3 m' tts='11:30 min' />
-  <sample time='8:10 min' depth='53.4 m' tts='0:00 min' />
+  <sample time='8:05 min' depth='54.3 m' />
+  <sample time='8:10 min' depth='53.4 m' />
   <sample time='8:15 min' depth='52.6 m' />
   <sample time='8:20 min' depth='51.8 m' />
   <sample time='8:25 min' depth='50.9 m' />
   <sample time='8:30 min' depth='50.1 m' />
   <sample time='8:35 min' depth='49.3 m' tts='10:50 min' />
-  <sample time='8:40 min' depth='48.4 m' tts='0:00 min' />
+  <sample time='8:40 min' depth='48.4 m' />
   <sample time='8:45 min' depth='47.6 m' />
   <sample time='8:50 min' depth='46.8 m' />
   <sample time='8:55 min' depth='45.9 m' />
   <sample time='9:00 min' depth='45.1 m' />
   <sample time='9:05 min' depth='44.3 m' temp='25.0 C' tts='10:10 min' />
-  <sample time='9:10 min' depth='43.4 m' tts='0:00 min' />
+  <sample time='9:10 min' depth='43.4 m' />
   <sample time='9:15 min' depth='42.6 m' />
   <sample time='9:20 min' depth='41.8 m' />
   <sample time='9:25 min' depth='40.9 m' />
   <sample time='9:30 min' depth='40.1 m' />
   <sample time='9:35 min' depth='39.3 m' tts='9:50 min' />
-  <sample time='9:40 min' depth='38.4 m' tts='0:00 min' />
+  <sample time='9:40 min' depth='38.4 m' />
   <sample time='9:45 min' depth='37.6 m' />
   <sample time='9:50 min' depth='36.8 m' />
   <sample time='9:55 min' depth='35.9 m' />
   <sample time='10:00 min' depth='35.1 m' />
   <sample time='10:05 min' depth='34.3 m' tts='9:10 min' />
-  <sample time='10:10 min' depth='33.4 m' tts='0:00 min' />
+  <sample time='10:10 min' depth='33.4 m' />
   <sample time='10:15 min' depth='32.6 m' />
   <sample time='10:20 min' depth='31.8 m' />
   <sample time='10:25 min' depth='30.9 m' />
   <sample time='10:30 min' depth='30.1 m' />
   <sample time='10:35 min' depth='29.6 m' tts='8:30 min' />
-  <sample time='10:40 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='10:40 min' depth='29.2 m' />
   <sample time='10:45 min' depth='28.8 m' />
   <sample time='10:50 min' depth='28.3 m' />
   <sample time='10:55 min' depth='27.9 m' />
   <sample time='11:00 min' depth='27.5 m' />
-  <sample time='11:05 min' depth='27.1 m' tts='8:30 min' />
-  <sample time='11:10 min' depth='26.7 m' tts='0:00 min' />
+  <sample time='11:05 min' depth='27.1 m' />
+  <sample time='11:10 min' depth='26.7 m' />
   <sample time='11:15 min' depth='26.3 m' />
   <sample time='11:20 min' depth='25.8 m' />
   <sample time='11:25 min' depth='25.4 m' />
   <sample time='11:30 min' depth='25.0 m' />
   <sample time='11:35 min' depth='24.6 m' tts='8:10 min' />
-  <sample time='11:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='11:40 min' depth='24.2 m' />
   <sample time='11:45 min' depth='23.8 m' />
   <sample time='11:50 min' depth='23.3 m' />
   <sample time='11:55 min' depth='22.9 m' />
   <sample time='12:00 min' depth='22.5 m' />
-  <sample time='12:05 min' depth='22.1 m' tts='8:10 min' />
-  <sample time='12:10 min' depth='21.7 m' tts='0:00 min' />
+  <sample time='12:05 min' depth='22.1 m' />
+  <sample time='12:10 min' depth='21.7 m' />
   <sample time='12:15 min' depth='21.3 m' />
   <sample time='12:20 min' depth='20.8 m' />
   <sample time='12:25 min' depth='20.4 m' />
   <sample time='12:30 min' depth='20.0 m' />
   <sample time='12:35 min' depth='19.6 m' tts='7:50 min' />
-  <sample time='12:40 min' depth='19.2 m' tts='0:00 min' />
+  <sample time='12:40 min' depth='19.2 m' />
   <sample time='12:45 min' depth='18.8 m' />
   <sample time='12:50 min' depth='18.3 m' />
   <sample time='12:55 min' depth='17.9 m' />
   <sample time='13:00 min' depth='17.5 m' />
   <sample time='13:05 min' depth='17.1 m' tts='7:30 min' />
-  <sample time='13:10 min' depth='16.7 m' tts='0:00 min' />
+  <sample time='13:10 min' depth='16.7 m' />
   <sample time='13:15 min' depth='16.3 m' />
   <sample time='13:20 min' depth='15.8 m' />
   <sample time='13:25 min' depth='15.4 m' />
   <sample time='13:30 min' depth='15.0 m' />
   <sample time='13:35 min' depth='14.6 m' temp='26.0 C' tts='6:50 min' />
-  <sample time='13:40 min' depth='14.2 m' tts='0:00 min' />
+  <sample time='13:40 min' depth='14.2 m' />
   <sample time='13:45 min' depth='13.8 m' />
   <sample time='13:50 min' depth='13.3 m' />
   <sample time='13:55 min' depth='12.9 m' />
   <sample time='14:00 min' depth='12.5 m' />
   <sample time='14:05 min' depth='12.1 m' temp='25.0 C' tts='6:30 min' />
-  <sample time='14:10 min' depth='11.7 m' tts='0:00 min' />
+  <sample time='14:10 min' depth='11.7 m' />
   <sample time='14:15 min' depth='11.3 m' />
   <sample time='14:20 min' depth='10.8 m' />
   <sample time='14:25 min' depth='10.4 m' />
   <sample time='14:30 min' depth='10.0 m' />
   <sample time='14:35 min' depth='9.6 m' temp='26.0 C' tts='6:00 min' />
-  <sample time='14:40 min' depth='9.2 m' tts='0:00 min' />
+  <sample time='14:40 min' depth='9.2 m' />
   <sample time='14:45 min' depth='8.8 m' />
   <sample time='14:50 min' depth='8.3 m' />
   <sample time='14:55 min' depth='7.9 m' />
   <sample time='15:00 min' depth='7.5 m' />
   <sample time='15:05 min' depth='7.1 m' temp='25.0 C' tts='5:40 min' />
-  <sample time='15:10 min' depth='6.7 m' tts='0:00 min' />
+  <sample time='15:10 min' depth='6.7 m' />
   <sample time='15:15 min' depth='6.3 m' />
   <sample time='15:20 min' depth='5.8 m' />
   <sample time='15:25 min' depth='5.4 m' />
   <sample time='15:30 min' depth='5.0 m' />
   <sample time='15:35 min' depth='4.6 m' tts='5:20 min' />
-  <sample time='15:40 min' depth='4.2 m' tts='0:00 min' />
+  <sample time='15:40 min' depth='4.2 m' />
   <sample time='15:45 min' depth='3.8 m' />
   <sample time='15:50 min' depth='3.3 m' />
   <sample time='15:55 min' depth='2.9 m' />
   <sample time='16:00 min' depth='2.5 m' />
   <sample time='16:05 min' depth='2.1 m' tts='4:40 min' />
-  <sample time='16:10 min' depth='1.7 m' tts='0:00 min' />
+  <sample time='16:10 min' depth='1.7 m' />
   <sample time='16:15 min' depth='1.3 m' />
   <sample time='16:20 min' depth='0.8 m' />
   <sample time='16:25 min' depth='0.4 m' />
@@ -1994,187 +1994,187 @@
   <sample time='0:55 min' depth='15.1 m' />
   <sample time='1:00 min' depth='16.3 m' />
   <sample time='1:05 min' depth='17.6 m' ndl='0:30 min' tts='3:00 min' />
-  <sample time='1:10 min' depth='18.8 m' tts='0:00 min' />
+  <sample time='1:10 min' depth='18.8 m' />
   <sample time='1:15 min' depth='20.1 m' />
   <sample time='1:20 min' depth='20.9 m' />
   <sample time='1:25 min' depth='21.7 m' />
   <sample time='1:30 min' depth='22.6 m' />
-  <sample time='1:35 min' depth='23.4 m' ndl='0:13 min' tts='3:00 min' />
-  <sample time='1:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='1:35 min' depth='23.4 m' ndl='0:13 min' />
+  <sample time='1:40 min' depth='24.2 m' />
   <sample time='1:45 min' depth='25.1 m' />
   <sample time='1:50 min' depth='25.9 m' />
   <sample time='1:55 min' depth='26.7 m' />
   <sample time='2:00 min' depth='27.6 m' />
-  <sample time='2:05 min' depth='28.4 m' ndl='0:08 min' tts='3:00 min' />
-  <sample time='2:10 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='2:05 min' depth='28.4 m' ndl='0:08 min' />
+  <sample time='2:10 min' depth='29.2 m' />
   <sample time='2:15 min' depth='30.1 m' />
   <sample time='2:20 min' depth='30.9 m' />
   <sample time='2:25 min' depth='31.7 m' />
   <sample time='2:30 min' depth='32.6 m' />
-  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' tts='3:00 min' />
-  <sample time='2:40 min' depth='34.2 m' tts='0:00 min' />
+  <sample time='2:35 min' depth='33.4 m' ndl='0:05 min' />
+  <sample time='2:40 min' depth='34.2 m' />
   <sample time='2:45 min' depth='35.1 m' />
   <sample time='2:50 min' depth='35.9 m' />
   <sample time='2:55 min' depth='36.7 m' />
   <sample time='3:00 min' depth='37.6 m' />
-  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' tts='3:00 min' />
-  <sample time='3:10 min' depth='39.2 m' tts='0:00 min' />
+  <sample time='3:05 min' depth='38.4 m' ndl='0:03 min' />
+  <sample time='3:10 min' depth='39.2 m' />
   <sample time='3:15 min' depth='40.1 m' />
   <sample time='3:20 min' depth='40.9 m' />
   <sample time='3:25 min' depth='41.7 m' />
   <sample time='3:30 min' depth='42.5 m' />
-  <sample time='3:35 min' depth='43.4 m' ndl='0:02 min' tts='3:00 min' />
-  <sample time='3:40 min' depth='44.2 m' tts='0:00 min' />
+  <sample time='3:35 min' depth='43.4 m' ndl='0:02 min' />
+  <sample time='3:40 min' depth='44.2 m' />
   <sample time='3:45 min' depth='45.0 m' />
   <sample time='3:50 min' depth='45.9 m' />
   <sample time='3:55 min' depth='46.7 m' />
   <sample time='4:00 min' depth='47.5 m' />
-  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' tts='3:00 min' />
-  <sample time='4:10 min' depth='49.2 m' tts='0:00 min' />
+  <sample time='4:05 min' depth='48.4 m' ndl='0:01 min' />
+  <sample time='4:10 min' depth='49.2 m' />
   <sample time='4:15 min' depth='50.0 m' />
   <sample time='4:20 min' depth='50.6 m' />
   <sample time='4:25 min' depth='51.2 m' />
   <sample time='4:30 min' depth='51.8 m' />
-  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' tts='3:00 min' />
-  <sample time='4:40 min' depth='53.0 m' tts='0:00 min' />
+  <sample time='4:35 min' depth='52.4 m' ndl='0:00 min' />
+  <sample time='4:40 min' depth='53.0 m' />
   <sample time='4:45 min' depth='53.5 m' />
   <sample time='4:50 min' depth='54.1 m' />
   <sample time='4:55 min' depth='54.7 m' />
   <sample time='5:00 min' depth='55.3 m' />
-  <sample time='5:05 min' depth='55.9 m' tts='3:00 min' />
-  <sample time='5:10 min' depth='56.5 m' tts='0:00 min' />
+  <sample time='5:05 min' depth='55.9 m' />
+  <sample time='5:10 min' depth='56.5 m' />
   <sample time='5:15 min' depth='57.0 m' />
   <sample time='5:20 min' depth='57.6 m' />
   <sample time='5:25 min' depth='58.2 m' />
   <sample time='5:30 min' depth='58.8 m' />
   <sample time='5:35 min' depth='59.4 m' temp='25.0 C' tts='11:10 min' />
-  <sample time='5:40 min' depth='60.0 m' tts='0:00 min' />
+  <sample time='5:40 min' depth='60.0 m' />
   <sample time='5:45 min' depth='60.5 m' />
   <sample time='5:50 min' depth='61.1 m' />
   <sample time='5:55 min' depth='61.7 m' />
   <sample time='6:00 min' depth='62.3 m' />
   <sample time='6:05 min' depth='62.9 m' tts='13:10 min' />
-  <sample time='6:10 min' depth='63.5 m' tts='0:00 min' />
+  <sample time='6:10 min' depth='63.5 m' />
   <sample time='6:15 min' depth='64.0 m' />
   <sample time='6:20 min' depth='64.6 m' />
   <sample time='6:25 min' depth='65.2 m' />
   <sample time='6:30 min' depth='65.8 m' />
   <sample time='6:35 min' depth='66.4 m' tts='16:50 min' />
-  <sample time='6:40 min' depth='67.0 m' tts='0:00 min' />
+  <sample time='6:40 min' depth='67.0 m' />
   <sample time='6:45 min' depth='67.5 m' />
   <sample time='6:50 min' depth='68.1 m' />
   <sample time='6:55 min' depth='68.7 m' />
   <sample time='7:00 min' depth='69.3 m' />
   <sample time='7:05 min' depth='69.9 m' tts='20:30 min' />
-  <sample time='7:10 min' depth='68.8 m' tts='0:00 min' />
+  <sample time='7:10 min' depth='68.8 m' />
   <sample time='7:15 min' depth='66.7 m' />
   <sample time='7:20 min' depth='64.6 m' />
   <sample time='7:25 min' depth='62.6 m' />
   <sample time='7:30 min' depth='60.5 m' />
   <sample time='7:35 min' depth='59.3 m' temp='26.0 C' tts='16:10 min' />
-  <sample time='7:40 min' depth='58.4 m' tts='0:00 min' />
+  <sample time='7:40 min' depth='58.4 m' />
   <sample time='7:45 min' depth='57.6 m' />
   <sample time='7:50 min' depth='56.8 m' />
   <sample time='7:55 min' depth='55.9 m' />
   <sample time='8:00 min' depth='55.1 m' />
   <sample time='8:05 min' depth='54.3 m' tts='16:50 min' />
-  <sample time='8:10 min' depth='53.4 m' tts='0:00 min' />
+  <sample time='8:10 min' depth='53.4 m' />
   <sample time='8:15 min' depth='52.6 m' />
   <sample time='8:20 min' depth='51.8 m' />
   <sample time='8:25 min' depth='50.9 m' />
   <sample time='8:30 min' depth='50.1 m' />
   <sample time='8:35 min' depth='49.3 m' temp='25.0 C' tts='16:10 min' />
-  <sample time='8:40 min' depth='48.4 m' tts='0:00 min' />
+  <sample time='8:40 min' depth='48.4 m' />
   <sample time='8:45 min' depth='47.6 m' />
   <sample time='8:50 min' depth='46.8 m' />
   <sample time='8:55 min' depth='45.9 m' />
   <sample time='9:00 min' depth='45.1 m' />
   <sample time='9:05 min' depth='44.3 m' tts='15:30 min' />
-  <sample time='9:10 min' depth='43.4 m' tts='0:00 min' />
+  <sample time='9:10 min' depth='43.4 m' />
   <sample time='9:15 min' depth='42.6 m' />
   <sample time='9:20 min' depth='41.8 m' />
   <sample time='9:25 min' depth='40.9 m' />
   <sample time='9:30 min' depth='40.1 m' />
   <sample time='9:35 min' depth='39.3 m' tts='15:10 min' />
-  <sample time='9:40 min' depth='38.4 m' tts='0:00 min' />
+  <sample time='9:40 min' depth='38.4 m' />
   <sample time='9:45 min' depth='37.6 m' />
   <sample time='9:50 min' depth='36.8 m' />
   <sample time='9:55 min' depth='35.9 m' />
   <sample time='10:00 min' depth='35.1 m' />
   <sample time='10:05 min' depth='34.3 m' tts='14:30 min' />
-  <sample time='10:10 min' depth='33.4 m' tts='0:00 min' />
+  <sample time='10:10 min' depth='33.4 m' />
   <sample time='10:15 min' depth='32.6 m' />
   <sample time='10:20 min' depth='31.8 m' />
   <sample time='10:25 min' depth='30.9 m' />
   <sample time='10:30 min' depth='30.1 m' />
   <sample time='10:35 min' depth='29.6 m' tts='14:10 min' />
-  <sample time='10:40 min' depth='29.2 m' tts='0:00 min' />
+  <sample time='10:40 min' depth='29.2 m' />
   <sample time='10:45 min' depth='28.8 m' />
   <sample time='10:50 min' depth='28.3 m' />
   <sample time='10:55 min' depth='27.9 m' />
   <sample time='11:00 min' depth='27.5 m' />
-  <sample time='11:05 min' depth='27.1 m' tts='14:10 min' />
-  <sample time='11:10 min' depth='26.7 m' tts='0:00 min' />
+  <sample time='11:05 min' depth='27.1 m' />
+  <sample time='11:10 min' depth='26.7 m' />
   <sample time='11:15 min' depth='26.3 m' />
   <sample time='11:20 min' depth='25.8 m' />
   <sample time='11:25 min' depth='25.4 m' />
   <sample time='11:30 min' depth='25.0 m' />
   <sample time='11:35 min' depth='24.6 m' tts='13:50 min' />
-  <sample time='11:40 min' depth='24.2 m' tts='0:00 min' />
+  <sample time='11:40 min' depth='24.2 m' />
   <sample time='11:45 min' depth='23.8 m' />
   <sample time='11:50 min' depth='23.3 m' />
   <sample time='11:55 min' depth='22.9 m' />
   <sample time='12:00 min' depth='22.5 m' />
   <sample time='12:05 min' depth='22.1 m' tts='13:30 min' />
-  <sample time='12:10 min' depth='21.7 m' tts='0:00 min' />
+  <sample time='12:10 min' depth='21.7 m' />
   <sample time='12:15 min' depth='21.3 m' />
   <sample time='12:20 min' depth='20.8 m' />
   <sample time='12:25 min' depth='20.4 m' />
   <sample time='12:30 min' depth='20.0 m' />
   <sample time='12:35 min' depth='19.6 m' tts='13:10 min' />
-  <sample time='12:40 min' depth='19.2 m' tts='0:00 min' />
+  <sample time='12:40 min' depth='19.2 m' />
   <sample time='12:45 min' depth='18.8 m' />
   <sample time='12:50 min' depth='18.3 m' />
   <sample time='12:55 min' depth='17.9 m' />
   <sample time='13:00 min' depth='17.5 m' />
   <sample time='13:05 min' depth='17.1 m' tts='12:50 min' />
-  <sample time='13:10 min' depth='16.7 m' tts='0:00 min' />
+  <sample time='13:10 min' depth='16.7 m' />
   <sample time='13:15 min' depth='16.3 m' />
   <sample time='13:20 min' depth='15.8 m' />
   <sample time='13:25 min' depth='15.4 m' />
   <sample time='13:30 min' depth='15.0 m' />
   <sample time='13:35 min' depth='14.6 m' tts='12:30 min' />
-  <sample time='13:40 min' depth='14.2 m' tts='0:00 min' />
+  <sample time='13:40 min' depth='14.2 m' />
   <sample time='13:45 min' depth='13.8 m' />
   <sample time='13:50 min' depth='13.3 m' />
   <sample time='13:55 min' depth='12.9 m' />
   <sample time='14:00 min' depth='12.5 m' />
   <sample time='14:05 min' depth='12.1 m' tts='12:00 min' />
-  <sample time='14:10 min' depth='11.7 m' tts='0:00 min' />
+  <sample time='14:10 min' depth='11.7 m' />
   <sample time='14:15 min' depth='11.3 m' />
   <sample time='14:20 min' depth='10.8 m' />
   <sample time='14:25 min' depth='10.4 m' />
   <sample time='14:30 min' depth='10.0 m' />
   <sample time='14:35 min' depth='9.6 m' tts='11:40 min' />
-  <sample time='14:40 min' depth='9.2 m' tts='0:00 min' />
+  <sample time='14:40 min' depth='9.2 m' />
   <sample time='14:45 min' depth='8.8 m' />
   <sample time='14:50 min' depth='8.3 m' />
   <sample time='14:55 min' depth='7.9 m' />
   <sample time='15:00 min' depth='7.5 m' />
   <sample time='15:05 min' depth='7.1 m' tts='11:00 min' />
-  <sample time='15:10 min' depth='6.7 m' tts='0:00 min' />
+  <sample time='15:10 min' depth='6.7 m' />
   <sample time='15:15 min' depth='6.3 m' />
   <sample time='15:20 min' depth='5.8 m' />
   <sample time='15:25 min' depth='5.4 m' />
   <sample time='15:30 min' depth='5.0 m' />
   <sample time='15:35 min' depth='4.6 m' tts='10:20 min' />
-  <sample time='15:40 min' depth='4.2 m' tts='0:00 min' />
+  <sample time='15:40 min' depth='4.2 m' />
   <sample time='15:45 min' depth='3.8 m' />
   <sample time='15:50 min' depth='3.3 m' />
   <sample time='15:55 min' depth='2.9 m' />
   <sample time='16:00 min' depth='2.5 m' />
   <sample time='16:05 min' depth='2.1 m' tts='10:00 min' />
-  <sample time='16:10 min' depth='1.7 m' tts='0:00 min' />
+  <sample time='16:10 min' depth='1.7 m' />
   <sample time='16:15 min' depth='1.3 m' />
   <sample time='16:20 min' depth='0.8 m' />
   <sample time='16:25 min' depth='0.4 m' />


### PR DESCRIPTION
It appears that we used to get additional tts=0:00min tags on Seabear
parsing. I would assume these to be incorrect as there other values
right before these that look more sensible. Also the resent change to
streamline the feature of not storing repeating values causes the test
to fail. Anyway, just grabbing the new result to compare with as it
seems sensible.

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>