### PR TITLE
[RFC] Make report_error() thread safe

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -719,7 +719,7 @@ extern "C" {
 
 extern int report_error(const char *fmt, ...);
 extern const char *get_error_string(void);
-extern void set_error_cb(void(*cb)(void));
+extern void set_error_cb(void(*cb)(char *));	// Callback takes ownership of passed string
 
 extern struct dive *find_dive_including(timestamp_t when);
 extern bool dive_within_time_range(struct dive *dive, timestamp_t when, timestamp_t offset);

--- a/core/errorhelper.c
+++ b/core/errorhelper.c
@@ -8,43 +8,23 @@
 
 #define VA_BUF(b, fmt) do { va_list args; va_start(args, fmt); put_vformat(b, fmt, args); va_end(args); } while (0)
 
-static struct membuffer error_string_buffer = { 0 };
-static void (*error_cb)(void) = NULL;
-/*
- * Note that the act of "getting" the error string
- * buffer doesn't de-allocate the buffer, but it does
- * set the buffer length to zero, so that any future
- * error reports will overwrite the string rather than
- * append to it.
- */
-const char *get_error_string(void)
-{
-	const char *str;
-
-	if (!error_string_buffer.len)
-		return "";
-	str = mb_cstring(&error_string_buffer);
-	error_string_buffer.len = 0;
-	return str;
-}
+static void (*error_cb)(char *) = NULL;
 
 int report_error(const char *fmt, ...)
 {
-	struct membuffer *buf = &error_string_buffer;
+	struct membuffer buf = { 0 };
 
-	/* Previous unprinted errors? Add a newline in between */
-	if (buf->len)
-		put_bytes(buf, "\n", 1);
-	VA_BUF(buf, fmt);
-	mb_cstring(buf);
+	/* if there is no error callback registered, don't produce errors */
+	if (!error_cb)
+		return -1;
 
-	/* if an error callback is registered, call it */
-	if (error_cb)
-		error_cb();
+	VA_BUF(&buf, fmt);
+	mb_cstring(&buf);
+	error_cb(detach_buffer(&buf));
 
 	return -1;
 }
 
-void set_error_cb(void(*cb)(void)) {
+void set_error_cb(void(*cb)(char *)) {
 	error_cb = cb;
 }

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -222,9 +222,6 @@ void DownloadFromDCWidget::updateState(states state)
 	else if (state == ERROR) {
 		timer->stop();
 
-		// Show messages that worker thread produced.
-		MainWindow::instance()->showErrors();
-
 		QMessageBox::critical(this, TITLE_OR_TEXT(tr("Error"), thread.error), QMessageBox::Ok);
 		markChildrenAsEnabled();
 		progress_bar_text = "";

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -89,9 +89,11 @@ extern "C" int updateProgress(const char *text)
 
 MainWindow *MainWindow::m_Instance = NULL;
 
-extern "C" void showErrorFromC()
+extern "C" void showErrorFromC(char *buf)
 {
-	emit MainWindow::instance()->showError(get_error_string());
+	QString error(buf);
+	free(buf);
+	emit MainWindow::instance()->showError(error);
 }
 
 MainWindow::MainWindow() : QMainWindow(),

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -91,21 +91,9 @@ MainWindow *MainWindow::m_Instance = NULL;
 
 extern "C" void showErrorFromC()
 {
-	// Show errors only if we are running in the GUI thread.
-	// If we're not in the GUI thread, let errors accumulate.
-	if (QThread::currentThread() != QCoreApplication::instance()->thread())
-		return;
-
 	MainWindow *mainwindow = MainWindow::instance();
 	if (mainwindow)
-		mainwindow->showErrors();
-}
-
-void MainWindow::showErrors()
-{
-	const char *error = get_error_string();
-	if (!empty_string(error))
-		getNotificationWidget()->showNotification(error, KMessageWidget::Error);
+		emit mainwindow->showError(get_error_string());
 }
 
 MainWindow::MainWindow() : QMainWindow(),
@@ -219,6 +207,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget(), SLOT(printDecoPlan()));
 	connect(this, SIGNAL(startDiveSiteEdit()), this, SLOT(on_actionDiveSiteEdit_triggered()));
 	connect(information(), SIGNAL(diveSiteChanged(struct dive_site *)), mapWidget, SLOT(centerOnDiveSite(struct dive_site *)));
+	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	wtu = new WindowTitleUpdate();
 	connect(WindowTitleUpdate::instance(), SIGNAL(updateTitle()), this, SLOT(setAutomaticTitle()));

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -91,9 +91,7 @@ MainWindow *MainWindow::m_Instance = NULL;
 
 extern "C" void showErrorFromC()
 {
-	MainWindow *mainwindow = MainWindow::instance();
-	if (mainwindow)
-		emit mainwindow->showError(get_error_string());
+	emit MainWindow::instance()->showError(get_error_string());
 }
 
 MainWindow::MainWindow() : QMainWindow(),

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -88,10 +88,6 @@ public:
 	void enableDisableCloudActions();
 	void setCheckedActionFilterTags(bool checked);
 
-	// Shows errors that have accumulated.
-	// Must be called from GUI thread.
-	void showErrors();
-
 private
 slots:
 	/* file menu action */
@@ -159,6 +155,7 @@ protected:
 
 signals:
 	void startDiveSiteEdit();
+	void showError(QString message);
 
 public
 slots:

--- a/desktop-widgets/notificationwidget.cpp
+++ b/desktop-widgets/notificationwidget.cpp
@@ -3,8 +3,7 @@
 
 NotificationWidget::NotificationWidget(QWidget *parent) : KMessageWidget(parent)
 {
-	future_watcher = new QFutureWatcher<void>();
-	connect(future_watcher, SIGNAL(finished()), this, SLOT(finish()));
+	connect(&future_watcher, SIGNAL(finished()), this, SLOT(finish()));
 }
 
 void NotificationWidget::showNotification(QString message, KMessageWidget::MessageType type)
@@ -29,15 +28,10 @@ QString NotificationWidget::getNotificationText()
 
 void NotificationWidget::setFuture(const QFuture<void> &future)
 {
-	future_watcher->setFuture(future);
+	future_watcher.setFuture(future);
 }
 
 void NotificationWidget::finish()
 {
 	hideNotification();
-}
-
-NotificationWidget::~NotificationWidget()
-{
-	delete future_watcher;
 }

--- a/desktop-widgets/notificationwidget.cpp
+++ b/desktop-widgets/notificationwidget.cpp
@@ -16,6 +16,11 @@ void NotificationWidget::showNotification(QString message, KMessageWidget::Messa
 	animatedShow();
 }
 
+void NotificationWidget::showError(QString message)
+{
+	showNotification(message, KMessageWidget::Error);
+}
+
 void NotificationWidget::hideNotification()
 {
 	animatedHide();

--- a/desktop-widgets/notificationwidget.h
+++ b/desktop-widgets/notificationwidget.h
@@ -20,10 +20,9 @@ public:
 	void showNotification(QString message, KMessageWidget::MessageType type);
 	void hideNotification();
 	QString getNotificationText();
-	~NotificationWidget();
 
 private:
-	QFutureWatcher<void> *future_watcher;
+	QFutureWatcher<void> future_watcher;
 
 private
 slots:

--- a/desktop-widgets/notificationwidget.h
+++ b/desktop-widgets/notificationwidget.h
@@ -21,6 +21,9 @@ public:
 	void hideNotification();
 	QString getNotificationText();
 
+public
+slots:
+	void showError(QString message);
 private:
 	QFutureWatcher<void> future_watcher;
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -36,11 +36,12 @@ QMLManager *QMLManager::m_instance = NULL;
 
 #define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
 
-extern "C" void showErrorFromC()
+extern "C" void showErrorFromC(char *buf)
 {
+	QString error(buf);
+	free(buf);
 	// By using invokeMethod with Qt:AutoConnection, the error string is safely
 	// transported across thread boundaries, if not called from the UI thread.
-	QString error(get_error_string());
 	QMetaObject::invokeMethod(QMLManager::instance(), "registerError", Qt::AutoConnection, Q_ARG(QString, error));
 }
 

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -58,6 +58,8 @@ public:
 	};
 
 	static QMLManager *instance();
+	Q_INVOKABLE void registerError(const QString &error);
+	QString consumeError();
 
 	QString cloudUserName() const;
 	void setCloudUserName(const QString &cloudUserName);
@@ -200,6 +202,7 @@ private:
 	QString m_ssrfGpsWebUserid;
 	QString m_startPageText;
 	QString m_logText;
+	QString m_lastError;
 	bool m_locationServiceEnabled;
 	bool m_locationServiceAvailable;
 	bool m_verboseEnabled;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR is supposed to make the whole `report_error()` thing thread safe. The global error buffer is removed. Collecting of errors is done in the frontend. The collected errors are protected by mutexes. Desktop version slightly tested.