### PR TITLE
core: ignore bogus m in cylinder

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -394,6 +394,18 @@ static void parse_cylinder_keyvalue(void *_cylinder, const char *key, const char
 		cylinder->depth = get_depth(value);
 		return;
 	}
+	if (!strcmp(key, "m'") && strlen(value) == 0) {
+		/* found a bogus key/value pair in the cylinder, consisting
+		 * of a lonely "m" without value. This is caused by commit
+		 * 46004c39e26 and fixed in 48d9c8eb6eb0. See referenced
+		 * commits for more info.
+		 *
+		 * Just ignore this key/value pair. No processing is broken
+		 * due to this, as the git storage stores only metric SI type data.
+		 * In fact, the m unit is superfluous anyway.
+		 */
+		return;
+	}
 	report_error("Unknown cylinder key/value pair (%s/%s)", key, value);
 }
 


### PR DESCRIPTION
A bogus key/value pair was introduced in the cylinder, consisting of a lonely "m" without value. This is caused
by commit 46004c39e26 and fixed in 48d9c8eb6eb0. See referenced commits for more info.

Just ignore this key/value pair. No processing is broken due to this, as the git storage stores only metric SI type data. In fact, the m unit is superfluous anyway.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Mentions:
@dirkhh