### PR TITLE
Mobile: new Kirigami and related fallout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,13 @@ endif()
 
 # global settings
 
+set(CMAKE_MODULE_PATH
+	${${PROJECT_NAME}_SOURCE_DIR}/cmake/Modules
+	${CMAKE_MODULE_PATH}
+)
+
 set(CMAKE_AUTOMOC ON)
-include(cmake/Modules/MacroOutOfSourceBuild.cmake)
+include(MacroOutOfSourceBuild)
 MACRO_ENSURE_OUT_OF_SOURCE_BUILD(
     "We don't support building in source, please create a build folder elsewhere and remember to run git clean -xdf to remove temporary files created by CMake."
 )
@@ -62,12 +67,6 @@ endif()
 set(SUBSURFACE_SOURCE ${CMAKE_SOURCE_DIR})
 add_definitions(-DSUBSURFACE_SOURCE="${SUBSURFACE_SOURCE}")
 
-#evenrything's correct, moving on.
-set(CMAKE_MODULE_PATH
-	${CMAKE_MODULE_PATH}
-	${${PROJECT_NAME}_SOURCE_DIR}/cmake/Modules
-)
-
 #
 # TODO: This Compilation part should go on the Target specific CMake.
 #
@@ -112,7 +111,7 @@ set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
 
 # pkgconfig for required libraries
 find_package(PkgConfig)
-include(cmake/Modules/pkgconfig_helper.cmake)
+include(pkgconfig_helper)
 
 # The 'HandleFindXXX' are special libraries that subsurface needs
 # to find and configure in a few different ways because of a few
@@ -120,16 +119,16 @@ include(cmake/Modules/pkgconfig_helper.cmake)
 # everyone happy. It also sets some variables for each library, so
 # if you think a module miss anything, take a look on the specific
 # module file.
-include(cmake/Modules/HandleFindGit2.cmake)
-include(cmake/Modules/HandleFindLibDiveComputer.cmake)
+include(HandleFindGit2)
+include(HandleFindLibDiveComputer)
 if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")
-	include(cmake/Modules/HandleFindGrantlee.cmake)
-	include(cmake/Modules/HandleUserManual.cmake)
+        include(HandleFindGrantlee)
+	include(HandleUserManual)
 endif()
-include(cmake/Modules/HandleFtdiSupport.cmake)
-include(cmake/Modules/HandleVersionGeneration.cmake)
-include(cmake/Modules/RunOnBuildDir.cmake)
-include(cmake/Modules/cmake_variables_helper.cmake)
+include(HandleFtdiSupport)
+include(HandleVersionGeneration)
+include(RunOnBuildDir)
+include(cmake_variables_helper)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	include_directories(${CMAKE_OSX_SYSROOT}/usr/include/libxml2)

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -73,9 +73,20 @@ cp $BREEZE/icons/actions/22/overflow-menu.svg $MC/icons
 # kirigami now needs the breeze-icons internally as well
 pushd $MC
 ln -s $SRC/$BREEZE .
+
+# do not show the action buttons when the keyboard is open
 sed -i -e "s/visible: root.action/visible: root.action \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
 sed -i -e "s/visible: root.leftAction/visible: root.leftAction \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
 sed -i -e "s/visible: root.rightAction/visible: root.rightAction \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
+
+# another hack. Do not include the Kirigami resources (on static build). It causes
+# double defined symbols in our setting. I would like a nicer fix for this
+# issue, but failed to find one. For example, not adding the resource in
+# our build causes the qrc file not to be generated. Manual generation
+# of the resource file (using rcc) introduces the double symbols again. 
+# so it seems some Kirigami weirdness (but their staticcmake example compiles
+# correctly).
+sed -i -e "s/#include <qrc_kirigami.cpp>/\/\/#include <qrc_kirigami.cpp>/" src/kirigamiplugin.cpp
 popd
 
 echo org.kde.plasma.kirigami synced from upstream

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -33,7 +33,7 @@ if [ "$NOPULL" = "" ] ; then
 	git checkout master
 	git pull origin master
 	# if we want to pin a specific Kirigami version, we can do this here
-	git checkout 3606ef16375f9deb132565463d1ab11cea2548df
+	git checkout 3023536f809b165eb90300aa356407f4079c6507
 	popd
 fi
 if [ ! -d breeze-icons ] ; then


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
While most new commits are QML improvements, there is a change in the Kirigami build related to static building (like we do), and Cmake restyles to make things more Qt compliant.

As now the (generated) qrc_kirigami.cpp is included from kirigamiplugin.cpp, for static builds, our build fails on
double defined symbols. 

Fixing this build problem is definitely a hack. Do not include the Kirigami resources (on static build). I would like a nicer fix for this issue, but failed to find one. For example, not adding the resource in our build causes the qrc file not to be generated. Manual generation of the resource file (using rcc) introduces the double symbols again. So it seems some Kirigami weirdness (but their staticcmake example compiles correctly).

Finally some trivial cleanup. It seems a little weird to first define a CMAKE_MODULE_PATH search path and then explicitly include files including a hard coded path instead of letting the include command search for the modules we like to include.

### Changes made:
See commits

### Mentions:
@dirkhh (for approval of the hack)
