### PR TITLE
Correct comment for deco subsurface_conservatism_factor

### DIFF
--- a/core/deco.c
+++ b/core/deco.c
@@ -26,8 +26,9 @@
 
 #define cube(x) (x * x * x)
 
-// Subsurface appears to produce marginally less conservative plans than our benchmarks
-// Introduce 1.2% additional conservatism
+// Subsurface until v4.6.2 appeared to produce marginally less conservative plans than our benchmarks.
+// This factor was used to correct this. Since a fix for the saturation and desaturation rates
+// was introduced in v4.6.3 this can be set to a value of 1.0 which means no correction.
 #define subsurface_conservatism_factor 1.0
 
 


### PR DESCRIPTION
This is only a change in a comment on the "subsurface_conservatism_factor" in the deco calculation.
But it may be important to correct it to understand the situation and history at some time.