### PR TITLE
Remove function isCloudUrl()

### DIFF
--- a/core/file.c
+++ b/core/file.c
@@ -497,9 +497,8 @@ int parse_file(const char *filename)
 		return git_load_dives(git, branch);
 
 	if ((ret = readfile(filename, &mem)) < 0) {
-		/* we don't want to display an error if this was the default file or the cloud storage */
-		if ((prefs.default_filename && !strcmp(filename, prefs.default_filename)) ||
-		    isCloudUrl(filename))
+		/* we don't want to display an error if this was the default file  */
+		if (same_string(filename, prefs.default_filename))
 			return 0;
 
 		return report_error(translate("gettextFromC", "Failed to read '%s'"), filename);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1449,16 +1449,6 @@ extern "C" char *cloud_url()
 	return strdup(filename.toUtf8().data());
 }
 
-extern "C" bool isCloudUrl(const char *filename)
-{
-	QString email = QString(prefs.cloud_storage_email);
-	email.replace(QRegularExpression("[^a-zA-Z0-9@._+-]"), "");
-	if (!email.isEmpty() &&
-	    QString(QString(prefs.cloud_git_url) + "/%1[%1]").arg(email) == filename)
-		return true;
-	return false;
-}
-
 extern "C" bool getProxyString(char **buffer)
 {
 	if (prefs.proxy_type == QNetworkProxy::HttpProxy) {

--- a/core/qthelperfromc.h
+++ b/core/qthelperfromc.h
@@ -5,7 +5,6 @@
 bool getProxyString(char **buffer);
 bool canReachCloudServer();
 void updateWindowTitle();
-bool isCloudUrl(const char *filename);
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);
 void copy_image_and_overwrite(const char *cfileName, const char *path, const char *cnewName);


### PR DESCRIPTION
The function isCloudUrl() was only called in one place, parse_file().
But, isCloudUrl() could only return true if the filename was of the
git-repository kind (url[branch]). In such a case, control flow would
never reach the point where isCloudUrl() is called, since
is_git_repository() returns non-NULL and the function returns early.

Therefore, remove this function. Moreover, adapt the affected if-statement
by replacing "str && !strcmp(str, ...)" with the more concise
"same_string(str, ...)".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This minor cleanup removes one function that doesn't seem to be used. At the moment I can't compile and test -> let's wait for CI

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
