### PR TITLE
desktop: clear tags when hitting new logbook

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -585,7 +585,6 @@ void MainTab::updateDiveInfo(bool clear)
 
 		volume_t gases[MAX_CYLINDERS] = {};
 		get_gas_used(&displayed_dive, gases);
-		QString volumes;
 		int mean[MAX_CYLINDERS], duration[MAX_CYLINDERS];
 		per_cylinder_mean_depth(&displayed_dive, select_dc(&displayed_dive), mean, duration);
 
@@ -629,6 +628,7 @@ void MainTab::updateDiveInfo(bool clear)
 		ui.timeEdit->setSpecialValueText(QString("-"));
 		ui.timeEdit->setMinimumTime(QTime(0, 0, 0, 0));
 		ui.timeEdit->setTime(QTime(0, 0, 0, 0));
+		ui.tagWidget->clear();
 	}
 	editMode = rememberEM;
 	ui.cylinders->view()->hideColumn(CylindersModel::DEPTH);


### PR DESCRIPTION
A very simple commit to start 2018. When hitting new logbook from a currently open logbook, and the current dive has tags filled in, they stayed around in the UI. Just clear them. Further, delete an unused variable.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>