### PR TITLE
[RFC] Introduce empty_string helper function

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1205,7 +1205,7 @@ static struct event *find_previous_event(struct divecomputer *dc, struct event *
 	struct event *ev = dc->events;
 	struct event *previous = NULL;
 
-	if (same_string(event->name, ""))
+	if (empty_string(event->name))
 		return NULL;
 	while (ev && ev != event) {
 		if (same_string(ev->name, event->name))
@@ -2969,7 +2969,7 @@ void taglist_cleanup(struct tag_entry **tag_list)
 	struct tag_entry **tl = tag_list;
 	while (*tl) {
 		/* skip tags that are empty or that we have seen before */
-		if (same_string((*tl)->tag->name, "") || tag_seen_before(*tag_list, *tl)) {
+		if (empty_string((*tl)->tag->name) || tag_seen_before(*tag_list, *tl)) {
 			*tl = (*tl)->next;
 			continue;
 		}
@@ -3160,7 +3160,7 @@ int count_dives_with_tag(const char *tag)
 	struct dive *d;
 
 	for_each_dive (i, d) {
-		if (same_string(tag, "")) {
+		if (empty_string(tag)) {
 			// count dives with no tags
 			if (d->tag_list == NULL)
 				counter++;
@@ -3180,9 +3180,9 @@ int count_dives_with_person(const char *person)
 	struct dive *d;
 
 	for_each_dive (i, d) {
-		if (same_string(person, "")) {
+		if (empty_string(person)) {
 			// solo dive
-			if (same_string(d->buddy, "") && same_string(d->divemaster, ""))
+			if (empty_string(d->buddy) && empty_string(d->divemaster))
 				counter++;
 		} else if (string_sequence_contains(d->buddy, person) || string_sequence_contains(d->divemaster, person)) {
 			counter++;

--- a/core/dive.h
+++ b/core/dive.h
@@ -38,6 +38,11 @@ static inline bool same_string_caseinsensitive(const char *a, const char *b)
 	return !strcasecmp(a ?: "", b ?: "");
 }
 
+static inline bool empty_string(const char *s)
+{
+	return !s || !*s;
+}
+
 static inline bool includes_string_caseinsensitive(const char *haystack, const char *needle)
 {
 	if (!needle)

--- a/core/dive.h
+++ b/core/dive.h
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <time.h>
 #include <math.h>
 #include <zip.h>
@@ -27,17 +28,17 @@
 
 #define IS_FP_SAME(_a, _b) (fabs((_a) - (_b)) <= 0.000001 * MAX(fabs(_a), fabs(_b)))
 
-static inline int same_string(const char *a, const char *b)
+static inline bool same_string(const char *a, const char *b)
 {
 	return !strcmp(a ?: "", b ?: "");
 }
 
-static inline int same_string_caseinsensitive(const char *a, const char *b)
+static inline bool same_string_caseinsensitive(const char *a, const char *b)
 {
 	return !strcasecmp(a ?: "", b ?: "");
 }
 
-static inline int includes_string_caseinsensitive(const char *haystack, const char *needle)
+static inline bool includes_string_caseinsensitive(const char *haystack, const char *needle)
 {
 	if (!needle)
 		return 1; /* every string includes the NULL string */
@@ -66,8 +67,6 @@ static inline char *copy_string(const char *s)
 
 #ifdef __cplusplus
 extern "C" {
-#else
-#include <stdbool.h>
 #endif
 
 extern int last_xml_version;

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -158,7 +158,7 @@ extern "C" void set_dc_nickname(struct dive *dive)
 	struct divecomputer *dc;
 
 	for_each_dc (dive, dc) {
-		if (dc->model && *dc->model && dc->deviceid &&
+		if (!empty_string(dc->model) && dc->deviceid &&
 		    !dcList.getExact(dc->model, dc->deviceid)) {
 			// we don't have this one, yet
 			const DiveComputerNode *existNode = dcList.get(dc->model);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1187,11 +1187,11 @@ void filter_dive(struct dive *d, bool shown)
  * (or the second one if the first one is empty */
 void combine_trips(struct dive_trip *trip_a, struct dive_trip *trip_b)
 {
-	if (same_string(trip_a->location, "") && trip_b->location) {
+	if (empty_string(trip_a->location) && trip_b->location) {
 		free(trip_a->location);
 		trip_a->location = strdup(trip_b->location);
 	}
-	if (same_string(trip_a->notes, "") && trip_b->notes) {
+	if (empty_string(trip_a->notes) && trip_b->notes) {
 		free(trip_a->notes);
 		trip_a->notes = strdup(trip_b->notes);
 	}

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -239,9 +239,9 @@ uint32_t create_dive_site_with_gps(const char *name, degrees_t latitude, degrees
 /* a uuid is always present - but if all the other fields are empty, the dive site is pointless */
 bool dive_site_is_empty(struct dive_site *ds)
 {
-	return same_string(ds->name, "") &&
-	       same_string(ds->description, "") &&
-	       same_string(ds->notes, "") &&
+	return empty_string(ds->name) &&
+	       empty_string(ds->description) &&
+	       empty_string(ds->notes) &&
 	       ds->latitude.udeg == 0 &&
 	       ds->longitude.udeg == 0;
 }

--- a/core/file.c
+++ b/core/file.c
@@ -300,7 +300,7 @@ int check_git_sha(const char *filename, struct git_repository **git_p, const cha
 	 * get the SHA and compare with what we currently have */
 	if (git && git != dummy_git_repository) {
 		const char *sha = get_sha(git, branch);
-		if (!same_string(sha, "") &&
+		if (!empty_string(sha) &&
 		    same_string(sha, current_sha)) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
 			free(current_sha);
@@ -333,7 +333,7 @@ int parse_file(const char *filename)
 	 * get the SHA and compare with what we currently have */
 	if (git && git != dummy_git_repository) {
 		const char *sha = get_sha(git, branch);
-		if (!same_string(sha, "") &&
+		if (!empty_string(sha) &&
 		    same_string(sha, current_sha) &&
 		    !unsaved_changes()) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);

--- a/core/file.c
+++ b/core/file.c
@@ -389,4 +389,3 @@ int parse_file(const char *filename)
 	free(mem.buffer);
 	return ret;
 }
-

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -528,7 +528,8 @@ int parse_txt_file(const char *filename, const char *csv)
 		cur_cylinder_index++;
 
 		lineptr = strstr(memtxt.buffer, "Dive started at");
-		while (!empty_string(lineptr) && (lineptr = strchr(lineptr, '\n')) && ++lineptr) {
+		while (!empty_string(lineptr) && (lineptr = strchr(lineptr, '\n'))) {
+			++lineptr;	// Skip over '\n'
 			key = next_mkvi_key(lineptr);
 			if (!key)
 				break;

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -528,7 +528,7 @@ int parse_txt_file(const char *filename, const char *csv)
 		cur_cylinder_index++;
 
 		lineptr = strstr(memtxt.buffer, "Dive started at");
-		while (lineptr && *lineptr && (lineptr = strchr(lineptr, '\n')) && ++lineptr) {
+		while (!empty_string(lineptr) && (lineptr = strchr(lineptr, '\n')) && ++lineptr) {
 			key = next_mkvi_key(lineptr);
 			if (!key)
 				break;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -232,7 +232,7 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 			fill_default_cylinder(&dive->cylinder[i]);
 		}
 		/* whatever happens, make sure there is a name for the cylinder */
-		if (same_string(dive->cylinder[i].type.description, ""))
+		if (empty_string(dive->cylinder[i].type.description))
 			dive->cylinder[i].type.description = strdup(translate("gettextFromC", "unknown"));
 	}
 	return DC_STATUS_SUCCESS;

--- a/core/linux.c
+++ b/core/linux.c
@@ -31,12 +31,12 @@ void subsurface_user_info(struct user_info *user)
 	const char *username = getenv("USER");
 
 	if (pwd) {
-		if (pwd->pw_gecos && *pwd->pw_gecos)
+		if (!empty_string(pwd->pw_gecos))
 			user->name = pwd->pw_gecos;
 		if (!username)
 			username = pwd->pw_name;
 	}
-	if (username && *username) {
+	if (!empty_string(username)) {
 		char hostname[64];
 		struct membuffer mb = {};
 		gethostname(hostname, sizeof(hostname));

--- a/core/linux.c
+++ b/core/linux.c
@@ -81,7 +81,7 @@ const char *system_default_filename(void)
 	static const char *path = NULL;
 	if (!path) {
 		const char *user = getenv("LOGNAME");
-		if (same_string(user, ""))
+		if (empty_string(user))
 			user = "username";
 		char *filename = calloc(strlen(user) + 5, 1);
 		strcat(filename, user);

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -217,7 +217,7 @@ static void parse_dive_location(char *line, struct membuffer *str, void *_dive)
 		dive->dive_site_uuid = uuid;
 	} else {
 		// we already had a dive site linked to the dive
-		if (same_string(ds->name, "")) {
+		if (empty_string(ds->name)) {
 			ds->name = strdup(name);
 		} else {
 			// and that dive site had a name. that's weird - if our name is different, add it to the notes

--- a/core/macos.c
+++ b/core/macos.c
@@ -84,7 +84,7 @@ const char *system_default_filename(void)
 	static const char *path = NULL;
 	if (!path) {
 		const char *user = getenv("LOGNAME");
-		if (same_string(user, ""))
+		if (empty_string(user))
 			user = "username";
 		char *filename = calloc(strlen(user) + 5, 1);
 		strcat(filename, user);

--- a/core/parse.c
+++ b/core/parse.c
@@ -469,7 +469,7 @@ void add_dive_site(char *ds_name, struct dive *dive)
 		}
 		if (ds) {
 			// we have a uuid, let's hope there isn't a different name
-			if (same_string(ds->name, "")) {
+			if (empty_string(ds->name)) {
 				ds->name = copy_string(buffer);
 			} else if (!same_string(ds->name, buffer)) {
 				// if it's not the same name, it's not the same dive site

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -408,7 +408,7 @@ extern "C" void copy_image_and_overwrite(const char *cfileName, const char *path
 
 extern "C" bool string_sequence_contains(const char *string_sequence, const char *text)
 {
-	if (same_string(text, "") || same_string(string_sequence, ""))
+	if (empty_string(text) || empty_string(string_sequence))
 		return false;
 
 	QString stringSequence(string_sequence);
@@ -525,7 +525,7 @@ QString uiLanguage(QLocale *callerLoc)
 	if (callerLoc)
 		*callerLoc = loc;
 
-	if (!prefs.date_format_override || same_string(prefs.date_format_short, "") || same_string(prefs.date_format, "")) {
+	if (!prefs.date_format_override || empty_string(prefs.date_format_short) || empty_string(prefs.date_format)) {
 		// derive our standard date format from what the locale gives us
 		// the short format is fine
 		// the long format uses long weekday and month names, so replace those with the short ones
@@ -536,16 +536,16 @@ QString uiLanguage(QLocale *callerLoc)
 		// special hack for Swedish as our switching from long weekday names to short weekday names
 		// messes things up there
 		dateFormat.replace("'en' 'den' d:'e'", " d");
-		if (!prefs.date_format_override || same_string(prefs.date_format, "")) {
+		if (!prefs.date_format_override || empty_string(prefs.date_format)) {
 			free((void *)prefs.date_format);
 			prefs.date_format = strdup(qPrintable(dateFormat));
 		}
-		if (!prefs.date_format_override || same_string(prefs.date_format_short, "")) {
+		if (!prefs.date_format_override || empty_string(prefs.date_format_short)) {
 			free((void *)prefs.date_format_short);
 			prefs.date_format_short = strdup(qPrintable(shortDateFormat));
 		}
 	}
-	if (!prefs.time_format_override || same_string(prefs.time_format, "")) {
+	if (!prefs.time_format_override || empty_string(prefs.time_format)) {
 		timeFormat = loc.timeFormat();
 		timeFormat.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
 		timeFormat.replace(".ss", "").replace(":ss", "").replace("ss", "");
@@ -1186,7 +1186,7 @@ void hashPicture(struct picture *picture)
 		return;
 	char *oldHash = copy_string(picture->hash);
 	learnHash(picture, hashFile(localFilePath(picture->filename)));
-	if (!same_string(picture->hash, "") && !same_string(picture->hash, oldHash))
+	if (!empty_string(picture->hash) && !same_string(picture->hash, oldHash))
 		mark_divelist_changed((true));
 	free(oldHash);
 	picture_free(picture);
@@ -1430,7 +1430,7 @@ int getCloudURL(QString &filename)
 {
 	QString email = QString(prefs.cloud_storage_email);
 	email.replace(QRegularExpression("[^a-zA-Z0-9@._+-]"), "");
-	if (email.isEmpty() || same_string(prefs.cloud_storage_password, ""))
+	if (email.isEmpty() || empty_string(prefs.cloud_storage_password))
 		return report_error("Please configure Cloud storage email and password in the preferences");
 	if (email != prefs.cloud_storage_email_encoded) {
 		free((void *)prefs.cloud_storage_email_encoded);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1163,7 +1163,7 @@ QString localFilePath(const QString originalFilename)
 
 QString fileFromHash(const char *hash)
 {
-	if (!hash || !*hash)
+	if (empty_string(hash))
 		return "";
 	QMutexLocker locker(&hashOfMutex);
 

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1088,11 +1088,11 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 			nr = dive->number;
 
 		put_format(msg, "dive %d: %s", nr, location);
-		if (trip && trip->location && *trip->location && strcmp(trip->location, location))
+		if (trip && !empty_string(trip->location) && strcmp(trip->location, location))
 			put_format(msg, " (%s)", trip->location);
 		put_format(msg, "\n");
 		do {
-			if (dc->model && *dc->model) {
+			if (!empty_string(dc->model)) {
 				put_format(msg, "%s%s", sep, dc->model);
 				sep = ", ";
 			}

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -168,7 +168,7 @@ void print_files()
 	const char *filename, *local_git;
 
 	printf("\nFile locations:\n\n");
-	if (!same_string(prefs.cloud_storage_email, "") && !same_string(prefs.cloud_storage_password, "")) {
+	if (!empty_string(prefs.cloud_storage_email) && !empty_string(prefs.cloud_storage_password)) {
 		filename = cloud_url();
 
 		is_git_repository(filename, &branch, &remote, true);

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -112,7 +112,7 @@ static void uemis_add_string(const char *buffer, char **text, const char *delimi
 {
 	/* do nothing if this is an empty buffer (Uemis sometimes returns a single
 	 * space for empty buffers) */
-	if (!buffer || !*buffer || (*buffer == ' ' && *(buffer + 1) == '\0'))
+	if (empty_string(buffer) || (*buffer == ' ' && *(buffer + 1) == '\0'))
 		return;
 	if (!*text) {
 		*text = strdup(buffer);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -112,13 +112,13 @@ void DownloadFromDCWidget::updateProgressBar()
 {
 	static char *last_text = NULL;
 
-	if (same_string(last_text, "")) {
+	if (empty_string(last_text)) {
 		// if we get the first actual text after the download is finished
 		// (which happens for example on the OSTC), then don't bother
-		if (!same_string(progress_bar_text, "") && IS_FP_SAME(progress_bar_fraction, 1.0))
+		if (!empty_string(progress_bar_text) && IS_FP_SAME(progress_bar_fraction, 1.0))
 			progress_bar_text = "";
 	}
-	if (!same_string(progress_bar_text , "")) {
+	if (!empty_string(progress_bar_text)) {
 		ui.progressBar->setFormat(progress_bar_text);
 #if defined(Q_OS_MAC)
 		// on mac the progress bar doesn't show its text

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -186,7 +186,7 @@ void LocationInformationWidget::acceptChanges()
 	// if the user entered a different contriy, first update the taxonomy
 	// for the displayed dive site; this below will get copied into the currentDs
 	if (!same_string(uiString, taxonomy_get_country(&displayed_dive_site.taxonomy)) &&
-	    !same_string(uiString, ""))
+	    !empty_string(uiString))
 		taxonomy_set_country(&displayed_dive_site.taxonomy, uiString, taxonomy_origin::GEOMANUAL);
 	else
 		free(uiString);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1669,7 +1669,7 @@ int MainWindow::file_save_as(void)
 	selection_dialog.setAcceptMode(QFileDialog::AcceptSave);
 	selection_dialog.setFileMode(QFileDialog::AnyFile);
 	selection_dialog.setDefaultSuffix("");
-	if (same_string(default_filename, "")) {
+	if (empty_string(default_filename)) {
 		QFileInfo defaultFile(system_default_filename());
 		selection_dialog.setDirectory(qPrintable(defaultFile.absolutePath()));
 	}

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -102,7 +102,7 @@ extern "C" void showErrorFromC()
 void MainWindow::showErrors()
 {
 	const char *error = get_error_string();
-	if (error && error[0])
+	if (!empty_string(error))
 		getNotificationWidget()->showNotification(error, KMessageWidget::Error);
 }
 
@@ -1766,7 +1766,7 @@ void MainWindow::setAutomaticTitle()
 
 void MainWindow::setTitle()
 {
-	if (!existing_filename || !existing_filename[0]) {
+	if (empty_string(existing_filename)) {
 		setWindowTitle("Subsurface");
 		return;
 	}

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -272,8 +272,8 @@ SubsurfaceWebServices::SubsurfaceWebServices(QWidget *parent, Qt::WindowFlags f)
 	QString userid(prefs.userid);
 
 	if (userid.isEmpty() &&
-	    !same_string(prefs.cloud_storage_email, "") &&
-	    !same_string(prefs.cloud_storage_password, "") &&
+	    !empty_string(prefs.cloud_storage_email) &&
+	    !empty_string(prefs.cloud_storage_password) &&
 	    GpsLocation::hasInstance())
 		userid = GpsLocation::instance()->getUserid(prefs.cloud_storage_email, prefs.cloud_storage_password);
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -309,7 +309,7 @@ void QMLManager::finishSetup()
 		// but we need to make sure we stay the only ones accessing git storage
 		alreadySaving = true;
 		openLocalThenRemote(url);
-	} else if (!same_string(existing_filename, "") && credentialStatus() != CS_UNKNOWN) {
+	} else if (!empty_string(existing_filename) && credentialStatus() != CS_UNKNOWN) {
 		setCredentialStatus(CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
@@ -433,8 +433,8 @@ void QMLManager::checkCredentialsAndExecute(execute_function_type execute)
 {
 	// if the cloud credentials are present, we should try to get the GPS Webservice ID
 	// and (if we haven't done so) load the dive list
-	if (!same_string(prefs.cloud_storage_email, "") &&
-	    !same_string(prefs.cloud_storage_password, "")) {
+	if (!empty_string(prefs.cloud_storage_email) &&
+	    !empty_string(prefs.cloud_storage_password)) {
 		setStartPageText(tr("Testing cloud credentials"));
 		appendTextToLog("Have credentials, let's see if they are valid");
 		CloudStorageAuthenticate *csa = new CloudStorageAuthenticate(this);
@@ -540,7 +540,7 @@ void QMLManager::retrieveUserid()
 	setCredentialStatus(CS_VERIFIED);
 	QString userid(prefs.userid);
 	if (userid.isEmpty()) {
-		if (same_string(prefs.cloud_storage_email, "") || same_string(prefs.cloud_storage_password, "")) {
+		if (empty_string(prefs.cloud_storage_email) || empty_string(prefs.cloud_storage_password)) {
 			appendTextToLog("cloud user name or password are empty, can't retrieve web user id");
 			revertToNoCloudIfNeeded();
 			return;
@@ -1116,7 +1116,7 @@ void QMLManager::saveChangesLocal()
 {
 	if (unsaved_changes()) {
 		if (credentialStatus() == CS_NOCLOUD) {
-			if (same_string(existing_filename, "")) {
+			if (empty_string(existing_filename)) {
 				char *filename = NOCLOUD_LOCALSTORAGE;
 				if (git_create_local_repo(filename))
 					appendTextToLog(get_error_string());
@@ -1680,7 +1680,7 @@ QStringList QMLManager::cylinderInit() const
 	int i = 0;
 	for_each_dive (i, d) {
 		for (int j = 0; j < MAX_CYLINDERS; j++) {
-			if (! same_string(d->cylinder[j].type.description, ""))
+			if (!empty_string(d->cylinder[j].type.description))
 				cylinders << d->cylinder[j].type.description;
 		}
 	}

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -80,7 +80,7 @@ void DiveEventItem::setupPixmap()
 
 #define EVENT_PIXMAP(PIX) QPixmap(QString(PIX)).scaled(sz_pix, sz_pix, Qt::KeepAspectRatio, Qt::SmoothTransformation)
 #define EVENT_PIXMAP_BIGGER(PIX) QPixmap(QString(PIX)).scaled(sz_bigger, sz_bigger, Qt::KeepAspectRatio, Qt::SmoothTransformation)
-	if (same_string(internalEvent->name, "")) {
+	if (empty_string(internalEvent->name)) {
 		setPixmap(EVENT_PIXMAP(":status-warning-icon"));
 	} else if (internalEvent->type == SAMPLE_EVENT_BOOKMARK) {
 		setPixmap(EVENT_PIXMAP(":dive-bookmark-icon"));

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -746,7 +746,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 	while (event) {
 		// if print mode is selected only draw headings, SP change, gas events or bookmark event
 		if (printMode) {
-			if (same_string(event->name, "") ||
+			if (empty_string(event->name) ||
 			    !(strcmp(event->name, "heading") == 0 ||
 			      (same_string(event->name, "SP change") && event->time.seconds == 0) ||
 			      event_is_gaschange(event) ||
@@ -1519,7 +1519,7 @@ void ProfileWidget2::hideEvents()
 	if (QMessageBox::question(this,
 				  TITLE_OR_TEXT(tr("Hide events"), tr("Hide all %1 events?").arg(event->name)),
 				  QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
-		if (!same_string(event->name, "")) {
+		if (!empty_string(event->name)) {
 			for (int i = 0; i < evn_used; i++) {
 				if (same_string(event->name, ev_namelist[i].ev_name)) {
 					ev_namelist[i].plot_ev = false;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -151,7 +151,7 @@ void DivePlannerPointsModel::setupCylinders()
 			if (!cylinder_none(&(displayed_dive.cylinder[i])))
 				return;		// We have at least one cylinder
 	}
-	if (!same_string(prefs.default_cylinder, "")) {
+	if (!empty_string(prefs.default_cylinder)) {
 		fill_default_cylinder(&displayed_dive.cylinder[0]);
 	}
 	if (cylinder_none(&displayed_dive.cylinder[0])) {

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -70,7 +70,7 @@ QVariant TripItem::data(int column, int role) const
 			}
 			if (countShown < trip->nrdives)
 				shownText = tr("(%1 shown)").arg(countShown);
-			if (trip->location && *trip->location)
+			if (!empty_string(trip->location))
 				ret = QString(trip->location) + ", " + get_trip_date_string(trip->when, trip->nrdives, oneDayTrip) + " "+ shownText;
 			else
 				ret = get_trip_date_string(trip->when, trip->nrdives, oneDayTrip) + shownText;

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -95,7 +95,7 @@ static void smtk_date_to_tm(char *d_buffer, struct tm *tm_date)
 {
 	int n, d, m, y;
 
-	if ((d_buffer) && (!same_string(d_buffer, ""))) {
+	if ((d_buffer) && (!empty_string(d_buffer))) {
 		n = sscanf(d_buffer, "%d/%d/%d ", &m, &d, &y);
 		y = (y < 70) ? y + 100 : y;
 		if (n == 3) {
@@ -118,7 +118,7 @@ static void smtk_time_to_tm(char *t_buffer, struct tm *tm_date)
 {
 	int n, hr, min, sec;
 
-	if ((t_buffer) && (!same_string(t_buffer, ""))) {
+	if ((t_buffer) && (!empty_string(t_buffer))) {
 		n = sscanf(t_buffer, "%*[0-9/] %d:%d:%d ", &hr, &min, &sec);
 		if (n == 3) {
 			tm_date->tm_hour = hr;
@@ -143,7 +143,7 @@ static unsigned int smtk_time_to_secs(char *t_buffer)
 {
 	int n, hr, min, sec;
 
-	if (!same_string(t_buffer, "")) {
+	if (!empty_string(t_buffer)) {
 		n = sscanf(t_buffer, "%*[0-9/] %d:%d:%d ", &hr, &min, &sec);
 		return((n == 3) ? (((hr*60)+min)*60)+sec : 0);
 	} else {
@@ -607,11 +607,11 @@ static char *smtk_locate_buddy(MdbHandle *mdb, char *dive_idx)
 	 * it's not a good idea to use a complex data structure and algorithm.
 	 */
 	while (mdb_fetch_row(table)) {
-		if (!same_string(col[3]->bind_ptr, ""))
+		if (!empty_string(col[3]->bind_ptr))
 			fullname = smtk_concat_str(fullname, " ", "%s", col[3]->bind_ptr);
-		if (!same_string(col[4]->bind_ptr, ""))
+		if (!empty_string(col[4]->bind_ptr))
 			fullname = smtk_concat_str(fullname, " ", "%s", col[4]->bind_ptr);
-		if (!same_string(col[2]->bind_ptr, ""))
+		if (!empty_string(col[2]->bind_ptr))
 			fullname = smtk_concat_str(fullname, " ", "%s", col[2]->bind_ptr);
 		if (fullname && !same_string(col[1]->bind_ptr, fullname))
 			buddies[atoi(col[0]->bind_ptr)] = smtk_concat_str(buddies[atoi(col[0]->bind_ptr)], "", "%s (%s)", col[1]->bind_ptr, fullname);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

I noticed that there are ca. 50 constructs of the kind `same_string(s, "")` to check for empty or NULL string, so I thought that maybe this warrants an individual helper `empty_string()` (commit 2). Of course, the old version is also quite expressive, so I'm a bit undecided with this commit.

Commit 3 then additionally deploys this helper to a dozen or so manual checks of the kind `s && *s` for consistency reason. If we don't want `empty_string()`, these should probably be replaced by `same_string(s, "")`.

Commit 1 and 4 are minor cleanups which are independent of the rest: Let string-comparison functions return bool and make an ominous loop-construct more clear.

Note: This compiles, but is only lightly tested.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
