### PR TITLE
mobile: another navigation related fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-_ mobile: fixed weird navigation problem after dive edit (#875)
+- mobile: Faulty navigation after aborted dive edit (#932)
+- mobile: fixed weird navigation problem after dive edit (#875)
 - mobile: improves button handling on download screen (issue #895)
 - Show all pictures of a selected trip in the pictures tab
 - Add detection of new libdivecomputer divemode DC_DIVEMODE_SCR for semi-closed rebreathers

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -8,6 +8,7 @@ import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.Page {
 	id: diveDetailsPage // but this is referenced as detailsWindow
+	objectName: "DiveDetails"
 	property alias currentIndex: diveDetailsListView.currentIndex
 	property alias currentItem: diveDetailsListView.currentItem
 	property alias dive_id: detailsEdit.dive_id

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -19,7 +19,6 @@ Kirigami.ApplicationWindow {
 		preferredHeight: Math.round(Kirigami.Units.gridUnit * (Qt.platform.os == "ios" ? 2 : 1.5))
 		maximumHeight: Kirigami.Units.gridUnit * 2
 	}
-
 	property alias oldStatus: manager.oldStatus
 	property alias notificationText: manager.notificationText
 	property alias syncToCloud: manager.syncToCloud

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -19,6 +19,7 @@ Kirigami.ApplicationWindow {
 		preferredHeight: Math.round(Kirigami.Units.gridUnit * (Qt.platform.os == "ios" ? 2 : 1.5))
 		maximumHeight: Kirigami.Units.gridUnit * 2
 	}
+
 	property alias oldStatus: manager.oldStatus
 	property alias notificationText: manager.notificationText
 	property alias syncToCloud: manager.syncToCloud
@@ -436,7 +437,17 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				easing.type: Easing.OutQuad
 			}
 		}
+	}
 
+	pageStack.onCurrentItemChanged: {
+	// This is called whenever the user navigates using the breadcrumbs in the header
+
+		// In case we land on any page, not being the DiveDetails (which can be
+		// in multiple states, such as add, edit or view), just end the edit/add mode
+		if (pageStack.currentItem.objectName !== "DiveDetails" &&
+				(detailsWindow.state === 'edit' || detailsWindow.state === 'add')) {
+				detailsWindow.endEditMode()
+		}
 	}
 
 	QMLManager {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Navigating using the breadcrumb in the header did leave the dive detail edit (and add) mode in such a way that (for example) navigation in the dive list was suspended. Obviously, it is debatable what should be done. Saving the edits/add, or cancelling them. For now, this commit cancels them silently. This is the exact same thing that is happening when the user selects the dive list from the drawer menu.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
see commit

### Related issues:
Fixes: #932

### Release note:
yes, added.