### PR TITLE
Code cleanup: Gflow/high, obsolete declaration, indentation, emitDataChanged function

### DIFF
--- a/core/deco.c
+++ b/core/deco.c
@@ -543,8 +543,7 @@ void clear_deco(struct deco_state *ds, double surface_pressure)
 		ds->n2_regen_radius[ci] = get_crit_radius_N2();
 		ds->he_regen_radius[ci] = get_crit_radius_He();
 	}
-	ds->gf_low_pressure_this_dive = surface_pressure;
-		ds->gf_low_pressure_this_dive += buehlmann_config.gf_low_position_min;
+	ds->gf_low_pressure_this_dive = surface_pressure + buehlmann_config.gf_low_position_min;
 	ds->max_ambient_pressure = 0.0;
 }
 

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -220,7 +220,6 @@ signals:
 	void showCCRSensorsChanged(bool value);
 	void zoomedPlotChanged(bool value);
 	void showSacChanged(bool value);
-	void gfLowAtMaxDepthChanged(bool value);
 	void displayUnusedTanksChanged(bool value);
 	void showAverageDepthChanged(bool value);
 	void showPicturesInProfileChanged(bool value);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -430,8 +430,6 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.drop_stone_mode, SIGNAL(toggled(bool)), plannerModel, SLOT(setDropStoneMode(bool)));
 	connect(ui.gfhigh, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFHigh(int)));
 	connect(ui.gflow, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFLow(int)));
-	connect(ui.gfhigh, SIGNAL(editingFinished()), plannerModel, SLOT(triggerGFHigh()));
-	connect(ui.gflow, SIGNAL(editingFinished()), plannerModel, SLOT(triggerGFLow()));
 	connect(ui.vpmb_conservatism, SIGNAL(valueChanged(int)), plannerModel, SLOT(setVpmbConservatism(int)));
 	connect(ui.backgasBreaks, SIGNAL(toggled(bool)), this, SLOT(setBackgasBreaks(bool)));
 	connect(ui.switch_at_req_stop, SIGNAL(toggled(bool)), plannerModel, SLOT(setSwitchAtReqStop(bool)));

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -583,14 +583,14 @@ void DivePlannerPointsModel::setDecoMode(int mode)
 	auto planner = SettingsObjectWrapper::instance()->planner_settings;
 	planner->setDecoMode(deco_mode(mode));
 	emit recreationChanged(mode == int(prefs.planner_deco_mode));
-	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, COLUMNS -1));
+	emitDataChanged();
 }
 
 void DivePlannerPointsModel::setSafetyStop(bool value)
 {
 	auto planner = SettingsObjectWrapper::instance()->planner_settings;
 	planner->setSafetyStop(value);
-	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, COLUMNS -1));
+	emitDataChanged();
 }
 
 void DivePlannerPointsModel::setReserveGas(int reserve)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -470,9 +470,9 @@ void DivePlannerPointsModel::triggerGFHigh()
 	}
 }
 
-void DivePlannerPointsModel::setGFLow(const int ghflow)
+void DivePlannerPointsModel::setGFLow(const int gflow)
 {
-	tempGFLow = ghflow;
+	tempGFLow = gflow;
 	triggerGFLow();
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -404,9 +404,7 @@ int DivePlannerPointsModel::rowCount(const QModelIndex &parent) const
 
 DivePlannerPointsModel::DivePlannerPointsModel(QObject *parent) : QAbstractTableModel(parent),
 	mode(NOTHING),
-	recalc(false),
-	tempGFHigh(100),
-	tempGFLow(100)
+	recalc(false)
 {
 	memset(&diveplan, 0, sizeof(diveplan));
 	startTime.setTimeSpec(Qt::UTC);
@@ -455,25 +453,18 @@ void DivePlannerPointsModel::setProblemSolvingTime(int minutes)
 
 void DivePlannerPointsModel::setGFHigh(const int gfhigh)
 {
-	tempGFHigh = gfhigh;
-	// GFHigh <= 34 can cause infinite deco at 6m - don't trigger a recalculation
-	// for smaller GFHigh unless the user explicitly leaves the field
-	if (tempGFHigh > 34)
-		triggerGFHigh();
-}
-
-void DivePlannerPointsModel::triggerGFHigh()
-{
-	if (diveplan.gfhigh != tempGFHigh) {
-		diveplan.gfhigh = tempGFHigh;
+	if (diveplan.gfhigh != gfhigh) {
+		diveplan.gfhigh = gfhigh;
 		emitDataChanged();
 	}
 }
 
 void DivePlannerPointsModel::setGFLow(const int gflow)
 {
-	tempGFLow = gflow;
-	triggerGFLow();
+	if (diveplan.gflow != gflow) {
+		diveplan.gflow = gflow;
+		emitDataChanged();
+	}
 }
 
 void DivePlannerPointsModel::setRebreatherMode(int mode)
@@ -483,14 +474,6 @@ void DivePlannerPointsModel::setRebreatherMode(int mode)
 	for (i=0; i < rowCount(); i++)
 		divepoints[i].setpoint = mode == CCR ? prefs.defaultsetpoint : 0;
 	emitDataChanged();
-}
-
-void DivePlannerPointsModel::triggerGFLow()
-{
-	if (diveplan.gflow != tempGFLow) {
-		diveplan.gflow = tempGFLow;
-		emitDataChanged();
-	}
 }
 
 void DivePlannerPointsModel::setVpmbConservatism(int level)

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -64,7 +64,7 @@ slots:
 	void addCylinder_clicked();
 	void setGFHigh(const int gfhigh);
 	void triggerGFHigh();
-	void setGFLow(const int ghflow);
+	void setGFLow(const int gflow);
 	void triggerGFLow();
 	void setVpmbConservatism(int level);
 	void setSurfacePressure(int pressure);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -63,9 +63,7 @@ slots:
 	int addStop(int millimeters = 0, int seconds = 0, int cylinderid_in = -1, int ccpoint = 0, bool entered = true);
 	void addCylinder_clicked();
 	void setGFHigh(const int gfhigh);
-	void triggerGFHigh();
 	void setGFLow(const int gflow);
-	void triggerGFLow();
 	void setVpmbConservatism(int level);
 	void setSurfacePressure(int pressure);
 	void setSalinity(int salinity);
@@ -123,8 +121,6 @@ private:
 	bool recalc;
 	QVector<divedatapoint> divepoints;
 	QDateTime startTime;
-	int tempGFHigh;
-	int tempGFLow;
 	int instanceCounter = 0;
 	struct deco_state ds_after_previous_dives;
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While trying to understand a reported issue I found a couple of items to clean up:
- Typo "ghflow"
- An obsolete function declaration
- Special handling for gflow/high which is afaik not longer needed
- One indentation mistake
- A not consistently used function

As usually please review this carefully!


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
