### PR TITLE
Summervacation

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -913,6 +913,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 void calc_crushing_pressure(double pressure);
 void vpmb_start_gradient();
 void clear_vpmb_state();
+void printdecotable(struct decostop *table);
 
 void delete_single_dive(int idx);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -905,11 +905,14 @@ struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po
 #if DEBUG_PLAN
 void dump_plan(struct diveplan *diveplan);
 #endif
-bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
+struct decostop {
+	int depth;
+	int time;
+};
+bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct decostop *decostoptable, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
 void calc_crushing_pressure(double pressure);
 void vpmb_start_gradient();
 void clear_vpmb_state();
-
 
 void delete_single_dive(int idx);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -835,6 +835,8 @@ extern void subsurface_command_line_exit(int *, char ***);
 
 #define FRACTION(n, x) ((unsigned)(n) / (x)), ((unsigned)(n) % (x))
 
+#define DECOTIMESTEP 60 /* seconds. Unit of deco stop times */
+
 struct deco_state {
 	double tissue_n2_sat[16];
 	double tissue_he_sat[16];
@@ -903,10 +905,11 @@ struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po
 #if DEBUG_PLAN
 void dump_plan(struct diveplan *diveplan);
 #endif
-bool plan(struct diveplan *diveplan, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
+bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
 void calc_crushing_pressure(double pressure);
 void vpmb_start_gradient();
 void clear_vpmb_state();
+
 
 void delete_single_dive(int idx);
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -627,7 +627,6 @@ int wait_until(struct dive *dive, int clock, int min, int leap, int stepsize, in
 {
 	// Round min + leap up to the next multiple of stepsize
 	int upper = min + leap + stepsize - 1 - (min + leap - 1) % stepsize;
-	printf("clock: %d min: %d leap: %d, depth %d\n", clock / 60, min / 60, leap, depth);
 	// Is the upper boundary too small?
 	if (!trial_ascent(upper - clock, depth, target_depth, avg_depth, bottom_time, gasmix, po2, surface_pressure, dive))
 		return wait_until(dive, clock, upper, leap, stepsize, depth, target_depth, avg_depth, bottom_time, gasmix, po2, surface_pressure);

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -411,8 +411,12 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					mingas_pressure = get_pressure_units(lastbottomdp->minimum_gas.mbar, &pressure_unit);
 					mingas_depth = get_depth_units(lastbottomdp->depth.mm, NULL, &depth_unit);
 					/* Print it to results */
+					bool minok = (mingasv.mliter <=
+							cyl->deco_gas_used.mliter +
+							lrint((double)cyl->end.mbar * cyl->type.size.mliter / 1000.0 / gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0)));
 					if (cyl->start.mbar > lastbottomdp->minimum_gas.mbar) snprintf(mingas, sizeof(mingas),
-						translate("gettextFromC", "<br>&nbsp;&mdash; <span style='color: green;'>Minimum gas</span> (based on %.1fxSAC/+%dmin@%.0f%s): %.0f%s/%.0f%s"),
+						translate("gettextFromC", "<br>&nbsp;&mdash; <span style='color: %s;'>Minimum gas</span> (based on %.1fxSAC/+%dmin@%.0f%s): %.0f%s/%.0f%s"),
+						minok ? "green" :"red",
 						prefs.sacfactor / 100.0, prefs.problemsolvingtime,
 						mingas_depth, depth_unit,
 						mingas_volume, unit,

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -101,7 +101,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				get_current_date());
 	}
 
-	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin<br></div>"),
+	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin VARIATIONS<br></div>"),
 			diveplan_duration(diveplan));
 
 	if (!plan_verbatim) {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1714,3 +1714,21 @@ char *intdup(int index)
 	tmpbuf[20] = 0;
 	return strdup(tmpbuf);
 }
+
+QHash<int, double> factor_cache;
+
+extern "C" double cache_value(int tissue, int timestep, enum inertgas inertgas)
+{
+	int key = (timestep << 5) + (tissue << 1);
+	if (inertgas == HE)
+		++key;
+	return factor_cache.value(key);
+}
+
+extern "C" void cache_insert(int tissue, int timestep, enum inertgas inertgas, double value)
+{
+	int key = (timestep << 5) + (tissue << 1);
+	if (inertgas == HE)
+		++key;
+	factor_cache.insert(key, value);
+}

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -49,5 +49,8 @@ QString getUUID();
 QStringList imageExtensionFilters();
 char *intdup(int index);
 extern "C" int parse_seabear_header(const char *filename, char **params, int pnr);
+enum inertgas {N2, HE};
+extern "C" double cache_value(int tissue, int timestep, enum inertgas gas);
+extern "C" void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 
 #endif // QTHELPER_H

--- a/core/qthelperfromc.h
+++ b/core/qthelperfromc.h
@@ -22,6 +22,8 @@ const char *subsurface_user_agent();
 enum deco_mode decoMode();
 int parse_seabear_header(const char *filename, char **params, int pnr);
 extern const char *get_current_date();
-
+enum inertgas {N2, HE};
+double cache_value(int tissue, int timestep, enum inertgas gas);
+void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 
 #endif // QTHELPERFROMC_H

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -842,7 +842,7 @@ void DivePlannerPointsModel::createTemporaryPlan()
 	dump_plan(&diveplan);
 #endif
 	if (recalcQ() && !diveplan_empty(&diveplan)) {
-		plan(&diveplan, &cache, isPlanner(), false);
+		plan(&diveplan, &displayed_dive, DECOTIMESTEP, &cache, isPlanner(), false);
 		emit calculatedPlanNotes();
 	}
 	// throw away the cache
@@ -878,7 +878,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	setRecalc(oldRecalc);
 
 	//TODO: C-based function here?
-	plan(&diveplan, &cache, isPlanner(), true);
+	plan(&diveplan, &displayed_dive, DECOTIMESTEP, &cache, isPlanner(), true);
 	free(cache);
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing on

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -842,7 +842,8 @@ void DivePlannerPointsModel::createTemporaryPlan()
 	dump_plan(&diveplan);
 #endif
 	if (recalcQ() && !diveplan_empty(&diveplan)) {
-		plan(&diveplan, &displayed_dive, DECOTIMESTEP, &cache, isPlanner(), false);
+		struct decostop stoptable[60];
+		plan(&diveplan, &displayed_dive, DECOTIMESTEP, stoptable, &cache, isPlanner(), false);
 		emit calculatedPlanNotes();
 	}
 	// throw away the cache
@@ -878,7 +879,8 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	setRecalc(oldRecalc);
 
 	//TODO: C-based function here?
-	plan(&diveplan, &displayed_dive, DECOTIMESTEP, &cache, isPlanner(), true);
+	struct decostop stoptable[60];
+	plan(&diveplan, &displayed_dive, DECOTIMESTEP, stoptable, &cache, isPlanner(), true);
 	free(cache);
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing on

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -107,6 +107,9 @@ private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);
 	void createPlan(bool replanCopy);
 	struct diveplan diveplan;
