### PR TITLE
mobile: stay on same dive after edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+_ mobile: fixed weird navigation problem after dive edit (#875)
 - mobile: improves button handling on download screen (issue #895)
 - Show all pictures of a selected trip in the pictures tab
 - Add detection of new libdivecomputer divemode DC_DIVEMODE_SCR for semi-closed rebreathers

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -93,8 +93,8 @@ void DiveListModel::removeDiveById(int id)
 void DiveListModel::updateDive(int i, dive *d)
 {
 	DiveObjectHelper *newDive = new DiveObjectHelper(d);
-	removeDive(i);
-	insertDive(i, newDive);
+	m_dives.replace(i, newDive);
+	emit dataChanged(createIndex(i, 0), createIndex(i, 0));
 }
 
 void DiveListModel::clear()


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
See issue #875. In hindsight the reason for this bug is easy to understand. When updating a dive, the dive was first removed from the model, and added in its new state again. This does seems reasonable, but the delete in the model causes the internal (QML) state to be changed, and the previous state (like the currentIndex that was pointing to the just deleted row, so that one is changed to something valid internally) is not restored at recreation of the edited dive. The QML engine has no way to understand that the remove and subsequent add are in fact one atomic operation.

This can be solved by simply updating the underlying data in place, and notifying the change using a dataChanged emitted signal. The dataChanged signal takes care of the repaint of the screen, and there is no need for removeRow/insertRow pairs.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit.

### Related issues:
Fixes: #875

### Additional information:
Unfortunately, I need to open a new issue for another dive edit problem (unrelated to this one). 

### Release note:
mobile: weird navigation after dive edit (#875)