### PR TITLE
Planner settings ascend and descende rate: Wire up UI elements correctly

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -359,16 +359,16 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.display_variations, SIGNAL(toggled(bool)), plannerModel, SLOT(setDisplayVariations(bool)));
 	connect(ui.safetystop, SIGNAL(toggled(bool)), plannerModel, SLOT(setSafetyStop(bool)));
 	connect(ui.reserve_gas, SIGNAL(valueChanged(int)), plannerModel, SLOT(setReserveGas(int)));
-	connect(ui.ascRate75, SIGNAL(valueChanged(int)), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRate50, SIGNAL(valueChanged(int)), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.descRate, SIGNAL(valueChanged(int)), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRate75, SIGNAL(editingFinished()), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRate50, SIGNAL(editingFinished()), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRateStops, SIGNAL(editingFinished()), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.ascRateLast6m, SIGNAL(editingFinished()), plannerModel, SLOT(emitDataChanged()));
-	connect(ui.descRate, SIGNAL(editingFinished()), plannerModel, SLOT(emitDataChanged()));
+	connect(ui.ascRate75, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscrate75(int)));
+	connect(ui.ascRate50, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscrate50(int)));
+	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscratestops(int)));
+	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscratelast6m(int)));
+	connect(ui.descRate, SIGNAL(valueChanged(int)), plannerModel, SLOT(setDescrate(int)));
+	connect(ui.ascRate75, SIGNAL(editingFinished()), plannerModel, SLOT(setAscrate75(int)));
+	connect(ui.ascRate50, SIGNAL(editingFinished()), plannerModel, SLOT(setAscrate50(int)));
+	connect(ui.ascRateStops, SIGNAL(editingFinished()), plannerModel, SLOT(setAscratestops(int)));
+	connect(ui.ascRateLast6m, SIGNAL(editingFinished()), plannerModel, SLOT(setAscratelast6m(int)));
+	connect(ui.descRate, SIGNAL(editingFinished()), plannerModel, SLOT(setDescrate(int)));
 	connect(ui.drop_stone_mode, SIGNAL(toggled(bool)), plannerModel, SLOT(setDropStoneMode(bool)));
 	connect(ui.gfhigh, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFHigh(int)));
 	connect(ui.gflow, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFLow(int)));
@@ -384,11 +384,11 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.bestmixEND, SIGNAL(valueChanged(int)), CylindersModel::instance(), SLOT(updateBestMixes()));
 
 	connect(modeMapper, SIGNAL(mapped(int)), this, SLOT(disableDecoElements(int)));
-	connect(ui.ascRate75, SIGNAL(valueChanged(int)), this, SLOT(setAscRate75(int)));
-	connect(ui.ascRate50, SIGNAL(valueChanged(int)), this, SLOT(setAscRate50(int)));
-	connect(ui.descRate, SIGNAL(valueChanged(int)), this, SLOT(setDescRate(int)));
-	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), this, SLOT(setAscRateStops(int)));
-	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), this, SLOT(setAscRateLast6m(int)));
+	connect(ui.ascRate75, SIGNAL(valueChanged(int)), this, SLOT(setAscrate75(int)));
+	connect(ui.ascRate50, SIGNAL(valueChanged(int)), this, SLOT(setAscrate50(int)));
+	connect(ui.descRate, SIGNAL(valueChanged(int)), this, SLOT(setDescrate(int)));
+	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), this, SLOT(setAscratestops(int)));
+	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), this, SLOT(setAscratelast6m(int)));
 	connect(ui.sacfactor, SIGNAL(valueChanged(double)), this, SLOT(sacFactorChanged(double)));
 	connect(ui.problemsolvingtime, SIGNAL(valueChanged(int)), this, SLOT(problemSolvingTimeChanged(int)));
 	connect(ui.bottompo2, SIGNAL(valueChanged(double)), this, SLOT(setBottomPo2(double)));
@@ -484,27 +484,27 @@ void PlannerSettingsWidget::printDecoPlan()
 {
 }
 
