### PR TITLE
Remove ascent rate value changed signals and add disable keyboardTrac…

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -364,11 +364,6 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscratestops(int)));
 	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), plannerModel, SLOT(setAscratelast6m(int)));
 	connect(ui.descRate, SIGNAL(valueChanged(int)), plannerModel, SLOT(setDescrate(int)));
-	connect(ui.ascRate75, SIGNAL(editingFinished()), plannerModel, SLOT(setAscrate75(int)));
-	connect(ui.ascRate50, SIGNAL(editingFinished()), plannerModel, SLOT(setAscrate50(int)));
-	connect(ui.ascRateStops, SIGNAL(editingFinished()), plannerModel, SLOT(setAscratestops(int)));
-	connect(ui.ascRateLast6m, SIGNAL(editingFinished()), plannerModel, SLOT(setAscratelast6m(int)));
-	connect(ui.descRate, SIGNAL(editingFinished()), plannerModel, SLOT(setDescrate(int)));
 	connect(ui.drop_stone_mode, SIGNAL(toggled(bool)), plannerModel, SLOT(setDropStoneMode(bool)));
 	connect(ui.gfhigh, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFHigh(int)));
 	connect(ui.gflow, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFLow(int)));
@@ -401,6 +396,14 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.gflow->setValue(prefs.gflow);
 	ui.gfhigh->setValue(prefs.gfhigh);
 	ui.vpmb_conservatism->setValue(prefs.vpmb_conservatism);
+
+	ui.ascRate75->setKeyboardTracking(false);
+	ui.ascRate50->setKeyboardTracking(false);
+	ui.ascRateLast6m->setKeyboardTracking(false);
+	ui.ascRateStops->setKeyboardTracking(false);
+	ui.descRate->setKeyboardTracking(false);
+	ui.gfhigh->setKeyboardTracking(false);
+	ui.gflow->setKeyboardTracking(false);
 
 	setMinimumWidth(0);
 	setMinimumHeight(0);


### PR DESCRIPTION
…king

The connection wasn't working anyway since the signal comes without
value while the slot wanted a value and thus only created a runtime
warning.

Turning of keyboard tracking means that when typing the number 123 the
value change signal is not fired three times (with values 1, 12, and 123)
but is only fired upon pressing enter or the spin box losing focus.

We should add a similar setting to the depth, duration and runtime
columns of the DivePlannerPointsModel but i have no clue how to do that.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove disfunctional connections (not working because of signature mismatch).
2) setKeyboardTracking property of spin boxes to false

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->