### PR TITLE
Correct, cleanup, translate and unify file filters

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -326,7 +326,7 @@ void OstcFirmwareCheck::upgradeFirmware()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append(saveFileName);
 	storeFirmware = QFileDialog::getSaveFileName(parent, tr("Save the downloaded firmware as"),
-						     filename, tr("Firmware files (*.hex *.bin)"));
+						     filename, tr("Firmware files") + " (*.hex *.bin)");
 	if (storeFirmware.isEmpty())
 		return;
 
@@ -1362,7 +1362,7 @@ void ConfigureDiveComputerDialog::on_backupButton_clicked()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
 	QString backupPath = QFileDialog::getSaveFileName(this, tr("Backup dive computer settings"),
-							  filename, tr("Backup files (*.xml)"));
+							  filename, tr("Backup files") + " (*.xml)");
 	if (!backupPath.isEmpty()) {
 		populateDeviceDetails();
 		if (!config->saveXMLBackup(backupPath, deviceDetails, &device_data)) {
@@ -1383,7 +1383,7 @@ void ConfigureDiveComputerDialog::on_restoreBackupButton_clicked()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
 	QString restorePath = QFileDialog::getOpenFileName(this, tr("Restore dive computer settings"),
-							   filename, tr("Backup files (*.xml)"));
+							   filename, tr("Backup files") + " (*.xml)");
 	if (!restorePath.isEmpty()) {
 		// Fw update is no longer a option, needs to be done on a untouched device
 		ui.updateFirmwareButton->setEnabled(false);
@@ -1405,7 +1405,7 @@ void ConfigureDiveComputerDialog::on_updateFirmwareButton_clicked()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath();
 	QString firmwarePath = QFileDialog::getOpenFileName(this, tr("Select firmware file"),
-							    filename, tr("All files (*.*)"));
+							    filename, tr("All files") + " (*.*)");
 	if (!firmwarePath.isEmpty()) {
 		ui.progressBar->setValue(0);
 		ui.progressBar->setFormat("%p%");
@@ -1466,7 +1466,7 @@ void ConfigureDiveComputerDialog::pickLogFile()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
-					       filename, tr("Log files (*.log)"));
+					       filename, tr("Log files") + " (*.log)");
 	if (!logFile.isEmpty()) {
 		free(logfile_name);
 		logfile_name = strdup(logFile.toUtf8().data());

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -138,27 +138,27 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		if (ui->exportUDDF->isChecked()) {
 			stylesheet = "uddf-export.xslt";
 			filename = QFileDialog::getSaveFileName(this, tr("Export UDDF file as"), lastDir,
-								tr("UDDF files (*.uddf *.UDDF)"));
+								tr("UDDF files") + " (*.uddf)");
 		} else if (ui->exportCSV->isChecked()) {
 			stylesheet = "xml2csv.xslt";
 			filename = QFileDialog::getSaveFileName(this, tr("Export CSV file as"), lastDir,
-								tr("CSV files (*.csv *.CSV)"));
+								tr("CSV files") + " (*.csv)");
 		} else if (ui->exportCSVDetails->isChecked()) {
 			stylesheet = "xml2manualcsv.xslt";
 			filename = QFileDialog::getSaveFileName(this, tr("Export CSV file as"), lastDir,
-								tr("CSV files (*.csv *.CSV)"));
+								tr("CSV files") + " (*.csv)");
 		} else if (ui->exportDivelogs->isChecked()) {
 			DivelogsDeWebServices::instance()->prepareDivesForUpload(ui->exportSelected->isChecked());
 		} else if (ui->exportDiveshare->isChecked()) {
 			DiveShareExportDialog::instance()->prepareDivesForUpload(ui->exportSelected->isChecked());
 		} else if (ui->exportWorldMap->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export world map"), lastDir,
-								tr("HTML files (*.html)"));
+								tr("HTML files") + " (*.html)");
 			if (!filename.isNull() && !filename.isEmpty())
 				export_worldmap_HTML(filename.toUtf8().data(), ui->exportSelected->isChecked());
 		} else if (ui->exportSubsurfaceXML->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface XML"), lastDir,
-								tr("XML files (*.xml *.ssrf)"));
+								tr("Subsurface files") + " (*.ssrf *.xml)");
 			if (!filename.isNull() && !filename.isEmpty()) {
 				if (!filename.contains('.'))
 					filename.append(".ssrf");
@@ -170,14 +170,14 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 			if (!filename.isNull() && !filename.isEmpty())
 				export_depths(filename.toUtf8().data(), ui->exportSelected->isChecked());
 		} else if (ui->exportTeX->isChecked()) {
-			filename = QFileDialog::getSaveFileName(this, tr("Export to TeX file"), lastDir, tr("TeX files (*.tex)"));
+			filename = QFileDialog::getSaveFileName(this, tr("Export to TeX file"), lastDir, tr("TeX files") + " (*.tex)");
 			if (!filename.isNull() && !filename.isEmpty())
 				export_TeX(filename.toUtf8().data(), ui->exportSelected->isChecked());
 		}
 		break;
 	case 1:
 		filename = QFileDialog::getSaveFileName(this, tr("Export HTML files as"), lastDir,
-							tr("HTML files (*.html)"));
+							tr("HTML files") + " (*.html)");
 		if (!filename.isNull() && !filename.isEmpty())
 			exportHtmlInit(filename);
 		break;

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -367,7 +367,7 @@ void DownloadFromDCWidget::pickLogFile()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	QString logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
-					       filename, tr("Log files (*.log)"));
+					       filename, tr("Log files") + " (*.log)");
 	if (!logFile.isEmpty()) {
 		free(logfile_name);
 		logfile_name = copy_string(logFile.toUtf8().data());
@@ -393,7 +393,7 @@ void DownloadFromDCWidget::pickDumpFile()
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.bin");
 	QString dumpFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer binary dump file"),
-						filename, tr("Dump files (*.bin)"));
+						filename, tr("Dump files") + " (*.bin)");
 	if (!dumpFile.isEmpty()) {
 		free(dumpfile_name);
 		dumpfile_name = copy_string(dumpFile.toUtf8().data());

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -537,7 +537,7 @@ void MainWindow::on_actionOpen_triggered()
 	// yes, this look wrong to use getSaveFileName() for the open dialog, but we need to be able
 	// to enter file names that don't exist in order to use our git syntax /path/to/dir[branch]
 	// with is a potentially valid input, but of course won't exist. So getOpenFileName() wouldn't work
-	QFileDialog dialog(this, tr("Open file"), lastUsedDir(), filter());
+	QFileDialog dialog(this, tr("Open file"), lastUsedDir(), filter_open());
 	dialog.setFileMode(QFileDialog::AnyFile);
 	dialog.setViewMode(QFileDialog::Detail);
 	dialog.setLabelText(QFileDialog::Accept, tr("Open"));
@@ -649,7 +649,7 @@ void learnImageDirs(QStringList dirnames)
 void MainWindow::on_actionHash_images_triggered()
 {
 	QFuture<void> future;
-	QFileDialog dialog(this, tr("Traverse image directories"), lastUsedDir(), filter());
+	QFileDialog dialog(this, tr("Traverse image directories"), lastUsedDir());
 	dialog.setFileMode(QFileDialog::Directory);
 	dialog.setViewMode(QFileDialog::Detail);
 	dialog.setLabelText(QFileDialog::Accept, tr("Scan"));
@@ -1258,43 +1258,89 @@ void MainWindow::on_actionUserSurvey_triggered()
 	survey->show();
 }
 
-QString MainWindow::filter()
+QString MainWindow::filter_open()
 {
 	QString f;
-	f += "Dive log files ( *.ssrf ";
-	f += "*.can *.CAN ";
-	f += "*.db *.DB " ;
-	f += "*.sql *.SQL " ;
-	f += "*.dld *.DLD ";
-	f += "*.jlb *.JLB ";
-	f += "*.lvd *.LVD ";
-	f += "*.sde *.SDE ";
-	f += "*.udcf *.UDCF ";
-	f += "*.uddf *.UDDF ";
-	f += "*.xml *.XML ";
-	f += "*.dlf *.DLF ";
-	f += "*.log *.LOG ";
-	f += "*.txt *.TXT) ";
-	f += "*.apd *.APD) ";
-	f += "*.dive *.DIVE ";
-	f += "*.zxu *.zxl *.ZXU *.ZXL ";
+	f += tr("Dive log files");
+	f += " (*.ssrf";
+	f += " *.xml";
+	f += " *.can";
+	f += " *.db" ;
+	f += " *.sql" ;
+	f += " *.dld";
+	f += " *.jlb";
+	f += " *.lvd";
+	f += " *.sde";
+	f += " *.udcf";
+	f += " *.uddf";
+	f += " *.dlf";
+	f += " *.log";
+	f += " *.txt";
+	f += " *.apd";
+	f += " *.dive";
+	f += " *.zxu *.zxl";
 	f += ");;";
 
-	f += "Subsurface (*.ssrf);;";
-	f += "Cochran (*.can *.CAN);;";
-	f += "DiveLogs.de (*.dld *.DLD);;";
-	f += "JDiveLog  (*.jlb *.JLB);;";
-	f += "Liquivision (*.lvd *.LVD);;";
-	f += "Suunto (*.sde *.SDE *.db *.DB);;";
-	f += "UDCF (*.udcf *.UDCF);;";
-	f += "UDDF (*.uddf *.UDDF);;";
-	f += "XML (*.xml *.XML);;";
-	f += "Divesoft (*.dlf *.DLF);;";
-	f += "Datatrak/WLog Files (*.log *.LOG);;";
-	f += "MkVI files (*.txt *.TXT);;";
-	f += "APD log viewer (*.apd *.APD);;";
-	f += "OSTCtools Files (*.dive *.DIVE);;";
-	f += "DAN DL7 (*.zxu *.zxl *.ZXU *.ZXL)";
+	f += tr("Subsurface files") + " (*.ssrf *.xml);;";
+	f += tr("Cochran") + " (*.can);;";
+	f += tr("DiveLogs.de") + " (*.dld);;";
+	f += tr("JDiveLog") + " (*.jlb);;";
+	f += tr("Liquivision") + " (*.lvd);;";
+	f += tr("Suunto") + " (*.sde *.db);;";
+	f += tr("UDCF") + " (*.udcf);;";
+	f += tr("UDDF") + " (*.uddf);;";
+	f += tr("XML") + " (*.xml);;";
+	f += tr("Divesoft") + " (*.dlf);;";
+	f += tr("Datatrak/WLog") + " (*.log);;";
+	f += tr("MkVI files") + " (*.txt);;";
+	f += tr("APD log viewer") + " (*.apd);;";
+	f += tr("OSTCtools") + " (*.dive);;";
+	f += tr("DAN DL7") + " (*.zxu *.zxl)";
+
+	return f;
+}
+
+QString MainWindow::filter_import()
+{
+	QString f;
+	f += tr("Dive log files");
+	f += " (*.ssrf";
+	f += " *.xml";
+	f += " *.can";
+	f += " *.csv";
+	f += " *.db" ;
+	f += " *.sql" ;
+	f += " *.dld";
+	f += " *.jlb";
+	f += " *.lvd";
+	f += " *.sde";
+	f += " *.udcf";
+	f += " *.uddf";
+	f += " *.dlf";
+	f += " *.log";
+	f += " *.txt";
+	f += " *.apd";
+	f += " *.dive";
+	f += " *.zxu *.zxl";
+	f += ");;";
+
+	f += tr("Subsurface files") + " (*.ssrf *.xml);;";
+	f += tr("Cochran") + " (*.can);;";
+	f += tr("CSV") + " (*.csv *.CSV);;";
+	f += tr("DiveLogs.de") + " (*.dld);;";
+	f += tr("JDiveLog") + " (*.jlb);;";
+	f += tr("Liquivision") + " (*.lvd);;";
+	f += tr("Suunto") + " (*.sde *.db);;";
+	f += tr("UDCF") + " (*.udcf);;";
+	f += tr("UDDF") + " (*.uddf);;";
+	f += tr("XML") + " (*.xml);;";
+	f += tr("Divesoft") + " (*.dlf);;";
+	f += tr("Datatrak/WLog") + " (*.log);;";
+	f += tr("MkVI files") + " (*.txt);;";
+	f += tr("APD log viewer") + " (*.apd);;";
+	f += tr("OSTCtools") + " (*.dive);;";
+	f += tr("DAN DL7") + " (*.zxu *.zxl);;";
+	f += tr("All files") + " (*.*)";
 
 	return f;
 }
@@ -1634,7 +1680,7 @@ int MainWindow::file_save_as(void)
 	}
 	// create a file dialog that allows us to save to a new file
 	QFileDialog selection_dialog(this, tr("Save file as"), default_filename,
-					 tr("Subsurface XML files (*.ssrf *.xml *.XML)"));
+					 tr("Subsurface files") + " (*.ssrf *.xml)");
 	selection_dialog.setAcceptMode(QFileDialog::AcceptSave);
 	selection_dialog.setFileMode(QFileDialog::AnyFile);
 	selection_dialog.setDefaultSuffix("");
