### PR TITLE
Add negate-checkbox to filter lists [alternative to #973]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- desktop: Add negation button to filter lists (#735)
+- desktop: Add select all/select none/invert selection context menu to filter lists
 - Fix dive site merging for cloud (and local git storage) users. (#939)
 - desktop: Add variable zoom-levels for the dive photos tab (#898)
 - mobile: Faulty navigation after aborted dive edit (#932)

--- a/desktop-widgets/listfilter.ui
+++ b/desktop-widgets/listfilter.ui
@@ -51,6 +51,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QToolButton" name="notButton">
+       <property name="text">
+        <string>¬</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -500,6 +500,13 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 	}
 }
 
+void FilterBase::addContextMenuEntry(const QString &s, void (FilterModelBase::*fn)())
+{
+	QAction *act = new QAction(s, this);
+	connect(act, &QAction::triggered, model, fn);
+	ui.filterList->addAction(act);
+}
+
 FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent)
 	: QWidget(parent)
 	, model(model_)
@@ -513,6 +520,11 @@ FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent)
 	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
 	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
 	ui.filterList->setModel(filter);
+
+	addContextMenuEntry(tr("Select All"), &FilterModelBase::selectAll);
+	addContextMenuEntry(tr("Unselect All"), &FilterModelBase::clearFilter);
+	addContextMenuEntry(tr("Invert Selection"), &FilterModelBase::invertSelection);
+	ui.filterList->setContextMenuPolicy(Qt::ActionsContextMenu);
 }
 
 void FilterBase::showEvent(QShowEvent *event)

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -519,6 +519,7 @@ FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent)
 	filter->setSourceModel(model);
 	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
 	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
+	connect(ui.notButton, &QToolButton::toggled, model, &FilterModelBase::setNegate);
 	ui.filterList->setModel(filter);
 
 	addContextMenuEntry(tr("Select All"), &FilterModelBase::selectAll);

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -500,109 +500,52 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 	}
 }
 
-TagFilter::TagFilter(QWidget *parent) : QWidget(parent)
+FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent)
+	: QWidget(parent)
+	, model(model_)
 {
 	ui.setupUi(this);
-	ui.label->setText(tr("Tags: "));
 #if QT_VERSION >= 0x050200
 	ui.filterInternalList->setClearButtonEnabled(true);
 #endif
 	QSortFilterProxyModel *filter = new QSortFilterProxyModel();
-	filter->setSourceModel(TagFilterModel::instance());
+	filter->setSourceModel(model);
 	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
 	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
 	ui.filterList->setModel(filter);
 }
 
-void TagFilter::showEvent(QShowEvent *event)
+void FilterBase::showEvent(QShowEvent *event)
 {
-	MultiFilterSortModel::instance()->addFilterModel(TagFilterModel::instance());
+	MultiFilterSortModel::instance()->addFilterModel(model);
 	QWidget::showEvent(event);
 }
 
-void TagFilter::hideEvent(QHideEvent *event)
+void FilterBase::hideEvent(QHideEvent *event)
 {
-	MultiFilterSortModel::instance()->removeFilterModel(TagFilterModel::instance());
+	MultiFilterSortModel::instance()->removeFilterModel(model);
 	QWidget::hideEvent(event);
 }
 
-BuddyFilter::BuddyFilter(QWidget *parent) : QWidget(parent)
+TagFilter::TagFilter(QWidget *parent) : FilterBase(TagFilterModel::instance(), parent)
 {
-	ui.setupUi(this);
+	ui.label->setText(tr("Tags: "));
+}
+
+BuddyFilter::BuddyFilter(QWidget *parent) : FilterBase(BuddyFilterModel::instance(), parent)
+{
 	ui.label->setText(tr("Person: "));
 	ui.label->setToolTip(tr("Searches for buddies and divemasters"));
-#if QT_VERSION >= 0x050200
-	ui.filterInternalList->setClearButtonEnabled(true);
-#endif
-	QSortFilterProxyModel *filter = new QSortFilterProxyModel();
-	filter->setSourceModel(BuddyFilterModel::instance());
-	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
-	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
-	ui.filterList->setModel(filter);
 }
 
