### PR TITLE
mobile cleanup: unduplicate code and do not loop over dives

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -411,21 +411,6 @@ QString DiveObjectHelper::firstGas() const
 	return gas;
 }
 
-QStringList DiveObjectHelper::suitList() const
-{
-	QStringList suits;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->suit;
-		if (!temp.isEmpty())
-			suits << d->suit;
-	}
-	suits.removeDuplicates();
-	suits.sort();
-	return suits;
-}
-
 QStringList DiveObjectHelper::locationList() const
 {
 	QStringList locations;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -429,28 +429,6 @@ QStringList DiveObjectHelper::locationList() const
 	return locations;
 }
 
-QStringList DiveObjectHelper::buddyList() const
-{
-	QStringList buddies;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->buddy;
-		if (!temp.isEmpty() && !temp.contains(",")){
-			buddies << d->buddy;
-		}
-		else if (!temp.isEmpty()){
-			QRegExp sep("(,\\s)");
-			QStringList tempList = temp.split(sep);
-			buddies << tempList;
-			buddies << tr("Multiple Buddies");
-		}
-	}
-	buddies.removeDuplicates();
-	buddies.sort();
-	return buddies;
-}
-
 QStringList DiveObjectHelper::divemasterList() const
 {
 	QStringList divemasters;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -428,18 +428,3 @@ QStringList DiveObjectHelper::locationList() const
 	locations.sort();
 	return locations;
 }
-
-QStringList DiveObjectHelper::divemasterList() const
-{
-	QStringList divemasters;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->divemaster;
-		if (!temp.isEmpty())
-			divemasters << d->divemaster;
-	}
-	divemasters.removeDuplicates();
-	divemasters.sort();
-	return divemasters;
-}

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -410,21 +410,3 @@ QString DiveObjectHelper::firstGas() const
 	gas = get_gas_string(m_dive->cylinder[0].gasmix);
 	return gas;
 }
-
-QStringList DiveObjectHelper::locationList() const
-{
-	QStringList locations;
-	struct dive *d;
-	struct dive_site *ds;
-	int i = 0;
-	for_each_dive (i, d) {
-		if ((ds = get_dive_site_by_uuid(d->dive_site_uuid)) != NULL) {
-			QString temp = ds->name;
-			if (!temp.isEmpty())
-				locations << temp;
-		}
-	}
-	locations.removeDuplicates();
-	locations.sort();
-	return locations;
-}

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -47,7 +47,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QStringList suitList READ suitList CONSTANT)
 	Q_PROPERTY(QStringList buddyList READ buddyList CONSTANT)
 	Q_PROPERTY(QStringList divemasterList READ divemasterList CONSTANT)
 	Q_PROPERTY(QStringList locationList READ locationList CONSTANT)
@@ -93,7 +92,6 @@ public:
 	QString startPressure() const;
 	QString endPressure() const;
 	QString firstGas() const;
-	QStringList suitList() const;
 	QStringList locationList() const;
 	QStringList buddyList() const;
 	QStringList divemasterList() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -47,7 +47,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QStringList divemasterList READ divemasterList CONSTANT)
 	Q_PROPERTY(QStringList locationList READ locationList CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
@@ -92,7 +91,6 @@ public:
 	QString endPressure() const;
 	QString firstGas() const;
 	QStringList locationList() const;
-	QStringList divemasterList() const;
 
 private:
 	struct dive *m_dive;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -47,7 +47,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QStringList buddyList READ buddyList CONSTANT)
 	Q_PROPERTY(QStringList divemasterList READ divemasterList CONSTANT)
 	Q_PROPERTY(QStringList locationList READ locationList CONSTANT)
 public:
@@ -93,7 +92,6 @@ public:
 	QString endPressure() const;
 	QString firstGas() const;
 	QStringList locationList() const;
-	QStringList buddyList() const;
 	QStringList divemasterList() const;
 
 private:

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -47,7 +47,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QStringList locationList READ locationList CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
 	~DiveObjectHelper();
