### PR TITLE
Choose water presets from a qcombobox in planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 - Add imperial support for UDCF import
+- Desktop: combo box with fresh, sea water and EN 13319 in dive planner
+- Desktop: Changed "salinity" to "water type" at dive planner and dive info
 # add new entries above this line

--- a/core/units.h
+++ b/core/units.h
@@ -30,6 +30,7 @@ extern "C" {
 
 /* Salinity is expressed in weight in grams per 10l */
 #define SEAWATER_SALINITY 10300
+#define EN13319_SALINITY 10200
 #define FRESHWATER_SALINITY 10000
 
 #include <stdint.h>

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -51,13 +51,15 @@ slots:
 	void settingsChanged();
 	void atmPressureChanged(const int pressure);
 	void heightChanged(const int height);
-	void salinityChanged(const double salinity);
+	void waterTypeChanged(const int index);
+	void customSalinityChanged(double density);
 	void printDecoPlan();
 	void setSurfacePressure(int surface_pressure);
 	void setSalinity(int salinity);
 private:
 	Ui::DivePlanner ui;
 	QAbstractButton *replanButton;
+	void waterTypeUpdateTexts();
 };
 
 #include "ui_plannerSettings.h"

--- a/desktop-widgets/diveplanner.ui
+++ b/desktop-widgets/diveplanner.ui
@@ -62,41 +62,6 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <property name="spacing">
-        <number>2</number>
-       </property>
-       <item row="5" column="0" colspan="3">
-        <widget class="TableView" name="tableWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>50</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="3">
-        <widget class="TableView" name="cylinderTableWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>50</height>
-          </size>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label">
          <property name="sizePolicy">
@@ -133,7 +98,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
+       <item row="1" column="2" colspan="2">
         <widget class="QDialogButtonBox" name="buttonBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -163,26 +128,7 @@
        <item row="2" column="2">
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Salinity</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QSpinBox" name="ATMPressure">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="suffix">
-          <string>mbar</string>
-         </property>
-         <property name="minimum">
-          <number>689</number>
-         </property>
-         <property name="maximum">
-          <number>1100</number>
+          <string>Water type</string>
          </property>
         </widget>
        </item>
@@ -208,8 +154,8 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="2">
-        <widget class="QDoubleSpinBox" name="salinity">
+       <item row="3" column="1">
+        <widget class="QSpinBox" name="ATMPressure">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -217,19 +163,106 @@
           </sizepolicy>
          </property>
          <property name="suffix">
+          <string>mbar</string>
+         </property>
+         <property name="minimum">
+          <number>689</number>
+         </property>
+         <property name="maximum">
+          <number>1100</number>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QComboBox" name="waterType">
+         <item>
+          <property name="text">
+           <string>Fresh water</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Sea water</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>EN13319</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Custom</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QDoubleSpinBox" name="customSalinity">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>90</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string extracomment="Custom water density"/>
+         </property>
+         <property name="suffix">
           <string>kg/ℓ</string>
          </property>
          <property name="minimum">
-          <double>1.000000000000000</double>
+          <double>0.990000000000000</double>
          </property>
          <property name="maximum">
-          <double>1.050000000000000</double>
+          <double>1.300000000000000</double>
          </property>
          <property name="singleStep">
           <double>0.010000000000000</double>
          </property>
          <property name="value">
-          <double>1.030000000000000</double>
+          <double>1.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="4">
+        <widget class="TableView" name="cylinderTableWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>50</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="4">
+        <widget class="TableView" name="tableWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>50</height>
+          </size>
          </property>
         </widget>
        </item>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -303,7 +303,7 @@
        <item row="4" column="1">
         <widget class="QGroupBox" name="groupBox_1">
          <property name="title">
-          <string>Salinity</string>
+          <string>Water type</string>
          </property>
          <layout class="QHBoxLayout" name="diveInfoSalinityLayout">
           <item>


### PR DESCRIPTION
Signed-off-by: Oliver Schwaneberg <oliver.schwaneberg@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [x] Language translation

### Pull request long description:
Added a qcombobox for water types. Defaults for fresh water and sea water are set from the defines SEAWATER_SALINITY and FRESHWATER_SALINITY in units.h. A new definition EN13319_SALINITY was added as the third preset. Custom values can be entered through a spin box when choosing "Custom".

**Translation required!**

### Changes made:
1) Added a qcombobox with defaults for fresh and seawater.
2) Custom values through a spin box like before.
3) Minimum custom density is changed to 0.99kg/l
4) Maximum custom density is changed to 1.30kg/l
5) Added EN13319_SALINITY to units.h
6) Changed word "salinity" to "water type" at planner and TabDiveInformation (to describe density values)

### Related issues:
#1090

### Additional information:

### Release note:
Desktop: combo box with fresh, sea water and EN 13319 in dive planner

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
@atdotde @dirkhh @sfuchs79 