### PR TITLE
Store and load the planner related depth info of a cylinder in logfile

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -390,6 +390,10 @@ static void parse_cylinder_keyvalue(void *_cylinder, const char *key, const char
 		cylinder->cylinder_use = cylinderuse_from_text(value);
 		return;
 	}
+	if (!strcmp(key, "depth")) {
+		cylinder->depth = get_depth(value);
+		return;
+	}
 	report_error("Unknown cylinder key/value pair (%s/%s)", key, value);
 }
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1467,6 +1467,8 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf)
 			return;
 		if (MATCH("use.cylinder", cylinder_use, &dive->cylinder[cur_cylinder_index].cylinder_use))
 			return;
+		if (MATCH("depth.cylinder", depth, &dive->cylinder[cur_cylinder_index].depth))
+			return;
 		if (MATCH("o2", gasmix, &dive->cylinder[cur_cylinder_index].gasmix.o2))
 			return;
 		if (MATCH("o2percent", gasmix, &dive->cylinder[cur_cylinder_index].gasmix.o2))

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -157,7 +157,8 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		put_pressure(b, cylinder->end, " end=", "bar");
 		if (cylinder->cylinder_use != OC_GAS)
 			put_format(b, " use=%s", cylinderuse_text[cylinder->cylinder_use]);
-
+		if (cylinder->depth.mm != 0)
+			put_milli(b, " depth='", cylinder->depth.mm, " m'");
 		put_string(b, "\n");
 	}
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -159,6 +159,8 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		put_pressure(b, cylinder->end, " end='", " bar'");
 		if (cylinder->cylinder_use != OC_GAS)
 			show_utf8(b, cylinderuse_text[cylinder->cylinder_use], " use='", "'", 1);
+		if (cylinder->depth.mm != 0)
+			put_milli(b, " depth='", cylinder->depth.mm, " m'");
 		put_format(b, " />\n");
 	}
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Store cylinder.depth in XML files and in git storage.
This info is in fact the gas switch depth of a specific gas/cylinder
in the planner.
This change avoids the need of typing in a user specific depth value
again when replanning an existing planned dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @RickMWalsh @janmulder 