### PR TITLE
mobile: fix crash on delete dive from divelist

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -162,9 +162,8 @@ Kirigami.ScrollablePage {
 						anchors.fill: parent
 						enabled: parent.visible
 						onClicked: {
-							parent.visible = false
+							deleteButtonVisible = false
 							timer.stop()
-							detailsWindow.showDiveIndex(index)
 							manager.deleteDive(dive.id)
 						}
 					}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1244,6 +1244,7 @@ void QMLManager::deleteDive(int id)
 	}
 	DiveListModel::instance()->removeDiveById(id);
 	delete_single_dive(get_idx_by_uniq_id(id));
+	DiveListModel::instance()->resetInternalData();
 	changesNeedSaving();
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -108,6 +108,16 @@ void DiveListModel::clear()
 	}
 }
 
+void DiveListModel::resetInternalData()
+{
+	// this is a hack. There is a long standing issue, that seems related to a
+	// sync problem between QML engine and underlying model data. It causes delete
+	// from divelist (on mobile) to crash. But not always. This function is part of
+	// an attempt to fix this. See commit.
+	beginResetModel();
+	endResetModel();
+}
+
 int DiveListModel::rowCount(const QModelIndex &) const
 {
 	return m_dives.count();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -46,6 +46,7 @@ public:
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 	QHash<int, QByteArray> roleNames() const;
 	QString startAddDive();
+	void resetInternalData();
 	Q_INVOKABLE DiveObjectHelper* at(int i);
 private:
 	QList<DiveObjectHelper*> m_dives;


### PR DESCRIPTION
This is a somewhat hacky commit. For a very long time, the delete from the divelist on mobile crashed. That is, not always for anyone, but for me almost consistently. This commit tries to solve it.

I found that trying to save the delete immediately after removing data from the underlying model seemed to cause the crash. Hacking around, I found that a simple beginResetModel/endResetModel between the delete of the underlying model data and actual save is sufficient to solve the crash.

The big question is, why does this all work? I suspect some of race condition between deleting model data, and giving the QML engine the opportunity to do its thing.

This is also related to issue #311, but that is not implemented here.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Mentions:
@dirkhh also read the comments added to #311
