### PR TITLE
Postpone error message display if not in GUI thread

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -220,6 +220,10 @@ void DownloadFromDCWidget::updateState(states state)
 	// got an error
 	else if (state == ERROR) {
 		timer->stop();
+
+		// Show messages that worker thread produced.
+		MainWindow::instance()->showErrors();
+
 		QMessageBox::critical(this, TITLE_OR_TEXT(tr("Error"), thread.error), QMessageBox::Ok);
 		markChildrenAsEnabled();
 		progress_bar_text = "";

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -88,12 +88,22 @@ MainWindow *MainWindow::m_Instance = NULL;
 
 extern "C" void showErrorFromC()
 {
+	// Show errors only if we are running in the GUI thread.
+	// If we're not in the GUI thread, let errors accumulate.
+	if (QThread::currentThread() != QCoreApplication::instance()->thread())
+		return;
+
 	MainWindow *mainwindow = MainWindow::instance();
-	if (mainwindow) {
-		mainwindow->getNotificationWidget()->showNotification(get_error_string(), KMessageWidget::Error);
-	}
+	if (mainwindow)
+		mainwindow->showErrors();
 }
 
+void MainWindow::showErrors()
+{
+	const char *error = get_error_string();
+	if (error && error[0])
+		getNotificationWidget()->showNotification(error, KMessageWidget::Error);
+}
 
 MainWindow::MainWindow() : QMainWindow(),
 	actionNextDive(0),

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -89,6 +89,10 @@ public:
 	void enableDisableCloudActions();
 	void setCheckedActionFilterTags(bool checked);
 
+	// Shows errors that have accumulated.
+	// Must be called from GUI thread.
+	void showErrors();
+
 private
 slots:
 	/* file menu action */


### PR DESCRIPTION
Calls to report_error() crashed if not called from GUI thread.
Fix this by postponing error message display if not in GUI thread.
Code that creates a thread which possibly calls report_error()
is responsible for calling MainWindow::showErrors() to flush
the accumulated messages.

Note that there is a race condition in report_error() and
get_error_string(). Nevertheless, hitting it should be rather
unlikely (two threads producing error messages at the same time)
and hopefully it can be fixed rather easily.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
