### PR TITLE
[Please test] Save Bluetooth devices to preferences

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -11,7 +11,7 @@ extern QMap<QString, dc_descriptor_t *> descriptorLookup;
 
 BTDiscovery *BTDiscovery::m_instance = NULL;
 
-static dc_descriptor_t *getDeviceType(QString btName)
+dc_descriptor_t *getDeviceType(QString btName)
 // central function to convert a BT name to a Subsurface known vendor/model pair
 {
 	QString vendor, product;

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -18,6 +18,7 @@
 
 void saveBtDeviceInfo(const QString &devaddr, QBluetoothDeviceInfo deviceInfo);
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr);
+dc_descriptor_t *getDeviceType(QString btName);
 
 class BTDiscovery : public QObject {
 	Q_OBJECT

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -228,7 +228,6 @@ void BtDeviceSelectionDialog::startScan()
 	if (remoteDeviceDiscoveryAgent) {
 		if (remoteDeviceDiscoveryAgent->isActive())
 			remoteDeviceDiscoveryAgent->stop();
-		ui->discoveredDevicesList->clear();
 		maxPriority = 0;
 		remoteDeviceDiscoveryAgent->start();
 		ui->dialogStatus->setText(tr("Scanning for remote devices..."));
@@ -301,13 +300,26 @@ void BtDeviceSelectionDialog::addRemoteDevice(const QBluetoothDeviceInfo &remote
 							      remoteDeviceInfo.address().toString(),
 							      pairingStatusLabel);
 #endif
-	// Create the new item, set its information and add it to the list
-	QListWidgetItem *item = new QListWidgetItem(deviceLabel);
+	// Check if item is already in list. Add it, if it isn't
+	int numRows = ui->discoveredDevicesList->count();
+	int row;
+	QListWidgetItem *item;
+	for (row = 0; row < numRows; ++row) {
+		item = ui->discoveredDevicesList->item(row);
+		if (item->data(Qt::UserRole).value<QBluetoothDeviceInfo>() == remoteDeviceInfo)
+			break;
+	}
 
+	if (row >= numRows) {
+		// Create the new item and add it to the list
+		item = new QListWidgetItem;
+		ui->discoveredDevicesList->addItem(item);
+	}
+
+	item->setText(deviceLabel);
 	item->setData(Qt::UserRole, QVariant::fromValue(remoteDeviceInfo));
 	item->setBackgroundColor(pairingColor);
 
-	ui->discoveredDevicesList->addItem(item);
 	int priority = getDevicePriority(connectable, remoteDeviceInfo);
 	if (priority > maxPriority) {
 		maxPriority = priority;

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QMenu>
+#include <QShowEvent>
 #include "core/btdiscovery.h"
 
 #include <QBluetoothUuid>
@@ -19,8 +20,7 @@ BtDeviceSelectionDialog::BtDeviceSelectionDialog(QWidget *parent) :
 
 	// Quit button callbacks
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
-	connect(quit, SIGNAL(activated()), this, SLOT(reject()));
-	connect(ui->quit, SIGNAL(clicked()), this, SLOT(reject()));
+	connect(quit, SIGNAL(activated()), this, SLOT(on_quit_clicked()));
 
 	// Translate the UI labels
 	ui->localDeviceDetails->setTitle(tr("Local Bluetooth device details"));
@@ -35,6 +35,16 @@ BtDeviceSelectionDialog::BtDeviceSelectionDialog(QWidget *parent) :
 	ui->save->setText(tr("Save"));
 	ui->save->setDefault(true);
 	ui->quit->setText(tr("Quit"));
+	setScanStatusInvalid();
+
+	ui->waitingSpinner->setRoundness(70.0);
+	ui->waitingSpinner->setMinimumTrailOpacity(15.0);
+	ui->waitingSpinner->setTrailFadePercentage(70.0);
+	ui->waitingSpinner->setNumberOfLines(8);
+	ui->waitingSpinner->setLineLength(5);
+	ui->waitingSpinner->setLineWidth(3);
+	ui->waitingSpinner->setInnerRadius(5);
+	ui->waitingSpinner->setRevolutionsPerSecond(1);
 
 	// Disable the save button because there is no device selected
 	ui->save->setEnabled(false);
@@ -84,25 +94,22 @@ BtDeviceSelectionDialog::~BtDeviceSelectionDialog()
 {
 	delete ui;
 
+	stopScan();
+	if (remoteDeviceDiscoveryAgent)
+		delete remoteDeviceDiscoveryAgent;
+
 	// Clean the local device
 	delete localDevice;
-
-	if (remoteDeviceDiscoveryAgent) {
-		// Clean the device discovery agent
-		if (remoteDeviceDiscoveryAgent->isActive())
-			remoteDeviceDiscoveryAgent->stop();
-		delete remoteDeviceDiscoveryAgent;
-	}
 }
 
 void BtDeviceSelectionDialog::on_changeDeviceState_clicked()
 {
-	if (localDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff) {
-		ui->dialogStatus->setText(tr("Trying to turn on the local Bluetooth device..."));
-		localDevice->powerOn();
-	} else {
+	if (isPoweredOn()) {
 		ui->dialogStatus->setText(tr("Trying to turn off the local Bluetooth device..."));
 		localDevice->setHostMode(QBluetoothLocalDevice::HostPoweredOff);
+	} else {
+		ui->dialogStatus->setText(tr("Trying to turn on the local Bluetooth device..."));
+		localDevice->powerOn();
 	}
 }
 
@@ -117,34 +124,39 @@ void BtDeviceSelectionDialog::on_save_clicked()
 	QString address = remoteDeviceInfo.address().isNull() ? remoteDeviceInfo.deviceUuid().toString() :
 								remoteDeviceInfo.address().toString();
 	saveBtDeviceInfo(address, remoteDeviceInfo);
-	if (remoteDeviceDiscoveryAgent->isActive()) {
-		// Stop the SDP agent if the clear button is pressed and enable the Scan button
-		remoteDeviceDiscoveryAgent->stop();
-		ui->scan->setEnabled(true);
-	}
+	stopScan();
 
 	// Close the device selection dialog and set the result code to Accepted
 	accept();
 }
 
+void BtDeviceSelectionDialog::on_quit_clicked()
+{
+	stopScan();
+
+	// Close the device selection dialog and set the result code to Rejected
+	reject();
+}
+
+void BtDeviceSelectionDialog::showEvent(QShowEvent *event)
+{
+}
+
 void BtDeviceSelectionDialog::on_clear_clicked()
 {
+	if (remoteDeviceDiscoveryAgent->isActive())
+		stopScan();
+
 	ui->dialogStatus->setText(tr("Remote devices list was cleared."));
 	ui->discoveredDevicesList->clear();
-
-	if (remoteDeviceDiscoveryAgent->isActive()) {
-		// Stop the SDP agent if the clear button is pressed and enable the Scan button
-		remoteDeviceDiscoveryAgent->stop();
-		ui->scan->setEnabled(true);
-	}
 }
 
 void BtDeviceSelectionDialog::on_scan_clicked()
 {
-	ui->dialogStatus->setText(tr("Scanning for remote devices..."));
-	ui->discoveredDevicesList->clear();
-	remoteDeviceDiscoveryAgent->start();
-	ui->scan->setEnabled(false);
+	if (remoteDeviceDiscoveryAgent->isActive())
+		stopScan();
+	else
+		startScan();
 }
 
 void BtDeviceSelectionDialog::remoteDeviceScanFinished()
@@ -156,7 +168,63 @@ void BtDeviceSelectionDialog::remoteDeviceScanFinished()
 	if (remoteDeviceDiscoveryAgent->error() == QBluetoothDeviceDiscoveryAgent::NoError)
 		ui->dialogStatus->setText(tr("Scanning finished successfully."));
 
+	setScanStatusOff();
+}
+
+bool BtDeviceSelectionDialog::isPoweredOn() const
+{
+	return localDevice->hostMode() != QBluetoothLocalDevice::HostPoweredOff;
+}
+
+void BtDeviceSelectionDialog::setScanStatusOn()
+{
+	ui->scanStatus->setText(tr("Scanning..."));
+	ui->scan->setText(tr("Stop scan"));
 	ui->scan->setEnabled(true);
+	ui->clear->setEnabled(true);
+	ui->waitingSpinner->start();
+}
+
+void BtDeviceSelectionDialog::setScanStatusOff()
+{
+	ui->scanStatus->setText(tr("Idle"));
+	ui->scan->setText(tr("Start scan"));
+	ui->scan->setEnabled(true);
+	ui->clear->setEnabled(true);
+	ui->waitingSpinner->stop();
+}
+
+void BtDeviceSelectionDialog::setScanStatusInvalid()
+{
+	ui->scanStatus->setText("-");
+	ui->scan->setText(tr("Start scan"));
+	ui->scan->setEnabled(false);
+	ui->clear->setEnabled(false);
+	ui->waitingSpinner->stop();
+}
+
+void BtDeviceSelectionDialog::stopScan()
+{
+	if (remoteDeviceDiscoveryAgent && remoteDeviceDiscoveryAgent->isActive()) {
+		remoteDeviceDiscoveryAgent->stop();
+		ui->dialogStatus->setText(tr("Stopped scanning..."));
+	}
+	if (isPoweredOn())
+		setScanStatusOff();
+	else
+		setScanStatusInvalid();
+}
+
+void BtDeviceSelectionDialog::startScan()
+{
+	if (remoteDeviceDiscoveryAgent) {
+		if (remoteDeviceDiscoveryAgent->isActive())
+			remoteDeviceDiscoveryAgent->stop();
+		ui->discoveredDevicesList->clear();
+		remoteDeviceDiscoveryAgent->start();
+		ui->dialogStatus->setText(tr("Scanning for remote devices..."));
+		setScanStatusOn();
+	}
 }
 
 void BtDeviceSelectionDialog::hostModeStateChanged(QBluetoothLocalDevice::HostMode mode)
@@ -167,7 +235,6 @@ void BtDeviceSelectionDialog::hostModeStateChanged(QBluetoothLocalDevice::HostMo
 	ui->dialogStatus->setText(tr("The local Bluetooth device was %1.")
 				  .arg(on? tr("turned on") : tr("turned off")));
 	ui->deviceState->setChecked(on);
-	ui->scan->setEnabled(on);
 }
 
 void BtDeviceSelectionDialog::addRemoteDevice(const QBluetoothDeviceInfo &remoteDeviceInfo)
@@ -386,6 +453,7 @@ void BtDeviceSelectionDialog::deviceDiscoveryError(QBluetoothDeviceDiscoveryAgen
 	}
 
 	ui->dialogStatus->setText(tr("Device discovery error: %1.").arg(errorDescription));
+	setScanStatusOff();
 }
 
 extern QString markBLEAddress(const QBluetoothDeviceInfo *device);
@@ -447,9 +515,8 @@ void BtDeviceSelectionDialog::updateLocalDeviceInformation()
 
 		// Disable the buttons
 		ui->save->setEnabled(false);
-		ui->scan->setEnabled(false);
-		ui->clear->setEnabled(false);
 		ui->changeDeviceState->setEnabled(false);
+		setScanStatusInvalid();
 
 		return;
 	}
