### PR TITLE
Incorporate ICD calculations in dive planner output

### DIFF
--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -35,11 +35,15 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 {
 	const unsigned int sz_buffer = 2000000;
 	const unsigned int sz_temp = 100000;
+	const unsigned int sz_icdbuf = 10000;
 	char *buffer = (char *)malloc(sz_buffer);
 	char *temp = (char *)malloc(sz_temp);
+	char *icdbuffer = (char *)malloc(sz_icdbuf);
+	char *prev_gasname = (char *)malloc(10);
 	const char *deco, *segmentsymbol;
 	static char buf[1000];
-	int len, lastdepth = 0, lasttime = 0, lastsetpoint = -1, newdepth = 0, lastprintdepth = 0, lastprintsetpoint = -1;
+	double deltaN2, deltaHe, maxdeltaN2, deltaPN2, deltaPHe;
+	int icyl, len, icdlen=0, runtime, lastdepth = 0, lasttime = 0, lastsetpoint = -1, newdepth = 0, lastprintdepth = 0, lastprintsetpoint = -1;
 	struct gasmix lastprintgasmix = {{ -1 }, { -1 }};
 	struct divedatapoint *dp = diveplan->dp;
 	bool plan_verbatim = prefs.verbatim_plan;
@@ -49,6 +53,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	bool gaschange_after = !plan_verbatim;
 	bool gaschange_before;
 	bool lastentered = true;
+	bool istrimix = false;
 	struct divedatapoint *nextdp = NULL;
 	struct divedatapoint *lastbottomdp = NULL;
 
@@ -66,6 +71,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	disclaimer = buf;
 
 	if (!dp) {
+		free((void *)prev_gasname);
+		free((void *)icdbuffer);
 		free((void *)buffer);
 		free((void *)temp);
 		return;
@@ -77,7 +84,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 		snprintf(buffer, sz_buffer, "<span style='color: red;'>%s </span> %s<br>",
 				translate("gettextFromC", "Warning:"), temp);
 		dive->notes = strdup(buffer);
-
+		free((void *)prev_gasname);
+		free((void *)icdbuffer);
 		free((void *)buffer);
 		free((void *)temp);
 		return;
@@ -91,6 +99,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				subsurface_canonical_version(),
 				translate("gettextFromC", "dive plan</b> (overlapping dives detected)"));
 				dive->notes = strdup(buffer);
+				free((void *)prev_gasname);
+				free((void *)icdbuffer);
 				free((void *)buffer);
 				free((void *)temp);
 				return;
@@ -135,6 +145,25 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				"<th style='padding-left: 10px; float: left;'>%s</th></tr></thead><tbody style='float: left;'>",
 				translate("gettextFromC", "gas"));
 	}
+	for (icyl=0; icyl<MAX_CYLINDERS; icyl++)	// If dive plan has an OC cylinder with helium, then initialise ICD table:
+		if ((dive->cylinder[icyl].cylinder_use == OC_GAS) && (dive->cylinder[icyl].gasmix.he.permille > 0)) {	
+			istrimix = true;
+			icdlen = 0;
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, 
+					"<table><tbody style='float: left;'><tr><td colspan=5>Isobaric counterdiffusion information:</td></tr>");
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, "<tr><td align='left'><b>%s</b></td>",
+					translate("gettextFromC", "runtime"));
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, "<td align='center'><b>%s</b></td>",
+					translate("gettextFromC", "gaschange"));
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, "<td style='padding-left: 15px;'><b>%s</b></td>",
+					translate("gettextFromC", "&#916;He"));
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, "%s",
+					translate("gettextFromC", "<td><b>&#916;N&#8322;</b></td>"));
+			icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, "<td><b>%s</b></td></tr>",
+					translate("gettextFromC", "max &#916;N&#8322;%"));
+			break;
+		}
+
 	do {
 		struct gasmix gasmix, newgasmix = {};
 		const char *depth_unit;
@@ -265,16 +294,33 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; float: right;'>%s</td>", temp);
 				}
 
+				if (istrimix) {
+					deltaN2 = ((1000 - newgasmix.he.permille - newgasmix.o2.permille) - (1000 - lastprintgasmix.he.permille - lastprintgasmix.o2.permille)) / 10.0;
+					deltaHe = (newgasmix.he.permille - lastprintgasmix.he.permille) / 10.0;
+					maxdeltaN2 = 0.02 * (lastprintgasmix.he.permille-newgasmix.he.permille);
+					runtime = (dp->time + 30) / 60;
+					deltaPN2 = depth_to_bar(dp->depth.mm, dive) * deltaN2 / 100;
+					deltaPHe = depth_to_bar(dp->depth.mm, dive) * deltaHe / 100;
+				}
+
 				/* Normally a gas change is displayed on the stopping segment, so only display a gas change at the end of
 				 * an ascent segment if it is not followed by a stop
 				 */
