### PR TITLE
divesite.c: fix double free() and small cleanup

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -314,7 +314,6 @@ void clear_dive_site(struct dive_site *ds)
 	free(ds->name);
 	free(ds->notes);
 	free(ds->description);
-	free(ds->name);
 	ds->name = 0;
 	ds->notes = 0;
 	ds->description = 0;

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -314,9 +314,9 @@ void clear_dive_site(struct dive_site *ds)
 	free(ds->name);
 	free(ds->notes);
 	free(ds->description);
-	ds->name = 0;
-	ds->notes = 0;
-	ds->description = 0;
+	ds->name = NULL;
+	ds->notes = NULL;
+	ds->description = NULL;
 	ds->latitude.udeg = 0;
 	ds->longitude.udeg = 0;
 	ds->uuid = 0;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
prevent an eventual crash when calling clear_dive_site(), due to a double free(). OS dependent, stdlib implementation dependent, undefined behaviour...

we might have caught this with static analysis.

### Changes made:
1) remove double free
2) use NULL instead of 0 for clarity

### Related issues:
none?

### Additional information:
none

### Mentions:
@dirkhh 