### PR TITLE
mobile: show message when going offline

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -182,11 +182,11 @@ Kirigami.ApplicationWindow {
 				}
 				Kirigami.Action {
 				iconName: syncToCloud ? "icons/ic_cloud_off.svg" : "icons/ic_cloud_done.svg"
-				text: syncToCloud ? qsTr("Offline mode") : qsTr("Enable auto cloud sync")
+				text: syncToCloud ? qsTr("Offline mode") : qsTr("Auto cloud sync enabled")
 					enabled: manager.credentialStatus !== QMLManager.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
-						if (!syncToCloud) {
+						if (syncToCloud) {
 							showPassiveNotification(qsTr("Turning off automatic sync to cloud causes all data to only be \
 stored locally. This can be very useful in situations with limited or no network access. Please choose 'Manual sync with cloud' \
 if you have network connectivity and want to sync your data to cloud storage."), 10000)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial fix. Show the message "Turning off automatic sync to cloud ..." when turning automatic sync to offline. Just a more logical moment to show this message. Also rephrase the message "Enable auto sync" to "Auto sync enabled". It shows a status, and not an action.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
