### PR TITLE
Trivial Bluetooth changes

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -40,9 +40,10 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		product = "EON Steel";
 	}
 
-	if (btName.startsWith("G2")) {
+	if (btName.startsWith("G2")  || btName.startsWith("Aladin")) {
 		vendor = "Scubapro";
-		product = "G2";
+		if (btName.startsWith("G2")) product = "G2";
+		if (btName.startsWith("Aladin")) product = "Aladin Sport Matrix";
 	}
 
 	if (!vendor.isEmpty() && !product.isEmpty())

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -40,6 +40,7 @@ BtDeviceSelectionDialog::BtDeviceSelectionDialog(QWidget *parent) :
 	ui->scan->setText(tr("Scan"));
 	ui->clear->setText(tr("Clear"));
 	ui->save->setText(tr("Save"));
+	ui->save->setDefault(true);
 	ui->quit->setText(tr("Quit"));
 
 	// Disable the save button because there is no device selected

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -555,7 +555,7 @@ void DownloadFromDCWidget::bluetoothSelectionDialogIsFinished(int result)
 		/* Make the selected Bluetooth device default */
 		QString selectedDeviceName = btDeviceSelectionDialog->getSelectedDeviceName();
 
-		if (selectedDeviceName == NULL || selectedDeviceName.isEmpty()) {
+		if (selectedDeviceName.isEmpty()) {
 			ui.device->setCurrentText(btDeviceSelectionDialog->getSelectedDeviceAddress());
 		} else {
 			ui.device->setCurrentText(selectedDeviceName);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Code cleanup
### Pull request long description:
<!-- Describe your pull request in detail. -->

These are three trivial changes to the Bluetooth code, which I split from a few commits sent to the mailing list. They should be rather uncontroversial. I'll wait with the remaining changes, as they are platform dependent and are much more likely to have unintended side effects.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Remove a bogus NULL check.
2) Add "Aladin" to the list of recognized Bluetooth names.
Note that the computer is recognized here as the "Scubapro Aladin Sport Matrix" even though the "Scubapro Aladin H Matrix" probably advertises the same name. Being very close variants, both probably use the same protocol making this a non issue.
3) Make the Save button the default button of the Bluetooth device selector, so that pressing return does not discard the selection.
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
