### PR TITLE
O2 breaks enhancements and cleanup, planner options UI

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -1000,7 +1000,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 				o2breaking = false;
 				stop_cylinder = current_cylinder;
-				if (prefs.doo2breaks) {
+				if (prefs.doo2breaks && prefs.last_stop) {
 					/* The backgas breaks option limits time on oxygen to 12 minutes, followed by 6 minutes on
 					 * backgas.  This could be customized if there were demand.
 					 */

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -250,13 +250,18 @@ void PlannerSettingsWidget::decoSacChanged(const double decosac)
 void PlannerSettingsWidget::disableDecoElements(int mode)
 {
 	if (mode == RECREATIONAL) {
+		ui.label_gflow->setDisabled(false);
+		ui.label_gfhigh->setDisabled(false);
 		ui.gflow->setDisabled(false);
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(true);
 		ui.backgasBreaks->setDisabled(true);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(true);
+		ui.safetystop->setDisabled(false);
+		ui.label_reserve_gas->setDisabled(false);
 		ui.reserve_gas->setDisabled(false);
+		ui.label_vpmb_conservatism->setDisabled(true);
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(true);
 		ui.min_switch_duration->setDisabled(true);
@@ -270,13 +275,18 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.problemsolvingtime->blockSignals(false);
 	}
 	else if (mode == VPMB) {
+		ui.label_gflow->setDisabled(true);
+		ui.label_gfhigh->setDisabled(true);
 		ui.gflow->setDisabled(true);
 		ui.gfhigh->setDisabled(true);
 		ui.lastStop->setDisabled(false);
 		ui.backgasBreaks->setDisabled(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
+		ui.safetystop->setDisabled(true);
+		ui.label_reserve_gas->setDisabled(true);
 		ui.reserve_gas->setDisabled(true);
+		ui.label_vpmb_conservatism->setDisabled(false);
 		ui.vpmb_conservatism->setDisabled(false);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);
@@ -286,13 +296,18 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.problemsolvingtime->setValue(prefs.problemsolvingtime);
 	}
 	else if (mode == BUEHLMANN) {
+		ui.label_gflow->setDisabled(false);
+		ui.label_gfhigh->setDisabled(false);
 		ui.gflow->setDisabled(false);
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(false);
 		ui.backgasBreaks->setDisabled(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
+		ui.safetystop->setDisabled(true);
+		ui.label_reserve_gas->setDisabled(true);
 		ui.reserve_gas->setDisabled(true);
+		ui.label_vpmb_conservatism->setDisabled(true);
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -318,6 +318,21 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 	}
 }
 
+void PlannerSettingsWidget::disableBackgasBreaks(bool enabled)
+{
+	if (enabled) {
+		ui.backgasBreaks->setDisabled(false);
+		ui.backgasBreaks->blockSignals(true);
+		ui.backgasBreaks->setChecked(prefs.doo2breaks);
+		ui.backgasBreaks->blockSignals(false);
+	} else {
+		ui.backgasBreaks->setDisabled(true);
+		ui.backgasBreaks->blockSignals(true);
+		ui.backgasBreaks->setChecked(false);
+		ui.backgasBreaks->blockSignals(false);
+	}
+}
+
 void DivePlannerWidget::printDecoPlan()
 {
 	MainWindow::instance()->printPlan();
@@ -351,6 +366,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.buehlmann_deco->setChecked(prefs.planner_deco_mode == BUEHLMANN);
 	ui.vpmb_deco->setChecked(prefs.planner_deco_mode == VPMB);
 	disableDecoElements((int) prefs.planner_deco_mode);
+	disableBackgasBreaks(prefs.last_stop);
 
 	// should be the same order as in dive_comp_type!
 	rebreather_modes << tr("Open circuit") << tr("CCR") << tr("pSCR");
@@ -367,6 +383,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.vpmb_deco, SIGNAL(clicked()), modeMapper, SLOT(map()));
 
 	connect(ui.lastStop, SIGNAL(toggled(bool)), plannerModel, SLOT(setLastStop6m(bool)));
+	connect(ui.lastStop, SIGNAL(toggled(bool)), this, SLOT(disableBackgasBreaks(bool)));
 	connect(ui.verbatim_plan, SIGNAL(toggled(bool)), plannerModel, SLOT(setVerbatim(bool)));
 	connect(ui.display_duration, SIGNAL(toggled(bool)), plannerModel, SLOT(setDisplayDuration(bool)));
 	connect(ui.display_runtime, SIGNAL(toggled(bool)), plannerModel, SLOT(setDisplayRuntime(bool)));

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -86,6 +86,7 @@ slots:
 	void setBestmixEND(int depth);
 	void setBackgasBreaks(bool dobreaks);
 	void disableDecoElements(int mode);
+	void disableBackgasBreaks(bool enabled);
 	void setDiveMode(int mode);
 
 private:

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -338,9 +338,9 @@
            </widget>
           </item>
           <item row="19" column="1">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="label_min_switch_duration">
             <property name="text">
-             <string>Min. switch duration</string>
+             <string>Min. switch duration O₂% below 100%</string>
             </property>
            </widget>
           </item>

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -273,7 +273,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_reserve_gas">
             <property name="text">
              <string>Reserve gas</string>
             </property>
@@ -338,7 +338,7 @@
            </spacer>
           </item>
           <item row="8" column="1">
-           <widget class="QLabel" name="label_15">
+           <widget class="QLabel" name="label_gflow">
             <property name="text">
              <string>GFLow</string>
             </property>
@@ -355,7 +355,7 @@
            </widget>
           </item>
           <item row="9" column="1">
-           <widget class="QLabel" name="label_16">
+           <widget class="QLabel" name="label_gfhigh">
             <property name="text">
              <string>GFHigh</string>
             </property>
@@ -490,7 +490,7 @@
            </spacer>
           </item>
           <item row="12" column="1">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="label_vpmb_conservatism">
             <property name="text">
              <string>Conservatism level</string>
             </property>

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -255,34 +255,7 @@
           <property name="spacing">
            <number>2</number>
           </property>
-          <item row="11" column="1">
-           <widget class="QRadioButton" name="vpmb_deco">
-            <property name="text">
-             <string>VPM-B deco</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QRadioButton" name="buehlmann_deco">
-            <property name="text">
-             <string>Bühlmann deco</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="label_reserve_gas">
-            <property name="text">
-             <string>Reserve gas</string>
-            </property>
-            <property name="indent">
-             <number>26</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
+          <item row="2" column="2">
            <widget class="QSpinBox" name="reserve_gas">
             <property name="suffix">
              <string>bar</string>
@@ -301,30 +274,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="2">
-           <widget class="QSpinBox" name="gfhigh">
-            <property name="suffix">
-             <string>%</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>150</number>
-            </property>
-           </widget>
-          </item>
-          <item row="17" column="1" colspan="2">
-           <widget class="QCheckBox" name="switch_at_req_stop">
-            <property name="toolTip">
-             <string>Postpone gas change if a stop is not required</string>
-            </property>
-            <property name="text">
-             <string>Only switch at required stops</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -337,24 +287,17 @@
             </property>
            </spacer>
           </item>
-          <item row="8" column="1">
-           <widget class="QLabel" name="label_gflow">
-            <property name="text">
-             <string>GFLow</string>
+          <item row="18" column="1" colspan="2">
+           <widget class="QCheckBox" name="switch_at_req_stop">
+            <property name="toolTip">
+             <string>Postpone gas change if a stop is not required</string>
             </property>
-            <property name="indent">
-             <number>26</number>
+            <property name="text">
+             <string>Only switch at required stops</string>
             </property>
            </widget>
           </item>
-          <item row="16" column="1" colspan="2">
-           <widget class="QCheckBox" name="backgasBreaks">
-            <property name="text">
-             <string>Plan backgas breaks</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <widget class="QLabel" name="label_gfhigh">
             <property name="text">
              <string>GFHigh</string>
@@ -364,7 +307,64 @@
             </property>
            </widget>
           </item>
-          <item row="18" column="2">
+          <item row="9" column="1">
+           <widget class="QLabel" name="label_gflow">
+            <property name="text">
+             <string>GFLow</string>
+            </property>
+            <property name="indent">
+             <number>26</number>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2">
+           <widget class="QSpinBox" name="gflow">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>150</number>
+            </property>
+           </widget>
+          </item>
+          <item row="15" column="1" colspan="2">
+           <widget class="QCheckBox" name="drop_stone_mode">
+            <property name="text">
+             <string>Drop to first depth</string>
+            </property>
+           </widget>
+          </item>
+          <item row="19" column="1">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Min. switch duration</string>
+            </property>
+           </widget>
+          </item>
+          <item row="21" column="1">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="17" column="1" colspan="2">
+           <widget class="QCheckBox" name="backgasBreaks">
+            <property name="text">
+             <string>Plan backgas breaks</string>
+            </property>
+           </widget>
+          </item>
+          <item row="19" column="2">
            <widget class="QSpinBox" name="min_switch_duration">
             <property name="suffix">
              <string>min</string>
@@ -383,14 +383,14 @@
             </property>
            </widget>
           </item>
-          <item row="15" column="1" colspan="2">
+          <item row="16" column="1" colspan="2">
            <widget class="QCheckBox" name="lastStop">
             <property name="text">
              <string>Last stop at 6m</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QRadioButton" name="recreational_deco">
             <property name="toolTip">
              <string>Maximize bottom time allowed by gas and no decompression limits</string>
@@ -400,18 +400,8 @@
             </property>
            </widget>
           </item>
-          <item row="19" column="1">
-           <widget class="QComboBox" name="rebreathermode">
-            <property name="currentText">
-             <string/>
-            </property>
-            <property name="maxVisibleItems">
-             <number>6</number>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="2">
-           <widget class="QSpinBox" name="gflow">
+          <item row="10" column="2">
+           <widget class="QSpinBox" name="gfhigh">
             <property name="suffix">
              <string>%</string>
             </property>
@@ -423,34 +413,34 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="1" colspan="2">
-           <widget class="QCheckBox" name="drop_stone_mode">
+          <item row="12" column="1">
+           <widget class="QRadioButton" name="vpmb_deco">
             <property name="text">
-             <string>Drop to first depth</string>
+             <string>VPM-B deco</string>
             </property>
            </widget>
           </item>
-          <item row="18" column="1">
-           <widget class="QLabel" name="label_4">
+          <item row="5" column="1">
+           <widget class="QRadioButton" name="buehlmann_deco">
             <property name="text">
-             <string>Min. switch duration</string>
+             <string>Bühlmann deco</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="20" column="1">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+          <item row="2" column="1">
+           <widget class="QLabel" name="label_reserve_gas">
+            <property name="text">
+             <string>Reserve gas</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="indent">
+             <number>26</number>
             </property>
-           </spacer>
+           </widget>
           </item>
-          <item row="2" column="1" alignment="Qt::AlignHCenter">
+          <item row="3" column="1" alignment="Qt::AlignHCenter">
            <widget class="QCheckBox" name="safetystop">
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
@@ -463,7 +453,7 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="11" column="1">
            <spacer name="verticalSpacer_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -476,7 +466,7 @@
             </property>
            </spacer>
           </item>
-          <item row="13" column="1">
+          <item row="14" column="1">
            <spacer name="verticalSpacer_5">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -489,7 +479,7 @@
             </property>
            </spacer>
           </item>
-          <item row="12" column="1">
+          <item row="13" column="1">
            <widget class="QLabel" name="label_vpmb_conservatism">
             <property name="text">
              <string>Conservatism level</string>
@@ -499,13 +489,30 @@
             </property>
            </widget>
           </item>
-          <item row="12" column="2">
+          <item row="13" column="2">
            <widget class="QSpinBox" name="vpmb_conservatism">
             <property name="prefix">
              <string>+</string>
             </property>
             <property name="maximum">
              <number>4</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QComboBox" name="rebreathermode">
+            <property name="currentText">
+             <string/>
+            </property>
+            <property name="maxVisibleItems">
+             <number>6</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_dive_type">
+            <property name="text">
+             <string>Dive mode</string>
             </property>
            </widget>
           </item>
@@ -819,6 +826,7 @@
   <tabstop>ascRateStops</tabstop>
   <tabstop>ascRateLast6m</tabstop>
   <tabstop>descRate</tabstop>
+  <tabstop>rebreathermode</tabstop>
   <tabstop>recreational_deco</tabstop>
   <tabstop>reserve_gas</tabstop>
   <tabstop>safetystop</tabstop>
@@ -832,7 +840,6 @@
   <tabstop>backgasBreaks</tabstop>
   <tabstop>switch_at_req_stop</tabstop>
   <tabstop>min_switch_duration</tabstop>
-  <tabstop>rebreathermode</tabstop>
   <tabstop>bottomSAC</tabstop>
   <tabstop>decoStopSAC</tabstop>
   <tabstop>sacfactor</tabstop>
@@ -844,6 +851,7 @@
   <tabstop>display_duration</tabstop>
   <tabstop>display_transitions</tabstop>
   <tabstop>verbatim_plan</tabstop>
+  <tabstop>display_variations</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
After the last fixes around the o2 breaks in the planner I found two other issue:
1. Now the minimum gas switch time for the switch to oxy is also suppressed if O2 breaks are switched on but no O2 breaks happen because O2 deco time is too short (<12min) for O2 breaks. Finally we decided to really always suppress minimum switch time for change to O2 but to also reflect this in the UI.
Plus does some cleanup of (unused) variables.

2. Disabling "last stop at 6m/20ft" still breaks the whole O2 breaks timing calculation with the current implementation. My proposal to fix this is to disable the whole O2 breaks feature if "last stop at 6m" is not activated. IMHO this makes sense - please correct me if I'm wrong! Benefit also would be reducing the number of possible combinations of planner options in this specific area (testing effort!).



All this comes also with two slightly off topic commit to even more consistently enable/disable some planner option and UI elements based on selected deco mode and change the position of the dive type selection in the planner UI. IMHO these ones are no brainers.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->


### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
