### PR TITLE
uemis: checking ack for getDive

### DIFF
--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1210,7 +1210,7 @@ static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, devi
 				} else {
 					uint32_t nr_found = 0;
 					char *logfilenr = strstr(mbuf, "logfilenr");
-					if (logfilenr) {
+					if (logfilenr && strstr(mbuf, "act{")) {
 						sscanf(logfilenr, "logfilenr{int{%u", &nr_found);
 						if (nr_found >= dive->dc.diveid || nr_found == 0) {
 							found_above = true;


### PR DESCRIPTION
get_matching_dive does not check if the DC wrote an acknowledgement for the requested dive.
As result, the sync stalls if dive number 0 is not available.

Signed-off-by: Oliver Schwaneberg <oliver.schwaneberg@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
One really weird thing about the uemis protocol is that getDiveLogs does not provide the dive numbers required as parameters to getDive later. So the code starts with dive number 0 and works its ways through the items. Unfortunately, it stalls if dive number 0 is not available.

### Changes made:
Added query for substring "act{" as prerequisite to interpret the returned logfilenr.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
Request unavailable dive number 0:

#### ::w req.txt "n044500000054getDive{6c1d7617a5981fce5d9471745e395957{notempty{0{{{"

and the DC will actually answer providing invalid dive data:

#### added "{dive{1.0{dive-conditions{1.0{dive-gear{1.0{dive-buddies{1.0{computer_id{int{17502{user_id{int{3{object_id{int{0{remote_object_id{int{0{sync_id{int{-442503120{deleted{bool{true{ctime{ts{1970-01-01T00:00:00{dive_no{int{3852464172{logfilenr{int{0{...

Note that sync_id is negative and ctime is a default date (1970-01-01) while logfilenr is actually 0. Therefore, the code sets the found_above flag which prevents that the parameter will be incremented.
Dive number 0 will be requested until the DC's memory is full and the sync fails.
However, if the dive number exists, the DC sends an acknowledgement for the log file number like this:

#### 1428act{divespot{checklist{{{

This "act{" substring must be within mbuf, if the command was accepted. If it was not accepted, we must continue the search by incrementing the dive number, which is done already at line 1228 (if not compensated by found_above).

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
