### PR TITLE
Fix user-manual syntax to work with a2x

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -4298,7 +4298,7 @@ Now power on the controller and enable authentication:
 		RX bytes:1026 acl:0 sco:0 events:47 errors:0
 		TX bytes:449 acl:0 sco:0 commands:46 errors:0
 
-Check that the status now includes +'UP', 'RUNNING' AND 'AUTH'+.
+Check that the status now includes '+UP+', '+RUNNING+' AND '+AUTH+'.
 
 If there are multiple controllers running, it's easiest to turn off the unused controller(s). For example, for +hci1+:
 


### PR DESCRIPTION
Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Current order formatting modifiers causes XML error when compiling PDF documentation.
```
xmllint --nonet --noout --valid user-manual.xml
user-manual.xml:5792: element literal: validity error : Element emphasis is not declared in literal list of possible children
/emphasis>, <emphasis>RUNNING</emphasis> AND <emphasis>AUTH</emphasis></literal>
```

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
