### PR TITLE
Dive picture handling: Re enable multi select, improve mouse events

### DIFF
--- a/desktop-widgets/divepicturewidget.cpp
+++ b/desktop-widgets/divepicturewidget.cpp
@@ -35,7 +35,11 @@ void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 		QString filename = model()->data(indexAt(event->pos()), Qt::DisplayPropertyRole).toString();
 
 		if (!filename.isEmpty()) {
+			int dim = lrint(defaultIconMetrics().sz_pic * 0.2);
+			
 			QPixmap pixmap = model()->data(indexAt(event->pos()), Qt::DecorationRole).value<QPixmap>();
+			pixmap = pixmap.scaled(dim, dim, Qt::KeepAspectRatio);
+			
 			QByteArray itemData;
 			QDataStream dataStream(&itemData, QIODevice::WriteOnly);
 			dataStream << filename << event->pos();
@@ -46,7 +50,6 @@ void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 			QDrag *drag = new QDrag(this);
 			drag->setMimeData(mimeData);
 			drag->setPixmap(pixmap);
-			drag->setHotSpot(event->pos() - rectForIndex(indexAt(event->pos())).topLeft());
 
 			drag->exec(Qt::CopyAction | Qt::MoveAction, Qt::CopyAction);
 		}

--- a/desktop-widgets/divepicturewidget.h
+++ b/desktop-widgets/divepicturewidget.h
@@ -12,13 +12,11 @@ class DivePictureWidget : public QListView {
 public:
 	DivePictureWidget(QWidget *parent);
 protected:
+	void mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 	void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 
 signals:
 	void photoDoubleClicked(const QString filePath);
-private
-slots:
-	void doubleClicked(const QModelIndex &index);
 };
 
 class DivePictureThumbnailThread : public QThread {

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -21,7 +21,7 @@ TabDivePhotos::TabDivePhotos(QWidget *parent)
 {
 	ui->setupUi(this);
 	ui->photosView->setModel(divePictureModel);
-	ui->photosView->setSelectionMode(QAbstractItemView::MultiSelection);
+	ui->photosView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
 	connect(ui->photosView, &DivePictureWidget::photoDoubleClicked,
 		[](const QString& path) {

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -22,6 +22,7 @@ TabDivePhotos::TabDivePhotos(QWidget *parent)
 	ui->setupUi(this);
 	ui->photosView->setModel(divePictureModel);
 	ui->photosView->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	ui->photosView->setResizeMode(QListView::Adjust);
 
 	connect(ui->photosView, &DivePictureWidget::photoDoubleClicked,
 		[](const QString& path) {

--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -10,6 +10,7 @@
 #include <QDesktopServices>
 #include <QGraphicsView>
 #include <QUrl>
+#include <QGraphicsSceneMouseEvent>
 
 DivePixmapItem::DivePixmapItem(QObject *parent) : QObject(parent), QGraphicsPixmapItem()
 {
@@ -129,8 +130,9 @@ DivePictureItem::~DivePictureItem(){
 
 void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	Q_UNUSED(event);
-	QDesktopServices::openUrl(QUrl::fromLocalFile(fileUrl));
+	if (event->button() == Qt::LeftButton) {
+		QDesktopServices::openUrl(QUrl::fromLocalFile(fileUrl));
+	}
 }
 
 void DivePictureItem::removePicture()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Some improvements for the dive picture tab and dive pictures in profile:
- Bugfix mouse event in profile: Only Left-click will open picture
- Bugfix mouse events in picture tab:
  - Re-enable context menu (Windows bug mainly)
  - Re-enable multi select
  - Only double-left-click will open picture

Smaller size for pixmap of picture during drag&drop.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #368 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
