### PR TITLE
Libdc divemode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Add detection of new libdivecomputer divemode DC_DIVEMODE_SCR for semi-closed rebreathers
 - Write profile images to correct directory in TeX export

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -735,8 +735,11 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		case DC_DIVEMODE_OC: /* Open circuit */
 			dive->dc.divemode = OC;
 			break;
-		case DC_DIVEMODE_CCR:  /* Closed circuit */
+		case DC_DIVEMODE_CCR:  /* Closed circuit rebreather*/
 			dive->dc.divemode = CCR;
+			break;
+		case DC_DIVEMODE_SCR:  /* Semi-closed circuit rebreather */
+			dive->dc.divemode = PSCR;
 			break;
 		}
 #endif

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -735,7 +735,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		case DC_DIVEMODE_OC: /* Open circuit */
 			dive->dc.divemode = OC;
 			break;
-		case DC_DIVEMODE_CC:  /* Closed circuit */
+		case DC_DIVEMODE_CCR:  /* Closed circuit */
 			dive->dc.divemode = CCR;
 			break;
 		}


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In libdivecomputer, a new divemode is added (DC_DIVEMODE_SCR) useful for dive computers that have specific functionality for semi-closed rebreathers. At this moment, only the HW computers seem to provide
this.

This commit takes care of proper recognition of this new divemode when importing data from a dive computer.

Tested on an actual import from an OSTC3 that contained dives in this new mode.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
1) Trivial rename due to libdc rename
2) Detect the new DC_DIVEMODE_SCR (as described above)

### Release note:
Add detection of new libdivecomputer divemode DC_DIVEMODE_SCR