### PR TITLE
profile: fix garbled profiles after visiting the planner

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -878,21 +878,21 @@ void ProfileWidget2::mousePressEvent(QMouseEvent *event)
 		return;
 	QGraphicsView::mousePressEvent(event);
 	if (currentState == PLAN || currentState == ADD || currentState == EDIT)
-		shouldCalculateMaxTime = false;
+		shouldCalculateMaxDepth = shouldCalculateMaxTime = false;
 }
 
 void ProfileWidget2::divePlannerHandlerClicked()
 {
 	if (zoomLevel)
 		return;
-	shouldCalculateMaxDepth = false;
+	shouldCalculateMaxDepth = shouldCalculateMaxTime = false;
 }
 
 void ProfileWidget2::divePlannerHandlerReleased()
 {
 	if (zoomLevel)
 		return;
-	shouldCalculateMaxDepth = true;
+	shouldCalculateMaxDepth = shouldCalculateMaxTime = true;
 	replot();
 }
 


### PR DESCRIPTION
See mentioned GitHub issue for the full issue, and images.

The reason for this weird behavior is the existence of 2 flags in the profile code: shouldCalculateMaxTime and shouldCalculateMaxDepth. When exactly following the use case and test data as attached to the GitHub issue (a very short dive, shorter than most of the dives in the logbook), the shouldCalculateMaxTime flag never got back to its true status, causing the the time scale not to adapt to other dives when just clicking (or selecting) them from the dive list.

The problem is fixed here by also setting the shouldCalculateMaxTime flag on manipulating way points in the dive plan.

Fixes: #1039

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>See mentioned GitHub issue for the full issue, and images.