### PR TITLE
Refine code and behavior of #863: refresh location filter list if dive site was edited

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -36,6 +36,8 @@ LocationInformationWidget::LocationInformationWidget(QWidget *parent) : QGroupBo
 	connect(this, SIGNAL(startFilterDiveSite(uint32_t)), MultiFilterSortModel::instance(), SLOT(startFilterDiveSite(uint32_t)));
 	connect(this, SIGNAL(stopFilterDiveSite()), MultiFilterSortModel::instance(), SLOT(stopFilterDiveSite()));
 	connect(ui.geoCodeButton, SIGNAL(clicked()), this, SLOT(reverseGeocode()));
+	connect(this, SIGNAL(nameChanged(const QString &, const QString &)),
+		LocationFilterModel::instance(), SLOT(changeName(const QString &, const QString &)));
 
 	SsrfSortFilterProxyModel *filter_model = new SsrfSortFilterProxyModel(this);
 	filter_model->setSourceModel(LocationInformationModel::instance());
@@ -156,6 +158,7 @@ void LocationInformationWidget::acceptChanges()
 	currentDs->latitude = displayed_dive_site.latitude;
 	currentDs->longitude = displayed_dive_site.longitude;
 	if (!same_string(uiString, currentDs->name)) {
+		emit nameChanged(QString(currentDs->name), ui.diveSiteName->text());
 		free(currentDs->name);
 		currentDs->name = uiString;
 	} else {

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -41,6 +41,7 @@ signals:
 	void stopFilterDiveSite();
 	void requestCoordinates();
 	void endRequestCoordinates();
+	void nameChanged(const QString &oldName, const QString &newName);
 
 private:
 	void clearLabels();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -159,10 +159,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	LocationInformationWidget * diveSiteEdit = new LocationInformationWidget();
 	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
 			this, &MainWindow::setDefaultState);
-
-	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
-			mainTab, &MainTab::refreshDiveInfo);
-
+	connect(diveSiteEdit, SIGNAL(endEditDiveSite()), this, SLOT(refreshDisplay()));
 	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
 			mainTab, &MainTab::refreshDisplayedDiveSite);
 

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -21,7 +21,9 @@
 #include "qt-models/weightmodel.h"
 #include "qt-models/divecomputerextradatamodel.h"
 #include "qt-models/divelocationmodel.h"
+#include "qt-models/filtermodels.h"
 #include "core/divesite.h"
+#include "desktop-widgets/locationinformation.h"
 #include "desktop-widgets/locationinformation.h"
 
 #include "TabDiveExtraInfo.h"
@@ -201,6 +203,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 	connect(ui.diveNotesMessage, &KMessageWidget::showAnimationFinished,
 					ui.location, &DiveLocationLineEdit::fixPopupPosition);
+	connect(this, SIGNAL(diveSiteAdded(const QString &)), LocationFilterModel::instance(), SLOT(addName(const QString &)));
 
 	// enable URL clickability in notes:
 	new TextHyperlinkEventFilter(ui.notes);//destroyed when ui.notes is destroyed
@@ -702,8 +705,10 @@ uint32_t MainTab::updateDiveSite(uint32_t pickedUuid, int divenr)
 		return origUuid;
 
 	if (pickedUuid == RECENTLY_ADDED_DIVESITE) {
-		pickedUuid = create_dive_site(ui.location->text().isEmpty() ? qPrintable(tr("New dive site")) : qPrintable(ui.location->text()), displayed_dive.when);
+		QString name = ui.location->text().isEmpty() ? tr("New dive site") : ui.location->text();
+		pickedUuid = create_dive_site(qPrintable(name), displayed_dive.when);
 		createdNewDive = true;
+		emit diveSiteAdded(name);
 	}
 
 	newDs = get_dive_site_by_uuid(pickedUuid);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -382,13 +382,6 @@ void MainTab::showLocation()
 		ui.location->clear();
 }
 
