### PR TITLE
Copy default filename string when assigning to default preferences

### DIFF
--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -295,7 +295,7 @@ void setup_system_prefs(void)
 	default_prefs.font_size = system_divelist_default_font_size;
 
 #if !defined(SUBSURFACE_MOBILE)
-	default_prefs.default_filename = system_default_filename();
+	default_prefs.default_filename = copy_string(system_default_filename());
 #endif
 	env = getenv("LC_MEASUREMENT");
 	if (!env)


### PR DESCRIPTION
This tries to remove subtle ownership issues. When copying preferences
structures, the default filename is copied. But the default preferences
struct simply takes a pointer to a global string which is free()d in main().

Now, this is not strictly a double-free() bug because the free()ing of preferences
resources is not implemented anyway. Yet, let's try to make this consistent.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This looks like a complete triviality, but let's try to fix the subtle ownership issues in the preferences code.  See also #825 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
