### PR TITLE
git storage: invalidate cache on merge dive site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix dive site merging for cloud (and local git storage) users. (#939)
 - desktop: Add variable zoom-levels for the dive photos tab (#898)
 - mobile: Faulty navigation after aborted dive edit (#932)
 - improve planner performance

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -336,6 +336,7 @@ void merge_dive_sites(uint32_t ref, uint32_t* uuids, int count)
 			if (d->dive_site_uuid != uuids[i] )
 				continue;
 			d->dive_site_uuid = ref;
+			invalidate_dive_cache(d);
 		}
 	}
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In hindsight a very simple bug to fix, but it requires some knowledge on the inner workings of our git storage. The changes on merge of dive sites were simply not saved (completely) because the git storage code has a cache that we need to invalidate selectively (ie. for the dive we just gave a new dive site uuid) to get things finally embedded in the overall commit.

The main reason this bug went unnoticed for more than 2 years is that most people use the XML/SSRF format (where this problem is non existent), and dive site merging is probably not a very much used feature either.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Fixes: #939

### Additional information:
Only on git storage (so cloud user affected).

### Release note:
Fix dive site merging for cloud (and local git storage) users. (#939)
