### PR TITLE
Remove redundant declaration of set_userid()

### DIFF
--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -110,12 +110,4 @@ slots:
 	virtual void buttonClicked(QAbstractButton *button) { Q_UNUSED(button) }
 };
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-extern void set_userid(char *user_id);
-#ifdef __cplusplus
-}
-#endif
-
 #endif // SUBSURFACEWEBSERVICES_H


### PR DESCRIPTION
set_userid() was declared in core/dive.h and dektop_widgets/subsurfacewebservices.h.
Remove the second instance because two declarations of the same function
are a recipe for disaster.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Minor cleanup
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
