### PR TITLE
Fix filter bug described in #675

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -445,7 +445,7 @@ MainWindow *MainWindow::instance()
 	return m_Instance;
 }
 
-// this gets called after we download dives from a divecomputer
+// This gets called after one or more dives were added, edited or downloaded for a dive computer
 void MainWindow::refreshDisplay(bool doRecreateDiveList)
 {
 	information()->reload();
@@ -469,6 +469,7 @@ void MainWindow::recreateDiveList()
 	BuddyFilterModel::instance()->repopulate();
 	LocationFilterModel::instance()->repopulate();
 	SuitsFilterModel::instance()->repopulate();
+	MultiFilterSortModel::instance()->myInvalidate();
 }
 
 void MainWindow::configureToolbar() {

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -277,15 +277,12 @@ bool LocationFilterModel::doFilter(struct dive *d, QModelIndex &index0, QAbstrac
 			return true;
 	}
 
-	// there is a location selected
+	// There is a location selected
 	QStringList locationList = stringList();
-	if (!locationList.isEmpty()) {
-		locationList.removeLast(); // remove the "Show Empty Tags";
-		for (int i = 0; i < rowCount(); i++) {
-			if (checkState[i] && (location.indexOf(stringList()[i]) != -1)) {
-				return true;
-			}
-		}
+	// Ignore last item, since this is the "Show Empty Tags" entry
+	for (int i = 0; i < rowCount() - 1; i++) {
+		if (checkState[i] && location == locationList[i])
+			return true;
 	}
 	return false;
 }

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #include <QDebug>
+#include <algorithm>
 
 #define CREATE_INSTANCE_METHOD( CLASS ) \
 CLASS *CLASS::instance() \
@@ -39,8 +40,7 @@ bool CLASS::setData(const QModelIndex &index, const QVariant &value, int role) \
 #define CREATE_CLEAR_FILTER_METHOD( CLASS ) \
 void CLASS::clearFilter() \
 { \
-	memset(checkState, false, rowCount()); \
-	checkState[rowCount() - 1] = false; \
+	std::fill(checkState.begin(), checkState.end(), false); \
 	anyChecked = false; \
 	emit dataChanged(createIndex(0,0), createIndex(rowCount()-1, 0)); \
 }
@@ -128,10 +128,8 @@ void SuitsFilterModel::repopulate()
 	qSort(list);
 	list << tr("No suit set");
 	setStringList(list);
-	delete[] checkState;
-	checkState = new bool[list.count()];
-	memset(checkState, false, list.count());
-	checkState[list.count() - 1] = false;
+	checkState.resize(list.count());
+	std::fill(checkState.begin(), checkState.end(), false);
 	anyChecked = false;
 }
 
@@ -153,10 +151,8 @@ void TagFilterModel::repopulate()
 	qSort(list);
 	list << tr("Empty tags");
 	setStringList(list);
-	delete[] checkState;
-	checkState = new bool[list.count()];
-	memset(checkState, false, list.count());
-	checkState[list.count() - 1] = false;
+	checkState.resize(list.count());
+	std::fill(checkState.begin(), checkState.end(), false);
 	anyChecked = false;
 }
 
@@ -248,10 +244,8 @@ void BuddyFilterModel::repopulate()
 	qSort(list);
 	list << tr("No buddies");
 	setStringList(list);
-	delete[] checkState;
-	checkState = new bool[list.count()];
-	memset(checkState, false, list.count());
-	checkState[list.count() - 1] = false;
+	checkState.resize(list.count());
+	std::fill(checkState.begin(), checkState.end(), false);
 	anyChecked = false;
 }
 
@@ -301,10 +295,8 @@ void LocationFilterModel::repopulate()
 	qSort(list);
 	list << tr("No location set");
 	setStringList(list);
-	delete[] checkState;
-	checkState = new bool[list.count()];
-	memset(checkState, false, list.count());
-	checkState[list.count() - 1] = false;
+	checkState.resize(list.count());
+	std::fill(checkState.begin(), checkState.end(), false);
 	anyChecked = false;
 }
 

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -16,7 +16,13 @@ public:
 	bool anyChecked;
 };
 
-class TagFilterModel : public QStringListModel, public MultiFilterInterface {
+class FilterModelBase : public QStringListModel, public MultiFilterInterface {
+protected:
+	explicit FilterModelBase(QObject *parent = 0);
+	void updateList(const QStringList &new_list);
+};
+
+class TagFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static TagFilterModel *instance();
@@ -33,7 +39,7 @@ private:
 	explicit TagFilterModel(QObject *parent = 0);
 };
 
-class BuddyFilterModel : public QStringListModel, public MultiFilterInterface {
+class BuddyFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static BuddyFilterModel *instance();
@@ -50,7 +56,7 @@ private:
 	explicit BuddyFilterModel(QObject *parent = 0);
 };
 
-class LocationFilterModel : public QStringListModel, public MultiFilterInterface {
+class LocationFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static LocationFilterModel *instance();
@@ -67,7 +73,7 @@ private:
 	explicit LocationFilterModel(QObject *parent = 0);
 };
 
-class SuitsFilterModel : public QStringListModel, public MultiFilterInterface {
+class SuitsFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static SuitsFilterModel *instance();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -5,13 +5,14 @@
 #include <QStringListModel>
 #include <QSortFilterProxyModel>
 #include <stdint.h>
+#include <vector>
 
 class MultiFilterInterface {
 public:
-	MultiFilterInterface() : checkState(NULL), anyChecked(false) {}
+	MultiFilterInterface() : anyChecked(false) {}
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
 	virtual void clearFilter() = 0;
-	bool *checkState;
+	std::vector<char> checkState;
 	bool anyChecked;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is my attempt at solving the filter bug described in #675. There actually were at least two problems. Firstly, the LocationFilter used substring instead of equality comparison, leading to additional dives being shown. Secondly, the filter widget was not updated after updating the dive list, thus showing a wrong number of listed dives.

Fixing the second problem was more complex than fixing the first: Repopulating the filter lists erased the user selections, thus all dives were shown again. Thus, the old selections are now transferred.

The second of the three commits replaces a C-style bool array by std::vector<char> to clean up the code and make it more portable/readable. This series could also be done with keeping old-style arrays, but since there was already lots of QMap<> and QVector<> usage, I thought it would be fine.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use equality instead of substring comparison in LocationFilter.
2) Replace bool * by std::vector<char> to clean up/simplify/fix code.
3) Update filters in refresh display.
4) Remember old filter selection when repopulating lists. Introduce a new base class for all FilterModels, which contains the necessary code.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Hopefully fixes #675. There are still problems with the buddy filter, but these seem to be unrelated.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
