### PR TITLE
Ignore Divesoft Button Press Events

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -3589,7 +3589,7 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size)
 		case 4: /* internal error */
 		case 5: /* device activity log */
 			//Event 18 is a button press. Lets ingore that event. 	 
-		    if (ptr[4] == 18)
+			if (ptr[4] == 18)
 				continue;
 			
 			event_start();

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -3588,6 +3588,10 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size)
 		case 3: /* diver error */
 		case 4: /* internal error */
 		case 5: /* device activity log */
+			//Event 18 is a button press. Lets ingore that event. 	 
+		    if (ptr[4] == 18)
+				continue;
+			
 			event_start();
 			cur_event.time.seconds = time;
 			switch (ptr[4]) {

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -3701,8 +3701,8 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size)
 				strcpy(cur_event.name, "Inconsistent");
 				break;
 			case 18:
-				// key pressed - probably not
-				// interesting to view on profile
+				// key pressed - It should never get in here
+				// as we ingored it at the parent 'case 5'. 
 				break;
 			case 19:
 				// obsolete


### PR DESCRIPTION
Prevent button press events from showing on the profile
graph when we import divesoft DLF files.

Fixed issue #543 

Reported-by: Marc Arndt
Signed-off-by: Marc Arndt <marc@marcarndt.com>