### PR TITLE
WIP: Mobile credential management (part 1) 

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -103,7 +103,7 @@ Item {
 			spacing: Kirigami.Units.smallSpacing
 			visible: rootItem.showPin
 			SsrfButton {
-				id:registerpin
+				id: registerpin
 				text: qsTr("Register") 
 				onClicked: {
 					saveCredentials()
@@ -131,7 +131,7 @@ Item {
 			visible: !rootItem.showPin
 
 			SsrfButton {
-				id:signin_register_normal
+				id: signin_register_normal
 				text: qsTr("Sign-in or Register")
 				onClicked: {
 					saveCredentials()

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -53,6 +53,7 @@ Item {
 
 		Kirigami.Label {
 			text: qsTr("Email")
+			visible: !rootItem.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
@@ -60,16 +61,15 @@ Item {
 		TextField {
 			id: login
 			text: manager.cloudUserName
+			visible: !rootItem.showPin
 			Layout.fillWidth: true
 			inputMethodHints: Qt.ImhEmailCharactersOnly |
 					  Qt.ImhNoAutoUppercase
-			onEditingFinished: {
-				saveCredentials()
-			}
 		}
 
 		Kirigami.Label {
 			text: qsTr("Password")
+			visible: !rootItem.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
@@ -77,14 +77,12 @@ Item {
 		TextField {
 			id: password
 			text: manager.cloudPassword
+			visible: !rootItem.showPin
 			echoMode: TextInput.PasswordEchoOnEdit
 			inputMethodHints: Qt.ImhSensitiveData |
 					  Qt.ImhHiddenText |
 					  Qt.ImhNoAutoUppercase
 			Layout.fillWidth: true
-			onEditingFinished: {
-				saveCredentials()
-			}
 		}
 
 		Kirigami.Label {
@@ -96,6 +94,62 @@ Item {
 			text: ""
 			Layout.fillWidth: true
 			visible: rootItem.showPin
+		}
+
+		RowLayout {
+			anchors.left: parent.left
+			anchors.right: parent.right
+			anchors.margins: Kirigami.Units.smallSpacing
+			spacing: Kirigami.Units.smallSpacing
+			visible: rootItem.showPin
+			SsrfButton {
+				id:registerpin
+				text: qsTr("Register") 
+				onClicked: {
+					saveCredentials()
+				}
+			}
+			Kirigami.Label {
+				text: ""  // Spacer between 2 button groups
+				Layout.fillWidth: true
+			}
+			SsrfButton {
+				id: cancelpin
+				text: qsTr("Cancel")
+				onClicked: {
+					manager.cancelCredentialsPinSetup()
+					rootItem.returnTopPage()
+				}
+			}
+		}
+
+		RowLayout {
+			anchors.left: parent.left
+			anchors.right: parent.right
+			anchors.margins: Kirigami.Units.smallSpacing
+			spacing: Kirigami.Units.smallSpacing
+			visible: !rootItem.showPin
+
+			SsrfButton {
+				id:signin_register_normal
+				text: qsTr("Sign-in or Register")
+				onClicked: {
+					saveCredentials()
+				}
+			}
+			Kirigami.Label {
+				text: ""  // Spacer between 2 button groups
+				Layout.fillWidth: true
+			}
+			SsrfButton {
+				id: toNoCloudMode
+				text: qsTr("No cloud mode")
+				onClicked: {
+					manager.syncToCloud = false
+					manager.credentialStatus = QMLManager.CS_NOCLOUD
+					manager.saveCloudCredentials()
+				}
+			}
 		}
 	}
 }

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -271,8 +271,8 @@ Kirigami.ScrollablePage {
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
 			if (visible) {
-				page.actions.main = page.saveAction
-				page.actions.right = page.offlineAction
+				page.actions.main = null
+				page.actions.right = null
 				page.title = qsTr("Cloud credentials")
 			} else if(manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
@@ -358,6 +358,7 @@ Kirigami.ScrollablePage {
 		onTriggered: {
 			manager.syncToCloud = false
 			manager.credentialStatus = QMLManager.CS_NOCLOUD
+			manager.saveCloudCredentials()
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -291,6 +291,7 @@ Kirigami.ScrollablePage {
 		}
 
 		Component.onCompleted: {
+			manager.finishSetup();
 			setupActions();
 		}
 	}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -274,7 +274,7 @@ Kirigami.ScrollablePage {
 				page.actions.main = null
 				page.actions.right = null
 				page.title = qsTr("Cloud credentials")
-			} else if(manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD) {
+			} else if (manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -13,16 +13,62 @@ Kirigami.ScrollablePage {
 	title: qsTr("Settings")
 
 	property real gridWidth: settingsPage.width - Kirigami.Units.gridUnit
+	property var describe: [qsTr("Undefined"),
+		qsTr("Incorrect username/password combination"),
+		qsTr("Credentials need to be verified"),
+		qsTr("Credentials verified"),
+		qsTr("No cloud mode")]
 
 	ColumnLayout {
 		width: gridWidth
-		CloudCredentials {
-			id: cloudCredentials
-			Layout.fillWidth: true
-			Layout.rightMargin: Kirigami.Units.smallSpacing
-			Layout.topMargin: - Kirigami.Units.gridUnit
-			property int headingLevel: 4
+		GridLayout {
+			id: cloudSetting
+			columns: 3
+			Layout.bottomMargin: Kirigami.Units.gridUnit
+
+			Kirigami.Heading {
+				text: qsTr("Cloud status")
+				color: subsurfaceTheme.textColor
+				level: 4
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+				Layout.columnSpan: 3
+			}
+			Kirigami.Label {
+				text: qsTr("Email")
+				Layout.alignment: Qt.AlignRight
+				Layout.preferredWidth:gridWidth * 0.15
+				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+			}
+			Kirigami.Label {
+				text: manager.credentialStatus === QMLManager.CS_NOCLOUD?qsTr("Not applicable"):manager.cloudUserName
+				Layout.alignment: Qt.AlignRight
+				Layout.preferredWidth:gridWidth * 0.60
+				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+			}
+			SsrfButton {
+				id:changeCloudSettings
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Change")
+				onClicked: {
+					manager.cancelCredentialsPinSetup()
+					rootItem.returnTopPage()
+				}
+			}
+			Kirigami.Label {
+				text: qsTr("Status")
+				Layout.alignment: Qt.AlignRight
+				Layout.preferredWidth:gridWidth * 0.15
+				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+			}
+			Kirigami.Label {
+				text: describe[manager.credentialStatus]
+				Layout.alignment: Qt.AlignRight
+				Layout.preferredWidth:gridWidth * 0.60
+				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+			}
 		}
+
 		Rectangle {
 			color: subsurfaceTheme.darkerPrimaryColor
 			height: 1

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -37,17 +37,17 @@ Kirigami.ScrollablePage {
 			Kirigami.Label {
 				text: qsTr("Email")
 				Layout.alignment: Qt.AlignRight
-				Layout.preferredWidth:gridWidth * 0.15
+				Layout.preferredWidth: gridWidth * 0.15
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Kirigami.Label {
-				text: manager.credentialStatus === QMLManager.CS_NOCLOUD?qsTr("Not applicable"):manager.cloudUserName
+				text: manager.credentialStatus === QMLManager.CS_NOCLOUD ? qsTr("Not applicable") : manager.cloudUserName
 				Layout.alignment: Qt.AlignRight
-				Layout.preferredWidth:gridWidth * 0.60
+				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			SsrfButton {
-				id:changeCloudSettings
+				id: changeCloudSettings
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Change")
 				onClicked: {
@@ -58,13 +58,13 @@ Kirigami.ScrollablePage {
 			Kirigami.Label {
 				text: qsTr("Status")
 				Layout.alignment: Qt.AlignRight
-				Layout.preferredWidth:gridWidth * 0.15
+				Layout.preferredWidth: gridWidth * 0.15
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Kirigami.Label {
 				text: describe[manager.credentialStatus]
 				Layout.alignment: Qt.AlignRight
-				Layout.preferredWidth:gridWidth * 0.60
+				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 		}
@@ -269,7 +269,7 @@ Kirigami.ScrollablePage {
 			Kirigami.Label {
 				text: qsTr("Distance threshold (meters)")
 				Layout.alignment: Qt.AlignRight
-				Layout.preferredWidth:gridWidth * 0.75
+				Layout.preferredWidth: gridWidth * 0.75
 			}
 
 			TextField {

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -11,18 +11,12 @@ Kirigami.ScrollablePage {
 	function saveCredentials() { cloudCredentials.saveCredentials() }
 
 	ColumnLayout {
-		Kirigami.Label {
-			id: explanationText
+		CloudCredentials {
+			id: cloudCredentials
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
-			Layout.topMargin: Kirigami.Units.gridUnit * 3
-			text: qsTr("To use Subsurface-mobile with Subsurface cloud storage, please enter your cloud credentials.\n") +
-				qsTr("If this is the first time you use Subsurface cloud storage, enter a valid email (all lower case) " +
-				"and a password of your choice (letters and numbers). " +
-				"The server will send a PIN to the email address provided that you will have to enter here.\n\n") +
-				qsTr("To use Subsurface-mobile only with local data on this device, tap " +
-				"on the no cloud icon below.")
-			wrapMode: Text.WordWrap
+			Layout.topMargin: 0
+			property int headingLevel: 3
 		}
 		Kirigami.Label {
 			id: messageArea
@@ -32,12 +26,32 @@ Kirigami.ScrollablePage {
 			text: manager.startPageText
 			wrapMode: Text.WordWrap
 		}
-		CloudCredentials {
-			id: cloudCredentials
+		Kirigami.Label {
+			id: explanationTextBasic
+			visible: !showPin
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
-			Layout.topMargin: 0
-			property int headingLevel: 3
+			Layout.topMargin: Kirigami.Units.gridUnit * 3
+			text: qsTr("To use Subsurface-mobile with Subsurface cloud storage, please enter your cloud credentials.\n\n") +
+				qsTr("If this is the first time you use Subsurface cloud storage, enter a valid email (all lower case) " +
+				"and a password of your choice (letters and numbers).\n\n") +
+				qsTr("To use Subsurface-mobile only with local data on this device, select " +
+				"the no cloud buttton above.")
+			wrapMode: Text.WordWrap
+		}
+		Kirigami.Label {
+			id: explanationTextPin
+			visible: showPin
+			Layout.fillWidth: true
+			Layout.margins: Kirigami.Units.gridUnit
+			Layout.topMargin: Kirigami.Units.gridUnit * 3
+			text: qsTr("Thank you for registering with Subsurface. We sent ") + manager.cloudUserName +
+				qsTr(" a PIN code to complete the registration. ") +
+				qsTr("If you do not receive an email from us within 15 minutes, please check " +
+					 "the correct spelling of your email address and your spam box first.\n\n" +
+					 "In case of any problems regarding cloud account setup, please contact us " +
+					 "at our user forum \(https://subsurface-divelog.org/user-forum/\).\n\n")
+			wrapMode: Text.WordWrap
 		}
 		Item { width: Kirigami.Units.gridUnit; height: 3 * Kirigami.Units.gridUnit}
 	}

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -32,10 +32,10 @@ Kirigami.ScrollablePage {
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3
-			text: qsTr("To use Subsurface-mobile with Subsurface cloud storage, please enter your cloud credentials.\n\n") +
-				qsTr("If this is the first time you use Subsurface cloud storage, enter a valid email (all lower case) " +
-				"and a password of your choice (letters and numbers).\n\n") +
-				qsTr("To use Subsurface-mobile only with local data on this device, select " +
+			text: qsTr("To use Subsurface-mobile with Subsurface cloud storage, please enter your cloud credentials.<br/><br/>" +
+				"If this is the first time you use Subsurface cloud storage, enter a valid email (all lower case) " +
+				"and a password of your choice (letters and numbers).<br/><br/>" +
+				"To use Subsurface-mobile only with local data on this device, select " +
 				"the no cloud buttton above.")
 			wrapMode: Text.WordWrap
 		}
@@ -45,12 +45,12 @@ Kirigami.ScrollablePage {
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3
-			text: qsTr("Thank you for registering with Subsurface. We sent ") + manager.cloudUserName +
-				qsTr(" a PIN code to complete the registration. ") +
-				qsTr("If you do not receive an email from us within 15 minutes, please check " +
-					 "the correct spelling of your email address and your spam box first.\n\n" +
-					 "In case of any problems regarding cloud account setup, please contact us " +
-					 "at our user forum \(https://subsurface-divelog.org/user-forum/\).\n\n")
+			text: qsTr("Thank you for registering with Subsurface. We sent <b>%1</b>" +
+				" a PIN code to complete the registration. " +
+				"If you do not receive an email from us within 15 minutes, please check " +
+				"the correct spelling of your email address and your spam box first.<br/><br/>" +
+				"In case of any problems regarding cloud account setup, please contact us " +
+				"at our user forum \(https://subsurface-divelog.org/user-forum/\).<br/><br/>").arg(manager.cloudUserName)
 			wrapMode: Text.WordWrap
 		}
 		Item { width: Kirigami.Units.gridUnit; height: 3 * Kirigami.Units.gridUnit}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -470,7 +470,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	}
 
 	Component.onCompleted: {
-		manager.finishSetup();
 		rootItem.visible = true
 		diveList.opacity = 1
 		rootItem.opacity = 1

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -231,7 +231,7 @@ void QMLManager::finishSetup()
 		// but we need to make sure we stay the only ones accessing git storage
 		alreadySaving = true;
 		openLocalThenRemote(url);
-	} else if (!same_string(existing_filename, "")) {
+	} else if (!same_string(existing_filename, "") && credentialStatus() != CS_UNKNOWN) {
 		setCredentialStatus(CS_NOCLOUD);
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -267,6 +267,7 @@ void QMLManager::finishSetup()
 		openLocalThenRemote(url);
 	} else if (!same_string(existing_filename, "") && credentialStatus() != CS_UNKNOWN) {
 		setCredentialStatus(CS_NOCLOUD);
+		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename);
 		if (error) {
@@ -337,6 +338,7 @@ void QMLManager::saveCloudCredentials()
 	s.beginGroup("CloudStorage");
 	s.setValue("email", cloudUser);
 	s.setValue("password", cloudPwd);
+	s.setValue("cloud_verification_status", credentialStatus());
 	s.sync();
 	if (!same_string(prefs.cloud_storage_email, qPrintable(cloudUser))) {
 		free(prefs.cloud_storage_email);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1413,8 +1413,10 @@ QMLManager::cloud_status_qml QMLManager::credentialStatus() const
 void QMLManager::setCredentialStatus(const cloud_status_qml value)
 {
 	if (m_credentialStatus != value) {
-		if (value == CS_NOCLOUD)
+		if (value == CS_NOCLOUD) {
 			appendTextToLog("Switching to no cloud mode");
+			set_filename(NOCLOUD_LOCALSTORAGE, true);
+		}
 		m_credentialStatus = value;
 		emit credentialStatusChanged();
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -222,6 +222,33 @@ void QMLManager::mergeLocalRepo()
 	process_dives(true, false);
 }
 
+void QMLManager::cancelCredentialsPinSetup()
+{
+	/*
+	 * The user selected <cancel> on the final stage of the
+	 * cloud account generation (entering the emailed PIN).
+	 *
+	 * For now, just reset all the cloud data. This brings the app
+	 * back to its initial state, and the user can startover again.
+	 *
+	 * Notice that this function is also used to switch to NOCLOUD
+	 * mode. So the name is not perfect.
+	 */
+	QSettings s;
+
+	setCloudUserName(NULL);
+	setCloudPassword(NULL);
+	setCredentialStatus(CS_UNKNOWN);
+	s.beginGroup("CloudStorage");
+	s.setValue("email", cloudUserName());
+	s.setValue("password", cloudPassword());
+	s.setValue("cloud_verification_status", credentialStatus());
+	s.sync();
+	setStartPageText(tr("Starting..."));
+
+	setShowPin(false);
+}
+
 void QMLManager::finishSetup()
 {
 	// Initialize cloud credentials.

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1413,6 +1413,7 @@ QMLManager::cloud_status_qml QMLManager::credentialStatus() const
 void QMLManager::setCredentialStatus(const cloud_status_qml value)
 {
 	if (m_credentialStatus != value) {
+		setOldStatus(m_credentialStatus);
 		if (value == CS_NOCLOUD) {
 			appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE, true);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -172,6 +172,9 @@ void QMLManager::openLocalThenRemote(QString url)
 	if (error) {
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
 		setNotificationText(tr("Opening local data file failed"));
+		// have cloud credentials, but there is no local repo (yet).
+		// this implies that the PIN verify is still to be done
+		setCredentialStatus(CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
 		if (credentialStatus() == CS_UNKNOWN)
@@ -192,6 +195,10 @@ void QMLManager::openLocalThenRemote(QString url)
 		DiveListModel::instance()->addAllDives();
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
+	}
+	if (credentialStatus() == CS_NEED_TO_VERIFY) {
+		appendTextToLog(QStringLiteral("have cloud credentials, but still needs PIN"));
+		setShowPin(true);
 	}
 	if (oldStatus() == CS_NOCLOUD) {
 		// if we switch to credentials from CS_NOCLOUD, we take things online temporarily

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -221,6 +221,7 @@ void QMLManager::finishSetup()
 	setCloudUserName(prefs.cloud_storage_email);
 	setCloudPassword(prefs.cloud_storage_password);
 	setSyncToCloud(!prefs.git_local_only);
+	setCredentialStatus((cloud_status_qml) prefs.cloud_verification_status);
 	// if the cloud credentials are valid, we should get the GPS Webservice ID as well
 	QString url;
 	if (!cloudUserName().isEmpty() &&

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -320,15 +320,18 @@ void QMLManager::saveCloudCredentials()
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
 	QString cloudPwd = cloudPassword();
 	QString cloudUser = cloudUserName();
-	if (cloudPwd.isEmpty() || !regExp.match(cloudPwd).hasMatch() || !regExp.match(cloudUser).hasMatch()) {
-		setStartPageText(RED_FONT + tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.") + END_FONT);
-		return;
-	}
-	// use the same simplistic regex as the backend to check email addresses
-	regExp = QRegularExpression("^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.+_-]+\\.[a-zA-Z0-9]+");
-	if (!regExp.match(cloudUser).hasMatch()) {
-		setStartPageText(RED_FONT + tr("Invalid format for email address") + END_FONT);
-		return;
+	if (credentialStatus() != CS_NOCLOUD) {
+		// in case of NO_CLOUD, the email address + passwd do not care, so do not check it.
+		if (cloudPwd.isEmpty() || !regExp.match(cloudPwd).hasMatch() || !regExp.match(cloudUser).hasMatch()) {
+			setStartPageText(RED_FONT + tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.") + END_FONT);
+			return;
+		}
+		// use the same simplistic regex as the backend to check email addresses
+		regExp = QRegularExpression("^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.+_-]+\\.[a-zA-Z0-9]+");
+		if (!regExp.match(cloudUser).hasMatch()) {
+			setStartPageText(RED_FONT + tr("Invalid format for email address") + END_FONT);
+			return;
+		}
 	}
 	setOldStatus(credentialStatus());
 	s.beginGroup("CloudStorage");

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -167,6 +167,7 @@ public slots:
 	void populateGpsData();
 	void cancelDownloadDC();
 	void clearGpsData();
+	void cancelCredentialsPinSetup();
 	void finishSetup();
 	void openLocalThenRemote(QString url);
 	void mergeLocalRepo();


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Please read the individual commit messages. 

This basically reworks the single credential page to two pages, and  tries to implement most of issue #515. It reworks the one credential page, with its dynamic PIN part, into two pages. Main driver of selecting one of the two pages is the showPin boolean. Page 1 contains the email/passwd field (and the option to use a no cloud setup). Page 2 only contains the PIN part (and the option to cancel the process).

### Changes made:
Please read the individual commit messages. 

### Related issues: #515 

### Additional information:
This PR is marked WIP. I believe that it is in a state to would justify a merge into master. However, me being mostly away from keyboard for the coming 10 days, it might be better to evaluate all this carefully, as there are definitely known and unknown bugs. 

The known bugs:
- after successful opening different account, move to its (refreshed) divelist. Does not always happen.
- log on with wrong password ... opens local cache (when present) without message to the user (in the same session), but in the next session it stops the user to enter the correct passwd
- switching from cloud -> nocloud (sometimes) clones repo to local repo, no harm done, but something to investigate.
- I am in the dark with respect to switching from nocloud -> cloud ... what is supposed to happen (before this PR)? 

### Mentions: @dirkhh, @jbygdell, @bocio
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
