### PR TITLE
Fix obscure display bug in profile widget, where heat map wasn't shown

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -839,7 +839,7 @@ void ProfileWidget2::settingsChanged()
 			percentageAxis->animateChangeLine(itemPos.percentageWithTankBar.expanded);
 			heartBeatAxis->setPos(itemPos.heartBeatWithTankBar.pos.on);
 			heartBeatAxis->animateChangeLine(itemPos.heartBeatWithTankBar.expanded);
-		}else {
+		} else {
 			percentageAxis->setPos(itemPos.percentage.pos.on);
 			percentageAxis->animateChangeLine(itemPos.percentage.expanded);
 			heartBeatAxis->setPos(itemPos.heartBeat.pos.on);
@@ -847,7 +847,6 @@ void ProfileWidget2::settingsChanged()
 		}
 		gasYAxis->setPos(itemPos.partialPressureTissue.pos.on);
 		gasYAxis->animateChangeLine(itemPos.partialPressureTissue.expanded);
-
 	} else if (PP_GRAPHS_ENABLED || prefs.hrgraph || prefs.percentagegraph) {
 		profileYAxis->animateChangeLine(itemPos.depth.intermediate);
 		temperatureAxis->setPos(itemPos.temperature.pos.on);
@@ -857,14 +856,14 @@ void ProfileWidget2::settingsChanged()
 			percentageAxis->setPos(itemPos.percentageWithTankBar.pos.on);
 			percentageAxis->animateChangeLine(itemPos.percentageWithTankBar.expanded);
 			gasYAxis->setPos(itemPos.partialPressureWithTankBar.pos.on);
-			gasYAxis->setLine(itemPos.partialPressureWithTankBar.expanded);
+			gasYAxis->animateChangeLine(itemPos.partialPressureWithTankBar.expanded);
 			heartBeatAxis->setPos(itemPos.heartBeatWithTankBar.pos.on);
 			heartBeatAxis->animateChangeLine(itemPos.heartBeatWithTankBar.expanded);
 		} else {
 			gasYAxis->setPos(itemPos.partialPressure.pos.on);
 			gasYAxis->animateChangeLine(itemPos.partialPressure.expanded);
 			percentageAxis->setPos(itemPos.percentage.pos.on);
-			percentageAxis->setLine(itemPos.percentage.expanded);
+			percentageAxis->animateChangeLine(itemPos.percentage.expanded);
 			heartBeatAxis->setPos(itemPos.heartBeat.pos.on);
 			heartBeatAxis->animateChangeLine(itemPos.heartBeat.expanded);
 		}


### PR DESCRIPTION
Fixes an obscure bug, which happened under very specific circumstances.
Precodition: fresh program start and neither of the partial pressure
graphs, nor the heat maps are shown. User clicks on heat map icon.
Bug: The heat map is not shown at the bottom of the graph.

The fix consists in replacing two percentageAxis->setLine() calls
by precentageAxis->animateChangeLine() calls.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a rather obscure display bug, where under very specific circumstances the heat map wasn't shown. The fix consisted in replacing calls to setLine() by calls to animateChangeLine(). Note that I haven't even the *slightest* idea what these functions do. All I know is that this fixed the problem.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
