### PR TITLE
Replace itemClicked() by currentItemChanged() in Bt device selection

### DIFF
--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -46,8 +46,8 @@ BtDeviceSelectionDialog::BtDeviceSelectionDialog(QWidget *parent) :
 	ui->save->setEnabled(false);
 
 	// Add event for item selection
-	connect(ui->discoveredDevicesList, SIGNAL(itemClicked(QListWidgetItem*)),
-		this, SLOT(itemClicked(QListWidgetItem*)));
+	connect(ui->discoveredDevicesList, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)),
+		this, SLOT(currentItemChanged(QListWidgetItem*,QListWidgetItem*)));
 
 #if defined(Q_OS_WIN)
 	ULONG       ulRetCode = SUCCESS;
@@ -172,7 +172,6 @@ void BtDeviceSelectionDialog::on_clear_clicked()
 {
 	ui->dialogStatus->setText(tr("Remote devices list was cleared."));
 	ui->discoveredDevicesList->clear();
-	ui->save->setEnabled(false);
 
 	if (remoteDeviceDiscoveryAgent->isActive()) {
 		// Stop the SDP agent if the clear button is pressed and enable the Scan button
@@ -263,8 +262,14 @@ void BtDeviceSelectionDialog::addRemoteDevice(const QBluetoothDeviceInfo &remote
 	ui->discoveredDevicesList->addItem(item);
 }
 
-void BtDeviceSelectionDialog::itemClicked(QListWidgetItem *item)
+void BtDeviceSelectionDialog::currentItemChanged(QListWidgetItem *item, QListWidgetItem *)
 {
+	// If the list is cleared, we get a signal with a null item pointer
+	if (!item) {
+		ui->save->setEnabled(false);
+		return;
+	}
+
 	// By default we assume that the devices are paired
 	QBluetoothDeviceInfo remoteDeviceInfo = item->data(Qt::UserRole).value<QBluetoothDeviceInfo>();
 	QString statusMessage = tr("The device %1 can be used for connection. You can press the Save button.")

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -68,7 +68,7 @@ private slots:
 	void remoteDeviceScanFinished();
 	void hostModeStateChanged(QBluetoothLocalDevice::HostMode mode);
 	void addRemoteDevice(const QBluetoothDeviceInfo &remoteDeviceInfo);
-	void itemClicked(QListWidgetItem *item);
+	void currentItemChanged(QListWidgetItem *item,QListWidgetItem *previous);
 	void displayPairingMenu(const QPoint &pos);
 	void pairingFinished(const QBluetoothAddress &address,QBluetoothLocalDevice::Pairing pairing);
 	void error(QBluetoothLocalDevice::Error error);


### PR DESCRIPTION
This fixes two problems:

1) Using the keybord or clicking below the list and moving the mouse up while holding the mouse button did not properly update the status message and the save button. For example, one could save with a non-paired device selected.

2) The code assumed that a device is selected if the save button is active, but the save button was not disabled on scan. Thus, one could provoke a crash by selecting an item, scanning and then pressing save. This problem is fixed indirectly, because the save button is now always disabled if the selection is cleared.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
1) Replace itemClicked() by currentItemChanged() in btdeviceselectiondialog.cpp.
2) Disable save button if selection is cleared.
3) Remove code to disable save button on clearing of list, because this is now done indirectly anyway.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
