### PR TITLE
Fix memory leaks in SettingsObjectWrapper.cpp

### DIFF
--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -731,6 +731,7 @@ void FacebookSettings::setAccessToken (const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("ConnectToken", value);
 #endif
+	free(prefs.facebook.access_token);
 	prefs.facebook.access_token = copy_string(qPrintable(value));
 	emit accessTokenChanged(value);
 }
@@ -745,6 +746,7 @@ void FacebookSettings::setUserId(const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("UserId", value);
 #endif
+	free(prefs.facebook.user_id);
 	prefs.facebook.user_id = copy_string(qPrintable(value));
 	emit userIdChanged(value);
 }
@@ -759,6 +761,7 @@ void FacebookSettings::setAlbumId(const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("AlbumId", value);
 #endif
+	free(prefs.facebook.album_id);
 	prefs.facebook.album_id = copy_string(qPrintable(value));
 	emit albumIdChanged(value);
 }
@@ -872,7 +875,7 @@ void ProxySettings::setHost(const QString& value)
 	s.beginGroup(group);
 	s.setValue("proxy_host", value);
 	free(prefs.proxy_host);
-	prefs.proxy_host = copy_string(qPrintable(value));;
+	prefs.proxy_host = copy_string(qPrintable(value));
 	emit hostChanged(value);
 }
 
@@ -1775,6 +1778,7 @@ void GeneralSettingsObjectWrapper::setDefaultFilename(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("default_filename", value);
+	free((void*)prefs.default_filename);
 	prefs.default_filename = copy_string(qPrintable(value));
 	emit defaultFilenameChanged(value);
 }
@@ -1787,6 +1791,7 @@ void GeneralSettingsObjectWrapper::setDefaultCylinder(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("default_cylinder", value);
+	free((void*)prefs.default_cylinder);
 	prefs.default_cylinder = copy_string(qPrintable(value));
 	emit defaultCylinderChanged(value);
 }
@@ -1979,7 +1984,7 @@ void LanguageSettingsObjectWrapper::setUseSystemLanguage(bool value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("UseSystemLanguage", value);
-	prefs.locale.use_system_language = copy_string(qPrintable(value));
+	prefs.locale.use_system_language = value;
 	emit useSystemLanguageChanged(value);
 }
 
@@ -1990,6 +1995,7 @@ void  LanguageSettingsObjectWrapper::setLangLocale(const QString &value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("UiLangLocale", value);
+	free((void*)prefs.locale.lang_locale);
 	prefs.locale.lang_locale = copy_string(qPrintable(value));
 	emit langLocaleChanged(value);
 }
@@ -2001,6 +2007,7 @@ void  LanguageSettingsObjectWrapper::setLanguage(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("UiLanguage", value);
+	free((void*)prefs.locale.language);
 	prefs.locale.language = copy_string(qPrintable(value));
 	emit languageChanged(value);
 }
@@ -2012,7 +2019,8 @@ void  LanguageSettingsObjectWrapper::setTimeFormat(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("time_format", value);
-	prefs.time_format = copy_string(qPrintable(value));;
+	free((void*)prefs.time_format);
+	prefs.time_format = copy_string(qPrintable(value));
 	emit timeFormatChanged(value);
 }
 
@@ -2024,7 +2032,8 @@ void  LanguageSettingsObjectWrapper::setDateFormat(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("date_format", value);
-	prefs.date_format = copy_string(qPrintable(value));;
+	free((void*)prefs.date_format);
+	prefs.date_format = copy_string(qPrintable(value));
 	emit dateFormatChanged(value);
 }
 
@@ -2036,7 +2045,8 @@ void  LanguageSettingsObjectWrapper::setDateFormatShort(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("date_format_short", value);
-	prefs.date_format_short = copy_string(qPrintable(value));;
+	free((void*)prefs.date_format_short);
+	prefs.date_format_short = copy_string(qPrintable(value));
 	emit dateFormatShortChanged(value);
 }
 


### PR DESCRIPTION
Free a bunch of C-style strings before assigning newly copied strings.
One case was particularly buggy:
`prefs.locale.use_system_language = copy_string(qPrintable(value));`
Note that prefs.locale.use_system_language is a bool, which of course
always evaluates to true! Probably nobody noticed because a restart
is required when changing locale.

Moreover remove a few double-semicolons.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a few memory leaks, one of which turns out to be an outright bug. Tested lightly. I'm not 100% sure that these were genuine oversights and perhaps there are some conditions were these strings must not be free()d? Especially the Facebook things I cannot test.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