@@ -461,7 +528,7 @@ void BtDeviceSelectionDialog::updateLocalDeviceInformation()
 	connect(localDevice, SIGNAL(hostModeStateChanged(QBluetoothLocalDevice::HostMode)),
 		this, SLOT(hostModeStateChanged(QBluetoothLocalDevice::HostMode)));
 
-	// Initialize the state of the local device and activate/deactive the scan button
+	// Initialize the state of the local device
 	hostModeStateChanged(localDevice->hostMode());
 
 	// Add context menu for devices to be able to pair them
@@ -485,8 +552,7 @@ void BtDeviceSelectionDialog::initializeDeviceDiscoveryAgent()
 		ui->dialogStatus->setText(tr("The device discovery agent was not created because the %1 address does not "
 					     "match the physical adapter address of any local Bluetooth device.")
 					    .arg(localDevice->address().toString()));
-		ui->scan->setEnabled(false);
-		ui->clear->setEnabled(false);
+		setScanStatusInvalid();
 		return;
 	}
 	connect(remoteDeviceDiscoveryAgent, SIGNAL(deviceDiscovered(QBluetoothDeviceInfo)),
@@ -495,4 +561,9 @@ void BtDeviceSelectionDialog::initializeDeviceDiscoveryAgent()
 		this, SLOT(remoteDeviceScanFinished()));
 	connect(remoteDeviceDiscoveryAgent, SIGNAL(error(QBluetoothDeviceDiscoveryAgent::Error)),
 		this, SLOT(deviceDiscoveryError(QBluetoothDeviceDiscoveryAgent::Error)));
