### PR TITLE
Add button to rescan BT devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add button to recan for BT devices
 - Compute plan variations in background to improve responsiveness
 - Improve profile rescaling in planner
 - Store the gas switch depth of a cylinder from the planner in the logbook

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -215,6 +215,14 @@ Kirigami.Page {
 					manager.appendTextToLog("exit DCDownload screen")
 				}
 			}
+			SsrfButton {
+				id:rescanbutton
+				text: qsTr("Rescan")
+				onClicked: {
+					manager.btRescan()
+				}
+			}
+
 			Controls.Label {
 				Layout.maximumWidth: parent.width - download.width - quitbutton.width
 				text: divesDownloaded ? qsTr(" Downloaded dives") :

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -100,6 +100,13 @@ void QMLManager::btHostModeChange(QBluetoothLocalDevice::HostMode state)
 }
 #endif
 
+void QMLManager::btRescan()
+{
+#if defined(BT_SUPPORT)
+	BTDiscovery::instance()->BTDiscoveryReDiscover();
+#endif
+}
+
 QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_verboseEnabled(false),
 	reply(0),

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -196,6 +196,8 @@ public slots:
 	void appendTextToLog(const QString &newText);
 	void quit();
 	void hasLocationSourceChanged();
+	void btRescan();
+
 
 private:
 	QString m_cloudUserName;

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -8,7 +8,7 @@ set -e
 TOP=$(pwd)
 SUBSURFACE_SOURCE=${TOP}/../../../subsurface
 IOS_QT=${TOP}/Qt
-QT_VERSION=$(cd ${IOS_QT}; ls -d 5.*)
+QT_VERSION=$(cd ${IOS_QT}; ls -d 5.*|perl -e 'print "5.".(sort {$b<=>$a} (map {/\d+\.(\d+.*)/; $1} <>))[0];')
 
 # Which versions are we building against?
 SQLITE_VERSION=3090200


### PR DESCRIPTION
Otherwise the divecomputer has to be in pairing mode
at app start time.

Unfortunately, this leaves less space for the progress message.
My time/qml knowledge does not suffice to move that to the next line
(when moving that out of the RowLayout it overlaps with
the buttons).

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add a button to trigger a rescan of BT devices (for those that were not active already at 
app start time)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
