### PR TITLE
Planner: Autom. move first datapoint gas to first gaslist position p2

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -756,12 +756,15 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	 * When moving divepoints rigorously, we might end up with index
 	 * out of range, thus returning the last one instead.
 	 */
+	int old_first_cylid = divepoints[0].cylinderid;
 	if (row >= divepoints.count())
 		return;
 	divepoints[row] = newData;
 	std::sort(divepoints.begin(), divepoints.end(), divePointsLessThan);
 	if (updateMaxDepth())
 		CylindersModel::instance()->updateBestMixes();
+	if (divepoints[0].cylinderid != old_first_cylid)
+		CylindersModel::instance()->moveAtFirst(divepoints[0].cylinderid);
 	emitDataChanged();
 }
 
@@ -790,6 +793,8 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 	if (!dp.entered)
 		return;
 
+	int old_first_cylid = divepoints[0].cylinderid;
+
 /* TODO: this seems so wrong.
  * We can't do this here if we plan to use QML on mobile
  * as mobile has no ControlModifier.
@@ -809,6 +814,8 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 	}
 	endRemoveRows();
 	CylindersModel::instance()->updateTrashIcon();
+	if (divepoints[0].cylinderid != old_first_cylid)
+		CylindersModel::instance()->moveAtFirst(divepoints[0].cylinderid);
 }
 
 struct diveplan &DivePlannerPointsModel::getDiveplan()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a amendment to 24bd5a8dcebec886b8fbbf077fabfb2106dc7dcd

Move the cylinder also to first position if first planner datapoint
cylinder change because a row is added or deleted to the dive datapoints.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
