### PR TITLE
Improve calculation of VPMB ceiling outside of planner

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -894,7 +894,7 @@ struct deco_state {
 	pressure_t max_bottom_ceiling_pressure;
 	int ci_pointing_to_guiding_tissue;
 	double gf_low_pressure_this_dive;
-	int bottom_time;
+	int deco_time;
 };
 
 extern void add_segment(double pressure, const struct gasmix *gasmix, int period_in_seconds, int setpoint, const struct dive *dive, int sac);

--- a/core/dive.h
+++ b/core/dive.h
@@ -894,7 +894,7 @@ struct deco_state {
 	pressure_t max_bottom_ceiling_pressure;
 	int ci_pointing_to_guiding_tissue;
 	double gf_low_pressure_this_dive;
-
+	int bottom_time;
 };
 
 extern void add_segment(double pressure, const struct gasmix *gasmix, int period_in_seconds, int setpoint, const struct dive *dive, int sac);

--- a/core/planner.c
+++ b/core/planner.c
@@ -652,7 +652,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	int bottom_gi;
 	int bottom_stopidx;
 	bool is_final_plan = true;
-	int deco_time;
+	int bottom_time;
 	int previous_deco_time;
 	struct deco_state *bottom_cache = NULL;
 	struct sample *sample;
@@ -713,7 +713,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	sample = &dive->dc.sample[dive->dc.samples - 1];
 
 	/* Keep time during the ascend */
-	deco_state->bottom_time = clock = previous_point_time = dive->dc.sample[dive->dc.samples - 1].time.seconds;
+	bottom_time = clock = previous_point_time = dive->dc.sample[dive->dc.samples - 1].time.seconds;
 
 	current_cylinder = get_cylinderid_at_time(dive, &dive->dc, sample->time);
 	gas = dive->cylinder[current_cylinder].gasmix;
@@ -721,7 +721,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	po2 = sample->setpoint.mbar;
 	depth = dive->dc.sample[dive->dc.samples - 1].depth.mm;
 	average_max_depth(diveplan, &avg_depth, &max_depth);
