### PR TITLE
Coding-style: remove superfluous parentheses

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -47,9 +47,9 @@ static dc_descriptor_t *getDeviceType(QString btName)
 	}
 
 	if (!vendor.isEmpty() && !product.isEmpty())
-		return(descriptorLookup.value(vendor + product));
+		return descriptorLookup.value(vendor + product);
 
-	return(NULL);
+	return NULL;
 }
 
 BTDiscovery::BTDiscovery(QObject *parent) : m_btValid(false),

--- a/core/dive.c
+++ b/core/dive.c
@@ -2720,7 +2720,7 @@ static int likely_same_dive(struct dive *a, struct dive *b)
 	if (fuzz < 60)
 		fuzz = 60;
 
-	return ((a->when <= b->when + fuzz) && (a->when >= b->when - fuzz));
+	return (a->when <= b->when + fuzz) && (a->when >= b->when - fuzz);
 }
 
 /*

--- a/core/exif.cpp
+++ b/core/exif.cpp
@@ -897,6 +897,6 @@ time_t easyexif::EXIFInfo::epoch()
 	tm.tm_hour = hour;
 	tm.tm_min = min;
 	tm.tm_sec = sec;
-	return (utc_mktime(&tm));
+	return utc_mktime(&tm);
 }
 

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -728,7 +728,7 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 	/* finally create an empty commit and push it to the remote */
 	if (do_git_save(repo, branch, remote, false, true))
 		return NULL;
-	return(repo);
+	return repo;
 }
 
 static git_repository *create_local_repo(const char *localdir, const char *remote, const char *branch, enum remote_transport rt)

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1194,7 +1194,7 @@ dc_status_t libdc_buffer_parser(struct dive *dive, device_data_t *data, unsigned
 		return rc;
 	}
 	dc_parser_destroy(parser);
-	return(DC_STATUS_SUCCESS);
+	return DC_STATUS_SUCCESS;
 }
 
 /*

--- a/core/linux.c
+++ b/core/linux.c
@@ -228,5 +228,5 @@ void subsurface_console_exit(void)
 
 bool subsurface_user_is_root()
 {
-	return (geteuid() == 0);
+	return geteuid() == 0;
 }

--- a/core/macos.c
+++ b/core/macos.c
@@ -218,5 +218,5 @@ void subsurface_console_exit(void)
 
 bool subsurface_user_is_root()
 {
-	return (geteuid() == 0);
+	return geteuid() == 0;
 }

--- a/core/parse.c
+++ b/core/parse.c
@@ -187,8 +187,8 @@ void event_end(void)
  */
 bool is_dive(void)
 {
-	return (cur_dive &&
-		(cur_dive->dive_site_uuid || cur_dive->when || cur_dive->dc.samples));
+	return cur_dive &&
+		(cur_dive->dive_site_uuid || cur_dive->when || cur_dive->dc.samples);
 }
 
 void reset_dc_info(struct divecomputer *dc)

--- a/core/profile.c
+++ b/core/profile.c
@@ -1524,7 +1524,7 @@ struct plot_data *get_plot_details_new(struct plot_info *pi, int time, struct me
 	}
 	if (entry)
 		plot_string(pi, entry, mb);
-	return (entry);
+	return entry;
 }
 
 /* Compare two plot_data entries and writes the results into a string */

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -49,7 +49,7 @@ QString weight_string(int weight_in_grams)
 		double lbs = grams_to_lbs(weight_in_grams);
 		str = QString("%1").arg(lbs, 0, 'f', lbs >= 40.0 ? 0 : 1);
 	}
-	return (str);
+	return str;
 }
 
 QString distance_string(int distanceInMeters)
@@ -608,7 +608,7 @@ QString get_weight_string(weight_t weight, bool showunit)
 	} else {
 		str = QString("%1%2").arg(str).arg(showunit ? translate("gettextFromC", "lbs") : "");
 	}
-	return (str);
+	return str;
 }
 
 QString get_weight_unit()
@@ -1017,7 +1017,7 @@ bool is_same_day(timestamp_t trip_when, timestamp_t dive_when)
 		utc_mkdate(twhen, &tmt);
 	}
 
-	return ((tmd.tm_mday == tmt.tm_mday) && (tmd.tm_mon == tmt.tm_mon) && (tmd.tm_year == tmt.tm_year));
+	return (tmd.tm_mday == tmt.tm_mday) && (tmd.tm_mon == tmt.tm_mon) && (tmd.tm_year == tmt.tm_year);
 }
 
 QString get_trip_date_string(timestamp_t when, int nr, bool getday)
@@ -1195,7 +1195,7 @@ void hashPicture(struct picture *picture)
 	char *oldHash = copy_string(picture->hash);
 	learnHash(picture, hashFile(localFilePath(picture->filename)));
 	if (!empty_string(picture->hash) && !same_string(picture->hash, oldHash))
-		mark_divelist_changed((true));
+		mark_divelist_changed(true);
 	free(oldHash);
 	picture_free(picture);
 }
