### PR TITLE
mobile: do not just create a new dive site

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -814,12 +814,16 @@ parsed:
 bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString location, QString gps)
 {
 	bool diveChanged = false;
-
-	struct dive_site *ds = get_dive_site_by_uuid(d->dive_site_uuid);
+	uint32_t uuid;
+	struct dive_site *ds = get_dive_site_for_dive(d);
 	if (myDive->location() != location) {
 		diveChanged = true;
-		ds = get_dive_site_by_uuid(create_dive_site(qPrintable(location), d->when));
-		d->dive_site_uuid = ds->uuid;
+		if (!ds) {
+			uuid = get_dive_site_uuid_by_name(qPrintable(location), NULL);
+			if (!uuid)
+				uuid = create_dive_site(qPrintable(location), d->when);
+		}
+		d->dive_site_uuid = uuid;
 	}
 	// now make sure that the GPS coordinates match - if the user changed the name but not
 	// the GPS coordinates, this still does the right thing as the now new dive site will


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes an annoying bug. When entering an existing divesite in the mobile app, always a new divesite (with same name) was created, resulting in multiple sites on the same gps location.

So, be more careful in checking and creating a new site.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>