### PR TITLE
Untangle Credential state enums

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -174,7 +174,8 @@ enum cloud_status {
 	CS_UNKNOWN,
 	CS_INCORRECT_USER_PASSWD,
 	CS_NEED_TO_VERIFY,
-	CS_VERIFIED
+	CS_VERIFIED,
+	CS_NOCLOUD
 };
 
 extern struct preferences prefs, default_prefs, git_prefs;

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -273,17 +273,17 @@ Kirigami.ScrollablePage {
 			if (visible) {
 				page.actions.main = page.saveAction
 				page.actions.right = page.offlineAction
-				title = qsTr("Cloud credentials")
+				page.title = qsTr("Cloud credentials")
 			} else if(manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.VALID_EMAIL || manager.credentialStatus === QMLManager.NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
-				title = qsTr("Dive list")
+				page.title = qsTr("Dive list")
 				if (diveListView.count === 0)
 					showPassiveNotification(qsTr("Please tap the '+' button to add a dive (or download dives from a supported dive computer)"), 3000)
 			} else {
 				page.actions.main = null
 				page.actions.right = null
-				title = qsTr("Dive list")
+				page.title = qsTr("Dive list")
 			}
 		}
 		onVisibleChanged: {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -24,7 +24,7 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.VALID_EMAIL) {
+			if (manager.credentialStatus === QMLManager.VALID) {
 				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
@@ -266,7 +266,7 @@ Kirigami.ScrollablePage {
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		opacity: credentialStatus === QMLManager.NOCLOUD || (credentialStatus === QMLManager.VALID || credentialStatus === QMLManager.VALID_EMAIL) ? 0 : 1
+		opacity: credentialStatus === QMLManager.NOCLOUD || (credentialStatus === QMLManager.VALID) ? 0 : 1
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
@@ -274,7 +274,7 @@ Kirigami.ScrollablePage {
 				page.actions.main = page.saveAction
 				page.actions.right = page.offlineAction
 				page.title = qsTr("Cloud credentials")
-			} else if(manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.VALID_EMAIL || manager.credentialStatus === QMLManager.NOCLOUD) {
+			} else if(manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -24,7 +24,7 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (manager.credentialStatus === QMLManager.VALID) {
+			if (manager.credentialStatus === QMLManager.CS_VERIFIED) {
 				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
@@ -266,7 +266,7 @@ Kirigami.ScrollablePage {
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		opacity: credentialStatus === QMLManager.NOCLOUD || (credentialStatus === QMLManager.VALID) ? 0 : 1
+		opacity: credentialStatus === QMLManager.CS_NOCLOUD || (credentialStatus === QMLManager.CS_VERIFIED) ? 0 : 1
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
@@ -274,7 +274,7 @@ Kirigami.ScrollablePage {
 				page.actions.main = page.saveAction
 				page.actions.right = page.offlineAction
 				page.title = qsTr("Cloud credentials")
-			} else if(manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD) {
+			} else if(manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")
@@ -289,6 +289,7 @@ Kirigami.ScrollablePage {
 		onVisibleChanged: {
 			setupActions();
 		}
+
 		Component.onCompleted: {
 			setupActions();
 		}
@@ -355,12 +356,12 @@ Kirigami.ScrollablePage {
 		iconName: "qrc:/qml/nocloud.svg"
 		onTriggered: {
 			manager.syncToCloud = false
-			manager.credentialStatus = QMLManager.NOCLOUD
+			manager.credentialStatus = QMLManager.CS_NOCLOUD
 		}
 	}
 
 	onBackRequested: {
-		if (startPage.visible && diveListView.count > 0 && manager.credentialStatus !== QMLManager.INVALID) {
+		if (startPage.visible && diveListView.count > 0 && manager.credentialStatus !== QMLManager.CS_INCORRECT_USER_PASSWD) {
 			manager.credentialStatus = oldStatus
 			event.accepted = true;
 		}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -117,10 +117,10 @@ Kirigami.ApplicationWindow {
 				text: qsTr("Dive list")
 				onTriggered: {
 					manager.appendTextToLog("requested dive list with credential status " + manager.credentialStatus)
-					if (manager.credentialStatus == QMLManager.UNKNOWN) {
+					if (manager.credentialStatus == QMLManager.CS_UNKNOWN) {
 						// the user has asked to change credentials - if the credentials before that
 						// were valid, go back to dive list
-						if (oldStatus == QMLManager.VALID) {
+						if (oldStatus == QMLManager.CS_VERIFIED) {
 							manager.credentialStatus = oldStatus
 						}
 					}
@@ -134,7 +134,7 @@ Kirigami.ApplicationWindow {
 				Kirigami.Action {
 					iconName: "icons/ic_add.svg"
 					text: qsTr("Add dive manually")
-					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD
+					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
 					onTriggered: {
 						returnTopPage()  // otherwise odd things happen with the page stack
 						startAddDive()
@@ -159,13 +159,13 @@ Kirigami.ApplicationWindow {
 				Kirigami.Action {
 					iconName: "icons/cloud_sync.svg"
 					text: qsTr("Manual sync with cloud")
-					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD
+					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
 					onTriggered: {
-						if (manager.credentialStatus === QMLManager.NOCLOUD) {
+						if (manager.credentialStatus === QMLManager.CS_NOCLOUD) {
 							returnTopPage()
 							oldStatus = manager.credentialStatus
 							manager.startPageText = "Enter valid cloud storage credentials"
-							manager.credentialStatus = QMLManager.UNKNOWN
+							manager.credentialStatus = QMLManager.CS_UNKNOWN
 							globalDrawer.close()
 						} else {
 							globalDrawer.close()
@@ -178,7 +178,7 @@ Kirigami.ApplicationWindow {
 				Kirigami.Action {
 				iconName: syncToCloud ? "icons/ic_cloud_off.svg" : "icons/ic_cloud_done.svg"
 				text: syncToCloud ? qsTr("Offline mode") : qsTr("Enable auto cloud sync")
-					enabled: manager.credentialStatus !== QMLManager.NOCLOUD
+					enabled: manager.credentialStatus !== QMLManager.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
 						if (!syncToCloud) {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -120,7 +120,7 @@ Kirigami.ApplicationWindow {
 					if (manager.credentialStatus == QMLManager.UNKNOWN) {
 						// the user has asked to change credentials - if the credentials before that
 						// were valid, go back to dive list
-						if (oldStatus == QMLManager.VALID || oldStatus == QMLManager.VALID_EMAIL) {
+						if (oldStatus == QMLManager.VALID) {
 							manager.credentialStatus = oldStatus
 						}
 					}
@@ -134,7 +134,7 @@ Kirigami.ApplicationWindow {
 				Kirigami.Action {
 					iconName: "icons/ic_add.svg"
 					text: qsTr("Add dive manually")
-					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.VALID_EMAIL || manager.credentialStatus === QMLManager.NOCLOUD
+					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD
 					onTriggered: {
 						returnTopPage()  // otherwise odd things happen with the page stack
 						startAddDive()
@@ -159,7 +159,7 @@ Kirigami.ApplicationWindow {
 				Kirigami.Action {
 					iconName: "icons/cloud_sync.svg"
 					text: qsTr("Manual sync with cloud")
-					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.VALID_EMAIL || manager.credentialStatus === QMLManager.NOCLOUD
+					enabled: manager.credentialStatus === QMLManager.VALID || manager.credentialStatus === QMLManager.NOCLOUD
 					onTriggered: {
 						if (manager.credentialStatus === QMLManager.NOCLOUD) {
 							returnTopPage()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -173,9 +173,9 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
 		setNotificationText(tr("Opening local data file failed"));
 	} else {
-		// if we can load from the cache, we know that we have at least a valid email
+		// if we can load from the cache, we know that we have a valid cloud account
 		if (credentialStatus() == UNKNOWN)
-			setCredentialStatus(VALID_EMAIL);
+			setCredentialStatus(VALID);
 		prefs.unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
 			git_prefs.units = IMPERIAL_units;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -573,7 +573,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		prefs.cloud_storage_password = NULL;
 		setCloudUserName("");
 		setCloudPassword("");
-		setCredentialStatus(INCOMPLETE);
+		setCredentialStatus(NOCLOUD);
 		set_filename(NOCLOUD_LOCALSTORAGE, true);
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -245,7 +245,7 @@ void QMLManager::finishSetup()
 			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(existing_filename));
 		}
 	} else {
-		setCredentialStatus(INCOMPLETE);
+		setCredentialStatus(UNKNOWN);
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -52,7 +52,6 @@ public:
 		INCOMPLETE,
 		UNKNOWN,
 		INVALID,
-		VALID_EMAIL,
 		VALID,
 		NOCLOUD
 	};

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -16,7 +16,7 @@
 
 class QMLManager : public QObject {
 	Q_OBJECT
-	Q_ENUMS(credentialStatus_t)
+	Q_ENUMS(cloud_status_qml)
 	Q_PROPERTY(QString cloudUserName READ cloudUserName WRITE setCloudUserName NOTIFY cloudUserNameChanged)
 	Q_PROPERTY(QString cloudPassword READ cloudPassword WRITE setCloudPassword NOTIFY cloudPasswordChanged)
 	Q_PROPERTY(QString cloudPin READ cloudPin WRITE setCloudPin NOTIFY cloudPinChanged)
@@ -29,8 +29,8 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool loadFromCloud READ loadFromCloud WRITE setLoadFromCloud NOTIFY loadFromCloudChanged)
 	Q_PROPERTY(QString startPageText READ startPageText WRITE setStartPageText NOTIFY startPageTextChanged)
 	Q_PROPERTY(bool verboseEnabled READ verboseEnabled WRITE setVerboseEnabled NOTIFY verboseEnabledChanged)
-	Q_PROPERTY(credentialStatus_t credentialStatus READ credentialStatus WRITE setCredentialStatus NOTIFY credentialStatusChanged)
-	Q_PROPERTY(credentialStatus_t oldStatus READ oldStatus WRITE setOldStatus NOTIFY oldStatusChanged)
+	Q_PROPERTY(cloud_status_qml credentialStatus READ credentialStatus WRITE setCredentialStatus NOTIFY credentialStatusChanged)
+	Q_PROPERTY(cloud_status_qml oldStatus READ oldStatus WRITE setOldStatus NOTIFY oldStatusChanged)
 	Q_PROPERTY(QString notificationText READ notificationText WRITE setNotificationText NOTIFY notificationTextChanged)
 	Q_PROPERTY(bool syncToCloud READ syncToCloud WRITE setSyncToCloud NOTIFY syncToCloudChanged)
 	Q_PROPERTY(int updateSelectedDive READ updateSelectedDive WRITE setUpdateSelectedDive NOTIFY updateSelectedDiveChanged)
@@ -48,11 +48,12 @@ public:
 	QMLManager();
 	~QMLManager();
 
-	enum credentialStatus_t {
-		UNKNOWN,
-		INVALID,
-		VALID,
-		NOCLOUD
+	enum cloud_status_qml {
+		CS_UNKNOWN,
+		CS_INCORRECT_USER_PASSWD,
+		CS_NEED_TO_VERIFY,
+		CS_VERIFIED,
+		CS_NOCLOUD
 	};
 
 	static QMLManager *instance();
@@ -91,11 +92,11 @@ public:
 	QString startPageText() const;
 	void setStartPageText(const QString& text);
 
-	credentialStatus_t credentialStatus() const;
-	void setCredentialStatus(const credentialStatus_t value);
+	cloud_status_qml credentialStatus() const;
+	void setCredentialStatus(const cloud_status_qml value);
 
-	credentialStatus_t oldStatus() const;
-	void setOldStatus(const credentialStatus_t value);
+	cloud_status_qml oldStatus() const;
+	void setOldStatus(const cloud_status_qml value);
 
 	QString logText() const;
 	void setLogText(const QString &logText);
@@ -207,8 +208,8 @@ private:
 	bool m_syncToCloud;
 	int m_updateSelectedDive;
 	int m_selectedDiveTimestamp;
-	credentialStatus_t m_credentialStatus;
-	credentialStatus_t m_oldStatus;
+	cloud_status_qml m_credentialStatus;
+	cloud_status_qml m_oldStatus;
 	qreal m_lastDevicePixelRatio;
 	QElapsedTimer timer;
 	bool alreadySaving;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -49,7 +49,6 @@ public:
 	~QMLManager();
 
 	enum credentialStatus_t {
-		INCOMPLETE,
 		UNKNOWN,
 		INVALID,
 		VALID,


### PR DESCRIPTION
Having two different enums around with more or less the same definition has lead to unclear code. After removing two not needed states on the mobile end, the remaining step to one enum for the credential state becomes almost is simple rename operation.

Unfortunately, I do not know a way to embed a plain C enum from pref.h into the QMLManager object. So after this, there are still 2 enums around, but now identical.

Additionally, one trivial commit slipped into this PR (9bcf713) and this is in fact the only one in this set that has any visible change, the remaining ones are code maintenance only.