### PR TITLE
Gpsfixes

### DIFF
--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -90,8 +90,8 @@ struct preferences default_prefs = {
 	},
 	.planner_deco_mode = BUEHLMANN,
 	.vpmb_conservatism = 3,
-	.distance_threshold = 1000,
-	.time_threshold = 600,
+	.distance_threshold = 50,
+	.time_threshold = 300,
 #if defined(SUBSURFACE_MOBILE)
 	.cloud_timeout = 10,
 #else

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -55,6 +55,13 @@ static void copy_gps_location(struct dive *from, struct dive *to)
 }
 
 #define SAME_GROUP 6 * 3600 // six hours
+#define SET_LOCATION(_dive, _gpsfix, _mark)\
+{ ;\
+	copy_gps_location(_gpsfix, _dive);\
+	changed ++;\
+	tracer = _mark;\
+}
+
 //TODO: C Code. static functions are not good if we plan to have a test for them.
 static bool merge_locations_into_dives(void)
 {
@@ -79,9 +86,7 @@ static bool merge_locations_into_dives(void)
 					if (time_during_dive_with_offset(dive, gpsfix->when, 0)) {
 						if (verbose)
 							qDebug() << "gpsfix is during the dive, pick that one";
-						copy_gps_location(gpsfix, dive);
-						changed++;
-						tracer = j;
+						SET_LOCATION(dive, gpsfix, j);
 						break;
 					} else {
 						/*
@@ -101,25 +106,19 @@ static bool merge_locations_into_dives(void)
 							} else if (gpsfix->when > dive_endtime(dive)) {
 								if (verbose)
 									qDebug() << "which is even later after the end of the dive, so pick the previous one";
-								copy_gps_location(gpsfix, dive);
-								changed++;
-								tracer = j;
+								SET_LOCATION(dive, gpsfix, j);
 								break;
 							} else {
 								/* ok, gpsfix is before, nextgpsfix is after */
 								if (dive->when - gpsfix->when <= nextgpsfix->when - dive_endtime(dive)) {
 									if (verbose)
 										qDebug() << "pick the one before as it's closer to the start";
-									copy_gps_location(gpsfix, dive);
-									changed++;
-									tracer = j;
+									SET_LOCATION(dive, gpsfix, j);
 									break;
 								} else {
 									if (verbose)
 										qDebug() << "pick the one after as it's closer to the start";
-									copy_gps_location(nextgpsfix, dive);
-									changed++;
-									tracer = j + 1;
+									SET_LOCATION(dive, nextgpsfix, j + 1);
 									break;
 								}
 							}
@@ -129,9 +128,7 @@ static bool merge_locations_into_dives(void)
 						} else {
 							if (verbose)
 								qDebug() << "which seems to be the best one for this dive, so pick it";
-							copy_gps_location(gpsfix, dive);
-							changed++;
-							tracer = j;
+							SET_LOCATION(dive, gpsfix, j);
 							break;
 						}
 					}

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -110,7 +110,7 @@ static bool merge_locations_into_dives(void)
 								break;
 							} else {
 								/* ok, gpsfix is before, nextgpsfix is after */
-								if (dive->when - gpsfix->when <= nextgpsfix->when - dive_endtime(dive)) {
+								if (dive->when - gpsfix->when <= nextgpsfix->when - dive->when) {
 									if (verbose)
 										qDebug() << "pick the one before as it's closer to the start";
 									SET_LOCATION(dive, gpsfix, j);

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -91,15 +91,6 @@ static bool merge_locations_into_dives(void)
 						    time_during_dive_with_offset(dive, nextgpsfix->when, SAME_GROUP)) {
 							if (verbose)
 								qDebug() << "look at the next gps fix @" << get_dive_date_string(nextgpsfix->when);
-							/* first let's test if this one is during the dive */
-							if (time_during_dive_with_offset(dive, nextgpsfix->when, 0)) {
-								if (verbose)
-									qDebug() << "which is during the dive, pick that one";
-								copy_gps_location(nextgpsfix, dive);
-								changed++;
-								tracer = j + 1;
-								break;
-							}
 							/* we know the gps fixes are sorted; if they are both before the dive, ignore the first,
 							 * if theay are both after the dive, take the first,
 							 * if the first is before and the second is after, take the closer one */


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fixes #666 , fixes unnoticed bug in logic and makes some cosmetics grouping code under a macro call.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
Fixes #666 
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Modify logic description in user-manual.txt.  With this change we always choose the gps position which is closer in time to the dive init (ATM we were preferring first fix taken during dive over those before dive, even if these were closer to the beginning of the dive.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
