### PR TITLE
Desktop cloud UI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Automatically sync with cloud when going online
 - Small UI fixes
 - Fix bug when using remembered BT/BLE addresses in dive computer download
 - Fix bug in cylider pressure lines

--- a/core/pref.h
+++ b/core/pref.h
@@ -145,7 +145,6 @@ struct preferences {
 	const char *cloud_storage_email_encoded;
 	bool save_password_local;
 	short cloud_verification_status;
-	bool cloud_background_sync;
 	geocoding_prefs_t geocoding;
 	enum deco_mode planner_deco_mode;
 	short vpmb_conservatism;

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1273,7 +1273,7 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 		return report_error("creating commit failed");
 
 	/* now sync the tree with the remote server */
-	if (remote && prefs.cloud_background_sync && !prefs.git_local_only)
+	if (remote && !prefs.git_local_only)
 		return sync_with_remote(repo, remote, branch, RT_HTTPS);
 	return 0;
 }

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1272,12 +1272,9 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 	if (create_new_commit(repo, remote, branch, &id, create_empty))
 		return report_error("creating commit failed");
 
-	if (remote && prefs.cloud_background_sync && !prefs.git_local_only) {
-		/* now sync the tree with the cloud server */
-		if (strstr(remote, prefs.cloud_git_url)) {
-			return sync_with_remote(repo, remote, branch, RT_HTTPS);
-		}
-	}
+	/* now sync the tree with the remote server */
+	if (remote && prefs.cloud_background_sync && !prefs.git_local_only)
+		return sync_with_remote(repo, remote, branch, RT_HTTPS);
 	return 0;
 }
 

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -983,11 +983,6 @@ short CloudStorageSettings::verificationStatus() const
 	return prefs.cloud_verification_status;
 }
 
-bool CloudStorageSettings::backgroundSync() const
-{
-	return prefs.cloud_background_sync;
-}
-
 QString CloudStorageSettings::userId() const
 {
 	return QString(prefs.userid);
@@ -1079,17 +1074,6 @@ void CloudStorageSettings::setVerificationStatus(short value)
 	s.setValue("cloud_verification_status", value);
 	prefs.cloud_verification_status = value;
 	emit verificationStatusChanged(value);
-}
-
-void CloudStorageSettings::setBackgroundSync(bool value)
-{
-	if (value == prefs.cloud_background_sync)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("cloud_background_sync", value);
-	prefs.cloud_background_sync = value;
-	emit backgroundSyncChanged(value);
 }
 
 void CloudStorageSettings::setSaveUserIdLocal(bool value)
@@ -2300,7 +2284,6 @@ void SettingsObjectWrapper::load()
 		GET_TXT("password", cloud_storage_password);
 	}
 	GET_INT("cloud_verification_status", cloud_verification_status);
