### PR TITLE
[RFC] Silence two warnings

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -175,25 +175,25 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 						 * for cuft sizes (as that's all that you can enter) */
 						dive->cylinder[i].type.workingpressure.mbar = lrint(
 							dive->cylinder[i].type.workingpressure.mbar * 206.843 / 206.7 );
-						char name_buffer[9];
+						char name_buffer[17];
 						int rounded_size = lrint(ml_to_cuft(gas_volume(&dive->cylinder[i],
 							dive->cylinder[i].type.workingpressure)));
 						rounded_size = (int)((rounded_size + 5) / 10) * 10;
 						switch (dive->cylinder[i].type.workingpressure.mbar) {
 						case 206843:
-							snprintf(name_buffer, 9, "AL%d", rounded_size);
+							snprintf(name_buffer, sizeof(name_buffer), "AL%d", rounded_size);
 							break;
 						case 234422: /* this is wrong - HP tanks tend to be 3440, but Suunto only allows 3400 */
-							snprintf(name_buffer, 9, "HP%d", rounded_size);
+							snprintf(name_buffer, sizeof(name_buffer), "HP%d", rounded_size);
 							break;
 						case 179263:
-							snprintf(name_buffer, 9, "LP+%d", rounded_size);
+							snprintf(name_buffer, sizeof(name_buffer), "LP+%d", rounded_size);
 							break;
 						case 165474:
-							snprintf(name_buffer, 9, "LP%d", rounded_size);
+							snprintf(name_buffer, sizeof(name_buffer), "LP%d", rounded_size);
 							break;
 						default:
-							snprintf(name_buffer, 9, "%d cuft", rounded_size);
+							snprintf(name_buffer, sizeof(name_buffer), "%d cuft", rounded_size);
 							break;
 						}
 						dive->cylinder[i].type.description = copy_string(name_buffer);

--- a/core/parse.c
+++ b/core/parse.c
@@ -16,7 +16,7 @@ int metric = 1;
 int diveid = -1;
 
 event_allocation_t event_allocation = { .event.deleted = 1 };
-
+struct parser_settings cur_settings;
 
 struct divecomputer *cur_dc = NULL;
 struct dive *cur_dive = NULL;

--- a/core/parse.h
+++ b/core/parse.h
@@ -24,13 +24,14 @@ extern struct sample *cur_sample;
 extern struct picture *cur_picture;
 
 
-struct {
+struct parser_settings {
 	struct {
 		const char *model;
 		uint32_t deviceid;
 		const char *nickname, *serial_nr, *firmware;
 	} dc;
-} cur_settings;
+};
+extern struct parser_settings cur_settings;
 
 extern bool in_settings;
 extern bool in_userid;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR silences two warnings. But I'm not 100% sure about them.

The first one really looks like questionable code to me: the `cur_settings` object was defined in the header `core/parse.h`. To be honest, I don't understand how this compiled at all - shouldn't this have ended in a multiple-symbols error on linking? Therefore, I feel that I'm missing something.

For the second one, the warning itself is questionable. The compiler recognizes that `%d` may result in up to eleven digits and therefore the string produced by `snprintf` may be truncated. One might argue that changing code for questionable warnings is not desirable. On the other hand, extending the buffer accordingly does not hurt and may actually help debugging in the (very unlikely) case that some data corruption takes place and indeed too long integers are obtained.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

  