### PR TITLE
QML UI: Scrolling in dive details

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -262,7 +262,7 @@ Kirigami.Page {
 			boundsBehavior: Flickable.StopAtBounds
 			maximumFlickVelocity: parent.width * 5
 			orientation: ListView.Horizontal
-			highlightFollowsCurrentItem: true
+			highlightFollowsCurrentItem: false
 			focus: true
 			clip: false
 			snapMode: ListView.SnapOneItem


### PR DESCRIPTION
While testing the mobile app on Qt 5.9.2, I encountered a show stopping issue. Select a dive in the dive list, go back to the dive list (as selecting a dive opens the details), now scroll down to a different dive, and select one. The app starts enumerating (moved smoothly according to the specs) all the dives between the old and the new selected dive. So, depending on the distance, this could take forever.
Explicitly: on 5.9.2. only.

From the Qt docs:

highlightFollowsCurrentItem : bool

If this property is true (the default value), the highlight is moved smoothly to follow the current item. Otherwise, the highlight is not moved by the view, and any movement must be implemented by the highlight.

End Qt docs.

Setting this property to false solves the issue. Tested on both Qt 5.9.1 and 5.9.2.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>