### PR TITLE
Planner variations - simpler deco stop time calculation and variables use for variations

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -986,32 +986,29 @@ struct divedatapoint * DivePlannerPointsModel::cloneDiveplan(struct diveplan *pl
 
 int DivePlannerPointsModel::analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit)
 {
+	int minsum = 0;
+	int midsum = 0;
+	int maxsum = 0;
 	int leftsum = 0;
 	int rightsum = 0;
-	while (mid->depth > min->depth)
-		++mid;
-	while (max->depth > mid->depth)
-		++max;
 
-	while (mid->depth) {
-		int left = mid->time - min->time;
-		leftsum += left;
-		int right = max->time - mid->time;
-		rightsum += right;
-#ifdef SHOWSTOPVARIATIONS
-		if (min->time + mid->time + max->time)
-			printf("%dm: %dmin + %ds/%s +- %ds/%s\n", mid->depth / 1000,
-			       (mid->time + 1)/60,
-			       (left + right) / 2, unit,
-			       (right - left) / 2, unit);
-#else
-		(void) unit;
-#endif
+	while (min->depth) {
+		minsum += min->time;
 		++min;
+	}
+	while (mid->depth) {
+		midsum += mid->time;
 		++mid;
+	}
+	while (max->depth) {
+		maxsum += max->time;
 		++max;
 	}
-#ifdef SHOWSTOPVARIATIONS
+
+	leftsum = midsum - minsum;
+	rightsum = maxsum - midsum;
+
+#ifdef DEBUG_STOPVAR
 	printf("Total + %d:%02d/%s +- %d s/%s\n\n", FRACTION((leftsum + rightsum) / 2, 60), unit,
 						       (rightsum - leftsum) / 2, unit);
 #endif
@@ -1093,7 +1090,7 @@ void DivePlannerPointsModel::computeVariations(struct diveplan *original_plan, s
 				FRACTION(analyzeVariations(shorter, original, longer, "min"), 60));
 
 		emit variationsComputed(QString(buf));
-#ifdef SHOWSTOPVARIATIONS
+#ifdef DEBUG_STOPVAR
 		printf("\n\n");
 #endif
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A few change proposals for the planner variations to be discussed with @atdotde 

BTW:
I really appreciate this added string "Stop times" in the planner notes. Now this is ok for me because it is clear that we are NOT printing runtime variations.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #878 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
