### PR TITLE
[RFC] Desktop: Don't hide errors on opening cloud storage

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -612,7 +612,6 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 		set_filename(fileNamePtr.data());
 		setTitle();
 	}
-	getNotificationWidget()->hideNotification();
 	process_dives(false, false);
 	hideProgressBar();
 	refreshDisplay();


### PR DESCRIPTION
In MainWindow::on_actionCloudstorageopen_triggered(),
getNotificationWidget()->hideNotification() was called, thus hiding
any error message produced by the cloud code. Notably, the information
"Cannot sync with cloud server, working with offline copy" was
not shown.

Therefore, remove this call. Note that on cloud save messages were
not hidden.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Background: I'm still failing to understand the cloud code. To my surprise, my test data was not actually synced with the cloud. But I didn't realize for a long time, because messages from the cloud machinery are hidden on cloud open. This trivial one-liner removes this hiding of messages.

I don't know if there is any reason that this was done. But I guess the correct way would be to either don't generate error message in the first place, or to hide only very specific error messages.

This is of course post-release material. Moreover, I'll be away for a few days, so happy new year everybody.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
