### PR TITLE
Mobile QML UI: upgrade main.qml to Kirigami 2.2

### DIFF
--- a/mobile-widgets/qml/About.qml
+++ b/mobile-widgets/qml/About.qml
@@ -8,6 +8,7 @@ Kirigami.ScrollablePage {
 	id: aboutPage
 	property int pageWidth: aboutPage.width - aboutPage.leftPadding - aboutPage.rightPadding
 	title: qsTr("About Subsurface-mobile")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	ColumnLayout {
 		spacing: Kirigami.Units.largeSpacing

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -176,6 +176,7 @@ Kirigami.Page {
 	actions.main: Kirigami.Action {
 		icon {
 			name: state !== "view" ? "document-save" : "document-edit"
+			color: subsurfaceTheme.primaryColor
 		}
 		onTriggered: {
 			manager.appendTextToLog("save/edit button triggered")

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -49,6 +49,7 @@ Kirigami.Page {
 	topPadding: Kirigami.Units.gridUnit * 2 // make room for the title bar
 	rightPadding: 0
 	bottomPadding: 0
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	states: [
 		State {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -50,6 +50,7 @@ Kirigami.ScrollablePage {
 			width: parent.width
 			height: diveListEntry.height + Kirigami.Units.smallSpacing
 			backgroundColor: checked ? subsurfaceTheme.primaryColor : subsurfaceTheme.backgroundColor
+			activeBackgroundColor: subsurfaceTheme.primaryColor
 			textColor: checked ? subsurfaceTheme.primaryTextColor : subsurfaceTheme.textColor
 
 			property real detailsOpacity : 0

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -333,6 +333,7 @@ Kirigami.ScrollablePage {
 	property QtObject downloadFromDCAction: Kirigami.Action {
 		icon {
 			name: "downloadDC"
+			color: subsurfaceTheme.primaryColor
 		}
 		onTriggered: {
 			downloadFromDc.dcImportModel.clearTable()

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -14,6 +14,7 @@ Kirigami.Page {
 	height: parent.height
 	Layout.fillWidth: true;
 	title: qsTr("Dive Computer")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	property alias dcImportModel: importModel
 	property bool divesDownloaded: false

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -12,6 +12,7 @@ Kirigami.ScrollablePage {
 	id: gpsListWindow
 	objectName: "gpsList"
 	title: qsTr("GPS Fixes")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	Component {
 		id: gpsDelegate

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -20,6 +20,10 @@ Kirigami.ScrollablePage {
 			id: gpsFix
 			enabled: true
 			width: parent.width
+			background: Rectangle {
+				color: subsurfaceTheme.backgroundColor
+				border.width: 1
+			}
 			GridLayout {
 				columns: 4
 				id: timeAndName

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -14,6 +14,7 @@ Kirigami.ScrollablePage {
 	anchors.margins: Kirigami.Units.gridUnit / 2
 	objectName: "Log"
 	title: qsTr("Application Log")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	ListView {
 		anchors.fill: parent

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -11,6 +11,7 @@ Kirigami.ScrollablePage {
 	objectName: "Settings"
 	id: settingsPage
 	title: qsTr("Settings")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	property real gridWidth: settingsPage.width - Kirigami.Units.gridUnit
 	property var describe: [qsTr("Undefined"),

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -8,6 +8,7 @@ import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.ScrollablePage {
 	id: startpage
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	function saveCredentials() { cloudCredentials.saveCredentials() }
 

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -8,6 +8,7 @@ import org.kde.kirigami 2.2 as Kirigami
 Kirigami.Page {
 
 	title: "Theme Information"
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	GridLayout {
 		id: themetest

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -18,6 +18,7 @@ Kirigami.ApplicationWindow {
 		minimumHeight: 0
 		preferredHeight: Math.round(Kirigami.Units.gridUnit * (Qt.platform.os == "ios" ? 2 : 1.5))
 		maximumHeight: Kirigami.Units.gridUnit * 2
+		background: Rectangle { color: subsurfaceTheme.primaryColor }
 	}
 	property alias oldStatus: manager.oldStatus
 	property alias notificationText: manager.notificationText

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -7,7 +7,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import org.subsurfacedivelog.mobile 1.0
-import org.kde.kirigami 2.0 as Kirigami
+import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.ApplicationWindow {
 	id: rootItem
@@ -443,17 +443,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 		property int columnWidth: Math.round(rootItem.width/(Kirigami.Units.gridUnit*28)) > 0 ? Math.round(rootItem.width / Math.round(rootItem.width/(Kirigami.Units.gridUnit*28))) : rootItem.width
 		Component.onCompleted: {
-			Kirigami.Theme.highlightColor = Qt.binding(function() { return primaryColor })
-			Kirigami.Theme.highlightedTextColor = Qt.binding(function() { return darkerPrimaryTextColor })
-			Kirigami.Theme.backgroundColor = Qt.binding(function() { return backgroundColor })
-			Kirigami.Theme.textColor = Qt.binding(function() { return textColor })
-			Kirigami.Theme.buttonHoverColor = Qt.binding(function() { return primaryColor })
-			Kirigami.Theme.viewBackgroundColor = Qt.binding(function() { return drawerColor })
-			Kirigami.Theme.viewTextColor = Qt.binding(function() { return textColor })
-			Kirigami.Theme.buttonBackgroundColor = Qt.binding(function() { return drawerColor })
-			Kirigami.Theme.buttonTextColor = Qt.binding(function() { return textColor })
-			Kirigami.Theme.buttonFocusColor = Qt.binding(function() { return "red" })
-
 			// this needs to pick the theme from persistent preference settings
 			var theme = manager.theme
 			if (theme == "Blue")

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -33,7 +33,7 @@ if [ "$NOPULL" = "" ] ; then
 	git checkout master
 	git pull origin master
 	# if we want to pin a specific Kirigami version, we can do this here
-	git checkout 3023536f809b165eb90300aa356407f4079c6507
+	git checkout 389f4c29acc3629a900dd5e1e52ef8b0bfe3519f
 	popd
 fi
 if [ ! -d breeze-icons ] ; then


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This PR upgrades our main.qml to Kirigami 2.2. We had to wait for this, as there where too much things still to be solved in Kirigami. In some cases, things can be considered a bug at our end, but in other cases it is just incompleteness at Kirigami side. Now, Kirigami is in a state that we finally do the upgrade of our main.qml tot Kirigami 2.2.

Useful is, is that the logging in the app log is much cleaner (less Kirigami warnings and errors). 

### Changes made:
See individual commits.

### Mentions:
@dirkhh 