### PR TITLE
Build system: correctly find libdivecomputer includes

### DIFF
--- a/cmake/Modules/FindLibdivecomputer.cmake
+++ b/cmake/Modules/FindLibdivecomputer.cmake
@@ -14,7 +14,9 @@ IF ( LIBDIVECOMPUTER_INCLUDE_DIR AND LIBDIVECOMPUTER_LIBRARIES )
 ENDIF ( LIBDIVECOMPUTER_INCLUDE_DIR AND LIBDIVECOMPUTER_LIBRARIES )
 
 FIND_PATH( LIBDIVECOMPUTER_INCLUDE_DIR
-NAMES libdivecomputer/hw.h
+NAMES
+    libdivecomputer/device.h
+    libdivecomputer/descriptor.h
 HINTS
     ${CMAKE_CURRENT_SOURCE_DIR}/../install-root/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../libdivecomputer/include/


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fully unsure when this got broken, but we tried to find the libdivecomputer includes based on the include file "hw.h". Interestingly, that file does not exisist (any more?) in libdivecomputer, so the search for the include fails. This is annoying, as the initial cmake fails on this in case of developer builds from QtCreator (which do not compile all dependencies like our home grown build scripts).

The solution is simple: just find the includes for libdivecomputer based on exiting files in this lib.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl
