### PR TITLE
Safeguards for Liquivision import

### DIFF
--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -278,6 +278,15 @@ static void parse_dives (int log_version, const unsigned char *buf, unsigned int
 			algorithm = *(buf + ptr++);	// 0=ZH-L16C+GF
 			sample_count = array_uint32_le(buf + ptr);
 		}
+
+		if (sample_count == 0) {
+			fprintf(stderr, "DEBUG: sample count 0 - terminating parser\n");
+			break;
+		}
+		if (ptr + sample_count * 4 + 4 > buf_size) {
+			fprintf(stderr, "DEBUG: BOF - terminating parser\n");
+			break;
+		}
 		// we aren't using the start_cns, dive_mode, and algorithm, yet
 		(void)start_cns;
 		(void)dive_mode;


### PR DESCRIPTION
I have received one sample log where after parsing a bunch of dives
properly, the sample count hits zero, and after that it is astronomical.
In case of zero, the only data we have is dive date and time of a
duplicate dive that we already parsed with proper dive profile. So
preventing a crash with this hack without properly understanding the
weird file format.

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
