### PR TITLE
divelist: prevent a crash for missing column width

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -25,9 +25,6 @@
 #include "core/metrics.h"
 #include "core/helpers.h"
 
-//                                #  Date  Rtg Dpth  Dur  Tmp Wght Suit  Cyl  Gas  SAC  OTU  CNS  Px  Loc
-static int defaultWidth[] =    {  70, 140, 90,  50,  50,  50,  50,  70,  50,  50,  70,  50,  50,  5, 500};
-
 DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false), sortColumn(0),
 	currentOrder(Qt::DescendingOrder), dontEmitDiveChangedSignal(false), selectionSaved(false)
 {
@@ -58,7 +55,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 
 	// TODO FIXME we need this to get the header names
 	// can we find a smarter way?
-	DiveTripModel *tripModel = new DiveTripModel(this);
+	tripModel = new DiveTripModel(this);
 
 	// set the default width as a minimum between the hard-coded defaults,
 	// the header text width and the (assumed) content width, calculated
@@ -94,8 +91,8 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 		if (sw > width)
 			width = sw;
 		width += zw; // small padding
-		if (width > defaultWidth[col])
-			defaultWidth[col] = width;
+		if (width > tripModel->columnWidth(col))
+			tripModel->setColumnWidth(col, width);
 	}
 	delete tripModel;
 
@@ -114,7 +111,7 @@ DiveListView::~DiveListView()
 		if (isColumnHidden(i))
 			continue;
 		// we used to hardcode them all to 100 - so that might still be in the settings
-		if (columnWidth(i) == 100 || columnWidth(i) == defaultWidth[i])
+		if (columnWidth(i) == 100 || columnWidth(i) == tripModel->columnWidth(i))
 			settings.remove(QString("colwidth%1").arg(i));
 		else
 			settings.setValue(QString("colwidth%1").arg(i), columnWidth(i));
@@ -140,7 +137,7 @@ void DiveListView::setupUi()
 		if (width.isValid())
 			setColumnWidth(i, width.toInt());
 		else
-			setColumnWidth(i, defaultWidth[i]);
+			setColumnWidth(i, tripModel->columnWidth(i));
 	}
 	settings.endGroup();
 	if (firstRun)

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -70,6 +70,7 @@ private:
 	QModelIndex contextMenuIndex;
 	bool dontEmitDiveChangedSignal;
 	bool selectionSaved;
+	DiveTripModel *tripModel;
 
 	/* if dive_trip_t is null, there's no problem. */
 	QMultiHash<dive_trip_t *, int> selectedDives;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -6,6 +6,7 @@
 #include "core/helpers.h"
 #include "core/dive.h"
 #include <QIcon>
+#include <QDebug>
 
 static int nitrox_sort_value(struct dive *dive)
 {
@@ -407,6 +408,18 @@ DiveTripModel::DiveTripModel(QObject *parent) :
 	currentLayout(TREE)
 {
 	columns = COLUMNS;
+	// setup the default width of columns (px)
+	columnWidthMap = QVector<int>(COLUMNS);
+	// pre-fill with 50px; the rest are explicit
+	for(int i = 0; i < COLUMNS; i++)
+		columnWidthMap[i] = 50;
+	columnWidthMap[NR] = 70;
+	columnWidthMap[DATE] = 140;
+	columnWidthMap[RATING] = 90;
+	columnWidthMap[SUIT] = 70;
+	columnWidthMap[SAC] = 70;
+	columnWidthMap[PHOTOS] = 5;
+	columnWidthMap[LOCATION] = 500;
 }
 
 Qt::ItemFlags DiveTripModel::flags(const QModelIndex &index) const
@@ -604,4 +617,22 @@ bool DiveTripModel::setData(const QModelIndex &index, const QVariant &value, int
 	if (!diveItem)
 		return false;
 	return diveItem->setData(index, value, role);
+}
+
+int DiveTripModel::columnWidth(int column)
+{
+	if (column > COLUMNS - 1 || column < 0) {
+		qWarning() << "DiveTripModel::columnWidth(): not a valid column index -" << column;
+		return 50;
+	}
+	return columnWidthMap[column];
+}
+
+void DiveTripModel::setColumnWidth(int column, int width)
+{
+	if (column > COLUMNS - 1 || column < 0) {
+		qWarning() << "DiveTripModel::setColumnWidth(): not a valid column index -" << column;
+		return;
+	}
+	columnWidthMap[column] = width;
 }

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -94,10 +94,13 @@ public:
 	DiveTripModel(QObject *parent = 0);
 	Layout layout() const;
 	void setLayout(Layout layout);
+	int columnWidth(int column);
+	void setColumnWidth(int column, int width);
 
 private:
 	void setupModelData();
 	QMap<dive_trip_t *, TripItem *> trips;
+	QVector<int> columnWidthMap;
 	Layout currentLayout;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The `static int defaultWidth[]` definition in divelistview.cpp
could potentially end up missing an element which can later result
in out-of-bounds access when iterating through the list of
columns and updating their widths.

Add a couple of methods in DiveTripModel for setting and getting
the widths and use those. The default values are now pre-set in a
QVector in the DiveTripModel() constructor.

Throw warnings if out-of-bounds columns are requested.

Reported-by: Gaetan Bisson <bisson@archlinux.org>
Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) remove the width array from divelistview.cpp
2) add and use the new width related methods in DiveTripModel for safety

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
none; reported by Gaetan Bisson at first, then i've reproduced the issue myself.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
without this fix a very odd crash can happen on certain machines and not on others.
the 'col' variable in divelistview.cpp can become larger than the defaultWidth array and the out-of-bound access overwrote stack memory in such a way that the loop continues to 2000+ instead of 16 (DiveTripModel::COLUMNS).

Most importantly this makes the developer edit a single file when adding a new column in the source code.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @tcanabrava