+	struct divedatapoint *cloneDiveplan(struct diveplan *plan_copy);
+	void computeVariations();
+	void analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
 	Mode mode;
 	bool recalc;
 	QVector<divedatapoint> divepoints;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -109,7 +109,7 @@ private:
 	struct diveplan diveplan;
 	struct divedatapoint *cloneDiveplan(struct diveplan *plan_copy);
 	void computeVariations();
-	void analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
+	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
 	Mode mode;
 	bool recalc;
 	QVector<divedatapoint> divepoints;

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -10,7 +10,8 @@
 #define DEBUG  1
 
 // testing the dive plan algorithm
-extern bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
+struct decostop stoptable[60];
+extern bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct decostop *decostoptable, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
 
 extern pressure_t first_ceiling_pressure;
 
@@ -364,7 +365,7 @@ void TestPlan::testMetric()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -404,7 +405,7 @@ void TestPlan::testImperial()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -444,7 +445,7 @@ void TestPlan::testVpmbMetric45m30minTx()
 	setupPlanVpmb45m30mTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -474,7 +475,7 @@ void TestPlan::testVpmbMetric60m10minTx()
 	setupPlanVpmb60m10mTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -504,7 +505,7 @@ void TestPlan::testVpmbMetric60m30minAir()
 	setupPlanVpmb60m30minAir(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -534,7 +535,7 @@ void TestPlan::testVpmbMetric60m30minEan50()
 	setupPlanVpmb60m30minEan50(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -570,7 +571,7 @@ void TestPlan::testVpmbMetric60m30minTx()
 	setupPlanVpmb60m30minTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -606,7 +607,7 @@ void TestPlan::testVpmbMetric100m60min()
 	setupPlanVpmb100m60min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -648,7 +649,7 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 	setupPlanVpmbMultiLevelAir(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -678,7 +679,7 @@ void TestPlan::testVpmbMetric100m10min()
 	setupPlanVpmb100m10min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -724,7 +725,7 @@ void TestPlan::testVpmbMetricRepeat()
 	setupPlanVpmb30m20min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -744,7 +745,7 @@ void TestPlan::testVpmbMetricRepeat()
 	int firstDiveRunTimeSeconds = displayed_dive.dc.duration.seconds;
 
 	setupPlanVpmb100mTo70m30min(&testPlan);
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -780,7 +781,7 @@ void TestPlan::testVpmbMetricRepeat()
 	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 127u * 60u + 20u, 127u * 60u + 20u));
 
 	setupPlanVpmb30m20min(&testPlan);
-	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -10,7 +10,7 @@
 #define DEBUG  1
 
 // testing the dive plan algorithm
-extern bool plan(struct diveplan *diveplan, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
+extern bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
 
 extern pressure_t first_ceiling_pressure;
 
@@ -364,7 +364,7 @@ void TestPlan::testMetric()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -404,7 +404,7 @@ void TestPlan::testImperial()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -444,7 +444,7 @@ void TestPlan::testVpmbMetric45m30minTx()
 	setupPlanVpmb45m30mTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -474,7 +474,7 @@ void TestPlan::testVpmbMetric60m10minTx()
 	setupPlanVpmb60m10mTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -504,7 +504,7 @@ void TestPlan::testVpmbMetric60m30minAir()
 	setupPlanVpmb60m30minAir(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -534,7 +534,7 @@ void TestPlan::testVpmbMetric60m30minEan50()
 	setupPlanVpmb60m30minEan50(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -570,7 +570,7 @@ void TestPlan::testVpmbMetric60m30minTx()
 	setupPlanVpmb60m30minTx(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -606,7 +606,7 @@ void TestPlan::testVpmbMetric100m60min()
 	setupPlanVpmb100m60min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -648,7 +648,7 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 	setupPlanVpmbMultiLevelAir(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -678,7 +678,7 @@ void TestPlan::testVpmbMetric100m10min()
 	setupPlanVpmb100m10min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -724,7 +724,7 @@ void TestPlan::testVpmbMetricRepeat()
 	setupPlanVpmb30m20min(&testPlan);
 	setCurrentAppState("PlanDive");
 
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -744,7 +744,7 @@ void TestPlan::testVpmbMetricRepeat()
 	int firstDiveRunTimeSeconds = displayed_dive.dc.duration.seconds;
 
 	setupPlanVpmb100mTo70m30min(&testPlan);
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);
@@ -780,7 +780,7 @@ void TestPlan::testVpmbMetricRepeat()
 	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 127u * 60u + 20u, 127u * 60u + 20u));
 
 	setupPlanVpmb30m20min(&testPlan);
-	plan(&testPlan, &cache, 1, 0);
+	plan(&testPlan, &displayed_dive, 60, &cache, 1, 0);
 
 #if DEBUG
 	free(displayed_dive.notes);


### PR DESCRIPTION
Instead of an essay, here is a pull request representing what I have done so far in my summer vacation.

The main goal is to provide information for contingency plans in the planner. To this end, we compute alternate plans where the final manually added segment is either deeper or shallower by 1m and either longer or shorter by 1min. From this we compute the change of total runtime upon these changes so the diver can estimate the effect of not exactly sticking to the plan (or allows a "per dive deco on the fly" calculation).

To this end, we need to compute stop times up to a second rather than up to a minute.

To not make this only a slow computation (rather than a terribly slow computation), on the way I improve the caching of Buehlmann factors to prevent recalculations of expensive transcendental functions and implement a binary search for the stop times (rather than repeatedly adding a fixed tilmestep). Those changes in themselves improve the responsiveness of the planner UI significantly in particular for dives with hours of decompression time.

What is still missing: 
A ui element to turn this expensive calculation off.
A way to do this calculation in the background (I tried to implement this but the planner is not reentrant to a degree that I failed even with huge locks)
The variation information is computed in seconds for individual stops as is the second derivative (which tells about the validity of linear extrapolation). Currently there is no way to present this information to the user (except by printfs to stdout).
Finally, thanks to signals/slots flying in all directions, I do not understand when exactly the planner is called. I am under the impression it is called three times upon each change of a dive parameter in the UI. By understanding this, there is a possible 200% performance gain in sight.