+	// On Windows scans block the UI, therefore we might not want to force the user to scan.
+	if (isPoweredOn())
+		setScanStatusOff();
+	else
+		setScanStatusInvalid();
 }

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -45,8 +45,8 @@ private:
 	QString previousDevice;
 	dc_descriptor_t *dcDescriptor;
 	int maxPriority;
-	QBluetoothLocalDevice *localDevice;
-	QBluetoothDeviceDiscoveryAgent *remoteDeviceDiscoveryAgent;
+	QScopedPointer<QBluetoothLocalDevice> localDevice;
+	QScopedPointer<QBluetoothDeviceDiscoveryAgent> remoteDeviceDiscoveryAgent;
 	QScopedPointer<QBluetoothDeviceInfo> selectedRemoteDeviceInfo;
 
 	void updateLocalDeviceInformation();

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -7,6 +7,7 @@
 #include <QPointer>
 #include <QtBluetooth/QBluetoothLocalDevice>
 #include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
+#include "core/libdivecomputer.h"
 
 namespace Ui {
 	class BtDeviceSelectionDialog;
@@ -16,7 +17,7 @@ class BtDeviceSelectionDialog : public QDialog {
 	Q_OBJECT
 
 public:
-	explicit BtDeviceSelectionDialog(QWidget *parent = 0);
+	explicit BtDeviceSelectionDialog(const QString &address, dc_descriptor_t *dc, QWidget *parent = 0);
 	~BtDeviceSelectionDialog();
 	QString getSelectedDeviceAddress();
 	QString getSelectedDeviceName();
@@ -41,6 +42,9 @@ private slots:
 
 private:
 	Ui::BtDeviceSelectionDialog *ui;
+	QString previousDevice;
+	dc_descriptor_t *dcDescriptor;
+	int maxPriority;
 	QBluetoothLocalDevice *localDevice;
 	QBluetoothDeviceDiscoveryAgent *remoteDeviceDiscoveryAgent;
 	QScopedPointer<QBluetoothDeviceInfo> selectedRemoteDeviceInfo;
@@ -54,6 +58,8 @@ private:
 	void startScan();
 	void stopScan();
 	void showEvent(QShowEvent *event);
+	void initializeDeviceList();
+	int getDevicePriority(bool connectable, const QBluetoothDeviceInfo &remoteDeviceInfo);
 };
 
 #endif // BTDEVICESELECTIONDIALOG_H

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -28,6 +28,7 @@ private slots:
 	void on_save_clicked();
 	void on_clear_clicked();
 	void on_scan_clicked();
+	void on_quit_clicked();
 	void remoteDeviceScanFinished();
 	void hostModeStateChanged(QBluetoothLocalDevice::HostMode mode);
 	void addRemoteDevice(const QBluetoothDeviceInfo &remoteDeviceInfo);
@@ -46,6 +47,13 @@ private:
 
 	void updateLocalDeviceInformation();
 	void initializeDeviceDiscoveryAgent();
+	bool isPoweredOn() const;
+	void setScanStatusOn();
+	void setScanStatusOff();
+	void setScanStatusInvalid();
+	void startScan();
+	void stopScan();
+	void showEvent(QShowEvent *event);
 };
 
 #endif // BTDEVICESELECTIONDIALOG_H

