### PR TITLE
Planner UI improvements: Enable/disable options

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -256,6 +256,9 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(true);
 		ui.backgasBreaks->setDisabled(true);
+		ui.backgasBreaks->blockSignals(true);
+		ui.backgasBreaks->setChecked(false);
+		ui.backgasBreaks->blockSignals(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(true);
 		ui.safetystop->setDisabled(false);
@@ -265,6 +268,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(true);
 		ui.min_switch_duration->setDisabled(true);
+		ui.label_min_switch_duration->setDisabled(true);
 		ui.sacfactor->setDisabled(true);
 		ui.problemsolvingtime->setDisabled(true);
 		ui.sacfactor->blockSignals(true);
@@ -280,7 +284,17 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.gflow->setDisabled(true);
 		ui.gfhigh->setDisabled(true);
 		ui.lastStop->setDisabled(false);
-		ui.backgasBreaks->setDisabled(false);
+		if (prefs.last_stop) {
+			ui.backgasBreaks->setDisabled(false);
+			ui.backgasBreaks->blockSignals(true);
+			ui.backgasBreaks->setChecked(prefs.doo2breaks);
+			ui.backgasBreaks->blockSignals(false);
+		} else {
+			ui.backgasBreaks->setDisabled(true);
+			ui.backgasBreaks->blockSignals(true);
+			ui.backgasBreaks->setChecked(false);
+			ui.backgasBreaks->blockSignals(false);
+		}
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -290,6 +304,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(false);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);
+		ui.label_min_switch_duration->setDisabled(false);
 		ui.sacfactor->setDisabled(false);
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
@@ -301,7 +316,17 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.gflow->setDisabled(false);
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(false);
-		ui.backgasBreaks->setDisabled(false);
+		if (prefs.last_stop) {
+			ui.backgasBreaks->setDisabled(false);
+			ui.backgasBreaks->blockSignals(true);
+			ui.backgasBreaks->setChecked(prefs.doo2breaks);
+			ui.backgasBreaks->blockSignals(false);
+		} else {
+			ui.backgasBreaks->setDisabled(true);
+			ui.backgasBreaks->blockSignals(true);
+			ui.backgasBreaks->setChecked(false);
+			ui.backgasBreaks->blockSignals(false);
+		}
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -311,6 +336,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.vpmb_conservatism->setDisabled(true);
 		ui.switch_at_req_stop->setDisabled(false);
 		ui.min_switch_duration->setDisabled(false);
+		ui.label_min_switch_duration->setDisabled(false);
 		ui.sacfactor->setDisabled(false);
 		ui.problemsolvingtime->setDisabled(false);
 		ui.sacfactor->setValue(prefs.sacfactor / 100.0);
@@ -320,6 +346,9 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 
 void PlannerSettingsWidget::disableBackgasBreaks(bool enabled)
 {
+	if (prefs.planner_deco_mode == RECREATIONAL)
+		return;
+
 	if (enabled) {
 		ui.backgasBreaks->setDisabled(false);
 		ui.backgasBreaks->blockSignals(true);
@@ -366,7 +395,6 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.buehlmann_deco->setChecked(prefs.planner_deco_mode == BUEHLMANN);
 	ui.vpmb_deco->setChecked(prefs.planner_deco_mode == VPMB);
 	disableDecoElements((int) prefs.planner_deco_mode);
-	disableBackgasBreaks(prefs.last_stop);
 
 	// should be the same order as in dive_comp_type!
 	rebreather_modes << tr("Open circuit") << tr("CCR") << tr("pSCR");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Don't accidentally enable o2breaks option when entering planner in
RECREATIONAL mode.
Disable also label for min_switch_duration according to dive mode.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
