### PR TITLE
Final Mobile QML changes before new release

### DIFF
--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -20,10 +20,6 @@ Kirigami.ScrollablePage {
 			id: gpsFix
 			enabled: true
 			width: parent.width
-			background: Rectangle {
-				color: subsurfaceTheme.backgroundColor
-				border.width: 1
-			}
 			GridLayout {
 				columns: 4
 				id: timeAndName

--- a/mobile-widgets/qml/Log.qml
+++ b/mobile-widgets/qml/Log.qml
@@ -10,15 +10,13 @@ import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.ScrollablePage {
 	id: logWindow
-	width: parent.width - Kirigami.Units.gridUnit
-	anchors.margins: Kirigami.Units.gridUnit / 2
+	width: subsurfaceTheme.columnWidth
 	objectName: "Log"
 	title: qsTr("Application Log")
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	ListView {
 		anchors.fill: parent
-		anchors.topMargin: Kirigami.Units.gridUnit * 2
 		model: logModel
 		currentIndex: -1
 		boundsBehavior: Flickable.StopAtBounds
@@ -32,6 +30,7 @@ Kirigami.ScrollablePage {
 			color: Kirigami.Theme.textColor
 			text : message
 			font.pointSize: subsurfaceTheme.smallPointSize
+			leftPadding: Kirigami.Units.gridUnit / 2
 		}
 	}
 }

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -13,7 +13,7 @@ Kirigami.ApplicationWindow {
 	id: rootItem
 	title: qsTr("Subsurface-mobile")
 	reachableModeEnabled: false // while it's a good idea, it seems to confuse more than help
-	wideScreen: true // workaround for probably Kirigami bug. See commit.
+	wideScreen: false // workaround for probably Kirigami bug. See commits.
 	header: Kirigami.ApplicationHeader {
 		minimumHeight: 0
 		preferredHeight: Math.round(Kirigami.Units.gridUnit * (Qt.platform.os == "ios" ? 2 : 1.5))

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -33,7 +33,7 @@ if [ "$NOPULL" = "" ] ; then
 	git checkout master
 	git pull origin master
 	# if we want to pin a specific Kirigami version, we can do this here
-	git checkout 389f4c29acc3629a900dd5e1e52ef8b0bfe3519f
+	git checkout 38a9dec7317945e5751c86a6c54de787c261e024
 	popd
 fi
 if [ ! -d breeze-icons ] ; then


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This is a bit strange set of commits; to be considered as a wrap up before a possible pending release of the mobile app. See below for more info.

### Changes made:
1) Again a new Kirigami SHA. These correct numerous run time warnings (which is good), and appear to do no other harm to our code, so just follow the current Kirigami master.
2) Reverted a background color commit (gpslist). While this is working in Qt 5.9.3 (official beta build) and 5.10.0 (self build), it breaks the gps list in Qt 5.10.1 (also self build). @dirkhh. I see another problem when going to 5.10.1 (related to the enumeration issues we have seen before, and related to commits cf75e6451d and 783f9ee565). This is just a word of warning at this time: be very very careful switching Qt versions. Further, I see that Travis android builds are against Qt 5.9.1 and the AppStore beta build from 22 feb against Qt 5.9.3. Needles to say that this does not feel right to me (and possibly complicates testing, and getting valid input from the beta stream).
3) Due to the wideScreen change, the application header is now dynamic (on device, not on mobile-on-desktop). When scrolling up, the application header is pushed out of the screen, and when scrolling down, the header appears again. Like an address bar in a mobile browser. I like this functional change.
4) Finally, corrected some stupid margin bugs on the developer log page.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
Not sure. This the dynamic header worth mentioning there?

### Mentions:
@dirkhh 