-void BuddyFilter::showEvent(QShowEvent *event)
+LocationFilter::LocationFilter(QWidget *parent) : FilterBase(LocationFilterModel::instance(), parent)
 {
-	MultiFilterSortModel::instance()->addFilterModel(BuddyFilterModel::instance());
-	QWidget::showEvent(event);
-}
-
-void BuddyFilter::hideEvent(QHideEvent *event)
-{
-	MultiFilterSortModel::instance()->removeFilterModel(BuddyFilterModel::instance());
-	QWidget::hideEvent(event);
-}
-
-LocationFilter::LocationFilter(QWidget *parent) : QWidget(parent)
-{
-	ui.setupUi(this);
 	ui.label->setText(tr("Location: "));
-#if QT_VERSION >= 0x050200
-	ui.filterInternalList->setClearButtonEnabled(true);
-#endif
-	QSortFilterProxyModel *filter = new QSortFilterProxyModel();
-	filter->setSourceModel(LocationFilterModel::instance());
-	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
-	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
-	ui.filterList->setModel(filter);
 }
 
-void LocationFilter::showEvent(QShowEvent *event)
+SuitFilter::SuitFilter(QWidget *parent) : FilterBase(SuitsFilterModel::instance(), parent)
 {
-	MultiFilterSortModel::instance()->addFilterModel(LocationFilterModel::instance());
-	QWidget::showEvent(event);
-}
-
-void LocationFilter::hideEvent(QHideEvent *event)
-{
-	MultiFilterSortModel::instance()->removeFilterModel(LocationFilterModel::instance());
-	QWidget::hideEvent(event);
-}
-
-SuitFilter::SuitFilter(QWidget *parent) : QWidget(parent)
-{
-	ui.setupUi(this);
 	ui.label->setText(tr("Suits: "));
-#if QT_VERSION >= 0x050200
-	ui.filterInternalList->setClearButtonEnabled(true);
-#endif
-	QSortFilterProxyModel *filter = new QSortFilterProxyModel();
-	filter->setSourceModel(SuitsFilterModel::instance());
-	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
-	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
-	ui.filterList->setModel(filter);
-}
-
-void SuitFilter::showEvent(QShowEvent *event)
-{
-	MultiFilterSortModel::instance()->addFilterModel(SuitsFilterModel::instance());
-	QWidget::showEvent(event);
-}
-
-void SuitFilter::hideEvent(QHideEvent *event)
-{
-	MultiFilterSortModel::instance()->removeFilterModel(SuitsFilterModel::instance());
-	QWidget::hideEvent(event);
 }
 
 MultiFilter::MultiFilter(QWidget *parent) : QWidget(parent)

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -167,6 +167,7 @@ public:
 };
 
 class FilterBase : public QWidget {
+	void addContextMenuEntry(const QString &s, void (FilterModelBase::*)());
 protected:
 	FilterBase(FilterModelBase *model, QWidget *parent = 0);
 	FilterModelBase *model;

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -5,6 +5,7 @@
 class MinMaxAvgWidgetPrivate;
 class QAbstractButton;
 class QNetworkReply;
+class FilterModelBase;
 
 #include <QWidget>
 #include <QGroupBox>
@@ -165,53 +166,37 @@ public:
 	Ui::FilterWidget2 ui;
 };
 
