### PR TITLE
Make handling of booleans consistent in the preferences code

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -1012,7 +1012,6 @@ extern double strtod_flags(const char *str, const char **ptr, unsigned int flags
 
 #define ascii_strtod(str, ptr) strtod_flags(str, ptr, STRTOD_ASCII)
 
-extern void set_save_userid_local(short value);
 extern void set_userid(char *user_id);
 extern void set_informational_units(char *units);
 extern void set_git_prefs(char *prefs);

--- a/core/pref.h
+++ b/core/pref.h
@@ -9,12 +9,11 @@ extern "C" {
 #include "units.h"
 #include "taxonomy.h"
 
-/* can't use 'bool' for the boolean values - different size in C and C++ */
 typedef struct
 {
-	short po2;
-	short pn2;
-	short phe;
+	bool po2;
+	bool pn2;
+	bool phe;
 	double po2_threshold_min;
 	double po2_threshold_max;
 	double pn2_threshold;
@@ -71,34 +70,34 @@ struct preferences {
 	bool date_format_override;
 	double font_size;
 	partial_pressure_graphs_t pp_graphs;
-	short mod;
+	bool mod;
 	double modpO2;
-	short ead;
-	short dcceiling;
-	short redceiling;
-	short calcceiling;
-	short calcceiling3m;
-	short calcalltissues;
-	short calcndltts;
+	bool ead;
+	bool dcceiling;
+	bool redceiling;
+	bool calcceiling;
+	bool calcceiling3m;
+	bool calcalltissues;
+	bool calcndltts;
 	short gflow;
 	short gfhigh;
 	int animation_speed;
 	bool gf_low_at_maxdepth;
 	bool show_ccr_setpoint;
 	bool show_ccr_sensors;
-	short display_invalid_dives;
+	bool display_invalid_dives;
 	short unit_system;
 	struct units units;
 	bool coordinates_traditional;
-	short show_sac;
-	short display_unused_tanks;
-	short show_average_depth;
-	short zoomed_plot;
-	short hrgraph;
-	short percentagegraph;
-	short rulergraph;
-	short tankbar;
-	short save_userid_local;
+	bool show_sac;
+	bool display_unused_tanks;
+	bool show_average_depth;
+	bool zoomed_plot;
+	bool hrgraph;
+	bool percentagegraph;
+	bool rulergraph;
+	bool tankbar;
+	bool save_userid_local;
 	const char *userid;
 	int ascrate75; // All rates in mm / sec
 	int ascrate50;
@@ -114,7 +113,7 @@ struct preferences {
 	int proxy_type;
 	const char *proxy_host;
 	int proxy_port;
-	short proxy_auth;
+	bool proxy_auth;
 	const char *proxy_user;
 	const char *proxy_pass;
 	bool doo2breaks;

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -169,17 +169,17 @@ PartialPressureGasSettings::PartialPressureGasSettings(QObject* parent):
 
 }
 
-short PartialPressureGasSettings::showPo2() const
+bool PartialPressureGasSettings::showPo2() const
 {
 	return prefs.pp_graphs.po2;
 }
 
-short PartialPressureGasSettings::showPn2() const
+bool PartialPressureGasSettings::showPn2() const
 {
 	return prefs.pp_graphs.pn2;
 }
 
-short PartialPressureGasSettings::showPhe() const
+bool PartialPressureGasSettings::showPhe() const
 {
 	return prefs.pp_graphs.phe;
 }
@@ -205,7 +205,7 @@ double PartialPressureGasSettings::pheThreshold() const
 	return prefs.pp_graphs.phe_threshold;
 }
 
-void PartialPressureGasSettings::setShowPo2(short value)
+void PartialPressureGasSettings::setShowPo2(bool value)
 {
 	if (value == prefs.pp_graphs.po2)
 		return;
@@ -217,7 +217,7 @@ void PartialPressureGasSettings::setShowPo2(short value)
 	emit showPo2Changed(value);
 }
 
-void PartialPressureGasSettings::setShowPn2(short value)
+void PartialPressureGasSettings::setShowPn2(bool value)
 {
 	if (value == prefs.pp_graphs.pn2)
 		return;
@@ -229,7 +229,7 @@ void PartialPressureGasSettings::setShowPn2(short value)
 	emit showPn2Changed(value);
 }
 
-void PartialPressureGasSettings::setShowPhe(short value)
+void PartialPressureGasSettings::setShowPhe(bool value)
 {
 	if (value == prefs.pp_graphs.phe)
 		return;
@@ -1092,7 +1092,7 @@ void CloudStorageSettings::setBackgroundSync(bool value)
 	emit backgroundSyncChanged(value);
 }
 
-void CloudStorageSettings::setSaveUserIdLocal(short int value)
+void CloudStorageSettings::setSaveUserIdLocal(bool value)
 {
 	//TODO: this is not saved on disk?
 	if (value == prefs.save_userid_local)
@@ -1101,7 +1101,7 @@ void CloudStorageSettings::setSaveUserIdLocal(short int value)
 	emit saveUserIdLocalChanged(value);
 }
 
-short int CloudStorageSettings::saveUserIdLocal() const
+bool CloudStorageSettings::saveUserIdLocal() const
 {
 	return prefs.save_userid_local;
 }
@@ -1895,7 +1895,7 @@ double DisplaySettingsObjectWrapper::fontSize() const
 	return prefs.font_size;
 }
 
-short DisplaySettingsObjectWrapper::displayInvalidDives() const
+bool DisplaySettingsObjectWrapper::displayInvalidDives() const
 {
 	return prefs.display_invalid_dives;
 }
@@ -1937,7 +1937,7 @@ void DisplaySettingsObjectWrapper::setFontSize(double value)
 	emit fontSizeChanged(value);
 }
 
-void DisplaySettingsObjectWrapper::setDisplayInvalidDives(short value)
+void DisplaySettingsObjectWrapper::setDisplayInvalidDives(bool value)
 {
 	if (value == prefs.display_invalid_dives)
 		return;
@@ -2272,7 +2272,7 @@ void SettingsObjectWrapper::load()
 	}
 	defaultFont.setPointSizeF(prefs.font_size);
 	qApp->setFont(defaultFont);
-	GET_INT("displayinvalid", display_invalid_dives);
+	GET_BOOL("displayinvalid", display_invalid_dives);
 	s.endGroup();
 
 	s.beginGroup("Animations");

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -74,9 +74,9 @@ private:
 /* Control the state of the Partial Pressure Graphs preferences */
 class PartialPressureGasSettings : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(short show_po2           READ showPo2         WRITE setShowPo2         NOTIFY showPo2Changed)
-	Q_PROPERTY(short show_pn2           READ showPn2         WRITE setShowPn2         NOTIFY showPn2Changed)
-	Q_PROPERTY(short show_phe	    READ showPhe         WRITE setShowPhe         NOTIFY showPheChanged)
+	Q_PROPERTY(bool   show_po2          READ showPo2         WRITE setShowPo2         NOTIFY showPo2Changed)
+	Q_PROPERTY(bool   show_pn2          READ showPn2         WRITE setShowPn2         NOTIFY showPn2Changed)
+	Q_PROPERTY(bool   show_phe	    READ showPhe         WRITE setShowPhe         NOTIFY showPheChanged)
 	Q_PROPERTY(double po2_threshold_min READ po2ThresholdMin WRITE setPo2ThresholdMin NOTIFY po2ThresholdMinChanged)
 	Q_PROPERTY(double po2_threshold_max READ po2ThresholdMax WRITE setPo2ThresholdMax NOTIFY po2ThresholdMaxChanged)
 	Q_PROPERTY(double pn2_threshold     READ pn2Threshold    WRITE setPn2Threshold    NOTIFY pn2ThresholdChanged)
@@ -84,27 +84,27 @@ class PartialPressureGasSettings : public QObject {
 
 public:
 	PartialPressureGasSettings(QObject *parent);
-	short showPo2() const;
-	short showPn2() const;
-	short showPhe() const;
+	bool showPo2() const;
+	bool showPn2() const;
+	bool showPhe() const;
 	double po2ThresholdMin() const;
 	double po2ThresholdMax() const;
 	double pn2Threshold() const;
 	double pheThreshold() const;
 
 public slots:
-	void setShowPo2(short value);
-	void setShowPn2(short value);
-	void setShowPhe(short value);
+	void setShowPo2(bool value);
+	void setShowPn2(bool value);
+	void setShowPhe(bool value);
 	void setPo2ThresholdMin(double value);
 	void setPo2ThresholdMax(double value);
 	void setPn2Threshold(double value);
 	void setPheThreshold(double value);
 
 signals:
-	void showPo2Changed(short value);
-	void showPn2Changed(short value);
-	void showPheChanged(short value);
+	void showPo2Changed(bool value);
+	void showPn2Changed(bool value);
+	void showPheChanged(bool value);
 	void po2ThresholdMaxChanged(double value);
 	void po2ThresholdMinChanged(double value);
 	void pn2ThresholdChanged(double value);
@@ -328,7 +328,7 @@ class CloudStorageSettings : public QObject {
 	Q_PROPERTY(QString userid            READ userId             WRITE setUserId             NOTIFY userIdChanged)
 	Q_PROPERTY(QString base_url          READ baseUrl            WRITE setBaseUrl            NOTIFY baseUrlChanged)
 	Q_PROPERTY(QString git_url           READ gitUrl             WRITE setGitUrl             NOTIFY gitUrlChanged)
-	Q_PROPERTY(short save_userid_local  READ saveUserIdLocal WRITE setSaveUserIdLocal NOTIFY saveUserIdLocalChanged)
+	Q_PROPERTY(bool save_userid_local    READ saveUserIdLocal    WRITE setSaveUserIdLocal    NOTIFY saveUserIdLocalChanged)
 	Q_PROPERTY(bool git_local_only       READ gitLocalOnly       WRITE setGitLocalOnly       NOTIFY gitLocalOnlyChanged)
 	Q_PROPERTY(bool save_password_local  READ savePasswordLocal  WRITE setSavePasswordLocal  NOTIFY savePasswordLocalChanged)
 	Q_PROPERTY(short verification_status READ verificationStatus WRITE setVerificationStatus NOTIFY verificationStatusChanged)
@@ -346,7 +346,7 @@ public:
 	short verificationStatus() const;
 	bool backgroundSync() const;
 	bool gitLocalOnly() const;
-	short saveUserIdLocal() const;
+	bool saveUserIdLocal() const;
 
 public slots:
 	void setPassword(const QString& value);
@@ -360,7 +360,7 @@ public slots:
 	void setVerificationStatus(short value);
 	void setBackgroundSync(bool value);
 	void setGitLocalOnly(bool value);
-	void setSaveUserIdLocal(short value);
+	void setSaveUserIdLocal(bool value);
 
 signals:
 	void passwordChanged(const QString& value);
@@ -374,7 +374,7 @@ signals:
 	void verificationStatusChanged(short value);
 	void backgroundSyncChanged(bool value);
 	void gitLocalOnlyChanged(bool value);
-	void saveUserIdLocalChanged(short value);
+	void saveUserIdLocalChanged(bool value);
 
 private:
 	const QString group = QStringLiteral("CloudStorage");
@@ -592,20 +592,20 @@ class DisplaySettingsObjectWrapper : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(QString divelist_font     READ divelistFont       WRITE setDivelistFont       NOTIFY divelistFontChanged)
 	Q_PROPERTY(double font_size          READ fontSize           WRITE setFontSize           NOTIFY fontSizeChanged)
-	Q_PROPERTY(short display_invalid_dives  READ displayInvalidDives     WRITE setDisplayInvalidDives       NOTIFY displayInvalidDivesChanged)
+	Q_PROPERTY(bool display_invalid_dives  READ displayInvalidDives     WRITE setDisplayInvalidDives       NOTIFY displayInvalidDivesChanged)
 public:
 	DisplaySettingsObjectWrapper(QObject *parent);
 	QString divelistFont() const;
 	double fontSize() const;
-	short displayInvalidDives() const;
+	bool displayInvalidDives() const;
 public slots:
 	void setDivelistFont(const QString& value);
 	void setFontSize(double value);
-	void setDisplayInvalidDives(short value);
+	void setDisplayInvalidDives(bool value);
 signals:
 	void divelistFontChanged(const QString& value);
 	void fontSizeChanged(double value);
-	void displayInvalidDivesChanged(short value);
+	void displayInvalidDivesChanged(bool value);
 private:
 	const QString group = QStringLiteral("Display");
 };

--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -113,7 +113,6 @@ slots:
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern void set_save_userid_local(short value);
 extern void set_userid(char *user_id);
 #ifdef __cplusplus
 }

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -61,11 +61,10 @@ void TestPreferences::testPreferences()
 	cloud->setSavePasswordLocal(false);
 	TEST(cloud->savePasswordLocal(), false);
 
-	// Why this is short and not bool?
 	cloud->setSaveUserIdLocal(1);
-	TEST(cloud->saveUserIdLocal(), (short)1);
+	TEST(cloud->saveUserIdLocal(), true);
 	cloud->setSaveUserIdLocal(0);
-	TEST(cloud->saveUserIdLocal(), (short)0);
+	TEST(cloud->saveUserIdLocal(), false);
 
 	cloud->setUserId("Tomaz");
 	TEST(cloud->userId(), QStringLiteral("Tomaz"));
@@ -189,9 +188,9 @@ void TestPreferences::testPreferences()
 	pp->setPn2Threshold(3.0);
 	pp->setPheThreshold(4.0);
 
-	TEST(pp->showPn2(), (short) false);
-	TEST(pp->showPhe(), (short) false);
-	TEST(pp->showPo2(), (short) false);
+	TEST(pp->showPn2(), false);
+	TEST(pp->showPhe(), false);
+	TEST(pp->showPo2(), false);
 	TEST(pp->pn2Threshold(), 3.0);
 	TEST(pp->pheThreshold(), 4.0);
 	TEST(pp->po2ThresholdMin(), 1.0);
@@ -205,9 +204,9 @@ void TestPreferences::testPreferences()
 	pp->setPn2Threshold(6.0);
 	pp->setPheThreshold(7.0);
 
-	TEST(pp->showPn2(), (short) true);
-	TEST(pp->showPhe(), (short) true);
-	TEST(pp->showPo2(), (short) true);
+	TEST(pp->showPn2(), true);
+	TEST(pp->showPhe(), true);
+	TEST(pp->showPo2(), true);
 	TEST(pp->pn2Threshold(), 6.0);
 	TEST(pp->pheThreshold(), 7.0);
 	TEST(pp->po2ThresholdMin(), 4.0);
@@ -457,7 +456,7 @@ void TestPreferences::testPreferences()
 
 	TEST(display->divelistFont(),QStringLiteral("comic"));
 	TEST(display->fontSize(), 10.0);
-	TEST(display->displayInvalidDives(),(short) true); //TODO: this is true / false.
+	TEST(display->displayInvalidDives(), true);
 
 	display->setDivelistFont("helvetica");
 	display->setFontSize(14.0);
@@ -465,7 +464,7 @@ void TestPreferences::testPreferences()
 
 	TEST(display->divelistFont(),QStringLiteral("helvetica"));
 	TEST(display->fontSize(), 14.0);
-	TEST(display->displayInvalidDives(),(short) false);
+	TEST(display->displayInvalidDives(), false);
 
 	auto language = pref->language_settings;
 	language->setLangLocale         ("en_US");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

These two commits make the handling of booleans consistent on both sides, C and C++, of the preferences code. They turn a number of shorts into bools. The C++-side was rather consistent, with the exception of five settings. The C-side was just randomly bool and short. Nevertheless, the patch for the C++-side is distinctly more complex, since it has to handle setters, getters and signals.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->

1) Turn the five settings
  showPo2
  showPn2
  showPhe
  saveUserIdLocal
  displayInvalidDives
into bools. This means adapting setters, getters, signals and tests.
2) Remove declaration of the unused set_save_userid_local() function.
3) Turn boolean settings in core/pref.h that were declared as short into bools.

<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