-// Seems wrong, since we can also call updateDiveInfo(), but since the updateDiveInfo
-// has a parameter on it's definition it didn't worked on the signal slot connection.
-void MainTab::refreshDiveInfo()
-{
-	MainWindow::instance()->refreshDisplay();
-}
-
 void MainTab::updateDepthDuration()
 {
 	ui.depth->setVisible(true);

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -64,7 +64,6 @@ public
 slots:
 	void addCylinder_clicked();
 	void addWeight_clicked();
-	void refreshDiveInfo();
 	void updateDiveInfo(bool clear = false);
 	void updateDepthDuration();
 	void acceptChanges();

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -60,6 +60,7 @@ signals:
 	void addDiveFinished();
 	void dateTimeChanged();
 	void diveSiteChanged(struct dive_site * ds);
+	void diveSiteAdded(const QString &);
 public
 slots:
 	void addCylinder_clicked();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -333,6 +333,20 @@ void LocationFilterModel::changeName(const QString &oldName, const QString &newN
 		checkState[newIndex] = true;
 }
 
+void LocationFilterModel::addName(const QString &newName)
+{
+	// If any item is checked and a new location is added, add the name
+	// of the new location in front of the list and mark it as checked.
+	// Thus, on subsequent repopulation of the list, the new entry will
+	// be registered as already checked.
+	QStringList list = stringList();
+	if (!anyChecked || newName.isEmpty() || list.indexOf(newName) >= 0)
+		return;
+	list.prepend(newName);
+	setStringList(list);
+	checkState.insert(checkState.begin(), true);
+}
+
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) :
 	QSortFilterProxyModel(parent),
 	divesDisplayed(0),

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -315,6 +315,24 @@ void LocationFilterModel::repopulate()
 	updateList(list);
 }
 
+void LocationFilterModel::changeName(const QString &oldName, const QString &newName)
+{
+	if (oldName.isEmpty() || newName.isEmpty() || oldName == newName)
+		return;
+	QStringList list = stringList();
+	int oldIndex = list.indexOf(oldName);
+	if (oldIndex < 0)
+		return;
+	int newIndex = list.indexOf(newName);
+	list[oldIndex] = newName;
+	setStringList(list);
+
+	// If there was already an entry with the new name, we are merging entries.
+	// Thus, if the old entry was selected, also select the new entry.
+	if (newIndex >= 0 && checkState[oldIndex])
+		checkState[newIndex] = true;
+}
+
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) :
 	QSortFilterProxyModel(parent),
 	divesDisplayed(0),

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -69,6 +69,7 @@ public
 slots:
 	void repopulate();
 	void changeName(const QString &oldName, const QString &newName);
+	void addName(const QString &newName);
 
 private:
 	explicit LocationFilterModel(QObject *parent = 0);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -68,6 +68,7 @@ public:
 public
 slots:
 	void repopulate();
+	void changeName(const QString &oldName, const QString &newName);
 
 private:
 	explicit LocationFilterModel(QObject *parent = 0);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a refinement of #863. The user visible change is that now the selection of an entry in the filter list is kept if the dive site is renamed.

### Changes made:
1) Simplify signal/slot handling. Instead of catching a signal in MainTab and calling MainWindow, directly connect the signal to MainWindow.
2) Tell the location filter that a dive site was renamed and take the necessary actions to keep the selection.
3) Optional (remove by removing 3rd commit): tell the location filter that a new dive site was added. If there was any filter selection also the new dive site will be selected.

I solved 2) and 3) by introducing new signal/slot combinations, since this seems to be the Qt-style. But I must say that I dont "get" this kind of programming. Intuitively, I would just introduce a method call where it is needed. I understand that the signal/slot way is more flexible and it's cool for widget libraries, where your users can't change the source. But it introduces an element of non-determinism/non-linearity that I find uncanny.

<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Refines #863.

<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79: If you find time, please let me know how this performs for your use-case.