### PR TITLE
Fallout of PR #1010

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1426,9 +1426,6 @@ void clear_dive_file_data()
 	clear_dive(&displayed_dive);
 	clear_dive_site(&displayed_dive_site);
 
-	free((void *)existing_filename);
-	existing_filename = NULL;
-
 	reset_min_datafile_version();
 	saved_git_id = "";
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -746,6 +746,7 @@ void MainWindow::closeCurrentFile()
 	/* free the dives and trips */
 	clear_git_id();
 	clear_dive_file_data();
+	setCurrentFile(NULL);
 	cleanUpEmpty();
 	mark_divelist_changed(false);
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -660,7 +660,6 @@ void MainWindow::on_actionCloudOnline_triggered()
 	prefs.git_local_only = isOffline;
 	if (!isOffline) {
 		// User requests to go online. Try to sync cloud storage
-		prefs.git_local_only = false;
 		if (unsaved_changes()) {
 			// If there are unsaved changes, ask the user if they want to save them.
 			// If they don't, they have to sync manually.

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -603,6 +603,7 @@ void QMLManager::loadDivesWithValidCredentials()
 		appendTextToLog(errorString);
 		setNotificationText(errorString);
 		revertToNoCloudIfNeeded();
+		set_filename(NULL);
 		return;
 	}
 	consumeFinishedLoad(currentDiveTimestamp);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are two minor cleanups, whereby one is also a bug-fix.

1) Remove the only manipulation of `existing_file` from C-code for a better frontend/backend separation. This fixes a bug introduced in #1010: If in cloud storage and "close file" was chosen, the "cloud online" menu entry stayed active.
2) Remove redundant assignment of `prefs.git_local_only`.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
