### PR TITLE
cleanup: less-than operators shall not use less-or-equal

### DIFF
--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -90,7 +90,7 @@ void PreferencesDialog::buttonClicked(QAbstractButton* btn)
 
 bool abstractpreferenceswidget_lessthan(AbstractPreferencesWidget *p1, AbstractPreferencesWidget *p2)
 {
-	return p1->positionHeight() <= p2->positionHeight();
+	return p1->positionHeight() < p2->positionHeight();
 }
 
 void PreferencesDialog::addPreferencePage(AbstractPreferencesWidget *page)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -659,7 +659,7 @@ void DivePlannerPointsModel::setStartTime(const QTime &t)
 
 bool divePointsLessThan(const divedatapoint &p1, const divedatapoint &p2)
 {
-	return p1.time <= p2.time;
+	return p1.time < p2.time;
 }
 
 int DivePlannerPointsModel::lastEnteredPoint()


### PR DESCRIPTION
See also commit c032006d91ee3c. Compare functions passed
to sort functions need to compare for less-than and not
less-or-equal.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>