### PR TITLE
Git storage fixes

### DIFF
--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -59,7 +59,8 @@ void CloudStorageAuthenticate::uploadFinished()
 			nw->hideNotification();
 		*/
 		myLastError.clear();
-	} else if (cloudAuthReply == QLatin1String("[VERIFY]")) {
+	} else if (cloudAuthReply == QLatin1String("[VERIFY]") ||
+		   cloudAuthReply == QLatin1String("Invalid PIN")) {
 		csSettings.setVerificationStatus(CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {

--- a/core/cloudstorage.h
+++ b/core/cloudstorage.h
@@ -21,7 +21,6 @@ slots:
 private:
 	QNetworkReply *reply;
 	QString userAgent;
-	bool verbose;
 };
 
 QNetworkAccessManager *manager();

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -474,6 +474,12 @@ static int tree_insert(git_treebuilder *dir, const char *name, int mkunique, git
 	}
 	ret = git_treebuilder_insert(NULL, dir, name, id, mode);
 	free_buffer(&uniquename);
+	if (ret) {
+		const git_error *gerr = giterr_last();
+		if (gerr) {
+			fprintf(stderr, "tree_insert failed with return %d error %s\n", ret, gerr->message);
+		}
+	}
 	return ret;
 }
 

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1096,7 +1096,7 @@ static void create_commit_message(struct membuffer *msg)
 		} while ((dc = dc->next) != NULL);
 		put_format(msg, "\n");
 	}
-	put_format(msg, "Created by subsurface %s\n", subsurface_user_agent());
+	put_format(msg, "Created by %s\n", subsurface_user_agent());
 }
 
 static int create_new_commit(git_repository *repo, const char *remote, const char *branch, git_oid *tree_id)

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1070,12 +1070,14 @@ static int get_authorship(git_repository *repo, git_signature **authorp)
 	return git_signature_now(authorp, user.name, user.email);
 }
 
-static void create_commit_message(struct membuffer *msg)
+static void create_commit_message(struct membuffer *msg, bool create_empty)
 {
 	int nr = dive_table.nr;
 	struct dive *dive = get_dive(nr-1);
 
-	if (dive) {
+	if (create_empty) {
+		put_string(msg, "Initial commit to create empty repo.\n\n");
+	} else if (dive) {
 		dive_trip_t *trip = dive->divetrip;
 		const char *location = get_dive_location(dive) ? : "no location";
 		struct divecomputer *dc = &dive->dc;
@@ -1153,7 +1155,7 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	} else {
 		struct membuffer commit_msg = { 0 };
 
-		create_commit_message(&commit_msg);
+		create_commit_message(&commit_msg, create_empty);
 		if (git_commit_create_v(&commit_id, repo, NULL, author, author, NULL, mb_cstring(&commit_msg), tree, parent != NULL, parent))
 			return report_error("Git commit create failed (%s)", strerror(errno));
 		free_buffer(&commit_msg);

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -41,7 +41,7 @@ void PreferencesNetwork::refreshSettings()
 	ui->cloud_background_sync->setChecked(prefs.cloud_background_sync);
 	ui->save_uid_local->setChecked(prefs.save_userid_local);
 	ui->default_uid->setText(QString(prefs.userid).toUpper());
-	cloudPinNeeded();
+	updateCloudAuthenticationState();
 }
 
 void PreferencesNetwork::syncSettings()
@@ -73,7 +73,7 @@ void PreferencesNetwork::syncSettings()
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 			} else {
 				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-				connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(cloudPinNeeded()));
+				connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(updateCloudAuthenticationState()));
 				connect(cloudAuth, SIGNAL(passwordChangeSuccessful()), this, SLOT(passwordUpdateSuccessfull()));
 				cloudAuth->backend(email, password, "", newpassword);
 				ui->cloud_storage_new_passwd->setText("");
@@ -94,7 +94,7 @@ void PreferencesNetwork::syncSettings()
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 			} else {
 				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::cloudPinNeeded);
+				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
 				cloudAuth->backend(email, password);
 			}
 		}
@@ -107,7 +107,7 @@ void PreferencesNetwork::syncSettings()
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 			}
 			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-			connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(cloudPinNeeded()));
+			connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(updateCloudAuthenticationState()));
 			cloudAuth->backend(email, password, pin);
 		}
 	}
@@ -119,7 +119,7 @@ void PreferencesNetwork::syncSettings()
 	cloud->setBaseUrl(prefs.cloud_base_url);
 }
 
-void PreferencesNetwork::cloudPinNeeded()
+void PreferencesNetwork::updateCloudAuthenticationState()
 {
 	ui->cloud_storage_pin->setEnabled(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
 	ui->cloud_storage_pin->setVisible(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
@@ -131,6 +131,10 @@ void PreferencesNetwork::cloudPinNeeded()
 	ui->cloud_storage_new_passwd_label->setVisible(prefs.cloud_verification_status == CS_VERIFIED);
 	if (prefs.cloud_verification_status == CS_VERIFIED) {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (credentials verified)"));
+	} else if (prefs.cloud_verification_status == CS_INCORRECT_USER_PASSWD) {
+		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (incorrect password)"));
+	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY) {
+		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (PIN required)"));
 	} else {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage"));
 	}

--- a/desktop-widgets/preferences/preferences_network.h
+++ b/desktop-widgets/preferences/preferences_network.h
@@ -19,7 +19,7 @@ public:
 
 public slots:
 	void proxyType_changed(int i);
-	void cloudPinNeeded();
+	void updateCloudAuthenticationState();
 
 private:
 	Ui::PreferencesNetwork *ui;

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -102,7 +102,11 @@ int main(int argc, char **argv)
 	}
 	MainWindow *m = MainWindow::instance();
 	filesOnCommandLine = !files.isEmpty() || !importedFiles.isEmpty();
+	if (verbose && !files.isEmpty())
+		qDebug() << "loading dive data from" << files;
 	m->loadFiles(files);
+	if (verbose && !importedFiles.isEmpty())
+		qDebug() << "importing dive data from" << importedFiles;
 	m->importFiles(importedFiles);
 
 	if (verbose > 0) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR mixes a few different changes:
a) add a bunch of debug information on which files are opened, which error git returns when the treebuilder fails
b) fix a bug where a local member variable hides the global 'verbose' variable
c) fix a bug that if you load from one git repo but store to a different git repo (specifically, cloud storage), the cached git objects per dive are invalid in the new repo and the treebuilder fails
d) adds a feature to correctly show the reason why cloud credentials weren't recognized (and especially don't confuse if the password was wrong or the PIN was wrong).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder - you looked at the authentication code on the mobile side
@torvalds - can you check that I'm doing the right thing when I invalidate the caches?
