### PR TITLE
Planner - Improve cylinder handling

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1858,7 +1858,7 @@ static int sort_event(struct event *a, struct event *b)
 static int same_gas(struct event *a, struct event *b)
 {
 	if (a->type == b->type && a->flags == b->flags && a->value == b->value && !strcmp(a->name, b->name) &&
-			a->gas.mix.o2.permille == b->gas.mix.o2.permille && a->gas.mix.he.permille == b->gas.mix.he.permille) {
+			same_gasmix(&a->gas.mix, &b->gas.mix)) {
 		return true;
 	}
 	return false;
@@ -2076,6 +2076,19 @@ int same_gasmix(struct gasmix *a, struct gasmix *b)
 	if (gasmix_is_air(a) && gasmix_is_air(b))
 		return 1;
 	return a->o2.permille == b->o2.permille && a->he.permille == b->he.permille;
+}
+
+int same_gasmix_cylinder(cylinder_t *cyl, int cylid, struct dive *dive, bool check_unused)
+{
+	struct gasmix *mygas = &cyl->gasmix;
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		if (i == cylid || cylinder_none(&dive->cylinder[i]))
+			continue;
+		struct gasmix *gas2 = &dive->cylinder[i].gasmix;
+		if (gasmix_distance(mygas, gas2) == 0 && (is_cylinder_used(dive, i) || check_unused))
+			return i;
+	}
+	return -1;
 }
 
 static int pdiff(pressure_t a, pressure_t b)

--- a/core/dive.c
+++ b/core/dive.c
@@ -2023,7 +2023,7 @@ static void add_initial_gaschange(struct dive *dive, struct divecomputer *dc)
 	add_gas_switch_event(dive, dc, 0, 0);
 }
 
-void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int mapping[])
+static void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int mapping[])
 {
 	int i;
 	struct event *ev;
@@ -2064,7 +2064,7 @@ void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int mappin
  * Also note that we assume that the initial cylinder is cylinder 0,
  * so if that got renamed, we need to create a fake gas change event
  */
-static void cylinder_renumber(struct dive *dive, int mapping[])
+void cylinder_renumber(struct dive *dive, int mapping[])
 {
 	struct divecomputer *dc;
 	for_each_dc (dive, dc)

--- a/core/dive.h
+++ b/core/dive.h
@@ -367,7 +367,7 @@ static inline bool dive_cache_is_valid(const struct dive *dive)
 }
 
 extern int get_cylinder_idx_by_use(struct dive *dive, enum cylinderuse cylinder_use_type);
-extern void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int mapping[]);
+extern void cylinder_renumber(struct dive *dive, int mapping[]);
 extern int same_gasmix_cylinder(cylinder_t *cyl, int cylid, struct dive *dive, bool check_unused);
 
 /* when selectively copying dive information, which parts should be copied? */

--- a/core/dive.h
+++ b/core/dive.h
@@ -368,6 +368,7 @@ static inline bool dive_cache_is_valid(const struct dive *dive)
 
 extern int get_cylinder_idx_by_use(struct dive *dive, enum cylinderuse cylinder_use_type);
 extern void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int mapping[]);