@@ -1842,24 +1888,7 @@ void MainWindow::loadFiles(const QStringList fileNames)
 
 void MainWindow::on_actionImportDiveLog_triggered()
 {
-	QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Open dive log file"), lastUsedDir(),
-		tr("Dive log files (*.ssrf *.can *.csv *.db *.sql *.dld *.jlb *.lvd *.sde *.udcf *.uddf *.xml *.txt *.dlf *.apd *.zxu *.zxl"
-			"*.SSRF *.CAN *.CSV *.DB *.SQL *.DLD *.JLB *.LVD *.SDE *.UDCF *.UDDF *.xml *.TXT *.DLF *.APD *.ZXU *.ZXL);;"
-			"Cochran files (*.can *.CAN);;"
-			"CSV files (*.csv *.CSV);;"
-			"DiveLog.de files (*.dld *.DLD);;"
-			"JDiveLog files (*.jlb *.JLB);;"
-			"Liquivision files (*.lvd *.LVD);;"
-			"MkVI files (*.txt *.TXT);;"
-			"Suunto files (*.sde *.db *.SDE *.DB);;"
-			"Divesoft files (*.dlf *.DLF);;"
-			"UDDF/UDCF files (*.uddf *.udcf *.UDDF *.UDCF);;"
-			"XML files (*.xml *.XML);;"
-			"APD log viewer (*.apd *.APD);;"
-			"Datatrak/WLog Files (*.log *.LOG);;"
-			"OSTCtools Files (*.dive *.DIVE);;"
-			"DAN DL7 (*.zxu *.zxl *.ZXU *.ZXL);;"
-			"All files (*)"));
+	QStringList fileNames = QFileDialog::getOpenFileNames(this, tr("Open dive log file"), lastUsedDir(), filter_import());
 
 	if (fileNames.isEmpty())
 		return;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -190,7 +190,8 @@ private:
 	QAction *actionPreviousDive;
 	UserManual *helpView;
 	CurrentState state;
