### PR TITLE
UI: Default cylinder from preferences can be self defined

### DIFF
--- a/ReleaseNotes/ReleaseNotes.txt
+++ b/ReleaseNotes/ReleaseNotes.txt
@@ -11,6 +11,9 @@ Some of the changes since _Subsurface_ 4.7.4
 - Fix issues related to debug logging on Windows
 - Add "Bluetooth mode" in the BT selection dialog: Auto, LE, Classical
 - Correct display of cylinder pressures for merged dives
+- Allow user defined cylinders as default in preferences (#821)
+- mobile: fix black/white switch in splash screen (#531)
+- UI: tag editing. Comma entry shows all tags (again) (#605)
 
 
 Some of the changes since _Subsurface_ 4.7.2

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -774,6 +774,11 @@ void MainWindow::showProfile()
 
 void MainWindow::on_actionPreferences_triggered()
 {
+	// the refreshPages() is currently done for just one
+	// reason. Allow the user to define a default cylinder that
+	// is not hardcoded but coming from the logbook.
+	PreferencesDialog::instance()->refreshPages();
+
 	PreferencesDialog::instance()->show();
 	PreferencesDialog::instance()->raise();
 }


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Currently, it was only possible to use a hard-coded default cylinder in the preferences. At the same time, the user is allowed to add own cylinders to a dive (by just typing in a new name and cylinder properties). These own cylinders could not be selected in the preferences, requiring the user to manually add this every dive.

Not sure the reason for all this was intentional, or just an overlooked aspect in the implementation. It appeared
that the selection list in the UI was constructed before any logbook was parsed, so at that moment, there are only hard-coded cylinders.

The fix is simple. Refresh the UI of the preferences just before it is shown. While opening the logbook, a new
list of cylinders, including the own cylinders is constructed, so the UI is refreshed to that.

### Changes made:
See commit. 

### Related issues:
Fixes: #821

### Additional information:
While a simple change, there is a use case that might be considered strange. Open a logbook, choose new logbook, and change the default cylinder preference to an own (from the previously opened logbook). Do **not** add a dive with the new (own) cylinder and save this logbook. Reopen this new logbook, and see that the default cylinder in the preferences is empty. This is logical, as the list of own possible cylinders is constructed from the (new) logbook, that has no dive with that specific own cylinder. I consider this acceptable behavior, as it can be also be used to copy own cylinders to a new logbook.

### Release note:
yes, added commit for that.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
