### PR TITLE
[RFC] First small steps to arbitrary git repositories

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -586,7 +586,7 @@ int sync_with_remote(git_repository *repo, const char *remote, const char *branc
 		return 0;
 	}
 
-	if (rt == RT_HTTPS && !canReachCloudServer()) {
+	if (is_subsurface_cloud && !canReachCloudServer()) {
 		// this is not an error, just a warning message, so return 0
 		report_error("Cannot connect to cloud server, working with local copy");
 		git_storage_update_progress(translate("gettextFromC", "Can't reach cloud server, working with local data"));
@@ -732,7 +732,7 @@ static git_repository *create_local_repo(const char *localdir, const char *remot
 	opts.fetch_opts.callbacks.certificate_check = certificate_check_cb;
 
 	opts.checkout_branch = branch;
-	if (rt == RT_HTTPS && !canReachCloudServer())
+	if (is_subsurface_cloud && !canReachCloudServer())
 		return 0;
 	if (verbose > 1)
 		fprintf(stderr, "git storage: calling git_clone()\n");

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -747,7 +747,7 @@ static git_repository *create_local_repo(const char *localdir, const char *remot
 		}
 		char *pattern = format_string("reference 'refs/remotes/origin/%s' not found", branch);
 		// it seems that we sometimes get 'Reference' and sometimes 'reference'
-		if (strstr(remote, prefs.cloud_git_url) && includes_string_caseinsensitive(msg, pattern)) {
+		if (includes_string_caseinsensitive(msg, pattern)) {
 			/* we're trying to open the remote branch that corresponds
 			 * to our cloud storage and the branch doesn't exist.
 			 * So we need to create the branch and push it to the remote */
@@ -794,18 +794,16 @@ static struct git_repository *get_remote_repo(const char *localdir, const char *
 		}
 		return update_local_repo(localdir, remote, branch, rt);
 	} else {
-		/* we have no local cache yet */
-		if (is_subsurface_cloud) {
-			/* and take us temporarly online to create a local and
-			 * remote cloud repo.
-			 */
-			git_repository *ret;
-			bool glo = prefs.git_local_only;
-			prefs.git_local_only = false;
-			ret = create_local_repo(localdir, remote, branch, rt);
-			prefs.git_local_only = glo;
-			return ret;
-		}
+		/* We have no local cache yet.
+		 * Take us temporarly online to create a local and
+		 * remote cloud repo.
+		 */
+		git_repository *ret;
+		bool glo = prefs.git_local_only;
+		prefs.git_local_only = false;
+		ret = create_local_repo(localdir, remote, branch, rt);
+		prefs.git_local_only = glo;
+		return ret;
 	}
 
 	/* all normal cases are handled above */

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -766,18 +766,21 @@ static git_repository *create_local_repo(const char *localdir, const char *remot
 	return cloned_repo;
 }
 
+enum remote_transport url_to_remote_transport(const char *remote)
+{
+	/* figure out the remote transport */
+	if (strncmp(remote, "ssh://", 6) == 0)
+		return RT_SSH;
+	else if (strncmp(remote, "https://", 8) == 0)
+		return RT_HTTPS;
+	else
+		return RT_OTHER;
+}
+
 static struct git_repository *get_remote_repo(const char *localdir, const char *remote, const char *branch)
 {
 	struct stat st;
-	enum remote_transport rt;
-
-	/* figure out the remote transport */
-	if (strncmp(remote, "ssh://", 6) == 0)
-		rt = RT_SSH;
-	else if (strncmp(remote, "https://", 8) == 0)
-		rt = RT_HTTPS;
-	else
-		rt = RT_OTHER;
+	enum remote_transport rt = url_to_remote_transport(remote);
 
 	if (verbose > 1) {
 		fprintf(stderr, "git_remote_repo: accessing %s\n", remote);

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -25,6 +25,7 @@ extern int do_git_save(git_repository *repo, const char *branch, const char *rem
 extern const char *saved_git_id;
 extern void clear_git_id(void);
 extern void set_git_id(const struct git_oid *);
+extern enum remote_transport url_to_remote_transport(const char *remote);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
 char *get_local_dir(const char *remote, const char *branch);

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1274,7 +1274,7 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 
 	/* now sync the tree with the remote server */
 	if (remote && !prefs.git_local_only)
-		return sync_with_remote(repo, remote, branch, RT_HTTPS);
+		return sync_with_remote(repo, remote, branch, url_to_remote_transport(remote));
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

These are first steps towards supporting arbitrary git repositories, here especially ssh:// repositories. This also unifies username handling of ssh:// and https:// repositories.

A major change is the handling of authentication. The code used to only support private-key based authentication. Now, if the private key does not exist, the cloud password is used. In the future, this should of course be handled on a per-repository basis.

The PR as-is is not yet useful without UI changes. With a different set of commits, I managed to save to a remote ssh:// repository. Though I had to check out a dummy branch - saving to checked-out master failed without error message(!). So it's all still a bit brittle.

I'm posting this for comments. I would be especially grateful if people using the private-key based ssh:// transport (if this actually used to work) could test the changes.