### PR TITLE
VPMB profile: use bottom_time to calculate deco_time in planner

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -34,6 +34,7 @@ int decostoplevels_imperial[] = { 0, 3048, 6096, 9144, 12192, 15240, 18288, 2133
 				325120, 345440, 365760, 386080 };
 
 double plangflow, plangfhigh;
+int bottom_time = 0;
 
 extern double regressiona();
 extern double regressionb();
@@ -669,7 +670,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	bool stopping = false;
 	bool pendinggaschange = false;
 	int clock, previous_point_time;
-	int avg_depth, max_depth, bottom_time = 0;
+	int avg_depth, max_depth;
 	int last_ascend_rate;
 	int best_first_ascend_cylinder;
 	struct gasmix gas, bottom_gas;
@@ -1065,6 +1066,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		diveplan->eff_gfhigh = lrint(100.0 * regressionb());
 		diveplan->eff_gflow = lrint(100.0 * (regressiona() * first_stop_depth + regressionb()));
 	}
+
 
 	create_dive_from_plan(diveplan, dive, is_planner);
 	add_plan_to_notes(diveplan, dive, show_disclaimer, error);

--- a/core/planner.c
+++ b/core/planner.c
@@ -1067,7 +1067,6 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		diveplan->eff_gflow = lrint(100.0 * (regressiona() * first_stop_depth + regressionb()));
 	}
 
-
 	create_dive_from_plan(diveplan, dive, is_planner);
 	add_plan_to_notes(diveplan, dive, show_disclaimer, error);
 	fixup_dc_duration(&dive->dc);

--- a/core/profile.c
+++ b/core/profile.c
@@ -1028,9 +1028,11 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 						if (first_iteration) {
 							nuclear_regeneration(t1);
 							vpmb_start_gradient();
-							/* For CVA calculations, start by guessing deco time = dive time remaining */
+							/* For CVA calculations, deco time = dive time remaining is a good guess,
+							   but we want to over-estimate deco_time for the first iteration so it
+							   converges correctly, so add 30min*/
 							if (!in_planner())
-								deco_time = pi->maxtime - t1;
+								deco_time = pi->maxtime - t1 + 1800;
 							vpmb_next_gradient(deco_time, surface_pressure / 1000.0);
 						}
 					}

--- a/core/profile.c
+++ b/core/profile.c
@@ -1085,7 +1085,9 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 			if (final_tts > 0)
 				deco_time = pi->maxtime + final_tts - time_deep_ceiling;
 			else if (time_clear_ceiling > 0)
-				deco_time = time_clear_ceiling - time_deep_ceiling;
+				/* Consistent with planner, deco_time ends after ascending (20-40s @9m/min from 3-6m)
+				   at end of whole minute after clearing ceiling */
+				deco_time = ROUND_UP(time_clear_ceiling, 60) + 30 - time_deep_ceiling;
 			vpmb_next_gradient(deco_time, surface_pressure / 1000.0);
 			final_tts = 0;
 			last_ndl_tts_calc_time = 0;


### PR DESCRIPTION
This corrects the issue where the displayed ceiling in the profile was
"broken" by the planner, especially for shorter and shallower dives.

Also fixes issue outside of planner where the deepest VPM-B ceiling was shown
too early, messing up the deco_time calculation.

VPM-B plans respond to change in O2% in gas as expected (in my testing)

Fixes: #630

Signed-off-by: Rick Walsh <rickmwalsh@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