+extern int same_gasmix_cylinder(cylinder_t *cyl, int cylid, struct dive *dive, bool check_unused);
 
 /* when selectively copying dive information, which parts should be copied? */
 struct dive_components {

--- a/core/planner.c
+++ b/core/planner.c
@@ -867,7 +867,13 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			deco_state->first_ceiling_pressure.mbar = deco_state->max_bottom_ceiling_pressure.mbar;
 
 		last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
-		if ((current_cylinder = get_gasidx(dive, &gas)) == -1) {
+		/* Always prefer the best_first_ascend_cylinder if it has the right gasmix.
+		 * Otherwise take first cylinder from list with rightgasmix  */
+		if (same_gasmix(&gas, &dive->cylinder[best_first_ascend_cylinder].gasmix))
+			current_cylinder = best_first_ascend_cylinder;
+		else
+			current_cylinder = get_gasidx(dive, &gas);
+		if (current_cylinder == -1) {
 			report_error(translate("gettextFromC", "Can't find gas %s"), gasname(&gas));
 			current_cylinder = 0;
 		}

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -76,7 +76,7 @@ void DiveHandler::changeGas()
 {
 	QAction *action = qobject_cast<QAction *>(sender());
 	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
-	plannerModel->gaschange(index.sibling(index.row() + 1, index.column()), action->data().toInt());
+	plannerModel->gasChange(index.sibling(index.row() + 1, index.column()), action->data().toInt());
 }
 
 void DiveHandler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -581,6 +581,27 @@ void CylindersModel::remove(const QModelIndex &index)
 	dataChanged(index, index);
 }
 
+void CylindersModel::moveAtFirst(int cylid)
+{
+	int mapping[MAX_CYLINDERS];
+	cylinder_t temp_cyl;
+
+	beginMoveRows(QModelIndex(), cylid, cylid, QModelIndex(), 0);
+	memmove(&temp_cyl, &displayed_dive.cylinder[cylid], sizeof(temp_cyl));
+	for (int i = cylid - 1; i >= 0; i--) {
+		memmove(&displayed_dive.cylinder[i + 1], &displayed_dive.cylinder[i], sizeof(temp_cyl));
+		mapping[i] = i + 1;
+	}
+	memmove(&displayed_dive.cylinder[0], &temp_cyl, sizeof(temp_cyl));
+	mapping[cylid] = 0;
+	for (int i = cylid + 1; i < MAX_CYLINDERS; i++)
+		mapping[i] = i;
+	changed = true;
+	endMoveRows();
+	cylinder_renumber(&displayed_dive, mapping);
+	DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
+}
+
 void CylindersModel::updateDecoDepths(pressure_t olddecopo2)
 {
 	pressure_t decopo2;

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -242,7 +242,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 				if (gasmix_distance(mygas, gas2) == 0 && is_cylinder_used(&displayed_dive, i))
 					same_gas = i;
 			}
-			if (same_gas == -1 &&
+			if ((in_planner() || same_gas == -1) &&
 				((DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING &&
 				DivePlannerPointsModel::instance()->tankInUse(index.row())) ||
 				(DivePlannerPointsModel::instance()->currentMode() == DivePlannerPointsModel::NOTHING &&
@@ -265,7 +265,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 				if (gasmix_distance(mygas, gas2) == 0 && is_cylinder_used(&displayed_dive, i))
 					same_gas = i;
 			}
-			if (same_gas == -1 &&
+			if ((in_planner() || same_gas == -1) &&
 				((DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING &&
 				DivePlannerPointsModel::instance()->tankInUse(index.row())) ||
 				(DivePlannerPointsModel::instance()->currentMode() == DivePlannerPointsModel::NOTHING &&
@@ -569,7 +569,7 @@ void CylindersModel::remove(const QModelIndex &index)
 		if (gasmix_distance(mygas, gas2) == 0 && is_cylinder_used(&displayed_dive, i))
 			same_gas = i;
 	}
-	if (same_gas == -1 &&
+	if ((in_planner() || same_gas == -1) &&
 			((DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING &&
 				DivePlannerPointsModel::instance()->tankInUse(index.row())) ||
 			(DivePlannerPointsModel::instance()->currentMode() == DivePlannerPointsModel::NOTHING &&

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -576,11 +576,8 @@ void CylindersModel::remove(const QModelIndex &index)
 	}
 	changed = true;
 	endRemoveRows();
-	struct divecomputer *dc = &displayed_dive.dc;
-	while (dc) {
-		dc_cylinder_renumber(&displayed_dive, dc, mapping);
-		dc = dc->next;
-	}
+	cylinder_renumber(&displayed_dive, mapping);
+	DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
 	dataChanged(index, index);
 }
 

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -40,6 +40,7 @@ public:
 	void copyFromDive(struct dive *d);
 	void updateDecoDepths(pressure_t olddecopo2);
 	void updateTrashIcon();
+	void moveAtFirst(int cylid);
 	cylinder_t *cylinderAt(const QModelIndex &index);
 	bool changed;
 	virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -348,7 +348,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 	return QAbstractItemModel::setData(index, value, role);
 }
 
-void DivePlannerPointsModel::gaschange(const QModelIndex &index, int newcylinderid)
+void DivePlannerPointsModel::gasChange(const QModelIndex &index, int newcylinderid)
 {
 	int i = index.row(), oldcylinderid = divepoints[i].cylinderid;
 	while (i < rowCount() && oldcylinderid == divepoints[i].cylinderid)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -337,6 +337,9 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 		case GAS:
 			if (value.toInt() >= 0 && value.toInt() < MAX_CYLINDERS)
 				p.cylinderid = value.toInt();
+				/* Did we change the start (dp 0) cylinder to another cylinderid than 0? */
+				if (value.toInt() != 0 && index.row() == 0)
+					CylindersModel::instance()->moveAtFirst(value.toInt());
 			CylindersModel::instance()->updateTrashIcon();
 			break;
 		}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -353,6 +353,13 @@ void DivePlannerPointsModel::gaschange(const QModelIndex &index, int newcylinder
 	emitDataChanged();
 }
 
+void DivePlannerPointsModel::cylinderRenumber(int mapping[])
+{
+	for (int i = 0; i < rowCount(); i++)
+		divepoints[i].cylinderid = mapping[divepoints[i].cylinderid];
+	emitDataChanged();
+}
+
 QVariant DivePlannerPointsModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
 	if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -181,7 +181,14 @@ QStringList &DivePlannerPointsModel::getGasList()
 		cylinder_t *cyl = &displayed_dive.cylinder[i];
 		if (cylinder_nodata(cyl))
 			break;
-		list.push_back(get_gas_string(cyl->gasmix));
+		/* Check if we have the same gasmix two or more times
+		 * If yes return more verbose string */
+		int same_gas = same_gasmix_cylinder(cyl, i, &displayed_dive, true);
+		if (same_gas == -1)
+			list.push_back(get_gas_string(cyl->gasmix));
+		else
+			list.push_back(get_gas_string(cyl->gasmix) + QString(" (%1 %2 ").arg(tr("cyl.")).arg(i + 1) +
+				cyl->type.description + ")");
 	}
 	return list;
 }
@@ -258,7 +265,15 @@ QVariant DivePlannerPointsModel::data(const QModelIndex &index, int role) const
 			else
 				return p.time / 60;
 		case GAS:
-			return get_gas_string(displayed_dive.cylinder[p.cylinderid].gasmix);
+			/* Check if we have the same gasmix two or more times
+			 * If yes return more verbose string */
+			int same_gas = same_gasmix_cylinder(&displayed_dive.cylinder[p.cylinderid], p.cylinderid, &displayed_dive, true);
+			if (same_gas == -1)
+				return get_gas_string(displayed_dive.cylinder[p.cylinderid].gasmix);
+			else
+				return get_gas_string(displayed_dive.cylinder[p.cylinderid].gasmix) +
+					QString(" (%1 %2 ").arg(tr("cyl.")).arg(p.cylinderid + 1) +
+						displayed_dive.cylinder[p.cylinderid].type.description + ")";
 		}
 	} else if (role == Qt::DecorationRole) {
 		switch (index.column()) {

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -32,6 +32,7 @@ public:
 	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	void gaschange(const QModelIndex &index, int newcylinderid);
+	void cylinderRenumber(int mapping[]);
 	void removeSelectedPoints(const QVector<int> &rows);
 	void setPlanMode(Mode mode);
 	bool isPlanner();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -31,7 +31,7 @@ public:
 	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-	void gaschange(const QModelIndex &index, int newcylinderid);
+	void gasChange(const QModelIndex &index, int newcylinderid);
 	void cylinderRenumber(int mapping[]);
 	void removeSelectedPoints(const QVector<int> &rows);
 	void setPlanMode(Mode mode);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Enhanced a few things around the cylinder handling in the planner.
Some items are more bug fixes:
- Update the dive planner points correctly when a cylinder is deleted
- Be more restrictive when removing cylinders in planner

Some items are new features:
- More verbose gas names when one has multiple gases with same mix
- Make the cylinder selected for the first planner datapoint automatically the first cylinder
- Prefer the last used bottom gas cylinder for first part of ascend and for gas breaks

Well, this needs really some testing mainly by people who plan more advanced dives because the changes could possibly break s.th. for them or are simply inconvenient. Please let me know about any issues!

While doing this work I found two items which I wasn't able to fix immediately so I filed an issue for them:
#662 
#661 


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
