### PR TITLE
mobile: clear internal data when edit/add dive is finished

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -207,6 +207,7 @@ Kirigami.Page {
 		state = "view";
 		focus = false;
 		Qt.inputMethod.hide();
+		detailsEdit.clearDetailsEdit();
 	}
 
 	function startEditMode() {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -39,6 +39,24 @@ Item {
 	property int rating
 	property int visibility
 
+	function clearDetailsEdit() {
+		detailsEdit.dive_id = 0
+		detailsEdit.number = 0
+		detailsEdit.dateText = ""
+		detailsEdit.locationText = ""
+		detailsEdit.durationText = ""
+		detailsEdit.depthText = ""
+		detailsEdit.airtempText = ""
+		detailsEdit.watertempText = ""
+		suitBox.currentIndex = -1
+		buddyBox.currentIndex = -1
+		divemasterBox.currentIndex = -1
+		cylinderBox.currentIndex = -1
+		detailsEdit.notesText = ""
+		detailsEdit.rating = 0
+		detailsEdit.visibility = 0
+	}
+
 	function saveData() {
 		diveDetailsPage.state = "view" // run the transition
 		// apply the changes to the dive_table
@@ -71,6 +89,7 @@ Item {
 		Qt.inputMethod.hide()
 		// now make sure we directly show the saved dive (this may be a new dive, or it may have moved)
 		showDiveIndex(newIdx)
+		clearDetailsEdit()
 	}
 
 	height: editArea.height


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When editing (or adding) a dive, the internal data containing the attributes on the edit page was not cleared when editing was finished (in any way, by saving the edit or by cancelling it). As long as the user only edits existing dives, all this poses no problem, as at the start of a dive edit, the data is filled from the dive to be edited. However, when manually adding a dive, data coming from previous edits shows up. This not clearing data also causes the strange effect as written in issue #950: adding a dive, deleting it, and adding a dive again, added the first added dive data, without the edit screen being shown.

All this can be solved by clearing the data from the edit when editing is done.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit.

### Related issues:
Fixes: #950

### Additional information:
In hindsight, the short lived issue 950 seemed not very useful, as fixing this was relatively easy. So it might be considered noise in the issue channel ... however ... just trying to tell that I'm a little struggling with opening issues and fixing them a few hours later.

### Release note:
no