-class TagFilter : public QWidget {
-	Q_OBJECT
-public:
-	TagFilter(QWidget *parent = 0);
+class FilterBase : public QWidget {
+protected:
+	FilterBase(FilterModelBase *model, QWidget *parent = 0);
+	FilterModelBase *model;
+	Ui::FilterWidget ui;
 	virtual void showEvent(QShowEvent *);
 	virtual void hideEvent(QHideEvent *);
-
-private:
-	Ui::FilterWidget ui;
 	friend class MultiFilter;
 };
 
-class BuddyFilter : public QWidget {
-	Q_OBJECT
+class TagFilter : public FilterBase {
+public:
+	TagFilter(QWidget *parent = 0);
+};
+
+class BuddyFilter : public FilterBase {
 public:
 	BuddyFilter(QWidget *parent = 0);
-	virtual void showEvent(QShowEvent *);
-	virtual void hideEvent(QHideEvent *);
-
-private:
-	Ui::FilterWidget ui;
 };
 
-class SuitFilter : public QWidget {
-	Q_OBJECT
+class SuitFilter : public FilterBase {
 public:
 	SuitFilter(QWidget *parent = 0);
-	virtual void showEvent(QShowEvent *);
-	virtual void hideEvent(QHideEvent *);
-
-private:
-	Ui::FilterWidget ui;
 };
 
-class LocationFilter : public QWidget {
-	Q_OBJECT
+class LocationFilter : public FilterBase {
 public:
 	LocationFilter(QWidget *parent = 0);
-	virtual void showEvent(QShowEvent *);
-	virtual void hideEvent(QHideEvent *);
-
-private:
-	Ui::FilterWidget ui;
 };
 
 class TextHyperlinkEventFilter : public QObject {
-	Q_OBJECT
 public:
 	explicit TextHyperlinkEventFilter(QTextEdit *txtEdit);
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -100,6 +100,21 @@ void FilterModelBase::clearFilter()
 	emit dataChanged(createIndex(0,0), createIndex(rowCount()-1, 0));
 }
 
+void FilterModelBase::selectAll()
+{
+	std::fill(checkState.begin(), checkState.end(), true);
+	anyChecked = true;
+	emit dataChanged(createIndex(0,0), createIndex(rowCount()-1, 0));
+}
+
+void FilterModelBase::invertSelection()
+{
+	for (char &b: checkState)
+		b = !b;
+	anyChecked = std::any_of(checkState.begin(), checkState.end(), [](char b){return !!b;});
+	emit dataChanged(createIndex(0,0), createIndex(rowCount()-1, 0));
+}
+
 SuitsFilterModel::SuitsFilterModel(QObject *parent) : FilterModelBase(parent)
 {
 }

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -79,6 +79,7 @@ CREATE_COMMON_METHODS_FOR_FILTER(SuitsFilterModel, count_dives_with_suit)
 CREATE_INSTANCE_METHOD(MultiFilterSortModel)
 
 FilterModelBase::FilterModelBase(QObject *parent) : QStringListModel(parent)
+						  , anyChecked(false)
 {
 }
 
@@ -401,7 +402,7 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 		}
 		return showTrip;
 	}
-	Q_FOREACH (MultiFilterInterface *model, models) {
+	Q_FOREACH (FilterModelBase *model, models) {
 		if (!model->doFilter(d, index0, sourceModel()))
 			shouldShow = false;
 	}
@@ -456,7 +457,7 @@ void MultiFilterSortModel::myInvalidate()
 #endif
 }
 
-void MultiFilterSortModel::addFilterModel(MultiFilterInterface *model)
+void MultiFilterSortModel::addFilterModel(FilterModelBase *model)
 {
 	QAbstractItemModel *itemModel = dynamic_cast<QAbstractItemModel *>(model);
 	Q_ASSERT(itemModel);
@@ -464,7 +465,7 @@ void MultiFilterSortModel::addFilterModel(MultiFilterInterface *model)
 	connect(itemModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(myInvalidate()));
 }
 
-void MultiFilterSortModel::removeFilterModel(MultiFilterInterface *model)
+void MultiFilterSortModel::removeFilterModel(FilterModelBase *model)
 {
 	QAbstractItemModel *itemModel = dynamic_cast<QAbstractItemModel *>(model);
 	Q_ASSERT(itemModel);
@@ -475,7 +476,7 @@ void MultiFilterSortModel::removeFilterModel(MultiFilterInterface *model)
 void MultiFilterSortModel::clearFilter()
 {
 	justCleared = true;
-	Q_FOREACH (MultiFilterInterface *iface, models) {
+	Q_FOREACH (FilterModelBase *iface, models) {
 		iface->clearFilter();
 	}
 	justCleared = false;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 class FilterModelBase : public QStringListModel {
+	Q_OBJECT
 public:
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
 	void clearFilter();
@@ -15,6 +16,10 @@ public:
 	void invertSelection();
 	std::vector<char> checkState;
 	bool anyChecked;
+	bool negate;
+public
+slots:
+	void setNegate(bool negate);
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
 	void updateList(const QStringList &new_list);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -11,6 +11,8 @@ class FilterModelBase : public QStringListModel {
 public:
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
 	void clearFilter();
+	void selectAll();
+	void invertSelection();
 	std::vector<char> checkState;
 	bool anyChecked;
 protected:

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -7,16 +7,12 @@
 #include <stdint.h>
 #include <vector>
 
-class MultiFilterInterface {
+class FilterModelBase : public QStringListModel {
 public:
-	MultiFilterInterface() : anyChecked(false) {}
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
 	virtual void clearFilter() = 0;
 	std::vector<char> checkState;
 	bool anyChecked;
-};
-
-class FilterModelBase : public QStringListModel, public MultiFilterInterface {
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
 	void updateList(const QStringList &new_list);
@@ -97,8 +93,8 @@ class MultiFilterSortModel : public QSortFilterProxyModel {
 public:
 	static MultiFilterSortModel *instance();
 	virtual bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
-	void addFilterModel(MultiFilterInterface *model);
-	void removeFilterModel(MultiFilterInterface *model);
+	void addFilterModel(FilterModelBase *model);
+	void removeFilterModel(FilterModelBase *model);
 	int divesDisplayed;
 public
 slots:
@@ -111,7 +107,7 @@ signals:
 	void filterFinished();
 private:
 	MultiFilterSortModel(QObject *parent = 0);
-	QList<MultiFilterInterface *> models;
+	QList<FilterModelBase *> models;
 	bool justCleared;
 	struct dive_site *curr_dive_site;
 };

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -10,57 +10,52 @@
 class FilterModelBase : public QStringListModel {
 public:
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
-	virtual void clearFilter() = 0;
+	void clearFilter();
 	std::vector<char> checkState;
 	bool anyChecked;
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
 	void updateList(const QStringList &new_list);
+	virtual int countDives(const char *) const = 0;
+private:
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 };
 
 class TagFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static TagFilterModel *instance();
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
-	void clearFilter();
 public
 slots:
 	void repopulate();
 
 private:
 	explicit TagFilterModel(QObject *parent = 0);
+	int countDives(const char *) const;
 };
 
 class BuddyFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static BuddyFilterModel *instance();
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
-	void clearFilter();
 public
 slots:
 	void repopulate();
 
 private:
 	explicit BuddyFilterModel(QObject *parent = 0);
+	int countDives(const char *) const;
 };
 
 class LocationFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static LocationFilterModel *instance();
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
-	void clearFilter();
 public
 slots:
 	void repopulate();
@@ -69,23 +64,21 @@ slots:
 
 private:
 	explicit LocationFilterModel(QObject *parent = 0);
+	int countDives(const char *) const;
 };
 
 class SuitsFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static SuitsFilterModel *instance();
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
-	void clearFilter();
 public
 slots:
 	void repopulate();
 
 private:
 	explicit SuitsFilterModel(QObject *parent = 0);
+	int countDives(const char *) const;
 };
 
 class MultiFilterSortModel : public QSortFilterProxyModel {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an alternative to #973. The first three clean-up commits are the same. But I reckon that #973 does perhaps not perfectly implement #435: Suppose that the user wants to access all dives without buddy X. They select buddy X and then invert the selection. This will not show dives with buddy X only (as expected), but it *will* show dives with buddy X *and* Y.

Therefore, this alternative PR implements a not-toggle button instead of the menu button. If selected, a checked entry means "select dives that do not fulfill this criterion".

The changes of #973 are implemented in the fourth commit as a context menu.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
