### PR TITLE
beginInsertRows requires last >= first

### DIFF
--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -108,8 +108,10 @@ void DivePictureModel::updateDivePictures()
 
 	updateThumbnails();
 
-	beginInsertRows(QModelIndex(), 0, pictures.count() - 1);
-	endInsertRows();
+	if (!pictures.isEmpty()) {
+		beginInsertRows(QModelIndex(), 0, pictures.count() - 1);
+		endInsertRows();
+	}
 }
 
 int DivePictureModel::columnCount(const QModelIndex &parent) const


### PR DESCRIPTION
Found while compiled against Qt 5.10 build from source. The assert Q_ASSERT(last >= first) is trapped by this beginInsertRows in case there are no pictures. Just do not call this when there are no pictures.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>