### PR TITLE
mobile: icon size in profile

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -71,7 +71,9 @@ void DiveEventItem::setupPixmap()
 	 // on iOS devices we need to adjust for Device Pixel Ratio
 	int sz_bigger = metrics.sz_med  * metrics.dpr;
 #else
-	int sz_bigger = metrics.sz_med;
+	// SUBSURFACE_MOBILE, seems a little big from the code,
+	// but looks fine on device
+	int sz_bigger = metrics.sz_big + metrics.sz_med;
 #endif
 #endif
 	int sz_pix = sz_bigger/2; // ex 20px


### PR DESCRIPTION
Size the event item icons in the profile a little bigger. Obviously, how big is big enhough is upto personal taste, but on Github a screendump is added to show the new size.

Fixes: #310

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
