### PR TITLE
dive.h: add handling of NULL in get_dive_dc()

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -608,7 +608,10 @@ static inline unsigned int number_of_computers(struct dive *dive)
 
 static inline struct divecomputer *get_dive_dc(struct dive *dive, int nr)
 {
-	struct divecomputer *dc = &dive->dc;
+	struct divecomputer *dc;
+	if (!dive)
+		return NULL;
+	dc = &dive->dc;
 
 	while (nr-- > 0) {
 		dc = dc->next;
@@ -941,7 +944,7 @@ static inline struct gasmix *get_gasmix(struct dive *dive, struct divecomputer *
 	if (!gasmix) {
 		int cyl = explicit_first_cylinder(dive, dc);
 		gasmix = &dive->cylinder[cyl].gasmix;
-		ev = dc->events;
+		ev = dc ? dc->events : NULL;
 	}
 	while (ev && ev->time.seconds < (unsigned int)time) {
 		gasmix = get_gasmix_from_event(dive, ev);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This line:
    `dc = &dive->dc`
can (potentially) SIGSEGV for a NULL 'dive' pointer.
return NULL if 'dive' is NULL.

Also handle NULL 'dc' in get_gasmix() and set 'ev' to NULL.

SIDENOTE: 
I was able to reproduce a weird case where this line:
`dc = &dive->dc`

didn't SIGSEGV and instead it returned the address `0x580` on Windows.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add NULL check in get_dive_dc()
2) add NULL check in get_gasmix()

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

none

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh @atdotde 
