### PR TITLE
profile: replot handles while planning

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -801,7 +801,14 @@ void ProfileWidget2::settingsChanged()
 {
 	// if we are showing calculated ceilings then we have to replot()
 	// because the GF could have changed; otherwise we try to avoid replot()
-	bool needReplot = prefs.calcceiling;
+	// but always replot in PLAN/ADD/EDIT mode to avoid a bug of DiveHandlers not
+	// being redrawn on setting changes, causing them to become unattached
+	// to the profile
+	bool needReplot;
+	if (currentState == ADD || currentState == PLAN || currentState ==  EDIT)
+		needReplot = true;
+	else
+		needReplot = prefs.calcceiling;
 #ifndef SUBSURFACE_MOBILE
 	gasYAxis->settingsChanged();	// Initialize ticks of partial pressure graph
 	if ((prefs.percentagegraph||prefs.hrgraph) && PP_GRAPHS_ENABLED) {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The settingsChanged() function of the profile widget tries to be clever and tries to prevent not needed replots of the profile. I'm not sure this is very relevant in the first place as change of settings are almost instantly, with or without replot. It appears that replot is always executed when there are calculated ceilings visible. But without calculated ceilings a replot is "optimized out". This does, however, introduce dangling divehandles in PLAN/EDIT and ADD mode of the profile, when any setting that influences the y-axis is changed.

The fix is trivial. Just force a replot in the PLAN/EDIT and ADD modes.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Fixes: #1070
