### PR TITLE
Updated strategy for removing cylinders

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2070,7 +2070,7 @@ static void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int
 	if (mapping[0] > 0)
 		add_initial_gaschange(dive, dc);
 
-	/* Remap the sensor indexes */
+	/* Remap or delete the sensor indexes */
 	for (i = 0; i < dc->samples; i++) {
 		struct sample *s = dc->sample + i;
 		int j;
@@ -2079,8 +2079,18 @@ static void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, int
 			int sensor;
 
 			sensor = mapping[s->sensor[j]];
-			if (sensor >= 0)
+			if (sensor == -1) {
+				// Remove sensor and gas pressure info
+				if (i == 0) {
+					s->sensor[j] = 0;
+					s->pressure[j].mbar = 0;
+				} else {
+					s->sensor[j] = s[-1].sensor[j];
+					s->pressure[j].mbar = s[-1].pressure[j].mbar;
+				}
+			} else {
 				s->sensor[j] = sensor;
+			}
 		}
 	}
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -808,6 +808,7 @@ extern void free_events(struct event *ev);
 extern void copy_cylinders(struct dive *s, struct dive *d, bool used_only);
 extern void copy_samples(struct divecomputer *s, struct divecomputer *d);
 extern bool is_cylinder_used(struct dive *dive, int idx);
+extern bool is_cylinder_prot(struct dive *dive, int idx);
 extern void fill_default_cylinder(cylinder_t *cyl);
 extern void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int time, int idx);
 extern struct event *add_event(struct divecomputer *dc, unsigned int time, int type, int flags, int value, const char *name);

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -345,6 +345,19 @@ bool is_cylinder_used(struct dive *dive, int idx)
 	return false;
 }
 
+bool is_cylinder_prot(struct dive *dive, int idx)
+{
+	struct divecomputer *dc;
+	if (cylinder_none(&dive->cylinder[idx]))
+		return false;
+
+	for_each_dc(dive, dc) {
+		if (has_gaschange_event(dive, dc, idx))
+			return true;
+	}
+	return false;
+}
+
 void get_gas_used(struct dive *dive, volume_t gases[MAX_CYLINDERS])
 {
 	int idx;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -362,8 +362,10 @@ void DivePlannerPointsModel::gasChange(const QModelIndex &index, int newcylinder
 
 void DivePlannerPointsModel::cylinderRenumber(int mapping[])
 {
-	for (int i = 0; i < rowCount(); i++)
-		divepoints[i].cylinderid = mapping[divepoints[i].cylinderid];
+	for (int i = 0; i < rowCount(); i++) {
+		if (mapping[divepoints[i].cylinderid] >= 0)
+			divepoints[i].cylinderid = mapping[divepoints[i].cylinderid];
+	}
 	emitDataChanged();
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Change the strategy when to allow cylinder removal from a dive:
- Not remove when cylinder has gas switch events, in any other cases
  allow removal
- Remove this whole "cylinder with same gas" thing being a criteria
  for cylinder removal

When removing a cylinder which has corresponding pressure info in
samples, also remove this pressure info from the samples.

This from my point of view simplifies our strategy for removing cylinders but also does some major changes:
- This whole "it's ok to remove a cylinder if there is another cylinder with same gas" is removed.
- Main remaining aspect for the decision if a cylinder can be removed outside the planner is "does it have gas change events" --> First cylinder will always have gas change event so never can be removed.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #869 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
