### PR TITLE
Constify strings in pref.h

### DIFF
--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -64,7 +64,7 @@ void CloudStorageAuthenticate::uploadFinished()
 		csSettings.setVerificationStatus(CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {
-		free(prefs.cloud_storage_password);
+		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = prefs.cloud_storage_newpassword;
 		prefs.cloud_storage_newpassword = NULL;
 		emit passwordChangeSuccessful();

--- a/core/dive.c
+++ b/core/dive.c
@@ -3623,11 +3623,12 @@ timestamp_t get_times()
 
 void set_userid(char *rUserId)
 {
+	char *userid = strdup(rUserId);
+	if (strlen(userid) > 30)
+		userid[30] = '\0';
 	if (prefs.userid)
-		free(prefs.userid);
-	prefs.userid = strdup(rUserId);
-	if (strlen(prefs.userid) > 30)
-		prefs.userid[30]='\0';
+		free((void *)prefs.userid);
+	prefs.userid = userid;
 }
 
 /* this sets a usually unused copy of the preferences with the units

--- a/core/pref.h
+++ b/core/pref.h
@@ -22,9 +22,9 @@ typedef struct
 } partial_pressure_graphs_t;
 
 typedef struct {
-	char *access_token;
-	char *user_id;
-	char *album_id;
+	const char *access_token;
+	const char *user_id;
+	const char *album_id;
 } facebook_prefs_t;
 
 typedef struct {
@@ -46,15 +46,15 @@ enum deco_mode {
 typedef struct {
 	bool dont_check_for_updates;
 	bool dont_check_exists;
-	char *last_version_used;
-	char *next_check;
+	const char *last_version_used;
+	const char *next_check;
 } update_manager_prefs_t;
 
 typedef struct {
-	char *vendor;
-	char *product;
-	char *device;
-	char *device_name;
+	const char *vendor;
+	const char *product;
+	const char *device;
+	const char *device_name;
 	int download_mode;
 } dive_computer_prefs_t;
 
@@ -99,7 +99,7 @@ struct preferences {
 	short rulergraph;
 	short tankbar;
 	short save_userid_local;
-	char *userid;
+	const char *userid;
 	int ascrate75; // All rates in mm / sec
 	int ascrate50;
 	int ascratestops;
@@ -112,11 +112,11 @@ struct preferences {
 	enum deco_mode display_deco_mode;
 	depth_t bestmixend;
 	int proxy_type;
-	char *proxy_host;
+	const char *proxy_host;
 	int proxy_port;
 	short proxy_auth;
-	char *proxy_user;
-	char *proxy_pass;
+	const char *proxy_user;
+	const char *proxy_pass;
 	bool doo2breaks;
 	bool drop_stone_mode;
 	bool last_stop;   // At 6m?
@@ -138,10 +138,10 @@ struct preferences {
 	bool use_default_file;
 	short default_file_behavior;
 	facebook_prefs_t facebook;
-	char *cloud_storage_password;
-	char *cloud_storage_newpassword;
-	char *cloud_storage_email;
-	char *cloud_storage_email_encoded;
+	const char *cloud_storage_password;
+	const char *cloud_storage_newpassword;
+	const char *cloud_storage_email;
+	const char *cloud_storage_email_encoded;
 	bool save_password_local;
 	short cloud_verification_status;
 	bool cloud_background_sync;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -537,11 +537,11 @@ QString uiLanguage(QLocale *callerLoc)
 		// messes things up there
 		dateFormat.replace("'en' 'den' d:'e'", " d");
 		if (!prefs.date_format_override || same_string(prefs.date_format, "")) {
-			free((void*)prefs.date_format);
+			free((void *)prefs.date_format);
 			prefs.date_format = strdup(qPrintable(dateFormat));
 		}
 		if (!prefs.date_format_override || same_string(prefs.date_format_short, "")) {
-			free((void*)prefs.date_format_short);
+			free((void *)prefs.date_format_short);
 			prefs.date_format_short = strdup(qPrintable(shortDateFormat));
 		}
 	}
@@ -549,7 +549,7 @@ QString uiLanguage(QLocale *callerLoc)
 		timeFormat = loc.timeFormat();
 		timeFormat.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
 		timeFormat.replace(".ss", "").replace(":ss", "").replace("ss", "");
-		free((void*)prefs.time_format);
+		free((void *)prefs.time_format);
 		prefs.time_format = strdup(qPrintable(timeFormat));
 	}
 	return uiLang;
@@ -1438,7 +1438,7 @@ int getCloudURL(QString &filename)
 	if (email.isEmpty() || same_string(prefs.cloud_storage_password, ""))
 		return report_error("Please configure Cloud storage email and password in the preferences");
 	if (email != prefs.cloud_storage_email_encoded) {
-		free(prefs.cloud_storage_email_encoded);
+		free((void *)prefs.cloud_storage_email_encoded);
 		prefs.cloud_storage_email_encoded = strdup(qPrintable(email));
 	}
 	filename = QString(QString(prefs.cloud_git_url) + "/%1[%1]").arg(email);

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -47,7 +47,7 @@ void DiveComputerSettings::setVendor(const QString& vendor)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("dive_computer_vendor", vendor);
-	free(prefs.dive_computer.vendor);
+	free((void *)prefs.dive_computer.vendor);
 	prefs.dive_computer.vendor = copy_string(qPrintable(vendor));
 }
 
@@ -59,7 +59,7 @@ void DiveComputerSettings::setProduct(const QString& product)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("dive_computer_product", product);
-	free(prefs.dive_computer.product);
+	free((void *)prefs.dive_computer.product);
 	prefs.dive_computer.product = copy_string(qPrintable(product));
 }
 
@@ -71,7 +71,7 @@ void DiveComputerSettings::setDevice(const QString& device)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("dive_computer_device", device);
-	free(prefs.dive_computer.device);
+	free((void *)prefs.dive_computer.device);
 	prefs.dive_computer.device = copy_string(qPrintable(device));
 }
 
@@ -83,7 +83,7 @@ void DiveComputerSettings::setDeviceName(const QString& device_name)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("dive_computer_device_name", device_name);
-	free(prefs.dive_computer.device_name);
+	free((void *)prefs.dive_computer.device_name);
 	prefs.dive_computer.device_name = copy_string(qPrintable(device_name));
 }
 
@@ -144,7 +144,7 @@ void UpdateManagerSettings::setLastVersionUsed(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("LastVersionUsed", value);
-	free (prefs.update_manager.last_version_used);
+	free((void *)prefs.update_manager.last_version_used);
 	prefs.update_manager.last_version_used = copy_string(qPrintable(value));
 	emit lastVersionUsedChanged(value);
 }
@@ -157,7 +157,7 @@ void UpdateManagerSettings::setNextCheck(const QDate& date)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("NextCheck", date);
-	free (prefs.update_manager.next_check);
+	free((void *)prefs.update_manager.next_check);
 	prefs.update_manager.next_check = copy_string(qPrintable(date.toString("dd/MM/yyyy")));
 	emit nextCheckChanged(date);
 }
@@ -748,7 +748,7 @@ void FacebookSettings::setAccessToken (const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("ConnectToken", value);
 #endif
-	free(prefs.facebook.access_token);
+	free((void *)prefs.facebook.access_token);
 	prefs.facebook.access_token = copy_string(qPrintable(value));
 	emit accessTokenChanged(value);
 }
@@ -763,7 +763,7 @@ void FacebookSettings::setUserId(const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("UserId", value);
 #endif
-	free(prefs.facebook.user_id);
+	free((void *)prefs.facebook.user_id);
 	prefs.facebook.user_id = copy_string(qPrintable(value));
 	emit userIdChanged(value);
 }
@@ -778,7 +778,7 @@ void FacebookSettings::setAlbumId(const QString& value)
 	s.beginGroup(subgroup);
 	s.setValue("AlbumId", value);
 #endif
-	free(prefs.facebook.album_id);
+	free((void *)prefs.facebook.album_id);
 	prefs.facebook.album_id = copy_string(qPrintable(value));
 	emit albumIdChanged(value);
 }
@@ -891,7 +891,7 @@ void ProxySettings::setHost(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("proxy_host", value);
-	free(prefs.proxy_host);
+	free((void *)prefs.proxy_host);
 	prefs.proxy_host = copy_string(qPrintable(value));
 	emit hostChanged(value);
 }
@@ -925,7 +925,7 @@ void ProxySettings::setUser(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("proxy_user", value);
-	free(prefs.proxy_user);
+	free((void *)prefs.proxy_user);
 	prefs.proxy_user = copy_string(qPrintable(value));
 	emit userChanged(value);
 }
@@ -937,7 +937,7 @@ void ProxySettings::setPass(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("proxy_pass", value);
-	free(prefs.proxy_pass);
+	free((void *)prefs.proxy_pass);
 	prefs.proxy_pass = copy_string(qPrintable(value));
 	emit passChanged(value);
 }
@@ -1010,7 +1010,7 @@ void CloudStorageSettings::setPassword(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("password", value);
-	free(prefs.cloud_storage_password);
+	free((void *)prefs.cloud_storage_password);
 	prefs.cloud_storage_password = copy_string(qPrintable(value));
 	emit passwordChanged(value);
 }
@@ -1020,7 +1020,7 @@ void CloudStorageSettings::setNewPassword(const QString& value)
 	if (value == prefs.cloud_storage_newpassword)
 		return;
 	/*TODO: This looks like wrong, but 'new password' is not saved on disk, why it's on prefs? */
-	free(prefs.cloud_storage_newpassword);
+	free((void *)prefs.cloud_storage_newpassword);
 	prefs.cloud_storage_newpassword = copy_string(qPrintable(value));
 	emit newPasswordChanged(value);
 }
@@ -1032,7 +1032,7 @@ void CloudStorageSettings::setEmail(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("email", value);
-	free(prefs.cloud_storage_email);
+	free((void *)prefs.cloud_storage_email);
 	prefs.cloud_storage_email = copy_string(qPrintable(value));
 	emit emailChanged(value);
 }
@@ -1044,7 +1044,7 @@ void CloudStorageSettings::setUserId(const QString& value)
 	//WARNING: UserId is stored outside of any group, but it belongs to Cloud Storage.
 	QSettings s;
 	s.setValue("subsurface_webservice_uid", value);
-	free(prefs.userid);
+	free((void *)prefs.userid);
 	prefs.userid = copy_string(qPrintable(value));
 	emit userIdChanged(value);
 }
