### PR TITLE
Do cylinder renumber for dive data points only when in planner mode

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -459,6 +459,7 @@ void CylindersModel::add()
 	rows++;
 	changed = true;
 	endInsertRows();
+	emit dataChanged(createIndex(row, 0), createIndex(row, COLUMNS - 1));
 }
 
 void CylindersModel::clear()

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -577,7 +577,8 @@ void CylindersModel::remove(const QModelIndex &index)
 	changed = true;
 	endRemoveRows();
 	cylinder_renumber(&displayed_dive, mapping);
-	DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
+	if (in_planner())
+		DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
 	dataChanged(index, index);
 }
 
@@ -599,7 +600,8 @@ void CylindersModel::moveAtFirst(int cylid)
 	changed = true;
 	endMoveRows();
 	cylinder_renumber(&displayed_dive, mapping);
-	DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
+	if (in_planner())
+		DivePlannerPointsModel::instance()->cylinderRenumber(mapping);
 }
 
 void CylindersModel::updateDecoDepths(pressure_t olddecopo2)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Do cylinder renumber for dive data points only when in planner mode.
Outside the planner there are no dive data points where you could renumber something!

Plus update dive planner points cylinder names also when cyl is added.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
