### PR TITLE
Use format_string() in core/git_access.c

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -674,7 +674,6 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 {
 	git_repository *repo;
 	git_config *conf;
-	int len;
 	char *variable_name, *merge_head;
 
 	if (verbose)
@@ -692,18 +691,15 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 
 	/* create a config so we can set the remote tracking branch */
 	git_repository_config(&conf, repo);
-	len = sizeof("branch..remote") + strlen(branch);
-	variable_name = malloc(len);
-	snprintf(variable_name, len, "branch.%s.remote", branch);
+	variable_name = format_string("branch.%s.remote", branch);
 	git_config_set_string(conf, variable_name, "origin");
-	/* we know this is shorter than the previous one, so we reuse the variable*/
-	snprintf(variable_name, len, "branch.%s.merge", branch);
-	len = sizeof("refs/heads/") + strlen(branch);
-	merge_head = malloc(len);
-	snprintf(merge_head, len, "refs/heads/%s", branch);
-	git_config_set_string(conf, variable_name, merge_head);
 	free(variable_name);
+
+	variable_name = format_string("branch.%s.merge", branch);
+	merge_head = format_string("refs/heads/%s", branch);
+	git_config_set_string(conf, variable_name, merge_head);
 	free(merge_head);
+	free(variable_name);
 
 	/* finally create an empty commit and push it to the remote */
 	if (do_git_save(repo, branch, remote, false, true))
@@ -743,10 +739,8 @@ static git_repository *create_local_repo(const char *localdir, const char *remot
 			 msg = giterr_last()->message;
 			 fprintf(stderr, "error message was %s\n", msg);
 		}
-		int len = sizeof("reference 'refs/remotes/origin/' not found") + strlen(branch);
-		char *pattern = malloc(len);
+		char *pattern = format_string("reference 'refs/remotes/origin/%s' not found", branch);
 		// it seems that we sometimes get 'Reference' and sometimes 'reference'
-		snprintf(pattern, len, "reference 'refs/remotes/origin/%s' not found", branch);
 		if (strstr(remote, prefs.cloud_git_url) && includes_string_caseinsensitive(msg, pattern)) {
 			/* we're trying to open the remote branch that corresponds
 			 * to our cloud storage and the branch doesn't exist.


### PR DESCRIPTION
Since this helper-function exists, we might just use it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a very small code-simplification: use the `format_string()` helper instead of determining size + `malloc()`ing by hand.
Two comments:
1) I did not test all code paths, since this would mean making a fresh cloud repository.
2) I'm not very happy about the "unsafe" `sprintf()`. Sure, we know that this works, but it somehow leaves a bad aftertaste. Perhaps replace this by a `format_string()` as well, even if this means an additional memory allocation?
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