@@ -1054,7 +1054,7 @@ void CloudStorageSettings::setEmailEncoded(const QString& value)
 	if (value == prefs.cloud_storage_email_encoded)
 		return;
 	/*TODO: This looks like wrong, but 'email encoded' is not saved on disk, why it's on prefs? */
-	free(prefs.cloud_storage_email_encoded);
+	free((void *)prefs.cloud_storage_email_encoded);
 	prefs.cloud_storage_email_encoded = copy_string(qPrintable(value));
 	emit emailEncodedChanged(value);
 }
@@ -1113,8 +1113,8 @@ void CloudStorageSettings::setBaseUrl(const QString& value)
 
 	// dont free data segment.
 	if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
-		free((void*)prefs.cloud_base_url);
-		free((void*)prefs.cloud_git_url);
+		free((void *)prefs.cloud_base_url);
+		free((void *)prefs.cloud_git_url);
 	}
 	QSettings s;
 	s.beginGroup(group);
@@ -1795,7 +1795,7 @@ void GeneralSettingsObjectWrapper::setDefaultFilename(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("default_filename", value);
-	free((void*)prefs.default_filename);
+	free((void *)prefs.default_filename);
 	prefs.default_filename = copy_string(qPrintable(value));
 	emit defaultFilenameChanged(value);
 }
