### PR TITLE
QML UI: repair long trip headers

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -185,7 +185,7 @@ Kirigami.ScrollablePage {
 	Component {
 		id: tripHeading
 		Item {
-			width: page.width - Kirigami.Units.gridUnit
+			width: page.width
 			height: childrenRect.height - Kirigami.Units.smallSpacing
 			Rectangle {
 				id: headingBackground
@@ -193,7 +193,6 @@ Kirigami.ScrollablePage {
 				anchors {
 					left: parent.left
 					right: parent.right
-					rightMargin: Kirigami.Units.gridUnit * -2
 				}
 				color: subsurfaceTheme.lightPrimaryColor
 				visible: section != ""


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Trip headers spanning more than one line where broken at incorrect locations in the string. Not exactly sure, but I think this came with the newest Kirigami SHA, and especially the Label change.

Carefully reading the code for the trip heading shows a "strange" negative margin. So the margin is on the outside. This margin was used to split the string, allowing for a small invisible part of the string to present as trip header.

This is solved by this commit.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
