### PR TITLE
mobile: use short date format in edit mode

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -714,7 +714,7 @@ bool QMLManager::checkDate(DiveObjectHelper *myDive, struct dive * d, QString da
 		// what a pain - Qt will not parse dates if the day of the week is incorrect
 		// so if the user changed the date but didn't update the day of the week (most likely behavior, actually),
 		// we need to make sure we don't try to parse that
-		QString format(QString(prefs.date_format) + QChar(' ') + prefs.time_format);
+		QString format(QString(prefs.date_format_short) + QChar(' ') + prefs.time_format);
 		if (format.contains(QLatin1String("ddd")) || format.contains(QLatin1String("dddd"))) {
 			QString dateFormatToDrop = format.contains(QLatin1String("ddd")) ? QStringLiteral("ddd") : QStringLiteral("dddd");
 			QDateTime ts;
@@ -1523,7 +1523,7 @@ QString QMLManager::getDate(const QString& diveId)
 	struct dive *d = get_dive_by_uniq_id(dive_id);
 	QString datestring;
 	if (d)
-		datestring = get_dive_date_string(d->when);
+		datestring = get_short_dive_date_string(d->when);
 	return datestring;
 }
 


### PR DESCRIPTION


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
See issue #949. In the dive list, dates are shown in short format, and when we start to edit an existing dive, the date field on the edit page is shown in sort format. However, when adding a new dive, the initial date shows up in long (normal) format. This in not only inconsistent, but also introduces the parsing problem, as described in the mentioned issue.

This can be fixed by using short formatted dates in all cases in the mobile app. As the screen real estate is precious on mobile, this seems the most logical choice.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit.

### Related issues:
Fixes: #949 
