### PR TITLE
Mobile UI: GPS page

### DIFF
--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -100,11 +100,5 @@ Kirigami.ScrollablePage {
 		cacheBuffer: Math.max(5000, parent.height * 5)
 		focus: true
 		clip: true
-		header: Kirigami.Heading {
-			x: Kirigami.Units.gridUnit / 2
-			height: paintedHeight + Kirigami.Units.gridUnit / 2
-			verticalAlignment: Text.AlignBottom
-			text: qsTr("List of stored GPS fixes")
-		}
 	}
 }

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -10,8 +10,6 @@ import org.kde.kirigami 2.0 as Kirigami
 
 Kirigami.ScrollablePage {
 	id: gpsListWindow
-	width: parent.width - Kirigami.Units.gridUnit
-	anchors.margins: Kirigami.Units.gridUnit / 2
 	objectName: "gpsList"
 	title: qsTr("GPS Fixes")
 


### PR DESCRIPTION
This fixes the width and header issues on the GPS fixes page.

Regarding the background colors and styling of this page, that was related to a Kirigami issue,
fix has been sent upstream for that.