### PR TITLE
Include qml-module-qtquick2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -98,7 +98,8 @@ sudo apt-get install git g++ make autoconf automake libtool cmake pkg-config \
 	libqt5webkit5-dev libqt5qml5 libqt5quick5 libqt5declarative5 \
 	qtscript5-dev libssh2-1-dev libcurl4-openssl-dev qttools5-dev \
 	qtconnectivity5-dev qtlocation5-dev qtpositioning5-dev \
-	libcrypto++-dev libssl-dev qml-module-qtpositioning qml-module-qtlocation
+	libcrypto++-dev libssl-dev qml-module-qtpositioning qml-module-qtlocation \
+	qml-module-qtquick2
 
 Package names for Ubuntu 16.10
 
@@ -109,7 +110,8 @@ sudo apt-get install git g++ make autoconf automake libtool cmake pkg-config \
 	libqt5webkit5-dev libqt5qml5 libqt5quick5 qtdeclarative5-dev \
 	qtscript5-dev libssh2-1-dev libcurl4-openssl-dev qttools5-dev \
 	qtconnectivity5-dev qtlocation5-dev qtpositioning5-dev \
-	libcrypto++-dev libssl-dev qml-module-qtpositioning qml-module-qtlocation
+	libcrypto++-dev libssl-dev qml-module-qtpositioning qml-module-qtlocation \
+	qml-module-qtquick2
 
 On PCLinuxOS you appear to need the following packages
 

--- a/packaging/ubuntu/debian/control
+++ b/packaging/ubuntu/debian/control
@@ -34,6 +34,7 @@ Build-Depends: asciidoc,
                qtpositioning5-dev,
                qml-module-qtpositioning,
                qml-module-qtlocation,
+	       qml-module-qtquick2,
                libcurl4-openssl-dev,
                qtconnectivity5-dev,
                libgrantlee5-dev


### PR DESCRIPTION
Ubuntu and Debian require package qml-module-qtquick2 to be installed.

Fixes #720

Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
