### PR TITLE
Preferences->Language: add pre-defined date and time formats

### DIFF
--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -89,14 +89,15 @@ void PreferencesLanguage::syncSettings()
 	lang->setDateFormatShort(ui->shortDateFormatEntry->text());
 	uiLanguage(NULL);
 
+	QString qDateTimeWeb = tr("These will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString");
 	QRegExp tfillegalchars("[^hHmszaApPt\\s:;\\.,]");
 	if (tfillegalchars.indexIn(ui->timeFormatEntry->text()) >= 0)
 		QMessageBox::warning(this, tr("Literal characters"),
-			tr("Non-special character(s) in time format.\nThese will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString"));
+			tr("Non-special character(s) in time format.\n") + qDateTimeWeb);
 
 	QRegExp dfillegalchars("[^dMy/\\s:;\\.,\\-]");
 	if (dfillegalchars.indexIn(ui->dateFormatEntry->currentText()) >= 0 ||
 	    dfillegalchars.indexIn(ui->shortDateFormatEntry->text()) >= 0)
 		QMessageBox::warning(this, tr("Literal characters"),
-				     tr("Non-special character(s) in time format.\nThese will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString"));
+			tr("Non-special character(s) in date format.\n") + qDateTimeWeb);
 }

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -22,11 +22,24 @@ PreferencesLanguage::PreferencesLanguage() : AbstractPreferencesWidget(tr("Langu
 	filterModel->sort(0);
 	connect(ui->languageFilter, &QLineEdit::textChanged,
 			filterModel, &QSortFilterProxyModel::setFilterFixedString);
+
+	dateFormatShortMap.insert("MM/dd/yyyy", "M/d/yy");
+	dateFormatShortMap.insert("dd.MM.yyyy", "d.M.yy");
+	dateFormatShortMap.insert("yyyy-MM-dd", "yy-M-d");
+	foreach (QString format, dateFormatShortMap.keys())
+		ui->dateFormatEntry->addItem(format);
+	connect(ui->dateFormatEntry, SIGNAL(currentIndexChanged(const QString&)),
+		this, SLOT(dateFormatChanged(const QString&)));
 }
 
 PreferencesLanguage::~PreferencesLanguage()
 {
 	delete ui;
+}
+
+void PreferencesLanguage::dateFormatChanged(const QString &text)
+{
+	ui->shortDateFormatEntry->setText(dateFormatShortMap.value(text));
 }
 
 void PreferencesLanguage::refreshSettings()
@@ -35,7 +48,7 @@ void PreferencesLanguage::refreshSettings()
 	ui->timeFormatSystemDefault->setChecked(!prefs.time_format_override);
 	ui->dateFormatSystemDefault->setChecked(!prefs.date_format_override);
 	ui->timeFormatEntry->setText(prefs.time_format);
-	ui->dateFormatEntry->setText(prefs.date_format);
+	ui->dateFormatEntry->setCurrentText(prefs.date_format);
 	ui->shortDateFormatEntry->setText(prefs.date_format_short);
 	QAbstractItemModel *m = ui->languageDropdown->model();
 	QModelIndexList languages = m->match(m->index(0, 0), Qt::UserRole, QString(prefs.locale.lang_locale).replace("-", "_"));
@@ -72,7 +85,7 @@ void PreferencesLanguage::syncSettings()
 	lang->setTimeFormatOverride(!ui->timeFormatSystemDefault->isChecked());
 	lang->setDateFormatOverride(!ui->dateFormatSystemDefault->isChecked());
 	lang->setTimeFormat(ui->timeFormatEntry->text());
-	lang->setDateFormat(ui->dateFormatEntry->text());
+	lang->setDateFormat(ui->dateFormatEntry->currentText());
 	lang->setDateFormatShort(ui->shortDateFormatEntry->text());
 	uiLanguage(NULL);
 
@@ -81,8 +94,8 @@ void PreferencesLanguage::syncSettings()
 		QMessageBox::warning(this, tr("Literal characters"),
 			tr("Non-special character(s) in time format.\nThese will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString"));
 
-	QRegExp dfillegalchars("[^dMy/\\s:;\\.,]");
-	if (dfillegalchars.indexIn(ui->dateFormatEntry->text()) >= 0 ||
+	QRegExp dfillegalchars("[^dMy/\\s:;\\.,\\-]");
+	if (dfillegalchars.indexIn(ui->dateFormatEntry->currentText()) >= 0 ||
 	    dfillegalchars.indexIn(ui->shortDateFormatEntry->text()) >= 0)
 		QMessageBox::warning(this, tr("Literal characters"),
 				     tr("Non-special character(s) in time format.\nThese will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString"));

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -30,6 +30,10 @@ PreferencesLanguage::PreferencesLanguage() : AbstractPreferencesWidget(tr("Langu
 		ui->dateFormatEntry->addItem(format);
 	connect(ui->dateFormatEntry, SIGNAL(currentIndexChanged(const QString&)),
 		this, SLOT(dateFormatChanged(const QString&)));
+
+	ui->timeFormatEntry->addItem("hh:mm");
+	ui->timeFormatEntry->addItem("h:mm AP");
+	ui->timeFormatEntry->addItem("hh:mm AP");
 }
 
 PreferencesLanguage::~PreferencesLanguage()
@@ -47,7 +51,7 @@ void PreferencesLanguage::refreshSettings()
 	ui->languageSystemDefault->setChecked(prefs.locale.use_system_language);
 	ui->timeFormatSystemDefault->setChecked(!prefs.time_format_override);
 	ui->dateFormatSystemDefault->setChecked(!prefs.date_format_override);
-	ui->timeFormatEntry->setText(prefs.time_format);
+	ui->timeFormatEntry->setCurrentText(prefs.time_format);
 	ui->dateFormatEntry->setCurrentText(prefs.date_format);
 	ui->shortDateFormatEntry->setText(prefs.date_format_short);
 	QAbstractItemModel *m = ui->languageDropdown->model();
@@ -84,14 +88,14 @@ void PreferencesLanguage::syncSettings()
 	lang->setUseSystemLanguage(ui->languageSystemDefault->isChecked());
 	lang->setTimeFormatOverride(!ui->timeFormatSystemDefault->isChecked());
 	lang->setDateFormatOverride(!ui->dateFormatSystemDefault->isChecked());
-	lang->setTimeFormat(ui->timeFormatEntry->text());
+	lang->setTimeFormat(ui->timeFormatEntry->currentText());
 	lang->setDateFormat(ui->dateFormatEntry->currentText());
 	lang->setDateFormatShort(ui->shortDateFormatEntry->text());
 	uiLanguage(NULL);
 
 	QString qDateTimeWeb = tr("These will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString");
 	QRegExp tfillegalchars("[^hHmszaApPt\\s:;\\.,]");
-	if (tfillegalchars.indexIn(ui->timeFormatEntry->text()) >= 0)
+	if (tfillegalchars.indexIn(ui->timeFormatEntry->currentText()) >= 0)
 		QMessageBox::warning(this, tr("Literal characters"),
 			tr("Non-special character(s) in time format.\n") + qDateTimeWeb);
 

--- a/desktop-widgets/preferences/preferences_language.h
+++ b/desktop-widgets/preferences/preferences_language.h
@@ -2,6 +2,7 @@
 #ifndef PREFERENCES_LANGUAGE_H
 #define PREFERENCES_LANGUAGE_H
 
+#include <QMap>
 #include "abstractpreferenceswidget.h"
 
 namespace Ui {
@@ -17,6 +18,9 @@ public:
 	virtual void syncSettings();
 private:
 	Ui::PreferencesLanguage *ui;
+	QMap<QString, QString> dateFormatShortMap;
+public slots:
+	void dateFormatChanged(const QString&);
 };
 
 #endif

--- a/desktop-widgets/preferences/prefs_language.ui
+++ b/desktop-widgets/preferences/prefs_language.ui
@@ -140,9 +140,18 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="timeFormatEntry">
+       <widget class="QComboBox" name="timeFormatEntry">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preferred time format&lt;/p&gt;&lt;p&gt;Commonly used format specifiers are&lt;/p&gt;&lt;p&gt;h (hours in 12h format)&lt;/p&gt;&lt;p&gt;H (hours in 24h format)&lt;/p&gt;&lt;p&gt;mm (2 digit minutes)&lt;/p&gt;&lt;p&gt;ss (2 digit seconds)&lt;/p&gt;&lt;p&gt;t/tt (a/p or am/pm)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -212,22 +221,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>timeFormatSystemDefault</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>timeFormatEntry</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>79</x>
-     <y>210</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>264</x>
-     <y>210</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>dateFormatSystemDefault</sender>
    <signal>toggled(bool)</signal>
    <receiver>shortDateFormatEntry</receiver>
@@ -256,6 +249,22 @@
     <hint type="destinationlabel">
      <x>273</x>
      <y>103</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>timeFormatSystemDefault</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>timeFormatEntry</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>89</x>
+     <y>190</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>190</y>
     </hint>
    </hints>
   </connection>

--- a/desktop-widgets/preferences/prefs_language.ui
+++ b/desktop-widgets/preferences/prefs_language.ui
@@ -74,13 +74,6 @@
       <string>Date format</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="dateFormatEntry">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preferred date format. Commonly used fields are&lt;/p&gt;&lt;p&gt;d (day of month)&lt;/p&gt;&lt;p&gt;ddd (abbr. day name)&lt;/p&gt;&lt;p&gt;M (month number)&lt;/p&gt;&lt;p&gt;MMM (abbr. month name)&lt;/p&gt;&lt;p&gt;yy/yyyy (2/4 digit year)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="dateFormatSystemDefault">
         <property name="text">
@@ -113,6 +106,16 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="dateFormatEntry">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preferred date format. Commonly used fields are&lt;/p&gt;&lt;p&gt;d (day of month)&lt;/p&gt;&lt;p&gt;ddd (abbr. day name)&lt;/p&gt;&lt;p&gt;M (month number)&lt;/p&gt;&lt;p&gt;MMM (abbr. month name)&lt;/p&gt;&lt;p&gt;yy/yyyy (2/4 digit year)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -209,22 +212,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>dateFormatSystemDefault</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>dateFormatEntry</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>79</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>264</x>
-     <y>132</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>timeFormatSystemDefault</sender>
    <signal>toggled(bool)</signal>
    <receiver>timeFormatEntry</receiver>
@@ -253,6 +240,22 @@
     <hint type="destinationlabel">
      <x>293</x>
      <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>dateFormatSystemDefault</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>dateFormatEntry</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>89</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>103</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
this PR adds support for combo-boxes in Preferences->Language for users to make a pick from a list  instead of understanding the format first and writing their own. the informational tooltips are preserved.

the combo boxes are still editable.

a combo-box is only added for the long format dates. Each long date format has a short date version retrieved using QMap when the user makes a pick via slot/signals.

`preferences: re-use a tr() string in _language.cpp` is just a side-patch to make a tr() string re-usable.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add combo-boxes for time and date formats instead of line edit widgets (2 patches)
2) re-use tr() string (1 separate patch)

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #276

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
let me know if you want more formats added?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@tcanabrava @dirkhh 