@@ -90,7 +89,6 @@ public:
 	QString startPressure() const;
 	QString endPressure() const;
 	QString firstGas() const;
-	QStringList locationList() const;
 
 private:
 	struct dive *m_dive;

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -241,7 +241,7 @@ Kirigami.Page {
 		} else {
 			buddyIndex = manager.buddyList.indexOf(currentItem.modelData.dive.buddy)
 		}
-		divemasterIndex = currentItem.modelData.dive.divemasterList.indexOf(currentItem.modelData.dive.divemaster)
+		divemasterIndex = manager.divemasterList.indexOf(currentItem.modelData.dive.divemaster)
 		notes = currentItem.modelData.dive.notes
 		if (currentItem.modelData.dive.singleWeight) {
 			// we have only one weight, go ahead, have fun and edit it

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -18,7 +18,6 @@ Kirigami.Page {
 	property alias watertemp: detailsEdit.watertempText
 	property alias buddyIndex: detailsEdit.buddyIndex
 	property alias buddyText: detailsEdit.buddyText
-	property alias buddyModel: detailsEdit.buddyModel
 	property alias divemasterIndex: detailsEdit.divemasterIndex
 	property alias divemasterText: detailsEdit.divemasterText
 	property alias divemasterModel: detailsEdit.divemasterModel
@@ -240,7 +239,7 @@ Kirigami.Page {
 		if (currentItem.modelData.dive.buddy.indexOf(",") > 0) {
 			buddyText = currentItem.modelData.dive.buddy;
 		} else {
-			buddyIndex = currentItem.modelData.dive.buddyList.indexOf(currentItem.modelData.dive.buddy)
+			buddyIndex = manager.buddyList.indexOf(currentItem.modelData.dive.buddy)
 		}
 		divemasterIndex = currentItem.modelData.dive.divemasterList.indexOf(currentItem.modelData.dive.divemaster)
 		notes = currentItem.modelData.dive.notes

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -30,7 +30,6 @@ Kirigami.Page {
 	property alias notes: detailsEdit.notesText
 	property alias suitIndex: detailsEdit.suitIndex
 	property alias suitText: detailsEdit.suitText
-	property alias suitModel: detailsEdit.suitModel
 	property alias weight: detailsEdit.weightText
 	property alias startpressure: detailsEdit.startpressureText
 	property alias endpressure: detailsEdit.endpressureText
@@ -237,7 +236,7 @@ Kirigami.Page {
 		depth = currentItem.modelData.dive.depth
 		airtemp = currentItem.modelData.dive.airTemp
 		watertemp = currentItem.modelData.dive.waterTemp
-		suitIndex = currentItem.modelData.dive.suitList.indexOf(currentItem.modelData.dive.suit)
+		suitIndex = manager.suitList.indexOf(currentItem.modelData.dive.suit)
 		if (currentItem.modelData.dive.buddy.indexOf(",") > 0) {
 			buddyText = currentItem.modelData.dive.buddy;
 		} else {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -129,8 +129,7 @@ Item {
 			}
 			HintsTextEdit {
 				id: txtLocation
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.locationList : null
+				model: manager.locationList
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 				onEditingFinished: {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -224,8 +224,7 @@ Item {
 			}
 			HintsTextEdit {
 				id: suitBox
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.suitList : null
+				model: manager.suitList
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -236,8 +236,7 @@ Item {
 			}
 			HintsTextEdit {
 				id: buddyBox
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.buddyList : null
+				model: manager.buddyList
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -48,6 +48,8 @@ Item {
 		detailsEdit.depthText = ""
 		detailsEdit.airtempText = ""
 		detailsEdit.watertempText = ""
+		detailsEdit.divemasterText = ""
+		detailsEdit.buddyText = ""
 		suitBox.currentIndex = -1
 		buddyBox.currentIndex = -1
 		divemasterBox.currentIndex = -1
@@ -248,8 +250,7 @@ Item {
 			}
 			HintsTextEdit {
 				id: divemasterBox
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.divemasterList : null
+				model: manager.divemasterList
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -92,7 +92,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.location = ""
 		detailsWindow.gps = ""
 		detailsWindow.duration = ""
-		detailsWindow.suitModel = manager.suitInit
+		detailsWindow.suitModel = manager.suitList
 		detailsWindow.suitIndex = -1
 		detailsWindow.suitText = ""
 		detailsWindow.cylinderModel = manager.cylinderInit

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -81,7 +81,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.date = manager.getDate(detailsWindow.dive_id)
 		detailsWindow.airtemp = ""
 		detailsWindow.watertemp = ""
-		detailsWindow.buddyModel = manager.buddyInit
+		detailsWindow.buddyModel = manager.buddyList
 		detailsWindow.buddyIndex = -1
 		detailsWindow.buddyText = ""
 		detailsWindow.depth = ""

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -85,7 +85,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.buddyIndex = -1
 		detailsWindow.buddyText = ""
 		detailsWindow.depth = ""
-		detailsWindow.divemasterModel = manager.divemasterInit
+		detailsWindow.divemasterModel = manager.divemasterList
 		detailsWindow.divemasterIndex = -1
 		detailsWindow.divemasterText = ""
 		detailsWindow.notes = ""

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -250,6 +250,7 @@ void QMLManager::openLocalThenRemote(QString url)
 	}
 	buddyModel.updateModel(); emit buddyListChanged();
 	suitModel.updateModel(); emit suitListChanged();
+	divemasterModel.updateModel(); emit divemasterListChanged();
 }
 
 void QMLManager::mergeLocalRepo()
@@ -1547,19 +1548,9 @@ QStringList QMLManager::buddyList() const
 	return buddyModel.stringList();
 }
 
-QStringList QMLManager::divemasterInit() const
+QStringList QMLManager::divemasterList() const
 {
-	QStringList divemasters;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->divemaster;
-		if (!temp.isEmpty())
-			divemasters << d->divemaster;
-	}
-	divemasters.removeDuplicates();
-	divemasters.sort();
-	return divemasters;
+	return divemasterModel.stringList();
 }
 
 QStringList QMLManager::cylinderInit() const

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -17,6 +17,7 @@
 
 #include "qt-models/divelistmodel.h"
 #include "qt-models/gpslistmodel.h"
+#include "qt-models/completionmodels.h"
 #include "core/divelist.h"
 #include "core/device.h"
 #include "core/pref.h"
@@ -247,6 +248,8 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("have cloud credentials, trying to connect"));
 		tryRetrieveDataFromBackend();
 	}
+	buddyModel.updateModel();
+	suitModel.updateModel(); emit suitListChanged();
 }
 
 void QMLManager::mergeLocalRepo()
@@ -1534,19 +1537,9 @@ void QMLManager::quit()
 	QApplication::quit();
 }
 
-QStringList QMLManager::suitInit() const
+QStringList QMLManager::suitList() const
 {
-	QStringList suits;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->suit;
-		if (!temp.isEmpty())
-			suits << d->suit;
-	}
-	suits.removeDuplicates();
-	suits.sort();
-	return suits;
+	return suitModel.stringList();
 }
 
 QStringList QMLManager::buddyInit() const

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -248,7 +248,7 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("have cloud credentials, trying to connect"));
 		tryRetrieveDataFromBackend();
 	}
-	buddyModel.updateModel();
+	buddyModel.updateModel(); emit buddyListChanged();
 	suitModel.updateModel(); emit suitListChanged();
 }
 
