### PR TITLE
Reset device field in DownloadFromDCWidget according to dive computer

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -258,18 +258,7 @@ void DownloadFromDCWidget::on_vendor_currentIndexChanged(const QString &vendor)
 
 void DownloadFromDCWidget::on_product_currentIndexChanged(const QString &product)
 {
-	// Set up the DC descriptor
-	dc_descriptor_t *descriptor = NULL;
-	descriptor = descriptorLookup[ui.vendor->currentText() + product];
-
-	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
-	if (dc_descriptor_get_transport(descriptor) == DC_TRANSPORT_SERIAL) {
-		// if the dc_transport_t is DC_TRANSPORT_SERIAL, then enable the device node box.
-		ui.device->setEnabled(true);
-	} else {
-		// otherwise disable the device node box
-		ui.device->setEnabled(false);
-	}
+	updateDeviceEnabled();
 }
 
 void DownloadFromDCWidget::on_search_clicked()
@@ -489,6 +478,22 @@ void DownloadFromDCWidget::on_ok_clicked()
 	accept();
 }
 
+void DownloadFromDCWidget::updateDeviceEnabled()
+{
+	// Set up the DC descriptor
+	dc_descriptor_t *descriptor = NULL;
+	descriptor = descriptorLookup[ui.vendor->currentText() + ui.product->currentText()];
+
+	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
+	if (dc_descriptor_get_transport(descriptor) == DC_TRANSPORT_SERIAL) {
+		// if the dc_transport_t is DC_TRANSPORT_SERIAL, then enable the device node box.
+		ui.device->setEnabled(true);
+	} else {
+		// otherwise disable the device node box
+		ui.device->setEnabled(false);
+	}
+}
+
 void DownloadFromDCWidget::markChildrenAsDisabled()
 {
 	ui.device->setEnabled(false);
@@ -511,7 +516,7 @@ void DownloadFromDCWidget::markChildrenAsDisabled()
 
 void DownloadFromDCWidget::markChildrenAsEnabled()
 {
-	ui.device->setEnabled(true);
+	updateDeviceEnabled();
 	ui.vendor->setEnabled(true);
 	ui.product->setEnabled(true);
 	ui.forceDownload->setEnabled(true);

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -58,6 +58,7 @@ slots:
 private:
 	void markChildrenAsDisabled();
 	void markChildrenAsEnabled();
+	void updateDeviceEnabled();
 
 	Ui::DownloadFromDiveComputer ui;
 	DownloadThread thread;


### PR DESCRIPTION
Fixes minor interface inconsistency: The device field in the
download-from-dive-computer widget is disabled when selecting
a non-serial-transport dive computer. In contrast, post-download
the field was reset to enabled for all dive computers.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Fix minor interface inconsistency

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
