### PR TITLE
map-widget: don't crash if the map QML failed to load

### DIFF
--- a/mobile-widgets/qml/MapWidgetError.qml
+++ b/mobile-widgets/qml/MapWidgetError.qml
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.0
+
+Item {
+	Text {
+		anchors.fill: parent
+		horizontalAlignment: Text.AlignHCenter
+		verticalAlignment: Text.AlignVCenter
+		color: "red"
+		text: qsTr("MapWidget.qml failed to load!
+The QML modules QtPositioning and QtLocation could be missing!")
+	}
+}

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file alias="MapWidget.qml">mobile-widgets/qml/MapWidget.qml</file>
+        <file alias="MapWidgetError.qml">mobile-widgets/qml/MapWidgetError.qml</file>
         <file alias="MapWidgetContextMenu.qml">mobile-widgets/qml/MapWidgetContextMenu.qml</file>
         <file alias="mapwidget-marker">mobile-widgets/qml/icons/mapwidget-marker.png</file>
         <file alias="mapwidget-marker-selected">mobile-widgets/qml/icons/mapwidget-marker-selected.png</file>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
If the QML modules for QtLocation and QtPositioning are
missing the QML in mapwidget.cpp will fail to load,
which can lead to crashes.

To solve the issue check if the QML has loaded and set
a flag 'isReady' to true. If the loading has failed
load another QML which is for showing a red error text
in the lines of `MapWidget.qml failed to load!`.

If the map QML has failed, use a macro in all relevant
MapWidget members to turn them into a NOP. This approach
leaves the rest of the codebase intact - e.g. no checks
in classes which connect to the MapWidget class.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added a new small QML file for the purpose of showing an error message
2) made fixes in mapwidget.cpp

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #596

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @mturkia @sfuchs79 
