### PR TITLE
map-widget: interaction improvements

### DIFF
--- a/ReleaseNotes/ReleaseNotes.txt
+++ b/ReleaseNotes/ReleaseNotes.txt
@@ -20,6 +20,10 @@ Some of the changes since _Subsurface_ 4.7.4
   of the previous templates would be created (#847)
 - Fix issues with filters not updating after changes to the dive list
   (#551, #675)
+- map-widget: allow updating coordinates on the map when the user
+  is editing a dive site by pressing Enter or clicking a "flag" button
+- map-widget: prevent glitches when the user is interacting with the map
+  while animations are in progress
 
 
 Some of the changes since _Subsurface_ 4.7.2

--- a/desktop-widgets/locationInformation.ui
+++ b/desktop-widgets/locationInformation.ui
@@ -54,20 +54,20 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2" rowspan="2" colspan="2">
+   <item row="7" column="2" rowspan="2" colspan="3">
     <widget class="QPlainTextEdit" name="diveSiteNotes">
      <property name="focusPolicy">
       <enum>Qt::ClickFocus</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" colspan="2">
+   <item row="1" column="2" colspan="3">
     <widget class="QLineEdit" name="diveSiteName"/>
    </item>
-   <item row="5" column="2" colspan="2">
+   <item row="5" column="2" colspan="3">
     <widget class="QLineEdit" name="diveSiteDescription"/>
    </item>
-   <item row="3" column="3">
+   <item row="3" column="4">
     <widget class="QToolButton" name="geoCodeButton">
      <property name="toolTip">
       <string>Reverse geo lookup</string>
@@ -81,7 +81,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="4">
+   <item row="0" column="0" colspan="5">
     <widget class="KMessageWidget" name="diveSiteMessage">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -91,7 +91,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="4">
+   <item row="9" column="0" colspan="5">
     <widget class="QGroupBox" name="diveSiteGroupBox">
      <property name="title">
       <string>Dive sites on same coordinates</string>
@@ -139,7 +139,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2" colspan="2">
+   <item row="4" column="2" colspan="3">
     <widget class="QLabel" name="locationTags">
      <property name="text">
       <string/>
@@ -153,8 +153,22 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2" colspan="2">
+   <item row="2" column="2" colspan="3">
     <widget class="QLineEdit" name="diveSiteCountry"/>
+   </item>
+   <item row="3" column="3">
+    <widget class="QToolButton" name="updateLocationButton">
+     <property name="toolTip">
+      <string>Update location on map</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../subsurface.qrc">
+       <normaloff>:/mapwidget-marker-selected</normaloff>:/mapwidget-marker-selected</iconset>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -170,6 +184,7 @@
   <tabstop>diveSiteName</tabstop>
   <tabstop>diveSiteCountry</tabstop>
   <tabstop>diveSiteCoordinates</tabstop>
+  <tabstop>updateLocationButton</tabstop>
   <tabstop>geoCodeButton</tabstop>
   <tabstop>diveSiteDescription</tabstop>
   <tabstop>diveSiteNotes</tabstop>

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -15,6 +15,7 @@ public:
 
 protected:
 	void showEvent(QShowEvent *);
+	void enableLocationButtons(bool enable);
 
 public slots:
 	void acceptChanges();
@@ -33,6 +34,7 @@ public slots:
 	void mergeSelectedDiveSites();
 private slots:
 	void updateLabels();
+	void updateLocationOnMap();
 signals:
 	void startEditDiveSite(uint32_t uuid);
 	void endEditDiveSite();

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -151,73 +151,73 @@ Item {
 			stopZoomAnimations()
 			if (!coordIsValid(coord)) {
 				console.warn("MapWidget.qml: centerOnCoordinate(): !coordIsValid()")
-			} else {
-				var newZoomOutFound = false
-				var zoomStored = zoomLevel
-				var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
-				newZoomOut = zoomLevel
-				newCenter = coord
-				zoomLevel = Math.floor(zoomLevel)
-				while (zoomLevel > minimumZoomLevel) {
-					var pt = fromCoordinate(coord)
-					if (pointIsVisible(pt)) {
-						newZoomOut = zoomLevel
-						newZoomOutFound = true
-						break
-					}
-					zoomLevel -= 1.0
-				}
-				if (!newZoomOutFound)
-					newZoomOut = defaultZoomOut
-				zoomLevel = zoomStored
-				center = centerStored
-				newZoom = zoomStored
-				mapAnimationZoomIn.restart()
+				return
 			}
+			var newZoomOutFound = false
+			var zoomStored = zoomLevel
+			var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
+			newZoomOut = zoomLevel
+			newCenter = coord
+			zoomLevel = Math.floor(zoomLevel)
+			while (zoomLevel > minimumZoomLevel) {
+				var pt = fromCoordinate(coord)
+				if (pointIsVisible(pt)) {
+					newZoomOut = zoomLevel
+					newZoomOutFound = true
+					break
+				}
+				zoomLevel -= 1.0
+			}
+			if (!newZoomOutFound)
+				newZoomOut = defaultZoomOut
+			zoomLevel = zoomStored
+			center = centerStored
+			newZoom = zoomStored
+			mapAnimationZoomIn.restart()
 		}
 
 		function centerOnRectangle(topLeft, bottomRight, centerRect) {
 			stopZoomAnimations()
 			if (newCenter.latitude === 0.0 && newCenter.longitude === 0.0) {
 				// Do nothing
-			} else {
-				var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
-				var zoomStored = zoomLevel
-				var newZoomOutFound = false
-				newCenter = centerRect
-				// calculate zoom out
-				newZoomOut = zoomLevel
-				while (zoomLevel > minimumZoomLevel) {
-					var ptCenter = fromCoordinate(centerStored)
-					var ptCenterRect = fromCoordinate(centerRect)
-					if (pointIsVisible(ptCenter) && pointIsVisible(ptCenterRect)) {
-						newZoomOut = zoomLevel
-						newZoomOutFound = true
-						break
-					}
-					zoomLevel -= 1.0
-				}
-				if (!newZoomOutFound)
-					newZoomOut = defaultZoomOut
-				// calculate zoom in
-				center = newCenter
-				zoomLevel = Math.floor(maximumZoomLevel)
-				var diagonalRect = topLeft.distanceTo(bottomRight)
-				while (zoomLevel > minimumZoomLevel) {
-					var c0 = toCoordinate(Qt.point(0.0, 0.0))
-					var c1 = toCoordinate(Qt.point(width, height))
-					if (c0.distanceTo(c1) > diagonalRect) {
-						newZoom = zoomLevel - 2.0
-						break
-					}
-					zoomLevel -= 1.0
-				}
-				if (newZoom > defaultZoomIn)
-					newZoom = defaultZoomIn
-				zoomLevel = zoomStored
-				center = centerStored
-				mapAnimationZoomIn.restart()
+				return
 			}
+			var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
+			var zoomStored = zoomLevel
+			var newZoomOutFound = false
+			newCenter = centerRect
+			// calculate zoom out
+			newZoomOut = zoomLevel
+			while (zoomLevel > minimumZoomLevel) {
+				var ptCenter = fromCoordinate(centerStored)
+				var ptCenterRect = fromCoordinate(centerRect)
+				if (pointIsVisible(ptCenter) && pointIsVisible(ptCenterRect)) {
+					newZoomOut = zoomLevel
+					newZoomOutFound = true
+					break
+				}
+				zoomLevel -= 1.0
+			}
+			if (!newZoomOutFound)
+				newZoomOut = defaultZoomOut
+			// calculate zoom in
+			center = newCenter
+			zoomLevel = Math.floor(maximumZoomLevel)
+			var diagonalRect = topLeft.distanceTo(bottomRight)
+			while (zoomLevel > minimumZoomLevel) {
+				var c0 = toCoordinate(Qt.point(0.0, 0.0))
+				var c1 = toCoordinate(Qt.point(width, height))
+				if (c0.distanceTo(c1) > diagonalRect) {
+					newZoom = zoomLevel - 2.0
+					break
+				}
+				zoomLevel -= 1.0
+			}
+			if (newZoom > defaultZoomIn)
+				newZoom = defaultZoomIn
+			zoomLevel = zoomStored
+			center = centerStored
+			mapAnimationZoomIn.restart()
 		}
 
 		function deselectMapLocation() {

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -112,15 +112,6 @@ Item {
 		}
 
 		ParallelAnimation {
-			id: mapAnimationZoomOut
-			NumberAnimation { target: map; property: "zoomLevel"; from: map.zoomLevel; to: map.newZoom; duration: 3000 }
-			SequentialAnimation {
-				PauseAnimation { duration: 2000 }
-				CoordinateAnimation { target: map; property: "center"; to: map.newCenter; duration: 2000 }
-			}
-		}
-
-		ParallelAnimation {
 			id: mapAnimationClick
 			CoordinateAnimation { target: map; property: "center"; to: map.newCenter; duration: 500	}
 			NumberAnimation { target: map; property: "zoomLevel"; to: map.newZoom; duration: 500 }
@@ -141,20 +132,12 @@ Item {
 			mapAnimationClick.restart()
 		}
 
-		function animateMapZoomOut() {
-			newCenter = defaultCenter
-			newZoom = defaultZoomOut
-			mapAnimationZoomIn.stop()
-			mapAnimationZoomOut.restart()
-		}
-
 		function pointIsVisible(pt) {
 			return !isNaN(pt.x)
 		}
 
 		function stopZoomAnimations() {
 			mapAnimationZoomIn.stop()
-			mapAnimationZoomOut.stop()
 		}
 
 		function centerOnCoordinate(coord) {
@@ -180,7 +163,6 @@ Item {
 				zoomLevel = zoomStored
 				newZoom = zoomStored
 				mapAnimationZoomIn.restart()
-				mapAnimationZoomOut.stop()
 			}
 		}
 
@@ -225,7 +207,6 @@ Item {
 				zoomLevel = zoomStored
 				center = centerStored
 				mapAnimationZoomIn.restart()
-				mapAnimationZoomOut.stop()
 			}
 		}
 

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -128,6 +128,8 @@ Item {
 
 		MouseArea {
 			anchors.fill: parent
+			onPressed: { map.stopZoomAnimations(); mouse.accepted = false }
+			onWheel: { map.stopZoomAnimations(); wheel.accepted = false }
 			onDoubleClicked: map.doubleClickHandler(map.toCoordinate(Qt.point(mouseX, mouseY)))
 		}
 
@@ -294,6 +296,7 @@ Item {
 		MouseArea {
 			anchors.fill: parent
 			onClicked: {
+				map.stopZoomAnimations()
 				map.newCenter = map.center
 				map.newZoom = map.zoomLevel + map.zoomStep
 				if (map.newZoom > map.maximumZoomLevel)
@@ -318,6 +321,7 @@ Item {
 		MouseArea {
 			anchors.fill: parent
 			onClicked: {
+				map.stopZoomAnimations()
 				map.newCenter = map.center
 				map.newZoom = map.zoomLevel - map.zoomStep
 				mapAnimationClick.restart()

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -104,9 +104,9 @@ Item {
 				target: map; property: "zoomLevel"; to: map.newZoomOut; duration: Math.abs(map.newZoomOut - map.zoomLevel) * 200
 			}
 			ParallelAnimation {
-				CoordinateAnimation { target: map; property: "center"; to: map.newCenter; duration: 1000 }
+				CoordinateAnimation { target: map; property: "center"; to: map.newCenter; duration: 2000; easing.type: Easing.OutCubic }
 				NumberAnimation {
-					target: map; property: "zoomLevel"; to: map.newZoom ; duration: 2000; easing.type: Easing.InCubic
+					target: map; property: "zoomLevel"; to: map.newZoom; duration: 2000
 				}
 			}
 		}

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -136,19 +136,28 @@ Item {
 			return !isNaN(pt.x)
 		}
 
+		function coordIsValid(coord) {
+			if (coord == null || isNaN(coord.latitude) || isNaN(coord.longitude) ||
+			    (coord.latitude === 0.0 && coord.longitude === 0.0))
+				return false;
+			return true;
+		}
+
 		function stopZoomAnimations() {
 			mapAnimationZoomIn.stop()
 		}
 
 		function centerOnCoordinate(coord) {
 			stopZoomAnimations()
-			if (coord.latitude === 0.0 && coord.longitude === 0.0) {
-				// Do nothing
+			if (!coordIsValid(coord)) {
+				console.warn("MapWidget.qml: centerOnCoordinate(): !coordIsValid()")
 			} else {
 				var newZoomOutFound = false
 				var zoomStored = zoomLevel
+				var centerStored = QtPositioning.coordinate(center.latitude, center.longitude)
 				newZoomOut = zoomLevel
 				newCenter = coord
+				zoomLevel = Math.floor(zoomLevel)
 				while (zoomLevel > minimumZoomLevel) {
 					var pt = fromCoordinate(coord)
 					if (pointIsVisible(pt)) {
@@ -156,11 +165,12 @@ Item {
 						newZoomOutFound = true
 						break
 					}
-					zoomLevel--
+					zoomLevel -= 1.0
 				}
 				if (!newZoomOutFound)
 					newZoomOut = defaultZoomOut
 				zoomLevel = zoomStored
+				center = centerStored
 				newZoom = zoomStored
 				mapAnimationZoomIn.restart()
 			}
@@ -185,13 +195,13 @@ Item {
 						newZoomOutFound = true
 						break
 					}
-					zoomLevel--
+					zoomLevel -= 1.0
 				}
 				if (!newZoomOutFound)
 					newZoomOut = defaultZoomOut
 				// calculate zoom in
 				center = newCenter
-				zoomLevel = maximumZoomLevel
+				zoomLevel = Math.floor(maximumZoomLevel)
 				var diagonalRect = topLeft.distanceTo(bottomRight)
 				while (zoomLevel > minimumZoomLevel) {
 					var c0 = toCoordinate(Qt.point(0.0, 0.0))
@@ -200,7 +210,7 @@ Item {
 						newZoom = zoomLevel - 2.0
 						break
 					}
-					zoomLevel--
+					zoomLevel -= 1.0
 				}
 				if (newZoom > defaultZoomIn)
 					newZoom = defaultZoomIn

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -238,11 +238,19 @@ void MapWidgetHelper::setEditMode(bool editMode)
 {
 	m_editMode = editMode;
 	MapLocation *exists = m_mapLocationModel->getMapLocationForUuid(displayed_dive_site.uuid);
-	// if divesite uuid doesn't exist in the model, add a new MapLocation.
-	if (editMode && !exists) {
-		QGeoCoordinate coord = m_map->property("center").value<QGeoCoordinate>();
-		m_mapLocationModel->add(new MapLocation(displayed_dive_site.uuid, coord,
-		                                        QString(displayed_dive_site.name)));
+	if (editMode) {
+		QGeoCoordinate coord;
+		// if divesite uuid doesn't exist in the model, add a new MapLocation.
+		if (!exists) {
+			coord = m_map->property("center").value<QGeoCoordinate>();
+			m_mapLocationModel->add(new MapLocation(displayed_dive_site.uuid, coord,
+			                                        QString(displayed_dive_site.name)));
+		} else {
+			coord = exists->coordinate();
+		}
+		displayed_dive_site.latitude.udeg = lrint(coord.latitude() * 1000000.0);
+		displayed_dive_site.longitude.udeg = lrint(coord.longitude() * 1000000.0);
+		emit coordinatesChanged();
 	}
 	emit editModeChanged();
 }

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -226,6 +226,7 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinatesToMap()
 	const qreal longitude = displayed_dive_site.longitude.udeg * 0.000001;
 	QGeoCoordinate coord(latitude, longitude);
 	m_mapLocationModel->updateMapLocationCoordinates(displayed_dive_site.uuid, coord);
+	QMetaObject::invokeMethod(m_map, "centerOnCoordinate", Q_ARG(QVariant, QVariant::fromValue(coord)));
 }
 
 bool MapWidgetHelper::editMode()

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -115,7 +115,7 @@ void MapWidgetHelper::reloadMapLocations()
 		// at least MIN_DISTANCE_BETWEEN_DIVE_SITES_M apart
 		if (locationNameMap.contains(name)) {
 			MapLocation *existingLocation = locationNameMap[name];
-			QGeoCoordinate coord = qvariant_cast<QGeoCoordinate>(existingLocation->getRole(MapLocation::Roles::RoleCoordinate));
+			QGeoCoordinate coord = existingLocation->coordinate();
 			if (dsCoord.distanceTo(coord) < MIN_DISTANCE_BETWEEN_DIVE_SITES_M)
 				continue;
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

These is a PR to make the `PART 2` additions from #754.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) move the map with the edited dive site
2) start dive site editing with coords pre-entered
3) use 'getter' function coordinate() for MapLocation
4) interrupt map animations on new interactions

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #754

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

@sfuchs79 please, ACK/NAK this PR once you review the UX changes.

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

```
- map-widget: follow the newly entered coordinates on the map when the user
  is editing a dive site
- map-widget: prevent glitches when the user is interacting with the map
  while animations are in progress
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh @sfuchs79 