### PR TITLE
printoptions.cpp: correctly remember the last selected template

### DIFF
--- a/desktop-widgets/printoptions.cpp
+++ b/desktop-widgets/printoptions.cpp
@@ -53,13 +53,15 @@ void PrintOptions::setupTemplates()
 	QStringList currList = printOptions->type == print_options::DIVELIST ?
 		grantlee_templates : grantlee_statistics_templates;
 
+	// temp. store the template from options, as addItem() updates it via:
+	// on_printTemplate_currentIndexChanged()
+	QString storedTemplate = printOptions->p_template;
 	qSort(currList);
 	int current_index = 0;
 	ui.printTemplate->clear();
 	Q_FOREACH(const QString& theme, currList) {
-		if (theme == printOptions->p_template){
+		if (theme == storedTemplate) // find the stored template in the list
 			current_index = currList.indexOf(theme);
-		}
 		ui.printTemplate->addItem(theme.split('.')[0], theme);
 	}
 	ui.printTemplate->setCurrentIndex(current_index);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

from the commit message:

```
To find the last selected template index in the combo box,
comparing against `printOptions->p_template` would work fine,
except the `on_printTemplate_currentIndexChanged()` slot updates
`printOptions->p_template` each time QComboBox::addItem() is
called. This makes the `for` loop to add new combo box items
and find the index of the last selected template not possible.

To work around the issue, a local QString variable `storedTemplate`
is introduced and it does not change during the `for` loop.
```

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added temp. QString variable

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#595

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @dirkhh 

please review / merge
thanks
