### PR TITLE
[WIP][RFC] Attempt at detangling the load/save code

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	cloudstorage.cpp
 	downloadfromdcthread.cpp
 	connectionlistmodel.cpp
+	filelocation.cpp
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp

--- a/core/checkcloudconnection.h
+++ b/core/checkcloudconnection.h
@@ -9,9 +9,10 @@
 class CheckCloudConnection : public QObject {
 	Q_OBJECT
 public:
-	CheckCloudConnection(QObject *parent = 0);
+	CheckCloudConnection(const QString &baseUrl, QObject *parent = 0);
 	bool checkServer();
 private:
+	QString baseUrl;
 	QNetworkReply *reply;
 private
 slots:

--- a/core/dive.h
+++ b/core/dive.h
@@ -723,7 +723,6 @@ extern int match_one_dc(struct divecomputer *a, struct divecomputer *b);
 extern void parse_xml_init(void);
 extern int parse_xml_buffer(const char *url, const char *buf, int size, struct dive_table *table, const char **params);
 extern void parse_xml_exit(void);
-extern void set_filename(const char *filename, bool force);
 
 extern int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table);
 extern int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table);
@@ -733,12 +732,14 @@ extern int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *
 extern int parse_dlf_buffer(unsigned char *buffer, size_t size);
 
 extern int parse_file(const char *filename);
+extern int parse_file_git(const char *repository, const char *branch, const char *user, bool is_remote, bool is_cloud);
 extern int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 extern int parse_seabear_log(const char *filename);
 extern int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 extern int parse_txt_file(const char *filename, const char *csv);
 extern int parse_manual_file(const char *filename, char **params, int pnr);
-extern int save_dives(const char *filename);
+extern int save_dives_file(const char *filename);
+extern int save_dives_git(const char *repository, const char *branch, const char *user, bool is_remote, bool is_cloud);
 extern int save_dives_logic(const char *filename, bool select_only);
 extern int save_dive(FILE *f, struct dive *dive);
 extern int export_dives_xslt(const char *filename, const bool selected, const int units, const char *export_xslt);
@@ -858,7 +859,6 @@ const char *monthname(int mon);
 #define UTF8_WHITESTAR "\xe2\x98\x86"
 #define UTF8_BLACKSTAR "\xe2\x98\x85"
 
-extern const char *existing_filename;
 extern void subsurface_command_line_init(int *, char ***);
 extern void subsurface_command_line_exit(int *, char ***);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -77,6 +77,7 @@ enum cylinderuse {OC_GAS, DILUENT, OXYGEN, NOT_USED, NUM_GAS_USE}; // The differ
 
 extern const char *cylinderuse_text[];
 extern const char *divemode_text[];
+struct git_state;
 
 struct gasmix {
 	fraction_t o2;
@@ -732,14 +733,14 @@ extern int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *
 extern int parse_dlf_buffer(unsigned char *buffer, size_t size);
 
 extern int parse_file(const char *filename);
-extern int parse_file_git(const char *repository, const char *branch, const char *user, bool is_remote, bool is_cloud);
+extern int parse_file_git(struct git_state *);
 extern int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 extern int parse_seabear_log(const char *filename);
 extern int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 extern int parse_txt_file(const char *filename, const char *csv);
 extern int parse_manual_file(const char *filename, char **params, int pnr);
 extern int save_dives_file(const char *filename);
-extern int save_dives_git(const char *repository, const char *branch, const char *user, bool is_remote, bool is_cloud);
+extern int save_dives_git(struct git_state *);
 extern int save_dives_logic(const char *filename, bool select_only);
 extern int save_dive(FILE *f, struct dive *dive);
 extern int export_dives_xslt(const char *filename, const bool selected, const int units, const char *export_xslt);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1424,8 +1424,7 @@ void clear_dive_file_data()
 	clear_dive(&displayed_dive);
 	clear_dive_site(&displayed_dive_site);
 
-	free((void *)existing_filename);
-	existing_filename = NULL;
+	set_current_file_none();
 
 	reset_min_datafile_version();
 	saved_git_id = "";

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1427,5 +1427,4 @@ void clear_dive_file_data()
 	set_current_file_none();
 
 	reset_min_datafile_version();
-	saved_git_id = "";
 }

--- a/core/file.c
+++ b/core/file.c
@@ -445,13 +445,15 @@ int check_git_sha(struct git_state *state, struct git_repository **git_p)
 	/* if this is a git repository, do we already have this exact state loaded ?
 	 * get the SHA and compare with what we currently have */
 	if (git && git != dummy_git_repository) {
-		const char *sha = get_sha(git, state->branch);
+		char *sha = get_sha(git, state->branch);
 		if (!same_string(sha, "") &&
 		    same_string(sha, current_sha)) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
 			free(current_sha);
+			free(sha);
 			return 0;
 		}
+		free(sha);
 	}
 	free(current_sha);
 	return 1;
@@ -472,14 +474,16 @@ int parse_file_git(struct git_state *state)
 	/* if this is a git repository, do we already have this exact state loaded ?
 	 * get the SHA and compare with what we currently have */
 	if (git && git != dummy_git_repository) {
-		const char *sha = get_sha(git, state->branch);
+		char *sha = get_sha(git, state->branch);
 		if (!same_string(sha, "") &&
 		    same_string(sha, current_sha) &&
 		    !unsaved_changes()) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
 			free(current_sha);
+			free(sha);
 			return 0;
 		}
+		free(sha);
 	}
 	free(current_sha);
 	if (git)

--- a/core/filelocation.cpp
+++ b/core/filelocation.cpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "core/filelocation.h"
+#include "core/pref.h"
+#include <QObject>
+#include <QFileInfo>
+#include <QDir>
+#include <utility>
+
+FileLocation currentFile;
+
+FileLocation::FileLocation() : type(NONE)
+{
+}
+
+bool isRemoteRepository(const QString &name)
+{
+	return name.startsWith("http://") || name.startsWith("https://") ||
+	       name.startsWith("ssh://") || name.startsWith("git://");
+}
+
+// For git repositories, remove "file://" and extract username, if any.
+// For local files or git repositories, do proper unicode encoding.
+void FileLocation::fixName()
+{
+	switch (type) {
+	default:
+	case NONE:
+		return;
+	case LOCAL_FILE:
+		name = QFile::encodeName(QDir::toNativeSeparators(name));
+		return;
+	case CLOUD_GIT:
+	case CLOUD_GIT_OFFLINE:
+	case GIT:
+		if (name.startsWith("file://", Qt::CaseInsensitive)) {
+			// Treat "file://..." URLs as local repositories.
+			name = name.mid(7);
+			name = QFile::encodeName(QDir::toNativeSeparators(name));
+		} else if(!isRemoteRepository(name)) {
+			name = QFile::encodeName(QDir::toNativeSeparators(name));
+		} else if(name.startsWith("https://", Qt::CaseInsensitive)) {
+			int at = name.indexOf('@');
+			int slash = name.indexOf('/', 8);
+			if (at >= 0 && slash >= 0 && slash > at) {
+				user = name.mid(8, at - 8);
+				name.remove(8, at - 7);
+			}
+		}
+	}
+}
+
+// Check if filename is of the form "repository[branch]" or "repository[branch].ssrf".
+static bool isGitFilename(const QString &name)
+{
+	QString trimmed = name.trimmed();
+	if (trimmed.endsWith(".ssrf", Qt::CaseInsensitive))
+		trimmed.truncate(trimmed.count() - 5);
+	return trimmed.right(1) == "]" &&
+	       trimmed.lastIndexOf('[') > 0;
+}
+
+// Returns (repository, branch) pair.
+static std::pair<QString, QString> parseGitFilename(const QString &fn)
+{
+	if (!isGitFilename(fn))							// Oops. Filename doesn't follow the rules. Leave branch empty.
+		return std::make_pair(fn, QString());
+
+	int branch_from = fn.lastIndexOf('[');
+	int branch_to = fn.lastIndexOf(']');
+	QString repository = fn.left(branch_from);				// Guaranteed OK owing to isGitFilename() == true
+	QString branch = fn.mid(branch_from + 1, branch_to - branch_from - 1);	// ditto
+	return std::make_pair(repository, branch);
+}
+
+FileLocation::FileLocation(Type type_, const QString &name_, const QString &branch_) : type(type_), name(name_), branch(branch_)
+{
+	if (type == NONE)
+		return;
+	fixName();
+}
+
+FileLocation::FileLocation(Type type_, const QString &name_) : type(type_)
+{
+	if (type == NONE)
+		return;
+	if (type == LOCAL_FILE) {
+		name = name_;
+	} else {
+		// Is a git repository
+		std::pair<QString, QString> repo_branch = parseGitFilename(name_);
+		name = repo_branch.first;
+		branch = repo_branch.second;
+	}
+	fixName();
+}
+
+FileLocation::FileLocation(const QString &type_, const QString &name_, const QString &branch_) : name(name_), branch(branch_)
+{
+	if (type_ == "none")
+		type = NONE;
+	else if (type_ == "local")
+		type = LOCAL_FILE;
+	else if (type_ == "cloud")
+		type = CLOUD_GIT;
+	else if (type_ == "cloud_offline")
+		type = CLOUD_GIT_OFFLINE;
+	else if (type_ == "git")
+		type = GIT;
+	else
+		*this = guessFromFileName(name_); // Unknown or empty type -> try to guess from filename
+	fixName();
+}
+
+FileLocation FileLocation::guessFromFileName(const QString &name)
+{
+	if (name.simplified().isEmpty()) {
+		return FileLocation();
+	} else if (isGitFilename(name)) {
+		std::pair<QString, QString> repo_branch = parseGitFilename(name);
+		// TODO: Check for git repository if local!!
+		return FileLocation(GIT, repo_branch.first, repo_branch.second);
+	}
+	return FileLocation(LOCAL_FILE, name, QString());
+}
+
+QString FileLocation::getName() const
+{
+	return name;
+}
+
+QString FileLocation::getBranch() const
+{
+	return branch;
+}
+
+QString FileLocation::getUser() const
+{
+	return user;
+}
+
+FileLocation::Type FileLocation::getType() const
+{
+	return type;
+}
+
+bool FileLocation::isNone() const
+{
+	return type == NONE;
+}
+
+bool FileLocation::isRemote() const
+{
+	if (type == CLOUD_GIT)
+		return true;
+	if (type != GIT)
+		return false;
+	return isRemoteRepository(name);
+}
+
+bool FileLocation::isCloud() const
+{
+	return type == CLOUD_GIT || type == CLOUD_GIT_OFFLINE;
+}
+
+QString FileLocation::typeAsString() const
+{
+	switch(type) {
+	default:
+	case NONE:		return QString("none");
+	case LOCAL_FILE:	return QString("local");
+	case CLOUD_GIT:		return QString("cloud");
+	case CLOUD_GIT_OFFLINE:	return QString("cloud_offline");
+	case GIT:		return QString("git");
+	}
+}
+
+QString FileLocation::formatShort() const
+{
+	switch(type) {
+	default:
+	case NONE:		return QFileInfo(prefs.default_filename).fileName();
+	case LOCAL_FILE:	return QFileInfo(name).fileName();
+	case CLOUD_GIT:		return QObject::tr("[cloud storage for] %1").arg(branch);
+	case CLOUD_GIT_OFFLINE:	return QObject::tr("[local cache for] %1").arg(branch);
+	case GIT:		return QObject::tr("[%1] in repository %2").arg(branch, repoName());
+	}
+}
+
+QString FileLocation::formatLong() const
+{
+	switch(type) {
+	default:
+	case NONE:		return prefs.default_filename;
+	case LOCAL_FILE:	return name;
+	case CLOUD_GIT:		return QObject::tr("[cloud storage for] %1").arg(branch);
+	case CLOUD_GIT_OFFLINE:	return QObject::tr("[local cache for] %1").arg(branch);
+	case GIT:		return QObject::tr("[%1] in repository %2").arg(branch, name);
+	}
+}
+
+QString FileLocation::path() const
+{
+	QFileInfo fi(type == NONE ?  prefs.default_filename : name);
+	return fi.absolutePath();
+}
+
+QString FileLocation::repoName() const
+{
+	if (isRemoteRepository(name))	// TODO: extract last element of URL?
+		return name;
+	else
+		return QDir(name).dirName();
+}
+
+bool FileLocation::operator==(const FileLocation &fl) const
+{
+	if (type != fl.type)
+		return false;
+	switch(type) {
+	default:
+	case NONE:
+		return true;
+	case LOCAL_FILE: {
+		QFileInfo f1(name);
+		QFileInfo f2(fl.name);
+		return f1 == f2;
+	}
+	case CLOUD_GIT:
+	case CLOUD_GIT_OFFLINE:
+	case GIT:
+		// TODO: Text comparison is too crude. For local repositories use QFileInfo,
+		// for remote repositories QUrl?
+		return name == fl.name && branch == fl.branch;
+	}
+}

