### PR TITLE
Fix PreferencesNetwork::passwordUpdateSuccessful slot

### DIFF
--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -72,8 +72,8 @@ void PreferencesNetwork::syncSettings()
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
 			} else {
 				CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-				connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(updateCloudAuthenticationState()));
-				connect(cloudAuth, SIGNAL(passwordChangeSuccessful()), this, SLOT(passwordUpdateSuccessful()));
+				connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
+				connect(cloudAuth, &CloudStorageAuthenticate::passwordChangeSuccessful, this, &PreferencesNetwork::passwordUpdateSuccessful);
 				cloudAuth->backend(email, password, "", newpassword);
 				ui->cloud_storage_new_passwd->setText("");
 				cloud->setNewPassword(newpassword);

--- a/desktop-widgets/preferences/preferences_network.h
+++ b/desktop-widgets/preferences/preferences_network.h
@@ -20,10 +20,10 @@ public:
 public slots:
 	void proxyType_changed(int i);
 	void updateCloudAuthenticationState();
+	void passwordUpdateSuccessful();
 
 private:
 	Ui::PreferencesNetwork *ui;
-	void passwordUpdateSuccessful();
 };
 
 #endif


### PR DESCRIPTION
In preferences_network.cpp, the CloudStorageAuthenticate::passwordChangeSuccessful
signal was connected to the PreferencesNetwork::passwordUpdateSuccessful
slot. This never worked, because passwordUpdateSuccessful() was declared
as a normal member function, not a slot (hooray for Qt's weird runtime-checked
signal system).

While touching this code, change the weird SIGNAL/SLOT macros to
actual member function, to at least get *some* compile-time checks.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is something between a cleanup and a bug fix. In any case, the old code never did what it was intended to do. I'm not sure if this had any problematic consequences.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
