### PR TITLE
Desktop: follow autogroup setting in UI

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -475,6 +475,7 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 	dive_list()->setEnabled(true);
 	dive_list()->setFocus();
 	WSInfoModel::instance()->updateInfo();
+	ui.actionAutoGroup->setChecked(autogroup);
 	if (amount_selected == 0)
 		cleanUpEmpty();
 }
@@ -615,7 +616,6 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 	process_dives(false, false);
 	hideProgressBar();
 	refreshDisplay();
-	ui.actionAutoGroup->setChecked(autogroup);
 }
 
 void MainWindow::on_actionCloudstoragesave_triggered()
@@ -1802,7 +1802,6 @@ void MainWindow::loadFiles(const QStringList fileNames)
 	process_dives(false, false);
 
 	refreshDisplay();
-	ui.actionAutoGroup->setChecked(autogroup);
 
 	int min_datafile_version = get_min_datafile_version();
 	if (min_datafile_version >0 && min_datafile_version < DATAFORMAT_VERSION) {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When importing a dive (using import from logfile) and it is a ssrf/xml file that contains the autogroup setting, the autogroup is effectuated in the dive list. Not sure that I like this behavior, but thats the way it currently is. Simply wrong is that in this case the menu item toggle is not adapted so we end up with a dive list that is autogrouped, but the menu toggle is off.

This can be solved by setting the UI toggle in a more central location.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
