### PR TITLE
Format update

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2645,6 +2645,7 @@ static int likely_same_dive(struct dive *a, struct dive *b)
 	 */
 	if (!similar(a->maxdepth.mm, b->maxdepth.mm, 1000) ||
 	    (a->meandepth.mm && b->meandepth.mm && !similar(a->meandepth.mm, b->meandepth.mm, 1000)) ||
+	    !a->duration.seconds || !b->duration.seconds ||
 	    !similar(a->duration.seconds, b->duration.seconds, 5 * 60))
 		return 0;
 

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -424,7 +424,8 @@ static void save_dc(struct membuffer *b, struct dive *dive, struct divecomputer 
  */
 static void create_dive_buffer(struct dive *dive, struct membuffer *b)
 {
-	put_format(b, "duration %u:%02u min\n", FRACTION(dive->dc.duration.seconds, 60));
+	if (dive->dc.duration.seconds > 0)
+		put_format(b, "duration %u:%02u min\n", FRACTION(dive->dc.duration.seconds, 60));
 	SAVE("rating", rating);
 	SAVE("visibility", visibility);
 	cond_put_format(dive->tripflag == NO_TRIP, b, "notrip\n");

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -457,8 +457,11 @@ void save_one_dive_to_mb(struct membuffer *b, struct dive *dive)
 			fprintf(stderr, "removed reference to non-existant dive site with uuid %08x\n", dive->dive_site_uuid);
 	}
 	show_date(b, dive->when);
-	put_format(b, " duration='%u:%02u min'>\n",
-		   FRACTION(dive->dc.duration.seconds, 60));
+	if (dive->dc.duration.seconds > 0)
+		put_format(b, " duration='%u:%02u min'>\n",
+			   FRACTION(dive->dc.duration.seconds, 60));
+	else
+		put_format(b, ">\n");
 	save_overview(b, dive);
 	save_cylinder_info(b, dive);
 	save_weightsystem_info(b, dive);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -354,8 +354,9 @@ static void show_date(struct membuffer *b, timestamp_t when)
 
 	put_format(b, " date='%04u-%02u-%02u'",
 		   tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
-	put_format(b, " time='%02u:%02u:%02u'",
-		   tm.tm_hour, tm.tm_min, tm.tm_sec);
+	if (tm.tm_hour || tm.tm_min || tm.tm_sec)
+		put_format(b, " time='%02u:%02u:%02u'",
+			   tm.tm_hour, tm.tm_min, tm.tm_sec);
 }
 
 static void save_samples(struct membuffer *b, struct dive *dive, struct divecomputer *dc)

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -282,7 +282,10 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 		put_milli(b, " po2='", sample->setpoint.mbar, " bar'");
 		old->setpoint = sample->setpoint;
 	}
-	show_index(b, sample->heartbeat, "heartbeat='", "'");
+	if (sample->heartbeat != old->heartbeat) {
+		show_index(b, sample->heartbeat, "heartbeat='", "'");
+		old->heartbeat = sample->heartbeat;
+	}
 	if (sample->bearing.degrees != old->bearing.degrees) {
 		show_index(b, sample->bearing.degrees, "bearing='", "'");
 		old->bearing.degrees = sample->bearing.degrees;

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -283,7 +283,10 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 		old->setpoint = sample->setpoint;
 	}
 	show_index(b, sample->heartbeat, "heartbeat='", "'");
-	show_index(b, sample->bearing.degrees, "bearing='", "'");
+	if (sample->bearing.degrees != old->bearing.degrees) {
+		show_index(b, sample->bearing.degrees, "bearing='", "'");
+		old->bearing.degrees = sample->bearing.degrees;
+	}
 	put_format(b, " />\n");
 }
 


### PR DESCRIPTION
This includes some fixes to subsurface storage format that were reported by a user converting from v2 to v3. Mostly we save info that does not exist or is unnecessary (i.e. has not changed after the previous sample).