### PR TITLE
[RFC] Mobile: try to detangle the IO interface

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -722,10 +722,6 @@ successful_exit:
 		noCloudToCloud = false;
 		mark_divelist_changed(true);
 		saveChangesLocal();
-		if (git_local_only == false) {
-			appendTextToLog(QStringLiteral("taking things back offline now that storage is synced"));
-			git_local_only = true;
-		}
 	}
 	return;
 }
@@ -738,10 +734,6 @@ void QMLManager::revertToNoCloudIfNeeded()
 		// and cloud data) failed - so let's delete the cloud credentials and go
 		// back to CS_NOCLOUD mode in order to prevent us from losing the locally stored
 		// dives
-		if (git_local_only == true) {
-			appendTextToLog(QStringLiteral("taking things back offline since sync with cloud failed"));
-			git_local_only = false;
-		}
 		free((void *)prefs.cloud_storage_email);
 		prefs.cloud_storage_email = NULL;
 		free((void *)prefs.cloud_storage_password);
@@ -1311,16 +1303,13 @@ void QMLManager::saveChangesLocal()
 			return;
 		}
 		alreadySaving = true;
-		bool glo = git_local_only;
 		git_local_only = true;
 		if (save_dives(existing_filename)) {
 			setNotificationText(consumeError());
 			set_filename(NULL);
-			git_local_only = glo;
 			alreadySaving = false;
 			return;
 		}
-		git_local_only = glo;
 		mark_divelist_changed(false);
 		alreadySaving = false;
 	} else {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1352,12 +1352,9 @@ void QMLManager::saveChangesCloud(bool forceRemoteSync)
 		return;
 	}
 
-	bool glo = git_local_only;
-	git_local_only = false;
 	alreadySaving = true;
 	loadDivesWithValidCredentials();
 	alreadySaving = false;
-	git_local_only = glo;
 }
 
 void QMLManager::undo()

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -208,7 +208,7 @@ public slots:
 	void copyAppLogToClipboard();
 	bool createSupportEmail();
 	void finishSetup();
-	void openLocalThenRemote(QString url);
+	void openLocalThenRemote(QString url, bool localOnly);
 	void mergeLocalRepo();
 	QString getNumber(const QString& diveId);
 	QString getDate(const QString& diveId);
@@ -258,7 +258,6 @@ private:
 	bool checkLocation(DiveSiteChange &change, const DiveObjectHelper &myDive, struct dive *d, QString location, QString gps);
 	bool checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration);
 	bool checkDepth(const DiveObjectHelper &myDive, struct dive *d, QString depth);
-	bool currentGitLocalOnly;
 	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;
 	bool m_btEnabled;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is part of a long-term project attempting to establish a clear interface between the GUI and the IO backend. Sorry for the slow progress - I'm horribly busy at the moment.

One particularly intransparent aspect of the current implementation is the `prefs.git_local_only` flag, which is a mix of state, input and output parameter. A first step in cleaning this up will be making `prefs.git_local_only` effectively an input/output parameter. And in a second step also explicitly (see also 
#928).

Indeed, the mobile version already has a "property" `m_syncToCloud`, which makes `prefs.git_local_only` look kind of redundant. This PR attempts to make `m_syncToCloud` the authoritative flag and use `prefs.git_local_only` only to control the IO code.

I'm posting this as an RFC and it's obviously post-release material. It was tested lightly (sync to cloud with and without network), but I probably butchered it in a nasty way. It will be hard to test all the special cases.

BTW: As opposed to the desktop version, the mobile version does not seem to have something like an offline-mode. Is this correct?
  
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
