### PR TITLE
Two more (minor) recent files changes.

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -203,6 +203,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
 	for (int i = 0; i < NUM_RECENT_FILES; i++) {
 		actionsRecent[i] = new QAction(this);
+		actionsRecent[i]->setData(i);
 		ui.menuFile->insertAction(ui.actionQuit, actionsRecent[i]);
 		connect(actionsRecent[i], SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
 	}
@@ -1592,9 +1593,10 @@ void MainWindow::recentFileTriggered(bool checked)
 	if (!okToClose(tr("Please save or cancel the current dive edit before opening a new file.")))
 		return;
 
-	QAction *actionRecent = (QAction *)sender();
-
-	const QString &filename = actionRecent->toolTip();
+	int filenr = ((QAction *)sender())->data().toInt();
+	if (filenr >= recentFiles.count())
+		return;
+	const QString &filename = recentFiles[filenr];
 
 	updateLastUsedDir(QFileInfo(filename).dir().path());
 	closeCurrentFile();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -201,11 +201,12 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget(), SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget(), SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
-	// TODO: Make the number of actions depend on NUM_RECENT_FILES
-	connect(ui.actionRecent1, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
-	connect(ui.actionRecent2, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
-	connect(ui.actionRecent3, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
-	connect(ui.actionRecent4, SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
+	for (int i = 0; i < NUM_RECENT_FILES; i++) {
+		actionsRecent[i] = new QAction(this);
+		ui.menuFile->insertAction(ui.actionQuit, actionsRecent[i]);
+		connect(actionsRecent[i], SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
+	}
+	ui.menuFile->insertSeparator(ui.actionQuit);
 	connect(information(), SIGNAL(addDiveFinished()), graphics(), SLOT(setProfileState()));
 	connect(information(), SIGNAL(dateTimeChanged()), graphics(), SLOT(dateTimeChanged()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCreated()), this, SLOT(planCreated()));
@@ -1543,7 +1544,7 @@ void MainWindow::loadRecentFiles()
 void MainWindow::updateRecentFilesMenu()
 {
 	for (int c = 0; c < NUM_RECENT_FILES; c++) {
-		QAction *action = this->findChild<QAction *>(QString("actionRecent%1").arg(c + 1));
+		QAction *action = actionsRecent[c];
 
 		if (recentFiles.count() > c) {
 			QFileInfo fi(recentFiles.at(c));

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -222,6 +222,7 @@ private:
 	struct dive_components what;
 	QList<QAction *> profileToolbarActions;
 	QStringList recentFiles;
+	QAction *actionsRecent[NUM_RECENT_FILES];
 
 	struct WidgetForQuadrant {
 		WidgetForQuadrant(QWidget *tl = 0, QWidget *tr = 0, QWidget *bl = 0, QWidget *br = 0) :

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -75,11 +75,6 @@
     <addaction name="separator"/>
     <addaction name="actionHash_images"/>
     <addaction name="actionConfigure_Dive_Computer"/>
-    <addaction name="actionRecent1"/>
-    <addaction name="actionRecent2"/>
-    <addaction name="actionRecent3"/>
-    <addaction name="actionRecent4"/>
-    <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuLog">
@@ -419,26 +414,6 @@
    </property>
    <property name="shortcut">
     <string notr="true">F11</string>
-   </property>
-  </action>
-  <action name="actionRecent1">
-   <property name="visible">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="actionRecent2">
-   <property name="visible">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="actionRecent3">
-   <property name="visible">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="actionRecent4">
-   <property name="visible">
-    <bool>false</bool>
    </property>
   </action>
   <action name="action_Check_for_Updates">


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

This is a small continuation of #892. In #892 a constant describing the number of recent files was introduced. In the first commit therefore generate the correct number of actions according to this constant. Someone with Qt knowledge please check this.

The second commit uses the user data of the action to access the correct file instead of using the tooltip property. At the moment this is not necessary because only local files are supported, but in the future one might also support more complex things git repositories, etc. Then this way is more flexible.
### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Dynamically generate recent file actions.
2) Use the user data instead of the tooltip of the recent file actions to access the filename.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
