### PR TITLE
WIP: Planner second minimum gas switch time for below 30m/100ft

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -930,7 +930,12 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 							(get_o2(&gas) + 5) / 10, (get_he(&gas) + 5) / 10, gaschanges[gi].depth / 1000.0);
 #endif
 						/* Stop for the minimum duration to switch gas unless we switch to o2 */
-						if (!last_segment_min_switch && get_o2(&dive->cylinder[current_cylinder].gasmix) != 1000) {
+						if (!last_segment_min_switch && depth > (prefs.units.length == METERS ? 30000 : 30480)) {
+							add_segment(depth_to_bar(depth, dive),
+								&dive->cylinder[current_cylinder].gasmix,
+								prefs.min_switch_duration_deep, po2, dive, prefs.decosac);
+							clock += prefs.min_switch_duration_deep;
+						} else if (!last_segment_min_switch && get_o2(&dive->cylinder[current_cylinder].gasmix) != 1000) {
 							add_segment(depth_to_bar(depth, dive),
 								&dive->cylinder[current_cylinder].gasmix,
 								prefs.min_switch_duration, po2, dive, prefs.decosac);
@@ -984,7 +989,12 @@ bool plan(struct diveplan *diveplan, struct dive *dive, int timestep, struct dec
 						(get_o2(&gas) + 5) / 10, (get_he(&gas) + 5) / 10, gaschanges[gi + 1].depth / 1000.0);
 #endif
 					/* Stop for the minimum duration to switch gas unless we switch to o2 */
-					if (!last_segment_min_switch && get_o2(&dive->cylinder[current_cylinder].gasmix) != 1000) {
+					if (!last_segment_min_switch && depth > (prefs.units.length == METERS ? 30000 : 30480)) {
+						add_segment(depth_to_bar(depth, dive),
+							&dive->cylinder[current_cylinder].gasmix,
+							prefs.min_switch_duration_deep, po2, dive, prefs.decosac);
+						clock += prefs.min_switch_duration_deep;
+					} else if (!last_segment_min_switch && get_o2(&dive->cylinder[current_cylinder].gasmix) != 1000) {
 						add_segment(depth_to_bar(depth, dive),
 							&dive->cylinder[current_cylinder].gasmix,
 							prefs.min_switch_duration, po2, dive, prefs.decosac);

--- a/core/pref.h
+++ b/core/pref.h
@@ -128,6 +128,7 @@ struct preferences {
 	bool switch_at_req_stop;
 	int reserve_gas;
 	int min_switch_duration; // seconds
+	int min_switch_duration_deep; // seconds
 	int bottomsac;
 	int decosac;
 	int o2consumption; // ml per min

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -1234,6 +1234,11 @@ int DivePlannerSettings::minSwitchDuration() const
 	return prefs.min_switch_duration;
 }
 
+int DivePlannerSettings::minSwitchDurationDeep() const
+{
+	return prefs.min_switch_duration_deep;
+}
+
 int DivePlannerSettings::bottomSac() const
 {
 	return prefs.bottomsac;
@@ -1504,6 +1509,18 @@ void DivePlannerSettings::setMinSwitchDuration(int value)
 	s.setValue("min_switch_duration", value);
 	prefs.min_switch_duration = value;
 	emit minSwitchDurationChanged(value);
+}
+
+void DivePlannerSettings::setMinSwitchDurationDeep(int value)
+{
+	if (value == prefs.min_switch_duration_deep)
+		return;
+
+	QSettings s;
+	s.beginGroup(group);
+	s.setValue("min_switch_duration_deep", value);
+	prefs.min_switch_duration_deep = value;
+	emit minSwitchDurationDeepChanged(value);
 }
 
 void DivePlannerSettings::setBottomSac(int value)
@@ -2323,6 +2340,7 @@ void SettingsObjectWrapper::load()
 	GET_INT("decopo2", decopo2);
 	GET_INT("bestmixend", bestmixend.mm);
 	GET_INT("min_switch_duration", min_switch_duration);
+	GET_INT("min_switch_duration_deep", min_switch_duration_deep);
 	GET_INT("bottomsac", bottomsac);
 	GET_INT("decosac", decosac);
 
@@ -2381,6 +2399,7 @@ void SettingsObjectWrapper::sync()
 	s.setValue("drop_stone_mode", prefs.drop_stone_mode);
 	s.setValue("switch_at_req_stop", prefs.switch_at_req_stop);
 	s.setValue("min_switch_duration", prefs.min_switch_duration);
+	s.setValue("min_switch_duration_deep", prefs.min_switch_duration_deep);
 	s.setValue("bottomsac", prefs.bottomsac);
 	s.setValue("decosac", prefs.decosac);
 	s.setValue("deco_mode", int(prefs.planner_deco_mode));

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -400,6 +400,7 @@ class DivePlannerSettings : public QObject {
 	Q_PROPERTY(int bestmixend           READ bestmixend           WRITE setBestmixend           NOTIFY bestmixendChanged)
 	Q_PROPERTY(int reserve_gas          READ reserveGas           WRITE setReserveGas           NOTIFY reserveGasChanged)
 	Q_PROPERTY(int min_switch_duration  READ minSwitchDuration    WRITE setMinSwitchDuration    NOTIFY minSwitchDurationChanged)
+	Q_PROPERTY(int min_switch_duration_deep  READ minSwitchDurationDeep    WRITE setMinSwitchDurationDeep    NOTIFY minSwitchDurationDeepChanged)
 	Q_PROPERTY(int bottomsac            READ bottomSac            WRITE setBottomSac            NOTIFY bottomSacChanged)
 	Q_PROPERTY(int decosac              READ decoSac              WRITE setDecoSac              NOTIFY decoSacChanged)
 	Q_PROPERTY(deco_mode decoMode       READ decoMode             WRITE setDecoMode             NOTIFY decoModeChanged)
@@ -428,6 +429,7 @@ public:
 	int bestmixend() const;
 	int reserveGas() const;
 	int minSwitchDuration() const;
+	int minSwitchDurationDeep() const;
 	int bottomSac() const;
 	int decoSac() const;
 	deco_mode decoMode() const;
@@ -455,6 +457,7 @@ public slots:
 	void setBestmixend(int value);
 	void setReserveGas(int value);
 	void setMinSwitchDuration(int value);
+	void setMinSwitchDurationDeep(int value);
 	void setBottomSac(int value);
 	void setDecoSac(int value);
 	void setDecoMode(deco_mode value);
@@ -482,6 +485,7 @@ signals:
 	void bestmixendChanged(int value);
 	void reserveGasChanged(int value);
 	void minSwitchDurationChanged(int value);
+	void minSwitchDurationDeepChanged(int value);
 	void bottomSacChanged(int value);
 	void decoSacChanged(int value);
 	void decoModeChanged(deco_mode value);

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -61,6 +61,7 @@ struct preferences default_prefs = {
 	.drop_stone_mode = false,
 	.switch_at_req_stop = false,
 	.min_switch_duration = 60,
+	.min_switch_duration_deep = 60,
 	.last_stop = false,
 	.verbatim_plan = false,
 	.display_runtime = true,

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -265,6 +265,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(true);
 		ui.min_switch_duration->setDisabled(true);
+		ui.min_switch_duration_deep->setDisabled(true);
 		ui.sacfactor->setDisabled(true);
 		ui.problemsolvingtime->setDisabled(true);
 		ui.sacfactor->blockSignals(true);
@@ -290,6 +291,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(false);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);
+		ui.min_switch_duration_deep->setDisabled(false);
 		ui.sacfactor->setDisabled(false);
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
@@ -311,6 +313,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);
+		ui.min_switch_duration_deep->setDisabled(false);
 		ui.sacfactor->setDisabled(false);
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
@@ -362,6 +365,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.drop_stone_mode->setChecked(prefs.drop_stone_mode);
 	ui.switch_at_req_stop->setChecked(prefs.switch_at_req_stop);
 	ui.min_switch_duration->setValue(prefs.min_switch_duration / 60);
+	ui.min_switch_duration_deep->setValue(prefs.min_switch_duration_deep / 60);
 	ui.recreational_deco->setChecked(prefs.planner_deco_mode == RECREATIONAL);
 	ui.buehlmann_deco->setChecked(prefs.planner_deco_mode == BUEHLMANN);
 	ui.vpmb_deco->setChecked(prefs.planner_deco_mode == VPMB);
@@ -405,6 +409,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.backgasBreaks, SIGNAL(toggled(bool)), this, SLOT(setBackgasBreaks(bool)));
 	connect(ui.switch_at_req_stop, SIGNAL(toggled(bool)), plannerModel, SLOT(setSwitchAtReqStop(bool)));
 	connect(ui.min_switch_duration, SIGNAL(valueChanged(int)), plannerModel, SLOT(setMinSwitchDuration(int)));
+	connect(ui.min_switch_duration_deep, SIGNAL(valueChanged(int)), plannerModel, SLOT(setMinSwitchDurationDeep(int)));
 	connect(ui.rebreathermode, SIGNAL(currentIndexChanged(int)), plannerModel, SLOT(setRebreatherMode(int)));
 
 	connect(ui.bottompo2, SIGNAL(valueChanged(double)), CylindersModel::instance(), SLOT(updateBestMixes()));
@@ -467,12 +472,16 @@ void PlannerSettingsWidget::settingsChanged()
 		ui.asc50to6->setText(tr("50% avg. depth to 20ft"));
 		ui.asc6toSurf->setText(tr("20ft to surface"));
 		ui.bestmixEND->setSuffix(tr("ft"));
+		ui.label_min_switch->setToolTip(tr("For gas switches at and above 100ft. Not applied for O₂% at 100%."));
+		ui.label_min_switch_deep->setToolTip(tr("For gas switches below 100ft."));
 	} else {
 		vs.append(tr("m/min"));
 		ui.lastStop->setText(tr("Last stop at 6m"));
 		ui.asc50to6->setText(tr("50% avg. depth to 6m"));
 		ui.asc6toSurf->setText(tr("6m to surface"));
 		ui.bestmixEND->setSuffix(tr("m"));
+		ui.label_min_switch->setToolTip(tr("For gas switches at and above 30m. Not applied for O₂% at 100%."));
+		ui.label_min_switch_deep->setToolTip(tr("For gas switches below 30m."));
 	}
 	if(get_units()->volume == units::CUFT) {
 		ui.bottomSAC->setSuffix(tr("cuft/min"));

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -338,9 +338,12 @@
            </widget>
           </item>
           <item row="19" column="1">
-           <widget class="QLabel" name="label_min_switch_duration">
+           <widget class="QLabel" name="label_min_switch">
+            <property name="toolTip">
+             <string>For gas switches at and above 30m. Not applied for O₂% at 100%.</string>
+            </property>
             <property name="text">
-             <string>Min. switch duration O₂% below 100%</string>
+             <string>Min. switch duration</string>
             </property>
            </widget>
           </item>
@@ -513,6 +516,35 @@
            <widget class="QLabel" name="label_dive_type">
             <property name="text">
              <string>Dive mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="1">
+           <widget class="QLabel" name="label_min_switch_deep">
+            <property name="toolTip">
+             <string>For gas switches below 30m.</string>
+            </property>
+            <property name="text">
+             <string>Min. switch duration deep</string>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="2">
+           <widget class="QSpinBox" name="min_switch_duration_deep">
+            <property name="suffix">
+             <string>min</string>
+            </property>
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>9</number>
+            </property>
+            <property name="value">
+             <number>1</number>
             </property>
            </widget>
           </item>
@@ -840,6 +872,7 @@
   <tabstop>backgasBreaks</tabstop>
   <tabstop>switch_at_req_stop</tabstop>
   <tabstop>min_switch_duration</tabstop>
+  <tabstop>min_switch_duration_deep</tabstop>
   <tabstop>bottomSAC</tabstop>
   <tabstop>decoStopSAC</tabstop>
   <tabstop>sacfactor</tabstop>

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -653,6 +653,13 @@ void DivePlannerPointsModel::setMinSwitchDuration(int duration)
 	emitDataChanged();
 }
 
+void DivePlannerPointsModel::setMinSwitchDurationDeep(int duration)
+{
+	auto planner = SettingsObjectWrapper::instance()->planner_settings;
+	planner->setMinSwitchDurationDeep(duration * 60);
+	emitDataChanged();
+}
+
 void DivePlannerPointsModel::setStartDate(const QDate &date)
 {
 	startTime.setDate(date);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -94,6 +94,7 @@ slots:
 	void setReserveGas(int reserve);
 	void setSwitchAtReqStop(bool value);
 	void setMinSwitchDuration(int duration);
+	void setMinSwitchDurationDeep(int duration);
 	void setSacFactor(double factor);
 	void setProblemSolvingTime(int minutes);
 	void setAscrate75(int rate);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Added a second minimum gas switch duration for gas switches below
30m/100ft.
This is needed because at this depth one doesn't want to prolong
gas switches where at the same moment for shallower switches one does.

Yeah, I once again have here a tiny, lovely, little new feature for the planner.
It is once again such a "please tell me if you like it or not - I won't be angry if we don't merge it into master" thing.
On the other hand the feature for sure is awesome! ;-)

After possible "yes" decision I will take care about release notes and docu.



### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
