### PR TITLE
mapwidgethelper: support Qt 5.5.x

### DIFF
--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -188,11 +188,11 @@ void MapWidgetHelper::calculateSmallCircleRadius(QGeoCoordinate coord)
 {
 	QPointF point;
 	QMetaObject::invokeMethod(m_map, "fromCoordinate", Q_RETURN_ARG(QPointF, point),
-	                          Q_ARG(QGeoCoordinate, coord), Q_ARG(bool, false));
+	                          Q_ARG(QGeoCoordinate, coord));
 	QPointF point2(point.x() + SMALL_CIRCLE_RADIUS_PX, point.y());
 	QGeoCoordinate coord2;
 	QMetaObject::invokeMethod(m_map, "toCoordinate", Q_RETURN_ARG(QGeoCoordinate, coord2),
-	                          Q_ARG(QPointF, point2), Q_ARG(bool, false));
+	                          Q_ARG(QPointF, point2));
 	m_smallCircleRadius = coord2.distanceTo(coord);
 }
 


### PR DESCRIPTION
MapWidgetHelper::calculateSmallCircleRadius() uses
the second argument (boolean) of QDeclarativeGeoMap::toCoordinate()
and QDeclarativeGeoMap::fromCoordinate(), which isn't supported
in Qt 5.5.x and errors will be thrown on runtime.

This argument usage is redundant for the calculateSmallCircleRadius()
use case.

If the argument is set to "false" it tells the map to avoid
clipping the viewport and always return a valid QPointF/QGeoCoordinate.
Given that calculateSmallCircleRadius() only works with the
map center - i.e it's called like so in MapWidget.qml:
    onZoomLevelChanged: mapHelper.calculateSmallCircleRadius(map.center)

The only way for the radius estimation to fail is if the map widget
width is smaller than SMALL_CIRCLE_RADIUS_PX * 2 = 52px, which is not
possible as the MainWindow splitter prevents it.

If the map widget becomes that small it would be hardly usable,
yet no errors should be thrown related to this change.

Tested-by: Stefan Fuchs <sfuchs@gmx.de>
Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>