### PR TITLE
Filter invalidate

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -445,6 +445,7 @@ void MultiFilterSortModel::myInvalidate()
 	divesDisplayed = 0;
 
 	invalidateFilter();
+	MainWindow::instance()->dive_list()->fixMessyQtModelBehaviour();
 
 	// first make sure the trips are no longer shown as selected
 	// (but without updating the selection state of the dives... this just cleans

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -58,6 +58,7 @@ void FilterModelBase::updateList(const QStringList &newList)
 		anyChecked = true;
 	}
 	setStringList(newList);
+	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
 }
 
 Qt::ItemFlags FilterModelBase::flags(const QModelIndex &index) const
@@ -353,8 +354,10 @@ void LocationFilterModel::changeName(const QString &oldName, const QString &newN
 
 	// If there was already an entry with the new name, we are merging entries.
 	// Thus, if the old entry was selected, also select the new entry.
-	if (newIndex >= 0 && checkState[oldIndex])
+	if (newIndex >= 0 && checkState[oldIndex]) {
 		checkState[newIndex] = true;
+		emit dataChanged(createIndex(newIndex, 0), createIndex(newIndex, 0));
+	}
 }
 
 void LocationFilterModel::addName(const QString &newName)
@@ -369,6 +372,7 @@ void LocationFilterModel::addName(const QString &newName)
 	list.prepend(newName);
 	setStringList(list);
 	checkState.insert(checkState.begin(), true);
+	emit dataChanged(createIndex(0, 0), createIndex(0, 0));
 }
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent),

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -440,7 +440,7 @@ void MultiFilterSortModel::myInvalidate()
 
 	divesDisplayed = 0;
 
-	invalidate();
+	invalidateFilter();
 
 	// first make sure the trips are no longer shown as selected
 	// (but without updating the selection state of the dives... this just cleans


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Possible bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This "bug" is found using Qt 5.10 compiled in developer mode. Access the filers, click a little around here, close the filters. Almost every time the following assert is triggered:

```
ASSERT failure in QPersistentModelIndex::~QPersistentModelIndex:
"persistent model indexes corrupted", file itemmodels/qabstractitemmodel.cpp, line 643
```

This is relatively deep down in Qt, and it is triggered by clearing the filters. Trying to force a crash when using the same scenario in Qt 5.10 compiled for production (so no active asserts) did not result in a crash. So, up to this time, it is unclear if the Qt assert points out a real problem, or it is some false alarm (for whatever reason).

Further investigation shows that the assert can be solved by changing the invalidate() to an invalidateFilter(). Indeed, the last variant is a little more lightweight, and does seem to do the same job from a functional point of view (in this case).

Unfortunately, a well known problem was introduced. Incorrect width setting for the spanning trip lines. And as there is even a specific function for that, just call this. The reason the mentioned commit introduces this, is that invalidate() causes layoutChanged signals, and invalidateFilter() does not.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
Carefully read the individual commits

### Additional information:
Original problem can only be seen when running Qt 5.10 from source with enabled asserts

### Mentions:
@dirkhh, @bstoeger 
