### PR TITLE
Planner: Do not translate VARIATIONS

### DIFF
--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -111,8 +111,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	}
 
 	if (prefs.display_variations)
-		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin VARIATIONS<br></div>"),
-				diveplan_duration(diveplan));
+		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin %s"),
+				diveplan_duration(diveplan), "VARIATIONS<br></div>");
 	else
 		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin<br></div>"),
 				diveplan_duration(diveplan));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This string is substituted with the runtime increments derived of slight variations in depth or bottom time in:

diveplannermodel.cpp:1058:
displayed_dive.notes = strdup(notes.replace("VARIATIONS", QString(buf)).toUtf8().data());

Translating it avoids substitution and we just get the translated string.

Signed-off-by: Salvador Cuñat <salvador.cunat@gmail.com>

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![screenshot](https://user-images.githubusercontent.com/17911757/32123021-f6a3b800-bb62-11e7-8adb-08603c50ee87.jpg)
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

