### PR TITLE
cleanup: remove empty function

### DIFF
--- a/core/linux.c
+++ b/core/linux.c
@@ -18,11 +18,6 @@ const char linux_system_divelist_default_font[] = "Sans";
 const char *system_divelist_default_font = linux_system_divelist_default_font;
 double system_divelist_default_font_size = -1.0;
 
-void subsurface_OS_pref_setup(void)
-{
-	// nothing
-}
-
 bool subsurface_ignore_font(const char *font)
 {
 	// there are no old default fonts to ignore

--- a/core/pref.h
+++ b/core/pref.h
@@ -188,7 +188,6 @@ extern double system_divelist_default_font_size;
 extern const char *system_default_directory(void);
 extern const char *system_default_filename();
 extern bool subsurface_ignore_font(const char *font);
-extern void subsurface_OS_pref_setup();
 extern void copy_prefs(struct preferences *src, struct preferences *dest);
 
 #ifdef __cplusplus

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -290,7 +290,6 @@ void setup_system_prefs(void)
 {
 	const char *env;
 
-	subsurface_OS_pref_setup();
 	default_prefs.divelist_font = strdup(system_divelist_default_font);
 	default_prefs.font_size = system_divelist_default_font_size;
 


### PR DESCRIPTION
subsurface_OS_pref_setup() is not not used. Remove it.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>