### PR TITLE
Mobile: Enable editing multiple buddies

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -229,7 +229,7 @@ Kirigami.Page {
 		watertemp = currentItem.modelData.dive.waterTemp
 		suitIndex = currentItem.modelData.dive.suitList.indexOf(currentItem.modelData.dive.suit)
 		if (currentItem.modelData.dive.buddy.indexOf(",") > 0) {
-			buddyIndex = currentItem.modelData.dive.buddyList.indexOf(qsTr("Multiple Buddies"));
+			buddyText = currentItem.modelData.dive.buddy;
 		} else {
 			buddyIndex = currentItem.modelData.dive.buddyList.indexOf(currentItem.modelData.dive.buddy)
 		}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1008,11 +1008,9 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		if (buddy.contains(",")){
 			buddy = buddy.replace(QRegExp("\\s*,\\s*"), ", ");
 		}
-		if (!buddy.contains("Multiple Buddies")) {
-			diveChanged = true;
-			free(d->buddy);
-			d->buddy = strdup(qPrintable(buddy));
-		}
+		diveChanged = true;
+		free(d->buddy);
+		d->buddy = strdup(qPrintable(buddy));
 	}
 	if (myDive->divemaster() != diveMaster) {
 		diveChanged = true;


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fixes #608, while the autocomplete function only works for the first entry
adding multiple comma separated buddies can still be done.
This also makes all buddies visible on the edit page.

### Related issues:
Fixes #608
