### PR TITLE
QML UI: do not overflow right margin on BT text

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -229,7 +229,7 @@ Kirigami.Page {
 			}
 
 			Controls.Label {
-				Layout.maximumWidth: parent.width - download.width - quitbutton.width
+				Layout.maximumWidth: parent.width - download.width - quitbutton.width - rescanbutton.width
 				text: divesDownloaded ? qsTr(" Downloaded dives") :
 							(manager.progressMessage != "" ? qsTr("Info:") + " " + manager.progressMessage : btMessage)
 				wrapMode: Text.WrapAtWordBoundaryOrAnywhere


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Trivial and cosmetics only fix. The width of the rescan button was forgotten, and this pushed the right margin to the right, causing the combo menus to overflow the right margin.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>