### PR TITLE
VPM-B profile: calculate parameters when in planner mode

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -998,7 +998,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 				entry->ceiling = (entry - 1)->ceiling;
 			} else {
 				/* Keep updating the VPM-B gradients until the start of the ascent phase of the dive. */
-				if (decoMode() == VPMB && !in_planner() && last_ceiling >= first_ceiling && first_iteration == true) {
+				if (decoMode() == VPMB && last_ceiling >= first_ceiling && first_iteration == true) {
 					nuclear_regeneration(t1);
 					vpmb_start_gradient();
 					/* For CVA calculations, start by guessing deco time = dive time remaining */
@@ -1012,7 +1012,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 					current_ceiling = entry->ceiling;
 				last_ceiling = current_ceiling;
 				/* If using VPM-B outside the planner, take first_ceiling_pressure as the deepest ceiling */
-				if (decoMode() == VPMB && !in_planner()) {
+				if (decoMode() == VPMB) {
 					if  (current_ceiling > first_ceiling) {
 						time_deep_ceiling = t1;
 						first_ceiling = current_ceiling;


### PR DESCRIPTION
Calculating parameters when in the planner mode is necessary to display the correct ceiling.

Fixes #601

Signed-off-by: Rick Walsh <rickmwalsh@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
