### PR TITLE
build system: split qt-models into parts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 	target_link_libraries(
 		${SUBSURFACE_TARGET}
 		subsurface_profile
-		subsurface_models
+		subsurface_models_mobile
 		subsurface_corelib
 		${SUBSURFACE_LINK_LIBRARIES}
 	)
@@ -337,7 +337,7 @@ elseif(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
 		${FACEBOOK_INTEGRATION}
 		subsurface_profile
 		subsurface_statistics
-		subsurface_models
+		subsurface_models_desktop
 		subsurface_corelib
 		${SUBSURFACE_LINK_LIBRARIES}
 	)
@@ -345,7 +345,7 @@ elseif(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
 	add_dependencies(subsurface_statistics subsurface_generated_ui)
 	add_dependencies(subsurface_interface subsurface_generated_ui)
 	add_dependencies(subsurface_profile subsurface_generated_ui)
-	add_dependencies(subsurface_models subsurface_generated_ui)
+	add_dependencies(subsurface_models_desktop subsurface_generated_ui)
 	add_dependencies(subsurface_generated_ui version)
 endif()
 

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -1,31 +1,47 @@
 # the data models that will interface
 # with the views.
-set(SUBSURFACE_MODELS_LIB_SRCS
+
+# models used both mobile and desktop builds
+set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
 	cleanertablemodel.cpp
 	cylindermodel.cpp
-	diveplannermodel.cpp
 	models.cpp
-	filtermodels.cpp
 	tankinfomodel.cpp
-	weigthsysteminfomodel.cpp
-	weightmodel.cpp
-	divecomputermodel.cpp
-	treemodel.cpp
-	yearlystatisticsmodel.cpp
-	divetripmodel.cpp
-	divecomputerextradatamodel.cpp
-	completionmodels.cpp
 	divepicturemodel.cpp
+	diveplannermodel.cpp
+	treemodel.cpp
 	diveplotdatamodel.cpp
-	divelocationmodel.cpp
-	ssrfsortfilterproxymodel.cpp
-	divelistmodel.cpp
-	gpslistmodel.cpp
 	diveimportedmodel.cpp
-	messagehandlermodel.cpp
-	maplocationmodel.cpp
 )
 
-source_group("Subsurface Models" FILES ${SUBSURFACE_MODELS})
-add_library(subsurface_models STATIC ${SUBSURFACE_MODELS_LIB_SRCS})
-target_link_libraries(subsurface_models ${QT_LIBRARIES})
+# models exclusively used in desktop builds
+set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
+	maplocationmodel.cpp
+	yearlystatisticsmodel.cpp
+	weigthsysteminfomodel.cpp
+ 	weightmodel.cpp
+	filtermodels.cpp
+	divecomputermodel.cpp
+	divetripmodel.cpp
+	divecomputerextradatamodel.cpp
+ 	completionmodels.cpp
+	divelocationmodel.cpp
+	ssrfsortfilterproxymodel.cpp
+)
+
+# models exclusively used in mobile builds
+set(SUBSURFACE_MOBILE_MODELS_LIB_SRCS
+	divelistmodel.cpp
+	messagehandlermodel.cpp
+	gpslistmodel.cpp
+)
+
+if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
+	add_library(subsurface_models_desktop STATIC ${SUBSURFACE_GENERIC_MODELS_LIB_SRCS}
+		${SUBSURFACE_DESKTOP_MODELS_LIB_SRCS})
+	target_link_libraries(subsurface_models_desktop ${QT_LIBRARIES})
+elseif(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
+	add_library(subsurface_models_mobile STATIC ${SUBSURFACE_GENERIC_MODELS_LIB_SRCS}
+		${SUBSURFACE_MOBILE_MODELS_LIB_SRCS})
+	target_link_libraries(subsurface_models_mobile ${QT_LIBRARIES})
+endif()


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
For a long time, I did not realize that a lot of qt-models are only used in the mobile app, or only used in the desktop application.

This commit splits the qt-models in 3 parts. Used in both mobile and desktop, used in desktop only, used in mobile only.

There is no other code change in here, other than cmake changes.

To me, this gives at least developers more insight where code is actually used, and there is a small benefit in footprint.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl

### Additional information:
WARNING: this is my very first proper cmake change, so please review

### Mentions:
@dirkhh 