### PR TITLE
Filter invalidate version 2

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -441,6 +441,7 @@ void MultiFilterSortModel::myInvalidate()
 	divesDisplayed = 0;
 
 	invalidateFilter();
+	MainWindow::instance()->dive_list()->fixMessyQtModelBehaviour();
 
 	// first make sure the trips are no longer shown as selected
 	// (but without updating the selection state of the dives... this just cleans

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -440,7 +440,7 @@ void MultiFilterSortModel::myInvalidate()
 
 	divesDisplayed = 0;
 
-	invalidate();
+	invalidateFilter();
 
 	// first make sure the trips are no longer shown as selected
 	// (but without updating the selection state of the dives... this just cleans

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -349,12 +349,12 @@ void LocationFilterModel::changeName(const QString &oldName, const QString &newN
 		return;
 	int newIndex = list.indexOf(newName);
 	list[oldIndex] = newName;
-	setStringList(list);
 
 	// If there was already an entry with the new name, we are merging entries.
 	// Thus, if the old entry was selected, also select the new entry.
 	if (newIndex >= 0 && checkState[oldIndex])
 		checkState[newIndex] = true;
+	setStringList(list);
 }
 
 void LocationFilterModel::addName(const QString &newName)
@@ -367,8 +367,8 @@ void LocationFilterModel::addName(const QString &newName)
 	if (!anyChecked || newName.isEmpty() || list.indexOf(newName) >= 0)
 		return;
 	list.prepend(newName);
-	setStringList(list);
 	checkState.insert(checkState.begin(), true);
+	setStringList(list);
 }
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent),


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Possible bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
I could have force pushed, the work described in PR #986, but decided not to, and open this new one. Basically, the 2nd commit is changed as a result of the review comment of Berthold.

This "bug" is found using Qt 5.10 compiled in developer mode. Access the filters, click a little around here, close the filters. Almost every time the following assert is triggered:

```
ASSERT failure in QPersistentModelIndex::~QPersistentModelIndex:
"persistent model indexes corrupted", file itemmodels/qabstractitemmodel.cpp, line 643
```

This is relatively deep down in Qt, and it is triggered by clearing the filters. Trying to force a crash when using the same scenario in Qt 5.10 compiled for production (so no active asserts) did not result in a crash. So, up to this time, it is unclear if the Qt assert points out a real problem, or it is some false alarm (for whatever reason).

Further investigation shows that the assert can be solved by changing the invalidate() to an invalidateFilter(). Indeed, the last variant is a little more lightweight, and does seem to do the same job from a functional point of view (in this case).

Unfortunately, a well known problem was introduced. Incorrect width setting for the spanning trip lines. And as there is even a specific function for that, just call this. The reason the mentioned commit introduces this, is that invalidate() causes layoutChanged signals, and invalidateFilter() does not.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
Carefully read the individual commits

### Additional information:
Original problem can only be seen when running Qt 5.10 from source with enabled asserts, and see (abandoned) PR #986, for the earlier review comment.

### Mentions:
@dirkhh, @bstoeger 