### PR TITLE
Show all autocompletes after entry of comma in tag list

### DIFF
--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -91,7 +91,7 @@ void TagWidget::reparse()
 	 * Do not show the completer when not in edit mode - basically
 	 * this returns when we are accepting or discarding the changes.
 	 */
-	if (MainWindow::instance()->information()->isEditing() == false || currentText.length() == 0) {
+	if (MainWindow::instance()->information()->isEditing() == false) {
 		return;
 	}
 


### PR DESCRIPTION
The almost 3 year old commit e1db5f21b15b2 introduced the behavior that you need to type at least 1 character for a tag to show any autocompleted data. While this went unnoticed for years, there
is always a user that notices this changed behavior.

The solution is rather simple. Do allow the 0 length string to act as seed for autocompletion instead of just returning, and doing no autocomplete at all.

As the afore mentioned commit was explicitly meant to prevent over active firing of the tag list autocompleter, this (simple) change is carefully tested on this, and no adverse effects are visible.

Fixes: #605 (wrt the 1 character issue)

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 
