### PR TITLE
Don't change visibility of depth and duration UI field when no dive

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -548,11 +548,13 @@ void MainTab::updateDiveInfo(bool clear)
 			weightModel->updateDive();
 			taglist_get_tagstring(displayed_dive.tag_list, buf, 1024);
 			ui.tagWidget->setText(QString(buf));
-			bool isManual = !current_dive || same_string(current_dive->dc.model, "manually added dive");
-			ui.depth->setVisible(isManual);
-			ui.depthLabel->setVisible(isManual);
-			ui.duration->setVisible(isManual);
-			ui.durationLabel->setVisible(isManual);
+			if (current_dive) {
+				bool isManual = same_string(current_dive->dc.model, "manually added dive");
+				ui.depth->setVisible(isManual);
+				ui.depthLabel->setVisible(isManual);
+				ui.duration->setVisible(isManual);
+				ui.durationLabel->setVisible(isManual);
+			}
 		}
 		ui.duration->setText(QDateTime::fromTime_t(displayed_dive.duration.seconds).toUTC().toString("h:mm"));
 		ui.depth->setText(get_depth_string(displayed_dive.maxdepth, true));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
After one selected a dive and then selects NO dive don't touch
the visibility of UI fields for depth and duration.
So if previously selected dive was a manually added dive, keep them
visible. If it was no manually added dive keep them invisible.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in ReleaseNotes/ReleaseNotes.txt. -->
<!-- Also, please make sure to update the ReleaseNotes/ReleaseNotes.txt file itself. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
