### PR TITLE
Android build: use Qt 5.9.3

### DIFF
--- a/packaging/android/android-build-wrapper.sh
+++ b/packaging/android/android-build-wrapper.sh
@@ -22,7 +22,7 @@ USE_X=$(case $- in *x*) echo "-x" ;; esac)
 # these are the current versions for Qt, Android SDK & NDK:
 
 QT_VERSION=5.9
-LATEST_QT=5.9.1
+LATEST_QT=5.9.3
 NDK_VERSION=r14b
 SDK_VERSION=3859397  # if you change this version, you'll likely have to change the android-sdk-license key fallback below
 

--- a/packaging/android/build.sh
+++ b/packaging/android/build.sh
@@ -80,6 +80,8 @@ export ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT-$SUBSURFACE_SOURCE/../android-ndk-r14
 
 if [ -n "${QT5_ANDROID+X}" ] ; then
 	echo "Using Qt5 in $QT5_ANDROID"
+elif [ -d "$SUBSURFACE_SOURCE/../Qt/5.9.3" ] ; then
+	export QT5_ANDROID=$SUBSURFACE_SOURCE/../Qt/5.9.3
 elif [ -d "$SUBSURFACE_SOURCE/../Qt/5.9.1" ] ; then
 	export QT5_ANDROID=$SUBSURFACE_SOURCE/../Qt/5.9.1
 elif [ -d "$SUBSURFACE_SOURCE/../Qt/5.9" ] ; then


### PR DESCRIPTION
At least, now the Travis builds use the same Qt version as the production builds from Dirk that go to the AppStores.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>