### PR TITLE
Cleanups in Windows implementation of BT device discovery agent

### DIFF
--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -668,7 +668,7 @@ void WinBluetoothDeviceDiscoveryAgent::run()
 				// Get the last error and emit a signal
 				lastErrorToString = qt_error_string();
 				lastError = QBluetoothDeviceDiscoveryAgent::UnknownError;
-				emit(lastError);
+				emit error(lastError);
 
 				break;
 			}
@@ -690,7 +690,7 @@ void WinBluetoothDeviceDiscoveryAgent::run()
 			// Get the last error and emit a signal
 			lastErrorToString = qt_error_string();
 			lastError = QBluetoothDeviceDiscoveryAgent::UnknownError;
-			emit(lastError);
+			emit error(lastError);
 		}
 	}
 

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -682,7 +682,7 @@ void WinBluetoothDeviceDiscoveryAgent::run()
 			deviceAddress.truncate(BTH_ADDR_PRETTY_STRING_LEN);
 
 			// Create an object with information about the discovered device
-			QBluetoothDeviceInfo deviceInfo = QBluetoothDeviceInfo(QBluetoothAddress(deviceAddress), deviceName, 0);
+			QBluetoothDeviceInfo deviceInfo(QBluetoothAddress(deviceAddress), deviceName, 0);
 
 			// Raise a signal with information about the found remote device
 			emit deviceDiscovered(deviceInfo);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Two small cleanups, one of which could also be considered a bug: I don't see how emitting of the error-signal could have ever worked. But maybe there is some magic involved?

This is  not even compile-tested, since I don't have a Windows machine at my disposal.

BTW: `error()` is overloaded once as a setter function and once as a signal. But this is inherited from Qt's own  `QBluetoothDeviceDiscoveryAgent`. What?

<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