--- a/desktop-widgets/btdeviceselectiondialog.ui
+++ b/desktop-widgets/btdeviceselectiondialog.ui
@@ -48,6 +48,125 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="discoveredDevicesLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Discovered devices</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" rowspan="2">
+    <layout class="QVBoxLayout" name="remoteDevicesSection">
+     <item>
+      <widget class="QListWidget" name="discoveredDevicesList">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="scanLayout">
+       <item row="1" column="0">
+        <widget class="QLabel" name="btModeLabel">
+         <property name="text">
+          <string>Bluetooth mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="btMode">
+         <item>
+          <property name="text">
+           <string>Auto</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force LE</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force classical</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="scanStatusLabel">
+         <property name="text">
+          <string>Scan status:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <layout class="QHBoxLayout" name="scanStatusLayout">
+         <item>
+          <widget class="QLabel" name="scanStatus">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QtWaitingSpinner" name="waitingSpinner" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="scan">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPushButton" name="clear">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Clear</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="btModeSection"/>
+     </item>
+    </layout>
+   </item>
    <item row="1" column="1">
     <widget class="QGroupBox" name="localDeviceDetails">
      <property name="sizePolicy">
@@ -97,7 +216,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QCheckBox" name="deviceState">
         <property name="enabled">
          <bool>false</bool>
