### PR TITLE
Do not overwrite start and end pressures on cylinder

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -663,9 +663,17 @@ int nr_weightsystems(struct dive *dive)
 void copy_cylinders(struct dive *s, struct dive *d, bool used_only)
 {
 	int i,j;
+	cylinder_t t[MAX_CYLINDERS];
 	if (!s || !d)
 		return;
+
 	for (i = 0; i < MAX_CYLINDERS; i++) {
+		// Store the original start and end pressures
+		t[i].start.mbar = d->cylinder[i].start.mbar;
+		t[i].end.mbar = d->cylinder[i].end.mbar;
+		t[i].sample_start.mbar = d->cylinder[i].sample_start.mbar;
+		t[i].sample_end.mbar = d->cylinder[i].sample_end.mbar;
+
 		free((void *)d->cylinder[i].type.description);
 		memset(&d->cylinder[i], 0, sizeof(cylinder_t));
 	}
@@ -677,6 +685,13 @@ void copy_cylinders(struct dive *s, struct dive *d, bool used_only)
 			d->cylinder[j].depth = s->cylinder[i].depth;
 			d->cylinder[j].cylinder_use = s->cylinder[i].cylinder_use;
 			d->cylinder[j].manually_added = true;
+
+			// Restore the start and end pressures from original cylinder
+			d->cylinder[i].start.mbar = t[i].start.mbar;
+			d->cylinder[i].end.mbar = t[i].end.mbar;
+			d->cylinder[i].sample_start.mbar = t[i].sample_start.mbar;
+			d->cylinder[i].sample_end.mbar = t[i].sample_end.mbar;
+
 			j++;
 		}
 	}


### PR DESCRIPTION
The pressure information of cylinder should be kept intact when
copy-pasting other cylinder related information from other dive.

According to Dirk, the gas mix is wanted to be changed as technical
divers might have always the same multiple cylinders and wish to copy
the gasmix information over.

Fixes #689

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
