### PR TITLE
mobile: silence deprecated messages in logging about Kirigami.Label

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
@@ -51,14 +51,14 @@ Item {
 			Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Email")
 			visible: !rootItem.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
 
-		TextField {
+		Controls.TextField {
 			id: login
 			text: manager.cloudUserName
 			visible: !rootItem.showPin
@@ -67,14 +67,14 @@ Item {
 					  Qt.ImhNoAutoUppercase
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Password")
 			visible: !rootItem.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
 
-		TextField {
+		Controls.TextField {
 			id: password
 			text: manager.cloudPassword
 			visible: !rootItem.showPin
@@ -85,11 +85,11 @@ Item {
 			Layout.fillWidth: true
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("PIN")
 			visible: rootItem.showPin
 		}
-		TextField {
+		Controls.TextField {
 			id: pin
 			text: ""
 			Layout.fillWidth: true
@@ -109,7 +109,7 @@ Item {
 					saveCredentials()
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: ""  // Spacer between 2 button groups
 				Layout.fillWidth: true
 			}
@@ -137,7 +137,7 @@ Item {
 					saveCredentials()
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: ""  // Spacer between 2 button groups
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import org.subsurfacedivelog.mobile 1.0
@@ -88,24 +88,24 @@ Item {
 				Layout.columnSpan: 2
 				text: qsTr("Dive %1").arg(number)
 			}
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Date:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtDate;
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Location:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtLocation;
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -113,12 +113,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Coordinates:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtGps
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -126,7 +126,7 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Use current\nGPS location:")
 				visible: manager.locationServiceAvailable
@@ -141,12 +141,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Depth:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtDepth
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /[^-]*/ }
@@ -154,12 +154,12 @@ Item {
 					focus = false
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Duration:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtDuration
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /[^-]*/ }
@@ -168,12 +168,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Air Temp:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtAirTemp
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -181,12 +181,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Water Temp:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtWaterTemp
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -194,7 +194,7 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Suit:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -207,7 +207,7 @@ Item {
 				Layout.fillWidth: true
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Buddy:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -220,7 +220,7 @@ Item {
 				Layout.fillWidth: true
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Divemaster:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -233,12 +233,12 @@ Item {
 				Layout.fillWidth: true
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Weight:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtWeight
 				readOnly: text === "cannot edit multiple weight systems"
 				Layout.fillWidth: true
@@ -247,7 +247,7 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Cylinder:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -260,12 +260,12 @@ Item {
 				Layout.fillWidth: true
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Gas mix:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtGasMix
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
@@ -274,12 +274,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Start Pressure:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtStartPressure
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -287,12 +287,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("End Pressure:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextField {
+			Controls.TextField {
 				id: txtEndPressure
 				Layout.fillWidth: true
 				onEditingFinished: {
@@ -300,12 +300,12 @@ Item {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Rating:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			SpinBox {
+			Controls.SpinBox {
 				id: ratingPicker
 				from: 0
 				to: 5
@@ -313,12 +313,12 @@ Item {
 				onValueChanged: rating = value
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Visibility:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			SpinBox {
+			Controls.SpinBox {
 				id: visibilityPicker
 				from: 0
 				to: 5
@@ -326,13 +326,13 @@ Item {
 				onValueChanged: visibility = value
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				Layout.columnSpan: 2
 				Layout.alignment: Qt.AlignLeft
 				text: qsTr("Notes:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			TextArea {
+			Controls.TextArea {
 				Layout.columnSpan: 2
 				width: parent.width
 				id: txtNotes

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -5,6 +5,7 @@ import QtWebView 1.0
 */
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 2.0 as Controls
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.0 as Kirigami
 
@@ -33,7 +34,7 @@ Item {
 		width: parent.width - Kirigami.Units.gridUnit
 		height: childrenRect.height - Kirigami.Units.smallSpacing
 		anchors.left: parent.left
-		Kirigami.Label {
+		Controls.Label {
 			id: locationText
 			text: dive.location
 			font.weight: Font.Bold
@@ -73,21 +74,21 @@ Item {
 				bottom: numberText.bottom
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: dive.date + " " + dive.time
 				width: Math.max(locationText.width * 0.45, paintedWidth)
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
 			// let's try to show the depth / duration very compact
-			Kirigami.Label {
+			Controls.Label {
 				text: dive.depth + ' / ' + dive.duration
 				width: Math.max(Kirigami.Units.gridUnit * 3, paintedWidth)
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: numberText
 			text: "#" + dive.number
 			font.pointSize: subsurfaceTheme.smallPointSize
@@ -102,7 +103,7 @@ Item {
 				left: dateRow.left
 				top: numberText.bottom
 			}
-			Kirigami.Label {
+			Controls.Label {
 				id: ratingText
 				text: qsTr("Rating:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -144,7 +145,7 @@ Item {
 				right: numberText.right
 				top: numberText.bottom
 			}
-			Kirigami.Label {
+			Controls.Label {
 				id: visibilityText
 				text: qsTr("Visibility:")
 				font.pointSize: subsurfaceTheme.smallPointSize
@@ -212,7 +213,7 @@ Item {
 				anchors.fill: parent
 			}
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: noProfile
 			visible: dive.noDive
 			Layout.fillWidth: true
@@ -224,19 +225,19 @@ Item {
 
 		// first row
 		//-----------
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Suit:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Air Temp:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Water Temp:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -245,19 +246,19 @@ Item {
 
 		// second row
 		//------------
-		Kirigami.Label {
+		Controls.Label {
 			id: txtSuit
 			text: dive.suit
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: txtAirTemp
 			text: dive.airTemp
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: txtWaterTemp
 			text: dive.waterTemp
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -274,21 +275,21 @@ Item {
 
 		// thrid row
 		//------------
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Cylinder:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			Layout.bottomMargin: 0
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Weight:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 			Layout.bottomMargin: 0
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("SAC:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -298,19 +299,19 @@ Item {
 
 		// fourth row
 		//------------
-		Kirigami.Label {
+		Controls.Label {
 			id: txtCylinder
 			text: dive.getCylinder
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: txtWeight
 			text: dive.sumWeight
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: txtSAC
 			text: dive.sac
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -327,14 +328,14 @@ Item {
 
 		// fifth row
 		//-----------
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Divemaster:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			Layout.bottomMargin: 0
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: qsTr("Buddy:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -345,13 +346,13 @@ Item {
 
 		// sixth row
 		//-----------
-		Kirigami.Label {
+		Controls.Label {
 			id: txtDiveMaster
 			text: dive.divemaster
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: txtBuddy
 			text: dive.buddy
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -368,7 +369,7 @@ Item {
 		}
 
 
-		Kirigami.Label {
+		Controls.Label {
 			Layout.fillWidth: true
 			opacity: 0.6
 			text: qsTr("Notes")
@@ -376,7 +377,7 @@ Item {
 			Layout.columnSpan: 3
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			id: txtNotes
 			text: dive.notes
 			focus: true

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
@@ -88,7 +88,7 @@ Kirigami.ScrollablePage {
 					width: parent.width - Kirigami.Units.gridUnit * (innerListItem.deleteButtonVisible ? 3 : 1)
 					height: childrenRect.height - Kirigami.Units.smallSpacing
 					anchors.left: leftBarDive.right
-					Kirigami.Label {
+					Controls.Label {
 						id: locationText
 						text: dive.location
 						font.weight: Font.Bold
@@ -110,7 +110,7 @@ Kirigami.ScrollablePage {
 							bottom: numberText.bottom
 						}
 
-						Kirigami.Label {
+						Controls.Label {
 							id: dateLabel
 							text: dive.date + " " + dive.time
 							width: Math.max(locationText.width * 0.45, paintedWidth) // helps vertical alignment throughout listview
@@ -118,14 +118,14 @@ Kirigami.ScrollablePage {
 							color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor
 						}
 						// let's try to show the depth / duration very compact
-						Kirigami.Label {
+						Controls.Label {
 							text: dive.depth + ' / ' + dive.duration
 							width: Math.max(Kirigami.Units.gridUnit * 3, paintedWidth) // helps vertical alignment throughout listview
 							font.pointSize: subsurfaceTheme.smallPointSize
 							color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor
 						}
 					}
-					Kirigami.Label {
+					Controls.Label {
 						id: numberText
 						text: "#" + dive.number
 						font.pointSize: subsurfaceTheme.smallPointSize
@@ -208,7 +208,7 @@ Kirigami.ScrollablePage {
 						left: parent.left
 						leftMargin: Kirigami.Units.smallSpacing
 					}
-					Label {
+					Controls.Label {
 						text: {	section.replace(/.*\+\+/, "").replace(/::.*/, "").replace("@", "\n'") }
 						color: subsurfaceTheme.primaryTextColor
 						font.pointSize: subsurfaceTheme.smallPointSize
@@ -222,7 +222,7 @@ Kirigami.ScrollablePage {
 					}
 				}
 
-				Kirigami.Label {
+				Controls.Label {
 					id: sectionText
 					text: {
 						// if the tripMeta (which we get as "section") ends in ::-- we know
@@ -298,7 +298,7 @@ Kirigami.ScrollablePage {
 
 	Text {
 		// make sure this gets pushed far enough down so that it's not obscured by the page title
-		// it would be nicer to use Kirigami.Label, but due to a QML bug that isn't possible with a
+		// it would be nicer to use Controls.Label, but due to a QML bug that isn't possible with a
 		// weird "component versioning" error
 		// using this property means that we require Qt 5.6 / QtQuick2.6
 		topPadding: Kirigami.Units.iconSizes.large

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.3
@@ -60,14 +60,14 @@ Kirigami.Page {
 		Layout.fillWidth: true
 		GridLayout {
 			columns: 2
-			Kirigami.Label { text: qsTr(" Vendor name: ") }
+			Controls.Label { text: qsTr(" Vendor name: ") }
 			property var vendoridx: downloadThread.data().getDetectedVendorIndex()
-			ComboBox {
+			Controls.ComboBox {
 				id: comboVendor
 				Layout.fillWidth: true
 				model: vendorList
 				currentIndex: parent.vendoridx
-				delegate: ItemDelegate {
+				delegate: Controls.ItemDelegate {
 					width: comboVendor.width
 					contentItem: Text {
 						text: modelData
@@ -91,14 +91,14 @@ Kirigami.Page {
 						comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex(currentText)
 				}
 			}
-			Kirigami.Label { text: qsTr(" Dive Computer:") }
-			ComboBox {
+			Controls.Label { text: qsTr(" Dive Computer:") }
+			Controls.ComboBox {
 				id: comboProduct
 				property var productidx: downloadThread.data().getDetectedProductIndex(comboVendor.currentText)
 				Layout.fillWidth: true
 				model: null
 				currentIndex: productidx
-				delegate: ItemDelegate {
+				delegate: Controls.ItemDelegate {
 					width: comboProduct.width
 					contentItem: Text {
 						text: modelData
@@ -126,13 +126,13 @@ Kirigami.Page {
 					currentIndex = productidx
 				}
 			}
-			Kirigami.Label { text: qsTr(" Connection:") }
-			ComboBox {
+			Controls.Label { text: qsTr(" Connection:") }
+			Controls.ComboBox {
 				id: comboConnection
 				Layout.fillWidth: true
 				model: connectionListModel
 				currentIndex: -1
-				delegate: ItemDelegate {
+				delegate: Controls.ItemDelegate {
 					width: comboConnection.width
 					contentItem: Text {
 						text: modelData
@@ -162,7 +162,7 @@ Kirigami.Page {
 			}
 		}
 
-		ProgressBar {
+		Controls.ProgressBar {
 			id: progressBar
 			Layout.fillWidth: true
 			indeterminate: true
@@ -197,7 +197,7 @@ Kirigami.Page {
 					manager.appendTextToLog("exit DCDownload screen")
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				Layout.maximumWidth: parent.width - download.width - quitbutton.width
 				text: divesDownloaded ? qsTr(" Downloaded dives") :
 							(manager.progressMessage != "" ? qsTr("Info:") + " " + manager.progressMessage : btMessage)
@@ -226,7 +226,7 @@ Kirigami.Page {
 
 		RowLayout {
 			Layout.fillWidth: true
-			Kirigami.Label {
+			Controls.Label {
 				text: ""  // Spacer on the left for hamburger menu
 				Layout.fillWidth: true
 			}
@@ -243,7 +243,7 @@ Kirigami.Page {
 					stackView.pop();
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: ""  // Spacer between 2 button groups
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.6
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.3
@@ -45,14 +45,14 @@ Kirigami.AbstractListItem {
 				importModel.selectRow(index)
 			}
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: dateLabel
 			text: innerListItem.datetime
 			width: Math.round(parent.width * 0.35)
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: textColor
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: innerListItem.depth + ' / ' + innerListItem.duration
 			width: Math.round(parent.width * 0.35)
 			font.pointSize: subsurfaceTheme.smallPointSize

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
@@ -23,48 +23,48 @@ Kirigami.ScrollablePage {
 				columns: 4
 				id: timeAndName
 				width: parent.width
-				Kirigami.Label {
+				Controls.Label {
 					text: qsTr('Date: ')
 					color: subsurfaceTheme.textColor
 					opacity: 0.6
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: date
 					color: subsurfaceTheme.textColor
 					Layout.preferredWidth: Math.max(parent.width / 5, paintedWidth)
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: qsTr('Name: ')
 					color: subsurfaceTheme.textColor
 					opacity: 0.6
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: name
 					color: subsurfaceTheme.textColor
 					Layout.preferredWidth: Math.max(parent.width / 5, paintedWidth)
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: qsTr('Latitude: ')
 					color: subsurfaceTheme.textColor
 					opacity: 0.6
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: latitude
 					color: subsurfaceTheme.textColor
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: qsTr('Longitude: ')
 					color: subsurfaceTheme.textColor
 					opacity: 0.6
 					font.pointSize: subsurfaceTheme.smallPointSize
 				}
-				Kirigami.Label {
+				Controls.Label {
 					text: longitude
 					color: subsurfaceTheme.textColor
 					font.pointSize: subsurfaceTheme.smallPointSize

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
@@ -34,13 +34,13 @@ Kirigami.ScrollablePage {
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 3
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Email")
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.15
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: manager.credentialStatus === QMLManager.CS_NOCLOUD ? qsTr("Not applicable") : manager.cloudUserName
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
@@ -55,13 +55,13 @@ Kirigami.ScrollablePage {
 					rootItem.returnTopPage()
 				}
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Status")
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.15
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: describe[manager.credentialStatus]
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
@@ -88,7 +88,7 @@ Kirigami.ScrollablePage {
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 3
 			}
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Blue")
 				color: subsurfaceTheme.textColor
 				rightPadding: Kirigami.Units.gridUnit
@@ -140,7 +140,7 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				id: pinkLabel
 				text: qsTr("Pink")
 				rightPadding: Kirigami.Units.gridUnit
@@ -193,7 +193,7 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Dark")
 				color: subsurfaceTheme.textColor
 				rightPadding: Kirigami.Units.gridUnit
@@ -266,13 +266,13 @@ Kirigami.ScrollablePage {
 				Layout.columnSpan: 2
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Distance threshold (meters)")
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 
-			TextField {
+			Controls.TextField {
 				id: distanceThreshold
 				text: manager.distanceThreshold
 				Layout.preferredWidth: gridWidth * 0.25
@@ -282,13 +282,13 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Time threshold (minutes)")
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 
-			TextField {
+			Controls.TextField {
 				id: timeThreshold
 				text: manager.timeThreshold
 				Layout.preferredWidth: gridWidth * 0.25
@@ -318,7 +318,7 @@ Kirigami.ScrollablePage {
 				Layout.columnSpan: 2
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Save detailed log")
 				Layout.preferredWidth: gridWidth * 0.75
 			}
@@ -350,7 +350,7 @@ Kirigami.ScrollablePage {
 				Layout.columnSpan: 2
 			}
 
-			Kirigami.Label {
+			Controls.Label {
 				text: qsTr("Display Developer menu")
 				Layout.preferredWidth: gridWidth * 0.75
 			}

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.5
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 2.0 as Controls
 import org.kde.kirigami 2.0 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
@@ -18,7 +19,7 @@ Kirigami.ScrollablePage {
 			Layout.topMargin: 0
 			property int headingLevel: 3
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: messageArea
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
@@ -26,7 +27,7 @@ Kirigami.ScrollablePage {
 			text: manager.startPageText
 			wrapMode: Text.WordWrap
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: explanationTextBasic
 			visible: !showPin
 			Layout.fillWidth: true
@@ -39,7 +40,7 @@ Kirigami.ScrollablePage {
 				"the no cloud buttton above.")
 			wrapMode: Text.WordWrap
 		}
-		Kirigami.Label {
+		Controls.Label {
 			id: explanationTextPin
 			visible: showPin
 			Layout.fillWidth: true

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.5
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import org.kde.kirigami 2.0 as Kirigami
 
@@ -27,31 +28,31 @@ Kirigami.Page {
 			id: fm
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Geometry (pixels):"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: rootItem.width + "x" + rootItem.height
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Geometry (gridUnits):"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: Math.round(rootItem.width / Kirigami.Units.gridUnit) + "x" + Math.round(rootItem.height / Kirigami.Units.gridUnit)
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Units.gridUnit:"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: Kirigami.Units.gridUnit
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Units.devicePixelRatio:"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: Screen.devicePixelRatio
 		}
 
@@ -61,56 +62,56 @@ Kirigami.Page {
 			Layout.columnSpan: 2
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "FontMetrics pointSize:"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: fm.font.pointSize
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "FontMetrics pixelSize:"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: Number(fm.height).toFixed(2)
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "FontMetrics devicePixelRatio:"
 		}
-		Kirigami.Label {
+		Controls.Label {
 			text: Number(fm.height / fm.font.pointSize).toFixed(2)
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Text item pixelSize:"
 		}
 		Text {
 			text: font.pixelSize
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Text item pointSize:"
 		}
 		Text {
 			text: font.pointSize
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Pixel density:"
 		}
 		Text {
 			text: Number(Screen.pixelDensity).toFixed(2)
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "Height of default font:"
 		}
 		Text {
 			text: Number(font.pixelSize / Screen.pixelDensity).toFixed(2) + "mm"
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			text: "2cm x 2cm square:"
 		}
 		Rectangle {
@@ -119,7 +120,7 @@ Kirigami.Page {
 			color: "black"
 		}
 
-		Kirigami.Label {
+		Controls.Label {
 			Layout.columnSpan: 2
 			Layout.fillHeight: true
 		}


### PR DESCRIPTION
Commit 8f6827ab122 brought a new SHA for Kirigami, but that introduces a very noisy logging of "Kirigami.Label is deprecated. Use QtQuickControls2.Label instead".

So, that's what done here.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>