### PR TITLE
desktop-main.cpp: round the fractional part of the GL version

### DIFF
--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -190,7 +190,7 @@ void validateGL()
 		}
 		if (sscanf(verChar, "%f", &verFloat) == 1) {
 			verMajor = (GLint)verFloat;
-			verMinor = (GLint)((verFloat - verMajor) * 10.f);
+			verMinor = (GLint)roundf((verFloat - verMajor) * 10.f);
 		}
 	}
 	// attempt to detect version using the newer API


### PR DESCRIPTION
When verMinor is extracted with the glGetString() method,
use roundf() to round the GL MINOR version to an integer.

2.1 is split in 2 and 1.

Without this patch rounding issues are present as for 32bit IEEE
the default rounding makes (0.1f * 10.f) into 0.999999f.

Given the MINOR is a single digit for GL, calling roundf() on
0.999999 gives the expected result 1 for the MINOR.

Reported-by: Murillo Fernandes Bernardes <notifications@github.com>
Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
