### PR TITLE
fix weights rounding

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -43,12 +43,8 @@ QString weight_string(int weight_in_grams)
 {
 	QString str;
 	if (get_units()->weight == units::KG) {
-		int gr = weight_in_grams % 1000;
-		int kg = weight_in_grams / 1000;
-		if (kg >= 20.0)
-			str = QString("%1").arg(kg + (gr >= 500 ? 1 : 0));
-		else
-			str = QString("%1.%2").arg(kg).arg((unsigned)(gr + 50) / 100);
+		double kg = (double) weight_in_grams / 1000.0;
+		str = QString("%1").arg(kg, 0, 'f', kg >= 20.0 ? 0 : 1);
 	} else {
 		double lbs = grams_to_lbs(weight_in_grams);
 		str = QString("%1").arg(lbs, 0, 'f', lbs >= 40.0 ? 0 : 1);


### PR DESCRIPTION
Simplify and fix presentation of weights. Due to the attempt to round only the grams part (by just adding 50 to it, and truncating afterwards) a weird effect was introduced. For example, a value 0.98 was presented as 0.10. Just replay the old logic, and see what happens. Rewrote the logic to a simpler and better one.

fixes: #532

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>