### PR TITLE
Cleanup: Remove a redefinition and a variable in Bluetooth code

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -18,9 +18,6 @@ namespace DownloadFromDcGlobal {
 	const char *err_string;
 };
 
-// Workaround abuse of old libdc types
-#define DC_TRANSPORT_BLUETOOTH 1024
-
 DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f),
 	downloading(false),
 	previousLast(0),

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -14,10 +14,6 @@
 #include <QMessageBox>
 #include <QShortcut>
 
-namespace DownloadFromDcGlobal {
-	const char *err_string;
-};
-
 DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f),
 	downloading(false),
 	previousLast(0),


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Two minor cleanups in the Bluetooth code:

1) Remove redefinition of DC_TRANSPORT_BLUETOOTH. This is defined to two different values in Subsurface and libdc. Currently not a problem, because it is only used in a single file and not returned by libdc. But a disaster waiting to happen.
2) Remove unused variable from Gtk days.