### PR TITLE
add MapWidget support for PluginParameters

### DIFF
--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -5,16 +5,8 @@ import QtPositioning 5.3
 import org.subsurfacedivelog.mobile 1.0
 
 Item {
+	id: rootItem
 	property int nSelectedDives: 0
-
-	Plugin {
-		id: mapPlugin
-		name: "googlemaps"
-		Component.onCompleted: {
-			if (availableServiceProviders.indexOf(name) === -1)
-				console.warn("MapWidget.qml: cannot find a plugin with the name '" + name + "'")
-		}
-	}
 
 	MapWidgetHelper {
 		id: mapHelper
@@ -23,15 +15,19 @@ Item {
 		onSelectedDivesChanged: nSelectedDives = list.length
 		onEditModeChanged: editMessage.isVisible = editMode === true ? 1 : 0
 		onCoordinatesChanged: {}
+		Component.onCompleted: {
+			map.plugin = Qt.createQmlObject(pluginObject, rootItem)
+			map.mapType = { "STREET": map.supportedMapTypes[0], "SATELLITE": map.supportedMapTypes[1] }
+			map.activeMapType = map.mapType.SATELLITE
+		}
 	}
 
 	Map {
 		id: map
 		anchors.fill: parent
-		plugin: mapPlugin
 		zoomLevel: 1
 
-		readonly property var mapType: { "STREET": supportedMapTypes[0], "SATELLITE": supportedMapTypes[1] }
+		property var mapType
 		readonly property var defaultCenter: QtPositioning.coordinate(0, 0)
 		readonly property real defaultZoomIn: 12.0
 		readonly property real defaultZoomOut: 1.0
@@ -42,7 +38,6 @@ Item {
 		property real newZoomOut: 1.0
 		property var clickCoord: QtPositioning.coordinate(0, 0)
 
-		Component.onCompleted: activeMapType = mapType.SATELLITE
 		onZoomLevelChanged: mapHelper.calculateSmallCircleRadius(map.center)
 
 		MapItemView {

--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -249,6 +249,7 @@ QString MapWidgetHelper::pluginObject()
 	str += "    id: mapPlugin;";
 	str += "    name: 'googlemaps';";
 	str += "    PluginParameter { name: 'googlemaps.maps.language'; value: '%lang%' }";
+	str += "    PluginParameter { name: 'googlemaps.cachefolder'; value: '%cacheFolder%' }";
 	str += "    Component.onCompleted: {";
 	str += "        if (availableServiceProviders.indexOf(name) === -1) {";
 	str += "            console.warn('MapWidget.qml: cannot find a plugin named: ' + name);";
@@ -257,5 +258,7 @@ QString MapWidgetHelper::pluginObject()
 	str += "}";
 	QString lang = uiLanguage(NULL).replace('_', '-');
 	str.replace("%lang%", lang);
+	QString cacheFolder = QString(system_default_directory()).append("/googlemaps");
+	str.replace("%cacheFolder%", cacheFolder.replace("\\", "/"));
 	return str;
 }

--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -8,6 +8,7 @@
 #include "qmlmapwidgethelper.h"
 #include "core/dive.h"
 #include "core/divesite.h"
+#include "core/helpers.h"
 #include "qt-models/maplocationmodel.h"
 
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
@@ -237,4 +238,24 @@ void MapWidgetHelper::setEditMode(bool editMode)
 		                          Q_ARG(QVariant, QVariant::fromValue(coord)));
 	}
 	emit editModeChanged();
+}
+
+QString MapWidgetHelper::pluginObject()
+{
+	QString str;
+	str += "import QtQuick 2.0;";
+	str += "import QtLocation 5.3;";
+	str += "Plugin {";
+	str += "    id: mapPlugin;";
+	str += "    name: 'googlemaps';";
+	str += "    PluginParameter { name: 'googlemaps.maps.language'; value: '%lang%' }";
+	str += "    Component.onCompleted: {";
+	str += "        if (availableServiceProviders.indexOf(name) === -1) {";
+	str += "            console.warn('MapWidget.qml: cannot find a plugin named: ' + name);";
+	str += "        }";
+	str += "    }";
+	str += "}";
+	QString lang = uiLanguage(NULL).replace('_', '-');
+	str.replace("%lang%", lang);
+	return str;
 }

--- a/mobile-widgets/qmlmapwidgethelper.h
+++ b/mobile-widgets/qmlmapwidgethelper.h
@@ -15,6 +15,7 @@ class MapWidgetHelper : public QObject {
 	Q_PROPERTY(QObject *map MEMBER m_map)
 	Q_PROPERTY(MapLocationModel *model MEMBER m_mapLocationModel NOTIFY modelChanged)
 	Q_PROPERTY(bool editMode READ editMode WRITE setEditMode NOTIFY editModeChanged)
+	Q_PROPERTY(QString pluginObject READ pluginObject NOTIFY pluginObjectChanged)
 
 public:
 	explicit MapWidgetHelper(QObject *parent = NULL);
@@ -27,6 +28,7 @@ public:
 	Q_INVOKABLE void selectVisibleLocations();
 	bool editMode();
 	void setEditMode(bool editMode);
+	QString pluginObject();
 
 private:
 	QObject *m_map;
@@ -43,6 +45,7 @@ signals:
 	void editModeChanged();
 	void selectedDivesChanged(QList<int> list);
 	void coordinatesChanged();
+	void pluginObjectChanged();
 };
 
 extern "C" const char *printGPSCoords(int lat, int lon);


### PR DESCRIPTION
this PR contains a couple of patches:

**mapwidgethelper: use dynamic creation of the Plugin object**
this patch adds the [PluginParameters](http://doc.qt.io/qt-5/qml-qtlocation-pluginparameter.html) support by making the creation of the google maps Plugin object dynamic (e.g. via `Qt.createQmlObject()`)
at the same time it adds language support for the map tiles.

language support for the tiles doesn't matter much for the Satellite map type, but it matters for the Road and Hybrid map as those have labels. by default it picks up the user system language, but that may differ from the Subsurface UI language, so we use the helper uiLanguage() to fetch it.

one side effect here is that if the user has already cached road map tiles in one language, by switching the Subsurface language from Settings, the plugin will start downloading tiles in another language and it would end up with a mixture of tiles with different languages....we might want to clear the tile cache if the Subsurface language changes, but i would leave that to discussion,.

the plugin itself needs 2 small patch to enable support for a PluginParameter for language and to enable Road map language support:
https://github.com/vladest/googlemaps/pull/12

**mapwidgethelper: use system_default_directory() for cache**
this moves the googlemaps tile cache to a the system_default_directory() which is passed via a PluginParameter