### PR TITLE
Remove function-call indirection in qmlmanager.cpp

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -426,7 +426,7 @@ void QMLManager::saveCloudCredentials()
 	}
 }
 
-void QMLManager::checkCredentialsAndExecute(execute_function_type execute)
+void QMLManager::tryRetrieveDataFromBackend()
 {
 	// if the cloud credentials are present, we should try to get the GPS Webservice ID
 	// and (if we haven't done so) load the dive list
@@ -477,13 +477,8 @@ void QMLManager::checkCredentialsAndExecute(execute_function_type execute)
 		reply = manager()->get(request);
 		connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(handleError(QNetworkReply::NetworkError)));
 		connect(reply, &QNetworkReply::sslErrors, this, &QMLManager::handleSslErrors);
-		connect(reply, &QNetworkReply::finished, this, execute, Qt::UniqueConnection);
+		connect(reply, &QNetworkReply::finished, this, &QMLManager::retrieveUserid, Qt::UniqueConnection);
 	}
-}
-
-void QMLManager::tryRetrieveDataFromBackend()
-{
-	checkCredentialsAndExecute(&QMLManager::retrieveUserid);
 }
 
 void QMLManager::provideAuth(QNetworkReply *reply, QAuthenticator *auth)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -126,7 +126,6 @@ public:
 	bool btEnabled() const;
 	void setBtEnabled(bool value);
 
-	typedef void (QMLManager::*execute_function_type)();
 	DiveListSortModel *dlSortModel;
 
 	QStringList suitInit() const;
@@ -146,7 +145,6 @@ public slots:
 	void applicationStateChanged(Qt::ApplicationState state);
 	void savePreferences();
 	void saveCloudCredentials();
-	void checkCredentialsAndExecute(execute_function_type execute);
 	void tryRetrieveDataFromBackend();
 	void handleError(QNetworkReply::NetworkError nError);
 	void handleSslErrors(const QList<QSslError> &errors);


### PR DESCRIPTION
QMLManager::tryRetrieveDataFromBackend() was a one-liner calling
void QMLManager::checkCredentialsAndExecute() with a pointer-to-member.
The latter was never called with a different pointer, therefore
fold the latter into the former and remove the indirection.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial clean-up, which looks quite obvious. It removes a function, which was called only once with always the same pointer-to-member-function. Should this be needed in the future, it can be re-added, but let's keep it simple for now.

Somewhat related: I also tried to remove the `error_cb`, by simply defining show-error functions in `mainwindow.cpp` and `qmlmanager.cpp`. This failed, because the tests are also compiled against the error-code. Is there a common file linked with all test executables, where one could place such a dummy routine?
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
