### PR TITLE
Typo: modp02 -> modpO2

### DIFF
--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -296,7 +296,7 @@ void TechnicalDetailsSettings::setDecoMode(deco_mode d)
 	emit decoModeChanged(d);
 }
 
-double TechnicalDetailsSettings:: modp02() const
+double TechnicalDetailsSettings:: modpO2() const
 {
 	return prefs.modpO2;
 }
@@ -416,7 +416,7 @@ bool TechnicalDetailsSettings::showPicturesInProfile() const
 	return prefs.show_pictures_in_profile;
 }
 
-void TechnicalDetailsSettings::setModp02(double value)
+void TechnicalDetailsSettings::setModpO2(double value)
 {
 	if (value == prefs.modpO2)
 		return;

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -112,7 +112,7 @@ private:
 
 class TechnicalDetailsSettings : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(double modpO2         READ modp02          WRITE setModp02          NOTIFY modpO2Changed)
+	Q_PROPERTY(double modpO2         READ modpO2          WRITE setModpO2          NOTIFY modpO2Changed)
 	Q_PROPERTY(bool ead              READ ead             WRITE setEad             NOTIFY eadChanged)
 	Q_PROPERTY(bool mod              READ mod             WRITE setMod             NOTIFY modChanged)
 	Q_PROPERTY(bool dcceiling        READ dcceiling       WRITE setDCceiling       NOTIFY dcceilingChanged)
@@ -141,7 +141,7 @@ class TechnicalDetailsSettings : public QObject {
 public:
 	TechnicalDetailsSettings(QObject *parent);
 
-	double modp02() const;
+	double modpO2() const;
 	bool ead() const;
 	bool mod() const;
 	bool dcceiling() const;
@@ -169,7 +169,7 @@ public:
 
 public slots:
 	void setMod(bool value);
-	void setModp02(double value);
+	void setModpO2(double value);
 	void setEad(bool value);
 	void setDCceiling(bool value);
 	void setRedceiling(bool value);

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -62,7 +62,7 @@ void PreferencesGraph::syncSettings()
 	pp_gas->setPn2Threshold(ui->pn2Threshold->value());
 
 	auto tech = SettingsObjectWrapper::instance()->techDetails;
-	tech->setModp02(ui->maxpo2->value());
+	tech->setModpO2(ui->maxpo2->value());
 	tech->setRedceiling(ui->red_ceiling->isChecked());
 	tech->setBuehlmann(ui->buehlmann->isChecked());
 	tech->setGflow(ui->gflow->value());

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -78,10 +78,10 @@ void TestPreferences::testPreferences()
 	TEST(cloud->verificationStatus(), (short)1);
 
 	auto tecDetails = pref->techDetails;
-	tecDetails->setModp02(0.2);
-	TEST(tecDetails->modp02(), 0.2);
-	tecDetails->setModp02(1.0);
-	TEST(tecDetails->modp02(), 1.0);
+	tecDetails->setModpO2(0.2);
+	TEST(tecDetails->modpO2(), 0.2);
+	tecDetails->setModpO2(1.0);
+	TEST(tecDetails->modpO2(), 1.0);
 
 	tecDetails->setGflow(2);
 	TEST(tecDetails->gflow(), 2);


### PR DESCRIPTION
Fixes two function names where O2 was written as 02.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Typo

### Pull request long description:
<!-- Describe your pull request in detail. -->

Fixes two function names. Compiles and runs.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
