### PR TITLE
init_deco and CNS calculation - correctly identify previous dives and report overlapping dives

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -910,7 +910,7 @@ struct diveplan {
 	short vpmb_conservatism;
 	struct divedatapoint *dp;
 	int eff_gflow, eff_gfhigh;
-	unsigned int surface_interval;
+	int surface_interval;
 };
 
 struct divedatapoint *plan_add_segment(struct diveplan *diveplan, int duration, int depth, int cylinderid, int po2, bool entered);

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -15,7 +15,7 @@ extern void update_cylinder_related_info(struct dive *);
 extern void mark_divelist_changed(int);
 extern int unsaved_changes(void);
 extern void remove_autogen_trips(void);
-extern unsigned int init_decompression(struct dive *dive);
+extern int init_decompression(struct dive *dive);
 
 /* divelist core logic functions */
 extern void process_dives(bool imported, bool prefer_imported);

--- a/core/planner.c
+++ b/core/planner.c
@@ -127,7 +127,7 @@ void interpolate_transition(struct dive *dive, duration_t t0, duration_t t1, dep
 }
 
 /* returns the tissue tolerance at the end of this (partial) dive */
-unsigned int tissue_at_end(struct dive *dive, struct deco_state **cached_datap)
+int tissue_at_end(struct dive *dive, struct deco_state **cached_datap)
 {
 	struct divecomputer *dc;
 	struct sample *sample, *psample;
@@ -135,7 +135,7 @@ unsigned int tissue_at_end(struct dive *dive, struct deco_state **cached_datap)
 	depth_t lastdepth = {};
 	duration_t t0 = {}, t1 = {};
 	struct gasmix gas;
-	unsigned int surface_interval = 0;
+	int surface_interval = 0;
 
 	if (!dive)
 		return 0;

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -85,19 +85,28 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 
 	len = show_disclaimer ? snprintf(buffer, sz_buffer, "<div><b>%s</b><br></div>", disclaimer) : 0;
 
-	if (diveplan->surface_interval > 60) {
+	if (diveplan->surface_interval < 0) {
+		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s<br>",
+				translate("gettextFromC", "Subsurface"),
+				subsurface_canonical_version(),
+				translate("gettextFromC", "dive plan</b> (Overlapping dives detected)"));
+				dive->notes = strdup(buffer);
+				free((void *)buffer);
+				free((void *)temp);
+				return;
+	} else if (diveplan->surface_interval >= 48 * 60 *60) {
+		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %s</b><br>",
+				translate("gettextFromC", "Subsurface"),
+				subsurface_canonical_version(),
+				translate("gettextFromC", "dive plan</b> created on"),
+				get_current_date());
+	} else {
 		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
 				translate("gettextFromC", "Subsurface"),
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> (surface interval "),
 				FRACTION(diveplan->surface_interval / 60, 60),
 				translate("gettextFromC", "created on"),
-				get_current_date());
-	} else {
-		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %s</b><br>",
-				translate("gettextFromC", "Subsurface"),
-				subsurface_canonical_version(),
-				translate("gettextFromC", "dive plan</b> created on"),
 				get_current_date());
 	}
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1076,6 +1076,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		copy_dive(&displayed_dive, current_dive);
 	}
 	mark_divelist_changed(true);
+	sort_table(&dive_table);
 
 	// Remove and clean the diveplan, so we don't delete
 	// the dive by mistake.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When changing the date/time of a dive in the planner the dive may end
up in a totaly new position in respect to date/time of other dives in
dive list table. It can be moved to the past or the future before or after
other existing dives. It also could overlap with an existing dive.

This change enables identification of a new "virtual" dive list position
and based on this starts looking for previous dives.
Then it (as before the change) does init the deco/CNS calculation with any
applicable previous dive and surface interval.
If some of these applicable dives overlap it returns a neg. surface time
which is then used in the planner notes to prohibit display of results.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This is work in progress and needs further review/testing.
I for the moment put a lot of debug output which would be removed or turned off by default lateron.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
