### PR TITLE
[RFC] Enter offline mode if sync with cloud failed

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -608,6 +608,8 @@ int sync_with_remote(git_repository *repo, const char *remote, const char *branc
 			// If we returned GIT_EUSER during authentication, giterr_last() returns NULL
 			fprintf(stderr, "remote fetch failed (%s)\n",
 				giterr_last() ? giterr_last()->message : "authentication failed");
+		// Since we failed to sync with online repository, enter offline mode
+		prefs.git_local_only = true;
 		error = 0;
 	} else {
 		error = check_remote_status(repo, origin, remote, branch, rt);


### PR DESCRIPTION
In case syncing with the online repository failed, enter offline mode.
This reflects the message sent to the user ("working with local copy").

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not sure about this one. Background: Apparently I am too stupid to compile a working libgit2 (to make cloud syncing work, I have to comment out the `git_config_delete_entry(conf, "http.proxy");` line, but that is a different story). Anyway, I was surprised that it tells me that I'm working with an offline copy and yet I'm in online mode. This commit switches to offline mode if syncing failed for whatever reason.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

  