### PR TITLE
map widget: start with normal zoomlevel

### DIFF
--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -37,8 +37,13 @@ Item {
 		property real newZoom: 1.0
 		property real newZoomOut: 1.0
 		property var clickCoord: QtPositioning.coordinate(0, 0)
+		property bool isReady: false
 
-		onZoomLevelChanged: mapHelper.calculateSmallCircleRadius(map.center)
+		Component.onCompleted: isReady = true
+		onZoomLevelChanged: {
+			if (isReady)
+				mapHelper.calculateSmallCircleRadius(map.center)
+		}
 
 		MapItemView {
 			id: mapItemView

--- a/mobile-widgets/qml/MapWidget.qml
+++ b/mobile-widgets/qml/MapWidget.qml
@@ -25,7 +25,7 @@ Item {
 	Map {
 		id: map
 		anchors.fill: parent
-		zoomLevel: 1
+		zoomLevel: defaultZoomIn
 
 		property var mapType
 		readonly property var defaultCenter: QtPositioning.coordinate(0, 0)


### PR DESCRIPTION
Commit 344d9765936 resulted in the start of Subsurface with a map of the whole world. The user has to zoom in (assuming the case that the first selected dive has a position), in every session. This is solved by setting the zoomlevel at startup at the default value. Ok, this results in a map of central London, UK, when starting Subsurface with a dive without location, but is this as good as any map.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>