### PR TITLE
Fix warning

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -610,6 +610,11 @@ static void get_uint8(char *buffer, uint8_t *i)
 	*i = atoi(buffer);
 }
 
+static void get_uint16(char *buffer, uint16_t *i)
+{
+	*i = atoi(buffer);
+}
+
 static void get_bearing(char *buffer, bearing_t *bearing)
 {
 	bearing->degrees = atoi(buffer);
@@ -990,7 +995,7 @@ static void try_to_fill_sample(struct sample *sample, const char *name, char *bu
 		return;
 	if (MATCH("stopdepth.sample", depth, &sample->stopdepth))
 		return;
-	if (MATCH("cns.sample", get_uint8, &sample->cns))
+	if (MATCH("cns.sample", get_uint16, &sample->cns))
 		return;
 	if (MATCH("rbt.sample", sampletime, &sample->rbt))
 		return;


### PR DESCRIPTION
Commit 97712559192ca82d introduces a compiler warning due to mismatched pointer types. Fixed here.

Reported-by: Stefan Fuchs <sfuchs@gmx.de>
Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>