### PR TITLE
smtk-import: Fix error management issue

### DIFF
--- a/smtk-import/smrtk2ssrfc_window.cpp
+++ b/smtk-import/smrtk2ssrfc_window.cpp
@@ -11,6 +11,14 @@
 
 QStringList inputFiles;
 QString outputFile;
+QString error_buf;
+
+extern "C" void getErrorFromC(char *buf)
+{
+	QString error(buf);
+	free(buf);
+	error_buf = error;
+}
 
 Smrtk2ssrfcWindow::Smrtk2ssrfcWindow(QWidget *parent) :
 	QMainWindow(parent),
@@ -76,11 +84,12 @@ void Smrtk2ssrfcWindow::on_importButton_clicked()
 
 	ui->plainTextEdit->setDisabled(false);
 	ui->progressBar->setRange(0, inputFiles.size());
+	set_error_cb(&getErrorFromC);
 	for (int i = 0; i < inputFiles.size(); ++i) {
 		ui->progressBar->setValue(i);
 		fileNamePtr = QFile::encodeName(inputFiles.at(i));
 		smartrak_import(fileNamePtr.data(), &dive_table);
-		ui->plainTextEdit->appendPlainText(QString(get_error_string()));
+		ui->plainTextEdit->appendPlainText(error_buf);
 	}
 	ui->progressBar->setValue(inputFiles.size());
 	save_dives_logic(outputFile.toUtf8().data(), false);


### PR DESCRIPTION
In commits eccd4b993 to 8f81a22e7 global error buffer and get_error_string()
func, were moved to a call back function.
This patch makes smtk2ssrf suport those changes and build again.

Signed-off-by: Salvador Cuñat <salvador.cunat@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In commits eccd4b993 to 8f81a22e7 global error buffer and get_error_string()
func, were moved to a call back function.
This patch makes smtk2ssrf suport those changes and build again.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Substitute get_error_string() function with new call back
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->