### PR TITLE
Refresh display if a dive site was edited

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -386,7 +386,7 @@ void MainTab::showLocation()
 // has a parameter on it's definition it didn't worked on the signal slot connection.
 void MainTab::refreshDiveInfo()
 {
-	updateDiveInfo();
+	MainWindow::instance()->refreshDisplay();
 }
 
 void MainTab::updateDepthDuration()


### PR DESCRIPTION
Calls MainWindow::refreshDisplay() if a dive site was edited so that
the filter lists are updated. The old call to updateDiveInfo() was
removed because it is call implicitly in MainWindow::refreshDisplay()
anyway.

Fixes #675.

Requested-by: Stefan Fuchs <sfuchs@gmx.de>

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Refresh filter lists if a dive site was edited. Unfortunately this means that if an the old dive site was selected in the filter, the selection is lost, because at the moment a crude string comparison is done.

@tcanabrava: I'm not feeling too good about this. If you find time, please check if I inserted the function call in a decent place. There are numerous possibilities and the program flow is quite confusing!.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #675.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