@@ -1499,7 +1499,7 @@ void setCurrentAppState(QByteArray state)
 
 extern "C" bool in_planner()
 {
-	return (currentApplicationState == "PlanDive" || currentApplicationState == "EditPlannedDive");
+	return currentApplicationState == "PlanDive" || currentApplicationState == "EditPlannedDive";
 }
 
 extern "C" enum deco_mode decoMode()

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -119,7 +119,7 @@ QString DiveObjectHelper::gps_decimal() const
 	prefs.coordinates_traditional = false;
 	val = gps();
 	prefs.coordinates_traditional = savep;
-	return(val);
+	return val;
 }
 
 QString DiveObjectHelper::duration() const

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -355,7 +355,7 @@ bool TechnicalDetailsSettings::calcndltts() const
 
 bool TechnicalDetailsSettings::buehlmann() const
 {
-	return (prefs.planner_deco_mode == BUEHLMANN);
+	return prefs.planner_deco_mode == BUEHLMANN;
 }
 
 int TechnicalDetailsSettings::gflow() const

--- a/core/windows.c
+++ b/core/windows.c
@@ -437,5 +437,5 @@ void subsurface_console_exit(void)
 bool subsurface_user_is_root()
 {
 	/* FIXME: Detect admin rights */
-	return (false);
+	return false;
 }

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -260,7 +260,7 @@ QVariant ColumnNameResult::data(const QModelIndex &index, int role) const
 		return QVariant();
 
 	if (index.row() == 0) {
-		return (columnNames[index.column()]);
+		return columnNames[index.column()];
 	}
 	// make sure the element exists before returning it - this might get called before the
 	// model is correctly set up again (e.g., when changing separators)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -968,10 +968,10 @@ bool ProfileWidget2::isPointOutOfBoundaries(const QPointF &point) const
 {
 	double xpos = timeAxis->valueAt(point);
 	double ypos = profileYAxis->valueAt(point);
-	return (xpos > timeAxis->maximum() ||
-		xpos < timeAxis->minimum() ||
-		ypos > profileYAxis->maximum() ||
-		ypos < profileYAxis->minimum());
+	return xpos > timeAxis->maximum() ||
+	       xpos < timeAxis->minimum() ||
+	       ypos > profileYAxis->maximum() ||
+	       ypos < profileYAxis->minimum();
 }
 
 void ProfileWidget2::scrollViewTo(const QPoint &pos)

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -136,7 +136,7 @@ void LocationInformationModel::update()
 
 QStringList LocationInformationModel::allSiteNames() const
 {
-	return(locationNames);
+	return locationNames;
 }
 
 bool LocationInformationModel::setData(const QModelIndex &index, const QVariant &value, int role)
@@ -200,5 +200,5 @@ bool filter_same_gps_cb (QAbstractItemModel *model, int sourceRow, const QModelI
 	if (ds->latitude.udeg == 0 || ds->longitude.udeg == 0)
 		return false;
 
-	return (ds->latitude.udeg == ref_lat && ds->longitude.udeg == ref_lon && ds->uuid != ref_uuid);
+	return ds->latitude.udeg == ref_lat && ds->longitude.udeg == ref_lon && ds->uuid != ref_uuid;
 }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -178,7 +178,7 @@ bool DivePlannerPointsModel::updateMaxDepth()
 		if (p.depth.mm > displayed_dive.maxdepth.mm)
 			displayed_dive.maxdepth.mm = p.depth.mm;
 	}
-	return (displayed_dive.maxdepth.mm != prevMaxDepth);
+	return displayed_dive.maxdepth.mm != prevMaxDepth;
 }
 
 void DivePlannerPointsModel::removeDeco()

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -408,7 +408,7 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 		ds = get_dive_site_by_uuid(d->dive_site_uuid);
 		if (!ds)
 			return false;
-		return (same_string(ds->name, curr_dive_site->name) || ds->uuid == curr_dive_site->uuid);
+		return same_string(ds->name, curr_dive_site->name) || ds->uuid == curr_dive_site->uuid;
 	}
 
 	if (justCleared || models.isEmpty())

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -145,7 +145,7 @@ static unsigned int smtk_time_to_secs(char *t_buffer)
 
 	if (!empty_string(t_buffer)) {
 		n = sscanf(t_buffer, "%*[0-9/] %d:%d:%d ", &hr, &min, &sec);
-		return((n == 3) ? (((hr*60)+min)*60)+sec : 0);
+		return (n == 3) ? (((hr*60)+min)*60)+sec : 0;
 	} else {
 		return 0;
 	}

--- a/theme/list_lib.js
+++ b/theme/list_lib.js
@@ -1147,7 +1147,7 @@ function mbar_to_bar(mbar)
 
 function mbar_to_psi(mbar)
 {
-	return (mbar * 0.0145037738);
+	return mbar * 0.0145037738;
 }
 
 function mm_to_meter(mm)


### PR DESCRIPTION
Mostly replace "return (expression);" by "return expression;" and one
case of "function((parameter))" by "function(parameter)".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It may not be rational, but `return (expression);` statements bother me. Replace them by the idiomatic `return expression;`.
I left things like `return (a==b) && (c==d)` intact.