### PR TITLE
code cleanup: translators are not global

### DIFF
--- a/core/qt-init.cpp
+++ b/core/qt-init.cpp
@@ -7,7 +7,7 @@
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 
 char *settings_suffix = NULL;
-QTranslator *qtTranslator, *ssrfTranslator;
+static QTranslator *qtTranslator, *ssrfTranslator;
 
 void init_qt_late()
 {

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -10,9 +10,6 @@
 #include <QTranslator>
 #include <QDir>
 
-// global pointers for our translation
-extern QTranslator *qtTranslator, *ssrfTranslator;
-
 QString weight_string(int weight_in_grams);
 QString distance_string(int distanceInMeters);
 bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_text, bool *parsed_out = 0);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

Un-globalize unused global variables.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