@@ -1808,7 +1808,7 @@ void GeneralSettingsObjectWrapper::setDefaultCylinder(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("default_cylinder", value);
-	free((void*)prefs.default_cylinder);
+	free((void *)prefs.default_cylinder);
 	prefs.default_cylinder = copy_string(qPrintable(value));
 	emit defaultCylinderChanged(value);
 }
@@ -2012,7 +2012,7 @@ void  LanguageSettingsObjectWrapper::setLangLocale(const QString &value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("UiLangLocale", value);
-	free((void*)prefs.locale.lang_locale);
+	free((void *)prefs.locale.lang_locale);
 	prefs.locale.lang_locale = copy_string(qPrintable(value));
 	emit langLocaleChanged(value);
 }
@@ -2024,7 +2024,7 @@ void  LanguageSettingsObjectWrapper::setLanguage(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("UiLanguage", value);
-	free((void*)prefs.locale.language);
+	free((void *)prefs.locale.language);
 	prefs.locale.language = copy_string(qPrintable(value));
 	emit languageChanged(value);
 }
@@ -2036,7 +2036,7 @@ void  LanguageSettingsObjectWrapper::setTimeFormat(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("time_format", value);
-	free((void*)prefs.time_format);
+	free((void *)prefs.time_format);
 	prefs.time_format = copy_string(qPrintable(value));
 	emit timeFormatChanged(value);
 }
