### PR TITLE
Better error message on BLE connection timeout

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -326,10 +326,14 @@ dc_status_t qt_ble_open(dc_custom_io_t *io, dc_context_t *context, const char *d
 	case QLowEnergyController::ConnectedState:
 		qDebug() << "connected to the controller for device" << devaddr;
 		break;
+	case QLowEnergyController::ConnectingState:
+		qDebug() << "timeout while trying to connect to the controller " << devaddr;
+		report_error("Timeout while trying to connect to %s", devaddr);
+		delete controller;
+		return DC_STATUS_IO;
 	default:
 		qDebug() << "failed to connect to the controller " << devaddr << "with error" << controller->errorString();
 		report_error("Failed to connect to %s: '%s'", devaddr, controller->errorString().toUtf8().data());
-		controller->disconnectFromDevice();
 		delete controller;
 		return DC_STATUS_IO;
 	}
@@ -354,7 +358,6 @@ dc_status_t qt_ble_open(dc_custom_io_t *io, dc_context_t *context, const char *d
 	if (ble->preferredService() == nullptr) {
 		qDebug() << "failed to find suitable service on" << devaddr;
 		report_error("Failed to find suitable service on '%s'", devaddr);
-		controller->disconnectFromDevice();
 		delete ble;
 		return DC_STATUS_IO;
 	}
@@ -369,7 +372,6 @@ dc_status_t qt_ble_open(dc_custom_io_t *io, dc_context_t *context, const char *d
 	if (ble->preferredService()->state() != QLowEnergyService::ServiceDiscovered) {
 		qDebug() << "failed to find suitable service on" << devaddr;
 		report_error("Failed to find suitable service on '%s'", devaddr);
-		controller->disconnectFromDevice();
 		delete ble;
 		return DC_STATUS_IO;
 	}


### PR DESCRIPTION
On BLE connection timeout a weird error-message was shown, because
the controller was still in connecting state and no error string was
set. Therefore, handle the timeout case with a special case label.

Moreover, remove three unnecessary calls to disconnectFromDevice(),
which is called in the destructor of the controller anyway (verified
by looking at Qt source).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation
- [x] Minor cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
