### PR TITLE
Fix leak(s) in core/git-access.c

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -204,10 +204,12 @@ int credential_ssh_cb(git_cred **out,
 		return GIT_EUSER;
 	}
 
-	const char *priv_key = format_string("%s/%s", system_default_directory(), "ssrf_remote.key");
-	const char *passphrase = prefs.cloud_storage_password ? strdup(prefs.cloud_storage_password) : strdup("");
+	char *priv_key = format_string("%s/%s", system_default_directory(), "ssrf_remote.key");
+	const char *passphrase = prefs.cloud_storage_password ? prefs.cloud_storage_password : "";
 
-	return git_cred_ssh_key_new(out, username_from_url, NULL, priv_key, passphrase);
+	int res = git_cred_ssh_key_new(out, username_from_url, NULL, priv_key, passphrase);
+	free(priv_key);
+	return res;
 }
 
 int credential_https_cb(git_cred **out,
@@ -228,7 +230,7 @@ int credential_https_cb(git_cred **out,
 	}
 
 	const char *username = prefs.cloud_storage_email_encoded;
-	const char *password = prefs.cloud_storage_password ? strdup(prefs.cloud_storage_password) : strdup("");
+	const char *password = prefs.cloud_storage_password ? prefs.cloud_storage_password : "";
 
 	return git_cred_userpass_plaintext_new(out, username, password);
 }


### PR DESCRIPTION
The libgit2 functions git_cred_ssh_key_new() and git_cred_userpass_plaintext_new()
copy their arguments. Therefore, free the string arguments or don't
copy them in the first place.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a leak fix - not much more to say about this.