### PR TITLE
Don't create GeneralSettingsObjectWrapper object

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1104,9 +1104,9 @@ void QMLManager::openNoCloudRepo()
 		if (git_create_local_repo(filename))
 			appendTextToLog(get_error_string());
 		set_filename(filename);
-		GeneralSettingsObjectWrapper s(this);
-		s.setDefaultFilename(filename);
-		s.setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
+		auto s = SettingsObjectWrapper::instance()->general_settings;
+		s->setDefaultFilename(filename);
+		s->setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
 	}
 
 	openLocalThenRemote(filename);
@@ -1121,9 +1121,9 @@ void QMLManager::saveChangesLocal()
 				if (git_create_local_repo(filename))
 					appendTextToLog(get_error_string());
 				set_filename(filename);
-				GeneralSettingsObjectWrapper s(this);
-				s.setDefaultFilename(filename);
-				s.setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
+				auto s = SettingsObjectWrapper::instance()->general_settings;
+				s->setDefaultFilename(filename);
+				s->setDefaultFileBehavior(LOCAL_DEFAULT_FILE);
 			}
 		} else if (!loadFromCloud()) {
 			// this seems silly, but you need a common ancestor in the repository in


### PR DESCRIPTION
Instead use the application-wide instance. Creating a local
object defeats the whole purpose of these objects - nobody
can receive signals in case the settings changed.

No other cases of locally created SettingsObjectWrapper
objects were found.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a minor code-cleanup which brings usage of the GeneralSettingsObjectWrapper object in line with all the other *SettingsObjectWrappers. Note that I don't have Android SDK, so this is untested.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
