### PR TITLE
On failed cloud save hide progress bar

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -610,8 +610,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 
 	showProgressBar();
 	QByteArray fileNamePtr = QFile::encodeName(filename);
-	error = parse_file(fileNamePtr.data());
-	if (!error) {
+	if (!parse_file(fileNamePtr.data())) {
 		set_filename(fileNamePtr.data(), true);
 		setTitle(MWTF_FILENAME);
 	}
@@ -638,11 +637,10 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 		information()->acceptChanges();
 
 	showProgressBar();
-
-	if (save_dives(filename.toUtf8().data()))
-		return;
-
+	int error = save_dives(filename.toUtf8().data());
 	hideProgressBar();
+	if (error)
+		return;
 
 	set_filename(filename.toUtf8().data(), true);
 	setTitle(MWTF_FILENAME);


### PR DESCRIPTION
The progressbar was not hidden on failed save to cloud. In return
remove an unnecessary variable on loading from cloud.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a very minor code cleanup concerning showing/hiding the progress bar in the main window. Only compile tested. All other uses were OK.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
