### PR TITLE
Do not save WebserviceID in preferences until asked for

### DIFF
--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -336,8 +336,6 @@ void SubsurfaceWebServices::buttonClicked(QAbstractButton *button)
 			if (!d_eq_f || s_eq_d)
 				s.setValue("subsurface_webservice_uid", qDialogUid);
 			set_userid(qDialogUid.toLocal8Bit().data());
-		} else {
-			s.setValue("subsurface_webservice_uid", qDialogUid);
 		}
 		s.sync();
 		hide();


### PR DESCRIPTION
Do not save the WebserviceID in the preferences until we ask for this. That is simply wrong.

This is definitely not a full fix for all the weirdness that is going in related to the WebserviceID but saving the ID even if we do not ask for it, adds to possible confusion.

To always automatically pull in the ID from the server based on cloud credentials, just leave the ID field empty in the network preferences.

Fixes: #1013 (well ... a tiny part of this mess)

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>