### PR TITLE
Mobile credendentials improvement nr 3

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -148,6 +148,7 @@ Item {
 					manager.syncToCloud = false
 					manager.credentialStatus = QMLManager.CS_NOCLOUD
 					manager.saveCloudCredentials()
+					manager.openNoCloudRepo()
 				}
 			}
 		}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -197,9 +197,18 @@ void QMLManager::openLocalThenRemote(QString url)
 	if (error) {
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
 		setNotificationText(tr("Opening local data file failed"));
-		// have cloud credentials, but there is no local repo (yet).
-		// this implies that the PIN verify is still to be done
-		setCredentialStatus(CS_NEED_TO_VERIFY);
+		/* there can be 2 reasons for this:
+		 * 1) we have cloud credentials, but there is no local repo (yet).
+		 *    This implies that the PIN verify is still to be done.
+		 * 2) we are in a very clean state after installing the app, and
+		 *    want to use a NO CLOUD setup. The intial repo has no initial
+		 *    commit in it, so its master branch does not yet exist. We do not
+		 *    care about this, as the very first commit of dive data to the
+		 *    no cloud repo solves this.
+		 */
+
+		if (credentialStatus() != CS_NOCLOUD)
+			setCredentialStatus(CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
 		if (credentialStatus() == CS_UNKNOWN)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -163,6 +163,7 @@ public slots:
 			   QString diveMaster, QString weight, QString notes, QString startpressure,
 			   QString endpressure, QString gasmix, QString cylinder, int rating, int visibility);
 	void changesNeedSaving();
+	void openNoCloudRepo();
 	void saveChangesLocal();
 	void saveChangesCloud(bool forceRemoteSync);
 	void deleteDive(int id);
@@ -175,6 +176,7 @@ public slots:
 	void populateGpsData();
 	void cancelDownloadDC();
 	void clearGpsData();
+	void clearCredentials();
 	void cancelCredentialsPinSetup();
 	void finishSetup();
 	void openLocalThenRemote(QString url);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
mobile: No cloud repo creation more explicit

Before this change, there was only one way to create the local no cloud repo on the device. The user needed to add at least one dive to the no cloud account (so that there is something to save). While this worked in some scenarios, it could also get things in an inconsistent state: credential status = CS_NOCLOUD but no local repo. This was a dead end.

In this commit, the creation of the no cloud repo is made more explicit. When asking for no cloud mode, just create an (empty) repo for it when it does not yet exist, and otherwise, just open the existing (possibly empty) repo.

Now, a user can have no cloud repo, next to (any number of) cloud accounts. And it is possible to switch between the no cloud account and any true cloud account as if it were unrelated repos.

### Changes made:
See individual commit messages.

### Related issues:
Fixes: #667

### Additional information:
This leaves one functional aspect left: how does a user abandon the no cloud repo, by merging his data into a true cloud account. There is code for this, that tries to do this merge in a smart way. This seems to be broken (too). To be clear: this is no part of this commit.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
