### PR TITLE
 Add Scubapro Aladin Sport Matrix to list of supported dive computers

### DIFF
--- a/SupportedDivecomputers.txt
+++ b/SupportedDivecomputers.txt
@@ -16,7 +16,7 @@ Mares: Airlab, Darwin, Darwin Air, Icon HD, Icon HD Net Ready, M1, M2, Matrix, N
 Oceanic: Atom 1.0, Atom 2.0, Atom 3.0, Atom 3.1, Datamask, F10, F11, Geo, Geo 2.0, OC1, OCS, OCi, Pro Plus 2, Pro Plus 2.1, Pro Plus 3, VT 4.1, VT Pro, VT3, VT4, VTX, Veo 1.0, Veo 180, Veo 2.0, Veo 200, Veo 250, Veo 3.0, Versa Pro
 Ratio: iDive Deep, iDive Easy, iDive Free, iDive Tech+, iX3M Deep, iX3M Easy, iX3M Pro Deep, iX3M Pro Easy, iX3M Pro Tech+, iX3M Reb, iX3M Tech+
 Reefnet: Sensus, Sensus Pro, Sensus Ultra
-Scubapro: Chromis, G2, Mantis, Mantis 2, Meridian, XTender 5
+Scubapro: Aladin Sport Matrix, Chromis, G2, Mantis, Mantis 2, Meridian, XTender 5
 Seabaer: T1, H3, HUDC
 Seemann: XP5
 Shearwater: Nerd, Perdix, Perdix AI, Petrel, Petrel 2, Predator

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -40,9 +40,10 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		product = "EON Steel";
 	}
 
-	if (btName.startsWith("G2")) {
+	if (btName.startsWith("G2") || btName.startsWith("Aladin")) {
 		vendor = "Scubapro";
-		product = "G2";
+		if(btName.startsWith("G2")) product = "G2";
+		if(btName.startsWith("Aladin")) product = "Aladin Sport Matrix";
 	}
 
 	if (!vendor.isEmpty() && !product.isEmpty())

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -43,6 +43,7 @@ void DownloadThread::run()
 	Q_ASSERT(internalData->download_table != nullptr);
 	const char *errorText;
 	import_thread_cancelled = false;
+	error.clear();
 	if (!strcmp(internalData->vendor, "Uemis"))
 		errorText = do_uemis_import(internalData);
 	else


### PR DESCRIPTION
The protocol is essentially identical to the Scubapro G2.

Moreover, recognize Bluetooth devices advertised as "Aladin" as Aladin Sport Matrix.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Documentation change
- [ ] Language translation
