### PR TITLE
Correct the ftdi pid for Cressi devices

### DIFF
--- a/android-mobile/res/xml/device_filter.xml
+++ b/android-mobile/res/xml/device_filter.xml
@@ -10,7 +10,7 @@
     <!-- Suunto Custom PID -->
     <usb-device vendor-id="1027" product-id="63104"/>
     <!-- Cressi (Leonardo) Custom PID -->
-    <usb-device vendor-id="1027" product-id="63104"/>
+    <usb-device vendor-id="1027" product-id="34768"/>
     <!-- EON Steel -->
     <usb-device vendor-id="5267" product-id="48"/>
     <!-- EON Steel core -->

--- a/android/res/xml/device_filter.xml
+++ b/android/res/xml/device_filter.xml
@@ -10,7 +10,7 @@
     <!-- Suunto Custom PID -->
     <usb-device vendor-id="1027" product-id="63104"/>
     <!-- Cressi (Leonardo) Custom PID -->
-    <usb-device vendor-id="1027" product-id="63104"/>
+    <usb-device vendor-id="1027" product-id="34768"/>
     <!-- EON Steel -->
     <usb-device vendor-id="5267" product-id="48"/>
     <!-- EON Steel core -->


### PR DESCRIPTION
Way back in time there was a copy paste error in the Cressi pid. This
corrects it.

This relates to:
https://groups.google.com/forum/#!category-topic/subsurface-divelog/5hNvowAr0OQ