### PR TITLE
MapWidget enhancements

### DIFF
--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -171,6 +171,10 @@ Item {
 			mapAnimationZoomOut.stop()
 		}
 
+		function centerOnRectangle(topLeft, bottomRight, center) {
+			// TODO
+		}
+
 		function deselectMapLocation() {
 			animateMapZoomOut()
 		}

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -148,7 +148,17 @@ Item {
 			mapAnimationZoomOut.restart()
 		}
 
+		function pointIsVisible(pt) {
+			return !isNaN(pt.x)
+		}
+
+		function stopZoomAnimations() {
+			mapAnimationZoomIn.stop()
+			mapAnimationZoomOut.stop()
+		}
+
 		function centerOnCoordinate(coord) {
+			stopZoomAnimations()
 			newCenter = coord
 			if (coord.latitude === 0.0 && coord.longitude === 0.0) {
 				newZoom = 2.6
@@ -157,8 +167,8 @@ Item {
 				var zoomStored = zoomLevel
 				newZoomOut = zoomLevel
 				while (zoomLevel > minimumZoomLevel) {
-					var pt = fromCoordinate(coord, false)
-					if (pt.x > 0 && pt.y > 0 && pt.x < width && pt.y < height) {
+					var pt = fromCoordinate(coord)
+					if (pointIsVisible(pt)) {
 						newZoomOut = zoomLevel
 						break
 					}

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -181,8 +181,49 @@ Item {
 			mapAnimationZoomOut.stop()
 		}
 
-		function centerOnRectangle(topLeft, bottomRight, center) {
-			// TODO
+		function centerOnRectangle(topLeft, bottomRight, centerRect) {
+			stopZoomAnimations()
+			newCenter = centerRect
+			if (newCenter.latitude === 0.0 && newCenter.longitude === 0.0) {
+				newZoom = 2.6
+				newZoomOut = newZoom
+			} else {
+				var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
+				var zoomStored = zoomLevel
+				var ptCenter
+				var ptTopLeft
+				var ptBottomRight
+				// calculate zoom out
+				newZoomOut = zoomLevel
+				while (zoomLevel > minimumZoomLevel) {
+					ptCenter = fromCoordinate(centerStored)
+					ptTopLeft = fromCoordinate(topLeft)
+					ptBottomRight = fromCoordinate(bottomRight)
+					if (pointIsVisible(ptCenter) && pointIsVisible(ptTopLeft) && pointIsVisible(ptBottomRight)) {
+						newZoomOut = zoomLevel
+						break
+					}
+					zoomLevel--
+				}
+				// calculate zoom in
+				center = newCenter
+				zoomLevel = maximumZoomLevel
+				while (zoomLevel > minimumZoomLevel) {
+					ptTopLeft = fromCoordinate(topLeft)
+					ptBottomRight = fromCoordinate(bottomRight)
+					if (pointIsVisible(ptTopLeft) && pointIsVisible(ptBottomRight)) {
+						newZoom = zoomLevel
+						break
+					}
+					zoomLevel--
+				}
+				if (newZoom > defaultZoomIn)
+					newZoom = defaultZoomIn
+				zoomLevel = zoomStored
+				center = centerStored
+			}
+			mapAnimationZoomIn.restart()
+			mapAnimationZoomOut.stop()
 		}
 
 		function deselectMapLocation() {

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -10,6 +10,10 @@ Item {
 	Plugin {
 		id: mapPlugin
 		name: "googlemaps"
+		Component.onCompleted: {
+			if (availableServiceProviders.indexOf(name) === -1)
+				console.warn("MapWidget.qml: cannot find a plugin with the name '" + name + "'")
+		}
 	}
 
 	MapWidgetHelper {

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -27,7 +27,7 @@ Item {
 		plugin: mapPlugin
 		zoomLevel: 1
 
-		readonly property var mapType: { "STREET": supportedMapTypes[0], "SATELLITE": supportedMapTypes[3] }
+		readonly property var mapType: { "STREET": supportedMapTypes[0], "SATELLITE": supportedMapTypes[1] }
 		readonly property var defaultCenter: QtPositioning.coordinate(0, 0)
 		readonly property real defaultZoomIn: 12.0
 		readonly property real defaultZoomOut: 1.0

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -345,6 +345,9 @@ Item {
 			case contextMenu.actions.COPY_LOCATION_SEXAGESIMAL:
 				mapHelper.copyToClipboardCoordinates(map.center, true)
 				break
+			case contextMenu.actions.SELECT_VISIBLE_LOCATIONS:
+				mapHelper.selectVisibleLocations()
+				break
 			}
 		}
 	}

--- a/mobile-widgets/qml/MapWidgetContextMenu.qml
+++ b/mobile-widgets/qml/MapWidgetContextMenu.qml
@@ -8,12 +8,14 @@ Item {
 	readonly property var actions: {
 		"OPEN_LOCATION_IN_GOOGLE_MAPS": 0,
 		"COPY_LOCATION_DECIMAL":        1,
-		"COPY_LOCATION_SEXAGESIMAL":    2
+		"COPY_LOCATION_SEXAGESIMAL":    2,
+		"SELECT_VISIBLE_LOCATIONS":     3
 	}
 	readonly property var menuItemData: [
 		{ idx: actions.OPEN_LOCATION_IN_GOOGLE_MAPS, itemText: qsTr("Open location in Google Maps") },
 		{ idx: actions.COPY_LOCATION_DECIMAL,        itemText: qsTr("Copy location to clipboard (decimal)") },
-		{ idx: actions.COPY_LOCATION_SEXAGESIMAL,    itemText: qsTr("Copy location to clipboard (sexagesimal)") }
+		{ idx: actions.COPY_LOCATION_SEXAGESIMAL,    itemText: qsTr("Copy location to clipboard (sexagesimal)") },
+		{ idx: actions.SELECT_VISIBLE_LOCATIONS,     itemText: qsTr("Select visible dive locations") }
 	]
 	readonly property real itemTextPadding: 10.0
 	readonly property real itemHeight: 34.0

--- a/mobile-widgets/qmlmapwidgethelper.h
+++ b/mobile-widgets/qmlmapwidgethelper.h
@@ -24,6 +24,7 @@ public:
 	Q_INVOKABLE void copyToClipboardCoordinates(QGeoCoordinate coord, bool formatTraditional);
 	Q_INVOKABLE void calculateSmallCircleRadius(QGeoCoordinate coord);
 	Q_INVOKABLE void updateCurrentDiveSiteCoordinates(quint32 uuid, QGeoCoordinate coord);
+	Q_INVOKABLE void selectVisibleLocations();
 	bool editMode();
 	void setEditMode(bool editMode);
 


### PR DESCRIPTION
this PR implements the requested functionality to be able to:
1) select a trip or any list of dives and the Map widget should estimate a center coordinate and a zoom level so that the list of selected dives locations are centered in the Map viewport
2) select a list of dives in the dive list based on selecting a list of markers on the map

for 2, i was thinking about adding tools such as circular or rectangular marquee selection or even lasso, but this is hard to maintain and is awkward on mobile. instead, the current implementation uses the viewport as the selection tool in the lines of "select visible dive locations". so, if a set of flags are visible on the map, this context menu action will select the associated dives in the dive list.

NOTES:
**mapwidget: use "satallite" maps instead of "hybrid"**
a subject to discussion, but i encourage that the above commit is applied, because some users might report the missing (black) tiles soon. both i and the plugin author don't have a solution for this ATM....one way to fix the "hybrid" map would be to cache tiles from the current zoom level and if the next zoom level shows a completely black tile - load tiles from the working zoom level. a very hacky solution...

also, the "satallite" map turns completely white at maximum zoom, i think this might be an issue in the QtLocation Map, because nothing works on the "googlemaps map plugin" side.
