### PR TITLE
OSTC: initialize CNS correctly

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -644,6 +644,16 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 	if (rc == DC_STATUS_SUCCESS)
 		dive->dc.maxdepth.mm = lrint(maxdepth * 1000);
 
+	// Parse the initial CNS%
+	unsigned int tmp_cns = 0;
+	rc = dc_parser_get_field(parser, DC_FIELD_INIT_CNS, 0, &tmp_cns);
+	if (rc != DC_STATUS_SUCCESS && rc != DC_STATUS_UNSUPPORTED) {
+		dev_info(devdata, translate("gettextFromC", "Error parsing the initial CNS%"));
+		return rc;
+	}
+	if (rc == DC_STATUS_SUCCESS)
+		cns = tmp_cns;
+
 #if DC_VERSION_CHECK(0, 5, 0) && defined(DC_GASMIX_UNKNOWN)
 	// if this is defined then we have a fairly late version of libdivecomputer
 	// from the 0.5 development cylcle - most likely temperatures and tank sizes


### PR DESCRIPTION
WARNING: requires commit cb38734df61b97 from Suburface-branch of libdivecomputer

As the OSTC stores the CNS at the start of the dive in the dive header, we can initialize the CNS value correctly. The current code did some sort of initialization, and carried CNS data from another dive to
the initial part of the profile (before a CNS sample was received), resulting in strange data, for example, in the info box.

See also: #789

### Additional information:
requires commit cb38734df61b97 from Suburface-branch of libdivecomputer. Needs to be merged first to compile correctly.