### PR TITLE
build system: fix build of libdivecomputer

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -341,7 +341,7 @@ cd $SRC
 
 cd subsurface
 
-if [ ! -d subsurface/libdivecomputer/src ] ; then
+if [ ! -d libdivecomputer/src ] ; then
 	git submodule update --recursive
 fi
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Trivial fix. Do not first cd to the ./src/subsurface directory, and then prepend the subsurface directory to the path.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>