### PR TITLE
MXE: move the objcopy calls to cmakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,18 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	install(CODE "execute_process(COMMAND cp -a ${_qt5Core_install_prefix}/qml/QtPositioning ${CMAKE_BINARY_DIR}/${APP_BUNDLE_DIR}/Contents/Resources/qml)")
 	install(CODE "message(STATUS \"two ERRORS here about libmysqlclient and libpq not found are harmless\")")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+	if (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+		if(NOT DEFINED OBJCOPY)
+			set(OBJCOPY i686-w64-mingw32.shared-objcopy)
+		endif()
+		message(STATUS "Build type is 'RelWithDebInfo'. Creating debug symbols in a separate file.")
+		add_custom_command(TARGET ${SUBSURFACE_TARGET} POST_BUILD
+			COMMAND ${OBJCOPY} --only-keep-debug ${SUBSURFACE_TARGET}.exe ${SUBSURFACE_TARGET}.exe.debug
+			COMMAND ${OBJCOPY} --strip-debug --strip-unneeded ${SUBSURFACE_TARGET}.exe
+			COMMAND ${OBJCOPY} --add-gnu-debuglink=${SUBSURFACE_TARGET}.exe.debug ${SUBSURFACE_TARGET}.exe
+		)
+	endif()
+
 	# Windows bundling rules
 	# We don't have a helpful tool like macdeployqt for Windows, so we hardcode
 	# which libs we need.

--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -281,10 +281,3 @@ i686-w64-mingw32.shared-cmake \
 	"$BASEDIR"/subsurface
 
 make $JOBS "$@"
-
-OBJCOPY="i686-w64-mingw32.shared-objcopy"
-if [[ "$RELEASE_MAIN" == "RelWithDebInfo" ]] ; then
-	$OBJCOPY --only-keep-debug subsurface.exe subsurface.exe.debug
-	$OBJCOPY --strip-debug --strip-unneeded subsurface.exe
-	$OBJCOPY --add-gnu-debuglink=subsurface.exe.debug subsurface.exe
-fi


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

follow up on #811.

The objcopy calls to strip the debug symbols out of
subsurface.exe need to happen before the installer is
created (staged).

**note: WIP! please, do not merge until we get this right.**

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh @sfuchs79 