### PR TITLE
Fix preferences handling with invalid passwords 

### DIFF
--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -69,7 +69,12 @@ void PreferencesNetwork::syncSettings()
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
-				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				report_error(qPrintable(tr("Change ignored. Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				return;
+			} else if (!reg.match(email).hasMatch() || (!newpassword.isEmpty() && !reg.match(newpassword).hasMatch())) {
+				report_error(qPrintable(tr("Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				ui->cloud_storage_new_passwd->setText("");
+				return;
 			} else {
 				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
 				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
@@ -85,12 +90,15 @@ void PreferencesNetwork::syncSettings()
 		   password != prefs.cloud_storage_password) {
 
 		// different credentials - reset verification status
+		int oldVerificationStatus = cloud->verificationStatus();
 		cloud->setVerificationStatus(CS_UNKNOWN);
 		if (!email.isEmpty() && !password.isEmpty()) {
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				cloud->setVerificationStatus(oldVerificationStatus);
+				return;
 			} else {
 				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
 				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
@@ -104,6 +112,7 @@ void PreferencesNetwork::syncSettings()
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || !reg.match(password).hasMatch()) {
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				return;
 			}
 			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
 			connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(updateCloudAuthenticationState()));

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -71,18 +71,18 @@ void PreferencesNetwork::syncSettings()
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
 				report_error(qPrintable(tr("Change ignored. Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 				return;
-			} else if (!reg.match(email).hasMatch() || (!newpassword.isEmpty() && !reg.match(newpassword).hasMatch())) {
+			}
+			if (!reg.match(email).hasMatch() || (!newpassword.isEmpty() && !reg.match(newpassword).hasMatch())) {
 				report_error(qPrintable(tr("Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 				ui->cloud_storage_new_passwd->setText("");
 				return;
-			} else {
-				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
-				connect(cloudAuth, &CloudStorageAuthenticate::passwordChangeSuccessful, this, &PreferencesNetwork::passwordUpdateSuccessful);
-				cloudAuth->backend(email, password, "", newpassword);
-				ui->cloud_storage_new_passwd->setText("");
-				cloud->setNewPassword(newpassword);
 			}
+			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
+			connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
+			connect(cloudAuth, &CloudStorageAuthenticate::passwordChangeSuccessful, this, &PreferencesNetwork::passwordUpdateSuccessful);
+			cloudAuth->backend(email, password, "", newpassword);
+			ui->cloud_storage_new_passwd->setText("");
+			cloud->setNewPassword(newpassword);
 		}
 	} else if (prefs.cloud_verification_status == CS_UNKNOWN ||
 		   prefs.cloud_verification_status == CS_INCORRECT_USER_PASSWD ||
@@ -99,11 +99,10 @@ void PreferencesNetwork::syncSettings()
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 				cloud->setVerificationStatus(oldVerificationStatus);
 				return;
-			} else {
-				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
-				cloudAuth->backend(email, password);
 			}
+			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
+			connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
+			cloudAuth->backend(email, password);
 		}
 	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY) {
 		QString pin = ui->cloud_storage_pin->text();


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This fixes 2 problems related to entering passwords with illegal characters in it:

1. Do not save an invalid password in the preferences, but keep the old one.
2. On password change, check both old and new password for format validity instead of pushing an invalid password to the server that has to ignore it.

Fixes: #1048

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Additional information:
Perfectly happy to squash the 2 commits, but I prefer white space separate.