### PR TITLE
mapwidget: revert QtQuick version to 2.0

### DIFF
--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.6
+import QtQuick 2.0
 import QtLocation 5.3
 import QtPositioning 5.3
 import org.subsurfacedivelog.mobile 1.0

--- a/map-widget/qml/MapWidgetContextMenu.qml
+++ b/map-widget/qml/MapWidgetContextMenu.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.6
+import QtQuick 2.0
 
 Item {
 	id: container

--- a/map-widget/qml/MapWidgetError.qml
+++ b/map-widget/qml/MapWidgetError.qml
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.6
+import QtQuick 2.0
 
 Item {
 	Text {


### PR DESCRIPTION
In commit f3d978b8a5fb6 the QtQuick version was upgraded to 2.6 (from 2.0 for the mapwidget). This is, apparently, too aggressive, as there are still mainstream distributions that are still on Qt 5.5.1 for which 2.6 of QtQuick is too new. And as a sidenote: Qt 5.5.1 was released in October 2015.

So partially revert commit f3d978b8a5fb6.

Fixes: #978

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>