### PR TITLE
mobile: buttons on Download screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- mobile: improves button handling on download screen (issue #895)
 - Show all pictures of a selected trip in the pictures tab
 - Add detection of new libdivecomputer divemode DC_DIVEMODE_SCR for semi-closed rebreathers
 - Write profile images to correct directory in TeX export

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -213,6 +213,8 @@ Kirigami.Page {
 					if (!progressBar.visible) {
 						stackView.pop();
 						download.text = qsTr("Download")
+						divesDownloaded = false
+						manager.progressMessage = ""
 					}
 					manager.appendTextToLog("exit DCDownload screen")
 				}
@@ -277,6 +279,7 @@ Kirigami.Page {
 					diveModel.addAllDives()
 					stackView.pop();
 					download.text = qsTr("Download")
+					divesDownloaded = false
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -210,8 +210,10 @@ Kirigami.Page {
 				text: progressBar.visible ? qsTr("Cancel") : qsTr("Quit")
 				onClicked: {
 					manager.cancelDownloadDC()
-					if (!progressBar.visible)
+					if (!progressBar.visible) {
 						stackView.pop();
+						download.text = qsTr("Download")
+					}
 					manager.appendTextToLog("exit DCDownload screen")
 				}
 			}
@@ -274,6 +276,7 @@ Kirigami.Page {
 					diveModel.clear()
 					diveModel.addAllDives()
 					stackView.pop();
+					download.text = qsTr("Download")
 				}
 			}
 			Controls.Label {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

Reset the Retry button on exit of the Download from divecomputer page. So, it it not reset when swiping this page away, or cancelling a running download, but resetting it on accepting downloaded dives.

As we do not have real error reporting (from download failures), this all is a little arbitrary. Another "fix" could be, not changing the button text at all.

Further notice, this is not specific iOS, but also Android.

Fixes: #895

Further, a second commit: Set download screen in a sane state after a previous download session using this screen. The erroneous behavior was very similar to the one fixed in above commit 7fe9bbe. For example,
download some dives, quit the screen, go back, and the bottom buttons are still selectable.

This commit resets some values when leaving the download screen (ie. not only swiping it away), so that it looks sane at a next visit.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit messages.

### Related issues:
Fixes: #895

### Additional information:
The second commit in the PR fixes a non reported error, very similar to the reported one.

### Release note:
mobile: download button becomes Retry forever after a failed download (#895)
mobile: download accept button stays active forever after a successful download
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
