### PR TITLE
profile: fix weird disappearance of cylinder pressure line

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -904,7 +904,7 @@ void ProfileWidget2::mouseReleaseEvent(QMouseEvent *event)
 		return;
 	QGraphicsView::mouseReleaseEvent(event);
 	if (currentState == PLAN || currentState == ADD || currentState == EDIT) {
-		shouldCalculateMaxTime = true;
+		shouldCalculateMaxTime = shouldCalculateMaxDepth = true;
 		replot();
 	}
 }


### PR DESCRIPTION
The reason for this issue, and fix for this is very similar to commit b4d37e8ee. Just set both recalculate flags on a mouse release event, so that the cylinder pressure line is recalculated.

Fixes: #1071 

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>