@@ -122,7 +241,17 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="localSelectedDevice"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectDeviceLabel">
+        <property name="text">
+         <string>Select device:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
        <widget class="QPushButton" name="changeDeviceState">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -141,114 +270,18 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="localSelectedDevice"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectDeviceLabel">
-        <property name="text">
-         <string>Select device:</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="discoveredDevicesLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Discovered devices</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" rowspan="2">
-    <layout class="QVBoxLayout" name="remoteDevicesSection">
-     <item>
-      <widget class="QListWidget" name="discoveredDevicesList">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="btModeSection">
-       <item>
-        <widget class="QLabel" name="btModeLabel">
-         <property name="text">
-          <string>Bluetooth mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="btMode">
-         <item>
-          <property name="text">
-           <string>Auto</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force LE</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Force classical</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="scanningControls">
-       <item>
-        <widget class="QPushButton" name="scan">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="clear">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Clear</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QtWaitingSpinner</class>
+   <extends>QWidget</extends>
+   <header>qtwaitingspinner.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -1473,7 +1473,7 @@ void ConfigureDiveComputerDialog::pickLogFile()
 void ConfigureDiveComputerDialog::selectRemoteBluetoothDevice()
 {
 	if (!btDeviceSelectionDialog) {
-		btDeviceSelectionDialog = new BtDeviceSelectionDialog(this);
+		btDeviceSelectionDialog = new BtDeviceSelectionDialog(ui.device->currentText(), device_data.descriptor, this);
 		connect(btDeviceSelectionDialog, SIGNAL(finished(int)),
 			this, SLOT(bluetoothSelectionDialogIsFinished(int)));
 	}

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -523,11 +523,15 @@ void DownloadFromDCWidget::on_ok_clicked()
 	accept();
 }
 
+dc_descriptor_t *DownloadFromDCWidget::getDescriptor() const
+{
+	return descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
+}
+
 void DownloadFromDCWidget::updateDeviceEnabled()
 {
 	// Set up the DC descriptor
-	dc_descriptor_t *descriptor = NULL;
-	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
+	dc_descriptor_t *descriptor = getDescriptor();
 
 	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
 	if (dc_descriptor_get_transports(descriptor) & (DC_TRANSPORT_SERIAL | DC_TRANSPORT_USBSTORAGE)) {
@@ -586,7 +590,7 @@ void DownloadFromDCWidget::markChildrenAsEnabled()
 void DownloadFromDCWidget::selectRemoteBluetoothDevice()
 {
 	if (!btDeviceSelectionDialog) {
-		btDeviceSelectionDialog = new BtDeviceSelectionDialog(this);
+		btDeviceSelectionDialog = new BtDeviceSelectionDialog(ui.device->currentText(), getDescriptor(), this);
 		connect(btDeviceSelectionDialog, SIGNAL(finished(int)),
 			this, SLOT(bluetoothSelectionDialogIsFinished(int)));
 	}

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -66,6 +66,7 @@ private:
 	void markChildrenAsEnabled();
 	void updateDeviceEnabled();
 	void showRememberedDCs();
+	dc_descriptor_t *getDescriptor() const;
 
 	QStringListModel vendorModel;
 	QStringListModel productModel;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

Currently, the BT device selector starts with an empty list, which means that the user always has to click on scan. This PR tries to starts the scan of the BT device selection dialog on creation, power on or change of local device. Moreover, an appropriate device is automatically selected according to priority:
1) Previous device
2) BT name corresponding to selected dive computer
3) BT name recognized as dive computer
4) Any paired device

Thus, an accidental raising of the dialog can immediately be dismissed by pressing enter.

This is WIP, which currently has only been tested on Linux.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->

1) Start scan if dialog is initialized, power is turned on or local device is changed.
2) Add a scan status field with the states "invalid" (powered off), "idle" (powered on, but not scanning) or "scanning"
3) If scanning, allow the user to abort the scan.
4) Automatically select detected devices according to priority.

<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
the BT device selector list is auto-filled.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
