### PR TITLE
Use displayed_dc instead of current_dc

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -549,6 +549,7 @@ extern int selected_dive;
 extern unsigned int dc_number;
 #define current_dive (get_dive(selected_dive))
 #define current_dc (get_dive_dc(current_dive, dc_number))
+#define displayed_dc (get_dive_dc(&displayed_dive, dc_number))
 
 static inline struct dive *get_dive(int nr)
 {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -909,6 +909,7 @@ void MainWindow::setupForAddAndPlan(const char *model)
 	displayed_dive.id = dive_getUniqID(&displayed_dive);
 	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
 	displayed_dive.dc.model = strdup(model); // don't translate! this is stored in the XML file
+	dc_number = 1;
 	// setup the dive cylinders
 	DivePlannerPointsModel::instance()->clear();
 	DivePlannerPointsModel::instance()->setupCylinders();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -798,7 +798,6 @@ void MainTab::acceptChanges()
 			addedId = displayed_dive.id;
 		}
 		struct dive *cd = current_dive;
-		struct divecomputer *displayed_dc = get_dive_dc(&displayed_dive, dc_number);
 		// now check if something has changed and if yes, edit the selected dives that
 		// were identical with the master dive shown (and mark the divelist as changed)
 		if (!same_string(displayed_dive.suit, cd->suit))
@@ -1145,7 +1144,6 @@ void MainTab::divetype_Changed(int index)
 {
 	if (editMode == IGNORE)
 		return;
-	struct divecomputer *displayed_dc = get_dive_dc(&displayed_dive, dc_number);
 	displayed_dc->divemode = (enum dive_comp_type) index;
 	update_setpoint_events(&displayed_dive, displayed_dc);
 	markChangedWidget(ui.DiveType);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -428,7 +428,7 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 			struct gasmix *gasmix = NULL;
 			struct event *ev = NULL;
 			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
-			gasmix = get_gasmix(&displayed_dive, current_dc, sec, &ev, gasmix);
+			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);
 			int inert = 1000 - get_o2(gasmix);
 			mypen.setBrush(QBrush(ColorScale(value, inert)));
 			painter->setPen(mypen);


### PR DESCRIPTION
current_dc is a macro that determines the dive computer
based on the current dive number. When the planner is started
from an emtpy dive list, the dive number ends up being -1 and
that doesn't produce a valid dive computer. Use the divecomputer
of the displayed_dive instead. This is done via a macro that
can also be used in two other places. Without this patch, the
planner crashed when called on an empty dive list.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
