### PR TITLE
QML UI: remove "show password" switch and only show pw on first entry

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -79,32 +79,13 @@ Item {
 		TextField {
 			id: password
 			text: manager.cloudPassword
-			echoMode: TextInput.Password
+			echoMode: TextInput.PasswordEchoOnEdit
 			inputMethodHints: Qt.ImhSensitiveData |
 					  Qt.ImhHiddenText |
 					  Qt.ImhNoAutoUppercase
 			Layout.fillWidth: true
 			onEditingFinished: {
 				saveCredentials()
-			}
-		}
-
-		GridLayout {
-			columns: 2
-
-			Kirigami.Label {
-				text: qsTr("Show password")
-				Layout.preferredWidth: col1Width
-			}
-			SsrfSwitch {
-				checked: false
-				id: showPassword
-				Layout.preferredWidth: col2Width
-				onCheckedChanged: {
-					if (checked)
-						password.text = "" // don't show a hidden password
-					password.echoMode = checked ? TextInput.Normal : TextInput.Password
-				}
 			}
 		}
 


### PR DESCRIPTION
Like the subject says. We do not want the password to be made visible, so a switch to show it, is useless and is therefore removed. Further, the entry mode is set to PasswordEchoOnEdit, which causes the passwd to be visible (for easy entry), but can't be made visible again after save/end edit.

Fixes: #512

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>