--- a/core/filelocation.cpp
+++ b/core/filelocation.cpp
@@ -17,6 +17,7 @@ git_state FileLocation::gitState() const
 	ret.location = strdup(qPrintable(name));
 	ret.branch = strdup(qPrintable(branch));
 	ret.user = strdup(qPrintable(user));
+	ret.sha = strdup(qPrintable(sha));
 	ret.is_remote = isRemote();
 	ret.is_cloud = isCloud();
 	ret.auth_attempt = 0;
@@ -189,6 +190,11 @@ bool FileLocation::isRemote() const
 bool FileLocation::isCloud() const
 {
 	return type == CLOUD_GIT || type == CLOUD_GIT_OFFLINE;
+}
+
+void FileLocation::setSHA(const char *s)
+{
+	sha = s;
 }
 
 QString FileLocation::typeAsString() const

--- a/core/filelocation.h
+++ b/core/filelocation.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef FILELOCATION_H
+#define FILELOCATION_H
+
+#include <QString>
+
+class FileLocation {
+public:
+	enum Type {
+		NONE,
+		LOCAL_FILE,
+		CLOUD_GIT,
+		CLOUD_GIT_OFFLINE,
+		GIT,
+	};
+private:
+	Type type;
+	QString name;					// Name of file or git repository
+	QString branch;					// For git repos
+	QString user;					// For https:// git repos
+
+	void fixName();
+public:
+	FileLocation();					// Default to none
+	FileLocation(const QString &type, const QString &name, const QString &branch);
+	FileLocation(Type type, const QString &name, const QString &branch);
+	FileLocation(Type type, const QString &name);	// For git repos parse as "repo[branch]"
+
+	static FileLocation none();
+	static FileLocation guessFromFileName(const QString &name_);
+
+	QString getName() const;
+	QString getBranch() const;
+	QString getUser() const;
+	Type getType() const;
+	bool isNone() const;
+	bool isRemote() const;
+	bool isCloud() const;
+	QString formatShort() const;
+	QString formatLong() const;
+	QString typeAsString() const;
+	QString path() const;
+	QString repoName() const;
+
+	bool operator==(const FileLocation &) const;	// So that we can find location in list
+};
+
+extern FileLocation currentFile;
+
+#endif

--- a/core/filelocation.h
+++ b/core/filelocation.h
@@ -20,6 +20,7 @@ private:
 	QString name;					// Name of file or git repository
 	QString branch;					// For git repos
 	QString user;					// For https:// git repos
+	QString sha;					// For git repos - sha of last commit
 
 	void fixName();
 public:
@@ -38,6 +39,7 @@ public:
 	bool isNone() const;
 	bool isRemote() const;
 	bool isCloud() const;
+	void setSHA(const char *);
 	QString formatShort() const;
 	QString formatLong() const;
 	QString typeAsString() const;

--- a/core/filelocation.h
+++ b/core/filelocation.h
@@ -4,6 +4,8 @@
 
 #include <QString>
 
