### PR TITLE
mainwindow: disable fullscreen support by default

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -313,6 +313,14 @@ MainWindow::MainWindow() : QMainWindow(),
 	ui.profTankbar->setChecked(sWrapper->techDetails->tankBar());
 	ui.profTissues->setChecked(sWrapper->techDetails->percentageGraph());
 	ui.profScaled->setChecked(sWrapper->techDetails->zoomedPlot());
+
+// full screen support is buggy on Windows and Ubuntu.
+// require the FULLSCREEN_SUPPORT macro to enable it!
+#ifndef FULLSCREEN_SUPPORT
+	ui.actionFullScreen->setEnabled(false);
+	ui.actionFullScreen->setVisible(false);
+	setWindowState(windowState() & ~Qt::WindowFullScreen);
+#endif
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Require the FULLSCREEN_SUPPORT macro to enable fullscreen
support.

The toggle was added 4 years ago in Subsurface, but with the
current version of Qt 5.9.x, it's very buggy on Windows and
Ubuntu. While it's possible to make this work on Windows,
it seems to behave broken in different ways on different
versiosn of Ubuntu.

Fixes #705

Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add a macro check to enable fullscreen support explicitly

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #705

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @sfuchs79 
