### PR TITLE
QML: newer QML imports and Kirigami SHA 

### DIFF
--- a/core/qt-gui.h
+++ b/core/qt-gui.h
@@ -11,7 +11,6 @@ void set_non_bt_addresses();
 
 #if defined(SUBSURFACE_MOBILE)
 #include <QQuickWindow>
-extern QObject *qqWindowObject;
 #endif
 
 #endif // QT_GUI_H

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.0
+import QtQuick 2.6
 import QtLocation 5.3
 import QtPositioning 5.3
 import org.subsurfacedivelog.mobile 1.0

--- a/map-widget/qml/MapWidgetContextMenu.qml
+++ b/map-widget/qml/MapWidgetContextMenu.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.0
+import QtQuick 2.6
 
 Item {
 	id: container

--- a/map-widget/qml/MapWidgetError.qml
+++ b/map-widget/qml/MapWidgetError.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.0
+import QtQuick 2.6
 
 Item {
 	Text {

--- a/mobile-widgets/qml/About.qml
+++ b/mobile-widgets/qml/About.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 

--- a/mobile-widgets/qml/About.qml
+++ b/mobile-widgets/qml/About.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Layouts 1.1
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0

--- a/mobile-widgets/qml/About.qml
+++ b/mobile-widgets/qml/About.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
 import QtQuick.Layouts 1.1
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.ScrollablePage {

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -3,7 +3,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 Item {

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2
 import org.subsurfacedivelog.mobile 1.0

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.4
+import QtQuick 2.6
 import QtQuick.Controls 2.0
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.Page {
 	id: diveDetailsPage // but this is referenced as detailsWindow

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -2,7 +2,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0 as Controls
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Item {
 	id: detailsEdit

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.0 as Controls
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import org.subsurfacedivelog.mobile 1.0

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -5,7 +5,7 @@ import QtWebView 1.0
 */
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -4,7 +4,7 @@ import QtQuick 2.6
 import QtWebView 1.0
 */
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.2 as Controls
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -7,7 +7,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0 as Controls
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Item {
 	id: detailsView

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 /*
 import QtWebView 1.0
 */

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0 as Controls
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.ScrollablePage {

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -5,7 +5,7 @@ import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.3
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.Page {
 	id: diveComputerDownloadWindow

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.3

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -4,7 +4,7 @@ import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.3
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.AbstractListItem {
 	id: innerListItem

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -3,7 +3,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -6,7 +6,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.ScrollablePage {
 	id: gpsListWindow

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1

--- a/mobile-widgets/qml/HintsTextEdit.qml
+++ b/mobile-widgets/qml/HintsTextEdit.qml
@@ -3,7 +3,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.0
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 TextField {
 	id: root

--- a/mobile-widgets/qml/HintsTextEdit.qml
+++ b/mobile-widgets/qml/HintsTextEdit.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.2
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.2
 import org.kde.kirigami 2.2 as Kirigami

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -6,7 +6,7 @@ import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
 import QtQuick.Controls 2.1
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.ScrollablePage {
 	id: logWindow

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -4,7 +4,7 @@ import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
-import QtQuick.Controls 2.1
+import QtQuick.Controls 2.2
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -2,7 +2,7 @@
 import QtQuick 2.6
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Controls 2.2
 import org.subsurfacedivelog.mobile 1.0

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -3,7 +3,7 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.ScrollablePage {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1

--- a/mobile-widgets/qml/SsrfButton.qml
+++ b/mobile-widgets/qml/SsrfButton.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.2
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/SsrfButton.qml
+++ b/mobile-widgets/qml/SsrfButton.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
 import QtQuick.Controls 2.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Button {
 	id: root

--- a/mobile-widgets/qml/SsrfCheckBox.qml
+++ b/mobile-widgets/qml/SsrfCheckBox.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
 import QtQuick.Controls 2.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 CheckBox {
 	id: root

--- a/mobile-widgets/qml/SsrfCheckBox.qml
+++ b/mobile-widgets/qml/SsrfCheckBox.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.2
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/SsrfSwitch.qml
+++ b/mobile-widgets/qml/SsrfSwitch.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.3
+import QtQuick 2.6
 import QtQuick.Controls 2.2
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/SsrfSwitch.qml
+++ b/mobile-widgets/qml/SsrfSwitch.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.3
 import QtQuick.Controls 2.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Switch {
 	id: root

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
 import QtQuick.Layouts 1.1
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -2,7 +2,7 @@
 import QtQuick 2.5
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0 as Controls
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.5
+import QtQuick 2.6
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0 as Controls
 import org.kde.kirigami 2.2 as Kirigami

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.2 as Controls
 import org.kde.kirigami 2.2 as Kirigami
 import org.subsurfacedivelog.mobile 1.0

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -3,7 +3,7 @@ import QtQuick 2.5
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.Page {
 

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import org.kde.kirigami 2.2 as Kirigami

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.5
+import QtQuick 2.6
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0 as Controls
 import QtQuick.Window 2.2

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
 import QtQuick.Layouts 1.1
-import QtQuick.Controls 2.0 as Controls
+import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import org.kde.kirigami 2.2 as Kirigami
 

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.1
+import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.0 as Kirigami

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.4
+import QtQuick 2.6
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.1
 import QtQuick.Window 2.2

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -33,7 +33,7 @@ if [ "$NOPULL" = "" ] ; then
 	git checkout master
 	git pull origin master
 	# if we want to pin a specific Kirigami version, we can do this here
-	git checkout 162b877ad4b03d4843e21e7e4674f5b74c7688fe
+	git checkout 2f5b6fc2a2fa9fb6578a6a709d2d7c51582f2e29
 	popd
 fi
 if [ ! -d breeze-icons ] ; then

--- a/subsurface-desktop-helper.cpp
+++ b/subsurface-desktop-helper.cpp
@@ -22,7 +22,6 @@
 #include "mobile-widgets/qmlmanager.h"
 #include "qt-models/divelistmodel.h"
 #include "mobile-widgets/qmlprofile.h"
-QObject *qqWindowObject = NULL;
 #endif
 
 static MainWindow *window = NULL;


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Mainly upgrading of QML imported versions. Notice the not-upgrading to Kirigami 2.2 for our main.qml.  With version 2.2, there is a new way of theming, that is not (yet) compatible with our current code., Further notice that the new Kirigami SHA in not the current master. Also here, something breaks our main.qml that needs further investigation. 

### Changes made:
See individual commits. 

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
As there is very limited work on the mobile version at this time, I leave this PR open for comment for some days, and then will merge it, assuming no one comes with blocking issues related to this. 

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
