### PR TITLE
Display values in info box only if value is interesting

### DIFF
--- a/core/device.c
+++ b/core/device.c
@@ -114,6 +114,7 @@ struct divecomputer *fake_dc(struct divecomputer *dc, bool alloc)
 	static struct sample fake_samples[6];
 	static struct divecomputer fakedc;
 	struct sample *fake = fake_samples;
+	int i;
 
 	fakedc = (*dc);
 	if (alloc)
@@ -129,6 +130,10 @@ struct divecomputer *fake_dc(struct divecomputer *dc, bool alloc)
 
 	memset(fake, 0, sizeof(fake_samples));
 	fake[5].time.seconds = max_t;
+	for (i = 0; i < 6; i++) {
+		fake_samples[i].bearing.degrees = -1;
+		fake_samples[i].ndl.seconds = -1;
+	}
 	if (!max_t || !max_d)
 		return &fakedc;
 

--- a/core/display.h
+++ b/core/display.h
@@ -25,7 +25,6 @@ struct plot_info {
 	enum {AIR, NITROX, TRIMIX, FREEDIVING} dive_type;
 	double endtempcoord;
 	double maxpp;
-	bool has_ndl;
 	struct plot_data *entry;
 };
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -1727,7 +1727,7 @@ static void merge_one_sample(struct sample *sample, int time, struct divecompute
 {
 	int last = dc->samples - 1;
 	if (last >= 0) {
-		static struct sample surface;
+		static struct sample surface = { .bearing.degrees = -1, .ndl.seconds = -1 };
 		struct sample *prev = dc->sample + last;
 		int last_time = prev->time.seconds;
 		int last_depth = prev->depth.mm;
@@ -1772,7 +1772,7 @@ static void merge_samples(struct divecomputer *res, struct divecomputer *a, stru
 
 	for (;;) {
 		int at, bt;
-		struct sample sample;
+		struct sample sample = { .bearing.degrees = -1, .ndl.seconds = -1 };
 
 		if (!res)
 			return;

--- a/core/dive.c
+++ b/core/dive.c
@@ -753,6 +753,10 @@ struct sample *prepare_sample(struct divecomputer *dc)
 			sample->sensor[0] = sample[-1].sensor[0];
 			sample->sensor[1] = sample[-1].sensor[1];
 		}
+		// Init some values with -1
+		sample->bearing.degrees = -1;
+		sample->ndl.seconds = -1;
+		
 		return sample;
 	}
 	return NULL;
@@ -1261,12 +1265,12 @@ static void fixup_meandepth(struct dive *dive)
 static void fixup_duration(struct dive *dive)
 {
 	struct divecomputer *dc;
-	unsigned int duration = 0;
+	duration_t duration = { };
 
 	for_each_dc (dive, dc)
-		duration = MAX(duration, dc->duration.seconds);
+		duration.seconds = MAX(duration.seconds, dc->duration.seconds);
 
-	dive->duration.seconds = duration;
+	dive->duration.seconds = duration.seconds;
 }
 
 /*

--- a/core/dive.c
+++ b/core/dive.c
@@ -1423,6 +1423,19 @@ static void fixup_dc_depths(struct dive *dive, struct divecomputer *dc)
 		dive->maxdepth.mm = maxdepth;
 }
 
+static void fixup_dc_ndl(struct dive *dive, struct divecomputer *dc)
+{
+	int i;
+
+	for (i = 0; i < dc->samples; i++) {
+		struct sample *sample = dc->sample + i;
+		if (sample->ndl.seconds != 0)
+			break;
+		if (sample->ndl.seconds == 0)
+			sample->ndl.seconds = -1;
+	}
+}
+
 static void fixup_dc_temp(struct dive *dive, struct divecomputer *dc)
 {
 	int i;
@@ -1639,6 +1652,9 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 
 	/* Fix up sample depth data */
 	fixup_dc_depths(dive, dc);
+
+	/* Fix up first sample ndl data */
+	fixup_dc_ndl(dive, dc);
 
 	/* Fix up dive temperatures based on dive computer samples */
 	fixup_dc_temp(dive, dc);

--- a/core/dive.h
+++ b/core/dive.h
@@ -199,28 +199,28 @@ void get_gas_string(const struct gasmix *gasmix, char *text, int len);
 const char *gasname(const struct gasmix *gasmix);
 
 #define MAX_SENSORS 2
-struct sample                         // BASE TYPE BYTES  UNITS    RANGE      DESCRIPTION
-{                                     // --------- -----  -----    -----      -----------
-	duration_t time;               // uint32_t   4  seconds  (0-68 yrs)   elapsed dive time up to this sample
-	duration_t stoptime;           // uint32_t   4  seconds  (0-18 h)     time duration of next deco stop
-	duration_t ndl;                // uint32_t   4  seconds  (0-18 h)     time duration before no-deco limit
-	duration_t tts;                // uint32_t   4  seconds  (0-18 h)     time duration to reach the surface
-	duration_t rbt;                // uint32_t   4  seconds  (0-18 h)     remaining bottom time
-	depth_t depth;                 // int32_t    4    mm     (0-2000 km)  dive depth of this sample
-	depth_t stopdepth;             // int32_t    4    mm     (0-2000 km)  depth of next deco stop
-	temperature_t temperature;     // int32_t    4  mdegrK   (0-2 MdegK)  ambient temperature
-	pressure_t pressure[MAX_SENSORS]; // int32_t    4    mbar   (0-2 Mbar)   cylinder pressures (main and CCR o2)
-	o2pressure_t setpoint;         // uint16_t   2    mbar   (0-65 bar)   O2 partial pressure (will be setpoint)
-	o2pressure_t o2sensor[3];      // uint16_t   6    mbar   (0-65 bar)   Up to 3 PO2 sensor values (rebreather)
-	bearing_t bearing;             // int16_t    2  degrees  (-32k to 32k deg) compass bearing
-	uint8_t sensor[MAX_SENSORS];   // uint8_t    1  sensorID (0-255)      ID of cylinder pressure sensor
-	uint16_t cns;                  // uint16_t   1     %     (0-64k %)    cns% accumulated
-	uint8_t heartbeat;             // uint8_t    1  beats/m  (0-255)      heart rate measurement
-	volume_t sac;                  //            4  ml/min                predefined SAC
-	bool in_deco;                  // bool       1    y/n      y/n        this sample is part of deco
-	bool manually_entered;         // bool       1    y/n      y/n        this sample was entered by the user,
-				       //                                     not calculated when planning a dive
-};                      // Total size of structure: 57 bytes, excluding padding at end
+struct sample                         // BASE TYPE BYTES  UNITS    RANGE               DESCRIPTION
+{                                     // --------- -----  -----    -----               -----------
+	duration_t time;                  // int32_t    4  seconds  (0-34 yrs)             elapsed dive time up to this sample
+	duration_t stoptime;              // int32_t    4  seconds  (0-34 yrs)             time duration of next deco stop
+	duration_t ndl;                   // int32_t    4  seconds  (-1 no val, 0-34 yrs)  time duration before no-deco limit
+	duration_t tts;                   // int32_t    4  seconds  (0-34 yrs)             time duration to reach the surface
+	duration_t rbt;                   // int32_t    4  seconds  (0-34 yrs)             remaining bottom time
+	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
+	depth_t stopdepth;                // int32_t    4    mm     (0-2000 km)            depth of next deco stop
+	temperature_t temperature;        // int32_t    4  mdegrK   (0-2 MdegK)            ambient temperature
+	pressure_t pressure[MAX_SENSORS]; // int32_t    4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
+	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
+	o2pressure_t o2sensor[3];         // uint16_t   6    mbar   (0-65 bar)             Up to 3 PO2 sensor values (rebreather)
+	bearing_t bearing;                // int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
+	uint8_t sensor[MAX_SENSORS];      // uint8_t    1  sensorID (0-255)                ID of cylinder pressure sensor
+	uint16_t cns;                     // uint16_t   1     %     (0-64k %)              cns% accumulated
+	uint8_t heartbeat;                // uint8_t    1  beats/m  (0-255)                heart rate measurement
+	volume_t sac;                     //            4  ml/min                          predefined SAC
+	bool in_deco;                     // bool       1    y/n      y/n                  this sample is part of deco
+	bool manually_entered;            // bool       1    y/n      y/n                  this sample was entered by the user,
+	                                  //                                               not calculated when planning a dive
+};	                                  // Total size of structure: 57 bytes, excluding padding at end
 
 struct divetag {
 	/*

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -350,7 +350,7 @@ static void save_samples(struct membuffer *b, struct dive *dive, struct divecomp
 	int nr;
 	int o2sensor;
 	struct sample *s;
-	struct sample dummy = {};
+	struct sample dummy = { .bearing.degrees = -1, .ndl.seconds = -1 };
 
 	/* Is this a CCR dive with the old-style "o2pressure" sensor? */
 	o2sensor = legacy_format_o2pressures(dive, dc);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -364,7 +364,7 @@ static void save_samples(struct membuffer *b, struct dive *dive, struct divecomp
 	int nr;
 	int o2sensor;
 	struct sample *s;
-	struct sample dummy = {};
+	struct sample dummy = { .bearing.degrees = -1, .ndl.seconds = -1 };
 
 	/* Set up default pressure sensor indexes */
 	o2sensor = legacy_format_o2pressures(dive, dc);

--- a/core/units.h
+++ b/core/units.h
@@ -42,8 +42,11 @@ extern "C" {
  * We also strive to make '0' a meaningless number saying "not
  * initialized", since many values are things that may not have
  * been reported (eg cylinder pressure or temperature from dive
- * computers that don't support them). But sometimes -1 is an even
- * more explicit way of saying "not there".
+ * computers that don't support them). But for some of the values
+ * 0 doesn't works as a flag for not initialized. Examples are
+ * compass bearing (bearing_t) or NDL (duration_t).
+ * Therefore some types have a default value which is -1 and has to
+ * be set at certain points in the code.
  *
  * Thus "millibar" for pressure, for example, or "millikelvin" for
  * temperatures. Doing temperatures in celsius or fahrenheit would
@@ -70,7 +73,7 @@ typedef int64_t timestamp_t;
 
 typedef struct
 {
-	uint32_t seconds; // durations up to 68 yrs
+	int32_t seconds; // durations up to 34 yrs
 } duration_t;
 
 typedef struct


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Valid flag introduced for some of the defined types.
Valid flag used for compass bearing and NDL.
Here big ? on my side if this is acceptable/a good idea or not.

Display bearing only if a bearing was set in the DC based on valid flag.
Some DCs seem to return -1 if no bearing is set.

Display NDL based on the valid flag.

Display pXX, EAD, END, density, MOD only if values are larger than 0.

In profile don't display data from two first and two last plot_data
entries in info box.

Plus one typo corrected which broke a translation of string "density:".

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This is my proposal for #692 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
