### PR TITLE
QML UI: prevent full overflow of bottom buttons

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -224,6 +224,7 @@ Kirigami.Page {
 				top: buttonBar.bottom
 				topMargin: Kirigami.Units.smallSpacing * 4
 			}
+			Layout.bottomMargin: bottomButtons.height * 1.5
 			Layout.fillWidth: true
 			Layout.fillHeight: true
 
@@ -243,6 +244,7 @@ Kirigami.Page {
 		}
 
 		RowLayout {
+			id: bottomButtons
 			Layout.fillWidth: true
 			Controls.Label {
 				text: ""  // Spacer on the left for hamburger menu


### PR DESCRIPTION
A not perfect improvement, but way better IMHO. Prevent the list of downloaded dives to grow over the buttons at the bottom. Just a simple change by adding a bottomMargin to the list.

Notice that there is still some overlap, but for now I consider this a trade-off between the scarce screen real-estate and the wish to present and much as possible dowloaded dives.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>