### PR TITLE
Remove superfluous QScopedPointer<>s in singletons

### DIFF
--- a/core/gettextfromc.cpp
+++ b/core/gettextfromc.cpp
@@ -18,8 +18,8 @@ void gettextFromC::reset(void)
 
 gettextFromC *gettextFromC::instance()
 {
-	static QScopedPointer<gettextFromC> self(new gettextFromC());
-	return self.data();
+	static gettextFromC self;
+	return &self;
 }
 
 extern "C" const char *trGettext(const char *text)

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -31,8 +31,8 @@ QVariant CylindersModel::headerData(int section, Qt::Orientation orientation, in
 CylindersModel *CylindersModel::instance()
 {
 
-	static QScopedPointer<CylindersModel> self(new CylindersModel());
-	return self.data();
+	static CylindersModel self;
+	return &self;
 }
 
 static QString get_cylinder_string(cylinder_t *cyl)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -414,8 +414,8 @@ DivePlannerPointsModel::DivePlannerPointsModel(QObject *parent) : QAbstractTable
 
 DivePlannerPointsModel *DivePlannerPointsModel::instance()
 {
-	static QScopedPointer<DivePlannerPointsModel> self(new DivePlannerPointsModel());
-	return self.data();
+	static DivePlannerPointsModel self;
+	return &self;
 }
 
 void DivePlannerPointsModel::emitDataChanged()

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -32,8 +32,8 @@ Qt::ItemFlags GasSelectionModel::flags(const QModelIndex &index) const
 
 GasSelectionModel *GasSelectionModel::instance()
 {
-	static QScopedPointer<GasSelectionModel> self(new GasSelectionModel());
-	return self.data();
+	static GasSelectionModel self;
+	return &self;
 }
 
 //TODO: Remove this #include here when the issue below is fixed.

--- a/qt-models/tankinfomodel.cpp
+++ b/qt-models/tankinfomodel.cpp
@@ -6,8 +6,8 @@
 
 TankInfoModel *TankInfoModel::instance()
 {
-	static QScopedPointer<TankInfoModel> self(new TankInfoModel());
-	return self.data();
+	static TankInfoModel self;
+	return &self;
 }
 
 const QString &TankInfoModel::biggerString() const

--- a/qt-models/weigthsysteminfomodel.cpp
+++ b/qt-models/weigthsysteminfomodel.cpp
@@ -6,8 +6,8 @@
 
 WSInfoModel *WSInfoModel::instance()
 {
-	static QScopedPointer<WSInfoModel> self(new WSInfoModel());
-	return self.data();
+	static WSInfoModel self;
+	return &self;
 }
 
 bool WSInfoModel::insertRows(int row, int count, const QModelIndex &parent)


### PR DESCRIPTION
There was a curious pattern of singletons being implemented based on
QScopedPointer<>s. This is an unnecessary level of indirection:
The lifetime of the smart pointer is the same as that of the
pointed-to object. Therefore, replace these pointers by the respective
objects.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Small simplification concerning the singletons that used QScopedPointers. This indirection is unnecessary. Most of the remaining singletons could also be simplified, but since this would introduce automatic destruction of the objects, it requires more analysis.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
