### PR TITLE
Fix BuddyFilterModel

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -228,10 +228,12 @@ bool BuddyFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 		return true;
 	}
 	// Checked means 'Show', Unchecked means 'Hide'.
-	QString diveBuddy(d->buddy);
-	QString divemaster(d->divemaster);
+	QString persons = QString(d->buddy) + "," + QString(d->divemaster);
+	QStringList personsList = persons.split(',', QString::SkipEmptyParts);
+	for (QString &s: personsList)
+		s = s.trimmed();
 	// only show empty buddie dives if the user checked that.
-	if (diveBuddy.isEmpty() && divemaster.isEmpty()) {
+	if (personsList.isEmpty()) {
 		if (rowCount() > 0)
 			return checkState[rowCount() - 1];
 		else
@@ -242,7 +244,7 @@ bool BuddyFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 	QStringList buddyList = stringList();
 	// Ignore last item, since this is the "Show Empty Tags" entry
 	for (int i = 0; i < rowCount() - 1; i++) {
-		if (checkState[i] && (diveBuddy == buddyList[i] || divemaster == buddyList[i]))
+		if (checkState[i] && personsList.contains(buddyList[i], Qt::CaseInsensitive))
 			return true;
 	}
 	return false;


### PR DESCRIPTION
Commit 6343515fedbc43be4fd2cb3f1b3fea384e362c59 introduced equality
instead of substring comparison for filters. This broke the buddy
filter in the case of more than one buddy, because in such a case
the buddy list is a comma-separated string.

Fix this by splitting the buddy string, trimming the individual
strings and search in the list.

Fixes #969

Reported-by: <yrevawerd@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
