### PR TITLE
Simplify recent files logic in desktop version

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -200,6 +200,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget(), SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget(), SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
+	// TODO: Make the number of actions depend on NUM_RECENT_FILES
 	connect(ui.actionRecent1, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
 	connect(ui.actionRecent2, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
 	connect(ui.actionRecent3, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
@@ -1439,7 +1440,7 @@ void MainWindow::readSettings()
 #if !defined(SUBSURFACE_MOBILE)
 	QSettings s; //TODO: this 's' exists only for the loadRecentFiles, remove it.
 
-	loadRecentFiles(&s);
+	loadRecentFiles();
 	if (firstRun) {
 		checkSurvey(&s);
 		firstRun = false;
@@ -1521,49 +1522,32 @@ MainTab *MainWindow::information()
 	return qobject_cast<MainTab*>(applicationState["Default"].topLeft);
 }
 
-void MainWindow::loadRecentFiles(QSettings *s)
+void MainWindow::loadRecentFiles()
 {
-	QStringList files;
-	bool modified = false;
-
-	s->beginGroup("Recent_Files");
-	for (int c = 1; c <= 4; c++) {
-		QString key = QString("File_%1").arg(c);
-		if (s->contains(key)) {
-			QString file = s->value(key).toString();
-
-			if (QFile::exists(file)) {
-				files.append(file);
-			} else {
-				modified = true;
-			}
-		} else {
+	recentFiles.clear();
+	QSettings s;
+	s.beginGroup("Recent_Files");
+	foreach (const QString &key, s.childKeys()) {
+		// TODO Sorting only correct up to 9 entries. Currently, only 4 used, so no problem.
+		if (!key.startsWith("File_"))
+			continue;
+		QString file = s.value(key).toString();
+		if (QFile::exists(file))
+			recentFiles.append(file);
+		if (recentFiles.count() > NUM_RECENT_FILES)
 			break;
-		}
 	}
+	s.endGroup();
+	updateRecentFilesMenu();
+}
 
-	if (modified) {
-		for (int c = 0; c < 4; c++) {
-			QString key = QString("File_%1").arg(c + 1);
-
-			if (files.count() > c) {
-				s->setValue(key, files.at(c));
-			} else {
-				if (s->contains(key)) {
-					s->remove(key);
-				}
-			}
-		}
-
-		s->sync();
-	}
-	s->endGroup();
-
-	for (int c = 0; c < 4; c++) {
+void MainWindow::updateRecentFilesMenu()
+{
+	for (int c = 0; c < NUM_RECENT_FILES; c++) {
 		QAction *action = this->findChild<QAction *>(QString("actionRecent%1").arg(c + 1));
 
-		if (files.count() > c) {
-			QFileInfo fi(files.at(c));
+		if (recentFiles.count() > c) {
+			QFileInfo fi(recentFiles.at(c));
 			action->setText(fi.fileName());
 			action->setToolTip(fi.absoluteFilePath());
 			action->setVisible(true);
@@ -1573,99 +1557,32 @@ void MainWindow::loadRecentFiles(QSettings *s)
 	}
 }
 
-void MainWindow::addRecentFile(const QStringList &newFiles)
+void MainWindow::addRecentFile(const QString &file, bool update)
 {
-	QStringList files;
-	QSettings s;
-
-	if (newFiles.isEmpty())
-		return;
-
-	s.beginGroup("Recent_Files");
-
-	for (int c = 1; c <= 4; c++) {
-		QString key = QString("File_%1").arg(c);
-		if (s.contains(key)) {
-			QString file = s.value(key).toString();
-
-			files.append(file);
-		} else {
-			break;
-		}
-	}
-
-	foreach (const QString &file, newFiles) {
-		int index = files.indexOf(QDir::toNativeSeparators(file));
-
-		if (index >= 0) {
-			files.removeAt(index);
-		}
-	}
-
-	foreach (const QString &file, newFiles) {
-		if (QFile::exists(file)) {
-			files.prepend(QDir::toNativeSeparators(file));
-		}
-	}
-
-	while (files.count() > 4) {
-		files.removeLast();
-	}
-
-	for (int c = 1; c <= 4; c++) {
-		QString key = QString("File_%1").arg(c);
-
-		if (files.count() >= c) {
-			s.setValue(key, files.at(c - 1));
-		} else {
-			if (s.contains(key)) {
-				s.remove(key);
-			}
-		}
-	}
-	s.endGroup();
-	s.sync();
-
-	loadRecentFiles(&s);
+	QString localFile = QDir::toNativeSeparators(file);
+	int index = recentFiles.indexOf(localFile);
+	if (index >= 0)
+		recentFiles.removeAt(index);
+	recentFiles.prepend(localFile);
+	while (recentFiles.count() > NUM_RECENT_FILES)
+		recentFiles.removeLast();
+	if (update)
+		updateRecentFiles();
 }
 
-void MainWindow::removeRecentFile(QStringList failedFiles)
+void MainWindow::updateRecentFiles()
 {
-	QStringList files;
 	QSettings s;
 
-	if (failedFiles.isEmpty())
-		return;
-
 	s.beginGroup("Recent_Files");
-
-	for (int c = 1; c <= 4; c++) {
+	s.remove("");	// Remove all old entries
+	for (int c = 1; c <= recentFiles.count(); c++) {
 		QString key = QString("File_%1").arg(c);
-
-		if (s.contains(key)) {
-			QString file = s.value(key).toString();
-			files.append(file);
-		} else {
-			break;
-		}
+		s.setValue(key, recentFiles.at(c - 1));
 	}
-
-	foreach (const QString &file, failedFiles)
-		files.removeAll(file);
-
-	for (int c = 1; c <= 4; c++) {
-		QString key = QString("File_%1").arg(c);
-
-		if (files.count() >= c)
-			s.setValue(key, files.at(c - 1));
-		else if (s.contains(key))
-			s.remove(key);
-	}
-
 	s.endGroup();
 	s.sync();
-
-	loadRecentFiles(&s);
+	updateRecentFilesMenu();
 }
 
 void MainWindow::recentFileTriggered(bool checked)
@@ -1733,7 +1650,7 @@ int MainWindow::file_save_as(void)
 	set_filename(filename.toUtf8().data(), true);
 	setTitle(MWTF_FILENAME);
 	mark_divelist_changed(false);
-	addRecentFile(QStringList() << filename);
+	addRecentFile(filename, true);
 	return 0;
 }
 
@@ -1768,7 +1685,7 @@ int MainWindow::file_save(void)
 	if (is_cloud)
 		hideProgressBar();
 	mark_divelist_changed(false);
-	addRecentFile(QStringList() << QString(existing_filename));
+	addRecentFile(QString(existing_filename), true);
 	return 0;
 }
 
@@ -1871,25 +1788,19 @@ void MainWindow::loadFiles(const QStringList fileNames)
 		return;
 	}
 	QByteArray fileNamePtr;
-	QStringList failedParses;
 
 	showProgressBar();
 	for (int i = 0; i < fileNames.size(); ++i) {
-		int error;
-
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		error = parse_file(fileNamePtr.data());
-		if (!error) {
+		if (!parse_file(fileNamePtr.data())) {
 			set_filename(fileNamePtr.data(), true);
+			addRecentFile(fileNamePtr, false);
 			setTitle(MWTF_FILENAME);
-		} else {
-			failedParses.append(fileNames.at(i));
 		}
 	}
 	hideProgressBar();
+	updateRecentFiles();
 	process_dives(false, false);
-	addRecentFile(fileNames);
-	removeRecentFile(failedParses);
 
 	refreshDisplay();
 	ui.actionAutoGroup->setChecked(autogroup);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1437,13 +1437,11 @@ void MainWindow::readSettings()
 	// now make sure that the cloud menu items are enabled IFF cloud account is verified
 	enableDisableCloudActions();
 
-#if !defined(SUBSURFACE_MOBILE)
 	loadRecentFiles();
 	if (firstRun) {
 		checkSurvey();
 		firstRun = false;
 	}
-#endif
 }
 
 #undef TOOLBOX_PREF_BUTTON

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1438,11 +1438,9 @@ void MainWindow::readSettings()
 	enableDisableCloudActions();
 
 #if !defined(SUBSURFACE_MOBILE)
-	QSettings s; //TODO: this 's' exists only for the loadRecentFiles, remove it.
-
 	loadRecentFiles();
 	if (firstRun) {
-		checkSurvey(&s);
+		checkSurvey();
 		firstRun = false;
 	}
 #endif
@@ -1450,22 +1448,23 @@ void MainWindow::readSettings()
 
 #undef TOOLBOX_PREF_BUTTON
 
-void MainWindow::checkSurvey(QSettings *s)
+void MainWindow::checkSurvey()
 {
-	s->beginGroup("UserSurvey");
-	if (!s->contains("FirstUse42")) {
+	QSettings s;
+	s.beginGroup("UserSurvey");
+	if (!s.contains("FirstUse42")) {
 		QVariant value = QDate().currentDate();
-		s->setValue("FirstUse42", value);
+		s.setValue("FirstUse42", value);
 	}
 	// wait a week for production versions, but not at all for non-tagged builds
 	int waitTime = 7;
-	QDate firstUse42 = s->value("FirstUse42").toDate();
-	if (run_survey || (firstUse42.daysTo(QDate().currentDate()) > waitTime && !s->contains("SurveyDone"))) {
+	QDate firstUse42 = s.value("FirstUse42").toDate();
+	if (run_survey || (firstUse42.daysTo(QDate().currentDate()) > waitTime && !s.contains("SurveyDone"))) {
 		if (!survey)
 			survey = new UserSurvey(this);
 		survey->show();
 	}
-	s->endGroup();
+	s.endGroup();
 }
 
 void MainWindow::writeSettings()

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -83,7 +83,7 @@ public:
 	ProfileWidget2 *graphics() const;
 	PlannerDetails *plannerDetails() const;
 	void printPlan();
-	void checkSurvey(QSettings *s);
+	void checkSurvey();
 	void setApplicationState(const QByteArray& state);
 	void setStateProperties(const QByteArray& state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl,const PropertyList& br);
 	bool inPlanner();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -19,6 +19,8 @@
 #include "core/windowtitleupdate.h"
 #include "core/gpslocation.h"
 
+#define NUM_RECENT_FILES 4
+
 class QSortFilterProxyModel;
 class DiveTripModel;
 class QItemSelection;
@@ -63,9 +65,10 @@ public:
 	virtual ~MainWindow();
 	static MainWindow *instance();
 	MainTab *information();
-	void loadRecentFiles(QSettings *s);
-	void addRecentFile(const QStringList &newFiles);
-	void removeRecentFile(QStringList failedFiles);
+	void loadRecentFiles();
+	void updateRecentFiles();
+	void updateRecentFilesMenu();
+	void addRecentFile(const QString &file, bool update);
 	DiveListView *dive_list();
 	DivePlannerWidget *divePlannerWidget();
 	PlannerSettingsWidget *divePlannerSettingsWidget();
@@ -218,6 +221,7 @@ private:
 	struct dive copyPasteDive;
 	struct dive_components what;
 	QList<QAction *> profileToolbarActions;
+	QStringList recentFiles;
 
 	struct WidgetForQuadrant {
 		WidgetForQuadrant(QWidget *tl = 0, QWidget *tr = 0, QWidget *bl = 0, QWidget *br = 0) :


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR attempts to simplify the recent files logic in mainwindow.cpp. Not only is it ~80 lines shorter, it also avoids unnecessary writes to the session object. It was tested only lightly.

Note that the code in MainWindow::loadFiles() is rather complex because it allows the loading of multiple files simultaneously, but in test I was not able to select multiple files.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Don't add and remove files that failed to load. Simply only add files when loading succeeded.
2) Don't sync culled files from recentFiles list on load. The changes will be written anyway if a new file is loaded.
3) More clearly separate the logic of the recent file methods.
4) Make the number of recent files a compile-time constant.
5) Remove a seemingly redundant #if preprocessor conditional.

<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
