### PR TITLE
Fix memory leak in download-from-dive-computer widget

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -60,14 +60,14 @@ private:
 	void markChildrenAsEnabled();
 	void updateDeviceEnabled();
 
+	QStringListModel vendorModel;
+	QStringListModel productModel;
 	Ui::DownloadFromDiveComputer ui;
 	DownloadThread thread;
 	bool downloading;
 
 	int previousLast;
 
-	QStringListModel *vendorModel;
-	QStringListModel *productModel;
 	void fill_device_list(int dc_type);
 	QTimer *timer;
 	bool dumpWarningShown;


### PR DESCRIPTION
Instead of (re)allocating the vendor and product models, use the
setStringList method on sub objects.

Even though only a theoretical problem, the model objects are moved
in front of the ui object, so that the widgets referencing the models
are destroyed first.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Fix a memory leak (which was annotated as such). Since this code was a bit hairy, maybe wait post-release.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

Replace dynamically allocated models by sub objects. Why fight with ownership problems if there is no need to?

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
