### PR TITLE
map-widget: marker edit improvements

### DIFF
--- a/ReleaseNotes/ReleaseNotes.txt
+++ b/ReleaseNotes/ReleaseNotes.txt
@@ -11,6 +11,10 @@ Some of the changes since _Subsurface_ 4.7.2
 - Write log messages into files when not started from a console on Windows
 - Improved detection of OpenGL versions (prevents potential crash on more
   operating systems with ancient gfx drivers)
+- Improve the map widget editing behavior. Allow updating the location of
+  a marker that is being edited by entering new coordinates in the text field
+  in "real-time". Also, don't place new markers at the 0,0 coordinate and
+  instead place them at the current map center.
 
 
 Some of the changes since _Subsurface_ 4.7.1

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -52,6 +52,8 @@ LocationInformationWidget::LocationInformationWidget(QWidget *parent) : QGroupBo
 		this, &LocationInformationWidget::updateGpsCoordinates);
 	connect(this, &LocationInformationWidget::endEditDiveSite,
 		MapWidget::instance(), &MapWidget::repopulateLabels);
+	connect(this, &LocationInformationWidget::coordinatesChanged,
+		MapWidget::instance(), &MapWidget::updateCurrentDiveSiteCoordinatesToMap);
 }
 
 bool LocationInformationWidget::eventFilter(QObject *, QEvent *ev)

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -118,6 +118,12 @@ void MapWidget::coordinatesChangedLocal()
 	emit coordinatesChanged();
 }
 
+void MapWidget::updateCurrentDiveSiteCoordinatesToMap()
+{
+	CHECK_IS_READY_RETURN_VOID();
+	m_mapHelper->updateCurrentDiveSiteCoordinatesToMap();
+}
+
 MapWidget::~MapWidget()
 {
 	m_instance = NULL;

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -35,6 +35,7 @@ public slots:
 	void selectedDivesChanged(QList<int>);
 	void coordinatesChangedLocal();
 	void doneLoading(QQuickWidget::Status status);
+	void updateCurrentDiveSiteCoordinatesToMap();
 
 private:
 	void setEditMode(bool editMode);

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -72,7 +72,7 @@ Item {
 						onDoubleClicked: map.doubleClickHandler(mapItem.coordinate)
 						onReleased: {
 							if (mapHelper.editMode && mapHelper.model.selectedUuid === model.uuid) {
-								mapHelper.updateCurrentDiveSiteCoordinates(mapHelper.model.selectedUuid, mapItem.coordinate)
+								mapHelper.updateCurrentDiveSiteCoordinatesFromMap(mapHelper.model.selectedUuid, mapItem.coordinate)
 							}
 						}
 					}

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -231,11 +231,9 @@ void MapWidgetHelper::setEditMode(bool editMode)
 	MapLocation *exists = m_mapLocationModel->getMapLocationForUuid(displayed_dive_site.uuid);
 	// if divesite uuid doesn't exist in the model, add a new MapLocation.
 	if (editMode && !exists) {
-		QGeoCoordinate coord(0.0, 0.0);
+		QGeoCoordinate coord = m_map->property("center").value<QGeoCoordinate>();
 		m_mapLocationModel->add(new MapLocation(displayed_dive_site.uuid, coord,
 		                                        QString(displayed_dive_site.name)));
-		QMetaObject::invokeMethod(m_map, "centerOnCoordinate",
-		                          Q_ARG(QVariant, QVariant::fromValue(coord)));
 	}
 	emit editModeChanged();
 }

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -210,7 +210,7 @@ void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool form
 	prefs.coordinates_traditional = savep;
 }
 
