### PR TITLE
Cleanups in imageLoader

### DIFF
--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -9,7 +9,7 @@
 
 #include <QtConcurrent>
 
-QUrl cloudImageURL(const char *hash)
+static QUrl cloudImageURL(const char *hash)
 {
 	return QUrl::fromUserInput(QString("https://cloud.subsurface-divelog.org/images/").append(hash));
 }
@@ -78,11 +78,11 @@ void ImageDownloader::saveImage(QNetworkReply *reply)
 
 }
 
-QSet<QString> queuedPictures;
-QMutex pictureQueueMutex;
-
-void loadPicture(struct picture *picture, bool fromHash)
+static void loadPicture(struct picture *picture, bool fromHash)
 {
+	static QSet<QString> queuedPictures;
+	static QMutex pictureQueueMutex;
+
 	if (!picture)
 		return;
 	QMutexLocker locker(&pictureQueueMutex);

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -89,6 +89,8 @@ static void loadPicture(struct picture *picture, bool fromHash)
 	if (queuedPictures.contains(QString(picture->filename)))
 		return;
 	queuedPictures.insert(QString(picture->filename));
+	locker.unlock();
+
 	ImageDownloader download(picture);
 	download.load(fromHash);
 }

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -8,9 +8,6 @@
 
 typedef QPair<QString, QByteArray> SHashedFilename;
 
-extern QUrl cloudImageURL(const char *hash);
-
-
 class ImageDownloader : public QObject {
 	Q_OBJECT;
 public:

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -6,8 +6,6 @@
 #include <QFuture>
 #include <QNetworkReply>
 
-typedef QPair<QString, QByteArray> SHashedFilename;
-
 class ImageDownloader : public QObject {
 	Q_OBJECT;
 public:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Two trivial cleanups and a borderline bugfix: The way I see it, a mutex wasn't unlocked, thereby serializing all image loading. (Then why use threads in the first place?)

PS: We might want to remove entries from the `queuedPictures` set after loading. But then we'd have to either change the lookup logic or live with a small (tiny) window where pictures could be loaded twice.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make local things of static linkage
2) Remove stale `typedef`
3) Unlock mutex
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde: Please check commit no. 3.