### PR TITLE
mobile: black and white backgrounds on starting

### DIFF
--- a/android-mobile/res/drawable/splash.xml
+++ b/android-mobile/res/drawable/splash.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle" >
-            <solid android:color="#000000FF"/>
+            <solid android:color="#FFFFFF" />
         </shape>
     </item>
     <item>


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

This very simple commit has a long story. See the mailing list
subject "mobile: android splash screen (and issue 513) opacity
weirdness".

There is even more. I found the following deccription on Internet:
https://falsinsoft.blogspot.nl/2017/07/qml-show-android-native-splash-screen.html
and tried to implement this with the potentially nice Qt functionality
(since 5.8) to manually get rid of the splash screen. Unfortunately,
this does not work. Notice that there are subtile differences in
the here found internet page, and the method originally implemented
in commit 04e994b575.

This fix is as minimalistic as it can be. Just do not set black but
white for the initial background. Unfortunately, there is still
a small position change of the icon. It is known why, but solving
is left as an exercise to the reader.

Fixes: #513

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>