@@ -1542,25 +1542,9 @@ QStringList QMLManager::suitList() const
 	return suitModel.stringList();
 }
 
-QStringList QMLManager::buddyInit() const
+QStringList QMLManager::buddyList() const
 {
-	QStringList buddies;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		QString temp = d->buddy;
-		if (!temp.isEmpty() && !temp.contains(",")){
-			buddies << d->buddy;
-		}
-		else if (!temp.isEmpty()){
-			QRegExp sep("(,\\s)");
-			QStringList tempList = temp.split(sep);
-			buddies << tempList;
-		}
-	}
-	buddies.removeDuplicates();
-	buddies.sort();
-	return buddies;
+	return buddyModel.stringList();
 }
 
 QStringList QMLManager::divemasterInit() const

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -248,6 +248,11 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("have cloud credentials, trying to connect"));
 		tryRetrieveDataFromBackend();
 	}
+	updateAllGlobalLists();
+}
+
+void QMLManager::updateAllGlobalLists()
+{
 	buddyModel.updateModel(); emit buddyListChanged();
 	suitModel.updateModel(); emit suitListChanged();
 	divemasterModel.updateModel(); emit divemasterListChanged();
@@ -1083,6 +1088,7 @@ void QMLManager::changesNeedSaving()
 #elif !defined(Q_OS_IOS)
 	saveChangesCloud(false);
 #endif
+	updateAllGlobalLists();
 }
 
 void QMLManager::openNoCloudRepo()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -251,6 +251,7 @@ void QMLManager::openLocalThenRemote(QString url)
 	buddyModel.updateModel(); emit buddyListChanged();
 	suitModel.updateModel(); emit suitListChanged();
 	divemasterModel.updateModel(); emit divemasterListChanged();
