### PR TITLE
dive-list: maintain a single instance of DiveTripModel

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -427,7 +427,7 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 	if (oldModel) {
 		oldModel->deleteLater();
 	}
-	DiveTripModel *tripModel = new DiveTripModel(this);
+	tripModel = new DiveTripModel(this);
 	tripModel->setLayout(layout);
 
 	m->setSourceModel(tripModel);


### PR DESCRIPTION
amends:
https://github.com/Subsurface-divelog/subsurface/pull/631

```
A weird crash occurs if DiveListView creates another local
instance of DiveTripModel inside reload(). Re-use the member
variable tripModel and assign it a new instance of DiveTripModel.
```

with a missing re-use of a member variable.
i cannot explain why crashes and weird 0px width columns happen; it was only on @vesath 's end.

@dirkhh