### PR TITLE
Trivial: Replace a QSharedPointer by a QScopedPointer

### DIFF
--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -152,7 +152,7 @@ void BtDeviceSelectionDialog::on_save_clicked()
 	QBluetoothDeviceInfo remoteDeviceInfo = currentItem->data(Qt::UserRole).value<QBluetoothDeviceInfo>();
 
 	// Save the selected device
-	selectedRemoteDeviceInfo = QSharedPointer<QBluetoothDeviceInfo>(new QBluetoothDeviceInfo(remoteDeviceInfo));
+	selectedRemoteDeviceInfo.reset(new QBluetoothDeviceInfo(remoteDeviceInfo));
 	QString address = remoteDeviceInfo.address().isNull() ? remoteDeviceInfo.deviceUuid().toString() :
 								remoteDeviceInfo.address().toString();
 	saveBtDeviceInfo(address.toUtf8().constData(), remoteDeviceInfo);
@@ -460,9 +460,8 @@ QString BtDeviceSelectionDialog::getSelectedDeviceAddress()
 
 QString BtDeviceSelectionDialog::getSelectedDeviceName()
 {
-	if (selectedRemoteDeviceInfo) {
+	if (selectedRemoteDeviceInfo)
 		return selectedRemoteDeviceInfo.data()->name();
-	}
 
 	return QString();
 }

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -83,7 +83,7 @@ private:
 	QBluetoothLocalDevice *localDevice;
 	QBluetoothDeviceDiscoveryAgent *remoteDeviceDiscoveryAgent;
 #endif
-	QSharedPointer<QBluetoothDeviceInfo> selectedRemoteDeviceInfo;
+	QScopedPointer<QBluetoothDeviceInfo> selectedRemoteDeviceInfo;
 
 	void updateLocalDeviceInformation();
 	void initializeDeviceDiscoveryAgent();


### PR DESCRIPTION
Since the QSharedPointer is never passed or copied, reference counting
is certainly not needed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->

Replace an unnecessarily reference-counted QSharedPointer by a simple QScopedPointer. I only found one other QSharedPointer and this one is correct, since it is passed to a function expecting QSharedPointers.

By the way: QScopedPointer seems to be an anachronism for pre-C++11 code. But the code already uses C++11 features (e.g. auto). Sooner or later QScopedPointer should therefore be replaced by std::unique_ptr. Reference: https://stackoverflow.com/questions/40346393/should-i-use-qscopedpointer-or-stdunique-ptr
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
