### PR TITLE
mobile: enable switching BT on/off during session

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -60,6 +60,12 @@ BTDiscovery::BTDiscovery(QObject *parent)
 	}
 	m_instance = this;
 #if defined(BT_SUPPORT)
+	BTDiscoveryReDiscover();
+#endif
+}
+
+void BTDiscovery::BTDiscoveryReDiscover()
+{
 #if !defined(Q_OS_IOS)
 	if (localBtDevice.isValid() &&
 	    localBtDevice.hostMode() == QBluetoothLocalDevice::HostConnectable) {
@@ -99,7 +105,6 @@ BTDiscovery::BTDiscovery(QObject *parent)
 		qDebug() << "localBtDevice isn't valid";
 		m_btValid = false;
 	}
-#endif
 #endif
 }
 

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -46,6 +46,8 @@ public:
 	void getBluetoothDevices();
 #endif
 	QList<btVendorProduct> getBtDcs();
+	QBluetoothLocalDevice localBtDevice;
+	void BTDiscoveryReDiscover();
 
 private:
 	static BTDiscovery *m_instance;
@@ -59,7 +61,6 @@ private:
 #endif
 
 	QList<struct btPairedDevice> btPairedDevices;
-	QBluetoothLocalDevice localBtDevice;
 	QBluetoothDeviceDiscoveryAgent *discoveryAgent;
 
 signals:

--- a/core/connectionlistmodel.cpp
+++ b/core/connectionlistmodel.cpp
@@ -42,3 +42,10 @@ void ConnectionListModel::addAddress(const QString address)
 	m_addresses.append(address);
 	endInsertRows();
 }
+
+void ConnectionListModel::removeAllAddresses()
+{
+	beginRemoveRows(QModelIndex(), 0, rowCount());
+	m_addresses.clear();
+	endRemoveRows();
+}

--- a/core/connectionlistmodel.h
+++ b/core/connectionlistmodel.h
@@ -15,6 +15,7 @@ public:
 	QString address(int idx) const;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	void addAddress(const QString address);
+	void removeAllAddresses();
 private:
 	QStringList m_addresses;
 };

--- a/core/qt-gui.h
+++ b/core/qt-gui.h
@@ -7,6 +7,7 @@ void init_ui();
 
 void run_ui();
 void exit_ui();
+void set_non_bt_addresses();
 
 #if defined(SUBSURFACE_MOBILE)
 #include <QQuickWindow>

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -17,8 +17,8 @@ Kirigami.Page {
 
 	property alias dcImportModel: importModel
 	property bool divesDownloaded: false
-	property bool btEnabled: manager.btEnabled()
-	property string btMessage: manager.btEnabled() ? "" : qsTr("Bluetooth is not enabled")
+	property bool btEnabled: manager.btEnabled
+	property string btMessage: manager.btEnabled ? "" : qsTr("Bluetooth is not enabled")
 
 	DCDownloadThread {
 		id: downloadThread

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -45,6 +45,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QString progressMessage READ progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
 	Q_PROPERTY(bool libdcLog READ libdcLog WRITE setLibdcLog NOTIFY libdcLogChanged)
 	Q_PROPERTY(bool developer READ developer WRITE setDeveloper NOTIFY developerChanged)
+	Q_PROPERTY(bool btEnabled READ btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
 
 public:
 	QMLManager();
@@ -124,6 +125,9 @@ public:
 	bool developer() const;
 	void setDeveloper(bool value);
 
+	bool btEnabled() const;
+	void setBtEnabled(bool value);
+
 	typedef void (QMLManager::*execute_function_type)();
 	DiveListSortModel *dlSortModel;
 
@@ -134,7 +138,7 @@ public:
 	bool showPin() const;
 	void setShowPin(bool enable);
 	Q_INVOKABLE void setStatusbarColor(QColor color);
-	Q_INVOKABLE bool btEnabled() const;
+	void btHostModeChange(QBluetoothLocalDevice::HostMode state);
 
 #if defined(Q_OS_ANDROID)
 	void writeToAppLogFile(QString logText);
@@ -258,6 +262,7 @@ signals:
 	void progressMessageChanged();
 	void libdcLogChanged();
 	void developerChanged();
+	void btEnabledChanged();
 };
 
 #endif

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -30,6 +30,19 @@
 
 QObject *qqWindowObject = NULL;
 
+void set_non_bt_addresses() {
+#if defined(Q_OS_ANDROID)
+	connectionListModel.addAddress("FTDI");
+#elif defined(Q_OS_LINUX) // since this is in the else, it does NOT include Android
+	connectionListModel.addAddress("/dev/ttyS0");
+	connectionListModel.addAddress("/dev/ttyS1");
+	connectionListModel.addAddress("/dev/ttyS2");
+	connectionListModel.addAddress("/dev/ttyS3");
+	// this makes debugging so much easier - use the simulator
+	connectionListModel.addAddress("/tmp/ttyS1");
+#endif
+}
+
 void init_ui()
 {
 	init_qt_late();
@@ -76,16 +89,8 @@ void run_ui()
 	ctxt->setContextProperty("diveModel", sortModel);
 	ctxt->setContextProperty("gpsModel", gpsSortModel);
 	ctxt->setContextProperty("vendorList", vendorList);
-#if defined(Q_OS_ANDROID)
-	connectionListModel.addAddress("FTDI");
-#elif defined(Q_OS_LINUX) // since this is in the else, it does NOT include Android
-	connectionListModel.addAddress("/dev/ttyS0");
-	connectionListModel.addAddress("/dev/ttyS1");
-	connectionListModel.addAddress("/dev/ttyS2");
-	connectionListModel.addAddress("/dev/ttyS3");
-	// this makes debugging so much easier - use the simulator
-	connectionListModel.addAddress("/tmp/ttyS1");
-#endif
+	set_non_bt_addresses();
+
 	ctxt->setContextProperty("connectionListModel", &connectionListModel);
 	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

This PR implements possible switching BT on and off during a session, so not needing a restart of the app when the user forgot to switch it on when starting the app.

For this, the following needed to be done: 1) create a handler that reacts on local BT device status changes. 2) repopulate the connection list in the download screen when a BT status change is detected.

Notice the subtile change of the Q_INVOKABLE btEnabled() function to a Q_PROPERTY. This gives a nice dynamic behavior when switching BT on/off with the app open.

### Changes made:
See individual commits

### Related issues:
Fixes: #556

### Additional information:
Tested on mobile-on-deskop and Android device. Supposed to work for ios too, but untested for that,

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
