### PR TITLE
googlemaps: clear the cache folder on language change

### DIFF
--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -51,6 +51,10 @@ void PreferencesLanguage::syncSettings()
 
 	if (useSystemLang != ui->languageSystemDefault->isChecked() ||
 		(!useSystemLang && currentText != prefs.locale.language)) {
+		// remove the marble cache folder on language change
+		QDir googlecachedir(QString(system_default_directory()).append("/googlemaps"));
+		googlecachedir.removeRecursively();
+
 		QMessageBox::warning(this, tr("Restart required"),
 			tr("To correctly load a new language you must restart Subsurface."));
 	}


### PR DESCRIPTION
Open the cache folder via QDir and call removeRecursively().
At that point the user needs to restart Subsurface to be able to
use the map in another language properly.

This change is triggered by the fact that the user might want to see
the street map in his preferred language after he/she picks another
language from Settings. But one problem here is that the cached files
do not carry a language flag - e.g. they are in the lines of:
    googlemaps_100-1-9-445-245.png

Which means that the only way to not mix tiles in different languages
is to clear the cache and start downloading the new tiles in the newly
picked language after Subsurface has restarted.

Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>