### PR TITLE
Save font_size in correct group

### DIFF
--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -1906,6 +1906,7 @@ void DisplaySettingsObjectWrapper::setFontSize(double value)
 		return;
 
 	QSettings s;
+	s.beginGroup(group);
 	s.setValue("font_size", value);
 	prefs.font_size = value;
 	QFont defaultFont = qApp->font();


### PR DESCRIPTION
A change of the font_size in preferences ended up in the wrong preferences group (the GeneralSettings group), appearing to the user as a non-saved preference. Fix is simple. Just set the the correct group before saving a change in font_size.

Fixes: #780

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>