### PR TITLE
Explicitly copy a cylinder which was marked as "unused" in the planner

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -670,7 +670,7 @@ void copy_cylinders(struct dive *s, struct dive *d, bool used_only)
 		memset(&d->cylinder[i], 0, sizeof(cylinder_t));
 	}
 	for (i = j = 0; i < MAX_CYLINDERS; i++) {
-		if (!used_only || is_cylinder_used(s, i)) {
+		if (!used_only || is_cylinder_used(s, i) || s->cylinder[i].cylinder_use == NOT_USED) {
 			d->cylinder[j].type = s->cylinder[i].type;
 			d->cylinder[j].type.description = copy_string(s->cylinder[i].type.description);
 			d->cylinder[j].gasmix = s->cylinder[i].gasmix;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When planning a new dive (not replan!!!) based on an existing (planned)
dive, the cylinders from the existing selected dive are copied.
This patch guarantees that cylinders which had been marked as "unused"
are indeed copied as well. Sounds strange at the first moment but makes
sense because if one marks a cylinder explicitly as "unused" in the
planner instead of deleting it that does mean that one wants to keep
this cylinder to have it available and be able to reenable it later-on.

Puhhh... what an explaination... if there are questions I also can show an example...

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
