### PR TITLE
Generate AppImage for each git push on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: c++
-
+sudo: true # for FUSE
 dist: trusty
 
-cache:
-    directories:
-        - Qt
+# cache:
+#     directories:
+#         - Qt
 
 addons:
     apt:
@@ -27,6 +27,8 @@ addons:
             - libcurl4-openssl-dev
             # Not a subsurface dependency, but a Qt dependency
             - mesa-common-dev
+            # Not a subsurface dependency, but a QtMultimedia/libdeclarative_multimedia.so dependency
+            - libpulse-mainloop-glib0
 
 before_install:
     - if [ ! -e Qt/5.9.1 ] ; then
@@ -39,11 +41,22 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
 
-
 script:
+    - export PATH=$PWD/Qt/5.9.1/gcc_64/bin:$PATH # Make sure correct qmake is found on the $PATH for linuxdeployqt
     - export CMAKE_PREFIX_PATH=$PWD/Qt/5.9.1/gcc_64/lib/cmake ;
       cd .. ;
-      bash -e ./subsurface/scripts/build.sh -both -no-bt ;
-      bash -e ./subsurface/scripts/build.sh -both
+      bash -e ./subsurface/scripts/build.sh -desktop -create-appdir
     - env CTEST_OUTPUT_ON_FAILURE=1 make -C subsurface/build check
-#    - env CTEST_OUTPUT_ON_FAILURE=1 make -C subsurface/build-mobile check
+    - # env CTEST_OUTPUT_ON_FAILURE=1 make -C subsurface/build-mobile check
+    - mkdir -p appdir/usr/plugins/ ; mv appdir/usr/home/travis/build/*/subsurface/Qt/5.9.1/gcc_64/plugins/* appdir/usr/plugins/
+    - sudo mv appdir/usr/lib/* /usr/local/lib/ # Workaround for https://github.com/probonopd/linuxdeployqt/issues/160
+    - rm -rf appdir/usr/home/ appdir/usr/include/ appdir/usr/share/man/ # No need to ship developer and man files as part of the AppImage
+    - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+    - chmod a+x linuxdeployqt*.AppImage
+    - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+    - export LD_LIBRARY_PATH=/usr/local/lib/ # Workaround for https://github.com/probonopd/linuxdeployqt/issues/160
+    - mkdir -p ./subsurface/map-widget ; cp ./subsurface/mobile-widgets/qml/{MapWidget,MapWidgetContextMenu,MapWidgetError}.qml ./subsurface/map-widget # FIXME: Workaround for https://github.com/Subsurface-divelog/subsurface/issues/769#issuecomment-341920456
+    - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=./subsurface/map-widget/ -verbose=2
+    - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=./subsurface/map-widget/ -verbose=2
+    - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+    - curl --upload-file ./Subsurface*.AppImage https://transfer.sh/Subsurface-git.$(cd subsurface/ ; git rev-parse --short HEAD)-x86_64.AppImage

--- a/subsurface.desktop
+++ b/subsurface.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=subsurface
+Name=Subsurface
 GenericName=dive log program
 Comment=manage and display dive computer data
 Icon=subsurface-icon


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.

### Changes made:
1) Build AppImage on Travis CI
2) Fix name in desktop file

### Related issues:
Closes #769

### Additional information:
A build can be tested at https://transfer.sh/YWxH0/Subsurface-git.21ac633-x86_64.AppImage

### Mentions:
@dirkhh 