-	GET_BOOL("cloud_background_sync", cloud_background_sync);
 	GET_BOOL("git_local_only", git_local_only);
 
 	// creating the git url here is simply a convenience when C code wants

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -331,7 +331,6 @@ class CloudStorageSettings : public QObject {
 	Q_PROPERTY(bool git_local_only       READ gitLocalOnly       WRITE setGitLocalOnly       NOTIFY gitLocalOnlyChanged)
 	Q_PROPERTY(bool save_password_local  READ savePasswordLocal  WRITE setSavePasswordLocal  NOTIFY savePasswordLocalChanged)
 	Q_PROPERTY(short verification_status READ verificationStatus WRITE setVerificationStatus NOTIFY verificationStatusChanged)
-	Q_PROPERTY(bool background_sync      READ backgroundSync     WRITE setBackgroundSync     NOTIFY backgroundSyncChanged)
 public:
 	CloudStorageSettings(QObject *parent);
 	QString password() const;
@@ -343,7 +342,6 @@ public:
 	QString gitUrl() const;
 	bool savePasswordLocal() const;
 	short verificationStatus() const;
-	bool backgroundSync() const;
 	bool gitLocalOnly() const;
 	bool saveUserIdLocal() const;
 
@@ -357,7 +355,6 @@ public slots:
 	void setGitUrl(const QString& value);
 	void setSavePasswordLocal(bool value);
 	void setVerificationStatus(short value);
-	void setBackgroundSync(bool value);
 	void setGitLocalOnly(bool value);
 	void setSaveUserIdLocal(bool value);
 
@@ -371,7 +368,6 @@ signals:
 	void gitUrlChanged(const QString& value);
 	void savePasswordLocalChanged(bool value);
 	void verificationStatusChanged(short value);
-	void backgroundSyncChanged(bool value);
 	void gitLocalOnlyChanged(bool value);
 	void saveUserIdLocalChanged(bool value);
 

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -81,7 +81,6 @@ struct preferences default_prefs = {
 		.access_token = NULL
 	},
 	.defaultsetpoint = 1100,
-	.cloud_background_sync = true,
 	.geocoding = {
 		.category = { 0 }
 	},

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -103,7 +103,7 @@ slots:
 	void on_actionClose_triggered();
 	void on_actionCloudstorageopen_triggered();
 	void on_actionCloudstoragesave_triggered();
-	void on_actionTake_cloud_storage_online_triggered();
+	void on_actionCloudOnline_triggered();
 	void on_actionPrint_triggered();
 	void on_actionPreferences_triggered();
 	void on_actionQuit_triggered();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -198,6 +198,8 @@ private:
 	bool askSaveChanges();
 	bool okToClose(QString message);
 	void closeCurrentFile();
+	void setCurrentFile(const char *f);
+	void updateCloudOnlineStatus();
 	void showProgressBar();
 	void hideProgressBar();
 	void writeSettings();

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -66,7 +66,7 @@
     <addaction name="actionSaveAs"/>
     <addaction name="actionCloudstorageopen"/>
     <addaction name="actionCloudstoragesave"/>
-    <addaction name="actionTake_cloud_storage_online"/>
+    <addaction name="actionCloudOnline"/>
     <addaction name="separator"/>
     <addaction name="actionClose"/>
     <addaction name="actionExport"/>
@@ -714,9 +714,12 @@
     <string>Facebook</string>
    </property>
   </action>
-  <action name="actionTake_cloud_storage_online">
+  <action name="actionCloudOnline">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
-    <string>Take cloud storage online</string>
+    <string>Cloud storage online</string>
    </property>
   </action>
  </widget>

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -38,7 +38,6 @@ void PreferencesNetwork::refreshSettings()
 	ui->cloud_storage_email->setText(prefs.cloud_storage_email);
 	ui->cloud_storage_password->setText(prefs.cloud_storage_password);
 	ui->save_password_local->setChecked(prefs.save_password_local);
-	ui->cloud_background_sync->setChecked(prefs.cloud_background_sync);
 	ui->save_uid_local->setChecked(prefs.save_userid_local);
 	ui->default_uid->setText(QString(prefs.userid).toUpper());
 	updateCloudAuthenticationState();
@@ -115,7 +114,6 @@ void PreferencesNetwork::syncSettings()
 	cloud->setSavePasswordLocal(ui->save_password_local->isChecked());
 	cloud->setPassword(password);
 	cloud->setVerificationStatus(prefs.cloud_verification_status);
-	cloud->setBackgroundSync(ui->cloud_background_sync->isChecked());
 	cloud->setBaseUrl(prefs.cloud_base_url);
 }
 

--- a/desktop-widgets/preferences/preferences_network.ui
+++ b/desktop-widgets/preferences/preferences_network.ui
@@ -216,13 +216,6 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="cloud_background_sync">
-        <property name="text">
-         <string>Sync to cloud in the background?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
        <widget class="QCheckBox" name="save_password_local">
         <property name="text">
          <string>Save Password locally?</string>

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -43,7 +43,6 @@ void TestGitStorage::initTestCase()
 	s.endGroup();
 	prefs.cloud_storage_email_encoded = strdup("ssrftest@hohndel.org");
 	prefs.cloud_storage_password = strdup("geheim");
-	prefs.cloud_background_sync = true;
 	QNetworkProxy proxy;
 	proxy.setType(QNetworkProxy::ProxyType(prefs.proxy_type));
 	proxy.setHostName(prefs.proxy_host);

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -25,10 +25,6 @@ void TestPreferences::testPreferences()
 	pref->load();
 
 	auto cloud = pref->cloud_storage;
-	cloud->setBackgroundSync(true);
-	TEST(cloud->backgroundSync(), true);
-	cloud->setBackgroundSync(false);
-	TEST(cloud->backgroundSync(), false);
 
 	cloud->setBaseUrl("test_one");
 	TEST(cloud->baseUrl(), QStringLiteral("test_one"));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are changes to the cloud desktop UI. In an attempt to make it possible to access non-cloud remote git repositories, a few adaptations to the UI were made. I think it will be easier to introduce these changes now and get feedback along the way. My problem is that I access dives from only one device, so I cannot really experience the cloud UI.

The changes here mostly concern the online/offline status. Firstly, I thought it was weird that "take cloud online" would not give any feedback. So this is changed to actually try to sync with the cloud. If this doesn't work, the user is informed. If it does work, the window title is changed to reflect the change.

Secondly, the preferences flag "sync with cloud in the background" (which does not do what it says) is replaced by a "take cloud offline" menu entry. This gives a symmetric interface (take cloud online/offline). More importantly, this can be used for arbitrary git repositories.

Thirdly, the options "take cloud online/offline" are now only enabled if the current file is the cloud. This can in the future simply be replaced by the condition "current file is remote git repository", with an appropriate renaming of the options.

Thanks for feedback / testing.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
