### PR TITLE
Hide outdated gas name strings in profile in planner

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1756,6 +1756,9 @@ void ProfileWidget2::pointsRemoved(const QModelIndex &, int start, int end)
 void ProfileWidget2::repositionDiveHandlers()
 {
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
+	#define HIDE_ALL(TYPE, CONTAINER) \
+		Q_FOREACH (TYPE *item, CONTAINER) item->setVisible(false);
+	HIDE_ALL(QGraphicsSimpleTextItem, gases);
 	// Re-position the user generated dive handlers
 	for (int i = 0; i < plannerModel->rowCount(); i++) {
 		struct divedatapoint datapoint = plannerModel->at(i);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When deleting dive planner points in the planner we currently sometimes
miss to hide the outdated gas name strings printed close to the profile
legs for manually entered legs.

See picture from 4.6.4 - please compare what is printed to the leg with what the tankbar is saying (the tankbar is correct!):
![grafik](https://user-images.githubusercontent.com/25316050/31320290-a4afb00c-ac72-11e7-997e-587c0df7d124.png)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
