### PR TITLE
Different preferences file for dektop and mobile

### DIFF
--- a/core/qt-init.cpp
+++ b/core/qt-init.cpp
@@ -27,10 +27,22 @@ void init_qt_late()
 	// enable user specific settings (based on command line argument)
 	if (settings_suffix) {
 		if (verbose)
+#if defined(SUBSURFACE_MOBILE) && ((defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || (defined(Q_OS_DARWIN) && !defined(Q_OS_IOS)))
+			qDebug() << "using custom config for" << QString("Subsurface-Mobile-%1").arg(settings_suffix);
+#else
 			qDebug() << "using custom config for" << QString("Subsurface-%1").arg(settings_suffix);
+#endif
+#if defined(SUBSURFACE_MOBILE) && ((defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || (defined(Q_OS_DARWIN) && !defined(Q_OS_IOS)))
+		QCoreApplication::setApplicationName(QString("Subsurface-Mobile-%1").arg(settings_suffix));
+#else
 		QCoreApplication::setApplicationName(QString("Subsurface-%1").arg(settings_suffix));
+#endif
 	} else {
+#if defined(SUBSURFACE_MOBILE) && ((defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || (defined(Q_OS_DARWIN) && !defined(Q_OS_IOS)))
+		QCoreApplication::setApplicationName("Subsurface-Mobile");
+#else
 		QCoreApplication::setApplicationName("Subsurface");
+#endif
 	}
 	// find plugins installed in the application directory (without this SVGs don't work on Windows)
 	SettingsObjectWrapper::instance()->load();


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This is a change mainly for developers working on both mobile and desktop application. As the current setup is that all preferences are stored in one file (Subsurface.conf), for both mobile and desktop, the unwary developer might get confused that the things tested on mobile-on-desktop are not working on mobile-on-device. As we share a lot of code between the desktop and the mobile code, also our fairly extensive set of preferences play a significant role in the inner workings of our applications.

So, this commit introduces an own preferences file for mobile (on desktop) resulting in the preferences between the plain desktop application now invisible to the mobile-on-desktop application and vise versa. Making the mobile-on-desktop a much more realistic test platform for mobile development.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Mentions: @dirkhh