### PR TITLE
github: add templates for pull requests and issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- Lines like this one are comments and will not be shown in the final output. -->
+<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
+
+### Describe the issue:
+<!-- Replace [ ] with [x] to select options. -->
+- [ ] Bug
+- [ ] Change request
+- [ ] New feature request
+- [ ] Discussion request
+
+### Issue long description:
+<!-- Describe the issue in detail. -->
+
+### Operating system:
+<!-- What OS are you running? -->
+<!-- What is the OS version? -->
+<!-- What device are you using? -->
+<!-- Does the same happen on another OS? -->
+
+### Subsurface version:
+<!-- What version of Subsurface are you running? -->
+<!-- Does the same happen on another Subsurface version? -->
+<!-- Are you using official release, test build, or compiled yourself? -->
+<!-- Provide Git hash if your are building Subsurface yourself. -->
+
+### Steps to reproduce:
+<!-- Provide reproduction steps separated with new lines - 1), 2), 3)... -->
+
+### Current behavior:
+<!-- What is the current behavior? -->
+
+### Expected behavior:
+<!-- What is the expected behavior? -->
+
+### Additional information:
+<!-- If a simple dive log file can reproduce the issue, please attach that to the report. -->
+<!-- With dive computer download issues consider adding Subsurface log file and Subsurface dumpfile to the report. -->
+
+### Mentions:
+<!-- Mention users that you want to review your issue with @<user-name>. Leave empty if not sure. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Lines like this one are comments and will not be shown in the final output. -->
+<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
+<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
+
+### Describe the pull request:
+<!-- Replace [ ] with [x] to select options. -->
+- [ ] Bug fix
+- [ ] Functional change
+- [ ] New feature
+- [ ] Documentation change
+- [ ] Language translation
+
+### Pull request long description:
+<!-- Describe your pull request in detail. -->
+
+### Changes made:
+<!-- Enumerate the changes with 1), 2), 3) etc. -->
+<!-- Ensure the test cases are updated if needed. -->
+
+### Related issues:
+<!-- Reference issues with #<issue-num>. -->
+<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
+
+### Additional information:
+<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
+
+### Mentions:
+<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->


### PR DESCRIPTION
**original commit message:**
```
.github/ISSUE_TEMPLATE.md will be used when the Github users
create new issues.

.github/PULL_REQUEST_TEMPLATE.md will be used when the Github users
create new pull requests.

The markdown supports HTML comments, which
can instruct the Github user how to create a detailed PR or issue
report.

Most big Github projects use such templates and these can help
the collaborators to examine the PRs and ISSUES faster.
```

i'm adding github templates support. please have a look for typos and for possible improvements.
my only concern is that these might be too verbose...yet it's often best to gather as much information as possible without asking the user.

thanks

refs:
Fixes #598

mentions:
@atdotde @dirkhh @glance- @janmulder @mturkia @tcanabrava @willemferguson
