### PR TITLE
Unify float calulations: use double

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -610,7 +610,7 @@ bool enough_gas(int current_cylinder)
 	if (!cyl->start.mbar)
 		return true;
 	if (cyl->type.size.mliter)
-		return (float)(cyl->end.mbar - prefs.reserve_gas) * cyl->type.size.mliter / 1000.0 > (float) cyl->deco_gas_used.mliter;
+		return (cyl->end.mbar - prefs.reserve_gas) / 1000.0 * cyl->type.size.mliter > cyl->deco_gas_used.mliter;
 	else
 		return true;
 }

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -401,8 +401,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					translate("gettextFromC", "Warning:"),
 					translate("gettextFromC", "this is more gas than available in the specified cylinder!"));
 			else
-				if ((float) cyl->end.mbar * cyl->type.size.mliter / 1000.0 / gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0)
-				    < (float) cyl->deco_gas_used.mliter)
+				if (cyl->end.mbar / 1000.0 * cyl->type.size.mliter / gas_compressibility_factor(&cyl->gasmix, cyl->end.mbar / 1000.0)
+				    < cyl->deco_gas_used.mliter)
 					snprintf(warning, sizeof(warning), "<br>&nbsp;&mdash; <span style='color: red;'>%s </span> %s",
 						translate("gettextFromC", "Warning:"),
 						translate("gettextFromC", "not enough reserve for gas sharing on ascent!"));

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -310,7 +310,7 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 		int i;
 		int qty_cyl;
 		int qty_weight;
-		float total_weight;
+		double total_weight;
 
 		if (need_pagebreak)
 			put_format(&buf, "\\vfill\\eject\n");

--- a/desktop-widgets/preferences/abstractpreferenceswidget.cpp
+++ b/desktop-widgets/preferences/abstractpreferenceswidget.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "abstractpreferenceswidget.h"
 
-AbstractPreferencesWidget::AbstractPreferencesWidget(const QString& name, const QIcon& icon, float positionHeight)
+AbstractPreferencesWidget::AbstractPreferencesWidget(const QString& name, const QIcon& icon, double positionHeight)
 : QWidget(), _icon(icon), _name(name), _positionHeight(positionHeight)
 {
 }
@@ -16,7 +16,7 @@ QString AbstractPreferencesWidget::name() const
 	return _name;
 }
 
-float AbstractPreferencesWidget::positionHeight() const
+double AbstractPreferencesWidget::positionHeight() const
 {
 	return _positionHeight;
 }

--- a/desktop-widgets/preferences/abstractpreferenceswidget.h
+++ b/desktop-widgets/preferences/abstractpreferenceswidget.h
@@ -8,10 +8,10 @@
 class AbstractPreferencesWidget : public QWidget {
 	Q_OBJECT
 public:
-	AbstractPreferencesWidget(const QString& name, const QIcon& icon, float positionHeight);
+	AbstractPreferencesWidget(const QString& name, const QIcon& icon, double positionHeight);
 	QIcon icon() const;
 	QString name() const;
-	float positionHeight() const;
+	double positionHeight() const;
 
 	/* gets the values from the preferences and should set the correct values in
 	 * the interface */
@@ -26,6 +26,6 @@ signals:
 private:
 	QIcon _icon;
 	QString _name;
-	float _positionHeight;
+	double _positionHeight;
 };
 #endif

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -152,7 +152,6 @@ void validateGL()
 	QOffscreenSurface surface;
 	QOpenGLFunctions *func;
 	const char *verChar;
-	float verFloat;
 
 	surface.setFormat(ctx.format());
 	surface.create();
@@ -182,9 +181,10 @@ void validateGL()
 			 "before running Subsurface!\n").toUtf8().data();
 			 return;
 		}
-		if (sscanf(verChar, "%f", &verFloat) == 1) {
-			verMajor = (GLint)verFloat;
-			verMinor = (GLint)roundf((verFloat - verMajor) * 10.f);
+		int min, maj;
+		if (sscanf(verChar, "%d.%d", &maj, &min) == 2) {
+			verMajor = (GLint)maj;
+			verMinor = (GLint)min;
 		}
 	}
 	// attempt to detect version using the newer API


### PR DESCRIPTION
Internal floating point (FP) calculations should be performed using double
unless there is a very good reason. This avoids headaches with conversions.
Indeed, the vast majority of FP calculations were already done using double.
This patch adapts most remaining calculations. Not converted where things
that were based on binary representations and variables which weren't used
anyway.

An analysis of all instances follows:

core/plannernotes.c, l.404:

This was a comparison between two floats. On the left side, first an integer
was cast to float then multiplied with and integer and divided by a constant
double. The right hand side was an integer cast to a float. Simply divide by
1000.0 first to convert to double and continue with calculations. On the right
hand side, remove the cast, because the integer will be implicitely cast to
double for comparison. This conversion actually emits less instructions,
because no conversion to double and back is performed.

core/planner.c, l.613:

Same analysis as previous case.

subsurface-desktop-main.cpp, l.155:

A local variable representing the version OpenGL version. Turn this into
integer logic. Not only does this avoid dreaded FP rounding issues, it also
works correctly for minor version > 10 (not that such a thing is to be
expected anytime soon).

abstractpreferenceswidget.[h/cpp]:

A widget where the position is described as a float. Turn into double.

desktop-widgets/divelogexportdialog.cpp, l.313:

total_weight is described as float. Use double arithmetics instead. This
instance fixes a truncation warning emitted by gcc.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This turns a few float calculations into double calculations. One of those fixes a warning (which could also be fixed by an explicit cast). There was some discussion on the mailing list, without a clear consensus. In my opinion, the float data type should only be used in very specific circumstances, such as performance, space considerations or binary representations.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
