### PR TITLE
Fix possible memory corruption

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -108,7 +108,7 @@ void DownloadFromDCWidget::updateProgressBar()
 		// if we get the first actual text after the download is finished
 		// (which happens for example on the OSTC), then don't bother
 		if (!same_string(progress_bar_text, "") && IS_FP_SAME(progress_bar_fraction, 1.0))
-			progress_bar_text = NULL;
+			progress_bar_text = "";
 	}
 	if (!same_string(progress_bar_text , "")) {
 		ui.progressBar->setFormat(progress_bar_text);


### PR DESCRIPTION
Version 2: 

A user reports a SIGSEGV that points to DownloadFromDCWidget::updateProgressBar() in relation to strlen()/strdup(), at end of download. Reading the code, as I can't reproduce the crash, it seems that the progress_bar_text is set to NULL and later strdup-ped. The man page is not fully clear on this, but setting it
to the empty strings is much safer.

Might fix: #507

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>