### PR TITLE
Fix small memory leak

### DIFF
--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -76,6 +76,7 @@ void DiveListModel::insertDive(int i, DiveObjectHelper *newDive)
 void DiveListModel::removeDive(int i)
 {
 	beginRemoveRows(QModelIndex(), i, i);
+	delete m_dives.at(i);
 	m_dives.removeAt(i);
 	endRemoveRows();
 }


### PR DESCRIPTION
When deleting a dive from the divelist model, also free the pointed to DiveObjectHelper data. There seems no harm done (other than a memory leak) by this missing free.

Found while (again) investigating the infamous crash occurring when deleting a dive from the mobile app when deleting a dive from the dive list.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>