### PR TITLE
Win32: enable proper verbose mode

### DIFF
--- a/ReleaseNotes/ReleaseNotes.txt
+++ b/ReleaseNotes/ReleaseNotes.txt
@@ -8,6 +8,7 @@ Some of the changes since _Subsurface_ 4.7.4
 
 - Limit min. GFlow to 10 and min. GFhigh to 40 in preferences for profile
   and planner
+- Fix issues related to debug logging on Windows
 
 
 _Subsurface_ 4.7.4 - November 11, 2017

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -148,14 +148,18 @@ const char *monthname(int mon)
  */
 bool imported = false;
 
-static void print_version()
+bool version_printed = false;
+void print_version()
 {
+	if (version_printed)
+		return;
 	printf("Subsurface v%s,\n", subsurface_git_version());
 	printf("built with libdivecomputer v%s\n", dc_version(NULL));
 	print_qt_versions();
 	int git_maj, git_min, git_rev;
 	git_libgit2_version(&git_maj, &git_min, &git_rev);
 	printf("built with libgit2 %d.%d.%d\n", git_maj, git_min, git_rev);
+	version_printed = true;
 }
 
 void print_files()

--- a/core/subsurfacestartup.h
+++ b/core/subsurfacestartup.h
@@ -19,6 +19,7 @@ void parse_argument(const char *arg);
 void free_prefs(void);
 void copy_prefs(struct preferences *src, struct preferences *dest);
 void print_files(void);
+void print_version(void);
 
 extern char *settings_suffix;
 

--- a/core/windows.c
+++ b/core/windows.c
@@ -410,6 +410,7 @@ void subsurface_console_init(void)
 		console_desc.out = freopen("CON", "w", stdout);
 		console_desc.err = freopen("CON", "w", stderr);
 	} else {
+		verbose = 1; /* set the verbose level to '1' */
 		console_desc.out = freopen("subsurface_out.log", "w", stdout);
 		console_desc.err = freopen("subsurface_err.log", "w", stderr);
 	}

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -29,12 +29,14 @@
 
 static bool filesOnCommandLine = false;
 static void validateGL();
+static void messageHandler(QtMsgType type, const QMessageLogContext &ctx, const QString &msg);
 
 int main(int argc, char **argv)
 {
 	int i;
 	bool no_filenames = true;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
+	qInstallMessageHandler(messageHandler);
 	QApplication *application = new QApplication(argc, argv);
 	(void)application;
 	QStringList files;
@@ -213,5 +215,29 @@ exit:
 		qWarning() << QStringLiteral(VALIDATE_GL_PREFIX "WARNING: %1. Using a software renderer!").arg(glError).toUtf8().data();
 		QQuickWindow::setSceneGraphBackend(QSGRendererInterface::Software);
 #endif
+	}
+}
+
+// install this message handler primarily so that the Windows build can log to files
+void messageHandler(QtMsgType type, const QMessageLogContext &ctx, const QString &msg)
+{
+	Q_UNUSED(ctx);
+	QByteArray localMsg = msg.toLocal8Bit();
+	switch (type) {
+	case QtDebugMsg:
+		fprintf(stdout, "%s\n", localMsg.constData());
+		break;
+	case QtInfoMsg:
+		fprintf(stdout, "%s\n", localMsg.constData());
+		break;
+	case QtWarningMsg:
+		fprintf(stderr, "%s\n", localMsg.constData());
+		break;
+	case QtCriticalMsg:
+		fprintf(stderr, "%s\n", localMsg.constData());
+		break;
+	case QtFatalMsg:
+		fprintf(stderr, "%s\n", localMsg.constData());
+		abort();
 	}
 }

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -33,17 +33,19 @@ static void messageHandler(QtMsgType type, const QMessageLogContext &ctx, const 
 
 int main(int argc, char **argv)
 {
+	subsurface_console_init();
+	qInstallMessageHandler(messageHandler);
+	if (verbose) /* print the version if the Win32 console_init() code enabled verbose. */
+		print_version();
+
 	int i;
 	bool no_filenames = true;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
-	qInstallMessageHandler(messageHandler);
 	QApplication *application = new QApplication(argc, argv);
 	(void)application;
 	QStringList files;
 	QStringList importedFiles;
 	QStringList arguments = QCoreApplication::arguments();
-
-	subsurface_console_init();
 
 	const char *default_directory = system_default_directory();
 	const char *default_filename = system_default_filename();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

**windows.c: enable verbose level 1 for desktop usage  …**

If the user has not started Subsurface from a terminal
make sure that verbosity is enabled (verbose = 1), so that
the log files are populated with information useful for
debugging.

**dekstop-main.cpp: install a message handler  …**

This way the Windows binaries can properly write to
log files.

**subsurface-startup: expose print_version() in the header  …**

The Windows auto-verbose + log file creation if starting
from a non-terminal has the problem that the print_version()
call is never made becase 'verbose' is updated programatically
in windows.c and not by the user (by passing -v).

To work around the issue:
- move the windows console creation call before *everything* else
- then immediatelly install the message handler
- then see if 'verbose' is set and explicitly call print_version()

print_version() now also has a flag (version_printed), to avoid
printing the version multiple times, if the user decided to add
an extra -v to the Desktop shortcut.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) fixed a bug preventing all the stderr/stdout to be written in log files on win32
2) fixed the issue where the version of subsurface is not printed in the logs if the user started from a desktop shortcut

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
none

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

seems like Davide was right that something is wrong.
also i think Tomaz suggested to use a message handler at some point.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh 