### PR TITLE
Add negate button to filter lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Do not introduce any more 1/1/1970 GPS fixes (#567)
-- desktop: Add select all/select none/invert selection context menu to filter list (#735)
+- desktop: Add negation button to filter lists (#435)
+- desktop: Add select all/select none/invert selection context menu to filter lists
 - Fix dive site merging for cloud (and local git storage) users. (#939)
 - desktop: Add variable zoom-levels for the dive photos tab (#898)
 - mobile: Faulty navigation after aborted dive edit (#932)

--- a/desktop-widgets/listfilter.ui
+++ b/desktop-widgets/listfilter.ui
@@ -51,6 +51,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QToolButton" name="notButton">
+       <property name="text">
+        <string>¬</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/desktop-widgets/listfilter.ui
+++ b/desktop-widgets/listfilter.ui
@@ -51,16 +51,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QToolButton" name="selectionButton">
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -498,6 +498,13 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 	}
 }
 
+void FilterBase::addContextMenuEntry(const QString &s, void (FilterModelBase::*fn)())
+{
+	QAction *act = new QAction(s, this);
+	connect(act, &QAction::triggered, model, fn);
+	ui.filterList->addAction(act);
+}
+
 FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent) : QWidget(parent),
 	model(model_)
 {
@@ -511,11 +518,10 @@ FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent) : QWidget(paren
 	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
 	ui.filterList->setModel(filter);
 
-	QMenu *menu = new QMenu(this);
-	menu->addAction(tr("Select All"), model, &FilterModelBase::selectAll);
-	menu->addAction(tr("Unselect All"), model, &FilterModelBase::clearFilter);
-	menu->addAction(tr("Invert Selection"), model, &FilterModelBase::invertSelection);
-	ui.selectionButton->setMenu(menu);
+	addContextMenuEntry(tr("Select All"), &FilterModelBase::selectAll);
+	addContextMenuEntry(tr("Unselect All"), &FilterModelBase::clearFilter);
+	addContextMenuEntry(tr("Invert Selection"), &FilterModelBase::invertSelection);
+	ui.filterList->setContextMenuPolicy(Qt::ActionsContextMenu);
 }
 
 void FilterBase::showEvent(QShowEvent *event)

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -516,6 +516,7 @@ FilterBase::FilterBase(FilterModelBase *model_, QWidget *parent) : QWidget(paren
 	filter->setSourceModel(model);
 	filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
 	connect(ui.filterInternalList, SIGNAL(textChanged(QString)), filter, SLOT(setFilterFixedString(QString)));
+	connect(ui.notButton, &QToolButton::toggled, model, &FilterModelBase::setNegate);
 	ui.filterList->setModel(filter);
 
 	addContextMenuEntry(tr("Select All"), &FilterModelBase::selectAll);

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -167,6 +167,7 @@ public:
 };
 
 class FilterBase : public QWidget {
+	void addContextMenuEntry(const QString &s, void (FilterModelBase::*)());
 protected:
 	FilterBase(FilterModelBase *model, QWidget *parent = 0);
 	FilterModelBase *model;

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -177,32 +177,26 @@ protected:
 };
 
 class TagFilter : public FilterBase {
-	Q_OBJECT
 public:
 	TagFilter(QWidget *parent = 0);
-	friend class MultiFilter;
 };
 
 class BuddyFilter : public FilterBase {
-	Q_OBJECT
 public:
 	BuddyFilter(QWidget *parent = 0);
 };
 
 class SuitFilter : public FilterBase {
-	Q_OBJECT
 public:
 	SuitFilter(QWidget *parent = 0);
 };
 
 class LocationFilter : public FilterBase {
-	Q_OBJECT
 public:
 	LocationFilter(QWidget *parent = 0);
 };
 
 class TextHyperlinkEventFilter : public QObject {
-	Q_OBJECT
 public:
 	explicit TextHyperlinkEventFilter(QTextEdit *txtEdit);
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -26,7 +26,8 @@ CREATE_INSTANCE_METHOD(SuitsFilterModel)
 CREATE_INSTANCE_METHOD(MultiFilterSortModel)
 
 FilterModelBase::FilterModelBase(QObject *parent) : QStringListModel(parent),
-	anyChecked(false)
+	anyChecked(false),
+	negate(false)
 {
 }
 
@@ -115,6 +116,12 @@ void FilterModelBase::invertSelection()
 	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
 }
 
+void FilterModelBase::setNegate(bool negateParam)
+{
+	negate = negateParam;
+	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
+}
+
 SuitsFilterModel::SuitsFilterModel(QObject *parent) : FilterModelBase(parent)
 {
 }
@@ -129,28 +136,25 @@ bool SuitsFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 	Q_UNUSED(index0);
 	Q_UNUSED(sourceModel);
 
-	if (!anyChecked) {
+	// rowCount() == 0 should never happen, because we have the "no suits" row
+	// let's handle it gracefully anyway.
+	if (!anyChecked || rowCount() == 0)
 		return true;
-	}
 
 	// Checked means 'Show', Unchecked means 'Hide'.
 	QString suit(d->suit);
 	// only show empty suit dives if the user checked that.
-	if (suit.isEmpty()) {
-		if (rowCount() > 0)
-			return checkState[rowCount() - 1];
-		else
-			return true;
-	}
+	if (suit.isEmpty())
+		return checkState[rowCount() - 1] != negate;
 
 	// there is a suit selected
 	QStringList suitList = stringList();
 	// Ignore last item, since this is the "Show Empty Tags" entry
 	for (int i = 0; i < rowCount() - 1; i++) {
 		if (checkState[i] && suit == suitList[i])
-			return true;
+			return !negate;
 	}
-	return false;
+	return negate;
 }
 
 void SuitsFilterModel::repopulate()
@@ -200,18 +204,16 @@ bool TagFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel *
 	Q_UNUSED(sourceModel);
 
 	// If there's nothing checked, this should show everything
-	if (!anyChecked) {
+	// rowCount() == 0 should never happen, because we have the "no tags" row
+	// let's handle it gracefully anyway.
+	if (!anyChecked || rowCount() == 0)
 		return true;
-	}
+
 	// Checked means 'Show', Unchecked means 'Hide'.
 	struct tag_entry *head = d->tag_list;
 
-	if (!head) { // last tag means "Show empty tags";
-		if (rowCount() > 0)
-			return checkState[rowCount() - 1];
-		else
-			return true;
-	}
+	if (!head) // last tag means "Show empty tags";
+		return checkState[rowCount() - 1] != negate;
 
 	// have at least one tag.
 	QStringList tagList = stringList();
@@ -221,11 +223,11 @@ bool TagFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel *
 			QString tagName(head->tag->name);
 			int index = tagList.indexOf(tagName);
 			if (checkState[index])
-				return true;
+				return !negate;
 			head = head->next;
 		}
 	}
