### PR TITLE
In maintab disable correct label when dive trip selected

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -493,7 +493,7 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.waterTempLabel->setVisible(false);
 			ui.watertemp->setVisible(false);
 			ui.dateEdit->setReadOnly(true);
-			ui.label->setVisible(false);
+			ui.timeLabel->setVisible(false);
 			ui.timeEdit->setVisible(false);
 			ui.diveTripLocation->show();
 			ui.location->hide();
@@ -538,7 +538,7 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.waterTempLabel->setVisible(true);
 			ui.watertemp->setVisible(true);
 			ui.dateEdit->setReadOnly(false);
-			ui.label->setVisible(true);
+			ui.timeLabel->setVisible(true);
 			ui.timeEdit->setVisible(true);
 			/* and fill them from the dive */
 			ui.rating->setCurrentStars(displayed_dive.rating);

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -82,7 +82,7 @@
               </widget>
              </item>
              <item row="0" column="0">
-              <widget class="QLabel" name="label">
+              <widget class="QLabel" name="dateLabel">
                <property name="text">
                 <string>Date</string>
                </property>
@@ -92,7 +92,7 @@
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QLabel" name="label_6">
+              <widget class="QLabel" name="timeLabel">
                <property name="text">
                 <string>Time</string>
                </property>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Until now accidentally the dateLabel was disabled and the timeLabel
was enabled. Changed this the other (correct) way round.

That things happen when using improper object names... ;-)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
