### PR TITLE
Remove unnecessary dynamic_cast<>s in filter code

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -479,18 +479,14 @@ void MultiFilterSortModel::myInvalidate()
 
 void MultiFilterSortModel::addFilterModel(FilterModelBase *model)
 {
-	QAbstractItemModel *itemModel = dynamic_cast<QAbstractItemModel *>(model);
-	Q_ASSERT(itemModel);
 	models.append(model);
-	connect(itemModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(myInvalidate()));
+	connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(myInvalidate()));
 }
 
 void MultiFilterSortModel::removeFilterModel(FilterModelBase *model)
 {
-	QAbstractItemModel *itemModel = dynamic_cast<QAbstractItemModel *>(model);
-	Q_ASSERT(itemModel);
 	models.removeAll(model);
-	disconnect(itemModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(myInvalidate()));
+	disconnect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(myInvalidate()));
 }
 
 void MultiFilterSortModel::clearFilter()


### PR DESCRIPTION
FilterModelBase is a direct subclass of QAbstractItemModel. Therefore,
dynamic_cast<>ing the former to the latter is unnecessary. Probably
an artifact of previous code.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removal of an unnecessary dynamic_cast<>.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
