### PR TITLE
mobile: manual add dive and cancel fails when repeated

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1260,6 +1260,7 @@ QString QMLManager::addDive()
 void QMLManager::addDiveAborted(int id)
 {
 	DiveListModel::instance()->removeDiveById(id);
+	delete_single_dive(get_idx_by_uniq_id(id));
 }
 
 QString QMLManager::getCurrentPosition()


### PR DESCRIPTION


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This commit fixes a very subtle bug. Probably there for ages, but never noticed. When manually adding a dive, and canceling the add right away, the divetable was extended by 1 dive (using the core function add_single_dive), but canceling never removed that dive (using delete_single_dive). This is corrected here.

Notice that commit ef543da5aff296e claims to fix issue #950. With this commit, however, that issue can be seen sometimes again.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit.

### Related issues:
related to #950 as well.

### Additional information:
Going to re-open #950
