### PR TITLE
Replace QMap::operator[] with QMap::value()

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -46,7 +46,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 	}
 
 	if (!vendor.isEmpty() && !product.isEmpty())
-		return(descriptorLookup[vendor + product]);
+		return(descriptorLookup.value(vendor + product));
 
 	return(NULL);
 }

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -908,7 +908,7 @@ void ConfigureDiveComputerDialog::getDeviceData()
 	device_data.vendor = strdup(selected_vendor.toUtf8().data());
 	device_data.product = strdup(selected_product.toUtf8().data());
 
-	device_data.descriptor = descriptorLookup[selected_vendor + selected_product];
+	device_data.descriptor = descriptorLookup.value(selected_vendor + selected_product);
 	device_data.deviceid = device_data.diveid = 0;
 
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -482,7 +482,7 @@ void DownloadFromDCWidget::updateDeviceEnabled()
 {
 	// Set up the DC descriptor
 	dc_descriptor_t *descriptor = NULL;
-	descriptor = descriptorLookup[ui.vendor->currentText() + ui.product->currentText()];
+	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
 
 	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
 	if (dc_descriptor_get_transport(descriptor) == DC_TRANSPORT_SERIAL) {

--- a/mobile-widgets/qmlmapwidgethelper.cpp
+++ b/mobile-widgets/qmlmapwidgethelper.cpp
@@ -113,7 +113,7 @@ void MapWidgetHelper::reloadMapLocations()
 		QString name(ds->name);
 		// don't add dive locations with the same name, unless they are
 		// at least MIN_DISTANCE_BETWEEN_DIVE_SITES_M apart
-		if (locationNameMap[name]) {
+		if (locationNameMap.contains(name)) {
 			MapLocation *existingLocation = locationNameMap[name];
 			QGeoCoordinate coord = qvariant_cast<QGeoCoordinate>(existingLocation->getRole(MapLocation::Roles::RoleCoordinate));
 			if (dsCoord.distanceTo(coord) < MIN_DISTANCE_BETWEEN_DIVE_SITES_M)


### PR DESCRIPTION
QMap::operator[] creates a new default constructed entry in the map
if no entry with the given key exists. While not problematic (since
typically nullptrs are inserted) this is usually not what you want
for read access.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is a tiny cleanup of a non-critical issue. Note that during testing I got a segfault which I couldn't reproduce. But I don't see how this patch could be responsible for a bug that wasn't there before (famous last words).

I didn't find any other suspicious QMap accesses. There's maybe one borderline case: profile_color. But in this case it seems an array would be preferred anyway.

PS: QMap::operator[] has different semantics for const and non-const objects. I find this disturbing.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

Replaced four occurrences of QMap::operator[] wuth QMap::value() or QMap::contains()

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
