### PR TITLE
Mobile: honour location service time threshold

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -56,6 +56,14 @@ GpsLocation::~GpsLocation()
 	m_Instance = NULL;
 }
 
+void GpsLocation::setGpsTimeThreshold(int seconds)
+{
+	if (m_GpsSource) {
+		m_GpsSource->setUpdateInterval(seconds * 1000);
+		status(QString("Set GPS service update interval to %1").arg(m_GpsSource->updateInterval()));
+	}
+}
+
 QGeoPositionInfoSource *GpsLocation::getGpsSource()
 {
 	if (haveSource == NOGPS)
@@ -86,7 +94,7 @@ QGeoPositionInfoSource *GpsLocation::getGpsSource()
 			connect(m_GpsSource, SIGNAL(positionUpdated(QGeoPositionInfo)), this, SLOT(newPosition(QGeoPositionInfo)));
 			connect(m_GpsSource, SIGNAL(updateTimeout()), this, SLOT(updateTimeout()));
 			connect(m_GpsSource, SIGNAL(error(QGeoPositionInfoSource::Error)), this, SLOT(positionSourceError(QGeoPositionInfoSource::Error)));
-			m_GpsSource->setUpdateInterval(5 * 60 * 1000); // 5 minutes so the device doesn't drain the battery
+			setGpsTimeThreshold(prefs.time_threshold);
 		} else {
 #ifdef SUBSURFACE_MOBILE
 			status("don't have GPS source");

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -33,6 +33,7 @@ public:
 	QString getUserid(QString user, QString passwd);
 	bool hasLocationsSource();
 	QString currentPosition();
+	void setGpsTimeThreshold(int seconds);
 
 	QMap<qint64, gpsTracker> currentGPSInfo() const;
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1307,6 +1307,7 @@ int QMLManager::timeThreshold() const
 void QMLManager::setTimeThreshold(int time)
 {
 	m_timeThreshold = time;
+	locationProvider->setGpsTimeThreshold(m_timeThreshold * 60);
 	emit timeThresholdChanged();
 }
 


### PR DESCRIPTION
Independent of the settings, the threshold to reset the GPS data was hard coded to 5 minutes. Now, honour the entered (and updated during a session) time to refresh the GPS data in the location service.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>