### PR TITLE
core: fix git storage save (regression 4.7.4 -> 4.7.5)

### DIFF
--- a/core/save-git.c
+++ b/core/save-git.c
@@ -158,7 +158,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		if (cylinder->cylinder_use != OC_GAS)
 			put_format(b, " use=%s", cylinderuse_text[cylinder->cylinder_use]);
 		if (cylinder->depth.mm != 0)
-			put_milli(b, " depth='", cylinder->depth.mm, " m'");
+			put_milli(b, " depth='", cylinder->depth.mm, "m'");
 		put_string(b, "\n");
 	}
 }


### PR DESCRIPTION
Commit 46004c39e266fe7 introduces a new field in the logbook outputs (depth of a cylinder). While in XML the depth unit is stored with a space between value and unit (m), in our git storage, the unit m is without space. As the git storage parser uses a space to separate individual key/value pairs, the erroneously saved space results in parsing warnings when opening the logbook.

The unwanted space is normally saved just after download of a new dive from the dive computers, so all desktop-git-storage uses are affected, and more worrying, mobile beta users.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Mentions:
@sfuchs79, @dirkhh 
