### PR TITLE
Do not remove seconds from duration input field

### DIFF
--- a/core/helpers.h
+++ b/core/helpers.h
@@ -36,6 +36,7 @@ int parseWeightToGrams(const QString &text);
 int parsePressureToMbar(const QString &text);
 int parseGasMixO2(const QString &text);
 int parseGasMixHE(const QString &text);
+QString render_seconds_to_string(int seconds);
 QString get_dive_duration_string(timestamp_t when, QString hoursText, QString minutesText, QString secondsText = QObject::tr("sec"), QString separator = ":", bool isFreeDive = false);
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -743,6 +743,14 @@ int gettimezoneoffset(timestamp_t when)
 	return dt2.secsTo(dt1);
 }
 
+QString render_seconds_to_string(int seconds)
+{
+	if (seconds % 60 == 0)
+		return QDateTime::fromTime_t(seconds).toUTC().toString("h:mm");
+	else
+		return QDateTime::fromTime_t(seconds).toUTC().toString("h:mm:ss");
+}
+
 int parseDurationToSeconds(const QString &text)
 {
 	int secs;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -393,7 +393,7 @@ void MainTab::updateDepthDuration()
 	ui.depthLabel->setVisible(true);
 	ui.duration->setVisible(true);
 	ui.durationLabel->setVisible(true);
-	ui.duration->setText(QDateTime::fromTime_t(displayed_dive.duration.seconds).toUTC().toString("h:mm"));
+	ui.duration->setText(render_seconds_to_string(displayed_dive.duration.seconds));
 	ui.depth->setText(get_depth_string(displayed_dive.maxdepth, true));
 }
 
@@ -579,7 +579,7 @@ void MainTab::updateDiveInfo(bool clear)
 				ui.durationLabel->setVisible(isManual);
 			}
 		}
-		ui.duration->setText(QDateTime::fromTime_t(displayed_dive.duration.seconds).toUTC().toString("h:mm"));
+		ui.duration->setText(render_seconds_to_string(displayed_dive.duration.seconds));
 		ui.depth->setText(get_depth_string(displayed_dive.maxdepth, true));
 		ui.DiveType->setCurrentIndex(get_dive_dc(&displayed_dive, dc_number)->divemode);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
If you enter a dive duration manually, the cell renderer cuts the seconds away when the changes are saved. The rendering of the cell is done at two places in the code, so I think it is cleaner to add a dedicated method for it. 
I added the helper "render_seconds_to_string" as a counterpart to "parseDurationToSeconds". The helper keeps the seconds if not null.

### Changes made:
1) Method render_seconds_to_string(int seconds) was added to qthelper. E.g., it converts 4200 to "1:10" and 4230 to "1:10:30".
2) The new method is used to render the string in the duration field of the add dive ui.

### Related issues:
#554 