-	return false;
+	return negate;
 }
 
 BuddyFilterModel::BuddyFilterModel(QObject *parent) : FilterModelBase(parent)
@@ -243,30 +245,28 @@ bool BuddyFilterModel::doFilter(dive *d, QModelIndex &index0, QAbstractItemModel
 	Q_UNUSED(sourceModel);
 
 	// If there's nothing checked, this should show everything
-	if (!anyChecked) {
+	// rowCount() == 0 should never happen, because we have the "no tags" row
+	// let's handle it gracefully anyway.
+	if (!anyChecked || rowCount() == 0)
 		return true;
-	}
+
 	// Checked means 'Show', Unchecked means 'Hide'.
 	QString persons = QString(d->buddy) + "," + QString(d->divemaster);
 	QStringList personsList = persons.split(',', QString::SkipEmptyParts);
 	for (QString &s : personsList)
 		s = s.trimmed();
 	// only show empty buddie dives if the user checked that.
-	if (personsList.isEmpty()) {
-		if (rowCount() > 0)
-			return checkState[rowCount() - 1];
-		else
-			return true;
-	}
+	if (personsList.isEmpty())
+		return checkState[rowCount() - 1] != negate;
 
 	// have at least one buddy
 	QStringList buddyList = stringList();
 	// Ignore last item, since this is the "Show Empty Tags" entry
 	for (int i = 0; i < rowCount() - 1; i++) {
 		if (checkState[i] && personsList.contains(buddyList[i], Qt::CaseInsensitive))
-			return true;
+			return !negate;
 	}
-	return false;
+	return negate;
 }
 
 void BuddyFilterModel::repopulate()
@@ -302,27 +302,25 @@ bool LocationFilterModel::doFilter(struct dive *d, QModelIndex &index0, QAbstrac
 	Q_UNUSED(index0);
 	Q_UNUSED(sourceModel);
 
-	if (!anyChecked) {
+	// rowCount() == 0 should never happen, because we have the "no location" row
+	// let's handle it gracefully anyway.
+	if (!anyChecked || rowCount() == 0)
 		return true;
-	}
+
 	// Checked means 'Show', Unchecked means 'Hide'.
 	QString location(get_dive_location(d));
 	// only show empty location dives if the user checked that.
-	if (location.isEmpty()) {
-		if (rowCount() > 0)
-			return checkState[rowCount() - 1];
-		else
-			return true;
-	}
+	if (location.isEmpty())
+		return checkState[rowCount() - 1] != negate;
 
 	// There is a location selected
 	QStringList locationList = stringList();
 	// Ignore last item, since this is the "Show Empty Tags" entry
 	for (int i = 0; i < rowCount() - 1; i++) {
 		if (checkState[i] && location == locationList[i])
-			return true;
+			return !negate;
 	}
-	return false;
+	return negate;
 }
 
 void LocationFilterModel::repopulate()

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 class FilterModelBase : public QStringListModel {
+	Q_OBJECT
 public:
 	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
 	void clearFilter();
@@ -15,6 +16,10 @@ public:
 	void invertSelection();
 	std::vector<char> checkState;
 	bool anyChecked;
+	bool negate;
+public
+slots:
+	void setNegate(bool negate);
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
 	void updateList(const QStringList &new_list);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a potential improvement over #973. The functionality of #973 is kept and moved into a context menu. The button was changed into a "negate" toggle-button. If toggled-on, a checked item means filter all dives that do *not* fulfill this criterion.

Example: User checks buddy X and toggles the negate-button. Result: All dives without buddy X are shown.
Doing the same with the previous implementation: Check buddy X and invert selection. This will not show dives with buddy X only. But it will show dives with buddy X *and* other buddies.

For me the behavior of this PR seems more logical than that of #973.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
