### PR TITLE
Do not save dive sites that are not used

### DIFF
--- a/core/save-git.c
+++ b/core/save-git.c
@@ -904,7 +904,7 @@ static void save_divesites(git_repository *repo, struct dir *tree)
 	for (int i = 0; i < dive_site_table.nr; i++) {
 		struct membuffer b = { 0 };
 		struct dive_site *ds = get_dive_site(i);
-		if (dive_site_is_empty(ds)) {
+		if (dive_site_is_empty(ds) || !is_dive_site_used(ds->uuid, false)) {
 			int j;
 			struct dive *d;
 			for_each_dive(j, d) {

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -571,7 +571,7 @@ void save_dives_buffer(struct membuffer *b, const bool select_only)
 		int j;
 		struct dive *d;
 		struct dive_site *ds = get_dive_site(i);
-		if (dive_site_is_empty(ds)) {
+		if (dive_site_is_empty(ds) || !is_dive_site_used(ds->uuid, false)) {
 			for_each_dive(j, d) {
 				if (d->dive_site_uuid == ds->uuid)
 					d->dive_site_uuid = 0;


### PR DESCRIPTION
### Describe the pull request:
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
As it is not possible to delete dive sites from the logbook, we need to make sure that we never save sites that are not tied to any dive. With this change, unused site that are currently in the logbook will also be removed, so it will also clear up (wrong) historical data.

Supposed to fix #786

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
Delete empty sites on  save.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 
