### PR TITLE
Initialize Facebook page only when dialog is shown

### DIFF
--- a/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
+++ b/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
@@ -300,6 +300,16 @@ void FacebookManager::uploadFinished()
 	emit sendDiveFinished();
 }
 
+void FacebookConnectWidget::showEvent(QShowEvent *event)
+{
+	if (FacebookManager::instance()->loggedIn()) {
+		facebookLoggedIn();
+	} else {
+		facebookDisconnect();
+	}
+	return QDialog::showEvent(event);
+}
+
 FacebookConnectWidget::FacebookConnectWidget(QWidget *parent) : QDialog(parent), ui(new Ui::FacebookConnectWidget) {
 	ui->setupUi(this);
 	FacebookManager *fb = FacebookManager::instance();
@@ -309,11 +319,6 @@ FacebookConnectWidget::FacebookConnectWidget(QWidget *parent) : QDialog(parent),
 	facebookWebView = new QWebView(this);
 #endif
 	ui->fbWebviewContainer->layout()->addWidget(facebookWebView);
-	if (fb->loggedIn()) {
-		facebookLoggedIn();
-	} else {
-		facebookDisconnect();
-	}
 #ifdef USE_WEBENGINE
 	connect(facebookWebView, &QWebEngineView::urlChanged, fb, &FacebookManager::tryLogin);
 #else

--- a/desktop-widgets/plugins/facebook/facebookconnectwidget.h
+++ b/desktop-widgets/plugins/facebook/facebookconnectwidget.h
@@ -70,6 +70,7 @@ public:
 	explicit FacebookConnectWidget(QWidget* parent = 0);
 	void facebookLoggedIn();
 	void facebookDisconnect();
+	void showEvent(QShowEvent *event);
 private:
 	Ui::FacebookConnectWidget *ui;
 #ifdef USE_WEBENGINE


### PR DESCRIPTION
Quick hack to avoid Facebook access on every program start. Move the initialization
of the login page from the FacebookConnectWidget constructor to the show event handler.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #798 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
