### PR TITLE
cmake: make sure to only handle objcopy from MXE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,12 +426,15 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		if(NOT DEFINED OBJCOPY)
 			set(OBJCOPY i686-w64-mingw32.shared-objcopy)
 		endif()
-		message(STATUS "Build type is 'RelWithDebInfo'. Creating debug symbols in a separate file.")
-		add_custom_command(TARGET ${SUBSURFACE_TARGET} POST_BUILD
-			COMMAND ${OBJCOPY} --only-keep-debug ${SUBSURFACE_TARGET}.exe ${SUBSURFACE_TARGET}.exe.debug
-			COMMAND ${OBJCOPY} --strip-debug --strip-unneeded ${SUBSURFACE_TARGET}.exe
-			COMMAND ${OBJCOPY} --add-gnu-debuglink=${SUBSURFACE_TARGET}.exe.debug ${SUBSURFACE_TARGET}.exe
-		)
+		find_program(OBJCOPY_FOUND ${OBJCOPY})
+		if (OBJCOPY_FOUND)
+			message(STATUS "Build type is 'RelWithDebInfo'. Creating debug symbols in a separate file.")
+			add_custom_command(TARGET ${SUBSURFACE_TARGET} POST_BUILD
+				COMMAND ${OBJCOPY} --only-keep-debug ${SUBSURFACE_TARGET}.exe ${SUBSURFACE_TARGET}.exe.debug
+				COMMAND ${OBJCOPY} --strip-debug --strip-unneeded ${SUBSURFACE_TARGET}.exe
+				COMMAND ${OBJCOPY} --add-gnu-debuglink=${SUBSURFACE_TARGET}.exe.debug ${SUBSURFACE_TARGET}.exe
+			)
+		endif()
 	endif()
 
 	# Windows bundling rules


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The native Windows build does not use the MXE tools
and call such as `i686-w64-mingw32.shared-objcopy`
can fail.

Attempt to first find if the program exists using
`find_program()` and only then call it.

Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh 