### PR TITLE
mobile: make sure old credentialStatus is defined

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -295,6 +295,7 @@ void QMLManager::saveCloudCredentials()
 		setStartPageText(RED_FONT + tr("Invalid format for email address") + END_FONT);
 		return;
 	}
+	setOldStatus(credentialStatus());
 	s.beginGroup("CloudStorage");
 	s.setValue("email", cloudUser);
 	s.setValue("password", cloudPwd);


### PR DESCRIPTION
In commit e76f527fe53063, the scenario of switching between 2 already VERIFIED cloud accounts was identified, which was working poorly. It needed a restart of the app to get the new account visible.

Reason for this, was the setting of the credentialStatus to the value of an undefined (never set) old credentialStatus. This commit makes sure we have a defined credentialStatus, just before changing it to
the new one.

A really mini step forward, as the behavior is still not perfect. Now, the user has to select the dive list manually, after entering credentials of the new cloud account.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>