### PR TITLE
core: free() in a safe way, reverse geolookup unstability

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -254,8 +254,10 @@ void copy_dive_site_taxonomy(struct dive_site *orig, struct dive_site *copy)
 		if (copy->taxonomy.category == NULL)
 			copy->taxonomy.category = alloc_taxonomy();
 		for (int i = 0; i < TC_NR_CATEGORIES; i++) {
-			if (i < copy->taxonomy.nr)
+			if (i < copy->taxonomy.nr) {
 				free((void *)copy->taxonomy.category[i].value);
+				copy->taxonomy.category[i].value = NULL;
+			}
 			if (i < orig->taxonomy.nr) {
 				copy->taxonomy.category[i] = orig->taxonomy.category[i];
 				copy->taxonomy.category[i].value = copy_string(orig->taxonomy.category[i].value);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
A simple one line change that solves (for me) numerous hard crashes when adding geo tags by reverse lookup from the dive site edit screen. This is one of those crashes that is might not be reproducible on any platform, or even between different builds on one platform.

This said, I found that the free() on line 99 of divesitehelpers.cpp tried to free pointers to random data, ie. not pointing to valid taxonomy category strings. And those pointers where simply caused by freeing the string earlier, and leaving the pointer around. So, this change is nothing more than setting the just freed pointer to NULL, to allow free() to be called later safely.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