@@ -2049,7 +2049,7 @@ void  LanguageSettingsObjectWrapper::setDateFormat(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("date_format", value);
-	free((void*)prefs.date_format);
+	free((void *)prefs.date_format);
 	prefs.date_format = copy_string(qPrintable(value));
 	emit dateFormatChanged(value);
 }
@@ -2062,7 +2062,7 @@ void  LanguageSettingsObjectWrapper::setDateFormatShort(const QString& value)
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("date_format_short", value);
-	free((void*)prefs.date_format_short);
+	free((void *)prefs.date_format_short);
 	prefs.date_format_short = copy_string(qPrintable(value));
 	emit dateFormatShortChanged(value);
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -383,7 +383,7 @@ void QMLManager::saveCloudCredentials()
 	s.setValue("cloud_verification_status", credentialStatus());
 	s.sync();
 	if (!same_string(prefs.cloud_storage_email, qPrintable(cloudUser))) {
-		free(prefs.cloud_storage_email);
+		free((void *)prefs.cloud_storage_email);
 		prefs.cloud_storage_email = strdup(qPrintable(cloudUser));
 		cloudCredentialsChanged = true;
 	}
@@ -396,7 +396,7 @@ void QMLManager::saveCloudCredentials()
 	}
 
 	if (!same_string(prefs.cloud_storage_password, qPrintable(cloudPwd))) {
-		free(prefs.cloud_storage_password);
+		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = strdup(qPrintable(cloudPwd));
 	}
 	if (cloudUser.isEmpty() || cloudPwd.isEmpty()) {
@@ -404,7 +404,7 @@ void QMLManager::saveCloudCredentials()
 	} else if (cloudCredentialsChanged) {
 		// let's make sure there are no unsaved changes
 		saveChangesLocal();
-		free(prefs.userid);
+		free((void *)prefs.userid);
 		prefs.userid = NULL;
 		syncLoadFromCloud();
 		QString url;
@@ -550,7 +550,7 @@ void QMLManager::retrieveUserid()
 	}
 	if (!userid.isEmpty()) {
 		// overwrite the existing userid
-		free(prefs.userid);
+		free((void *)prefs.userid);
 		prefs.userid = strdup(qPrintable(userid));
 		QSettings s;
 		s.setValue("subsurface_webservice_uid", prefs.userid);
@@ -649,9 +649,9 @@ void QMLManager::revertToNoCloudIfNeeded()
 			appendTextToLog(QStringLiteral("taking things back offline since sync with cloud failed"));
 			prefs.git_local_only = syncToCloud();
 		}
-		free(prefs.cloud_storage_email);
+		free((void *)prefs.cloud_storage_email);
 		prefs.cloud_storage_email = NULL;
-		free(prefs.cloud_storage_password);
+		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = NULL;
 		setCloudUserName("");
 		setCloudPassword("");


### PR DESCRIPTION
Make all char * pointers in pref.h const to make it clear that these
strings are not mutable. This meant adding a number of (void *) casts
in calls to free(). Apart from being the right thing to do, this commit
makes the code more consistent, as many of the strings in pref.h were
already const.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This patch makes the strings in pref.h consistently const char *. It is the right thing to do and makes the code more consistent.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
