### PR TITLE
Use correct date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Do not introduce any more 1/1/1970 GPS fixes (#567)
 - desktop: Add select all/select none/invert selection context menu to filter list (#735)
 - Fix dive site merging for cloud (and local git storage) users. (#939)
 - desktop: Add variable zoom-levels for the dive photos tab (#898)

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -601,7 +601,7 @@ void GpsLocation::downloadFromServer()
 			qDebug() << downloadedFixes.count() << "GPS fixes downloaded";
 			for (int i = 0; i < downloadedFixes.count(); i++) {
 				QJsonObject fix = downloadedFixes[i].toObject();
-				QDate date = QDate::fromString(fix.value("date").toString(), "yyy-M-d");
+				QDate date = QDate::fromString(fix.value("date").toString(), "yyyy-M-d");
 				QTime time = QTime::fromString(fix.value("time").toString(), "hh:m:s");
 				QString name = fix.value("name").toString();
 				QString latitude = fix.value("latitude").toString();


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
 Use correct date format

A very very trivial fix, for a mysterious issue. When loading GPS fix data from the server, the string date was parsed with the format "yyy-M-d". And no, the "yyy" is no typo here, but was the reason that data from the read from server got a 1/1/1970 data. And when a user decided to upload that data to the server again, we ended up with 2 copies of the GPS fix. One with correct data (as originally saved), and one new with the bogus date.

In order to get rid of those weird 1/1/1970 GPS fxes, users will have to remove them by hand.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Fixes: #567

### Release note:
Added.