-void PlannerSettingsWidget::setAscRate75(int rate)
+void PlannerSettingsWidget::setAscrate75(int rate)
 {
 	SettingsObjectWrapper::instance()->planner_settings->setAscrate75(lrint(rate * UNIT_FACTOR));
 }
 
-void PlannerSettingsWidget::setAscRate50(int rate)
+void PlannerSettingsWidget::setAscrate50(int rate)
 {
 	SettingsObjectWrapper::instance()->planner_settings->setAscrate50(lrint(rate * UNIT_FACTOR));
 }
 
-void PlannerSettingsWidget::setAscRateStops(int rate)
+void PlannerSettingsWidget::setAscratestops(int rate)
 {
 	SettingsObjectWrapper::instance()->planner_settings->setAscratestops(lrint(rate * UNIT_FACTOR));
 }
 
-void PlannerSettingsWidget::setAscRateLast6m(int rate)
+void PlannerSettingsWidget::setAscratelast6m(int rate)
 {
 	SettingsObjectWrapper::instance()->planner_settings->setAscratelast6m(lrint(rate * UNIT_FACTOR));
 }
 
-void PlannerSettingsWidget::setDescRate(int rate)
+void PlannerSettingsWidget::setDescrate(int rate)
 {
 	SettingsObjectWrapper::instance()->planner_settings->setDescrate(lrint(rate * UNIT_FACTOR));
 }

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -74,11 +74,11 @@ slots:
 	void bottomSacChanged(const double bottomSac);
 	void decoSacChanged(const double decosac);
 	void printDecoPlan();
-	void setAscRate75(int rate);
-	void setAscRate50(int rate);
-	void setAscRateStops(int rate);
-	void setAscRateLast6m(int rate);
-	void setDescRate(int rate);
+	void setAscrate75(int rate);
+	void setAscrate50(int rate);
+	void setAscratestops(int rate);
+	void setAscratelast6m(int rate);
+	void setDescrate(int rate);
 	void sacFactorChanged(const double factor);
 	void problemSolvingTimeChanged(const int min);
 	void setBottomPo2(double po2);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -10,6 +10,8 @@
 #include <QApplication>
 #include <QTextDocument>
 
+#define UNIT_FACTOR ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
+
 /* TODO: Port this to CleanerTableModel to remove a bit of boilerplate and
  * use the signal warningMessage() to communicate errors to the MainWindow.
  */
@@ -491,6 +493,41 @@ void DivePlannerPointsModel::setLastStop6m(bool value)
 {
 	auto planner = SettingsObjectWrapper::instance()->planner_settings;
 	planner->setLastStop(value);
+	emitDataChanged();
+}
+
+void DivePlannerPointsModel::setAscrate75(int rate)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setAscrate75(lrint(rate * UNIT_FACTOR));
+	emitDataChanged();
+}
+
+void DivePlannerPointsModel::setAscrate50(int rate)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setAscrate50(lrint(rate * UNIT_FACTOR));
+	emitDataChanged();
+}
+
+void DivePlannerPointsModel::setAscratestops(int rate)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setAscratestops(lrint(rate * UNIT_FACTOR));
+	emitDataChanged();
+}
+
+void DivePlannerPointsModel::setAscratelast6m(int rate)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setAscratelast6m(lrint(rate * UNIT_FACTOR));
+	emitDataChanged();
+}
+
+void DivePlannerPointsModel::setDescrate(int rate)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setDescrate(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
 

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -95,6 +95,11 @@ slots:
 	void setMinSwitchDuration(int duration);
 	void setSacFactor(double factor);
 	void setProblemSolvingTime(int minutes);
+	void setAscrate75(int rate);
+	void setAscrate50(int rate);
+	void setAscratestops(int rate);
+	void setAscratelast6m(int rate);
+	void setDescrate(int rate);
 
 signals:
 	void planCreated();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Wire up the UI elements (QSpinBoxes) for ascend rates (4x) and descend rate
(1x) correctly so that the profile and calculation is updated immediately
after the value is changed (e.g. increased/decresed by 1) by clicking
the QSpinBox arrows.
Until now one had to click into the profile or change another planner
preference first before the change became effective.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
