### PR TITLE
 mobile: do not clear email and passwd when cancelling

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -334,7 +334,6 @@ void QMLManager::saveCloudCredentials()
 			return;
 		}
 	}
-	setOldStatus(credentialStatus());
 	s.beginGroup("CloudStorage");
 	s.setValue("email", cloudUser);
 	s.setValue("password", cloudPwd);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -228,16 +228,18 @@ void QMLManager::cancelCredentialsPinSetup()
 	 * The user selected <cancel> on the final stage of the
 	 * cloud account generation (entering the emailed PIN).
 	 *
-	 * For now, just reset all the cloud data. This brings the app
-	 * back to its initial state, and the user can startover again.
+	 * Resets the cloud credential status to CS_UNKNOWN, resulting
+	 * in a return to the first crededentials page, with the
+	 * email and passwd still filled in. In case of a cancel
+	 * of registration (from the PIN page), the email address
+	 * was probably misspelled, so the user never received a PIN to
+	 * complete the process.
 	 *
-	 * Notice that this function is also used to switch to NOCLOUD
-	 * mode. So the name is not perfect.
+	 * Notice that this function is also used to switch to a different
+	 * cloud account, so the name is not perfect.
 	 */
 	QSettings s;
 
-	setCloudUserName(NULL);
-	setCloudPassword(NULL);
 	setCredentialStatus(CS_UNKNOWN);
 	s.beginGroup("CloudStorage");
 	s.setValue("email", cloudUserName());


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
 mobile: do not clear email and passwd when cancelling

Commit cf8e875 implemented a way to cancel pin setup, and this also has effects on an exit from the app after pressing the android exit. The change button started with clearing the email and passwd in order to get the credentail page(s) active again. While this worked ok, it confuses users that exit the app from the credential pages, resulting in the need to enter the credentials again after a restart. It appears that clearing
the credential state is sufficient to get the pages active.

Notice that the android exit is still not working (it seems a no-op), but the interaction with the buttons in the app
preserves the email/passwd.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commits.

### Related issues:
email on mailing list.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
