### PR TITLE
Update sample_start and sample_end pressures

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2155,6 +2155,11 @@ static void merge_one_cylinder(cylinder_t *a, cylinder_t *b)
 		a->start.mbar = b->start.mbar;
 	if (!a->end.mbar)
 		a->end.mbar = b->end.mbar;
+
+	if (a->sample_start.mbar && b->sample_start.mbar)
+		a->sample_start.mbar = a->sample_start.mbar > b->sample_start.mbar ?  a->sample_start.mbar : b->sample_start.mbar;
+	if (a->sample_end.mbar && b->sample_end.mbar)
+		a->sample_end.mbar = a->sample_end.mbar < b->sample_end.mbar ?  a->sample_end.mbar : b->sample_end.mbar;
 }
 
 /*


### PR DESCRIPTION
When we merge dives, the sample_start and sample_end pressures are only
used in-memory for displaying data to the user. However, we should
update them as well as this will show the user the correct data in the
equipment/cylinder and i.e. SAC calculation.

Fixes #577

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation