### PR TITLE
[TEST] mainwindow.cpp: experiment with not calling setWindowState()

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -338,7 +338,6 @@ MainWindow::MainWindow() : QMainWindow(),
 #ifndef FULLSCREEN_SUPPORT
 	ui.actionFullScreen->setEnabled(false);
 	ui.actionFullScreen->setVisible(false);
-	setWindowState(windowState() & ~Qt::WindowFullScreen);
 #endif
 }
 


### PR DESCRIPTION
#### DO NOT MERGE
**using the CI to create a test installer**

A user is experiencing a weird missing menu bar on Win32 with
4k resolution. Accodring to him the bug started with version
4.7.1. This is when the fullscreen change in 3f7900bf4e
was added.

This commit partially reverts the patch by not calling
setWindowState().

#776