-	last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
+	last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
 
 	/* if all we wanted was the dive just get us back to the surface */
 	if (!is_planner) {
@@ -765,7 +765,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 	if (decoMode() == RECREATIONAL) {
 		bool safety_stop = prefs.safetystop && max_depth >= 10000;
-		track_ascent_gas(depth, &dive->cylinder[current_cylinder], avg_depth, deco_state->bottom_time, safety_stop);
+		track_ascent_gas(depth, &dive->cylinder[current_cylinder], avg_depth, bottom_time, safety_stop);
 		// How long can we stay at the current depth and still directly ascent to the surface?
 		do {
 			add_segment(depth_to_bar(depth, dive),
@@ -773,7 +773,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 				    timestep, po2, dive, prefs.bottomsac);
 			update_cylinder_pressure(dive, depth, depth, timestep, prefs.bottomsac, &dive->cylinder[current_cylinder], false);
 			clock += timestep;
-		} while (trial_ascent(0, depth, 0, avg_depth, deco_state->bottom_time, &dive->cylinder[current_cylinder].gasmix,
+		} while (trial_ascent(0, depth, 0, avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix,
 				      po2, diveplan->surface_pressure / 1000.0, dive) &&
 			 enough_gas(current_cylinder));
 
@@ -787,11 +787,11 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		previous_point_time = clock;
 		do {
 			/* Ascend to surface */
-			int deltad = ascent_velocity(depth, avg_depth, deco_state->bottom_time) * TIMESTEP;
-			if (ascent_velocity(depth, avg_depth, deco_state->bottom_time) != last_ascend_rate) {
+			int deltad = ascent_velocity(depth, avg_depth, bottom_time) * TIMESTEP;
+			if (ascent_velocity(depth, avg_depth, bottom_time) != last_ascend_rate) {
 				plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false);
 				previous_point_time = clock;
-				last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
+				last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
 			}
 			if (depth - deltad < 0)
 				deltad = depth;
@@ -830,7 +830,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	// VPM-B or Buehlmann Deco
 	tissue_at_end(dive, cached_datap);
 	previous_deco_time = 100000000;
-	deco_time = 10000000;
+	deco_state->deco_time = 10000000;
 	cache_deco_state(&bottom_cache);  // Lets us make several iterations
 	bottom_depth = depth;
 	bottom_gi = gi;
@@ -840,16 +840,16 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	//CVA
 	do {
 		decostopcounter = 0;
-		is_final_plan = (decoMode() == BUEHLMANN) || (previous_deco_time - deco_time < 10);  // CVA time converges
-		if (deco_time != 10000000)
-			vpmb_next_gradient(deco_time, diveplan->surface_pressure / 1000.0);
+		is_final_plan = (decoMode() == BUEHLMANN) || (previous_deco_time - deco_state->deco_time < 10);  // CVA time converges
+		if (deco_state->deco_time != 10000000)
+			vpmb_next_gradient(deco_state->deco_time, diveplan->surface_pressure / 1000.0);
 
-		previous_deco_time = deco_time;
+		previous_deco_time = deco_state->deco_time;
 		restore_deco_state(bottom_cache, true);
 
 		depth = bottom_depth;
 		gi = bottom_gi;
-		clock = previous_point_time = deco_state->bottom_time;
+		clock = previous_point_time = bottom_time;
 		gas = bottom_gas;
 		stopping = false;
 		decodive = false;
@@ -866,7 +866,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		if (deco_state->max_bottom_ceiling_pressure.mbar > deco_state->first_ceiling_pressure.mbar)
 			deco_state->first_ceiling_pressure.mbar = deco_state->max_bottom_ceiling_pressure.mbar;
 
-		last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
+		last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
 		/* Always prefer the best_first_ascend_cylinder if it has the right gasmix.
 		 * Otherwise take first cylinder from list with rightgasmix  */
 		if (same_gasmix(&gas, &dive->cylinder[best_first_ascend_cylinder].gasmix))
@@ -882,13 +882,13 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			/* We will break out when we hit the surface */
 			do {
 				/* Ascend to next stop depth */
-				int deltad = ascent_velocity(depth, avg_depth, deco_state->bottom_time) * TIMESTEP;
-				if (ascent_velocity(depth, avg_depth, deco_state->bottom_time) != last_ascend_rate) {
+				int deltad = ascent_velocity(depth, avg_depth, bottom_time) * TIMESTEP;
+				if (ascent_velocity(depth, avg_depth, bottom_time) != last_ascend_rate) {
 					if (is_final_plan)
 						plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false);
 					previous_point_time = clock;
 					stopping = false;
-					last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
+					last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
 				}
 				if (depth - deltad < stoplevels[stopidx])
 					deltad = depth - stoplevels[stopidx];
@@ -921,7 +921,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 				if (current_cylinder != gaschanges[gi].gasidx) {
 					if (!prefs.switch_at_req_stop ||
-							!trial_ascent(0, depth, stoplevels[stopidx - 1], avg_depth, deco_state->bottom_time,
+							!trial_ascent(0, depth, stoplevels[stopidx - 1], avg_depth, bottom_time,
 							&dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0, dive) || get_o2(&dive->cylinder[current_cylinder].gasmix) < 160) {
 						current_cylinder = gaschanges[gi].gasidx;
 						gas = dive->cylinder[current_cylinder].gasmix;
@@ -950,7 +950,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			/* Save the current state and try to ascend to the next stopdepth */
 			while (1) {
 				/* Check if ascending to next stop is clear, go back and wait if we hit the ceiling on the way */
-				if (trial_ascent(0, depth, stoplevels[stopidx], avg_depth, deco_state->bottom_time,
+				if (trial_ascent(0, depth, stoplevels[stopidx], avg_depth, bottom_time,
 						&dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0, dive)) {
 					decostoptable[decostopcounter].depth = depth;
 					decostoptable[decostopcounter].time = 0;
@@ -992,7 +992,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 					pendinggaschange = false;
 				}
 
-				int new_clock = wait_until(dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth, deco_state->bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
+				int new_clock = wait_until(dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
 				laststoptime = new_clock - clock;
 				/* Finish infinite deco */
 				if (clock >= 48 * 3600 && depth >= 6000) {
@@ -1064,7 +1064,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		 * otherwise odd things can happen, such as CVA causing the final ascent to start *later*
 		 * if the ascent rate is slower, which is completely nonsensical.
 		 * Assume final ascent takes 20s, which is the time taken to ascend at 9m/min from 3m */
-		deco_time = clock - deco_state->bottom_time - stoplevels[2] / last_ascend_rate + 20;
+		deco_state->deco_time = clock - bottom_time - stoplevels[2] / last_ascend_rate + 20;
 	} while (!is_final_plan);
 	decostoptable[decostopcounter].depth = 0;
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -1060,8 +1060,11 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 				stopping = false;
 			}
 		}
-
-		deco_time = clock - deco_state->bottom_time;
+		/* When calculating deco_time, we should pretend the final ascent rate is always the same,
+		 * otherwise odd things can happen, such as CVA causing the final ascent to start *later*
+		 * if the ascent rate is slower, which is completely nonsensical.
+		 * Assume final ascent takes 20s, which is the time taken to ascend at 9m/min from 3m */
+		deco_time = clock - deco_state->bottom_time - stoplevels[2] / last_ascend_rate + 20;
 	} while (!is_final_plan);
 	decostoptable[decostopcounter].depth = 0;
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -34,7 +34,6 @@ int decostoplevels_imperial[] = { 0, 3048, 6096, 9144, 12192, 15240, 18288, 2133
 				325120, 345440, 365760, 386080 };
 
 double plangflow, plangfhigh;
-int bottom_time = 0;
 
 extern double regressiona();
 extern double regressionb();
@@ -713,13 +712,16 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	/* Let's start at the last 'sample', i.e. the last manually entered waypoint. */
 	sample = &dive->dc.sample[dive->dc.samples - 1];
 
+	/* Keep time during the ascend */
+	deco_state->bottom_time = clock = previous_point_time = dive->dc.sample[dive->dc.samples - 1].time.seconds;
+
 	current_cylinder = get_cylinderid_at_time(dive, &dive->dc, sample->time);
 	gas = dive->cylinder[current_cylinder].gasmix;
 
 	po2 = sample->setpoint.mbar;
 	depth = dive->dc.sample[dive->dc.samples - 1].depth.mm;
 	average_max_depth(diveplan, &avg_depth, &max_depth);
-	last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
+	last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
 
 	/* if all we wanted was the dive just get us back to the surface */
 	if (!is_planner) {
@@ -754,8 +756,6 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 	stoplevels = sort_stops(decostoplevels, stopidx + 1, gaschanges, gaschangenr);
 	stopidx += gaschangenr;
 
-	/* Keep time during the ascend */
-	bottom_time = clock = previous_point_time = dive->dc.sample[dive->dc.samples - 1].time.seconds;
 	gi = gaschangenr - 1;
 
 	/* Set tissue tolerance and initial vpmb gradient at start of ascent phase */
@@ -765,7 +765,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 	if (decoMode() == RECREATIONAL) {
 		bool safety_stop = prefs.safetystop && max_depth >= 10000;
-		track_ascent_gas(depth, &dive->cylinder[current_cylinder], avg_depth, bottom_time, safety_stop);
+		track_ascent_gas(depth, &dive->cylinder[current_cylinder], avg_depth, deco_state->bottom_time, safety_stop);
 		// How long can we stay at the current depth and still directly ascent to the surface?
 		do {
 			add_segment(depth_to_bar(depth, dive),
@@ -773,7 +773,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 				    timestep, po2, dive, prefs.bottomsac);
 			update_cylinder_pressure(dive, depth, depth, timestep, prefs.bottomsac, &dive->cylinder[current_cylinder], false);
 			clock += timestep;
-		} while (trial_ascent(0, depth, 0, avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix,
+		} while (trial_ascent(0, depth, 0, avg_depth, deco_state->bottom_time, &dive->cylinder[current_cylinder].gasmix,
 				      po2, diveplan->surface_pressure / 1000.0, dive) &&
 			 enough_gas(current_cylinder));
 
@@ -787,11 +787,11 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		previous_point_time = clock;
 		do {
 			/* Ascend to surface */
-			int deltad = ascent_velocity(depth, avg_depth, bottom_time) * TIMESTEP;
-			if (ascent_velocity(depth, avg_depth, bottom_time) != last_ascend_rate) {
+			int deltad = ascent_velocity(depth, avg_depth, deco_state->bottom_time) * TIMESTEP;
+			if (ascent_velocity(depth, avg_depth, deco_state->bottom_time) != last_ascend_rate) {
 				plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false);
 				previous_point_time = clock;
-				last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
+				last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
 			}
 			if (depth - deltad < 0)
 				deltad = depth;
@@ -849,7 +849,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 		depth = bottom_depth;
 		gi = bottom_gi;
-		clock = previous_point_time = bottom_time;
+		clock = previous_point_time = deco_state->bottom_time;
 		gas = bottom_gas;
 		stopping = false;
 		decodive = false;
@@ -866,7 +866,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		if (deco_state->max_bottom_ceiling_pressure.mbar > deco_state->first_ceiling_pressure.mbar)
 			deco_state->first_ceiling_pressure.mbar = deco_state->max_bottom_ceiling_pressure.mbar;
 
-		last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
+		last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
 		/* Always prefer the best_first_ascend_cylinder if it has the right gasmix.
 		 * Otherwise take first cylinder from list with rightgasmix  */
 		if (same_gasmix(&gas, &dive->cylinder[best_first_ascend_cylinder].gasmix))
@@ -882,13 +882,13 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			/* We will break out when we hit the surface */
 			do {
 				/* Ascend to next stop depth */
-				int deltad = ascent_velocity(depth, avg_depth, bottom_time) * TIMESTEP;
-				if (ascent_velocity(depth, avg_depth, bottom_time) != last_ascend_rate) {
+				int deltad = ascent_velocity(depth, avg_depth, deco_state->bottom_time) * TIMESTEP;
+				if (ascent_velocity(depth, avg_depth, deco_state->bottom_time) != last_ascend_rate) {
 					if (is_final_plan)
 						plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false);
 					previous_point_time = clock;
 					stopping = false;
-					last_ascend_rate = ascent_velocity(depth, avg_depth, bottom_time);
+					last_ascend_rate = ascent_velocity(depth, avg_depth, deco_state->bottom_time);
 				}
 				if (depth - deltad < stoplevels[stopidx])
 					deltad = depth - stoplevels[stopidx];
@@ -921,7 +921,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 
 				if (current_cylinder != gaschanges[gi].gasidx) {
 					if (!prefs.switch_at_req_stop ||
-							!trial_ascent(0, depth, stoplevels[stopidx - 1], avg_depth, bottom_time,
+							!trial_ascent(0, depth, stoplevels[stopidx - 1], avg_depth, deco_state->bottom_time,
 							&dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0, dive) || get_o2(&dive->cylinder[current_cylinder].gasmix) < 160) {
 						current_cylinder = gaschanges[gi].gasidx;
 						gas = dive->cylinder[current_cylinder].gasmix;
@@ -950,7 +950,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			/* Save the current state and try to ascend to the next stopdepth */
 			while (1) {
 				/* Check if ascending to next stop is clear, go back and wait if we hit the ceiling on the way */
-				if (trial_ascent(0, depth, stoplevels[stopidx], avg_depth, bottom_time,
+				if (trial_ascent(0, depth, stoplevels[stopidx], avg_depth, deco_state->bottom_time,
 						&dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0, dive)) {
 					decostoptable[decostopcounter].depth = depth;
 					decostoptable[decostopcounter].time = 0;
@@ -992,7 +992,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 					pendinggaschange = false;
 				}
 
-				int new_clock = wait_until(dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth, bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
+				int new_clock = wait_until(dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth, deco_state->bottom_time, &dive->cylinder[current_cylinder].gasmix, po2, diveplan->surface_pressure / 1000.0);
 				laststoptime = new_clock - clock;
 				/* Finish infinite deco */
 				if (clock >= 48 * 3600 && depth >= 6000) {
@@ -1061,7 +1061,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 			}
 		}
 
-		deco_time = clock - bottom_time;
+		deco_time = clock - deco_state->bottom_time;
 	} while (!is_final_plan);
 	decostoptable[decostopcounter].depth = 0;
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -1064,7 +1064,7 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 		 * otherwise odd things can happen, such as CVA causing the final ascent to start *later*
 		 * if the ascent rate is slower, which is completely nonsensical.
 		 * Assume final ascent takes 20s, which is the time taken to ascend at 9m/min from 3m */
-		deco_state->deco_time = clock - bottom_time - stoplevels[2] / last_ascend_rate + 20;
+		deco_state->deco_time = clock - bottom_time - stoplevels[stopidx + 1] / last_ascend_rate + 20;
 	} while (!is_final_plan);
 	decostoptable[decostopcounter].depth = 0;
 

--- a/core/profile.c
+++ b/core/profile.c
@@ -1080,7 +1080,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 			prev_deco_time = deco_state->deco_time;
 			// Do we need to update deco_time?
 			if (final_tts > 0)
-				deco_state->deco_time = pi->maxtime + final_tts - time_deep_ceiling;
+				deco_state->deco_time = last_ndl_tts_calc_time + final_tts - time_deep_ceiling;
 			else if (time_clear_ceiling > 0)
 				/* Consistent with planner, deco_time ends after ascending (20s @9m/min from 3m)
 				 * at end of whole minute after clearing ceiling. The deepest ceiling when planning a dive

--- a/core/profile.c
+++ b/core/profile.c
@@ -1036,7 +1036,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 					// Use the point where the ceiling clears as the end of deco phase for CVA calculations
 					if (current_ceiling > 0)
 						time_clear_ceiling = 0;
-					else if (time_clear_ceiling == 0)
+					else if (time_clear_ceiling == 0 && t1 > time_deep_ceiling)
 						time_clear_ceiling = t1;
 				}
 			}

--- a/core/profile.c
+++ b/core/profile.c
@@ -1085,8 +1085,10 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 				deco_time = pi->maxtime + final_tts - time_deep_ceiling;
 			else if (time_clear_ceiling > 0)
 				/* Consistent with planner, deco_time ends after ascending (20s @9m/min from 3m)
-				   at end of whole minute after clearing ceiling */
-				deco_time = ROUND_UP(time_clear_ceiling, 60) + 20 - time_deep_ceiling;
+				 * at end of whole minute after clearing ceiling. The deepest ceiling when planning a dive
+				 * comes typically 10-60s after the end of the bottom time, so add 20s to the calculated
+				 * deco time. */
+				deco_time = ROUND_UP(time_clear_ceiling - time_deep_ceiling + 20, 60) + 20;
 			vpmb_next_gradient(deco_time, surface_pressure / 1000.0);
 			final_tts = 0;
 			last_ndl_tts_calc_time = 0;

--- a/core/profile.c
+++ b/core/profile.c
@@ -1077,6 +1077,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 			}
 		}
 		if (decoMode() == VPMB && !in_planner()) {
+			int this_deco_time;
 			prev_deco_time = deco_state->deco_time;
 			// Do we need to update deco_time?
 			if (final_tts > 0)
@@ -1093,7 +1094,9 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 			first_ceiling = 0;
 			first_iteration = false;
 			count_iteration ++;
+			this_deco_time = deco_state->deco_time;
 			restore_deco_state(cache_data_initial, true);
+			deco_state->deco_time = this_deco_time;
 		} else {
 			// With Buhlmann iterating isn't needed.  This makes the while condition false.
 			prev_deco_time = deco_state->deco_time = 0;

--- a/core/profile.c
+++ b/core/profile.c
@@ -31,7 +31,6 @@ static struct plot_data *last_pi_entry_new = NULL;
 void populate_pressure_information(struct dive *, struct divecomputer *, struct plot_info *, int);
 
 extern bool in_planner();
-extern int bottom_time;
 
 #ifdef DEBUG_PI
 /* debugging tool - not normally used */
@@ -960,7 +959,7 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 	bool first_iteration = true;
 	int prev_deco_time = 10000000, time_deep_ceiling = 0;
 	if (in_planner())
-		deco_time = pi->maxtime - bottom_time;
+		deco_time = pi->maxtime - deco_state->bottom_time;
 	else
 		deco_time = 0;
 	struct deco_state *cache_data_initial = NULL;

--- a/core/profile.c
+++ b/core/profile.c
@@ -1084,9 +1084,9 @@ void calculate_deco_information(struct dive *dive, struct divecomputer *dc, stru
 			if (final_tts > 0)
 				deco_time = pi->maxtime + final_tts - time_deep_ceiling;
 			else if (time_clear_ceiling > 0)
-				/* Consistent with planner, deco_time ends after ascending (20-40s @9m/min from 3-6m)
+				/* Consistent with planner, deco_time ends after ascending (20s @9m/min from 3m)
 				   at end of whole minute after clearing ceiling */
-				deco_time = ROUND_UP(time_clear_ceiling, 60) + 30 - time_deep_ceiling;
+				deco_time = ROUND_UP(time_clear_ceiling, 60) + 20 - time_deep_ceiling;
 			vpmb_next_gradient(deco_time, surface_pressure / 1000.0);
 			final_tts = 0;
 			last_ndl_tts_calc_time = 0;


### PR DESCRIPTION
We make a number of assumptions when calculating VPM-B parameters for the profile outside of the planner, which mostly result in under-estimating deco_time (compared to the planner).  This  pull request makes a few tweaks to get better results.

Also:
-use deco_time (rather than bottom_time) directly from planner, and bring that into struct deco_state.
-pretend the final ascent rate in the planner is always 9m/min (the default) so that slowing the final ascent doesn't lead to over-estimating deco_time, resulting in more conservative gradients being calculated, and the final stop being *lengthened*, which is just nonsensical.

As always, @atdotde and @sfuchs79, and anyone else, please try to find bugs and inconsistencies.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