+	locationModel.update(); emit locationListChanged();
 }
 
 void QMLManager::mergeLocalRepo()
@@ -1551,6 +1552,11 @@ QStringList QMLManager::buddyList() const
 QStringList QMLManager::divemasterList() const
 {
 	return divemasterModel.stringList();
+}
+
+QStringList QMLManager::locationList() const
+{
+	return locationModel.allSiteNames();
 }
 
 QStringList QMLManager::cylinderInit() const

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -240,6 +240,7 @@ private:
 	bool m_libdcLog;
 	bool m_developer;
 	bool m_btEnabled;
+	void updateAllGlobalLists();
 
 #if defined(Q_OS_ANDROID)
 	QString appLogFileName;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -38,7 +38,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(int selectedDiveTimestamp MEMBER m_selectedDiveTimestamp WRITE setSelectedDiveTimestamp NOTIFY selectedDiveTimestampChanged)
 	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
 	Q_PROPERTY(QStringList buddyList READ buddyList NOTIFY buddyListChanged)
-	Q_PROPERTY(QStringList divemasterInit READ divemasterInit CONSTANT)
+	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
 	Q_PROPERTY(bool showPin MEMBER m_showPin WRITE setShowPin NOTIFY showPinChanged)
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
@@ -131,7 +131,7 @@ public:
 
 	QStringList suitList() const;
 	QStringList buddyList() const;
-	QStringList divemasterInit() const;
+	QStringList divemasterList() const;
 	QStringList cylinderInit() const;
 	bool showPin() const;
 	void setShowPin(bool enable);
@@ -197,6 +197,7 @@ public slots:
 private:
 	BuddyCompletionModel buddyModel;
 	SuitCompletionModel suitModel;
+	DiveMasterCompletionModel divemasterModel;
 	QString m_cloudUserName;
 	QString m_cloudPassword;
 	QString m_cloudPin;
@@ -269,6 +270,7 @@ signals:
 	void btEnabledChanged();
 	void suitListChanged();
 	void buddyListChanged();
+	void divemasterListChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -13,6 +13,7 @@
 #include "core/gpslocation.h"
 #include "core/downloadfromdcthread.h"
 #include "qt-models/divelistmodel.h"
