### PR TITLE
Use equality instead of substring comparison in suits and buddy filter

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -136,13 +136,10 @@ bool SuitsFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 
 	// there is a suit selected
 	QStringList suitList = stringList();
-	if (!suitList.isEmpty()) {
-		suitList.removeLast(); // remove the "Show Empty Suits";
-		for (int i = 0; i < rowCount(); i++) {
-			if (checkState[i] && (suit.indexOf(stringList()[i]) != -1)) {
-				return true;
-			}
-		}
+	// Ignore last item, since this is the "Show Empty Tags" entry
+	for (int i = 0; i < rowCount() - 1; i++) {
+		if (checkState[i] && suit == suitList[i])
+			return true;
 	}
 	return false;
 }
@@ -243,13 +240,10 @@ bool BuddyFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 
 	// have at least one buddy
 	QStringList buddyList = stringList();
-	if (!buddyList.isEmpty()) {
-		buddyList.removeLast(); // remove the "Show Empty Tags";
-		for (int i = 0; i < rowCount(); i++) {
-			if (checkState[i] && (diveBuddy.indexOf(stringList()[i]) != -1 || divemaster.indexOf(stringList()[i]) != -1)) {
-				return true;
-			}
-		}
+	// Ignore last item, since this is the "Show Empty Tags" entry
+	for (int i = 0; i < rowCount() - 1; i++) {
+		if (checkState[i] && (diveBuddy == buddyList[i] || divemaster == buddyList[i]))
+			return true;
 	}
 	return false;
 }


### PR DESCRIPTION
This commit is a continuation of commit 739b27427cfb5119eebe214c984843cd5d155620,
in which a substring comparison was replaced by equality comparison to
avoid confusing UI behavior of the filter interface.

The suit and buddy filters were plagued by the same problem, so change
their code in analogy.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In #857 I missed the fact that the buddy and suit filters suffer from the same problem. :( But now it should be fine - the remaining filter (tag) does not do substring comparison.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace substring by equality comparison when filtering suits and buddies.
2) Avoid deep copy of the respective stringLists, by looping over all elements except the last.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
