### PR TITLE
Use helper function dive_endtime() where apropriate

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -275,7 +275,7 @@ bool GpsLocation::applyLocations()
 					qDebug() << "processing gpsFix @" << get_dive_date_string(gpsTable[j].when) <<
 						    "which is withing six hours of dive from" <<
 						    get_dive_date_string(d->when) << "until" <<
-						    get_dive_date_string(d->when + d->duration.seconds);
+						    get_dive_date_string(dive_endtime(d));
 				/*
 				 * If position is fixed during dive. This is the good one.
 				 * Asign and mark position, and end gps_location loop
@@ -310,7 +310,7 @@ bool GpsLocation::applyLocations()
 							if (verbose)
 								qDebug() << "which is closer to the start of the dive, do continue with that";
 							continue;
-						} else if (gpsTable[j].when > d->when + d->duration.seconds) {
+						} else if (gpsTable[j].when > dive_endtime(d)) {
 							if (verbose)
 								qDebug() << "which is even later after the end of the dive, so pick the previous one";
 							copy_gps_location(gpsTable[j], d);
@@ -319,7 +319,7 @@ bool GpsLocation::applyLocations()
 							break;
 						} else {
 							/* ok, gpsFix is before, nextgpsFix is after */
-							if (d->when - gpsTable[j].when <= gpsTable[j+1].when - (d->when + d->duration.seconds)) {
+							if (d->when - gpsTable[j].when <= gpsTable[j+1].when - dive_endtime(d)) {
 								if (verbose)
 									qDebug() << "pick the one before as it's closer to the start";
 								copy_gps_location(gpsTable[j], d);
@@ -351,7 +351,7 @@ bool GpsLocation::applyLocations()
 				/* If position is out of SAME_GROUP range and in the future, mark position for
 				 * next dive iteration and end the gps_location loop
 				 */
-				if (gpsTable[j].when >= d->when + d->duration.seconds + SAME_GROUP) {
+				if (gpsTable[j].when >= dive_endtime(d) + SAME_GROUP) {
 					last = j;
 					break;
 				}

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -6,6 +6,7 @@
 #include <core/helpers.h>
 #include <core/statistics.h>
 #include <core/display.h>
+#include <core/dive.h>
 
 TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveInformation())
 {
@@ -81,7 +82,7 @@ void TabDiveInformation::updateData()
 	process_all_dives(&displayed_dive, &prevd);
 
 	if (prevd)
-		ui->surfaceIntervalText->setText(get_dive_surfint_string(displayed_dive.when - (prevd->when + prevd->duration.seconds), tr("d"), tr("h"), tr("min")));
+		ui->surfaceIntervalText->setText(get_dive_surfint_string(displayed_dive.when - (dive_endtime(prevd)), tr("d"), tr("h"), tr("min")));
 
 	else
 		ui->surfaceIntervalText->clear();

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -58,7 +58,7 @@ void DivePlannerPointsModel::setupStartTime()
 	startTime = QDateTime::currentDateTimeUtc().addSecs(3600 + gettimezoneoffset());
 	if (dive_table.nr) {
 		struct dive *d = get_dive(dive_table.nr - 1);
-		time_t ends = d->when + d->duration.seconds;
+		time_t ends = dive_endtime(d);
 		time_t diff = ends - startTime.toTime_t();
 		if (diff > 0) {
 			startTime = startTime.addSecs(diff + 3600);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -4,6 +4,7 @@
 #include "core/metrics.h"
 #include "core/divelist.h"
 #include "core/helpers.h"
+#include "core/dive.h"
 #include <QIcon>
 
 static int nitrox_sort_value(struct dive *dive)
@@ -325,12 +326,12 @@ QString DiveItem::displayDepthWithUnit() const
 int DiveItem::countPhotos(dive *dive) const
 {	// Determine whether dive has pictures, and whether they were taken during or before/after dive.
 	const int bufperiod = 120; // A 2-min buffer period. Photos within 2 min of dive are assumed as
-	int diveDuration = dive->duration.seconds;	// taken during the dive, not before/after.
+	int diveTotaltime = dive_endtime(dive) - dive->when;	// taken during the dive, not before/after.
 	int pic_offset, icon_index = 0;
 	FOR_EACH_PICTURE (dive) {		// Step through each of the pictures for this dive:
 		if (!picture) break;		// if there are no pictures for this dive, return 0
 		pic_offset = picture->offset.seconds;
-		if  ((pic_offset < -bufperiod) | (pic_offset > diveDuration+bufperiod)) {
+		if  ((pic_offset < -bufperiod) | (pic_offset > diveTotaltime+bufperiod)) {
 			icon_index |= 0x02;	// If picture is before/after the dive
 		}				//  then set the appropriate bit ...
 		else {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Calculating dive.when + dive.duration doesn't always give the correct
endtime of a dive especially when a dive has surface interval(s) in
the middle.
Using the helper function dive_endtime() fixes this issue.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#606 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Careful review needed. Check for other places to use dive_endtime needed.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @dirkhh 
