### PR TITLE
locationinformation: make sure to update the edited dive

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -134,10 +134,16 @@ void LocationInformationWidget::acceptChanges()
 	struct dive_site *currentDs;
 	uiString = ui.diveSiteName->text().toUtf8().data();
 
-	if (get_dive_site_by_uuid(displayed_dive_site.uuid) != NULL)
+	if (get_dive_site_by_uuid(displayed_dive_site.uuid) != NULL) {
 		currentDs = get_dive_site_by_uuid(displayed_dive_site.uuid);
-	else
-		currentDs = get_dive_site_by_uuid(create_dive_site_from_current_dive(uiString));
+	} else {
+		uint32_t new_uuid = create_dive_site_from_current_dive(uiString);
+		displayed_dive.dive_site_uuid = new_uuid;
+		struct dive *dive_in_table = get_dive_by_uniq_id(displayed_dive.id);
+		if (dive_in_table)
+			dive_in_table->dive_site_uuid = new_uuid;
+		currentDs = get_dive_site_by_uuid(new_uuid);
+	}
 
 	currentDs->latitude = displayed_dive_site.latitude;
 	currentDs->longitude = displayed_dive_site.longitude;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
If the user edits the dive site of a manually added dive, after
saving the dive site, for some reason the dive does not recieve
the dive site uuid if the user does not enter a dive site name.

more details at #633

### Changes made:
1) update displayed dive, dive in dive table with the uuid of the newly added dive site

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#633

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
i don't think this is the right fix; please have a look...
maybe there is a better fix?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@tcanabrava @dirkhh 