### PR TITLE
mapwidgetcontextmenu: use a QtQuick 2.0 import

### DIFF
--- a/mobile-widgets/qml/MapWidgetContextMenu.qml
+++ b/mobile-widgets/qml/MapWidgetContextMenu.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.6
+import QtQuick 2.0
 
 Item {
 	id: container


### PR DESCRIPTION
Following on beb0d5703a0e, the context menu seems to work fine
with a much older QtQuick import - version 2.0.

The 2.7 import is technically a development leftover
and a minimal version should have been considered earlier.

On older Qt setups (e.g. 5.5.x) this might throw a:
'module "QtQuick" version 2.6 is not installed'

Reported-by: Stefan Fuchs <sfuchs@gmx.de>
Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>