### PR TITLE
Cylinder pressure alternative

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -429,6 +429,7 @@ extern timestamp_t picture_get_timestamp(const char *filename);
 extern void dive_set_geodata_from_picture(struct dive *d, struct picture *pic);
 extern void picture_free(struct picture *picture);
 
+extern bool has_gaschange_event(struct dive *dive, struct divecomputer *dc, int idx);
 extern int explicit_first_cylinder(struct dive *dive, struct divecomputer *dc);
 extern int get_depth_at_time(struct divecomputer *dc, unsigned int time);
 
@@ -969,7 +970,6 @@ static inline struct gasmix *get_gasmix(struct dive *dive, struct divecomputer *
 	*evp = ev;
 	return gasmix;
 }
-
 
 /* these structs holds the information that
  * describes the cylinders / weight systems.

--- a/core/gaspressures.c
+++ b/core/gaspressures.c
@@ -331,8 +331,6 @@ static void debug_print_pressures(struct plot_info *pi)
 }
 #endif
 
-extern bool has_gaschange_event(struct dive *dive, struct divecomputer *dc, int idx);
-
 /* This function goes through the list of tank pressures, either SENSOR_PRESSURE(entry) or O2CYLINDER_PRESSURE(entry),
  * of structure plot_info for the dive profile where each item in the list corresponds to one point (node) of the
  * profile. It finds values for which there are no tank pressures (pressure==0). For each missing item (node) of

--- a/core/profile.c
+++ b/core/profile.c
@@ -835,8 +835,7 @@ static void setup_gas_sensor_pressure(struct dive *dive, struct divecomputer *dc
 		if (cyl < 0)
 			continue;
 
-		if (prev >= 0)
-			last[prev] = sec;
+		last[prev] = sec;
 		prev = cyl;
 
 		last[cyl] = sec;
@@ -846,8 +845,7 @@ static void setup_gas_sensor_pressure(struct dive *dive, struct divecomputer *dc
 			seen[cyl] = 1;
 		}
 	}
-	if (prev >= 0)
-		last[prev] = INT_MAX;
+	last[prev] = INT_MAX;
 
 	for (i = 0; i < MAX_CYLINDERS; i++) {
 		cylinder_t *cyl = dive->cylinder + i;


### PR DESCRIPTION
This is the github version of the possible alternative fix for @sfuchs79 cylinder pressure issue.

It's split up as three commits, two of which are pure cleanup, and then the third that extends on our use of the per-cylinder "seen[]" array to also mark cylinders as not interesting (either because they have no relevant pressure information, or because they are only mentioned by other dive computers)