### PR TITLE
strip unused model code from mobile

### DIFF
--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -135,7 +135,9 @@ void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	}
 }
 
+#ifndef SUBSURFACE_MOBILE
 void DivePictureItem::removePicture()
 {
 	DivePictureModel::instance()->removePicture(fileUrl, true);
 }
+#endif

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -24,7 +24,9 @@ public:
 	void setPixmap(const QPixmap& pix);
 public slots:
 	void settingsChanged();
+#ifndef SUBSURFACE_MOBILE
 	void removePicture();
+#endif
 	void setFileUrl(const QString& s);
 protected:
 	void hoverEnterEvent(QGraphicsSceneHoverEvent *event);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -639,8 +639,13 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 	 * so I'll *not* calculate everything if something is not being
 	 * shown.
 	 */
+
 	plotInfo = calculate_max_limits_new(&displayed_dive, currentdc);
+#ifndef SUBSURFACE_MOBILE
 	create_plot_info_new(&displayed_dive, currentdc, &plotInfo, !shouldCalculateMaxDepth, &DivePlannerPointsModel::instance()->final_deco_state);
+#else
+	create_plot_info_new(&displayed_dive, currentdc, &plotInfo, !shouldCalculateMaxDepth, nullptr);
+#endif
 	int newMaxtime = get_maxtime(&plotInfo);
 	if (shouldCalculateMaxTime || newMaxtime > maxtime)
 		maxtime = newMaxtime;
@@ -1695,11 +1700,11 @@ void ProfileWidget2::editName()
 
 void ProfileWidget2::disconnectTemporaryConnections()
 {
+#ifndef SUBSURFACE_MOBILE
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
 	disconnect(plannerModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(replot()));
 	disconnect(plannerModel, SIGNAL(cylinderModelEdited()), this, SLOT(replot()));
 
-#ifndef SUBSURFACE_MOBILE
 	disconnect(plannerModel, SIGNAL(rowsInserted(const QModelIndex &, int, int)),
 		   this, SLOT(pointInserted(const QModelIndex &, int, int)));
 	disconnect(plannerModel, SIGNAL(rowsRemoved(const QModelIndex &, int, int)),

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -797,8 +797,8 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 		DivePlannerPointsModel *model = DivePlannerPointsModel::instance();
 		model->deleteTemporaryPlan();
 	}
-#endif
 	plotPictures();
+#endif
 
 	// OK, how long did this take us? Anything above the second is way too long,
 	// so if we are calculation TTS / NDL then let's force that off.
@@ -1110,9 +1110,11 @@ void ProfileWidget2::setProfileState()
 		return;
 
 	disconnectTemporaryConnections();
+#ifndef SUBSURFACE_MOBILE
 	connect(DivePictureModel::instance(), SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(plotPictures()));
 	connect(DivePictureModel::instance(), SIGNAL(rowsInserted(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
 	connect(DivePictureModel::instance(), SIGNAL(rowsRemoved(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
+#endif
 	/* show the same stuff that the profile shows. */
 
 	emit enableShortcuts();
@@ -1985,7 +1987,6 @@ void ProfileWidget2::keyEscAction()
 	if (plannerModel->isPlanner())
 		plannerModel->cancelPlan();
 }
-#endif
 
 void ProfileWidget2::plotPictures()
 {
@@ -2025,6 +2026,7 @@ void ProfileWidget2::plotPictures()
 		pictures.push_back(item);
 	}
 }
+#endif
 
 void ProfileWidget2::dropEvent(QDropEvent *event)
 {
@@ -2046,7 +2048,9 @@ void ProfileWidget2::dropEvent(QDropEvent *event)
 			}
 		}
 		copy_dive(current_dive, &displayed_dive);
+#ifndef SUBSURFACE_MOBILE
 		DivePictureModel::instance()->updateDivePictures();
+#endif
 
 
 		if (event->source() == this) {

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -103,10 +103,10 @@ slots: // Necessary to call from QAction's signals.
 	void actionRequestedReplot(bool triggered);
 	void setEmptyState();
 	void setProfileState();
-	void plotPictures();
 	void setReplot(bool state);
 	void replot(dive *d = 0);
 #ifndef SUBSURFACE_MOBILE
+	void plotPictures();
 	void setPlanState();
 	void setAddState();
 	void changeGas();

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -3,28 +3,28 @@
 
 # models used both mobile and desktop builds
 set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
-	cleanertablemodel.cpp
-	cylindermodel.cpp
-	models.cpp
-	tankinfomodel.cpp
 	divepicturemodel.cpp
-	diveplannermodel.cpp
-	treemodel.cpp
 	diveplotdatamodel.cpp
 	diveimportedmodel.cpp
 )
 
 # models exclusively used in desktop builds
 set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
+	cleanertablemodel.cpp
+	models.cpp
+	tankinfomodel.cpp
+	treemodel.cpp
 	maplocationmodel.cpp
+	cylindermodel.cpp
 	yearlystatisticsmodel.cpp
 	weigthsysteminfomodel.cpp
- 	weightmodel.cpp
+	weightmodel.cpp
 	filtermodels.cpp
 	divecomputermodel.cpp
 	divetripmodel.cpp
+	diveplannermodel.cpp
 	divecomputerextradatamodel.cpp
- 	completionmodels.cpp
+	completionmodels.cpp
 	divelocationmodel.cpp
 	ssrfsortfilterproxymodel.cpp
 )

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -3,13 +3,13 @@
 
 # models used both mobile and desktop builds
 set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
-	divepicturemodel.cpp
 	diveplotdatamodel.cpp
 	diveimportedmodel.cpp
 )
 
 # models exclusively used in desktop builds
 set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
+	divepicturemodel.cpp
 	cleanertablemodel.cpp
 	models.cpp
 	tankinfomodel.cpp


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
2 commits:

1) Un-tie plannner model from profile on mobile:  Do not pull in the DivePlannerPointsModel::instance as this is not used in the called function. We (currently) do not support deco computations on mobile, so trying to pull in any deco state from the planner is futile anyway. With this uncoupling, 6 more model files are not needed in mobile any more.

2) Move divepicturemodel.cpp to the desktop only category and deal with the (limited) fallout. We, currently, do not support dive pictures tied to the profile on mobile, so there is no use including this code.

Notice that this represents the current state of functionality in mobile and desktop. This does not mean that we made any decision here ever to implement more of the desktop functionality in the mobile. But just do simply not burden the mobile code with too much things that are not used.