### PR TITLE
DiveList.qml: set detailsWindow index before deleting dive from list

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -162,6 +162,7 @@ Kirigami.ScrollablePage {
 						onClicked: {
 							parent.visible = false
 							timer.stop()
+							detailsWindow.showDiveIndex(index)
 							manager.deleteDive(dive.id)
 						}
 					}


### PR DESCRIPTION
This appears to fix the mystery crashes that can occur when deleting a dive from the dive list.

Fixes: #497

Signed-off-by: Rick Walsh <rickmwalsh@gmail.com>