+
 				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth.mm != nextdp->depth.mm || nextdp->entered)) {
 					if (dp->setpoint) {
 						snprintf(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) nextdp->setpoint / 1000.0);
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasname(&newgasmix),
 									temp);
 					} else {
-							len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s</b></td>", gasname(&newgasmix));
+						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s</b></td>", gasname(&newgasmix));
+						if (isascent && (lastprintgasmix.he.permille > 0)) {		// On ascent, save ICD info if previous cylinder had helium
+							icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, translate("gettextFromC", 
+							"<tr><td>%3dmin</td><td>%s&#10137;%s</td><td style='padding-left: 10px;' width='15%'>%+5.2f %<br>%+5.2f bar</td><td style= 'color:%s;' width= '15%'>%+5.1f %<br>%+5.2f bar</td><><td>%+5.1f %</td></tr>"),
+							runtime, prev_gasname, gasname(&newgasmix), deltaHe, deltaPHe, (deltaN2>maxdeltaN2) ? "red" : "black", deltaN2, deltaPN2, 
+							maxdeltaN2);
+						}
+						strcpy(prev_gasname, gasname(&newgasmix));
 					}
 					lastprintsetpoint = nextdp->setpoint;
 					lastprintgasmix = newgasmix;
@@ -286,7 +332,14 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasname(&gasmix),
 									temp);
 					} else {
-							len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s</b></td>", gasname(&gasmix));
+						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s</b></td>", gasname(&gasmix));
+						if (lastprintgasmix.he.permille > 0) {		// Save ICD info if previous cylinder had helium
+							icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen, translate("gettextFromC", 
+							"<tr><td>%3dmin</td><td>%s&#10137;%s</td><td style='padding-left: 10px;' width='15%'>%+5.2f %<br>%+5.2f bar</td><td style= 'color:%s;' width='15%'>%+5.1f %<br>%+5.2f bar</td><><td>%+5.1f</td></tr>"),
+							runtime, prev_gasname, gasname(&newgasmix), deltaPN2, deltaHe, (deltaN2>maxdeltaN2) ? "red" : "black",
+							deltaN2, maxdeltaN2);
+						}
+						strcpy(prev_gasname, gasname(&newgasmix));
 					}
 					// Set variables so subsequent iterations can test against the last gas printed
 					lastprintsetpoint = dp->setpoint;
@@ -308,11 +361,10 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 						snprintf(temp, sz_temp, translate("gettextFromC", "Switch gas to %s (SP = %.1fbar)"), gasname(&newgasmix), (double) nextdp->setpoint / 1000.0);
 					else
 						snprintf(temp, sz_temp, translate("gettextFromC", "Switch gas to %s"), gasname(&newgasmix));
-
-					len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
+						len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
 				}
 				gaschange_after = false;
-			gasmix = newgasmix;
+				gasmix = newgasmix;
 			}
 		}
 		lastprintdepth = newdepth;
@@ -469,6 +521,12 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 		len += snprintf(buffer + len, sz_buffer - len, "%s%s%s<br>", temp, warning, mingas);
 	}
 
+	/* For trimix OC dives, add ICD table here */
+	if (istrimix) {
+		icdlen += snprintf(icdbuffer + icdlen, sz_icdbuf - icdlen,"</tbody></table><br>");	// End the ICD table
+		len += snprintf(buffer + len, sz_buffer - len, "%s", icdbuffer);					// ..and add it to the html buffer
+	}
+
 	/* Print warnings for pO2 */
 	dp = diveplan->dp;
 	bool o2warning_exist = false;
@@ -509,9 +567,12 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 			dp = dp->next;
 		}
 	}
+
 	snprintf(buffer + len, sz_buffer - len, "</div>");
 	dive->notes = strdup(buffer);
 
+	free((void *)prev_gasname);
+	free((void *)icdbuffer);
 	free((void *)buffer);
 	free((void *)temp);
 }


### PR DESCRIPTION
1) Changes to wrong indentations
2) Print table of ICD info as part of planner output

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As in description at the top

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
I attended to almost all the comments received.
1) Adjusted code following coding rules
2) Fixed malloc with corresponding free instructions
3) adjusted table to have two rows per gas change
4) used depth_to_bar function
5) Improved html code generated by this C function

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
The formatting of the ICD table is still not perfect, but there are some limitations in the way that Qt interprets the html table. It is not fully HTML5 compliant.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

Stefan Fuchs

I am not sure where the sign-off is placed in a pull request.