### PR TITLE
Gracefully handle cloud authentication failure in verbose mode

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -607,7 +607,9 @@ int sync_with_remote(git_repository *repo, const char *remote, const char *branc
 		else
 			report_error("Unable to fetch remote '%s'", remote);
 		if (verbose)
-			fprintf(stderr, "remote fetch failed (%s)\n", giterr_last()->message);
+			// If we returned GIT_EUSER during authentication, giterr_last() returns NULL
+			fprintf(stderr, "remote fetch failed (%s)\n",
+				giterr_last() ? giterr_last()->message : "authentication failed");
 		error = 0;
 	} else {
 		error = check_remote_status(repo, origin, remote, branch, rt);


### PR DESCRIPTION
If the credential functions return GIT_EUSER, a call to git_remote_fetch
fails, but giterr_last() may return NULL. This led to a crash in
verbose mode.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a very obscure crash. To reproduce: set wrong password, run `subsurface -v` and open cloud storage.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