-	QString filter();
+	QString filter_open();
+	QString filter_import();
 	static MainWindow *m_Instance;
 	QString displayedFilename(QString fullFilename);
 	bool askSaveChanges();

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -20,7 +20,7 @@ PreferencesDefaults::~PreferencesDefaults()
 void PreferencesDefaults::on_chooseFile_clicked()
 {
 	QFileInfo fi(system_default_filename());
-	QString choosenFileName = QFileDialog::getOpenFileName(this, tr("Open default log file"), fi.absolutePath(), tr("Subsurface XML files (*.ssrf *.xml *.XML)"));
+	QString choosenFileName = QFileDialog::getOpenFileName(this, tr("Open default log file"), fi.absolutePath(), tr("Subsurface files") + " (*.ssrf *.xml)");
 
 	if (!choosenFileName.isEmpty())
 		ui->defaultfilename->setText(choosenFileName);

--- a/desktop-widgets/printoptions.cpp
+++ b/desktop-widgets/printoptions.cpp
@@ -129,7 +129,7 @@ void PrintOptions::on_editButton_clicked()
 void PrintOptions::on_importButton_clicked()
 {
 	QString filename = QFileDialog::getOpenFileName(this, tr("Import template file"), "",
-							tr("HTML files (*.html)"));
+							tr("HTML files") + " (*.html)");
 	if (filename.isEmpty())
 		return;
 	QFileInfo fileInfo(filename);
@@ -142,7 +142,7 @@ void PrintOptions::on_importButton_clicked()
 void PrintOptions::on_exportButton_clicked()
 {
 	QString filename = QFileDialog::getSaveFileName(this, tr("Export template files as"), "",
-							tr("HTML files (*.html)"));
+							tr("HTML files") + " (*.html)");
 	if (filename.isEmpty())
 		return;
 	QFile::copy(getPrintingTemplatePathUser() + QDir::separator() + getSelectedTemplate(), filename);

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -310,7 +310,7 @@ void ShiftImageTimesDialog::syncCameraClicked()
 	QStringList fileNames = QFileDialog::getOpenFileNames(this,
 							      tr("Open image file"),
 							      DiveListView::lastUsedImageDir(),
-							      tr("Image files (*.jpg *.jpeg)"));
+							      tr("Image files") + " (*.jpg *.jpeg)");
 	if (fileNames.isEmpty())
 		return;
 

