### PR TITLE
Fix ownership issues in preferences code

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -189,6 +189,7 @@ extern const char *system_default_directory(void);
 extern const char *system_default_filename();
 extern bool subsurface_ignore_font(const char *font);
 extern void subsurface_OS_pref_setup();
+extern void copy_prefs(struct preferences *src, struct preferences *dest);
 
 #ifdef __cplusplus
 }

--- a/core/prefs-macros.h
+++ b/core/prefs-macros.h
@@ -18,10 +18,10 @@
 	else                                                        \
 		prefs.units.field = default_prefs.units.field
 
-#define GET_UNIT_BOOL(name, field)                           \
+#define GET_UNIT_BOOL(name, field)                      \
 	v = s.value(QString(name));                     \
 	if (v.isValid())                                \
-		prefs.units.field = v.toBool();               \
+		prefs.units.field = v.toBool();         \
 	else                                            \
 		prefs.units.field = default_prefs.units.field
 
@@ -53,10 +53,10 @@
 	else                                        \
 		prefs.field = default_prefs.field
 
-#define GET_INT_DEF(name, field, defval)                                             \
+#define GET_INT_DEF(name, field, defval)                                 \
 	v = s.value(QString(name));                                      \
 	if (v.isValid())                                                 \
-		prefs.field = v.toInt(); \
+		prefs.field = v.toInt();                                 \
 	else                                                             \
 		prefs.field = defval
 
@@ -65,7 +65,7 @@
 	if (v.isValid())                                                 \
 		prefs.field = strdup(v.toString().toUtf8().constData()); \
 	else                                                             \
-		prefs.field = default_prefs.field
+		prefs.field = copy_string(default_prefs.field)
 
 #define SAVE_OR_REMOVE_SPECIAL(_setting, _default, _compare, _value)     \
 	if (_compare != _default)                                        \

--- a/core/subsurfacestartup.h
+++ b/core/subsurfacestartup.h
@@ -17,7 +17,6 @@ extern bool imported;
 void setup_system_prefs(void);
 void parse_argument(const char *arg);
 void free_prefs(void);
-void copy_prefs(struct preferences *src, struct preferences *dest);
 void print_files(void);
 void print_version(void);
 

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -109,7 +109,7 @@ void PreferencesDialog::refreshPages()
 		curr->setParent(0);
 	}
 
-	// Readd things.
+	// Read things
 	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
 		QListWidgetItem *item = new QListWidgetItem(page->icon(), page->name());
 		pagesList->addItem(item);
@@ -139,7 +139,7 @@ void PreferencesDialog::cancelRequested()
 
 void PreferencesDialog::defaultsRequested()
 {
-	prefs = default_prefs;
+	copy_prefs(&default_prefs, &prefs);
 	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
 		page->refreshSettings();
 	}

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 	setup_system_prefs();
 	if (uiLanguage(0).contains("-US"))
 		default_prefs.units = IMPERIAL_units;
-	prefs = default_prefs;
+	copy_prefs(&default_prefs, &prefs);
 	fill_profile_color();
 	fill_computer_list();
 


### PR DESCRIPTION
Each preferences object owns its string members. In three cases, pointers
were copied instead of strings, leading to (in the best case) dangling
pointers if the user edited values:
1) In the GET_TXT macro in core/prefs-macros.h
2) In the PreferencesDialog::defaultsRequested() method
3) In main() of the mobile version

This patch fixes these issues, by using copy_string() or copy_prefs()
as appropriate.

The only reason that the old code didn't crash regularly is that the
default_prefs object was only used at startup and defaultsRequested()
is (at the moment?) dead code.

This patch also aligns the backslashes in core/pref.h and fixes a typo.
The declaration of copy_prefs() is moved to the core/prefs.h header.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This fixes ownership issues, where the default_prefs object was left with dangling pointers if the user changed values. This was not a disaster at the moment, because the only code that uses the default_prefs object post-startup is dead code. But in the future, one might want to enable the reset-to-default functionality, which makes this clean-up necessary. Better do it right now.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace `prefs = default_prefs` by `copy_prefs(&default_prefs, &prefs)`
2) Copy string in GET_TXT macro
3) Align backslashes in core/prefs.h
4) Fix a typo
5) Move declaration of copy_prefs to core/prefs.h header

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
