### PR TITLE
[RFC] Introduce BLE-mode field in Bluetooth device selection dialog

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -132,18 +132,20 @@ extern void addBtUuid(QBluetoothUuid uuid);
 extern QHash<QString, QStringList> productList;
 extern QStringList vendorList;
 
+QString btDeviceAddress(const QBluetoothDeviceInfo *device, bool isBle)
+{
+	QString address = device->address().isNull() ?
+		device->deviceUuid().toString() : device->address().toString();
+	const char *prefix = isBle ? "LE:" : "";
+	return prefix + address;
+}
+
 QString markBLEAddress(const QBluetoothDeviceInfo *device)
 {
-	QBluetoothDeviceInfo::CoreConfigurations flags;
-	QString prefix = "";
+	QBluetoothDeviceInfo::CoreConfigurations flags = device->coreConfigurations();
+	bool isBle = flags == QBluetoothDeviceInfo::LowEnergyCoreConfiguration;
 
-	flags = device->coreConfigurations();
-	if (flags == QBluetoothDeviceInfo::LowEnergyCoreConfiguration)
-		prefix = "LE:";
-	if (device->address().isNull())
-		return prefix + device->deviceUuid().toString();
-	else
-		return prefix + device->address().toString();
+	return btDeviceAddress(device, isBle);
 }
 
 void BTDiscovery::btDeviceDiscovered(const QBluetoothDeviceInfo &device)

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -449,13 +449,25 @@ void BtDeviceSelectionDialog::deviceDiscoveryError(QBluetoothDeviceDiscoveryAgen
 }
 
 extern QString markBLEAddress(const QBluetoothDeviceInfo *device);
+extern QString btDeviceAddress(const QBluetoothDeviceInfo *device, bool isBle);
 
 QString BtDeviceSelectionDialog::getSelectedDeviceAddress()
 {
-	if (selectedRemoteDeviceInfo)
-		return markBLEAddress(selectedRemoteDeviceInfo.data());
+	if (!selectedRemoteDeviceInfo)
+		return QString();
 
-	return QString();
+	int btMode = ui->btMode->currentIndex();
+	QBluetoothDeviceInfo *device = selectedRemoteDeviceInfo.data();
+
+	switch (btMode) {
+	case 0:		// Auto
+	default:
+		return markBLEAddress(device);
+	case 1:		// Force LE
+		return btDeviceAddress(device, true);
+	case 2:		// Force classical
+		return btDeviceAddress(device, false);
+	}
 }
 
 QString BtDeviceSelectionDialog::getSelectedDeviceName()

--- a/desktop-widgets/btdeviceselectiondialog.ui
+++ b/desktop-widgets/btdeviceselectiondialog.ui
@@ -14,25 +14,6 @@
    <string>Remote Bluetooth device selection</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="discoveredDevicesLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Discovered devices</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="1">
     <layout class="QHBoxLayout" name="dialogControls">
      <item>
@@ -57,49 +38,15 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0" rowspan="2">
-    <layout class="QVBoxLayout" name="remoteDevicesSection">
-     <item>
-      <widget class="QListWidget" name="discoveredDevicesList">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="scanningControls">
-       <item>
-        <widget class="QPushButton" name="scan">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="clear">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Clear</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+   <item row="3" column="0">
+    <widget class="QLabel" name="dialogStatus">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="1" column="1">
     <widget class="QGroupBox" name="localDeviceDetails">
@@ -207,15 +154,98 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="dialogStatus">
-     <property name="text">
-      <string/>
+   <item row="0" column="0">
+    <widget class="QLabel" name="discoveredDevicesLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Discovered devices</string>
      </property>
     </widget>
+   </item>
+   <item row="1" column="0" rowspan="2">
+    <layout class="QVBoxLayout" name="remoteDevicesSection">
+     <item>
+      <widget class="QListWidget" name="discoveredDevicesList">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="btModeSection">
+       <item>
+        <widget class="QLabel" name="btModeLabel">
+         <property name="text">
+          <string>Bluetooth mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="btMode">
+         <item>
+          <property name="text">
+           <string>Auto</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force LE</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Force classical</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="scanningControls">
+       <item>
+        <widget class="QPushButton" name="scan">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="clear">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Clear</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Some BT devices support both, classical and BLE, modes. Users could
choose either by prepending or removing "LE:" in the device address
field. After commit d23bd46a1be2dfb25293639abcf06b5b4d4b94df, the
device field is always disabled in Bluetooth mode.

Therefore, add a BLE mode combo box to the Bluetooth device selection
dialog. In the default mode (auto), the old code path (based on
the Qt device flags) is used. The two other modes (force BLE, force
classical) allow the user to force the preferred behavior.

This feature is meant as a stop-gap measure until a more refined
transport choice is implemented. Therefore, the value of the new
combo box is not saved in the settings, to avoid cluttering of
the preferences with soon to be obsolete entries.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This PR is meant to address the concerns that a user might want to force BLE or classical Bluetooth modes. It is primarily meant as a stop-gap measure. Moreover, note that it is meant to be applied on top of #803, which will make the actions of the device selection dialog more transparent, because the address with or without LE: is shown.

I'm not sure if this feature is actually useful, so please let me know.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
added new combo-box in BT dialog.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