--- a/smtk-import/smrtk2ssrfc_window.cpp
+++ b/smtk-import/smrtk2ssrfc_window.cpp
@@ -49,8 +49,7 @@ void Smrtk2ssrfcWindow::updateLastUsedDir(const QString &dir)
 void Smrtk2ssrfcWindow::on_inputFilesButton_clicked()
 {
 	inputFiles = QFileDialog::getOpenFileNames(this, tr("Open SmartTrak files"), lastUsedDir(),
-		tr("SmartTrak files (*.slg *.SLG);;"
-		   "All files (*)"));
+		tr("SmartTrak files") + " (*.slg);;" + tr("All files") + " (*.*)");
 	if (inputFiles.isEmpty())
 		return;
 	updateLastUsedDir(QFileInfo(inputFiles[0]).dir().path());
@@ -61,8 +60,7 @@ void Smrtk2ssrfcWindow::on_inputFilesButton_clicked()
 void Smrtk2ssrfcWindow::on_outputFileButton_clicked()
 {
 	outputFile = QFileDialog::getSaveFileName(this, tr("Open Subsurface files"), lastUsedDir(),
-		tr("Subsurface files (*.ssrf *SSRF *.xml *.XML);;"
-		   "All files (*)"));
+		tr("Subsurface files") + " (*.ssrf *.xml);;" + tr("All files") + " (*.*)");
 	if (outputFile.isEmpty())
 		return;
 	updateLastUsedDir(QFileInfo(outputFile).dir().path());


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Started to correct many of the file filters all over the tool because there are a few real mistakes there today.

There are a few questions open before I can finalize this:
- Shall I change it even further and avoid to give any real filters stuff part of the strings like "(*.xyz *.XYZ)" to translation via Transifex? We know that with such stuff mistakes can happen easily. Or is there any need to translate these filters?
- Up to now we had "Subsurface files", "Log files", "Firmware files" and e.g. "Datatrak/Wlog files" but many others like "Cochran", "Divesoft",... Do we want to have the "files" suffix text everywhere or not?
- If I want to translate the name of the filter like "Subsurface files" or "OSTCtools files" shall I give the full name to Transifex or just the string "files"?

Yeah, boring stuff but also important to make the tool look very, very professional ;-)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
