### PR TITLE
Mobile: location autocomplete

### DIFF
--- a/ReleaseNotes/ReleaseNotes.txt
+++ b/ReleaseNotes/ReleaseNotes.txt
@@ -14,6 +14,7 @@ Some of the changes since _Subsurface_ 4.7.4
 - Allow user defined cylinders as default in preferences (#821)
 - mobile: fix black/white switch in splash screen (#531)
 - UI: tag editing. Comma entry shows all tags (again) (#605)
+- mobile: enable auto completion for dive site entry (#546)
 
 
 Some of the changes since _Subsurface_ 4.7.2

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -426,6 +426,23 @@ QStringList DiveObjectHelper::suitList() const
 	return suits;
 }
 
+QStringList DiveObjectHelper::locationList() const
+{
+	QStringList locations;
+	struct dive *d;
+	struct dive_site *ds;
+	int i = 0;
+	for_each_dive (i, d) {
+		ds = get_dive_site_by_uuid(d->dive_site_uuid);
+		QString temp = ds->name;
+		if (!temp.isEmpty())
+			locations << temp;
+	}
+	locations.removeDuplicates();
+	locations.sort();
+	return locations;
+}
+
 QStringList DiveObjectHelper::buddyList() const
 {
 	QStringList buddies;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -50,6 +50,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList suitList READ suitList CONSTANT)
 	Q_PROPERTY(QStringList buddyList READ buddyList CONSTANT)
 	Q_PROPERTY(QStringList divemasterList READ divemasterList CONSTANT)
+	Q_PROPERTY(QStringList locationList READ locationList CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
 	~DiveObjectHelper();
@@ -93,6 +94,7 @@ public:
 	QString endPressure() const;
 	QString firstGas() const;
 	QStringList suitList() const;
+	QStringList locationList() const;
 	QStringList buddyList() const;
 	QStringList divemasterList() const;
 

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -24,6 +24,7 @@ Kirigami.Page {
 	property alias depth: detailsEdit.depthText
 	property alias duration: detailsEdit.durationText
 	property alias location: detailsEdit.locationText
+	property alias locationModel: detailsEdit.locationModel
 	property alias gps: detailsEdit.gpsText
 	property alias notes: detailsEdit.notesText
 	property alias suitIndex: detailsEdit.suitIndex

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -35,6 +35,7 @@ Item {
 	property alias divemasterModel: divemasterBox.model
 	property alias buddyModel: buddyBox.model
 	property alias cylinderModel: cylinderBox.model
+	property alias locationModel: txtLocation.model
 	property int rating
 	property int visibility
 
@@ -105,12 +106,12 @@ Item {
 				text: qsTr("Location:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			Controls.TextField {
-				id: txtLocation;
+			HintsTextEdit {
+				id: txtLocation
+				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+					diveDetailsListView.currentItem.modelData.dive.locationList : null
+				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
-				onEditingFinished: {
-					focus = false
-				}
 			}
 
 			Controls.Label {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -112,6 +112,9 @@ Item {
 					diveDetailsListView.currentItem.modelData.dive.locationList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
+				onEditingFinished: {
+					gpsText = manager.getGpsFromSiteName(text)
+				}
 			}
 
 			Controls.Label {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1536,6 +1536,18 @@ QString QMLManager::getVersion() const
 	return versionRe.cap(1);
 }
 
+QString QMLManager::getGpsFromSiteName(const QString& siteName)
+{	uint32_t uuid;
+	struct dive_site *ds;
+
+	uuid = get_dive_site_uuid_by_name(qPrintable(siteName), NULL);
+	if (uuid) {
+		ds = get_dive_site_by_uuid(uuid);
+		return QString(printGPSCoords(ds->latitude.udeg, ds->longitude.udeg));
+	}
+	return "";
+}
+
 QString QMLManager::notificationText() const
 {
 	return m_notificationText;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -184,6 +184,7 @@ public slots:
 	QString getNumber(const QString& diveId);
 	QString getDate(const QString& diveId);
 	QString getCurrentPosition();
+	QString getGpsFromSiteName(const QString& siteName);
 	QString getVersion() const;
 	void deleteGpsFix(quint64 when);
 	void revertToNoCloudIfNeeded();


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Add the capability to select the location name from a list, constructed from the known dive sites in the logbook. As now the location is possibly known, we need to populate the GPS coordinate of the entered dive location as well. When the user enters a new site name (ie. currently unknown), the GPS coordinate stays empty.

### Changes made:
See individual commits

### Related issues:
Fixes: #546

### Additional information:
While relatively simple, please review and test. I will be afk the coming days and after that 2 weeks with limited internet presence. But this is very nice functionality to test on a dive trip :-)

### Release note:
Yes, will push a line for the Release notes.