### PR TITLE
Fix commit 46004c3 for real

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -394,11 +394,11 @@ static void parse_cylinder_keyvalue(void *_cylinder, const char *key, const char
 		cylinder->depth = get_depth(value);
 		return;
 	}
-	if (!strcmp(key, "m'") && strlen(value) == 0) {
+	if ((*key == 'm') && strlen(value) == 0) {
 		/* found a bogus key/value pair in the cylinder, consisting
-		 * of a lonely "m" without value. This is caused by commit
-		 * 46004c39e26 and fixed in 48d9c8eb6eb0. See referenced
-		 * commits for more info.
+		 * of a lonely "m" or m<single quote> without value. This
+		 * is caused by commit 46004c39e26 and fixed in 48d9c8eb6eb0 and
+		 * b984fb98c38e4. See referenced commits for more info.
 		 *
 		 * Just ignore this key/value pair. No processing is broken
 		 * due to this, as the git storage stores only metric SI type data.

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -158,7 +158,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		if (cylinder->cylinder_use != OC_GAS)
 			put_format(b, " use=%s", cylinderuse_text[cylinder->cylinder_use]);
 		if (cylinder->depth.mm != 0)
-			put_milli(b, " depth='", cylinder->depth.mm, "m'");
+			put_milli(b, " depth=", cylinder->depth.mm, "m");
 		put_string(b, "\n");
 	}
 }


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Unfortunately, in my commit 48d9c8e, I fixed only half of the problems related to the functionality introduced by Stefan in commit 46004c3. The lonely m (that was fixed) caused a parsing error, but forgotten where the single quotes around the depth value. These quotes simply causes the new functionality not to work. Again, the fix is simple: do not erroneously save quotes. And as the new functionality is pretty obscure (replanning a non-planned dive, and manually entering a gas switch depth), another bug that could go unnoticed for years.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Commits 46004c3, 48d9c8e and all commits mentioned there.