### PR TITLE
Correct time bookkeeping when doing O2 breaks

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -658,7 +658,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	struct sample *sample;
 	int po2;
 	int transitiontime, gi;
-	int current_cylinder;
+	int current_cylinder, stopcylinder;
 	int stopidx;
 	int depth;
 	struct gaschanges *gaschanges = NULL;
@@ -986,7 +986,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 					pendinggaschange = false;
 				}
 
-				int new_clock = wait_until(dive, clock, clock, laststoptime * 2, timestep, depth, stoplevels[stopidx], avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
+				int new_clock = wait_until(dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
 				laststoptime = new_clock - clock;
 				/* Finish infinite deco */
 				if (clock >= 48 * 3600 && depth >= 6000) {
@@ -995,6 +995,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 				}
 
 				o2breaking = false;
+				stopcylinder = current_cylinder;
 				if (prefs.doo2breaks) {
 					/* The backgas breaks option limits time on oxygen to 12 minutes, followed by 6 minutes on
 					 * backgas (first defined gas).  This could be customized if there were demand.
@@ -1029,13 +1030,13 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 						}
 					}
 				}
-				add_segment(depth_to_bar(depth, dive), &dive->cylinder[current_cylinder].gasmix,
+				add_segment(depth_to_bar(depth, dive), &dive->cylinder[stopcylinder].gasmix,
 					    laststoptime, po2, dive, prefs.decosac);
 				decostoptable[decostopcounter].depth = depth;
 				decostoptable[decostopcounter].time = laststoptime;
 				++decostopcounter;
 
-				clock = new_clock;
+				clock += laststoptime;
 				if (!o2breaking)
 					break;
 			}

--- a/core/planner.c
+++ b/core/planner.c
@@ -988,9 +988,6 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 				int new_clock = wait_until(dive, clock, clock, laststoptime * 2, timestep, depth, stoplevels[stopidx], avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
 				laststoptime = new_clock - clock;
-				decostoptable[decostopcounter].depth = depth;
-				decostoptable[decostopcounter].time = laststoptime;
-				++decostopcounter;
 				/* Finish infinite deco */
 				if (clock >= 48 * 3600 && depth >= 6000) {
 					error = LONGDECO;
@@ -1005,11 +1002,12 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 					if (get_o2(&dive->cylinder[current_cylinder].gasmix) == 1000) {
 						if (laststoptime >= 12 * 60) {
 							laststoptime = 12 * 60;
+							new_clock = clock + laststoptime;
 							o2breaking = true;
 							breaktime = 0;
 							breakcylinder = current_cylinder;
 							if (is_final_plan)
-								plan_add_segment(diveplan, clock + laststoptime - previous_point_time, depth, current_cylinder, po2, false);
+								plan_add_segment(diveplan, laststoptime, depth, current_cylinder, po2, false);
 							previous_point_time = clock + laststoptime;
 							current_cylinder = 0;
 							gas = dive->cylinder[current_cylinder].gasmix;
@@ -1018,10 +1016,11 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 						if (breaktime >= 0) {
 							if (laststoptime >= 6 * 60) {
 								laststoptime = 6 * 60;
+								new_clock = clock + laststoptime;
 								o2breaking  = true;
 								o2time = 0;
 								if (is_final_plan)
-									plan_add_segment(diveplan, clock + laststoptime - previous_point_time, depth, current_cylinder, po2, false);
+									plan_add_segment(diveplan, laststoptime, depth, current_cylinder, po2, false);
 								previous_point_time = clock + laststoptime;
 								current_cylinder = breakcylinder;
 								gas = dive->cylinder[current_cylinder].gasmix;
@@ -1032,6 +1031,10 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 				}
 				add_segment(depth_to_bar(depth, dive), &dive->cylinder[current_cylinder].gasmix,
 					    laststoptime, po2, dive, prefs.decosac);
+				decostoptable[decostopcounter].depth = depth;
+				decostoptable[decostopcounter].time = laststoptime;
+				++decostopcounter;
+
 				clock = new_clock;
 				if (!o2breaking)
 					break;

--- a/core/planner.c
+++ b/core/planner.c
@@ -924,12 +924,12 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 							(get_o2(&gas) + 5) / 10, (get_he(&gas) + 5) / 10, gaschanges[gi].depth / 1000.0);
 #endif
 						/* Stop for the minimum duration to switch gas */
-						add_segment(depth_to_bar(depth, dive),
-							&dive->cylinder[current_cylinder].gasmix,
-							prefs.min_switch_duration, po2, dive, prefs.decosac);
-						clock += prefs.min_switch_duration;
-						if (prefs.doo2breaks && get_o2(&dive->cylinder[current_cylinder].gasmix) == 1000)
-							o2time += prefs.min_switch_duration;
+						if (!(prefs.doo2breaks && get_o2(&dive->cylinder[current_cylinder].gasmix) == 1000)) {
+							add_segment(depth_to_bar(depth, dive),
+								&dive->cylinder[current_cylinder].gasmix,
+								prefs.min_switch_duration, po2, dive, prefs.decosac);
+							clock += prefs.min_switch_duration;
+						}
 					} else {
 						/* The user has selected the option to switch gas only at required stops.
 						 * Remember that we are waiting to switch gas
@@ -977,12 +977,12 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 						(get_o2(&gas) + 5) / 10, (get_he(&gas) + 5) / 10, gaschanges[gi + 1].depth / 1000.0);
 #endif
 					/* Stop for the minimum duration to switch gas */
-					add_segment(depth_to_bar(depth, dive),
-						&dive->cylinder[current_cylinder].gasmix,
-						prefs.min_switch_duration, po2, dive, prefs.decosac);
-					clock += prefs.min_switch_duration;
-					if (prefs.doo2breaks && get_o2(&dive->cylinder[current_cylinder].gasmix) == 1000)
-						o2time += prefs.min_switch_duration;
+					if (!(prefs.doo2breaks && get_o2(&dive->cylinder[current_cylinder].gasmix) == 1000)) {
+						add_segment(depth_to_bar(depth, dive),
+							&dive->cylinder[current_cylinder].gasmix,
+							prefs.min_switch_duration, po2, dive, prefs.decosac);
+						clock += prefs.min_switch_duration;
+					}
 					pendinggaschange = false;
 				}
 


### PR DESCRIPTION
These got mangled with previous changes to stop length determination.

I guess this
Fixes #662
but I am getting a bit tired. Please confirm @sfuchs79 

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
