### PR TITLE
mapwidget.qml: more improvements for the dynamic zoom-in/out

### DIFF
--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -164,16 +164,20 @@ Item {
 				newZoom = 2.6
 				newZoomOut = newZoom
 			} else {
+				var newZoomOutFound = false
 				var zoomStored = zoomLevel
 				newZoomOut = zoomLevel
 				while (zoomLevel > minimumZoomLevel) {
 					var pt = fromCoordinate(coord)
 					if (pointIsVisible(pt)) {
 						newZoomOut = zoomLevel
+						newZoomOutFound = true
 						break
 					}
 					zoomLevel--
 				}
+				if (!newZoomOutFound)
+					newZoomOut = defaultZoomOut
 				zoomLevel = zoomStored
 				newZoom = defaultZoomIn
 			}
@@ -190,29 +194,30 @@ Item {
 			} else {
 				var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
 				var zoomStored = zoomLevel
-				var ptCenter
-				var ptTopLeft
-				var ptBottomRight
+				var newZoomOutFound = false
 				// calculate zoom out
 				newZoomOut = zoomLevel
 				while (zoomLevel > minimumZoomLevel) {
-					ptCenter = fromCoordinate(centerStored)
-					ptTopLeft = fromCoordinate(topLeft)
-					ptBottomRight = fromCoordinate(bottomRight)
-					if (pointIsVisible(ptCenter) && pointIsVisible(ptTopLeft) && pointIsVisible(ptBottomRight)) {
+					var ptCenter = fromCoordinate(centerStored)
+					var ptCenterRect = fromCoordinate(centerRect)
+					if (pointIsVisible(ptCenter) && pointIsVisible(ptCenterRect)) {
 						newZoomOut = zoomLevel
+						newZoomOutFound = true
 						break
 					}
 					zoomLevel--
 				}
+				if (!newZoomOutFound)
+					newZoomOut = defaultZoomOut
 				// calculate zoom in
 				center = newCenter
 				zoomLevel = maximumZoomLevel
+				var diagonalRect = topLeft.distanceTo(bottomRight)
 				while (zoomLevel > minimumZoomLevel) {
-					ptTopLeft = fromCoordinate(topLeft)
-					ptBottomRight = fromCoordinate(bottomRight)
-					if (pointIsVisible(ptTopLeft) && pointIsVisible(ptBottomRight)) {
-						newZoom = zoomLevel
+					var c0 = toCoordinate(Qt.point(0.0, 0.0))
+					var c1 = toCoordinate(Qt.point(width, height))
+					if (c0.distanceTo(c1) > diagonalRect) {
+						newZoom = zoomLevel - 2.0
 						break
 					}
 					zoomLevel--

--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -154,18 +154,18 @@ void MapWidgetHelper::selectVisibleLocations()
 		struct dive_site *ds = get_dive_site_for_dive(dive);
 		if (!dive_site_has_gps_location(ds))
 			continue;
-		MapLocation *loc = m_mapLocationModel->getMapLocationForUuid(ds->uuid);
-		if (loc) {
-			QPointF point;
-			QMetaObject::invokeMethod(m_map, "fromCoordinate", Q_RETURN_ARG(QPointF, point),
-			                          Q_ARG(QGeoCoordinate, loc->coordinate()));
-			if (!qIsNaN(point.x())) {
-				if (!selectedFirst) {
-					m_mapLocationModel->setSelectedUuid(ds->uuid, false);
-					selectedFirst = true;
-				}
-				m_selectedDiveIds.append(idx);
+		const qreal latitude = ds->latitude.udeg * 0.000001;
+		const qreal longitude = ds->longitude.udeg * 0.000001;
+		QGeoCoordinate dsCoord(latitude, longitude);
+		QPointF point;
+		QMetaObject::invokeMethod(m_map, "fromCoordinate", Q_RETURN_ARG(QPointF, point),
+		                          Q_ARG(QGeoCoordinate, dsCoord));
+		if (!qIsNaN(point.x())) {
+			if (!selectedFirst) {
+				m_mapLocationModel->setSelectedUuid(ds->uuid, false);
+				selectedFirst = true;
 			}
+			m_selectedDiveIds.append(idx);
 		}
 	}
 	emit selectedDivesChanged(m_selectedDiveIds);


### PR DESCRIPTION
The QML Map has a couple of methods - toCoordinate(someQPointF) and
fromCoordinate(someQGeoCoordinate). Ideally, if one passes a point to
toCoordinate() and then attempts to convert the resulted coordinates
back to the point, the same point in the Map view port with minimal error
should be retrieved. That's not always the case - e.g. near
47.400200 -123.142066, which means that the methods are not exactly
*reliable* and there might be Map class bugs at hand.

The new zoom-in and zoom-out improvements try to work around the above:
- for both centerOnRectangle() and centerOnCoordinate(), if no good
zoom-out level is found (newZoomOut), the zoom-out is set to the default
value of defaultZoomOut. In practice, this prevents the case where the map
does not zoom-out at all when going from one place to another
- centerOnRectangle() now uses rectangle diagonals to estimate a fit,
instead of checking if 2 points (top-left and bottom-right) are visible
in the viewport. The usage of fromCoordinate() was giving bad results
in this case and comparing distances (diagonals) is more reliable
but more expensive on the CPU.

Due to the inconsistencies of toCoordinate() and fromCoordinate()
the dynamic zoom-in and zoom-out are still not ideal, but the current
implementation is somewhat usable with decent accuracy.

Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>