### PR TITLE
Uemis protocol bugfix

### DIFF
--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1202,7 +1202,7 @@ static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, devi
 	while (!found) {
 		if (import_thread_cancelled)
 			break;
-        snprintf(dive_to_read_buf, sizeof(dive_to_read_buf), "%d", dive_to_read+1);
+        	snprintf(dive_to_read_buf, sizeof(dive_to_read_buf), "%d", dive_to_read+1);
 		param_buff[2] = dive_to_read_buf;
 		(void)uemis_get_answer(mountpath, "getDive", 3, 0, NULL);
 #if UEMIS_DEBUG & 16

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -76,6 +76,14 @@ static int dive_to_read = 0;
 
 static int max_deleted_seen = -1;
 
+// Linked list to remember already executed divespot download requests
+struct divespot_downloads{
+	int divespot_id;
+	uint32_t dive_site_uuid;
+	struct divespot_downloads *next;
+};
+struct divespot_downloads *divespot_downloads = NULL;
+
 /* helper function to parse the Uemis data structures */
 static void uemis_ts(char *buffer, void *_when)
 {
@@ -243,7 +251,8 @@ static bool uemis_init(const char *path)
 {
 	char *ans_path;
 	int i;
-
+	// Wipe linked list
+	divespot_downloads = NULL;
 	if (!path)
 		return false;
 	/* let's check if this is indeed a Uemis DC */
@@ -1117,7 +1126,32 @@ static bool load_uemis_divespot(const char *mountpath, int divespot_id)
 static void get_uemis_divespot(const char *mountpath, int divespot_id, struct dive *dive)
 {
 	struct dive_site *nds = get_dive_site_by_uuid(dive->dive_site_uuid);
-	if (nds && nds->name && strstr(nds->name,"from Uemis")) {
+	struct divespot_downloads **pdl = &divespot_downloads;
+	struct divespot_downloads *dl = *pdl;
+	bool already_downloaded = false;
+
+	/*
+	 * Search linked list of already downloaded
+	 * divespots using the uemis's divespot_id
+	 */
+	while(dl && !already_downloaded)
+	{
+		if(dl->divespot_id == divespot_id)
+		{
+			/*
+			 * This divespot_id was already requested.
+			 */
+			already_downloaded = true;
+			dive->dive_site_uuid = dl->dive_site_uuid;
+#if UEMIS_DEBUG & 2
+			fprintf(debugfile, "Mapping dive spot with id %d to UUID %d\n", divespot_id, dive->dive_site_uuid);
+#endif
+		}
+		pdl = &dl->next;
+		dl = dl->next;
+	}
+	
+	if (!already_downloaded && nds && nds->name && strstr(nds->name,"from Uemis")) {
 		if (load_uemis_divespot(mountpath, divespot_id)) {
 			/* get the divesite based on the diveid, this should give us
 			* the newly created site
@@ -1135,6 +1169,13 @@ static void get_uemis_divespot(const char *mountpath, int divespot_id, struct di
 					dive->dive_site_uuid = ods->uuid;
 				}
 			}
+			/* Append this id to linked list
+			 */
+			struct divespot_downloads *ndl = (struct divespot_downloads*)calloc(1, sizeof(struct divespot_downloads));
+			ndl->divespot_id = divespot_id;
+			ndl->dive_site_uuid = dive->dive_site_uuid;
+			ndl->next = NULL;
+			dl = *pdl = ndl;
 		} else {
 			/* if we can't load the dive site details, delete the site we
 			* created in process_raw_buffer
@@ -1161,7 +1202,7 @@ static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, devi
 	while (!found) {
 		if (import_thread_cancelled)
 			break;
-		snprintf(dive_to_read_buf, sizeof(dive_to_read_buf), "%d", dive_to_read);
+        snprintf(dive_to_read_buf, sizeof(dive_to_read_buf), "%d", dive_to_read+1);
 		param_buff[2] = dive_to_read_buf;
 		(void)uemis_get_answer(mountpath, "getDive", 3, 0, NULL);
 #if UEMIS_DEBUG & 16


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
- Bugfix: Parameter of "getDive" must be >0 to avoid stalling.
- Optimization: uemis-downloader downloaded the dive spot for each dive, even if the same location was already downloaded before within the ongoing synchronization run. I modified the function "get_uemis_divespot" to remember all requested divespot_ids and their mapping to uuids.

### Changes made:
- Always add 1 to the dive_to_read integer when rendering the getDive command. This change solved the stalling of the synchronization with my Zurich.
- I extended the get_uemis_divespot function to remember the mapping of the Zurich's divespot_ids to the dive site uuid created by subsurface. This will speed up the synchronization and decrease the memory usage within the Zurich if several dives at the same dive spot must be synced. The mapping is erased on uemis_init to prevent problems that could (theoretically) occur when syncing two different Zurichs to subsurface.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
My Uemis Zurich is a used device and I used the "owner changed" function when I got it.
Internally, it continues with an ongoing dive number. So I see dive #1 and internally it is dive #261.
The first 260 dives are not accessible anymore and that seems to cause the problem that I have fixed by adding 1 to dive_to_read.

### Release note:
Fixed problems that might occur while syncing an Uemis Zurich SDA.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
Dirk Hohndel <dirk@hohndel.org>
