### PR TITLE
Planner creating dive from plan: No pressure for 1st sample with new gas

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -261,7 +261,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 	int oldpo2 = 0;
 	int lasttime = 0;
 	depth_t lastdepth = {.mm = 0};
-	int lastcylid = 0;
+	int lastcylid;
 	enum dive_comp_type type = dive->dc.divemode;
 
 	if (!diveplan || !diveplan->dp)
@@ -287,15 +287,17 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 		free(ev);
 	}
 	dp = diveplan->dp;
-	cyl = &dive->cylinder[lastcylid];
+	/* Create first sample at time = 0, not based on dp because 
+	 * there is no real dp for time = 0, set first cylinder to 0
+	 * O2 setpoint for this sample will be filled later from next dp */
+	cyl = &dive->cylinder[0];
 	sample = prepare_sample(dc);
-	sample->setpoint.mbar = dp->setpoint;
 	sample->sac.mliter = prefs.bottomsac;
-	oldpo2 = dp->setpoint;
 	if (track_gas && cyl->type.workingpressure.mbar)
 		sample->pressure[0].mbar = cyl->end.mbar;
 	sample->manually_entered = true;
 	finish_sample(dc);
+	lastcylid = 0;
 	while (dp) {
 		int po2 = dp->setpoint;
 		if (dp->setpoint)

--- a/core/planner.c
+++ b/core/planner.c
@@ -330,8 +330,6 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 			sample->depth = lastdepth;
 			sample->manually_entered = dp->entered;
 			sample->sac.mliter = dp->entered ? prefs.bottomsac : prefs.decosac;
-			if (track_gas && cyl->type.workingpressure.mbar)
-				sample->pressure[0].mbar = cyl->sample_end.mbar;
 			finish_sample(dc);
 			lastcylid = dp->cylinderid;
 		}

--- a/core/planner.c
+++ b/core/planner.c
@@ -59,7 +59,7 @@ void dump_plan(struct diveplan *diveplan)
 	       diveplan->surface_pressure);
 	dp = diveplan->dp;
 	while (dp) {
-		printf("\t%3u:%02u: %dmm gas: %d o2 %d h2\n", FRACTION(dp->time, 60), dp->depth, get_o2(&dp->gasmix), get_he(&dp->gasmix));
+		printf("\t%3u:%02u: %6dmm cylid: %2d setpoint: %d\n", FRACTION(dp->time, 60), dp->depth, dp->cylinderid, dp->setpoint);
 		dp = dp->next;
 	}
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In the planner when a dive is created from the diveplan every first
sample with a new gas shouldn't have a pressure value added.
Otherwise the interpolation code for the pressure graph in the profile
will draw the pressure graph incorrectly.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This is my proposal to fix #603 
Closes #603 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@torvalds (did the first part of a fix for this: e94af2c0b7ce0dd0e61e25b717829543120c4d33)
@atdotde 