### PR TITLE
Bugfix in plannermodel for very short dive durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix bug that alters manually entered dive durations
 - Desktop: don't ignore seconds in duration input field
 - Libdivecomputer: use a new version
 - Dekstop: fix instability crashes in reverse geo lookup function

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -108,7 +108,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	int cylinderid = 0;
 	last_sp.mbar = 0;
 	for (int i = 0; i < plansamples - 1; i++) {
-		if (dc->last_manual_time.seconds && lasttime.seconds >= dc->last_manual_time.seconds)
+		if (dc->last_manual_time.seconds && dc->last_manual_time.seconds > 120 && lasttime.seconds >= dc->last_manual_time.seconds)
 			break;
 		while (j * plansamples <= i * dc->samples) {
 			const sample &s = dc->sample[j];


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When adding a dive manually, you will likely clear the "duration" field and fill in your dive duration by hand. Unfortunately, commit #1052 introduced a bug that practically limited the dive duration to 6 minutes once the field was cleared:

![output](https://user-images.githubusercontent.com/35252661/35783335-b8c1212a-0a05-11e8-9f8a-32ef5285daff.gif)

### Changes made:
1) Added a condition to the for-loop breaker in DivePlannerPointsModel::loadFromDive.
I tried to limit the impact of the change to this specific situation. So I said the duration must be >120s for the breaker to apply. My test run:

![output](https://user-images.githubusercontent.com/35252661/35783383-56830f7c-0a06-11e8-992f-6e5d47eebf5e.gif)

### Release note:
Fix bug that alters manually entered dive durations.

### Mentions:
@willemferguson 