### PR TITLE
Cleanup: Use variable types temperature_t and duration_t more consistently

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -219,7 +219,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	duration_t rbt;                   // int32_t    4  seconds  (0-34 yrs)             remaining bottom time
 	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
 	depth_t stopdepth;                // int32_t    4    mm     (0-2000 km)            depth of next deco stop
-	temperature_t temperature;        // int32_t    4  mdegrK   (0-2 MdegK)            ambient temperature
+	temperature_t temperature;        // uint32_t   4  mdegrK   (0-4 MdegK)            ambient temperature
 	pressure_t pressure[MAX_SENSORS]; // int32_t    4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
 	o2pressure_t o2sensor[3];         // uint16_t   6    mbar   (0-65 bar)             Up to 3 PO2 sensor values (rebreather)

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -99,12 +99,15 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 			out << "\"AVG_SAC\":\"" << get_volume_string(stats_yearly[i].avg_sac) << "\",";
 			out << "\"MIN_SAC\":\"" << get_volume_string(stats_yearly[i].min_sac) << "\",";
 			out << "\"MAX_SAC\":\"" << get_volume_string(stats_yearly[i].max_sac) << "\",";
-			if ( stats_yearly[i].combined_count )
-				out << "\"AVG_TEMP\":\"" << QString::number(stats_yearly[i].combined_temp / stats_yearly[i].combined_count, 'f', 1) << "\",";
-			else
+			if ( stats_yearly[i].combined_count ) {
+				temperature_t avg_temp;
+				avg_temp.mkelvin = stats_yearly[i].combined_temp.mkelvin / stats_yearly[i].combined_count;
+				out << "\"AVG_TEMP\":\"" << get_temperature_string(avg_temp) << "\",";
+			} else {
 				out << "\"AVG_TEMP\":\"0.0\",";
-			out << "\"MIN_TEMP\":\"" << ( stats_yearly[i].min_temp == 0 ? 0 : get_temp_units(stats_yearly[i].min_temp, NULL)) << "\",";
-			out << "\"MAX_TEMP\":\"" << ( stats_yearly[i].max_temp == 0 ? 0 : get_temp_units(stats_yearly[i].max_temp, NULL)) << "\",";
+			}
+			out << "\"MIN_TEMP\":\"" << ( stats_yearly[i].min_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].min_temp)) << "\",";
+			out << "\"MAX_TEMP\":\"" << ( stats_yearly[i].max_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].max_temp)) << "\",";
 			out << "},";
 			total_stats.selection_size += stats_yearly[i].selection_size;
 			total_stats.total_time.seconds += stats_yearly[i].total_time.seconds;

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -99,15 +99,15 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 			out << "\"AVG_SAC\":\"" << get_volume_string(stats_yearly[i].avg_sac) << "\",";
 			out << "\"MIN_SAC\":\"" << get_volume_string(stats_yearly[i].min_sac) << "\",";
 			out << "\"MAX_SAC\":\"" << get_volume_string(stats_yearly[i].max_sac) << "\",";
