### PR TITLE
Clean up system_default_filename()

### DIFF
--- a/core/linux.c
+++ b/core/linux.c
@@ -83,18 +83,17 @@ const char *system_default_directory(void)
 
 const char *system_default_filename(void)
 {
-	static char *filename = NULL;
-	if (!filename) {
+	static const char *path = NULL;
+	if (!path) {
 		const char *user = getenv("LOGNAME");
 		if (same_string(user, ""))
 			user = "username";
-		filename = calloc(strlen(user) + 5, 1);
+		char *filename = calloc(strlen(user) + 5, 1);
 		strcat(filename, user);
 		strcat(filename, ".xml");
-	}
-	static const char *path = NULL;
-	if (!path)
 		path = system_default_path_append(filename);
+		free(filename);
+	}
 	return path;
 }
 

--- a/core/macos.c
+++ b/core/macos.c
@@ -81,18 +81,17 @@ const char *system_default_directory(void)
 
 const char *system_default_filename(void)
 {
-	static char *filename = NULL;
-	if (!filename) {
+	static const char *path = NULL;
+	if (!path) {
 		const char *user = getenv("LOGNAME");
 		if (same_string(user, ""))
 			user = "username";
-		filename = calloc(strlen(user) + 5, 1);
+		char *filename = calloc(strlen(user) + 5, 1);
 		strcat(filename, user);
 		strcat(filename, ".xml");
-	}
-	static const char *path = NULL;
-	if (!path)
 		path = system_default_path_append(filename);
+		free(filename);
+	}
 	return path;
 }
 

--- a/core/windows.c
+++ b/core/windows.c
@@ -103,17 +103,16 @@ const char *system_default_directory(void)
  */
 const char *system_default_filename(void)
 {
-	static wchar_t filename[UNLEN + 5] = { 0 };
-	if (!*filename) {
+	static const char *path = NULL;
+	if (!path) {
 		wchar_t username[UNLEN + 1] = { 0 };
 		DWORD username_len = UNLEN + 1;
 		GetUserNameW(username, &username_len);
+		wchar_t filename[UNLEN + 5] = { 0 };
 		wcscat(filename, username);
 		wcscat(filename, L".xml");
-	}
-	static const char *path = NULL;
-	if (!path)
 		path = system_default_path_append(filename);
+	}
 	return path;
 }
 


### PR DESCRIPTION
In the old implementation there were two static C-style strings, filename
and path, which were initialized to NULL and filled on first call of
the function (i.e. singletons).

There is no sense in having two static variables indicating whether
this function was called previously. Moreover, there is no point
in remembering filename accross function calls, because it is not
used once path is set to a non-NULL value.

Therefore, make the filename variable non-static and calculate it only on
first invocation (as indicated by a NULL path). Moreover, free() the filename
variable after its use to fix a memory leak of the old code.

The windows code is slightly different in that the temporary filename is
not dynamically allocated.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Perhaps I'm missing some subtleties, but this seems like an quite obvious clean up. It compiles and runs on Linux. Mac uses the same code, so should work likewise. Windows: let's wait for CI build....
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
