### PR TITLE
Make Bluetooth naming consistent

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -56,6 +56,7 @@ void DownloadThread::run()
 	dcs->setVendor(internalData->vendor);
 	dcs->setProduct(internalData->product);
 	dcs->setDevice(internalData->devname);
+	dcs->setDeviceName(m_data->devBluetoothName());
 }
 
 static void fill_supported_mobile_list()
@@ -239,6 +240,11 @@ QString DCDeviceData::devName() const
 	return data.devname;
 }
 
+QString DCDeviceData::devBluetoothName() const
+{
+	return m_devBluetoothName;
+}
+
 QString DCDeviceData::descriptor() const
 {
 	return "";
@@ -282,6 +288,11 @@ void DCDeviceData::setProduct(const QString& product)
 void DCDeviceData::setDevName(const QString& devName)
 {
 	data.devname = strdup(qPrintable(devName));
+}
+
+void DCDeviceData::setDevBluetoothName(const QString& name)
+{
+	m_devBluetoothName = name;
 }
 
 void DCDeviceData::setBluetoothMode(bool mode)

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -19,6 +19,7 @@ class DCDeviceData : public QObject {
 	Q_PROPERTY(QString product READ product WRITE setProduct)
 	Q_PROPERTY(bool bluetoothMode READ bluetoothMode WRITE setBluetoothMode)
 	Q_PROPERTY(QString devName READ devName WRITE setDevName)
+	Q_PROPERTY(QString devBluetoothName READ devBluetoothName WRITE setDevBluetoothName)
 	Q_PROPERTY(QString descriptor READ descriptor)
 	Q_PROPERTY(bool forceDownload READ forceDownload WRITE setForceDownload)
 	Q_PROPERTY(bool createNewTrip READ createNewTrip WRITE setCreateNewTrip)
@@ -34,6 +35,7 @@ public:
 	QString vendor() const;
 	QString product() const;
 	QString devName() const;
+	QString devBluetoothName() const;
 	QString descriptor() const;
 	bool bluetoothMode() const;
 	bool forceDownload() const;
@@ -57,6 +59,7 @@ public slots:
 	void setVendor(const QString& vendor);
 	void setProduct(const QString& product);
 	void setDevName(const QString& devName);
+	void setDevBluetoothName(const QString& devBluetoothName);
 	void setBluetoothMode(bool mode);
 	void setForceDownload(bool force);
 	void setCreateNewTrip(bool create);
@@ -67,6 +70,9 @@ public slots:
 private:
 	static DCDeviceData *m_instance;
 	device_data_t data;
+
+	// Bluetooth name is managed outside of libdivecomputer
+	QString m_devBluetoothName;
 };
 
 class DownloadThread : public QThread {

--- a/core/pref.h
+++ b/core/pref.h
@@ -54,6 +54,7 @@ typedef struct {
 	char *vendor;
 	char *product;
 	char *device;
+	char *device_name;
 	int download_mode;
 } dive_computer_prefs_t;
 

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -29,6 +29,11 @@ QString DiveComputerSettings::dc_device() const
 	return prefs.dive_computer.device;
 }
 
+QString DiveComputerSettings::dc_device_name() const
+{
+	return prefs.dive_computer.device_name;
+}
+
 int DiveComputerSettings::downloadMode() const
 {
 	return prefs.dive_computer.download_mode;
@@ -68,6 +73,18 @@ void DiveComputerSettings::setDevice(const QString& device)
 	s.setValue("dive_computer_device", device);
 	free(prefs.dive_computer.device);
 	prefs.dive_computer.device = copy_string(qPrintable(device));
+}
+
+void DiveComputerSettings::setDeviceName(const QString& device_name)
+{
+	if (device_name == prefs.dive_computer.device_name)
+		return;
+
+	QSettings s;
+	s.beginGroup(group);
+	s.setValue("dive_computer_device_name", device_name);
+	free(prefs.dive_computer.device_name);
+	prefs.dive_computer.device_name = copy_string(qPrintable(device_name));
 }
 
 void DiveComputerSettings::setDownloadMode(int mode)
@@ -2333,6 +2350,7 @@ void SettingsObjectWrapper::load()
 	GET_TXT("dive_computer_vendor",dive_computer.vendor);
 	GET_TXT("dive_computer_product", dive_computer.product);
 	GET_TXT("dive_computer_device", dive_computer.device);
+	GET_TXT("dive_computer_device_name", dive_computer.device_name);
 	GET_INT("dive_computer_download_mode", dive_computer.download_mode);
 	s.endGroup();
 

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -18,24 +18,28 @@ class DiveComputerSettings : public QObject {
 	Q_PROPERTY(QString vendor READ dc_vendor WRITE setVendor NOTIFY vendorChanged)
 	Q_PROPERTY(QString product READ dc_product WRITE setProduct NOTIFY productChanged)
 	Q_PROPERTY(QString device READ dc_device WRITE setDevice NOTIFY deviceChanged)
+	Q_PROPERTY(QString device_name READ dc_device_name WRITE setDeviceName NOTIFY deviceNameChanged)
 	Q_PROPERTY(int download_mode READ downloadMode WRITE setDownloadMode NOTIFY downloadModeChanged)
 public:
 	DiveComputerSettings(QObject *parent);
 	QString dc_vendor() const;
 	QString dc_product() const;
 	QString dc_device() const;
+	QString dc_device_name() const;
 	int downloadMode() const;
 
 public slots:
 	void setVendor(const QString& vendor);
 	void setProduct(const QString& product);
 	void setDevice(const QString& device);
+	void setDeviceName(const QString& device_name);
 	void setDownloadMode(int mode);
 
 signals:
 	void vendorChanged(const QString& vendor);
 	void productChanged(const QString& product);
 	void deviceChanged(const QString& device);
+	void deviceNameChanged(const QString& device_name);
 	void downloadModeChanged(int mode);
 private:
 	const QString group = QStringLiteral("DiveComputer");

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -467,6 +467,20 @@ QString BtDeviceSelectionDialog::getSelectedDeviceName()
 	return QString();
 }
 
+QString BtDeviceSelectionDialog::getSelectedDeviceText()
+{
+	return formatDeviceText(getSelectedDeviceAddress(), getSelectedDeviceName());
+}
+
+QString BtDeviceSelectionDialog::formatDeviceText(const QString &address, const QString &name)
+{
+	if (address.isEmpty())
+		return name;
+	if (name.isEmpty())
+		return address;
+	return QString("%1 (%2)").arg(name, address);
+}
+
 void BtDeviceSelectionDialog::updateLocalDeviceInformation()
 {
 #if defined(Q_OS_WIN)

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -59,6 +59,8 @@ public:
 	~BtDeviceSelectionDialog();
 	QString getSelectedDeviceAddress();
 	QString getSelectedDeviceName();
+	QString getSelectedDeviceText();
+	static QString formatDeviceText(const QString &address, const QString &name);
 
 private slots:
 	void on_changeDeviceState_clicked();

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -904,7 +904,9 @@ void ConfigureDiveComputerDialog::configError(QString err)
 
 void ConfigureDiveComputerDialog::getDeviceData()
 {
-	device_data.devname = strdup(ui.device->currentText().toUtf8().data());
+	QString device = ui.bluetoothMode && btDeviceSelectionDialog ?
+		btDeviceSelectionDialog->getSelectedDeviceAddress() : ui.device->currentText();
+	device_data.devname = strdup(device.toUtf8().data());
 	device_data.vendor = strdup(selected_vendor.toUtf8().data());
 	device_data.product = strdup(selected_product.toUtf8().data());
 
@@ -913,6 +915,8 @@ void ConfigureDiveComputerDialog::getDeviceData()
 
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
 	dc->setDevice(device_data.devname);
+	if (ui.bluetoothMode && btDeviceSelectionDialog)
+		dc->setDeviceName(btDeviceSelectionDialog->getSelectedDeviceName());
 }
 
 void ConfigureDiveComputerDialog::on_cancel_clicked()
@@ -1488,7 +1492,7 @@ void ConfigureDiveComputerDialog::selectRemoteBluetoothDevice()
 void ConfigureDiveComputerDialog::bluetoothSelectionDialogIsFinished(int result)
 {
 	if (result == QDialog::Accepted) {
-		ui.device->setCurrentText(btDeviceSelectionDialog->getSelectedDeviceAddress());
+		ui.device->setCurrentText(btDeviceSelectionDialog->getSelectedDeviceText());
 		device_data.bluetooth_mode = true;
 
 		ui.progressBar->setFormat("Connecting to device...");


### PR DESCRIPTION
Currently, on Linux, after selecting a Bluetooth device the name of the
device is shown. On reopening the download dialog, on the other hand,
the address is shown. In the device selection dialog both are shown.

This patch changes the download dialog such that both, name and address,
are shown. The bulk of the patch introduces the name of the device in
the preferences and DCDeviceData. It has to be noted that DCDeviceData
is an encapsulation of the libdivecomputer device_data_t. Nevertheless,
the new Bluetooth-name field is, at the moment, not passed through to
libdivecomputer.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

Show name and address of Bluetooth devices in the Download dialog. For this new name fields in preferences and DCDeviceData were introduced. In principle, name and address could be encoded in the preferences field, but it was felt that writing an appropriate parser would have been more brittle.

Since MacOS and Windows work very differently concerning Bluetooth, this will have to be tested. Moreover, I don't have a dive computer supported by "Configure dive computer", so this will have to be tested as well.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Introduce dive_computer.device_name preferences field
2) Introduce m_devBluetoothName DCDeviceData field
3) Show name and address in download and configure dive computer dialogs
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