+#include "qt-models/completionmodels.h"
 
 class QMLManager : public QObject {
 	Q_OBJECT
@@ -35,7 +36,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool syncToCloud MEMBER m_syncToCloud WRITE setSyncToCloud NOTIFY syncToCloudChanged)
 	Q_PROPERTY(int updateSelectedDive MEMBER m_updateSelectedDive WRITE setUpdateSelectedDive NOTIFY updateSelectedDiveChanged)
 	Q_PROPERTY(int selectedDiveTimestamp MEMBER m_selectedDiveTimestamp WRITE setSelectedDiveTimestamp NOTIFY selectedDiveTimestampChanged)
-	Q_PROPERTY(QStringList suitInit READ suitInit CONSTANT)
+	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
 	Q_PROPERTY(QStringList buddyInit READ buddyInit CONSTANT)
 	Q_PROPERTY(QStringList divemasterInit READ divemasterInit CONSTANT)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
@@ -128,7 +129,7 @@ public:
 
 	DiveListSortModel *dlSortModel;
 
-	QStringList suitInit() const;
+	QStringList suitList() const;
 	QStringList buddyInit() const;
 	QStringList divemasterInit() const;
 	QStringList cylinderInit() const;
@@ -194,6 +195,8 @@ public slots:
 
 
 private:
+	BuddyCompletionModel buddyModel;
+	SuitCompletionModel suitModel;
 	QString m_cloudUserName;
 	QString m_cloudPassword;
 	QString m_cloudPin;
@@ -264,6 +267,7 @@ signals:
 	void libdcLogChanged();
 	void developerChanged();
 	void btEnabledChanged();
+	void suitListChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -14,6 +14,7 @@
 #include "core/downloadfromdcthread.h"
 #include "qt-models/divelistmodel.h"
 #include "qt-models/completionmodels.h"
+#include "qt-models/divelocationmodel.h"
 
 class QMLManager : public QObject {
 	Q_OBJECT
@@ -39,6 +40,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
 	Q_PROPERTY(QStringList buddyList READ buddyList NOTIFY buddyListChanged)
 	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
+	Q_PROPERTY(QStringList locationList READ locationList NOTIFY locationListChanged)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
 	Q_PROPERTY(bool showPin MEMBER m_showPin WRITE setShowPin NOTIFY showPinChanged)
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
@@ -132,6 +134,7 @@ public:
 	QStringList suitList() const;
 	QStringList buddyList() const;
 	QStringList divemasterList() const;
+	QStringList locationList() const;
 	QStringList cylinderInit() const;
 	bool showPin() const;
 	void setShowPin(bool enable);
@@ -198,6 +201,7 @@ private:
 	BuddyCompletionModel buddyModel;
 	SuitCompletionModel suitModel;
 	DiveMasterCompletionModel divemasterModel;
+	LocationInformationModel locationModel;
 	QString m_cloudUserName;
 	QString m_cloudPassword;
 	QString m_cloudPin;
@@ -271,6 +275,7 @@ signals:
 	void suitListChanged();
 	void buddyListChanged();
 	void divemasterListChanged();
+	void locationListChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -37,7 +37,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(int updateSelectedDive MEMBER m_updateSelectedDive WRITE setUpdateSelectedDive NOTIFY updateSelectedDiveChanged)
 	Q_PROPERTY(int selectedDiveTimestamp MEMBER m_selectedDiveTimestamp WRITE setSelectedDiveTimestamp NOTIFY selectedDiveTimestampChanged)
 	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
-	Q_PROPERTY(QStringList buddyInit READ buddyInit CONSTANT)
+	Q_PROPERTY(QStringList buddyList READ buddyList NOTIFY buddyListChanged)
 	Q_PROPERTY(QStringList divemasterInit READ divemasterInit CONSTANT)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
 	Q_PROPERTY(bool showPin MEMBER m_showPin WRITE setShowPin NOTIFY showPinChanged)
@@ -130,7 +130,7 @@ public:
 	DiveListSortModel *dlSortModel;
 
 	QStringList suitList() const;
-	QStringList buddyInit() const;
+	QStringList buddyList() const;
 	QStringList divemasterInit() const;
 	QStringList cylinderInit() const;
 	bool showPin() const;
@@ -268,6 +268,7 @@ signals:
 	void developerChanged();
 	void btEnabledChanged();
 	void suitListChanged();
+	void buddyListChanged();
 };
 
 #endif

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
 	diveplotdatamodel.cpp
 	diveimportedmodel.cpp
 	completionmodels.cpp
