### PR TITLE
Fix crash when text empty

### DIFF
--- a/core/membuffer.c
+++ b/core/membuffer.c
@@ -213,7 +213,7 @@ void put_quoted(struct membuffer *b, const char *text, int is_attribute, int is_
 {
 	const char *p = text;
 
-	for (;;) {
+	for (;text;) {
 		const char *escape;
 
 		switch (*p++) {


### PR DESCRIPTION
Exporting to divelogs.de triggered this bug when divesite name is empty.

Fixes #656

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