-void MapWidgetHelper::updateCurrentDiveSiteCoordinates(quint32 uuid, QGeoCoordinate coord)
+void MapWidgetHelper::updateCurrentDiveSiteCoordinatesFromMap(quint32 uuid, QGeoCoordinate coord)
 {
 	MapLocation *loc = m_mapLocationModel->getMapLocationForUuid(uuid);
 	if (loc)
@@ -218,6 +218,14 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinates(quint32 uuid, QGeoCoordin
 	displayed_dive_site.latitude.udeg = lrint(coord.latitude() * 1000000.0);
 	displayed_dive_site.longitude.udeg = lrint(coord.longitude() * 1000000.0);
 	emit coordinatesChanged();
+}
+
+void MapWidgetHelper::updateCurrentDiveSiteCoordinatesToMap()
+{
+	const qreal latitude = displayed_dive_site.latitude.udeg * 0.000001;
+	const qreal longitude = displayed_dive_site.longitude.udeg * 0.000001;
+	QGeoCoordinate coord(latitude, longitude);
+	m_mapLocationModel->updateMapLocationCoordinates(displayed_dive_site.uuid, coord);
 }
 
 bool MapWidgetHelper::editMode()

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -24,8 +24,9 @@ public:
 	void reloadMapLocations();
 	Q_INVOKABLE void copyToClipboardCoordinates(QGeoCoordinate coord, bool formatTraditional);
 	Q_INVOKABLE void calculateSmallCircleRadius(QGeoCoordinate coord);
-	Q_INVOKABLE void updateCurrentDiveSiteCoordinates(quint32 uuid, QGeoCoordinate coord);
+	Q_INVOKABLE void updateCurrentDiveSiteCoordinatesFromMap(quint32 uuid, QGeoCoordinate coord);
 	Q_INVOKABLE void selectVisibleLocations();
+	void updateCurrentDiveSiteCoordinatesToMap();
 	bool editMode();
 	void setEditMode(bool editMode);
 	QString pluginObject();

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include <QDebug>
 #include "maplocationmodel.h"
 
 const char *MapLocation::PROPERTY_NAME_COORDINATE = "coordinate";
@@ -37,6 +38,11 @@ void MapLocation::setCoordinate(QGeoCoordinate coord)
 {
 	m_coordinate = coord;
 	emit coordinateChanged();
+}
+
+void MapLocation::setCoordinateNoEmit(QGeoCoordinate coord)
+{
+	m_coordinate = coord;
 }
 
 quint32 MapLocation::uuid()
@@ -135,4 +141,20 @@ MapLocation *MapLocationModel::getMapLocationForUuid(quint32 uuid)
 			return location;
 	}
 	return NULL;
+}
+
+void MapLocationModel::updateMapLocationCoordinates(quint32 uuid, QGeoCoordinate coord)
+{
+	MapLocation *location;
+	int row = 0;
+	foreach(location, m_mapLocations) {
+		if (uuid == location->uuid()) {
+			location->setCoordinateNoEmit(coord);
+			emit dataChanged(createIndex(0, row), createIndex(0, row));
+			return;
+		}
+		row++;
+	}
+	// should not happen, as this should be called only when editing an existing marker
+	qWarning() << "MapLocationModel::updateMapLocationCoordinates(): cannot find MapLocation for uuid:" << uuid;
 }

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -27,6 +27,7 @@ public:
 	QVariant getRole(int role) const;
 	QGeoCoordinate coordinate();
 	void setCoordinate(QGeoCoordinate coord);
+	void setCoordinateNoEmit(QGeoCoordinate coord);
 	quint32 uuid();
 
 	enum Roles {
@@ -62,6 +63,7 @@ public:
 	void addList(QVector<MapLocation *>);
 	void clear();
 	MapLocation *getMapLocationForUuid(quint32 uuid);
+	void updateMapLocationCoordinates(quint32 uuid, QGeoCoordinate coord);
 	Q_INVOKABLE void setSelectedUuid(QVariant uuid, QVariant fromClick = true);
 	quint32 selectedUuid();
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

**PATCH1:**

When starting to edit a new dive location, create
a marker at the current map center instead of zooming
out and centering on the 0,0 coordinate.

This will help (and speed up) a lot the edition,
if the user needs to add numerous dive markers
at a specific location close to each other.

**PATCH2:**

This patch allows updating the location of map markers
while editing a dive site and updating the text in the
LocationInformationWidget in real-time.

Currently it is only possible to see the marker changes by
clicking 'Apply'.

The modification required the following changes:
- add the MapWidget::updateCurrentDiveSiteCoordinatesToMap() slot
and call it each time the GPS text updates
- separate the updateCurrentDiveSiteCoordinates(FromMap/ToMap) logic
by having the FromMap/ToMap suffix to method names
- make MapWidgetHelper::updateCurrentDiveSiteCoordinatesToMap()
call a new MapLocationModel::updateMapLocationCoordinates()
method, which updates selected location coordinates and the model
- add MapLocation::setCoordinateNoEmit() that does not emit
a signal when updating a coordinate

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
see list above

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #754

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @janmulder @sfuchs79 