### PR TITLE
Bugfix last sample and surface sample to avoid incorrect data in logfile

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1747,6 +1747,9 @@ static void merge_one_sample(struct sample *sample, int time, struct divecompute
 		struct sample *prev = dc->sample + last;
 		int last_time = prev->time.seconds;
 		int last_depth = prev->depth.mm;
+		/* Init a few values from prev sample to avoid useless info in XML */
+		surface.bearing.degrees = prev->bearing.degrees;
+		surface.ndl.seconds = prev->ndl.seconds;
 
 		/*
 		 * Only do surface events if the samples are more than

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -762,7 +762,8 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 	struct dive *dive = NULL;
 
 	/* reset static data, that is only valid per dive */
-	ndl = stoptime = stopdepth = po2 = 0;
+	stoptime = stopdepth = po2 = cns = heartbeat = 0;
+	ndl = bearing = -1;
 	in_deco = false;
 	current_gas_index = -1;
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Today when importing from DCs like e.g. OSTC we will find some incorrect/useless data in the first sample of many dives and in the last sample of almost every dive.
This incorrect/useless data includes wrong CNS value carried over from other dive w/o applying any half time and incorrect/useless cns, ndl, stoptime and other values in the last sample.
This PR fixes these issues.
This PR comes together with a fix @janmulder already provided for libdivecomputer to fill initial cns into the first sample if available.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Take care to reset some values correctly in between dives
- Fill sticky values also into the last sample correctly and also some of them into the Subsurface internal "surface" samples


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #789

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
