### PR TITLE
Use lrint() for all degrees_t related rounding

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -171,8 +171,8 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 		gpsTracker gt;
 		gt.when = pos.timestamp().toTime_t();
 		gt.when += gettimezoneoffset(gt.when);
-		gt.latitude.udeg = (int)(pos.coordinate().latitude() * 1000000);
-		gt.longitude.udeg = (int)(pos.coordinate().longitude() * 1000000);
+		gt.latitude.udeg = lrint(pos.coordinate().latitude() * 1000000);
+		gt.longitude.udeg = lrint(pos.coordinate().longitude() * 1000000);
 		addFixToStorage(gt);
 	}
 }
@@ -626,8 +626,8 @@ void GpsLocation::downloadFromServer()
 
 				struct gpsTracker gt;
 				gt.when = timestamp.toMSecsSinceEpoch() / 1000;
-				gt.latitude.udeg = (int)(latitude.toDouble() * 1000000);
-				gt.longitude.udeg = (int)(longitude.toDouble() * 1000000);
+				gt.latitude.udeg = lrint(latitude.toDouble() * 1000000);
+				gt.longitude.udeg = lrint(longitude.toDouble() * 1000000);
 				gt.name = name;
 				// add this GPS fix to the QMap and the settings (remove existing fix at the same timestamp first)
 				if (m_trackers.keys().contains(gt.when)) {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1290,8 +1290,8 @@ extern "C" void picture_load_exif_data(struct picture *p)
 		goto picture_load_exit;
 	if (exif.parseFrom((const unsigned char *)mem.buffer, (unsigned)mem.size) != PARSE_EXIF_SUCCESS)
 		goto picture_load_exit;
-	p->longitude.udeg= llrint(1000000.0 * exif.GeoLocation.Longitude);
-	p->latitude.udeg  = llrint(1000000.0 * exif.GeoLocation.Latitude);
+	p->longitude.udeg = lrint(1000000.0 * exif.GeoLocation.Longitude);
+	p->latitude.udeg = lrint(1000000.0 * exif.GeoLocation.Latitude);
 
 picture_load_exit:
 	free(mem.buffer);

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -178,8 +178,8 @@ void LocationInformationWidget::acceptChanges()
 	if (!ui.diveSiteCoordinates->text().isEmpty()) {
 		double lat, lon;
 		parseGpsText(ui.diveSiteCoordinates->text(), &lat, &lon);
-		currentDs->latitude.udeg = (int)(lat * 1000000.0);
-		currentDs->longitude.udeg = (int)(lon * 1000000.0);
+		currentDs->latitude.udeg = lrint(lat * 1000000.0);
+		currentDs->longitude.udeg = lrint(lon * 1000000.0);
 	}
 	if (dive_site_is_empty(currentDs)) {
 		LocationInformationModel::instance()->removeRow(get_divesite_idx(currentDs));
@@ -256,8 +256,8 @@ void LocationInformationWidget::on_diveSiteCoordinates_textChanged(const QString
 	if (!same_string(qPrintable(text), coords)) {
 		double latitude, longitude;
 		if (parseGpsText(text, &latitude, &longitude)) {
-			displayed_dive_site.latitude.udeg = (int)(latitude * 1000000);
-			displayed_dive_site.longitude.udeg = (int)(longitude * 1000000);
+			displayed_dive_site.latitude.udeg = lrint(latitude * 1000000);
+			displayed_dive_site.longitude.udeg = lrint(longitude * 1000000);
 			markChangedWidget(ui.diveSiteCoordinates);
 			emit coordinatesChanged();
 			ui.geoCodeButton->setEnabled(latitude != 0 && longitude != 0);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -653,12 +653,12 @@ void QMLManager::refreshDiveList()
 static void setupDivesite(struct dive *d, struct dive_site *ds, double lat, double lon, const char *locationtext)
 {
 	if (ds) {
-		ds->latitude.udeg = (int) (lat * 1000000);
-		ds->longitude.udeg = (int) (lon * 1000000);
+		ds->latitude.udeg = lrint(lat * 1000000);
+		ds->longitude.udeg = lrint(lon * 1000000);
 	} else {
 		degrees_t latData, lonData;
-		latData.udeg = (int) lat;
-		lonData.udeg = (int) lon;
+		latData.udeg = lrint(lat);
+		lonData.udeg = lrint(lon);
 		d->dive_site_uuid = create_dive_site_with_gps(locationtext, latData, lonData, d->when);
 	}
 }

--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -201,8 +201,8 @@ void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool form
 	bool savep = prefs.coordinates_traditional;
 	prefs.coordinates_traditional = formatTraditional;
 
-	const int lat = llrint(1000000.0 * coord.latitude());
-	const int lon = llrint(1000000.0 * coord.longitude());
+	const int lat = lrint(1000000.0 * coord.latitude());
+	const int lon = lrint(1000000.0 * coord.longitude());
 	const char *coordinates = printGPSCoords(lat, lon);
 	QApplication::clipboard()->setText(QString(coordinates), QClipboard::Clipboard);
 
@@ -215,8 +215,8 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinates(quint32 uuid, QGeoCoordin
 	MapLocation *loc = m_mapLocationModel->getMapLocationForUuid(uuid);
 	if (loc)
 		loc->setCoordinate(coord);
-	displayed_dive_site.latitude.udeg = llrint(coord.latitude() * 1000000.0);
-	displayed_dive_site.longitude.udeg = llrint(coord.longitude() * 1000000.0);
+	displayed_dive_site.latitude.udeg = lrint(coord.latitude() * 1000000.0);
+	displayed_dive_site.longitude.udeg = lrint(coord.longitude() * 1000000.0);
 	emit coordinatesChanged();
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In certain places the `(int)` cast is used, while in other the
llrint() or lrint() functions. Make the conversation from degrees
in the `double` form to the `int` degrees_t consistent using lrint().

lrint() is the function which should give the best results,
because it accepts a `double` and results in a `long`
even if degrees_t is `int`. If the truncation from `long` to `int`
is discarding some of the precision then the next step
would be to turn degrees_t into a 64bit signed integer type.

### Changes made:
1) use `lrint()` in all location when converting to `degrees_t` from `double`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
possible fix for #625.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
they were some concerns before that rounding like this might break existing GPS, but i really think this is harmless. please, have a look.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @sfuchs79 
