### PR TITLE
In maintab fix change of text between "notes" and "trip notes" and enable/disable tabs

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -44,7 +44,9 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	cylindersModel(new CylindersModel(this)),
 	editMode(NONE),
 	copyPaste(false),
-	currentTrip(0)
+	currentTrip(0),
+	lastTabSelectedDive(0),
+	lastTabSelectedDiveTrip(0)
 {
 	ui.setupUi(this);
 
@@ -469,7 +471,18 @@ void MainTab::updateDiveInfo(bool clear)
 		ui.dateEdit->setDate(localTime.date());
 		ui.timeEdit->setTime(localTime.time());
 		if (MainWindow::instance() && MainWindow::instance()->dive_list()->selectedTrips().count() == 1) {
+			// Remember the tab selected for last dive
+			if (lastSelectedDive)
+				lastTabSelectedDive = ui.tabWidget->currentIndex();
 			ui.tabWidget->setTabText(0, tr("Trip notes"));
+			ui.tabWidget->setTabEnabled(1, false);
+			ui.tabWidget->setTabEnabled(2, false);
+			ui.tabWidget->setTabEnabled(4, false);
+			ui.tabWidget->setTabEnabled(5, false);
+			// Recover the tab selected for last dive trip
+			if (lastSelectedDive)
+				ui.tabWidget->setCurrentIndex(lastTabSelectedDiveTrip);
+			lastSelectedDive = false;
 			currentTrip = *MainWindow::instance()->dive_list()->selectedTrips().begin();
 			// only use trip relevant fields
 			ui.divemaster->setVisible(false);
@@ -511,7 +524,18 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.duration->setVisible(false);
 			ui.durationLabel->setVisible(false);
 		} else {
+			// Remember the tab selected for last dive trip
+			if (!lastSelectedDive)
+				lastTabSelectedDiveTrip = ui.tabWidget->currentIndex();
 			ui.tabWidget->setTabText(0, tr("Notes"));
+			ui.tabWidget->setTabEnabled(1, true);
+			ui.tabWidget->setTabEnabled(2, true);
+			ui.tabWidget->setTabEnabled(4, true);
+			ui.tabWidget->setTabEnabled(5, true);
+			// Recover the tab selected for last dive
+			if (!lastSelectedDive)
+				ui.tabWidget->setCurrentIndex(lastTabSelectedDive);
+			lastSelectedDive = true;
 			currentTrip = NULL;
 			// make all the fields visible writeable
 			ui.diveTripLocation->hide();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -469,7 +469,7 @@ void MainTab::updateDiveInfo(bool clear)
 		ui.dateEdit->setDate(localTime.date());
 		ui.timeEdit->setTime(localTime.time());
 		if (MainWindow::instance() && MainWindow::instance()->dive_list()->selectedTrips().count() == 1) {
-			setTabText(0, tr("Trip notes"));
+			ui.tabWidget->setTabText(0, tr("Trip notes"));
 			currentTrip = *MainWindow::instance()->dive_list()->selectedTrips().begin();
 			// only use trip relevant fields
 			ui.divemaster->setVisible(false);
@@ -511,7 +511,7 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.duration->setVisible(false);
 			ui.durationLabel->setVisible(false);
 		} else {
-			setTabText(0, tr("Notes"));
+			ui.tabWidget->setTabText(0, tr("Notes"));
 			currentTrip = NULL;
 			// make all the fields visible writeable
 			ui.diveTripLocation->hide();

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -115,6 +115,9 @@ private:
 	Completers completers;
 	bool modified;
 	bool copyPaste;
+	bool lastSelectedDive;
+	int lastTabSelectedDive;
+	int lastTabSelectedDiveTrip;
 	void resetPallete();
 	void saveTags();
 	void saveTaggedStrings();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While looking for s.th. completely different I stumbled across two lines of non functional code.
Idea of these lines was to change the text of the maintab between "Notes" and "Trip notes".
If we again like this to work -> use this PR
If we don't like it at all -> tell me, I will just change the PR to remove the two lines

[edit]
Ok, now I had an idea on top of this.
Honestly it was always little bit strange for me that when selecting a dive trip some of the tabs show info which is very specific for only ONE dive (the last one) from the dive trip. I think this is a little bit misleading. What about disabling these tabs?
One more remark: I would love to keep the pictures tab but only if we manage to show there ALL the combined pictures from all dives in the dive trip. Someone wants to implement this? ;-)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