-			if ( stats_yearly[i].combined_count ) {
+			if (stats_yearly[i].combined_count) {
 				temperature_t avg_temp;
 				avg_temp.mkelvin = stats_yearly[i].combined_temp.mkelvin / stats_yearly[i].combined_count;
 				out << "\"AVG_TEMP\":\"" << get_temperature_string(avg_temp) << "\",";
 			} else {
 				out << "\"AVG_TEMP\":\"0.0\",";
 			}
-			out << "\"MIN_TEMP\":\"" << ( stats_yearly[i].min_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].min_temp)) << "\",";
-			out << "\"MAX_TEMP\":\"" << ( stats_yearly[i].max_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].max_temp)) << "\",";
+			out << "\"MIN_TEMP\":\"" << (stats_yearly[i].min_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].min_temp)) << "\",";
+			out << "\"MAX_TEMP\":\"" << (stats_yearly[i].max_temp.mkelvin == 0 ? 0 : get_temperature_string(stats_yearly[i].max_temp)) << "\",";
 			out << "},";
 			total_stats.selection_size += stats_yearly[i].selection_size;
 			total_stats.total_time.seconds += stats_yearly[i].total_time.seconds;

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -73,15 +73,15 @@ static void process_dive(struct dive *dp, stats_t *stats)
 					stats->total_average_depth_time.seconds);
 	}
 	if (dp->sac > 100) { /* less than .1 l/min is bogus, even with a pSCR */
-		sac_time = stats->total_sac_time + duration;
-		stats->avg_sac.mliter = lrint((1.0 * stats->total_sac_time * stats->avg_sac.mliter +
+		sac_time = stats->total_sac_time.seconds + duration;
+		stats->avg_sac.mliter = lrint((1.0 * stats->total_sac_time.seconds * stats->avg_sac.mliter +
 					 duration * dp->sac) /
 					 sac_time);
 		if (dp->sac > stats->max_sac.mliter)
 			stats->max_sac.mliter = dp->sac;
 		if (stats->min_sac.mliter == 0 || dp->sac < stats->min_sac.mliter)
 			stats->min_sac.mliter = dp->sac;
-		stats->total_sac_time = sac_time;
+		stats->total_sac_time.seconds = sac_time;
 	}
 }
 

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -24,23 +24,23 @@ stats_t *stats_by_type = NULL;
 
 static void process_temperatures(struct dive *dp, stats_t *stats)
 {
-	int min_temp, mean_temp, max_temp = 0;
+	temperature_t min_temp, mean_temp, max_temp = {.mkelvin = 0};
 
-	max_temp = dp->maxtemp.mkelvin;
-	if (max_temp && (!stats->max_temp || max_temp > stats->max_temp))
-		stats->max_temp = max_temp;
+	max_temp.mkelvin = dp->maxtemp.mkelvin;
+	if (max_temp.mkelvin && (!stats->max_temp.mkelvin || max_temp.mkelvin > stats->max_temp.mkelvin))
+		stats->max_temp.mkelvin = max_temp.mkelvin;
 
-	min_temp = dp->mintemp.mkelvin;
-	if (min_temp && (!stats->min_temp || min_temp < stats->min_temp))
-		stats->min_temp = min_temp;
+	min_temp.mkelvin = dp->mintemp.mkelvin;
+	if (min_temp.mkelvin && (!stats->min_temp.mkelvin || min_temp.mkelvin < stats->min_temp.mkelvin))
+		stats->min_temp.mkelvin = min_temp.mkelvin;
 
-	if (min_temp || max_temp) {
-		mean_temp = min_temp;
-		if (mean_temp)
-			mean_temp = (mean_temp + max_temp) / 2;
+	if (min_temp.mkelvin || max_temp.mkelvin) {
+		mean_temp.mkelvin = min_temp.mkelvin;
+		if (mean_temp.mkelvin)
+			mean_temp.mkelvin = (mean_temp.mkelvin + max_temp.mkelvin) / 2;
 		else
-			mean_temp = max_temp;
-		stats->combined_temp += get_temp_units(mean_temp, NULL);
+			mean_temp.mkelvin = max_temp.mkelvin;
+		stats->combined_temp.mkelvin += mean_temp.mkelvin;
 		stats->combined_count++;
 	}
 }

--- a/core/statistics.h
+++ b/core/statistics.h
@@ -33,7 +33,7 @@ typedef struct
 	temperature_sum_t combined_temp;
 	unsigned int combined_count;
 	unsigned int selection_size;
-	unsigned int total_sac_time;
+	duration_t total_sac_time;
 	bool is_year;
 	bool is_trip;
 	char *location;

--- a/core/statistics.h
+++ b/core/statistics.h
@@ -28,9 +28,9 @@ typedef struct
 	volume_t max_sac;
 	volume_t min_sac;
 	volume_t avg_sac;
-	int max_temp;
-	int min_temp;
-	double combined_temp;
+	temperature_t max_temp;
+	temperature_t min_temp;
+	temperature_sum_t combined_temp;
 	unsigned int combined_count;
 	unsigned int selection_size;
 	unsigned int total_sac_time;

--- a/core/units.h
+++ b/core/units.h
@@ -110,6 +110,11 @@ typedef struct
 
 typedef struct
 {
+	uint64_t mkelvin; // up to 18446744073 MdegK (temperatures in K are always positive)
+} temperature_sum_t;
+
+typedef struct
+{
 	int mliter;
 } volume_t;
 

--- a/core/units.h
+++ b/core/units.h
@@ -105,7 +105,7 @@ typedef struct
 
 typedef struct
 {
-	uint32_t mkelvin; // up to 1750 degrees K (temperatures in K are always positive)
+	uint32_t mkelvin; // up to 4 MdegK (temperatures in K are always positive)
 } temperature_t;
 
 typedef struct

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -71,15 +71,12 @@ void TabDiveStatistics::updateData()
 	else
 		ui->sacLimits->setAverage("");
 
-	temperature_t temp;
-	temp.mkelvin = stats_selection.max_temp;
-	ui->tempLimits->setMaximum(get_temperature_string(temp, true));
-	temp.mkelvin = stats_selection.min_temp;
-	ui->tempLimits->setMinimum(get_temperature_string(temp, true));
-	if (stats_selection.combined_temp && stats_selection.combined_count) {
-		const char *unit;
-		get_temp_units(0, &unit);
-		ui->tempLimits->setAverage(QString("%1%2").arg(stats_selection.combined_temp / stats_selection.combined_count, 0, 'f', 1).arg(unit));
+	ui->tempLimits->setMaximum(get_temperature_string(stats_selection.max_temp, true));
+	ui->tempLimits->setMinimum(get_temperature_string(stats_selection.min_temp, true));
+	if (stats_selection.combined_temp.mkelvin && stats_selection.combined_count) {
+		temperature_t avg_temp;
+		avg_temp.mkelvin = stats_selection.combined_temp.mkelvin / stats_selection.combined_count;
+		ui->tempLimits->setAverage(get_temperature_string(avg_temp, true));
 	}
 
 

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -104,13 +104,9 @@ if (property == "year") {
 } else if (property == "dives") {
 	return object.year->selection_size;
 } else if (property == "min_temp") {
-	const char *unit;
-	double temp = get_temp_units(object.year->min_temp, &unit);
-	return object.year->min_temp == 0 ? "0" : QString::number(temp, 'g', 2) + unit;
+	return object.year->min_temp.mkelvin == 0 ? "0" : get_temperature_string(object.year->min_temp, true);
 } else if (property == "max_temp") {
-	const char *unit;
-	double temp = get_temp_units(object.year->max_temp, &unit);
-	return object.year->max_temp == 0 ? "0" : QString::number(temp, 'g', 2) + unit;
+	return object.year->max_temp.mkelvin == 0 ? "0" : get_temperature_string(object.year->max_temp, true);
 } else if (property == "total_time") {
 	return get_dive_duration_string(object.year->total_time.seconds, QObject::tr("h"),
 									QObject::tr("min"), QObject::tr("sec"), " ");

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -591,16 +591,15 @@ void DiveTemperatureItem::modelDataChanged(const QModelIndex &topLeft, const QMo
 
 void DiveTemperatureItem::createTextItem(int sec, int mkelvin)
 {
-	double deg;
-	const char *unit;
-	deg = get_temp_units(mkelvin, &unit);
+	temperature_t temp;
+	temp.mkelvin = mkelvin;
 
 	DiveTextItem *text = new DiveTextItem(this);
 	text->setAlignment(Qt::AlignRight | Qt::AlignBottom);
 	text->setBrush(getColor(TEMP_TEXT));
 	text->setPos(QPointF(hAxis->posAtValue(sec), vAxis->posAtValue(mkelvin)));
 	text->setScale(0.8); // need to call this BEFORE setText()
-	text->setText(QString("%1%2").arg(deg, 0, 'f', 1).arg(unit));
+	text->setText(get_temperature_string(temp, true));
 	texts.append(text);
 }
 

--- a/qt-models/yearlystatisticsmodel.cpp
+++ b/qt-models/yearlystatisticsmodel.cpp
@@ -39,7 +39,6 @@ YearStatisticsItem::YearStatisticsItem(stats_t interval) : stats_interval(interv
 
 QVariant YearStatisticsItem::data(int column, int role) const
 {
-	double value;
 	QVariant ret;
 
 	if (role == Qt::FontRole) {
@@ -91,19 +90,19 @@ QVariant YearStatisticsItem::data(int column, int role) const
 		ret = get_volume_string(stats_interval.max_sac);
 		break;
 	case AVG_TEMP:
-		if (stats_interval.combined_temp && stats_interval.combined_count) {
-			ret = QString::number(stats_interval.combined_temp / stats_interval.combined_count, 'f', 1);
+		if (stats_interval.combined_temp.mkelvin && stats_interval.combined_count) {
+			temperature_t avg_temp;
+			avg_temp.mkelvin = stats_interval.combined_temp.mkelvin / stats_interval.combined_count;
+			ret = get_temperature_string(avg_temp);
 		}
 		break;
 	case MIN_TEMP:
-		value = get_temp_units(stats_interval.min_temp, NULL);
-		if (value > -100.0)
-			ret = QString::number(value, 'f', 1);
+		if (stats_interval.min_temp.mkelvin)
+			ret = get_temperature_string(stats_interval.min_temp);
 		break;
 	case MAX_TEMP:
-		value = get_temp_units(stats_interval.max_temp, NULL);
-		if (value > -100.0)
-			ret = QString::number(value, 'f', 1);
+		if (stats_interval.max_temp.mkelvin)
+			ret = get_temperature_string(stats_interval.max_temp);
 		break;
 	}
 	return ret;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a prerequisite for the numerical format feature...

Use struct temperature_t for temperatures in struct stats_t and
use get_temperature_string() when printing these temperatures for
statistics and HTML export.

Use duration_t for total_sac_time in struct stats_t 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
