### PR TITLE
QML UI: show divelist from the top

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -13,6 +13,7 @@ Kirigami.ApplicationWindow {
 	id: rootItem
 	title: qsTr("Subsurface-mobile")
 	reachableModeEnabled: false // while it's a good idea, it seems to confuse more than help
+	wideScreen: true // workaround for probably Kirigami bug. See commit.
 	header: Kirigami.ApplicationHeader {
 		minimumHeight: 0
 		preferredHeight: Math.round(Kirigami.Units.gridUnit * (Qt.platform.os == "ios" ? 2 : 1.5))


### PR DESCRIPTION
In commit bdf6dc78281bec2, we pulled in some changes from Kirigami. I checked all the new commits and they seemed just fine, and a test (on desktop) on both Qt 5.9.1. and 5.9.2 showed no obvious
problems.

However, some time later, working on something else, I compiled from Android to test, and saw some strange behavior in the dive list. The topmost dive is partially hidden behind the application header on startup of the app, but can be pulled down. Not a big deal, but is does not look right.

After tedious testing, bisecting, etc, I found commit d0f3941a4d7f4d4c6 in Kirigami (obviosuly, it was not clear from the start that it was in Kirigami, as I could well have been some error in Subsurface, or even Qt). Mentioned commit is trivial, and handles with the wideScreen property of the application window. With wideScreen = false, the bug is visible, when true the bug is gone.

This all said. Just set the wideScreen to true, which can definitely be considered a workaround. I expect that this commit can be reverted later on when Kirigami is fixed.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
