### PR TITLE
Kiri sha update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,8 @@ if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 		mobile-widgets/qml/kirigami/src/kirigamiplugin.cpp
 		mobile-widgets/qml/kirigami/src/settings.cpp
 		mobile-widgets/qml/kirigami/src/enums.cpp
+                mobile-widgets/qml/kirigami/src/formlayoutattached.cpp
+                mobile-widgets/qml/kirigami/src/mnemonicattached.cpp
 		mobile-widgets/qml/kirigami/src/libkirigami/basictheme.cpp
 		mobile-widgets/qml/kirigami/src/libkirigami/kirigamipluginfactory.cpp
 		mobile-widgets/qml/kirigami/src/libkirigami/platformtheme.cpp

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -138,7 +138,9 @@ Kirigami.Page {
 
 	property QtObject deleteAction: Kirigami.Action {
 		text: qsTr("Delete dive")
-		iconName: "trash-empty"
+		icon {
+			name: "trash-empty"
+		}
 		onTriggered: {
 			var deletedId = currentItem.modelData.dive.id
 			var deletedIndex = diveDetailsListView.currentIndex
@@ -153,7 +155,9 @@ Kirigami.Page {
 
 	property QtObject cancelAction: Kirigami.Action {
 		text: qsTr("Cancel edit")
-		iconName: "dialog-cancel"
+		icon {
+			name: "dialog-cancel"
+		}
 		onTriggered: {
 			endEditMode()
 		}
@@ -161,14 +165,18 @@ Kirigami.Page {
 
 	property QtObject mapAction: Kirigami.Action {
 		text: qsTr("Show on map")
-		iconName: "gps"
+		icon {
+			name: "gps"
+		}
 		onTriggered: {
 			showMap(currentItem.modelData.dive.gps_decimal)
 		}
 	}
 
 	actions.main: Kirigami.Action {
-		iconName: state !== "view" ? "document-save" : "document-edit"
+		icon {
+			name: state !== "view" ? "document-save" : "document-edit"
+		}
 		onTriggered: {
 			manager.appendTextToLog("save/edit button triggered")
 			if (state === "edit" || state === "add") {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -332,7 +332,9 @@ Kirigami.ScrollablePage {
 	}
 
 	property QtObject downloadFromDCAction: Kirigami.Action {
-		iconName: "downloadDC"
+		icon {
+			name: "downloadDC"
+		}
 		onTriggered: {
 			downloadFromDc.dcImportModel.clearTable()
 			stackView.push(downloadFromDc)
@@ -340,14 +342,18 @@ Kirigami.ScrollablePage {
 	}
 
 	property QtObject addDiveAction: Kirigami.Action {
-		iconName: "list-add"
+		icon {
+			name: "list-add"
+		}
 		onTriggered: {
 			startAddDive()
 		}
 	}
 
 	property QtObject saveAction: Kirigami.Action {
-		iconName: "document-save"
+		icon {
+			name: "document-save"
+		}
 		onTriggered: {
 			Qt.inputMethod.hide()
 			startPage.saveCredentials();
@@ -355,7 +361,9 @@ Kirigami.ScrollablePage {
 	}
 
 	property QtObject offlineAction: Kirigami.Action {
-		iconName: "qrc:/qml/nocloud.svg"
+		icon {
+			name: "qrc:/qml/nocloud.svg"
+		}
 		onTriggered: {
 			manager.syncToCloud = false
 			manager.credentialStatus = QMLManager.CS_NOCLOUD

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -72,14 +72,18 @@ Kirigami.ScrollablePage {
 			}
 			actions: [
 				Kirigami.Action {
-					iconName: "trash-empty"
+					icon {
+						name: "trash-empty"
+					}
 					onTriggered: {
 						print("delete this!")
 						manager.deleteGpsFix(when)
 					}
 				},
 				Kirigami.Action {
-					iconName: "gps"
+					icon {
+						name: "gps"
+					}
 					onTriggered: {
 						showMap(latitude + " " + longitude)
 					}

--- a/mobile-widgets/qml/HintsTextEdit.qml
+++ b/mobile-widgets/qml/HintsTextEdit.qml
@@ -106,6 +106,7 @@ TextField {
 				bottomPadding: 0
 				leftPadding: 0
 				rightPadding: 0
+				icon: ""
 				implicitHeight: Kirigami.Units.gridUnit*2
 				checked: hintsView.currentIndex == index
 				onClicked: {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -115,7 +115,9 @@ Kirigami.ApplicationWindow {
 
 		actions: [
 			Kirigami.Action {
-				iconName: "icons/ic_home.svg"
+				icon {
+					name: "icons/ic_home.svg"
+				}
 				text: qsTr("Dive list")
 				onTriggered: {
 					manager.appendTextToLog("requested dive list with credential status " + manager.credentialStatus)
@@ -131,10 +133,14 @@ Kirigami.ApplicationWindow {
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_sync.svg"
+				icon {
+					name: "icons/ic_sync.svg"
+				}
 				text: qsTr("Dive management")
 				Kirigami.Action {
-					iconName: "icons/ic_add.svg"
+					icon {
+						name: "icons/ic_add.svg"
+					}
 					text: qsTr("Add dive manually")
 					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
 					onTriggered: {
@@ -145,7 +151,9 @@ Kirigami.ApplicationWindow {
 				}
 				Kirigami.Action {
 					// this of course assumes a white background - theming means this needs to change again
-					iconName: "icons/downloadDC-black.svg"
+					icon {
+						name: "icons/downloadDC-black.svg"
+					}
 					text: qsTr("Download from DC")
 					enabled: true
 					onTriggered: {
@@ -155,14 +163,18 @@ Kirigami.ApplicationWindow {
 					}
 				}
 				Kirigami.Action {
-					iconName: "icons/ic_add_location.svg"
+					icon {
+						name: "icons/ic_add_location.svg"
+					}
 					text: qsTr("Apply GPS fixes")
 					onTriggered: {
 						manager.applyGpsData();
 					}
 				}
 				Kirigami.Action {
-					iconName: "icons/cloud_sync.svg"
+					icon {
+						name: "icons/cloud_sync.svg"
+					}
 					text: qsTr("Manual sync with cloud")
 					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
 					onTriggered: {
@@ -181,7 +193,9 @@ Kirigami.ApplicationWindow {
 					}
 				}
 				Kirigami.Action {
-				iconName: syncToCloud ? "icons/ic_cloud_off.svg" : "icons/ic_cloud_done.svg"
+				icon {
+					name: syncToCloud ? "icons/ic_cloud_off.svg" : "icons/ic_cloud_done.svg"
+				}
 				text: syncToCloud ? qsTr("Offline mode") : qsTr("Auto cloud sync enabled")
 					enabled: manager.credentialStatus !== QMLManager.CS_NOCLOUD
 					onTriggered: {
@@ -195,12 +209,16 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_place.svg"
+				icon {
+					name: "icons/ic_place.svg"
+				}
 				text: qsTr("GPS")
 				visible: true
 
 				Kirigami.Action {
-					iconName: "icons/ic_cloud_upload.svg"
+					icon {
+						name: "icons/ic_cloud_upload.svg"
+					}
 					text: qsTr("Upload GPS data")
 					onTriggered: {
 						globalDrawer.close();
@@ -209,7 +227,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 
 				Kirigami.Action {
-					iconName: "icons/ic_cloud_download.svg"
+					icon {
+						name: "icons/ic_cloud_download.svg"
+					}
 					text: qsTr("Download GPS data")
 					onTriggered: {
 						globalDrawer.close();
@@ -218,7 +238,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 
 				Kirigami.Action {
-					iconName: "icons/ic_gps_fixed.svg"
+					icon {
+						name:"icons/ic_gps_fixed.svg"
+					}
 					text: qsTr("Show GPS fixes")
 					onTriggered: {
 						globalDrawer.close()
@@ -229,7 +251,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 
 				Kirigami.Action {
-					iconName: "icons/ic_clear.svg"
+					icon {
+						name: "icons/ic_clear.svg"
+					}
 					text: qsTr("Clear GPS cache")
 					onTriggered: {
 						globalDrawer.close();
@@ -238,7 +262,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 
 				Kirigami.Action {
-					iconName: locationServiceEnabled ? "icons/ic_location_off.svg" : "icons/ic_place.svg"
+					icon {
+						name: locationServiceEnabled ? "icons/ic_location_off.svg" : "icons/ic_place.svg"
+					}
 					text: locationServiceEnabled ? qsTr("Disable location service") : qsTr("Run location service")
 					onTriggered: {
 						globalDrawer.close();
@@ -247,7 +273,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_info_outline.svg"
+				icon {
+					name: "icons/ic_info_outline.svg"
+				}
 				text: qsTr("About")
 				onTriggered: {
 					globalDrawer.close()
@@ -256,7 +284,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_settings.svg"
+				icon {
+					name: "icons/ic_settings.svg"
+				}
 				text: qsTr("Settings")
 				onTriggered: {
 					globalDrawer.close()
@@ -265,7 +295,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_adb.svg"
+				icon {
+					name: "icons/ic_adb.svg"
+				}
 				text: qsTr("Developer")
 				visible: manager.developer
 				Kirigami.Action {
@@ -285,7 +317,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
-				iconName: "icons/ic_help_outline.svg"
+				icon {
+					name: "icons/ic_help_outline.svg"
+				}
 				text: qsTr("Help")
 				onTriggered: {
 					Qt.openUrlExternally("https://subsurface-divelog.org/documentation/subsurface-mobile-v2-user-manual/")

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -28,6 +28,8 @@
 	</qresource>
 	<qresource prefix="/">
 		<file>qtquickcontrols2.conf</file>
+	</qresource>
+	<qresource prefix="/org/kde/kirigami">
 		<file alias="icons/go-next-symbolic.svg">kirigami/icons/go-next.svg</file>
 		<file alias="icons/go-previous-symbolic.svg">kirigami/icons/go-previous.svg</file>
 		<file alias="icons/go-up.svg">kirigami/icons/go-up.svg</file>

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -33,7 +33,7 @@ if [ "$NOPULL" = "" ] ; then
 	git checkout master
 	git pull origin master
 	# if we want to pin a specific Kirigami version, we can do this here
-	git checkout 2f5b6fc2a2fa9fb6578a6a709d2d7c51582f2e29
+	git checkout 3606ef16375f9deb132565463d1ab11cea2548df
 	popd
 fi
 if [ ! -d breeze-icons ] ; then


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

First commit consists of the following 3 parts:
1. There are 2 source files added, adapt our build process accordingly.
2. Due to a change in icon and kirigami QML prefixes, we need to adapt for this as well. Changed mobile-resources.qrc for that. When this would not be changed, the icons will not be found.
3. To further prepare for the future, abandon the iconName property in favor of the new icon grouped property, which can have more attributes than only the name. But currently it is only a syntactic change.

The second commit fixes a mysteriously 300 extra warnings in the app log. It was caused by a code change in Kirigami. The way to suppress it is, in hindsight, after some hours of searching, trivial. A Kirigami.BasicListItem shall have an icon defined. And as we do not care about any icon here, just define it empty.

Tested on Android device, and no visible changes.

### Changes made:
See above.

### Related issues:
no
