### PR TITLE
QML UI: Dive Details and Download screens

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -71,7 +71,9 @@ Item {
 			anchors {
 				left: locationText.left
 				top: locationText.bottom
+				topMargin: Kirigami.Units.smallSpacing
 				bottom: numberText.bottom
+
 			}
 
 			Controls.Label {
@@ -96,12 +98,14 @@ Item {
 			anchors {
 				right: parent.right
 				top: locationText.bottom
+				topMargin: Kirigami.Units.smallSpacing
 			}
 		}
 		Row {
 			anchors {
 				left: dateRow.left
 				top: numberText.bottom
+				topMargin: Kirigami.Units.smallSpacing
 			}
 			Controls.Label {
 				id: ratingText
@@ -144,6 +148,7 @@ Item {
 			anchors {
 				right: numberText.right
 				top: numberText.bottom
+				topMargin: Kirigami.Units.smallSpacing
 			}
 			Controls.Label {
 				id: visibilityText

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -59,6 +59,11 @@ Kirigami.Page {
 		width: parent.width
 		Layout.fillWidth: true
 		GridLayout {
+			id: buttonGrid
+			anchors {
+				top: parent.top
+				topMargin: Kirigami.Units.smallSpacing * 4
+			}
 			columns: 2
 			Controls.Label { text: qsTr(" Vendor name: ") }
 			property var vendoridx: downloadThread.data().getDetectedVendorIndex()
@@ -163,6 +168,10 @@ Kirigami.Page {
 		}
 
 		Controls.ProgressBar {
+			anchors {
+				top: buttonGrid.bottom
+				topMargin: Kirigami.Units.smallSpacing * 4
+			}
 			id: progressBar
 			Layout.fillWidth: true
 			indeterminate: true
@@ -170,9 +179,13 @@ Kirigami.Page {
 		}
 
 		RowLayout {
-			anchors.left: parent.left
-			anchors.right: parent.right
-			anchors.margins: Kirigami.Units.smallSpacing
+			id: buttonBar
+			anchors {
+				left: parent.left
+				right: parent.right
+				top: progressBar.bottom
+				topMargin: Kirigami.Units.smallSpacing * 2
+			}
 			spacing: Kirigami.Units.smallSpacing
 			SsrfButton {
 				id: download
@@ -206,6 +219,11 @@ Kirigami.Page {
 		}
 
 		ListView {
+			id: dlList
+			anchors {
+				top: buttonBar.bottom
+				topMargin: Kirigami.Units.smallSpacing * 4
+			}
 			Layout.fillWidth: true
 			Layout.fillHeight: true
 

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -48,12 +48,14 @@ Kirigami.AbstractListItem {
 		Controls.Label {
 			id: dateLabel
 			text: innerListItem.datetime
+			anchors.verticalCenter: parent.verticalCenter
 			width: Math.round(parent.width * 0.35)
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: textColor
 		}
 		Controls.Label {
 			text: innerListItem.depth + ' / ' + innerListItem.duration
+			anchors.verticalCenter: parent.verticalCenter
 			width: Math.round(parent.width * 0.35)
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: textColor


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
As in a525fff, also the dive details top data was not nicely positioned any more due to the deprecated and removed Kirigami.Label. Further, the top button of the download screen was "glued" to the top of the screen, so added a little margin there. It appeared that all the other items on the screen (progressbar, 2 button rows, and the downloaded dive list) where not moving down due to the add of that little top margin. This was solved by anchor-ing the items together. Finally, the text of a downloaded dive was on the top of the delegate lines. Not sure where that came from, but easily solved by centering it explicitly.


### Changes made:
See above