+struct git_state;
+
 class FileLocation {
 public:
 	enum Type {
@@ -41,6 +43,7 @@ public:
 	QString typeAsString() const;
 	QString path() const;
 	QString repoName() const;
+	git_state gitState() const;
 
 	bool operator==(const FileLocation &) const;	// So that we can find location in list
 };

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -579,8 +579,9 @@ int sync_with_remote(git_repository *repo, struct git_state *state, enum remote_
 		return 0;
 	}
 
-	if (rt == RT_HTTPS && !canReachCloudServer()) {
-		// this is not an error, just a warning message, so return 0
+	if (state->is_cloud && !canReachCloudServer(state->location)) {
+		// this is not an error, just a warning message, so return 0 and set state to offline
+		state->is_remote = false;
 		report_error("Cannot connect to cloud server, working with local copy");
 		git_storage_update_progress(translate("gettextFromC", "Can't reach cloud server, working with local data"));
 		return 0;
@@ -729,8 +730,9 @@ static git_repository *create_local_repo(const char *localdir, struct git_state 
 	opts.fetch_opts.callbacks.payload = (void *)state;
 
 	opts.checkout_branch = state->branch;
-	if (rt == RT_HTTPS && !canReachCloudServer())
+	if (state->is_cloud && !canReachCloudServer(state->location)) {
 		return 0;
+	}
 	if (verbose > 1)
 		fprintf(stderr, "git storage: calling git_clone()\n");
 	error = git_clone(&cloned_repo, state->location, localdir, &opts);

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -287,7 +287,7 @@ static int update_remote(git_repository *repo, git_remote *origin, git_reference
 
 extern int update_git_checkout(git_repository *repo, git_object *parent, git_tree *tree);
 
-static int try_to_git_merge(git_repository *repo, git_reference **local_p, git_reference *remote, git_oid *base, const git_oid *local_id, const git_oid *remote_id)
+static int try_to_git_merge(git_repository *repo, git_reference **local_p, git_reference *remote, git_oid *base, const git_oid *local_id, const git_oid *remote_id, struct git_state *state)
 {
 	(void) remote;
 	git_tree *local_tree, *remote_tree, *base_tree;
@@ -395,7 +395,7 @@ static int try_to_git_merge(git_repository *repo, git_reference **local_p, git_r
 	}
 	if (git_reference_set_target(local_p, *local_p, &commit_oid, "Subsurface merge event"))
 		goto write_error;
-	set_git_id(&commit_oid);
+	set_git_id(state, &commit_oid);
 	git_signature_free(author);
 	if (verbose)
 		fprintf(stderr, "Successfully merged repositories");
@@ -489,7 +489,7 @@ static int try_to_update(git_repository *repo, git_remote *origin, git_reference
 	}
 	/* Ok, let's try to merge these */
 	git_storage_update_progress(translate("gettextFromC", "Try to merge local changes into cloud storage"));
-	ret = try_to_git_merge(repo, &local, remote, &base, local_id, remote_id);
+	ret = try_to_git_merge(repo, &local, remote, &base, local_id, remote_id, state);
 	if (ret == 0)
 		return update_remote(repo, origin, local, remote, state, rt);
 	else

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -17,6 +17,7 @@ struct git_state {
 	const char *location;
 	const char *branch;
 	const char *user;
+	const char *sha;	// New sha returned after successful read or write
 	bool is_remote;		// Is set to false if cloud can't be reached
 	bool is_cloud;
 	int auth_attempt;
@@ -29,12 +30,10 @@ extern struct git_repository *is_git_repository(struct git_state *state);
 extern int check_git_sha(struct git_state *loc, struct git_repository **git_p);
 extern int sync_with_remote(struct git_repository *repo, struct git_state *state, enum remote_transport rt);
 //extern int git_save_dives(struct git_repository *, struct git_state *state, bool select_only);
-extern int git_load_dives(struct git_repository *, const char *);
+extern int git_load_dives(struct git_repository *, struct git_state *);
 extern char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(git_repository *repo, struct git_state *state, bool select_only, bool create_empty);
-extern const char *saved_git_id;
-extern void clear_git_id(void);
-extern void set_git_id(const struct git_oid *);
+extern void set_git_id(struct git_state *, const struct git_oid *);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
 char *get_local_dir(const struct git_state *state);

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -17,7 +17,7 @@ struct git_state {
 	const char *location;
 	const char *branch;
 	const char *user;
-	bool is_remote;
+	bool is_remote;		// Is set to false if cloud can't be reached
 	bool is_cloud;
 	int auth_attempt;
 };

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -12,23 +12,34 @@ extern "C" {
 
 enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
 
+// State needed for git accesses. Data must be freed with free_git_state()
+struct git_state {
+	const char *location;
+	const char *branch;
+	const char *user;
+	bool is_remote;
+	bool is_cloud;
+	int auth_attempt;
+};
+
 struct git_oid;
 struct git_repository;
 #define dummy_git_repository ((git_repository *)3ul) /* Random bogus pointer, not NULL */
-extern struct git_repository *is_git_repository(const char *loc, const char *branch, const char *user, bool is_remote, bool is_cloud);
-extern int check_git_sha(const char *filename, const char *branch, const char *user, bool is_remote, bool is_cloud, struct git_repository **git_p);
-extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
-extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
+extern struct git_repository *is_git_repository(struct git_state *state);
+extern int check_git_sha(struct git_state *loc, struct git_repository **git_p);
+extern int sync_with_remote(struct git_repository *repo, struct git_state *state, enum remote_transport rt);
+//extern int git_save_dives(struct git_repository *, struct git_state *state, bool select_only);
 extern int git_load_dives(struct git_repository *, const char *);
 extern const char *get_sha(git_repository *repo, const char *branch);
-extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
+extern int do_git_save(git_repository *repo, struct git_state *state, bool select_only, bool create_empty);
 extern const char *saved_git_id;
 extern void clear_git_id(void);
 extern void set_git_id(const struct git_oid *);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
-char *get_local_dir(const char *remote, const char *branch);
+char *get_local_dir(const struct git_state *state);
 int git_create_local_repo(const char *directory);
+void free_git_state(struct git_state *state);
 
 #ifdef __cplusplus
 }

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -15,8 +15,8 @@ enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
 struct git_oid;
 struct git_repository;
 #define dummy_git_repository ((git_repository *)3ul) /* Random bogus pointer, not NULL */
-extern struct git_repository *is_git_repository(const char *filename, const char **branchp, const char **remote, bool dry_run);
-extern int check_git_sha(const char *filename, git_repository **git_p, const char **branch_p);
+extern struct git_repository *is_git_repository(const char *loc, const char *branch, const char *user, bool is_remote, bool is_cloud);
+extern int check_git_sha(const char *filename, const char *branch, const char *user, bool is_remote, bool is_cloud, struct git_repository **git_p);
 extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
 extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
 extern int git_load_dives(struct git_repository *, const char *);
@@ -28,7 +28,7 @@ extern void set_git_id(const struct git_oid *);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
 char *get_local_dir(const char *remote, const char *branch);
-int git_create_local_repo(const char *filename);
+int git_create_local_repo(const char *directory);
 
 #ifdef __cplusplus
 }

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -30,7 +30,7 @@ extern int check_git_sha(struct git_state *loc, struct git_repository **git_p);
 extern int sync_with_remote(struct git_repository *repo, struct git_state *state, enum remote_transport rt);
 //extern int git_save_dives(struct git_repository *, struct git_state *state, bool select_only);
 extern int git_load_dives(struct git_repository *, const char *);
-extern const char *get_sha(git_repository *repo, const char *branch);
+extern char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(git_repository *repo, struct git_state *state, bool select_only, bool create_empty);
 extern const char *saved_git_id;
 extern void clear_git_id(void);

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1715,12 +1715,13 @@ static int do_git_load(git_repository *repo, const char *branch)
 	return ret;
 }
 
-const char *get_sha(git_repository *repo, const char *branch)
+char *get_sha(git_repository *repo, const char *branch)
 {
-	static char git_id_buffer[GIT_OID_HEXSZ+1];
+	char *git_id_buffer;
 	git_commit *commit;
 	if (find_commit(repo, branch, &commit))
 		return NULL;
+	git_id_buffer = malloc(GIT_OID_HEXSZ+1);
 	git_oid_tostr(git_id_buffer, sizeof(git_id_buffer), (const git_oid *)commit);
 	return git_id_buffer;
 }

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1741,7 +1741,6 @@ int git_load_dives(struct git_repository *repo, const char *branch)
 		return report_error("Unable to open git repository at '%s'", branch);
 	ret = do_git_load(repo, branch);
 	git_repository_free(repo);
-	free((void *)branch);
 	finish_active_dive();
 	finish_active_trip();
 	return ret;

--- a/core/pref.h
+++ b/core/pref.h
@@ -64,7 +64,6 @@ struct preferences {
 	const char *default_filename;
 	const char *default_cylinder;
 	const char *cloud_base_url;
-	const char *cloud_git_url;
 	const char *time_format;
 	const char *date_format;
 	const char *date_format_short;

--- a/core/pref.h
+++ b/core/pref.h
@@ -142,7 +142,6 @@ struct preferences {
 	const char *cloud_storage_password;
 	const char *cloud_storage_newpassword;
 	const char *cloud_storage_email;
-	const char *cloud_storage_email_encoded;
 	bool save_password_local;
 	short cloud_verification_status;
 	bool cloud_background_sync;

--- a/core/pref.h
+++ b/core/pref.h
@@ -150,7 +150,6 @@ struct preferences {
 	short vpmb_conservatism;
 	int time_threshold;
 	int distance_threshold;
-	bool git_local_only;
 	short cloud_timeout;
 	locale_prefs_t locale; //: TODO: move the rest of locale based info here.
 	update_manager_prefs_t update_manager;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1740,7 +1740,7 @@ FileLocation getCloudLocation(bool isOffline)
 	if (currentFile.isCloud() && currentFile.isRemote() != isOffline)
 		return currentFile;
 	QString email = QString(prefs.cloud_storage_email);
-	QString url = QString(prefs.cloud_git_url) + "/" + email;
+	QString url = QString(prefs.cloud_base_url) + "/git/" + email;
 	return isOffline ? FileLocation(FileLocation::CLOUD_GIT_OFFLINE, url, email)
 			 : FileLocation(FileLocation::CLOUD_GIT, url, email);
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -579,7 +579,7 @@ char *get_current_file_name()
 
 void get_cloud_info(git_state *state)
 {
-	FileLocation location = getCloudLocation();
+	FileLocation location = getCloudLocation(false);
 	*state = location.gitState();
 }
 
@@ -1728,10 +1728,10 @@ extern "C" void unlock_planner()
 	planLock.unlock();
 }
 
-FileLocation getCloudLocation()
+FileLocation getCloudLocation(bool isOffline)
 {
 	QString email = QString(prefs.cloud_storage_email);
 	QString url = QString(prefs.cloud_git_url) + "/" + email;
-	return prefs.git_local_only ? FileLocation(FileLocation::CLOUD_GIT_OFFLINE, url, email)
-				    : FileLocation(FileLocation::CLOUD_GIT, url, email);
+	return isOffline ? FileLocation(FileLocation::CLOUD_GIT_OFFLINE, url, email)
+			 : FileLocation(FileLocation::CLOUD_GIT, url, email);
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -567,6 +567,12 @@ void set_filename(const FileLocation &location, bool force)
 	currentFile = location;
 }
 
+void set_filename(const FileLocation &location, const char *new_sha)
+{
+	set_filename(location, true);
+	currentFile.setSHA(new_sha);
+}
+
 void set_current_file_none()
 {
 	currentFile = FileLocation();
@@ -1730,6 +1736,9 @@ extern "C" void unlock_planner()
 
 FileLocation getCloudLocation(bool isOffline)
 {
+	// If current file is cloud location, return that to preserve the current SHA
+	if (currentFile.isCloud() && currentFile.isRemote() != isOffline)
+		return currentFile;
 	QString email = QString(prefs.cloud_storage_email);
 	QString url = QString(prefs.cloud_git_url) + "/" + email;
 	return isOffline ? FileLocation(FileLocation::CLOUD_GIT_OFFLINE, url, email)

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -58,5 +58,5 @@ void set_filename(const FileLocation &, bool force);
 extern "C" void set_current_file_none();
 extern "C" char *get_current_file_name();	// Caller must free() returned file name
 extern "C" void get_cloud_info(struct git_state *state);
-FileLocation getCloudLocation();		// Return FileLocation::NONE if no cloud was set
+FileLocation getCloudLocation(bool isOffline);	// Return FileLocation::NONE if no cloud was set
 #endif // QTHELPER_H

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -55,6 +55,7 @@ extern "C" void cache_insert(int tissue, int timestep, enum inertgas gas, double
 extern "C" void lock_planner();
 extern "C" void unlock_planner();
 void set_filename(const FileLocation &, bool force);
+void set_filename(const FileLocation &, const char *new_sha);
 extern "C" void set_current_file_none();
 extern "C" char *get_current_file_name();	// Caller must free() returned file name
 extern "C" void get_cloud_info(struct git_state *state);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include "dive.h"
 #include "divelist.h"
+#include "filelocation.h"
 #include <QTranslator>
 #include <QDir>
 
@@ -54,4 +55,9 @@ extern "C" double cache_value(int tissue, int timestep, enum inertgas gas);
 extern "C" void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 extern "C" void lock_planner();
 extern "C" void unlock_planner();
+void set_filename(const FileLocation &, bool force);
+extern "C" void set_current_file_none();
+extern "C" char *get_current_file_name();	// Caller must free() returned file name
+extern "C" int parse_git_filename(const char *fn, char **repo, char **branch);	// Caller must free() *repo and *branch
+FileLocation getCloudLocation();		// Return FileLocation::NONE if no cloud was set
 #endif // QTHELPER_H

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -38,7 +38,6 @@ depth_t string_to_depth(const char *str);
 pressure_t string_to_pressure(const char *str);
 volume_t string_to_volume(const char *str, pressure_t workp);
 fraction_t string_to_fraction(const char *str);
-int getCloudURL(QString &filename);
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
 QByteArray getCurrentAppState();
 void setCurrentAppState(QByteArray state);
@@ -58,6 +57,6 @@ extern "C" void unlock_planner();
 void set_filename(const FileLocation &, bool force);
 extern "C" void set_current_file_none();
 extern "C" char *get_current_file_name();	// Caller must free() returned file name
-extern "C" int parse_git_filename(const char *fn, char **repo, char **branch);	// Caller must free() *repo and *branch
+extern "C" void get_cloud_info(struct git_state *state);
 FileLocation getCloudLocation();		// Return FileLocation::NONE if no cloud was set
 #endif // QTHELPER_H

--- a/core/qthelperfromc.h
+++ b/core/qthelperfromc.h
@@ -5,7 +5,7 @@
 struct git_state;
 
 bool getProxyString(char **buffer);
-bool canReachCloudServer();
+bool canReachCloudServer(const char *cloud_url);
 void updateWindowTitle();
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);

--- a/core/qthelperfromc.h
+++ b/core/qthelperfromc.h
@@ -28,5 +28,8 @@ void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 void print_qt_versions();
 void lock_planner();
 void unlock_planner();
+void set_current_file_none();
+char *get_current_file_name();	// Caller must free() returned file name
+int parse_git_filename(const char *fn, char **repo, char **branch);	// Caller must free() *repo and *branch
 
 #endif // QTHELPERFROMC_H

--- a/core/qthelperfromc.h
+++ b/core/qthelperfromc.h
@@ -2,10 +2,11 @@
 #ifndef QTHELPERFROMC_H
 #define QTHELPERFROMC_H
 
+struct git_state;
+
 bool getProxyString(char **buffer);
 bool canReachCloudServer();
 void updateWindowTitle();
-bool isCloudUrl(const char *filename);
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);
 void copy_image_and_overwrite(const char *cfileName, const char *path, const char *cnewName);
@@ -31,5 +32,6 @@ void unlock_planner();
 void set_current_file_none();
 char *get_current_file_name();	// Caller must free() returned file name
 int parse_git_filename(const char *fn, char **repo, char **branch);	// Caller must free() *repo and *branch
+void get_cloud_info(struct git_state *state);
 
 #endif // QTHELPERFROMC_H

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1102,7 +1102,7 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 	put_format(msg, "Created by %s\n", subsurface_user_agent());
 }
 
-static int create_new_commit(git_repository *repo, const char *remote, const char *branch, git_oid *tree_id, bool create_empty)
+static int create_new_commit(git_repository *repo, struct git_state *state, git_oid *tree_id, bool create_empty)
 {
 	int ret;
 	git_reference *ref;
@@ -1112,31 +1112,23 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	git_commit *commit;
 	git_tree *tree;
 
-	ret = git_branch_lookup(&ref, repo, branch, GIT_BRANCH_LOCAL);
+	ret = git_branch_lookup(&ref, repo, state->branch, GIT_BRANCH_LOCAL);
 	switch (ret) {
 	default:
-		return report_error("Bad branch '%s' (%s)", branch, strerror(errno));
+		return report_error("Bad branch '%s' (%s)", state->branch, strerror(errno));
 	case GIT_EINVALIDSPEC:
-		return report_error("Invalid branch name '%s'", branch);
+		return report_error("Invalid branch name '%s'", state->branch);
 	case GIT_ENOTFOUND: /* We'll happily create it */
 		ref = NULL;
-		parent = try_to_find_parent(saved_git_id, repo);
+		parent = try_to_find_parent(state->sha, repo);
 		break;
 	case 0:
 		if (git_reference_peel(&parent, ref, GIT_OBJ_COMMIT))
-			return report_error("Unable to look up parent in branch '%s'", branch);
+			return report_error("Unable to look up parent in branch '%s'", state->branch);
 
-		if (saved_git_id) {
-			char *current_filename = get_current_file_name();
-			if (current_filename[0] && verbose)
-				fprintf(stderr, "existing filename %s\n", current_filename);
+		if (state->sha[0]) {
 			const git_oid *id = git_commit_id((const git_commit *) parent);
-			/* if we are saving to the same git tree we got this from, let's make
-			 * sure there is no confusion */
-			// TODO: Test this!
-			bool same = same_string(current_filename, remote);
-			free(current_filename);
-			if (same && git_oid_strcmp(id, saved_git_id))
+			if (git_oid_strcmp(id, state->sha))
 				return report_error("The git branch does not match the git parent of the source");
 		}
 
@@ -1170,8 +1162,8 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	}
 
 	if (!ref) {
-		if (git_branch_create(&ref, repo, branch, commit, 0))
-			return report_error("Failed to create branch '%s'", branch);
+		if (git_branch_create(&ref, repo, state->branch, commit, 0))
+			return report_error("Failed to create branch '%s'", state->branch);
 	}
 	/*
 	 * If it's a checked-out branch, try to also update the working
@@ -1185,12 +1177,12 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 			const git_error *err = giterr_last();
 			const char *errstr = err ? err->message : strerror(errno);
 			report_error("Git branch '%s' is checked out, but worktree is dirty (%s)",
-				branch, errstr);
+				state->branch, errstr);
 		}
 	}
 
 	if (git_reference_set_target(&ref, ref, &commit_id, "Subsurface save event"))
-		return report_error("Failed to update branch '%s'", branch);
+		return report_error("Failed to update branch '%s'", state->branch);
 
 	/*
 	 * if this was the empty commit to initialize a new repo, don't remember the
@@ -1198,7 +1190,7 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	 * the tree when we actually try to store the dive data
 	 */
 	if (! create_empty)
-		set_git_id(&commit_id);
+		set_git_id(state, &commit_id);
 
 	git_signature_free(author);
 
@@ -1245,7 +1237,7 @@ int do_git_save(git_repository *repo, struct git_state *state, bool select_only,
 	 * Check if we can do the cached writes - we need to
 	 * have the original git commit we loaded in the repo
 	 */
-	cached_ok = try_to_find_parent(saved_git_id, repo);
+	cached_ok = try_to_find_parent(state->sha, repo);
 
 	/* Start with an empty tree: no subdirectories, no files */
 	tree.name[0] = 0;
@@ -1265,7 +1257,7 @@ int do_git_save(git_repository *repo, struct git_state *state, bool select_only,
 		return report_error("git tree write failed");
 
 	/* And save the tree! */
-	if (create_new_commit(repo, state->location, state->branch, &id, create_empty))
+	if (create_new_commit(repo, state, &id, create_empty))
 		return report_error("creating commit failed");
 
 	if (prefs.cloud_background_sync && state->is_cloud && state->is_remote) {

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -18,7 +18,6 @@
 #include "device.h"
 #include "membuffer.h"
 #include "strndup.h"
-#include "git-access.h"
 #include "qthelperfromc.h"
 
 /*
@@ -544,7 +543,7 @@ static void save_one_device(void *_f, const char *model, uint32_t deviceid,
 	put_format(b, "/>\n");
 }
 
-int save_dives(const char *filename)
+int save_dives_file(const char *filename)
 {
 	return save_dives_logic(filename, false);
 }
@@ -713,13 +712,7 @@ int save_dives_logic(const char *filename, const bool select_only)
 {
 	struct membuffer buf = { 0 };
 	FILE *f;
-	void *git;
-	const char *branch, *remote;
 	int error;
-
-	git = is_git_repository(filename, &branch, &remote, false);
-	if (git)
-		return git_save_dives(git, branch, remote, select_only);
 
 	save_dives_buffer(&buf, select_only);
 

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -988,11 +988,6 @@ QString CloudStorageSettings::baseUrl() const
 	return QString(prefs.cloud_base_url);
 }
 
-QString CloudStorageSettings::gitUrl() const
-{
-	return QString(prefs.cloud_git_url);
-}
-
 void CloudStorageSettings::setPassword(const QString& value)
 {
 	if (value == prefs.cloud_storage_password)
@@ -1090,22 +1085,11 @@ void CloudStorageSettings::setBaseUrl(const QString& value)
 {
 	if (value == prefs.cloud_base_url)
 		return;
-
-	// dont free data segment.
-	if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
-		free((void *)prefs.cloud_base_url);
-		free((void *)prefs.cloud_git_url);
-	}
 	QSettings s;
 	s.beginGroup(group);
 	s.setValue("cloud_base_url", value);
+	free((void *)prefs.cloud_base_url);
 	prefs.cloud_base_url = copy_string(qPrintable(value));
-	prefs.cloud_git_url = copy_string(qPrintable(QString(prefs.cloud_base_url) + "/git"));
-}
-
-void CloudStorageSettings::setGitUrl(const QString& value)
-{
-	Q_UNUSED(value); /* no op */
 }
 
 DivePlannerSettings::DivePlannerSettings(QObject *parent) :
@@ -2271,10 +2255,7 @@ void SettingsObjectWrapper::load()
 	GET_INT("cloud_verification_status", cloud_verification_status);
 	GET_BOOL("cloud_background_sync", cloud_background_sync);
 
-	// creating the git url here is simply a convenience when C code wants
-	// to compare against that git URL - it's always derived from the base URL
 	GET_TXT("cloud_base_url", cloud_base_url);
-	prefs.cloud_git_url = strdup(qPrintable(QString(prefs.cloud_base_url) + "/git"));
 	s.endGroup();
 
 	// Subsurface webservice id is stored outside of the groups

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -948,11 +948,6 @@ CloudStorageSettings::CloudStorageSettings(QObject *parent) :
 
 }
 
-bool CloudStorageSettings::gitLocalOnly() const
-{
-	return prefs.git_local_only;
-}
-
 QString CloudStorageSettings::password() const
 {
 	return QString(prefs.cloud_storage_password);
@@ -1111,17 +1106,6 @@ void CloudStorageSettings::setBaseUrl(const QString& value)
 void CloudStorageSettings::setGitUrl(const QString& value)
 {
 	Q_UNUSED(value); /* no op */
-}
-
-void CloudStorageSettings::setGitLocalOnly(bool value)
-{
-	if (value == prefs.git_local_only)
-		return;
-	QSettings s;
-	s.beginGroup("CloudStorage");
-	s.setValue("git_local_only", value);
-	prefs.git_local_only = value;
-	emit gitLocalOnlyChanged(value);
 }
 
 DivePlannerSettings::DivePlannerSettings(QObject *parent) :
@@ -2286,7 +2270,6 @@ void SettingsObjectWrapper::load()
 	}
 	GET_INT("cloud_verification_status", cloud_verification_status);
 	GET_BOOL("cloud_background_sync", cloud_background_sync);
-	GET_BOOL("git_local_only", git_local_only);
 
 	// creating the git url here is simply a convenience when C code wants
 	// to compare against that git URL - it's always derived from the base URL

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -968,11 +968,6 @@ QString CloudStorageSettings::email() const
 	return QString(prefs.cloud_storage_email);
 }
 
-QString CloudStorageSettings::emailEncoded() const
-{
-	return QString(prefs.cloud_storage_email_encoded);
-}
-
 bool CloudStorageSettings::savePasswordLocal() const
 {
 	return prefs.save_password_local;
@@ -1047,16 +1042,6 @@ void CloudStorageSettings::setUserId(const QString& value)
 	free((void *)prefs.userid);
 	prefs.userid = copy_string(qPrintable(value));
 	emit userIdChanged(value);
-}
-
-void CloudStorageSettings::setEmailEncoded(const QString& value)
-{
-	if (value == prefs.cloud_storage_email_encoded)
-		return;
-	/*TODO: This looks like wrong, but 'email encoded' is not saved on disk, why it's on prefs? */
-	free((void *)prefs.cloud_storage_email_encoded);
-	prefs.cloud_storage_email_encoded = copy_string(qPrintable(value));
-	emit emailEncodedChanged(value);
 }
 
 void CloudStorageSettings::setSavePasswordLocal(bool value)

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -326,7 +326,6 @@ class CloudStorageSettings : public QObject {
 	Q_PROPERTY(QString email             READ email              WRITE setEmail              NOTIFY emailChanged)
 	Q_PROPERTY(QString userid            READ userId             WRITE setUserId             NOTIFY userIdChanged)
 	Q_PROPERTY(QString base_url          READ baseUrl            WRITE setBaseUrl            NOTIFY baseUrlChanged)
-	Q_PROPERTY(QString git_url           READ gitUrl             WRITE setGitUrl             NOTIFY gitUrlChanged)
 	Q_PROPERTY(bool save_userid_local    READ saveUserIdLocal    WRITE setSaveUserIdLocal    NOTIFY saveUserIdLocalChanged)
 	Q_PROPERTY(bool save_password_local  READ savePasswordLocal  WRITE setSavePasswordLocal  NOTIFY savePasswordLocalChanged)
 	Q_PROPERTY(short verification_status READ verificationStatus WRITE setVerificationStatus NOTIFY verificationStatusChanged)
@@ -338,7 +337,6 @@ public:
 	QString email() const;
 	QString userId() const;
 	QString baseUrl() const;
-	QString gitUrl() const;
 	bool savePasswordLocal() const;
 	short verificationStatus() const;
 	bool backgroundSync() const;
@@ -350,7 +348,6 @@ public slots:
 	void setEmail(const QString& value);
 	void setUserId(const QString& value);
 	void setBaseUrl(const QString& value);
-	void setGitUrl(const QString& value);
 	void setSavePasswordLocal(bool value);
 	void setVerificationStatus(short value);
 	void setBackgroundSync(bool value);
@@ -362,7 +359,6 @@ signals:
 	void emailChanged(const QString& value);
 	void userIdChanged(const QString& value);
 	void baseUrlChanged(const QString& value);
-	void gitUrlChanged(const QString& value);
 	void savePasswordLocalChanged(bool value);
 	void verificationStatusChanged(short value);
 	void backgroundSyncChanged(bool value);

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -324,7 +324,6 @@ class CloudStorageSettings : public QObject {
 	Q_PROPERTY(QString password          READ password           WRITE setPassword           NOTIFY passwordChanged)
 	Q_PROPERTY(QString newpassword       READ newPassword        WRITE setNewPassword        NOTIFY newPasswordChanged)
 	Q_PROPERTY(QString email             READ email              WRITE setEmail              NOTIFY emailChanged)
-	Q_PROPERTY(QString email_encoded     READ emailEncoded       WRITE setEmailEncoded       NOTIFY emailEncodedChanged)
 	Q_PROPERTY(QString userid            READ userId             WRITE setUserId             NOTIFY userIdChanged)
 	Q_PROPERTY(QString base_url          READ baseUrl            WRITE setBaseUrl            NOTIFY baseUrlChanged)
 	Q_PROPERTY(QString git_url           READ gitUrl             WRITE setGitUrl             NOTIFY gitUrlChanged)
@@ -338,7 +337,6 @@ public:
 	QString password() const;
 	QString newPassword() const;
 	QString email() const;
-	QString emailEncoded() const;
 	QString userId() const;
 	QString baseUrl() const;
 	QString gitUrl() const;
@@ -352,7 +350,6 @@ public slots:
 	void setPassword(const QString& value);
 	void setNewPassword(const QString& value);
 	void setEmail(const QString& value);
-	void setEmailEncoded(const QString& value);
 	void setUserId(const QString& value);
 	void setBaseUrl(const QString& value);
 	void setGitUrl(const QString& value);
@@ -366,7 +363,6 @@ signals:
 	void passwordChanged(const QString& value);
 	void newPasswordChanged(const QString& value);
 	void emailChanged(const QString& value);
-	void emailEncodedChanged(const QString& value);
 	void userIdChanged(const QString& value);
 	void baseUrlChanged(const QString& value);
 	void gitUrlChanged(const QString& value);

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -328,7 +328,6 @@ class CloudStorageSettings : public QObject {
 	Q_PROPERTY(QString base_url          READ baseUrl            WRITE setBaseUrl            NOTIFY baseUrlChanged)
 	Q_PROPERTY(QString git_url           READ gitUrl             WRITE setGitUrl             NOTIFY gitUrlChanged)
 	Q_PROPERTY(bool save_userid_local    READ saveUserIdLocal    WRITE setSaveUserIdLocal    NOTIFY saveUserIdLocalChanged)
-	Q_PROPERTY(bool git_local_only       READ gitLocalOnly       WRITE setGitLocalOnly       NOTIFY gitLocalOnlyChanged)
 	Q_PROPERTY(bool save_password_local  READ savePasswordLocal  WRITE setSavePasswordLocal  NOTIFY savePasswordLocalChanged)
 	Q_PROPERTY(short verification_status READ verificationStatus WRITE setVerificationStatus NOTIFY verificationStatusChanged)
 	Q_PROPERTY(bool background_sync      READ backgroundSync     WRITE setBackgroundSync     NOTIFY backgroundSyncChanged)
@@ -343,7 +342,6 @@ public:
 	bool savePasswordLocal() const;
 	short verificationStatus() const;
 	bool backgroundSync() const;
-	bool gitLocalOnly() const;
 	bool saveUserIdLocal() const;
 
 public slots:
@@ -356,7 +354,6 @@ public slots:
 	void setSavePasswordLocal(bool value);
 	void setVerificationStatus(short value);
 	void setBackgroundSync(bool value);
-	void setGitLocalOnly(bool value);
 	void setSaveUserIdLocal(bool value);
 
 signals:
@@ -369,7 +366,6 @@ signals:
 	void savePasswordLocalChanged(bool value);
 	void verificationStatusChanged(short value);
 	void backgroundSyncChanged(bool value);
-	void gitLocalOnlyChanged(bool value);
 	void saveUserIdLocalChanged(bool value);
 
 private:

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -10,7 +10,6 @@
 
 struct preferences prefs, git_prefs;
 struct preferences default_prefs = {
-	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
 	.units = SI_UNITS,
 	.unit_system = METRIC,
 	.coordinates_traditional = true,
@@ -289,6 +288,7 @@ void setup_system_prefs(void)
 #if !defined(SUBSURFACE_MOBILE)
 	default_prefs.default_filename = copy_string(system_default_filename());
 #endif
+	default_prefs.cloud_base_url = strdup("https://cloud.subsurface-divelog.org/");
 	env = getenv("LC_MEASUREMENT");
 	if (!env)
 		env = getenv("LC_ALL");
@@ -314,7 +314,6 @@ void copy_prefs(struct preferences *src, struct preferences *dest)
 	dest->default_filename = copy_string(src->default_filename);
 	dest->default_cylinder = copy_string(src->default_cylinder);
 	dest->cloud_base_url = copy_string(src->cloud_base_url);
-	dest->cloud_git_url = copy_string(src->cloud_git_url);
 	dest->userid = copy_string(src->userid);
 	dest->proxy_host = copy_string(src->proxy_host);
 	dest->proxy_user = copy_string(src->proxy_user);

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -164,15 +164,14 @@ void print_version()
 
 void print_files()
 {
-	const char *branch = 0;
-	const char *remote = 0;
+	char *branch = 0;
+	char *remote = 0;
 	const char *filename, *local_git;
 
 	printf("\nFile locations:\n\n");
 	if (!same_string(prefs.cloud_storage_email, "") && !same_string(prefs.cloud_storage_password, "")) {
 		filename = cloud_url();
-
-		is_git_repository(filename, &branch, &remote, true);
+		parse_git_filename(filename, &branch, &remote);
 	} else {
 		/* strdup so the free below works in either case */
 		filename = strdup("No valid cloud credentials set.\n");
@@ -183,6 +182,8 @@ void print_files()
 	} else {
 		printf("Unable to get local git directory\n");
 	}
+	free(branch);
+	free(remote);
 	printf("Cloud URL: %s\n", filename);
 	free((void *)filename);
 	char *tmp = hashfile_name_string();

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -164,28 +164,22 @@ void print_version()
 
 void print_files()
 {
-	char *branch = 0;
-	char *remote = 0;
-	const char *filename, *local_git;
+	struct git_state cloud_state;
+	char *local_git;
 
 	printf("\nFile locations:\n\n");
 	if (!same_string(prefs.cloud_storage_email, "") && !same_string(prefs.cloud_storage_password, "")) {
-		filename = cloud_url();
-		parse_git_filename(filename, &branch, &remote);
-	} else {
-		/* strdup so the free below works in either case */
-		filename = strdup("No valid cloud credentials set.\n");
-	}
-	if (branch && remote) {
-		local_git = get_local_dir(remote, branch);
+		get_cloud_info(&cloud_state);
+		printf("Cloud repository: %s\n", cloud_state.location);
+		printf("Cloud branch: %s\n", cloud_state.branch);
+		printf("Cloud user: %s\n", cloud_state.user);
+		printf("Cloud local only: %s\n", cloud_state.is_remote ? "no" : "yes");
+		local_git = get_local_dir(&cloud_state);
 		printf("Local git storage: %s\n", local_git);
+		free(local_git);
 	} else {
-		printf("Unable to get local git directory\n");
+		printf("No valid cloud credentials set.\n");
 	}
-	free(branch);
-	free(remote);
-	printf("Cloud URL: %s\n", filename);
-	free((void *)filename);
 	char *tmp = hashfile_name_string();
 	printf("Image hashes: %s\n", tmp);
 	free(tmp);
@@ -334,7 +328,6 @@ void copy_prefs(struct preferences *src, struct preferences *dest)
 	dest->cloud_storage_password = copy_string(src->cloud_storage_password);
 	dest->cloud_storage_newpassword = copy_string(src->cloud_storage_newpassword);
 	dest->cloud_storage_email = copy_string(src->cloud_storage_email);
-	dest->cloud_storage_email_encoded = copy_string(src->cloud_storage_email_encoded);
 	dest->facebook.access_token = copy_string(src->facebook.access_token);
 	dest->facebook.user_id = copy_string(src->facebook.user_id);
 	dest->facebook.album_id = copy_string(src->facebook.album_id);

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -11,9 +11,6 @@
 struct preferences prefs, git_prefs;
 struct preferences default_prefs = {
 	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
-#if defined(SUBSURFACE_MOBILE)
-	.git_local_only = true,
-#endif
 	.units = SI_UNITS,
 	.unit_system = METRIC,
 	.coordinates_traditional = true,

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -7,6 +7,7 @@
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 // For fill_computer_list, descriptorLookup
 #include "core/downloadfromdcthread.h"
+#include "core/filelocation.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -322,9 +323,7 @@ void OstcFirmwareCheck::upgradeFirmware()
 	QString saveFileName = latestFirmwareHexFile;
 	saveFileName.replace("http://www.heinrichsweikamp.net/autofirmware/", "");
 	saveFileName.replace("firmware", latestFirmwareAvailable);
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append(saveFileName);
+	QString filename = currentFile.path().append(QDir::separator()).append(saveFileName);
 	storeFirmware = QFileDialog::getSaveFileName(parent, tr("Save the downloaded firmware as"),
 						     filename, tr("Firmware files") + " (*.hex *.bin)");
 	if (storeFirmware.isEmpty())
@@ -1368,9 +1367,7 @@ void ConfigureDiveComputerDialog::reloadValuesOSTC4()
 
 void ConfigureDiveComputerDialog::on_backupButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
+	QString filename = currentFile.path().append(QDir::separator()).append("Backup.xml");
 	QString backupPath = QFileDialog::getSaveFileName(this, tr("Backup dive computer settings"),
 							  filename, tr("Backup files") + " (*.xml)");
 	if (!backupPath.isEmpty()) {
@@ -1389,9 +1386,7 @@ void ConfigureDiveComputerDialog::on_backupButton_clicked()
 
 void ConfigureDiveComputerDialog::on_restoreBackupButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
+	QString filename = currentFile.path().append(QDir::separator()).append("Backup.xml");
 	QString restorePath = QFileDialog::getOpenFileName(this, tr("Restore dive computer settings"),
 							   filename, tr("Backup files") + " (*.xml)");
 	if (!restorePath.isEmpty()) {
@@ -1411,9 +1406,7 @@ void ConfigureDiveComputerDialog::on_restoreBackupButton_clicked()
 
 void ConfigureDiveComputerDialog::on_updateFirmwareButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath();
+	QString filename = currentFile.path();
 	QString firmwarePath = QFileDialog::getOpenFileName(this, tr("Select firmware file"),
 							    filename, tr("All files") + " (*.*)");
 	if (!firmwarePath.isEmpty()) {
@@ -1472,9 +1465,7 @@ void ConfigureDiveComputerDialog::checkLogFile(int state)
 
 void ConfigureDiveComputerDialog::pickLogFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
+	QString filename = currentFile.path().append(QDir::separator()).append("subsurface.log");
 	logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
 					       filename, tr("Log files") + " (*.log)");
 	if (!logFile.isEmpty()) {

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -6,6 +6,7 @@
 #include "core/display.h"
 #include "core/uemis.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include "core/filelocation.h"
 #include "qt-models/models.h"
 #include "qt-models/diveimportedmodel.h"
 
@@ -358,9 +359,7 @@ void DownloadFromDCWidget::checkLogFile(int state)
 
 void DownloadFromDCWidget::pickLogFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
+	QString filename = currentFile.path().append(QDir::separator()).append("subsurface.log");
 	QString logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
 					       filename, tr("Log files") + " (*.log)");
 	if (!logFile.isEmpty()) {
@@ -384,9 +383,7 @@ void DownloadFromDCWidget::checkDumpFile(int state)
 
 void DownloadFromDCWidget::pickDumpFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
-	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.bin");
+	QString filename = currentFile.path().append(QDir::separator()).append("subsurface.bin");
 	QString dumpFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer binary dump file"),
 						filename, tr("Dump files") + " (*.bin)");
 	if (!dumpFile.isEmpty()) {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -619,7 +619,8 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 		report_error(qPrintable(tr("Don't save an empty log to the cloud")));
 		return;
 	}
-	if (getCloudURL(filename))
+	FileLocation location = getCloudLocation();
+	if (location.getType() == FileLocation::NONE)
 		return;
 
 	if (verbose)
@@ -627,7 +628,6 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 	if (information()->isEditing())
 		information()->acceptChanges();
 
-	FileLocation location = getCloudLocation();
 	showProgressBar();
 	int error = saveDives(location);
 	hideProgressBar();
@@ -1667,9 +1667,12 @@ int MainWindow::saveDives(const FileLocation &f)
 		break;
 	case FileLocation::GIT:
 	case FileLocation::CLOUD_GIT:
-	case FileLocation::CLOUD_GIT_OFFLINE:
-		res = save_dives_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
+	case FileLocation::CLOUD_GIT_OFFLINE: {
+		git_state state = f.gitState();
+		res = save_dives_git(&state);
+		free_git_state(&state);
 		break;
+	}
 	case FileLocation::NONE:
 	default:
 		;	// Leave error marker on
@@ -1691,9 +1694,12 @@ int MainWindow::loadDives(const FileLocation &f)
 		break;
 	case FileLocation::GIT:
 	case FileLocation::CLOUD_GIT:
-	case FileLocation::CLOUD_GIT_OFFLINE:
-		res = parse_file_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
+	case FileLocation::CLOUD_GIT_OFFLINE: {
+		git_state state = f.gitState();
+		res = parse_file_git(&state);
+		free_git_state(&state);
 		break;
+	}
 	case FileLocation::NONE:
 	default:
 		;	// Leave error marker on

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -19,6 +19,7 @@
 #include "desktop-widgets/notificationwidget.h"
 #include "core/windowtitleupdate.h"
 #include "core/gpslocation.h"
+#include "core/filelocation.h"
 
 #define NUM_RECENT_FILES 4
 
@@ -69,14 +70,14 @@ public:
 	void loadRecentFiles();
 	void updateRecentFiles();
 	void updateRecentFilesMenu();
-	void addRecentFile(const QString &file, bool update);
+	void addRecentFile(const FileLocation &file, bool update);
 	DiveListView *dive_list();
 	DivePlannerWidget *divePlannerWidget();
 	PlannerSettingsWidget *divePlannerSettingsWidget();
 	LocationInformationWidget *locationInformationWidget();
 	void setTitle(enum MainWindowTitleFormat format = MWTF_FILENAME);
 
-	void loadFiles(const QStringList files);
+	void loadFiles(const QList<FileLocation> &files);
 	void importFiles(const QStringList importFiles);
 	void importTxtFiles(const QStringList fileNames);
 	void cleanUpEmpty();
@@ -199,7 +200,6 @@ private:
 	QString filter_open();
 	QString filter_import();
 	static MainWindow *m_Instance;
-	QString displayedFilename(QString fullFilename);
 	bool askSaveChanges();
 	bool okToClose(QString message);
 	void closeCurrentFile();
@@ -208,10 +208,13 @@ private:
 	void writeSettings();
 	int file_save();
 	int file_save_as();
+	int loadDives(const FileLocation &);
+	int saveDives(const FileLocation &);
 	void beginChangeState(CurrentState s);
 	void saveSplitterSizes();
 	QString lastUsedDir();
 	void updateLastUsedDir(const QString &s);
+	void updateLastUsedDir(const FileLocation &);
 	void registerApplicationState(const QByteArray& state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight);
 	bool filesAsArguments;
 	UpdateManager *updateManager;
@@ -224,7 +227,7 @@ private:
 	struct dive copyPasteDive;
 	struct dive_components what;
 	QList<QAction *> profileToolbarActions;
-	QStringList recentFiles;
+	QList<FileLocation> recentFiles;
 	QAction *actionsRecent[NUM_RECENT_FILES];
 
 	struct WidgetForQuadrant {

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -229,6 +229,7 @@ private:
 	QList<QAction *> profileToolbarActions;
 	QList<FileLocation> recentFiles;
 	QAction *actionsRecent[NUM_RECENT_FILES];
+	bool cloudIsOffline;
 
 	struct WidgetForQuadrant {
 		WidgetForQuadrant(QWidget *tl = 0, QWidget *tr = 0, QWidget *bl = 0, QWidget *br = 0) :

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -28,13 +28,22 @@
 #include "core/membuffer.h"
 #include "qt-models/tankinfomodel.h"
 #include "core/downloadfromdcthread.h"
+#include "core/filelocation.h"
 
 QMLManager *QMLManager::m_instance = NULL;
 
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
 #define END_FONT QLatin1Literal("</font>")
 
-#define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
+static const FileLocation &noCloudLocalStorage()
+{
+	static FileLocation loc;
+	if (loc.isNone()) {
+		QString repo = QString(system_default_directory()) + "/cloudstorage/localrepo";
+		loc = FileLocation(FileLocation::GIT, repo, QString("master"));
+	}
+	return loc;
+}
 
 static void progressCallback(const char *text)
 {
@@ -186,15 +195,11 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 	}
 }
 
-void QMLManager::openLocalThenRemote(QString url)
+void QMLManager::openLocalThenRemote(const FileLocation &f)
 {
 	clear_dive_file_data();
 	setNotificationText(tr("Open local dive data file"));
-	QByteArray fileNamePrt = QFile::encodeName(url);
-	bool glo = prefs.git_local_only;
-	prefs.git_local_only = true;
-	int error = parse_file(fileNamePrt.data());
-	prefs.git_local_only = glo;
+	int error = parse_file_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
 	if (error) {
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
 		setNotificationText(tr("Opening local data file failed"));
@@ -240,7 +245,7 @@ void QMLManager::openLocalThenRemote(QString url)
 		prefs.git_local_only = false;
 		appendTextToLog(QStringLiteral("taking things online to be able to switch to cloud account"));
 	}
-	set_filename(fileNamePrt.data(), true);
+	set_filename(f, true);
 	if (prefs.git_local_only) {
 		appendTextToLog(QStringLiteral("have cloud credentials, but user asked not to connect to network"));
 		alreadySaving = false;
@@ -252,8 +257,8 @@ void QMLManager::openLocalThenRemote(QString url)
 
 void QMLManager::mergeLocalRepo()
 {
-	char *filename = NOCLOUD_LOCALSTORAGE;
-	parse_file(filename);
+	const FileLocation &f = noCloudLocalStorage();
+	parse_file_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
 	process_dives(true, false);
 }
 
@@ -308,21 +313,22 @@ void QMLManager::finishSetup()
 		// we know that we are the first ones to access git storage, so we don't need to test,
 		// but we need to make sure we stay the only ones accessing git storage
 		alreadySaving = true;
-		openLocalThenRemote(url);
-	} else if (!same_string(existing_filename, "") && credentialStatus() != CS_UNKNOWN) {
+		openLocalThenRemote(FileLocation(FileLocation::CLOUD_GIT, url));
+	} else if (currentFile.isNone() && credentialStatus() != CS_UNKNOWN) {
 		setCredentialStatus(CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
-		int error = parse_file(existing_filename);
+		const FileLocation &f = currentFile;
+		int error = parse_file_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
 		if (error) {
 			// we got an error loading the local file
-			appendTextToLog(QString("got error %2 when parsing file %1").arg(existing_filename, get_error_string()));
+			appendTextToLog(QString("got error %2 when parsing file %1").arg(currentFile.formatShort(), get_error_string()));
 			setNotificationText(tr("Error parsing local storage, giving up"));
-			set_filename(NULL, true);
+			set_filename(FileLocation(), true);
 		} else {
 			// successfully opened the local file, now add thigs to the dive list
 			consumeFinishedLoad(0);
-			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(existing_filename));
+			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(currentFile.formatShort()));
 		}
 	} else {
 		setCredentialStatus(CS_UNKNOWN);
@@ -408,8 +414,7 @@ void QMLManager::saveCloudCredentials()
 		free((void *)prefs.userid);
 		prefs.userid = NULL;
 		syncLoadFromCloud();
-		QString url;
-		getCloudURL(url);
+		FileLocation location = getCloudLocation();
 		manager()->clearAccessCache(); // remove any chached credentials
 		clear_git_id(); // invalidate our remembered GIT SHA
 		clear_dive_file_data();
@@ -423,7 +428,7 @@ void QMLManager::saveCloudCredentials()
 		// of whether we're in offline mode or not, to make sure the repository is synced
 		currentGitLocalOnly = prefs.git_local_only;
 		prefs.git_local_only = false;
-		openLocalThenRemote(url);
+		openLocalThenRemote(location);
 	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY && !cloudPin().isEmpty()) {
 		// the user entered a PIN?
 		tryRetrieveDataFromBackend();
@@ -574,11 +579,12 @@ void QMLManager::loadDivesWithValidCredentials()
 		revertToNoCloudIfNeeded();
 		return;
 	}
-	QByteArray fileNamePrt = QFile::encodeName(url);
+	FileLocation f(prefs.git_local_only ? FileLocation::CLOUD_GIT_OFFLINE : FileLocation::CLOUD_GIT, url);
 	git_repository *git;
-	const char *branch;
 	int error;
-	if (check_git_sha(fileNamePrt.data(), &git, &branch) == 0) {
+	QString branch = f.getBranch();
+	if (check_git_sha(qPrintable(f.getName()), qPrintable(branch), qPrintable(f.getUser()),
+			  f.isRemote(), f.isCloud(), &git) == 0) {
 		appendTextToLog("Cloud sync shows local cache was current");
 		goto successful_exit;
 	}
@@ -587,18 +593,18 @@ void QMLManager::loadDivesWithValidCredentials()
 	clear_dive_file_data();
 	if (git != dummy_git_repository) {
 		appendTextToLog(QString("have repository and branch %1").arg(branch));
-		error = git_load_dives(git, branch);
+		error = git_load_dives(git, qPrintable(branch));
 	} else {
 		appendTextToLog(QString("didn't receive valid git repo, try again"));
-		error = parse_file(fileNamePrt.data());
+		error = parse_file_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
 	}
 	if (!error) {
-		report_error("filename is now %s", fileNamePrt.data());
+		report_error("filename is now %s", qPrintable(f.formatShort()));
 		QString errorString(get_error_string());
 		appendTextToLog(errorString);
-		set_filename(fileNamePrt.data(), true);
+		set_filename(f, true);
 	} else {
-		report_error("failed to open file %s", fileNamePrt.data());
+		report_error("failed to open file %s", qPrintable(f.formatLong()));
 		QString errorString(get_error_string());
 		appendTextToLog(errorString);
 		setNotificationText(errorString);
@@ -657,7 +663,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		setCloudUserName("");
 		setCloudPassword("");
 		setCredentialStatus(CS_NOCLOUD);
-		set_filename(NOCLOUD_LOCALSTORAGE, true);
+		set_filename(noCloudLocalStorage(), true);
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}
 	alreadySaving = false;
@@ -1090,35 +1096,34 @@ void QMLManager::openNoCloudRepo()
  * is obviously empty when just created.
  */
 {
-	char *filename = NOCLOUD_LOCALSTORAGE;
-	const char *branch;
+	const FileLocation &f = noCloudLocalStorage();
 	struct git_repository *git;
 
-	git = is_git_repository(filename, &branch, NULL, false);
+	git = is_git_repository(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud());
 
 	if (git == dummy_git_repository) {
-		if (git_create_local_repo(filename))
+		if (git_create_local_repo(qPrintable(f.getName())))
 			appendTextToLog(get_error_string());
-		set_filename(filename, true);
+		set_filename(f, true);
 		GeneralSettingsObjectWrapper s(this);
-		s.setDefaultFilename(filename);
+		s.setDefaultFilename(f.getName());
 		s.setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
 	}
 
-	openLocalThenRemote(filename);
+	openLocalThenRemote(f);
 }
 
 void QMLManager::saveChangesLocal()
 {
 	if (unsaved_changes()) {
 		if (credentialStatus() == CS_NOCLOUD) {
-			if (same_string(existing_filename, "")) {
-				char *filename = NOCLOUD_LOCALSTORAGE;
-				if (git_create_local_repo(filename))
+			if (currentFile.isNone()) {
+				const FileLocation &f = noCloudLocalStorage();
+				if (git_create_local_repo(qPrintable(f.getName())))
 					appendTextToLog(get_error_string());
-				set_filename(filename, true);
+				set_filename(f, true);
 				GeneralSettingsObjectWrapper s(this);
-				s.setDefaultFilename(filename);
+				s.setDefaultFilename(f.getName());
 				s.setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
 			}
 		} else if (!loadFromCloud()) {
@@ -1132,18 +1137,15 @@ void QMLManager::saveChangesLocal()
 			return;
 		}
 		alreadySaving = true;
-		bool glo = prefs.git_local_only;
-		prefs.git_local_only = true;
-		if (save_dives(existing_filename)) {
+		const FileLocation &f = currentFile;
+		if (save_dives_git(qPrintable(f.getName()), qPrintable(f.getBranch()), qPrintable(f.getUser()), f.isRemote(), f.isCloud())) {
 			QString errorString(get_error_string());
 			appendTextToLog(errorString);
 			setNotificationText(errorString);
-			set_filename(NULL, true);
-			prefs.git_local_only = glo;
+			set_filename(FileLocation(), true);
 			alreadySaving = false;
 			return;
 		}
-		prefs.git_local_only = glo;
 		mark_divelist_changed(false);
 		alreadySaving = false;
 	} else {
@@ -1481,7 +1483,7 @@ void QMLManager::setCredentialStatus(const cloud_status_qml value)
 		setOldStatus(m_credentialStatus);
 		if (value == CS_NOCLOUD) {
 			appendTextToLog("Switching to no cloud mode");
-			set_filename(NOCLOUD_LOCALSTORAGE, true);
+			set_filename(noCloudLocalStorage(), true);
 			clearCredentials();
 		}
 		m_credentialStatus = value;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -175,7 +175,7 @@ public slots:
 	void clearCredentials();
 	void cancelCredentialsPinSetup();
 	void finishSetup();
-	void openLocalThenRemote(QString url);
+	void openLocalThenRemote(const FileLocation &file);
 	void mergeLocalRepo();
 	QString getNumber(const QString& diveId);
 	QString getDate(const QString& diveId);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -216,6 +216,7 @@ private:
 	struct dive_trip *deletedTrip;
 	QString m_notificationText;
 	bool m_syncToCloud;
+	bool m_cloudIsOffline;
 	int m_updateSelectedDive;
 	int m_selectedDiveTimestamp;
 	cloud_status_qml m_credentialStatus;

--- a/subsurface-desktop-helper.cpp
+++ b/subsurface-desktop-helper.cpp
@@ -13,6 +13,7 @@
 #include <QLibraryInfo>
 
 #include "core/qt-gui.h"
+#include "core/filelocation.h"
 
 #ifdef SUBSURFACE_MOBILE
 #include <QQuickWindow>
@@ -33,7 +34,7 @@ void init_ui()
 	PluginManager::instance().loadPlugins();
 
 	window = new MainWindow();
-	if (existing_filename && existing_filename[0] != '\0')
+	if (!currentFile.isNone())
 		window->setTitle(MWTF_FILENAME);
 	else
 		window->setTitle(MWTF_DEFAULT);
@@ -49,7 +50,6 @@ void exit_ui()
 {
 	delete window;
 	delete qApp;
-	free((void *)existing_filename);
 }
 
 double get_screen_dpi()

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 			if (!same_string(prefs.default_filename, ""))
 				files.push_back(FileLocation::guessFromFileName(prefs.default_filename));
 		} else if (prefs.default_file_behavior == CLOUD_DEFAULT_FILE) {
-			files.push_back(getCloudLocation());
+			files.push_back(getCloudLocation(false));
 		}
 	}
 	MainWindow *m = MainWindow::instance();

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -16,6 +16,7 @@
 #include "desktop-widgets/diveplanner.h"
 #include "core/color.h"
 #include "core/qthelper.h"
+#include "core/filelocation.h"
 #include "core/downloadfromdcthread.h" // for fill_computer_list
 
 #include <QStringList>
@@ -106,7 +107,10 @@ int main(int argc, char **argv)
 	filesOnCommandLine = !files.isEmpty() || !importedFiles.isEmpty();
 	if (verbose && !files.isEmpty())
 		qDebug() << "loading dive data from" << files;
-	m->loadFiles(files);
+	QList<FileLocation> locations;
+	Q_FOREACH (QString filename, files)
+		locations.append(FileLocation::guessFromFileName(filename));
+	m->loadFiles(locations);
 	if (verbose && !importedFiles.isEmpty())
 		qDebug() << "importing dive data from" << importedFiles;
 	m->importFiles(importedFiles);

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 	QApplication *application = new QApplication(argc, argv);
 	(void)application;
-	QStringList files;
+	QList<FileLocation> files;
 	QStringList importedFiles;
 	QStringList arguments = QCoreApplication::arguments();
 
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 			importedFiles.push_back(a);
 		} else {
 			no_filenames = false;
-			files.push_back(a);
+			files.push_back(FileLocation::guessFromFileName(a));
 		}
 	}
 	if (subsurface_user_is_root() && !force_root) {
@@ -94,23 +94,18 @@ int main(int argc, char **argv)
 	init_ui();
 	if (no_filenames) {
 		if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE) {
-			QString defaultFile(prefs.default_filename);
-			if (!defaultFile.isEmpty())
-				files.push_back(QString(prefs.default_filename));
+			if (!same_string(prefs.default_filename, ""))
+				files.push_back(FileLocation::guessFromFileName(prefs.default_filename));
 		} else if (prefs.default_file_behavior == CLOUD_DEFAULT_FILE) {
-			QString cloudURL;
-			if (getCloudURL(cloudURL) == 0)
-				files.push_back(cloudURL);
+			files.push_back(getCloudLocation());
 		}
 	}
 	MainWindow *m = MainWindow::instance();
 	filesOnCommandLine = !files.isEmpty() || !importedFiles.isEmpty();
 	if (verbose && !files.isEmpty())
-		qDebug() << "loading dive data from" << files;
-	QList<FileLocation> locations;
-	Q_FOREACH (QString filename, files)
-		locations.append(FileLocation::guessFromFileName(filename));
-	m->loadFiles(locations);
+		foreach(const FileLocation &f, files)
+			qDebug() << "loading dive data from" << f.formatLong();
+	m->loadFiles(files);
 	if (verbose && !importedFiles.isEmpty())
 		qDebug() << "importing dive data from" << importedFiles;
 	m->importFiles(importedFiles);

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -126,7 +126,6 @@ void run_ui()
 void exit_ui()
 {
 	delete qApp;
-	free((void *)existing_filename);
 }
 
 double get_screen_dpi()

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -13,6 +13,7 @@
 #include "core/qthelper.h"
 #include "core/helpers.h"
 #include "core/downloadfromdcthread.h"
+#include "core/filelocation.h"
 
 #include <QStringList>
 #include <QApplication>
@@ -52,9 +53,9 @@ int main(int argc, char **argv)
 	taglist_init_global();
 	init_ui();
 	if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE)
-		set_filename(prefs.default_filename, true);
+		set_filename(FileLocation::guessFromFileName(prefs.default_filename), true);
 	else
-		set_filename(NULL, true);
+		set_filename(FileLocation(), true);
 
 	// some hard coded settings
 	prefs.animation_speed = 0; // we render the profile to pixmap, no animations

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -36,9 +36,6 @@ void TestGitStorage::initTestCase()
 	s.beginGroup("CloudStorage");
 	GET_TXT("cloud_base_url", cloud_base_url);
 	QString gitUrl(prefs.cloud_base_url);
-	if (gitUrl.right(1) != "/")
-		gitUrl += "/";
-	prefs.cloud_git_url = strdup(qUtf8Printable(gitUrl + "git"));
 	prefs.cloud_storage_email = strdup(qUtf8Printable("ssrftest@hohndel.org"));
 	s.endGroup();
 	prefs.cloud_storage_password = strdup("geheim");

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -95,11 +95,11 @@ void TestGitStorage::testGitStorageLocal()
 	QString repoNameRead = prefixRead + testDirName;
 	QString repoNameWrite = prefixWrite + testDirName;
 	QCOMPARE(git_repository_init(&repo, qUtf8Printable(testDirName), false), 0);
-	QCOMPARE(save_dives(qUtf8Printable(repoNameWrite + "[test]")), 0);
-	QCOMPARE(save_dives("./SampleDivesV3.ssrf"), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(repoNameWrite), "test", "", false, false), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qUtf8Printable(repoNameRead + "[test]")), 0);
-	QCOMPARE(save_dives("./SampleDivesV3viagit.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(repoNameRead), "test", "", false, false), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3viagit.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesV3viagit.ssrf");
@@ -116,12 +116,13 @@ void TestGitStorage::testGitStorageCloud()
 	// test writing and reading back from cloud storage
 	// connect to the ssrftest repository on the cloud server
 	// and repeat the same test as before with the local git storage
-	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
+	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
+	QString cloudTestBranch("ssrftest@hohndel.org");
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesV3viacloud.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesV3viacloud.ssrf");
@@ -137,22 +138,22 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 {
 	// make a change to local cache repo (pretending that we did some offline changes)
 	// and then open the remote one again and check that things were propagated correctly
-	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
+	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
+	QString cloudTestBranch("ssrftest@hohndel.org");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	// read the local repo from the previous test and add dive 10
-	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml"), 0);
 	// calling process_dive() sorts the table, but calling it with
 	// is_imported == true causes it to try to update the window title... let's not do that
 	process_dives(false, false);
 	// now save only to the local cache but not to the remote server
-	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesV3plus10local.ssrf"), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3plus10local.ssrf"), 0);
 	clear_dive_file_data();
 	// open the cloud storage and compare
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesV3plus10viacloud.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3plus10viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10local.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesV3plus10viacloud.ssrf");
@@ -163,14 +164,14 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
 	// write back out to cloud storage, move away the local cache, open again and compare
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
 	QDir localCacheDirectory(localCacheDir);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectorySave.removeRecursively(), true);
 	QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesV3plus10fromcloud.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3plus10fromcloud.ssrf"), 0);
 	org.close();
 	org.open(QFile::ReadOnly);
 	QFile out2("./SampleDivesV3plus10fromcloud.ssrf");
@@ -187,20 +188,21 @@ void TestGitStorage::testGitStorageCloudMerge()
 	// now we need to mess with the local git repo to get an actual merge
 	// first we add another dive to the "moved away" repository, pretending we did
 	// another offline change there
-	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
+	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
+	QString cloudTestBranch("ssrftest@hohndel.org");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QString localCacheRepoSave = localCacheDir + "save[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qUtf8Printable(localCacheRepoSave)), 0);
+	QString localCacheRepoSave = localCacheDir + "save";
+	QCOMPARE(parse_file_git(qUtf8Printable(localCacheRepoSave), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives(qUtf8Printable(localCacheRepoSave)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(localCacheRepoSave), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -209,15 +211,15 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectory.rename(localCacheDir + "save", localCacheDir), true);
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12-merged.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3plus10-11-12-merged.ssrf"), 0);
 	clear_dive_file_data();
 	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf"), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12.ssrf"), 0);
+	QCOMPARE(save_dives_file("./SampleDivesV3plus10-11-12.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10-11-12-merged.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesV3plus10-11-12.ssrf");
@@ -234,15 +236,15 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	// delete a dive offline
 	// edit the same dive in the cloud repo
 	// merge
-	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
+	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
+	QString cloudTestBranch("ssrftest@hohndel.org");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
-	QCOMPARE(save_dives("./SampleDivesMinus1.ssrf"), 0);
-	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
+	QCOMPARE(save_dives_file("./SampleDivesMinus1.ssrf"), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -253,13 +255,13 @@ void TestGitStorage::testGitStorageCloudMerge2()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify that first dive
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	process_dives(false, false);
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
 	free(dive->notes);
 	dive->notes = strdup("These notes have been modified by TestGitStorage");
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -269,9 +271,9 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesMinus1-merged.ssrf"), 0);
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesMinus1-merged.ssrf"), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	QFile org("./SampleDivesMinus1-merged.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesMinus1.ssrf");
@@ -290,10 +292,10 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	// edit the same dive notes in the cloud repo
 	// merge
 	clear_dive_file_data();
-	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
+	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
+	QString cloudTestBranch("ssrftest@hohndel.org");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(0);
 	QVERIFY(dive != 0);
@@ -302,10 +304,10 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
 	dive = get_dive(2);
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
 
-	QCOMPARE(parse_file(qUtf8Printable(localCacheRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Create multi line dive notes\nDifferent line 2 and removed 3-5\n\nThat should be enough");
@@ -313,7 +315,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
 	dive = get_dive(2);
 	dive->notes = strdup("single line dive notes");
-	QCOMPARE(save_dives(qUtf8Printable(localCacheRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -324,7 +326,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify those first dive notes differently
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Completely different dive notes\nBut also multi line");
@@ -332,7 +334,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("single line dive notes");
 	dive = get_dive(2);
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
-	QCOMPARE(save_dives(qUtf8Printable(cloudTestRepo)), 0);
+	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -342,8 +344,8 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qUtf8Printable(cloudTestRepo)), 0);
-	QCOMPARE(save_dives("./SampleDivesMerge3.ssrf"), 0);
+	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_file("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge
 }

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -7,15 +7,14 @@
 #include "core/file.h"
 #include "core/prefs-macros.h"
 #include "core/subsurfacestartup.h"
+#include "core/filelocation.h"
+#include "core/git-access.h"
 
 #include <QDir>
 #include <QTextStream>
 #include <QNetworkProxy>
 #include <QSettings>
 #include <QDebug>
-
-// this is a local helper function in git-access.c
-extern "C" char *get_local_dir(const char *remote, const char *branch);
 
 void TestGitStorage::initTestCase()
 {
@@ -40,8 +39,8 @@ void TestGitStorage::initTestCase()
 	if (gitUrl.right(1) != "/")
 		gitUrl += "/";
 	prefs.cloud_git_url = strdup(qUtf8Printable(gitUrl + "git"));
+	prefs.cloud_storage_email = strdup(qUtf8Printable("ssrftest@hohndel.org"));
 	s.endGroup();
-	prefs.cloud_storage_email_encoded = strdup("ssrftest@hohndel.org");
 	prefs.cloud_storage_password = strdup("geheim");
 	prefs.cloud_background_sync = true;
 	QNetworkProxy proxy;
@@ -55,7 +54,10 @@ void TestGitStorage::initTestCase()
 	QNetworkProxy::setApplicationProxy(proxy);
 
 	// now cleanup the cache dir in case there's something weird from previous runs
-	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
+	FileLocation loc(FileLocation::CLOUD_GIT, "https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org");
+	git_state state = loc.gitState();
+	QString localCacheDir(get_local_dir(&state));
+	free_git_state(&state);
 	QDir localCacheDirectory(localCacheDir);
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 }
@@ -92,13 +94,15 @@ void TestGitStorage::testGitStorageLocal()
 	QDir testDir(testDirName);
 	QCOMPARE(testDir.removeRecursively(), true);
 	QCOMPARE(QDir().mkdir(testDirName), true);
-	QString repoNameRead = prefixRead + testDirName;
-	QString repoNameWrite = prefixWrite + testDirName;
+	FileLocation locRead(FileLocation::GIT, prefixRead + testDirName, "test");
+	FileLocation locWrite(FileLocation::GIT, prefixWrite + testDirName, "test");
+	git_state stateRead = locRead.gitState();
+	git_state stateWrite = locWrite.gitState();
 	QCOMPARE(git_repository_init(&repo, qUtf8Printable(testDirName), false), 0);
-	QCOMPARE(save_dives_git(qUtf8Printable(repoNameWrite), "test", "", false, false), 0);
+	QCOMPARE(save_dives_git(&stateWrite), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file_git(qUtf8Printable(repoNameRead), "test", "", false, false), 0);
+	QCOMPARE(parse_file_git(&stateRead), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3viagit.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -109,6 +113,8 @@ void TestGitStorage::testGitStorageLocal()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
+	free_git_state(&stateRead);
+	free_git_state(&stateWrite);
 }
 
 void TestGitStorage::testGitStorageCloud()
@@ -118,10 +124,12 @@ void TestGitStorage::testGitStorageCloud()
 	// and repeat the same test as before with the local git storage
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
 	QString cloudTestBranch("ssrftest@hohndel.org");
+	FileLocation loc(FileLocation::CLOUD_GIT, cloudTestRepo, cloudTestBranch);
+	git_state state = loc.gitState();
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -132,6 +140,7 @@ void TestGitStorage::testGitStorageCloud()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
+	free_git_state(&state);
 }
 
 void TestGitStorage::testGitStorageCloudOfflineSync()
@@ -140,19 +149,23 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	// and then open the remote one again and check that things were propagated correctly
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
 	QString cloudTestBranch("ssrftest@hohndel.org");
-	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
+	FileLocation loc(FileLocation::CLOUD_GIT, cloudTestRepo, cloudTestBranch);
+	git_state state = loc.gitState();
+	QString localCacheDir(get_local_dir(&state));
+	FileLocation loc_local(FileLocation::GIT, localCacheDir, cloudTestBranch);
+	git_state local_state = loc_local.gitState();
 	// read the local repo from the previous test and add dive 10
-	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(parse_file_git(&local_state), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml"), 0);
 	// calling process_dive() sorts the table, but calling it with
 	// is_imported == true causes it to try to update the window title... let's not do that
 	process_dives(false, false);
 	// now save only to the local cache but not to the remote server
-	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(save_dives_git(&local_state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3plus10local.ssrf"), 0);
 	clear_dive_file_data();
 	// open the cloud storage and compare
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3plus10viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10local.ssrf");
 	org.open(QFile::ReadOnly);
@@ -164,13 +177,13 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
 	// write back out to cloud storage, move away the local cache, open again and compare
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
 	QDir localCacheDirectory(localCacheDir);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectorySave.removeRecursively(), true);
 	QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3plus10fromcloud.ssrf"), 0);
 	org.close();
 	org.open(QFile::ReadOnly);
@@ -181,6 +194,8 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	readin = orgS2.readAll();
 	written = outS2.readAll();
 	QCOMPARE(readin, written);
+	free_git_state(&state);
+	free_git_state(&local_state);
 }
 
 void TestGitStorage::testGitStorageCloudMerge()
@@ -190,19 +205,25 @@ void TestGitStorage::testGitStorageCloudMerge()
 	// another offline change there
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
 	QString cloudTestBranch("ssrftest@hohndel.org");
-	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
+	FileLocation loc(FileLocation::CLOUD_GIT, cloudTestRepo, cloudTestBranch);
+	git_state state = loc.gitState();
+	QString localCacheDir(get_local_dir(&state));
+	FileLocation loc_local(FileLocation::GIT, localCacheDir, cloudTestBranch);
+	git_state local_state = loc_local.gitState();
 	QString localCacheRepoSave = localCacheDir + "save";
-	QCOMPARE(parse_file_git(qUtf8Printable(localCacheRepoSave), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	FileLocation loc_local_save(FileLocation::GIT, localCacheRepoSave, cloudTestBranch);
+	git_state local_save_state = loc_local.gitState();
+	QCOMPARE(parse_file_git(&local_save_state), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives_git(qUtf8Printable(localCacheRepoSave), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(save_dives_git(&local_save_state), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
 	process_dives(false, false);
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -211,7 +232,7 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectory.rename(localCacheDir + "save", localCacheDir), true);
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesV3plus10-11-12-merged.ssrf"), 0);
 	clear_dive_file_data();
 	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf"), 0);
@@ -229,6 +250,9 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
+	free_git_state(&state);
+	free_git_state(&local_state);
+	free_git_state(&local_save_state);
 }
 
 void TestGitStorage::testGitStorageCloudMerge2()
@@ -238,13 +262,17 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	// merge
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
 	QString cloudTestBranch("ssrftest@hohndel.org");
-	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	FileLocation loc(FileLocation::CLOUD_GIT, cloudTestRepo, cloudTestBranch);
+	git_state state = loc.gitState();
+	QString localCacheDir(get_local_dir(&state));
+	FileLocation loc_local(FileLocation::GIT, localCacheDir, cloudTestBranch);
+	git_state local_state = loc_local.gitState();
+	QCOMPARE(parse_file_git(&local_state), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
 	QCOMPARE(save_dives_file("./SampleDivesMinus1.ssrf"), 0);
-	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(save_dives_git(&local_state), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -255,13 +283,13 @@ void TestGitStorage::testGitStorageCloudMerge2()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify that first dive
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	process_dives(false, false);
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
 	free(dive->notes);
 	dive->notes = strdup("These notes have been modified by TestGitStorage");
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -271,9 +299,9 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesMinus1-merged.ssrf"), 0);
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	QFile org("./SampleDivesMinus1-merged.ssrf");
 	org.open(QFile::ReadOnly);
 	QFile out("./SampleDivesMinus1.ssrf");
@@ -283,6 +311,8 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QString readin = orgS.readAll();
 	QString written = outS.readAll();
 	QCOMPARE(readin, written);
+	free_git_state(&state);
+	free_git_state(&local_state);
 }
 
 void TestGitStorage::testGitStorageCloudMerge3()
@@ -294,8 +324,12 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	clear_dive_file_data();
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org");
 	QString cloudTestBranch("ssrftest@hohndel.org");
-	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	FileLocation loc(FileLocation::CLOUD_GIT, cloudTestRepo, cloudTestBranch);
+	git_state state = loc.gitState();
+	QString localCacheDir(get_local_dir(&state));
+	FileLocation loc_local(FileLocation::GIT, localCacheDir, cloudTestBranch);
+	git_state local_state = loc_local.gitState();
+	QCOMPARE(parse_file_git(&state), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(0);
 	QVERIFY(dive != 0);
@@ -304,10 +338,10 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
 	dive = get_dive(2);
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
 
-	QCOMPARE(parse_file_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(parse_file_git(&local_state), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Create multi line dive notes\nDifferent line 2 and removed 3-5\n\nThat should be enough");
@@ -315,7 +349,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
 	dive = get_dive(2);
 	dive->notes = strdup("single line dive notes");
-	QCOMPARE(save_dives_git(qUtf8Printable(localCacheDir), qUtf8Printable(cloudTestBranch), "", false, false), 0);
+	QCOMPARE(save_dives_git(&local_state), 0);
 	clear_dive_file_data();
 
 	// move the local cache away
@@ -326,7 +360,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify those first dive notes differently
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Completely different dive notes\nBut also multi line");
@@ -334,7 +368,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	dive->notes = strdup("single line dive notes");
 	dive = get_dive(2);
 	dive->notes = strdup("Line 2\nLine 3\nLine 4\nLine 5"); // keep the middle, remove first and last");
-	QCOMPARE(save_dives_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(save_dives_git(&state), 0);
 	clear_dive_file_data();
 
 	// now we move the saved local cache into place and try to open the cloud repo
@@ -344,10 +378,12 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file_git(qUtf8Printable(cloudTestRepo), qUtf8Printable(cloudTestBranch), "", true, true), 0);
+	QCOMPARE(parse_file_git(&state), 0);
 	QCOMPARE(save_dives_file("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge
+	free_git_state(&state);
+	free_git_state(&local_state);
 }
 
 QTEST_GUILESS_MAIN(TestGitStorage)

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -25,7 +25,7 @@ void TestMerge::testMergeEmpty()
 	process_dives(true, false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml"), 0);
 	process_dives(true, false);
-	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testmerge47+48.ssrf");
@@ -48,7 +48,7 @@ void TestMerge::testMergeBackwards()
 	process_dives(true, false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
 	process_dives(true, false);
-	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
 	QFile out("./testmerge47+48.ssrf");

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -149,7 +149,7 @@ void TestParse::testParse()
 	QCOMPARE(parseV3(), 0);
 	fprintf(stderr, "number of dives %d \n", dive_table.nr);
 
-	QCOMPARE(save_dives("./testout.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testout.ssrf"), 0);
 	FILE_COMPARE("./testout.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
 }
@@ -159,7 +159,7 @@ void TestParse::testParseDM4()
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &_sqlite3_handle), 0);
 	QCOMPARE(parse_dm4_buffer(_sqlite3_handle, 0, 0, 0, &dive_table), 0);
 
-	QCOMPARE(save_dives("./testdm4out.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testdm4out.ssrf"), 0);
 	FILE_COMPARE("./testdm4out.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.xml");
 }
@@ -169,7 +169,7 @@ void TestParse::testParseDM5()
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM5.db", &_sqlite3_handle), 0);
 	QCOMPARE(parse_dm5_buffer(_sqlite3_handle, 0, 0, 0, &dive_table), 0);
 
-	QCOMPARE(save_dives("./testdm5out.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testdm5out.ssrf"), 0);
 	FILE_COMPARE("./testdm5out.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/TestDiveDM5.xml");
 }
@@ -228,7 +228,7 @@ void TestParse::testParseHUDC()
 		dive->dc.when = 1255152761;
 	}
 
-	QCOMPARE(save_dives("./testhudcout.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testhudcout.ssrf"), 0);
 	FILE_COMPARE("./testhudcout.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.xml");
 }
@@ -260,7 +260,7 @@ void TestParse::testParseNewFormat()
 	}
 
 	fprintf(stderr, "number of dives %d \n", dive_table.nr);
-	QCOMPARE(save_dives("./testsbnewout.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testsbnewout.ssrf"), 0);
 
 	// Currently the CSV parse fails
 	FILE_COMPARE("./testsbnewout.ssrf",
@@ -283,7 +283,7 @@ void TestParse::testParseDLD()
 	 * clear_dive_file_data(), so we do have an additional DC nick
 	 * name field on the log.
 	 */
-	QCOMPARE(save_dives("./testdldout.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testdldout.ssrf"), 0);
 	FILE_COMPARE("./testdldout.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.xml")
 }
@@ -295,7 +295,7 @@ void TestParse::testParseMerge()
 	 */
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml"), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml"), 0);
-	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
+	QCOMPARE(save_dives_file("./testmerge.ssrf"), 0);
 	FILE_COMPARE("./testmerge.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
 }

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -40,11 +40,6 @@ void TestPreferences::testPreferences()
 	cloud->setEmail("tomaz@gmail.com");
 	TEST(cloud->email(), QStringLiteral("tomaz@gmail.com"));
 
-	cloud->setGitLocalOnly(true);
-	TEST(cloud->gitLocalOnly(), true);
-	cloud->setGitLocalOnly(false);
-	TEST(cloud->gitLocalOnly(), false);
-
 	// Why there's new password and password on the prefs?
 	cloud->setNewPassword("ABCD");
 	TEST(cloud->newPassword(), QStringLiteral("ABCD"));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a first attempt at detangling the backend load/save dives code from the frontend. There was no clear separation of the layers. The git code would use global variables (in the preferences structure as well as static globals), which alse were used to control it (e.g. git_local_only). The mobile version is especially nasty in this respect. Moreover, the type of location (local, git, cloud) was encoded in the filename. The interpretation was performed in various parts of the code.

Originally, the plan was to introduce a new structure describing a file location. I was unsure if this should be a C or a C++-style structure. In the end I opted for two structures, C and C++, which describe quite different things:

1) FileLocation
This C++ class describes the location of a file. It does all the parsing and explicitly keeps track of the kind of file and meta data (e.g. user name, sha of last access). I identified five types of files: none (program startup / file close), local filesystem, cloud, cloud in offline state, git repository (local or remote).

2) git_state
This C struct keeps track of the state needed by the git machinery. It serves as input as well as output struct and thus presents the interface between frontend and backend. At the moment there are two output parameters, is_remote (set to false if cloud is offline) and sha (SHA of the latest commit).

This is mostly a refactoring, but there are two (minor) user visible changes: Proper display of git repositories in the recent files list and no load from cloud if it has the same state.

Notes:

1) This will take some time/effort to stabilize.
2) So far I only bothered with desktop. The mobile code looks very complex. I'll look into it when desktop is done.
3) This is far from pretty, but I think a step in the right direction, because there is a clearer separation of the frontend and backend layers.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Introduce FileLocation class generally describing a file
2) Introduce git_state structure as input/ouput/state for the git machinery
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
