### PR TITLE
QML UI: hide action button when keyboard is visible

### DIFF
--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -72,6 +72,7 @@ cp $BREEZE/icons/actions/22/handle-right.svg $MC/icons
 # kirigami now needs the breeze-icons internally as well
 pushd $MC
 ln -s $SRC/$BREEZE .
+sed -i -e "s/visible: root.action/visible: root.action \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
 popd
 
 echo org.kde.plasma.kirigami synced from upstream


### PR DESCRIPTION
Until we get some solution from upstream this patch to Kirigami hides the action button when the keyboard is visible.

This is related to #496 