+	divelocationmodel.cpp
 )
 
 # models exclusively used in desktop builds
@@ -25,7 +26,6 @@ set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
 	divetripmodel.cpp
 	diveplannermodel.cpp
 	divecomputerextradatamodel.cpp
-	divelocationmodel.cpp
 	ssrfsortfilterproxymodel.cpp
 )
 

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
 	diveplotdatamodel.cpp
 	diveimportedmodel.cpp
+	completionmodels.cpp
 )
 
 # models exclusively used in desktop builds
@@ -24,7 +25,6 @@ set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
 	divetripmodel.cpp
 	diveplannermodel.cpp
 	divecomputerextradatamodel.cpp
-	completionmodels.cpp
 	divelocationmodel.cpp
 	ssrfsortfilterproxymodel.cpp
 )

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -128,7 +128,15 @@ void LocationInformationModel::update()
 	beginResetModel();
 	internalRowCount = dive_site_table.nr;
 	qSort(dive_site_table.dive_sites, dive_site_table.dive_sites + dive_site_table.nr, dive_site_less_than);
+	locationNames.clear();
+	for (int i = 0; i < internalRowCount; i++)
+		locationNames << QString(dive_site_table.dive_sites[i]->name);
 	endResetModel();
+}
+
+QStringList LocationInformationModel::allSiteNames() const
+{
+	return(locationNames);
 }
 
 bool LocationInformationModel::setData(const QModelIndex &index, const QVariant &value, int role)

--- a/qt-models/divelocationmodel.h
+++ b/qt-models/divelocationmodel.h
@@ -17,6 +17,7 @@ bool filter_same_gps_cb (QAbstractItemModel *m, int sourceRow, const QModelIndex
 class LocationInformationModel : public QAbstractTableModel {
 Q_OBJECT
 public:
+	LocationInformationModel(QObject *obj = 0);
 	enum Columns { UUID, NAME, LATITUDE, LONGITUDE, COORDS, DESCRIPTION, NOTES, TAXONOMY_1, TAXONOMY_2, TAXONOMY_3, COLUMNS};
 	enum Roles { UUID_ROLE = Qt::UserRole + 1 };
 	static LocationInformationModel *instance();
@@ -29,9 +30,10 @@ public:
 
 public slots:
 	void update();
+	QStringList allSiteNames() const;
 private:
-	LocationInformationModel(QObject *obj = 0);
 	int internalRowCount;
+	QStringList locationNames;
 	QLineEdit *textField;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/performance improvement
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This is a set of commits that are (very) similar. It appeared that a number of more or less static lists, which are constructed by a loop over all dives in the logbook, were executed when changing focus to a next dive. For example, the in this commit addressed list of used dive suits.

What was wrong was that the lists were linked to a dive. There is only a need to construct the list of used suits when data is changed (and obviously, once on startup of the app). Further, it appeared that a lot of code was duplicated and that we can use (in this case) the same code from the desktop completionmodels.cpp or other models.

There are no visible changes in the UI, other than a slight better performance when scrolling over dive details.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
Basically, this commit involves the following changes:

- include completionmodels.cpp in mobile and desktop (so move it from the desktop only category to the generic category).
- remove double code from DiveObjectHelper.cpp
- Do not differentiate in the init phase and the normal refresh of the list
- the per dive logic is now only the getting of a previously constructed list (in init or update of the divelist).

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
