### PR TITLE
Hashing: use-after-free fix & unification of XML & git saving

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1071,7 +1071,7 @@ QHash <QString, QImage > thumbnailCache;
 extern "C" char * hashstring(const char *filename)
 {
 	QMutexLocker locker(&hashOfMutex);
-	return hashOf[QString(filename)].toHex().data();
+	return strdup(hashOf[QString(filename)].toHex().data());
 }
 
 const QString hashfile_name()

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -604,12 +604,15 @@ static int save_one_picture(git_repository *repo, struct dir *dir, struct pictur
 	int offset = pic->offset.seconds;
 	struct membuffer buf = { 0 };
 	char sign = '+';
+	char *hash;
 	unsigned h;
 	int error;
 
 	show_utf8(&buf, "filename ", pic->filename, "\n");
 	show_gps(&buf, pic->latitude, pic->longitude);
-	show_utf8(&buf, "hash ", pic->hash, "\n");
+	hash = hashstring(pic->filename);
+	show_utf8(&buf, "hash ", hash, "\n");
+	free(hash);
 
 	/* Picture loading will load even negative offsets.. */
 	if (offset < 0) {

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -435,8 +435,10 @@ static void save_picture(struct membuffer *b, struct picture *pic)
 		put_degrees(b, pic->latitude, " gps='", " ");
 		put_degrees(b, pic->longitude, "", "'");
 	}
-	if (hashstring(pic->filename))
-		put_format(b, " hash='%s'", hashstring(pic->filename));
+	char *hash = hashstring(pic->filename);
+	if (!empty_string(hash))
+		put_format(b, " hash='%s'", hash);
+	free(hash);
 
 	put_string(b, "/>\n");
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The first commit is, in my opinion, a bug fix: data of a temporary object was returned.
The second commit unifies treatment of hashes in saving to XML and saving to git. The git code is converted to the XML code, since the latter seems to be more robust.