### PR TITLE
cleanup: remove unused include

### DIFF
--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -6,7 +6,6 @@
 #include <QListWidgetItem>
 #include <QPointer>
 #include <QtBluetooth/QBluetoothLocalDevice>
-#include <QtBluetooth/qbluetoothglobal.h>
 #include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
And why this one? Well, while this include is renamed in Qt 5.10 and gives deprecated compile warnings. And as it unused anyway, just remove it.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>