### PR TITLE
Improve profile display in planner

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -295,7 +295,7 @@ struct extra_data {
  */
 struct divecomputer {
 	timestamp_t when;
-	duration_t duration, surfacetime;
+	duration_t duration, surfacetime, last_manual_time;
 	depth_t maxdepth, meandepth;
 	temperature_t airtemp, watertemp;
 	pressure_t surface_pressure;

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -692,6 +692,9 @@ static void parse_dc_duration(char *line, struct membuffer *str, void *_dc)
 static void parse_dc_dctype(char *line, struct membuffer *str, void *_dc)
 { (void) str; struct divecomputer *dc = _dc; dc->divemode = get_dctype(line); }
 
+static void parse_dc_lastmanualtime(char *line, struct membuffer *str, void *_dc)
+{ (void) str; struct divecomputer *dc = _dc; dc->last_manual_time = get_duration(line); }
+
 static void parse_dc_maxdepth(char *line, struct membuffer *str, void *_dc)
 { (void) str; struct divecomputer *dc = _dc; dc->maxdepth = get_depth(line); }
 
@@ -979,7 +982,7 @@ struct keyword_action dc_action[] = {
 #undef D
 #define D(x) { #x, parse_dc_ ## x }
 	D(airtemp), D(date), D(dctype), D(deviceid), D(diveid), D(duration),
-	D(event), D(keyvalue), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
+	D(event), D(keyvalue), D(lastmanualtime), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
 	D(salinity), D(surfacepressure), D(surfacetime), D(time), D(watertemp)
 };
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -734,6 +734,8 @@ static int match_dc_data_fields(struct divecomputer *dc, const char *name, char 
 		return 1;
 	if (MATCH("divetimesec", duration, &dc->duration))
 		return 1;
+	if (MATCH("last-manual-time", duration, &dc->last_manual_time))
+		return 1;
 	if (MATCH("surfacetime", duration, &dc->surfacetime))
 		return 1;
 	if (MATCH("airtemp", temperature, &dc->airtemp))

--- a/core/planner.c
+++ b/core/planner.c
@@ -259,7 +259,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 	struct event *ev;
 	cylinder_t *cyl;
 	int oldpo2 = 0;
-	int lasttime = 0;
+	int lasttime = 0, last_manual_point = 0;
 	depth_t lastdepth = {.mm = 0};
 	int lastcylid;
 	enum dive_comp_type type = dive->dc.divemode;
@@ -342,6 +342,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 		sample[-1].setpoint.mbar = po2;
 		sample->setpoint.mbar = po2;
 		sample->time.seconds = lasttime = time;
+		if (dp->entered) last_manual_point = dp->time;
 		sample->depth = lastdepth = depth;
 		sample->manually_entered = dp->entered;
 		sample->sac.mliter = dp->entered ? prefs.bottomsac : prefs.decosac;
@@ -354,6 +355,8 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 		finish_sample(dc);
 		dp = dp->next;
 	}
+	dive->dc.last_manual_time.seconds = last_manual_point;
+
 	dc->divemode = type;
 #if DEBUG_PLAN & 32
 	save_dive(stdout, &displayed_dive);

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -395,6 +395,8 @@ static void save_events(struct membuffer *b, struct dive *dive, struct event *ev
 static void save_dc(struct membuffer *b, struct dive *dive, struct divecomputer *dc)
 {
 	show_utf8(b, "model ", dc->model, "\n");
+	if (dc->last_manual_time.seconds)
+		put_duration(b, dc->last_manual_time, "lastmanualtime ", "min\n");
 	if (dc->deviceid)
 		put_format(b, "deviceid %08x\n", dc->deviceid);
 	if (dc->diveid)

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -387,6 +387,8 @@ static void save_dc(struct membuffer *b, struct dive *dive, struct divecomputer 
 {
 	put_format(b, "  <divecomputer");
 	show_utf8(b, dc->model, " model='", "'", 1);
+	if (dc->last_manual_time.seconds)
+		put_duration(b, dc->last_manual_time, " last-manual-time='", " min'");
 	if (dc->deviceid)
 		put_format(b, " deviceid='%08x'", dc->deviceid);
 	if (dc->diveid)


### PR DESCRIPTION
This patch allows the planner to save the last manually-entered
dive planner point of a dive plan. When the plan has been saved
and re-opened for edit, the time of the last-entered dive planner
point is used to ensure that dive planning continues from the same
point in the profile as was when the original dive plan was saved.
Mechanism:

1) In dive.h, create a new dc attribute dc->last_manual_time
   with data type of duration_t.
2) In diveplanner.c, ensure that the last manually-entered
   dive planner point is saved in dc->last_manual_time.
3) In save-xml.c, create a new XML attribute for the <divecomputer>
   element, named last-manual-time. For dive plans, the element would
   now look like:
   <divecomputer model='planned dive' last-manual-time='31:17 min'>
4) In parse-xml.c, insert code that recognises the last-manual-time
   XML attribute, reads the time value and assigns this time to
   dc->last_manual_time.
5) In diveplannermodel.cpp, method DiveplannerPointModel::loadfromdive,
   insert code that sets the appropriate boolean value to dp->entered
   by comparing newtime (i.e. time of dp) with dc->last_manual_time.
6) Diveplannermodel.cpp also accepts profile data from normal dives in
   the dive log, whether hand-entered or loaded from dive computer. It
   looks like the reduction of dive points for dives with >100 points
   continues to work ok.
The result is that when a dive plan is saved with manually entered
points up to e.g. 10 minutes into the dive, it can be re-opened for edit
in the dive planner and the planner re-creates the plan with manually
entered points up to 10 minutes. The rest of the points are "soft"
points, shaped by the deco calculations of the planner.

Signed-off-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 
@sfuchs79 
