### PR TITLE
Do not add double ConnectionList items

### DIFF
--- a/core/connectionlistmodel.cpp
+++ b/core/connectionlistmodel.cpp
@@ -38,9 +38,11 @@ int ConnectionListModel::rowCount(const QModelIndex &parent) const
 
 void ConnectionListModel::addAddress(const QString address)
 {
-	beginInsertRows(QModelIndex(), rowCount(), rowCount());
-	m_addresses.append(address);
-	endInsertRows();
+	if (!m_addresses.contains(address)) {
+		beginInsertRows(QModelIndex(), rowCount(), rowCount());
+		m_addresses.append(address);
+		endInsertRows();
+	}
 }
 
 void ConnectionListModel::removeAllAddresses()


### PR DESCRIPTION
Refuse to add a ConnectionList row, when the row is already there. This, obviously, prevents double items.

Fixes: #1069

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>
