### PR TITLE
[RFC][WIP] Localization: Make Qt's locale-aware formatting accessible from C

### DIFF
--- a/core/membuffer.c
+++ b/core/membuffer.c
@@ -52,7 +52,7 @@ static void oom(void)
 	exit(1);
 }
 
-static void make_room(struct membuffer *b, unsigned int size)
+void make_room(struct membuffer *b, unsigned int size)
 {
 	unsigned int needed = b->len + size;
 	if (needed > b->alloc) {
@@ -138,6 +138,15 @@ void put_format(struct membuffer *b, const char *fmt, ...)
 
 	va_start(args, fmt);
 	put_vformat(b, fmt, args);
+	va_end(args);
+}
+
+void put_format_loc(struct membuffer *b, const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	put_vformat_loc(b, fmt, args);
 	va_end(args);
 }
 

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -22,6 +22,7 @@ struct membuffer {
 
 extern char *detach_buffer(struct membuffer *b);
 extern void free_buffer(struct membuffer *);
+extern void make_room(struct membuffer *b, unsigned int size);
 extern void flush_buffer(struct membuffer *, FILE *);
 extern void put_bytes(struct membuffer *, const char *, int);
 extern void put_string(struct membuffer *, const char *);
@@ -29,7 +30,9 @@ extern void put_quoted(struct membuffer *, const char *, int, int);
 extern void strip_mb(struct membuffer *);
 extern const char *mb_cstring(struct membuffer *);
 extern __printf(2, 0) void put_vformat(struct membuffer *, const char *, va_list);
+extern __printf(2, 0) void put_vformat_loc(struct membuffer *, const char *, va_list);
 extern __printf(2, 3) void put_format(struct membuffer *, const char *fmt, ...);
+extern __printf(2, 3) void put_format_loc(struct membuffer *, const char *fmt, ...);
 extern __printf(2, 0) char *add_to_string_va(const char *old, const char *fmt, va_list args);
 extern __printf(2, 3) char *add_to_string(const char *old, const char *fmt, ...);
 

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -57,21 +57,21 @@ int add_icd_entry(char *icdbuffer, unsigned int maxsize, struct icd_data *icdval
 		len += snprintf(icdbuffer + len, maxsize - len, "<td style='padding-left: 10px;'><b>%s</b></td></tr>",
 			translate("gettextFromC", "max &#916;N&#8322;"));
 	}		// Add one entry to the icd table:
-	len += snprintf(icdbuffer + len, maxsize - len, 
+	len += snprintf_loc(icdbuffer + len, maxsize - len,
 		"<tr><td rowspan='2' style= 'vertical-align:top;'>%3d%s</td>"
 		"<td rowspan=2 style= 'vertical-align:top;'>%s&#10137;",
 		(time_seconds + 30) / 60, translate("gettextFromC", "min"), gasname(gas_from));
-	len += snprintf(icdbuffer + len, maxsize - len, 
+	len += snprintf_loc(icdbuffer + len, maxsize - len,
 		"%s</td><td style='padding-left: 10px;'>%+5.1f%%</td>"
 		"<td style= 'padding-left: 15px; color:%s;'>%+5.1f%%</td>"
 		"<td style='padding-left: 15px;'>%+5.1f%%</td></tr>"
 		"<tr><td style='padding-left: 10px;'>%+5.2f%s</td>"
 		"<td style='padding-left: 15px; color:%s;'>%+5.2f%s</td>"
 		"<td style='padding-left: 15px;'>%+5.2f%s</td></tr>",
-		gasname(gas_to), icdvalues->dHe / 10.0, 
-		((5 * icdvalues->dN2) > -icdvalues->dHe) ? "red" : "#383838", icdvalues->dN2 / 10.0 , 0.2 * (-icdvalues->dHe / 10.0), 
+		gasname(gas_to), icdvalues->dHe / 10.0,
+		((5 * icdvalues->dN2) > -icdvalues->dHe) ? "red" : "#383838", icdvalues->dN2 / 10.0 , 0.2 * (-icdvalues->dHe / 10.0),
 		ambientpressure_mbar * icdvalues->dHe / 1e6f, translate("gettextFromC", "bar"), ((5 * icdvalues->dN2) > -icdvalues->dHe) ? "red" : "#383838",
-		ambientpressure_mbar * icdvalues->dN2 / 1e6f, translate("gettextFromC", "bar"), 
+		ambientpressure_mbar * icdvalues->dN2 / 1e6f, translate("gettextFromC", "bar"),
 		ambientpressure_mbar * -icdvalues->dHe / 5e6f, translate("gettextFromC", "bar"));
 	return len;
 }
@@ -145,7 +145,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 		free((void *)current_date);
 	} else {
 		const char *current_date = get_current_date();
-		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
+		len += snprintf_loc(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
 			translate("gettextFromC", "Subsurface"),
 			subsurface_canonical_version(),
 			translate("gettextFromC", "dive plan</b> (surface interval "),
@@ -156,10 +156,10 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	}
 
 	if (prefs.display_variations && decoMode() != RECREATIONAL)
-		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin%s"),
+		len += snprintf_loc(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin%s"),
 			diveplan_duration(diveplan), "VARIATIONS<br></div>");
 	else
-		len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin<br></div>"),
+		len += snprintf_loc(buffer + len, sz_buffer - len, translate("gettextFromC", "Runtime: %dmin<br></div>"),
 			diveplan_duration(diveplan));
 
 	if (!plan_verbatim) {
@@ -221,20 +221,20 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 			if (dp->depth.mm != lastprintdepth) {
 				if (plan_display_transitions || dp->entered || !dp->next || (gaschange_after && dp->next && dp->depth.mm != nextdp->depth.mm)) {
 					if (dp->setpoint) {
-						snprintf(temp, sz_temp, translate("gettextFromC", "%s to %.*f %s in %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
-							 dp->depth.mm < lastprintdepth ? translate("gettextFromC", "Ascend") : translate("gettextFromC", "Descend"),
-							 decimals, depthvalue, depth_unit,
-							 FRACTION(dp->time - lasttime, 60),
-							 FRACTION(dp->time, 60),
-							 gasname(&gasmix),
-							 (double) dp->setpoint / 1000.0);
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "%s to %.*f %s in %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
+							     dp->depth.mm < lastprintdepth ? translate("gettextFromC", "Ascend") : translate("gettextFromC", "Descend"),
+							     decimals, depthvalue, depth_unit,
+							     FRACTION(dp->time - lasttime, 60),
+							     FRACTION(dp->time, 60),
+							     gasname(&gasmix),
+							     (double) dp->setpoint / 1000.0);
 					} else {
-						snprintf(temp, sz_temp, translate("gettextFromC", "%s to %.*f %s in %d:%02d min - runtime %d:%02u on %s"),
-							 dp->depth.mm < lastprintdepth ? translate("gettextFromC", "Ascend") : translate("gettextFromC", "Descend"),
-							 decimals, depthvalue, depth_unit,
-							 FRACTION(dp->time - lasttime, 60),
-							 FRACTION(dp->time, 60),
-							 gasname(&gasmix));
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "%s to %.*f %s in %d:%02d min - runtime %d:%02u on %s"),
+							     dp->depth.mm < lastprintdepth ? translate("gettextFromC", "Ascend") : translate("gettextFromC", "Descend"),
+							     decimals, depthvalue, depth_unit,
+							     FRACTION(dp->time - lasttime, 60),
+							     FRACTION(dp->time, 60),
+							     gasname(&gasmix));
 					}
 					len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
 				}
@@ -243,18 +243,18 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 			} else {
 				if ((nextdp && dp->depth.mm != nextdp->depth.mm) || gaschange_after) {
 					if (dp->setpoint) {
-						snprintf(temp, sz_temp, translate("gettextFromC", "Stay at %.*f %s for %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
-							decimals, depthvalue, depth_unit,
-							FRACTION(dp->time - lasttime, 60),
-							FRACTION(dp->time, 60),
-							gasname(&gasmix),
-							(double) dp->setpoint / 1000.0);
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "Stay at %.*f %s for %d:%02d min - runtime %d:%02u on %s (SP = %.1fbar)"),
+							     decimals, depthvalue, depth_unit,
+							     FRACTION(dp->time - lasttime, 60),
+							     FRACTION(dp->time, 60),
+							     gasname(&gasmix),
+							     (double) dp->setpoint / 1000.0);
 					} else {
-						snprintf(temp, sz_temp, translate("gettextFromC", "Stay at %.*f %s for %d:%02d min - runtime %d:%02u on %s"),
-							decimals, depthvalue, depth_unit,
-							FRACTION(dp->time - lasttime, 60),
-							FRACTION(dp->time, 60),
-							gasname(&gasmix));
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "Stay at %.*f %s for %d:%02d min - runtime %d:%02u on %s"),
+							     decimals, depthvalue, depth_unit,
+							     FRACTION(dp->time - lasttime, 60),
+							     FRACTION(dp->time, 60),
+							     gasname(&gasmix));
 					}
 					len += snprintf(buffer + len, sz_buffer - len, "%s<br>", temp);
 					newdepth = dp->depth.mm;
@@ -312,7 +312,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				 */
 				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth.mm != nextdp->depth.mm || nextdp->entered)) {
 					if (dp->setpoint) {
-						snprintf(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) nextdp->setpoint / 1000.0);
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) nextdp->setpoint / 1000.0);
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>",
 							gasname(&newgasmix), temp);
 					} else {
@@ -333,7 +333,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				} else if (gaschange_before) {
 					// If a new gas has been used for this segment, now is the time to show it
 					if (dp->setpoint) {
-						snprintf(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) dp->setpoint / 1000.0);
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "(SP = %.1fbar)"), (double) dp->setpoint / 1000.0);
 						len += snprintf(buffer + len, sz_buffer - len, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>",
 							gasname(&gasmix), temp);
 					} else {
@@ -346,7 +346,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 								icdlen += add_icd_entry(icdbuffer+icdlen, sz_icdbuf-icdlen, &icdvalues, icdtableheader, lasttime, depth_to_mbar(dp->depth.mm, dive), &lastprintgasmix, &gasmix); // .. then print data to buffer.
 								icdtableheader = false;
 							}
-						} 
+						}
 					}
 					// Set variables so subsequent iterations can test against the last gas printed
 					lastprintsetpoint = dp->setpoint;
@@ -365,7 +365,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 			if (plan_verbatim) {
 				if (lastsetpoint >= 0) {
 					if (nextdp && nextdp->setpoint) {
-						snprintf(temp, sz_temp, translate("gettextFromC", "Switch gas to %s (SP = %.1fbar)"), gasname(&newgasmix), (double) nextdp->setpoint / 1000.0);
+						snprintf_loc(temp, sz_temp, translate("gettextFromC", "Switch gas to %s (SP = %.1fbar)"), gasname(&newgasmix), (double) nextdp->setpoint / 1000.0);
 					} else {
 						snprintf(temp, sz_temp, translate("gettextFromC", "Switch gas to %s"), gasname(&newgasmix));
 						if ((isascent) && (get_he(&lastprintgasmix) > 0)) {          // For a trimix gas change on ascent:
@@ -397,35 +397,35 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	dive->maxcns = 0;
 	update_cylinder_related_info(dive);
 	snprintf(temp, sz_temp, "%s", translate("gettextFromC", "CNS"));
-	len += snprintf(buffer + len, sz_buffer - len, "<div>%s: %i%%", temp, dive->cns);
+	len += snprintf_loc(buffer + len, sz_buffer - len, "<div>%s: %i%%", temp, dive->cns);
 	snprintf(temp, sz_temp, "%s", translate("gettextFromC", "OTU"));
-	len += snprintf(buffer + len, sz_buffer - len, "<br>%s: %i<br></div>", temp, dive->otu);
+	len += snprintf_loc(buffer + len, sz_buffer - len, "<br>%s: %i<br></div>", temp, dive->otu);
 
 	/* Print the settings for the diveplan next. */
 	if (decoMode() == BUEHLMANN) {
-		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Bühlmann ZHL-16C with GFLow = %d%% and GFHigh = %d%%"),
-			diveplan->gflow, diveplan->gfhigh);
+		snprintf_loc(temp, sz_temp, translate("gettextFromC", "Deco model: Bühlmann ZHL-16C with GFLow = %d%% and GFHigh = %d%%"),
+			     diveplan->gflow, diveplan->gfhigh);
 	} else if (decoMode() == VPMB){
 		int temp_len;
 		if (diveplan->vpmb_conservatism == 0)
 			temp_len = snprintf(temp, sz_temp, "%s", translate("gettextFromC", "Deco model: VPM-B at nominal conservatism"));
 		else
-			temp_len = snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: VPM-B at +%d conservatism"), diveplan->vpmb_conservatism);
+			temp_len = snprintf_loc(temp, sz_temp, translate("gettextFromC", "Deco model: VPM-B at +%d conservatism"), diveplan->vpmb_conservatism);
 		if (diveplan->eff_gflow)
-			temp_len += snprintf(temp + temp_len, sz_temp - temp_len,  translate("gettextFromC", ", effective GF=%d/%d"), diveplan->eff_gflow,
+			temp_len += snprintf_loc(temp + temp_len, sz_temp - temp_len,  translate("gettextFromC", ", effective GF=%d/%d"), diveplan->eff_gflow,
 				diveplan->eff_gfhigh);
 
 	} else if (decoMode() == RECREATIONAL){
-		snprintf(temp, sz_temp, translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d%% and GFHigh = %d%%"),
-			diveplan->gflow, diveplan->gfhigh);
+		snprintf_loc(temp, sz_temp, translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d%% and GFHigh = %d%%"),
+			     diveplan->gflow, diveplan->gfhigh);
 	}
 	len += snprintf(buffer + len, sz_buffer - len, "<div>%s<br>",temp);
 
 	const char *depth_unit;
 	int altitude = (int) get_depth_units((int) (log(1013.0 / diveplan->surface_pressure) * 7800000), NULL, &depth_unit);
 
-	len += snprintf(buffer + len, sz_buffer - len, translate("gettextFromC", "ATM pressure: %dmbar (%d%s)<br></div>"),
-		diveplan->surface_pressure, altitude, depth_unit);
+	len += snprintf_loc(buffer + len, sz_buffer - len, translate("gettextFromC", "ATM pressure: %dmbar (%d%s)<br></div>"),
+			    diveplan->surface_pressure, altitude, depth_unit);
 
 	/* Get SAC values and units for printing it in gas consumption */
 	double bottomsacvalue, decosacvalue;
@@ -442,8 +442,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	if (dive->dc.divemode == CCR)
 		snprintf(temp, sz_temp, "%s", translate("gettextFromC", "Gas consumption (CCR legs excluded):"));
 	else
-		snprintf(temp, sz_temp, "%s %.*f|%.*f%s/min):", translate("gettextFromC", "Gas consumption (based on SAC"),
-			sacdecimals, bottomsacvalue, sacdecimals, decosacvalue, sacunit);
+		snprintf_loc(temp, sz_temp, "%s %.*f|%.*f%s/min):", translate("gettextFromC", "Gas consumption (based on SAC"),
+			     sacdecimals, bottomsacvalue, sacdecimals, decosacvalue, sacunit);
 	len += snprintf(buffer + len, sz_buffer - len, "<div>%s<br>", temp);
 
 	/* Print gas consumption: This loop covers all cylinders */
@@ -498,20 +498,20 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					mingas_depth = get_depth_units(lastbottomdp->depth.mm, NULL, &depth_unit);
 					/* Print it to results */
 					if (cyl->start.mbar > lastbottomdp->minimum_gas.mbar) {
-						snprintf(mingas, sizeof(mingas), "<br>&nbsp;&mdash; <span style='color: %s;'>%s</span> (%s %.1fx%s/+%d%s@%.0f%s): "
-							"%.0f%s/%.0f%s<span style='color: %s;'>/&Delta;:%+.0f%s</span>",
-							mingas_d_pressure > 0 ? "green" :"red",
-							translate("gettextFromC", "Minimum gas"),
-							translate("gettextFromC", "based on"),
-							prefs.sacfactor / 100.0,
-							translate("gettextFromC", "SAC"),
-							prefs.problemsolvingtime,
-							translate("gettextFromC", "min"),
-							mingas_depth, depth_unit,
-							mingas_volume, unit,
-							mingas_pressure, pressure_unit,
-							mingas_d_pressure > 0 ? "grey" :"indianred",
-							mingas_d_pressure, pressure_unit);
+						snprintf_loc(mingas, sizeof(mingas), "<br>&nbsp;&mdash; <span style='color: %s;'>%s</span> (%s %.1fx%s/+%d%s@%.0f%s): "
+							     "%.0f%s/%.0f%s<span style='color: %s;'>/&Delta;:%+.0f%s</span>",
+							     mingas_d_pressure > 0 ? "green" :"red",
+							     translate("gettextFromC", "Minimum gas"),
+							     translate("gettextFromC", "based on"),
+							     prefs.sacfactor / 100.0,
+							     translate("gettextFromC", "SAC"),
+							     prefs.problemsolvingtime,
+							     translate("gettextFromC", "min"),
+							     mingas_depth, depth_unit,
+							     mingas_volume, unit,
+							     mingas_pressure, pressure_unit,
+							     mingas_d_pressure > 0 ? "grey" :"indianred",
+							     mingas_d_pressure, pressure_unit);
 					} else {
 						snprintf(warning, sizeof(warning), "<br>&nbsp;&mdash; <span style='color: red;'>%s </span> %s",
 							translate("gettextFromC", "Warning:"),
@@ -520,19 +520,19 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				}
 			/* Print the gas consumption for every cylinder here to temp buffer. */
 			if (lrint(volume) > 0) {
-				snprintf(temp, sz_temp, translate("gettextFromC", "%.0f%s/%.0f%s of <span style='color: red;'><b>%s</b></span> (%.0f%s/%.0f%s in planned ascent)"),
-					volume, unit, pressure, pressure_unit, gasname(&cyl->gasmix), deco_volume, unit, deco_pressure, pressure_unit);
+				snprintf_loc(temp, sz_temp, translate("gettextFromC", "%.0f%s/%.0f%s of <span style='color: red;'><b>%s</b></span> (%.0f%s/%.0f%s in planned ascent)"),
+					     volume, unit, pressure, pressure_unit, gasname(&cyl->gasmix), deco_volume, unit, deco_pressure, pressure_unit);
 			} else {
-				snprintf(temp, sz_temp, translate("gettextFromC", "%.0f%s/%.0f%s of <span style='color: red;'><b>%s</b></span>"),
-					volume, unit, pressure, pressure_unit, gasname(&cyl->gasmix));
+				snprintf_loc(temp, sz_temp, translate("gettextFromC", "%.0f%s/%.0f%s of <span style='color: red;'><b>%s</b></span>"),
+					     volume, unit, pressure, pressure_unit, gasname(&cyl->gasmix));
 			}
 		} else {
 			if (lrint(volume) > 0) {
-				snprintf(temp, sz_temp, translate("gettextFromC", "%.0f%s of <span style='color: red;'><b>%s</b></span> (%.0f%s during planned ascent)"),
-					volume, unit, gasname(&cyl->gasmix), deco_volume, unit);
+				snprintf_loc(temp, sz_temp, translate("gettextFromC", "%.0f%s of <span style='color: red;'><b>%s</b></span> (%.0f%s during planned ascent)"),
+					     volume, unit, gasname(&cyl->gasmix), deco_volume, unit);
 			} else {
-				snprintf(temp, sz_temp, translate("gettextFromC", "%.0f%s of <span style='color: red;'><b>%s</b></span>"),
-					volume, unit, gasname(&cyl->gasmix));
+				snprintf_loc(temp, sz_temp, translate("gettextFromC", "%.0f%s of <span style='color: red;'><b>%s</b></span>"),
+					     volume, unit, gasname(&cyl->gasmix));
 			}
 		}
 		/* Gas consumption: Now finally print all strings to output */
@@ -569,9 +569,9 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					if (!o2warning_exist)
 						len += snprintf(buffer + len, sz_buffer - len, "<div>");
 					o2warning_exist = true;
-					snprintf(temp, sz_temp,
-						 translate("gettextFromC", "high pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),
-						 pressures.o2, FRACTION(dp->time, 60), gasname(gasmix), decimals, depth_value, depth_unit);
+					snprintf_loc(temp, sz_temp,
+						     translate("gettextFromC", "high pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),
+						     pressures.o2, FRACTION(dp->time, 60), gasname(gasmix), decimals, depth_value, depth_unit);
 					len += snprintf(buffer + len, sz_buffer - len, "<span style='color: red;'>%s </span> %s<br>",
 							translate("gettextFromC", "Warning:"), temp);
 				} else if (pressures.o2 < 0.16) {
@@ -582,9 +582,9 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 					if (!o2warning_exist)
 						len += snprintf(buffer + len, sz_buffer - len, "<div>");
 					o2warning_exist = true;
-					snprintf(temp, sz_temp,
-						 translate("gettextFromC", "low pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),
-						 pressures.o2, FRACTION(dp->time, 60), gasname(gasmix), decimals, depth_value, depth_unit);
+					snprintf_loc(temp, sz_temp,
+						     translate("gettextFromC", "low pO₂ value %.2f at %d:%02u with gas %s at depth %.*f %s"),
+						     pressures.o2, FRACTION(dp->time, 60), gasname(gasmix), decimals, depth_value, depth_unit);
 					len += snprintf(buffer + len, sz_buffer - len, "<span style='color: red;'>%s </span> %s<br>",
 							translate("gettextFromC", "Warning:"), temp);
 

--- a/core/profile.c
+++ b/core/profile.c
@@ -1374,7 +1374,7 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 	const char *unit;
 
 	depthvalue = get_depth_units(entry->depth, NULL, &depth_unit);
-	put_format(b, translate("gettextFromC", "@: %d:%02d\nD: %.1f%s\n"), FRACTION(entry->sec, 60), depthvalue, depth_unit);
+	put_format_loc(b, translate("gettextFromC", "@: %d:%02d\nD: %.1f%s\n"), FRACTION(entry->sec, 60), depthvalue, depth_unit);
 	for (cyl = 0; cyl < MAX_CYLINDERS; cyl++) {
 		struct gasmix *mix;
 		int mbar = GET_PRESSURE(entry, cyl);
@@ -1382,31 +1382,31 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 			continue;
 		mix = &displayed_dive.cylinder[cyl].gasmix;
 		pressurevalue = get_pressure_units(mbar, &pressure_unit);
-		put_format(b, translate("gettextFromC", "P: %d%s (%s)\n"), pressurevalue, pressure_unit, gasname(mix));
+		put_format_loc(b, translate("gettextFromC", "P: %d%s (%s)\n"), pressurevalue, pressure_unit, gasname(mix));
 	}
 	if (entry->temperature) {
 		tempvalue = get_temp_units(entry->temperature, &temp_unit);
-		put_format(b, translate("gettextFromC", "T: %.1f%s\n"), tempvalue, temp_unit);
+		put_format_loc(b, translate("gettextFromC", "T: %.1f%s\n"), tempvalue, temp_unit);
 	}
 	speedvalue = get_vertical_speed_units(abs(entry->speed), NULL, &vertical_speed_unit);
 	/* Ascending speeds are positive, descending are negative */
 	if (entry->speed > 0)
 		speedvalue *= -1;
-	put_format(b, translate("gettextFromC", "V: %.1f%s\n"), speedvalue, vertical_speed_unit);
+	put_format_loc(b, translate("gettextFromC", "V: %.1f%s\n"), speedvalue, vertical_speed_unit);
 	sacvalue = get_volume_units(entry->sac, &decimals, &unit);
 	if (entry->sac && prefs.show_sac)
-		put_format(b, translate("gettextFromC", "SAC: %.*f%s/min\n"), decimals, sacvalue, unit);
+		put_format_loc(b, translate("gettextFromC", "SAC: %.*f%s/min\n"), decimals, sacvalue, unit);
 	if (entry->cns)
-		put_format(b, translate("gettextFromC", "CNS: %u%%\n"), entry->cns);
+		put_format_loc(b, translate("gettextFromC", "CNS: %u%%\n"), entry->cns);
 	if (prefs.pp_graphs.po2 && entry->pressures.o2 > 0)
-		put_format(b, translate("gettextFromC", "pO%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.o2);
+		put_format_loc(b, translate("gettextFromC", "pO%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.o2);
 	if (prefs.pp_graphs.pn2 && entry->pressures.n2 > 0)
-		put_format(b, translate("gettextFromC", "pN%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.n2);
+		put_format_loc(b, translate("gettextFromC", "pN%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.n2);
 	if (prefs.pp_graphs.phe && entry->pressures.he > 0)
-		put_format(b, translate("gettextFromC", "pHe: %.2fbar\n"), entry->pressures.he);
+		put_format_loc(b, translate("gettextFromC", "pHe: %.2fbar\n"), entry->pressures.he);
 	if (prefs.mod && entry->mod > 0) {
 		mod = lrint(get_depth_units(lrint(entry->mod), NULL, &depth_unit));
-		put_format(b, translate("gettextFromC", "MOD: %d%s\n"), mod, depth_unit);
+		put_format_loc(b, translate("gettextFromC", "MOD: %d%s\n"), mod, depth_unit);
 	}
 	eadd = lrint(get_depth_units(lrint(entry->eadd), NULL, &depth_unit));
 
@@ -1415,18 +1415,18 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 		case NITROX:
 			if (entry->ead > 0) {
 				ead = lrint(get_depth_units(lrint(entry->ead), NULL, &depth_unit));
-				put_format(b, translate("gettextFromC", "EAD: %d%s\nEADD: %d%s / %.1fg/ℓ\n"), ead, depth_unit, eadd, depth_unit, entry->density);
+				put_format_loc(b, translate("gettextFromC", "EAD: %d%s\nEADD: %d%s / %.1fg/ℓ\n"), ead, depth_unit, eadd, depth_unit, entry->density);
 				break;
 			}
 		case TRIMIX:
 			if (entry->end > 0) {
 				end = lrint(get_depth_units(lrint(entry->end), NULL, &depth_unit));
-				put_format(b, translate("gettextFromC", "END: %d%s\nEADD: %d%s / %.1fg/ℓ\n"), end, depth_unit, eadd, depth_unit, entry->density);
+				put_format_loc(b, translate("gettextFromC", "END: %d%s\nEADD: %d%s / %.1fg/ℓ\n"), end, depth_unit, eadd, depth_unit, entry->density);
 				break;
 			}
 		case AIR:
 			if (entry->density > 0) {
-				put_format(b, translate("gettextFromC", "Density: %.1fg/ℓ\n"), entry->density);
+				put_format_loc(b, translate("gettextFromC", "Density: %.1fg/ℓ\n"), entry->density);
 			}
 		case FREEDIVING:
 			/* nothing */
@@ -1438,31 +1438,31 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 		if (entry->ndl > 0) {
 			/* this is a safety stop as we still have ndl */
 			if (entry->stoptime)
-				put_format(b, translate("gettextFromC", "Safety stop: %umin @ %.0f%s\n"), DIV_UP(entry->stoptime, 60),
-					   depthvalue, depth_unit);
+				put_format_loc(b, translate("gettextFromC", "Safety stop: %umin @ %.0f%s\n"), DIV_UP(entry->stoptime, 60),
+					       depthvalue, depth_unit);
 			else
-				put_format(b, translate("gettextFromC", "Safety stop: unknown time @ %.0f%s\n"),
-					   depthvalue, depth_unit);
+				put_format_loc(b, translate("gettextFromC", "Safety stop: unknown time @ %.0f%s\n"),
+					       depthvalue, depth_unit);
 		} else {
 			/* actual deco stop */
 			if (entry->stoptime)
-				put_format(b, translate("gettextFromC", "Deco: %umin @ %.0f%s\n"), DIV_UP(entry->stoptime, 60),
-					   depthvalue, depth_unit);
+				put_format_loc(b, translate("gettextFromC", "Deco: %umin @ %.0f%s\n"), DIV_UP(entry->stoptime, 60),
+					       depthvalue, depth_unit);
 			else
-				put_format(b, translate("gettextFromC", "Deco: unknown time @ %.0f%s\n"),
-					   depthvalue, depth_unit);
+				put_format_loc(b, translate("gettextFromC", "Deco: unknown time @ %.0f%s\n"),
+					       depthvalue, depth_unit);
 		}
 	} else if (entry->in_deco) {
 		put_string(b, translate("gettextFromC", "In deco\n"));
 	} else if (entry->ndl >= 0) {
-		put_format(b, translate("gettextFromC", "NDL: %umin\n"), DIV_UP(entry->ndl, 60));
+		put_format_loc(b, translate("gettextFromC", "NDL: %umin\n"), DIV_UP(entry->ndl, 60));
 	}
 	if (entry->tts)
-		put_format(b, translate("gettextFromC", "TTS: %umin\n"), DIV_UP(entry->tts, 60));
+		put_format_loc(b, translate("gettextFromC", "TTS: %umin\n"), DIV_UP(entry->tts, 60));
 	if (entry->stopdepth_calc && entry->stoptime_calc) {
 		depthvalue = get_depth_units(entry->stopdepth_calc, NULL, &depth_unit);
-		put_format(b, translate("gettextFromC", "Deco: %umin @ %.0f%s (calc)\n"), DIV_UP(entry->stoptime_calc, 60),
-			   depthvalue, depth_unit);
+		put_format_loc(b, translate("gettextFromC", "Deco: %umin @ %.0f%s (calc)\n"), DIV_UP(entry->stoptime_calc, 60),
+				  depthvalue, depth_unit);
 	} else if (entry->in_deco_calc) {
 		/* This means that we have no NDL left,
 		 * and we have no deco stop,
@@ -1472,38 +1472,38 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 		put_string(b, translate("gettextFromC", "In deco (calc)\n"));
 	} else if (prefs.calcndltts && entry->ndl_calc != 0) {
 		if(entry->ndl_calc < MAX_PROFILE_DECO)
-			put_format(b, translate("gettextFromC", "NDL: %umin (calc)\n"), DIV_UP(entry->ndl_calc, 60));
+			put_format_loc(b, translate("gettextFromC", "NDL: %umin (calc)\n"), DIV_UP(entry->ndl_calc, 60));
 		else
-			put_format(b, "%s", translate("gettextFromC", "NDL: >2h (calc)\n"));
+			put_string(b, translate("gettextFromC", "NDL: >2h (calc)\n"));
 	}
 	if (entry->tts_calc) {
 		if (entry->tts_calc < MAX_PROFILE_DECO)
-			put_format(b, translate("gettextFromC", "TTS: %umin (calc)\n"), DIV_UP(entry->tts_calc, 60));
+			put_format_loc(b, translate("gettextFromC", "TTS: %umin (calc)\n"), DIV_UP(entry->tts_calc, 60));
 		else
-			put_format(b, "%s", translate("gettextFromC", "TTS: >2h (calc)\n"));
+			put_string(b, translate("gettextFromC", "TTS: >2h (calc)\n"));
 	}
 	if (entry->rbt)
-		put_format(b, translate("gettextFromC", "RBT: %umin\n"), DIV_UP(entry->rbt, 60));
+		put_format_loc(b, translate("gettextFromC", "RBT: %umin\n"), DIV_UP(entry->rbt, 60));
 	if (entry->ceiling) {
 		depthvalue = get_depth_units(entry->ceiling, NULL, &depth_unit);
-		put_format(b, translate("gettextFromC", "Calculated ceiling %.0f%s\n"), depthvalue, depth_unit);
+		put_format_loc(b, translate("gettextFromC", "Calculated ceiling %.0f%s\n"), depthvalue, depth_unit);
 		if (prefs.calcalltissues) {
 			int k;
 			for (k = 0; k < 16; k++) {
 				if (entry->ceilings[k]) {
 					depthvalue = get_depth_units(entry->ceilings[k], NULL, &depth_unit);
-					put_format(b, translate("gettextFromC", "Tissue %.0fmin: %.1f%s\n"), buehlmann_N2_t_halflife[k], depthvalue, depth_unit);
+					put_format_loc(b, translate("gettextFromC", "Tissue %.0fmin: %.1f%s\n"), buehlmann_N2_t_halflife[k], depthvalue, depth_unit);
 				}
 			}
 		}
 	}
 	if (entry->heartbeat && prefs.hrgraph)
-		put_format(b, translate("gettextFromC", "heart rate: %d\n"), entry->heartbeat);
+		put_format_loc(b, translate("gettextFromC", "heart rate: %d\n"), entry->heartbeat);
 	if (entry->bearing >= 0)
-		put_format(b, translate("gettextFromC", "bearing: %d\n"), entry->bearing);
+		put_format_loc(b, translate("gettextFromC", "bearing: %d\n"), entry->bearing);
 	if (entry->running_sum) {
 		depthvalue = get_depth_units(entry->running_sum / entry->sec, NULL, &depth_unit);
-		put_format(b, translate("gettextFromC", "mean depth to here %.1f%s\n"), depthvalue, depth_unit);
+		put_format_loc(b, translate("gettextFromC", "mean depth to here %.1f%s\n"), depthvalue, depth_unit);
 	}
 
 	strip_mb(b);
@@ -1600,42 +1600,42 @@ void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int 
 	avg_depth /= stop->sec - start->sec;
 	avg_speed /= stop->sec - start->sec;
 
-	snprintf(buf, bufsize, translate("gettextFromC", "%sT: %d:%02d min"), UTF8_DELTA, delta_time / 60, delta_time % 60);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%sT: %d:%02d min"), UTF8_DELTA, delta_time / 60, delta_time % 60);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(delta_depth, NULL, &depth_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DELTA, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DELTA, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(min_depth, NULL, &depth_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DOWNWARDS_ARROW, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DOWNWARDS_ARROW, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(max_depth, NULL, &depth_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_UPWARDS_ARROW, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_UPWARDS_ARROW, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(avg_depth, NULL, &depth_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s\n"), buf2, UTF8_AVERAGE, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s\n"), buf2, UTF8_AVERAGE, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(max_desc_speed), NULL, &vertical_speed_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s%sV:%.2f%s"), buf2, UTF8_DOWNWARDS_ARROW, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s%sV:%.2f%s"), buf2, UTF8_DOWNWARDS_ARROW, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(max_asc_speed), NULL, &vertical_speed_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_UPWARDS_ARROW, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_UPWARDS_ARROW, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(avg_speed), NULL, &vertical_speed_unit);
-	snprintf(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_AVERAGE, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_AVERAGE, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	/* Only print if gas has been used */
 	if (bar_used) {
 		pressurevalue = get_pressure_units(bar_used, &pressure_unit);
 		memcpy(buf2, buf, bufsize);
-		snprintf(buf, bufsize, translate("gettextFromC", "%s %sP:%d %s"), buf2, UTF8_DELTA, pressurevalue, pressure_unit);
+		snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sP:%d %s"), buf2, UTF8_DELTA, pressurevalue, pressure_unit);
 		cylinder_t *cyl = displayed_dive.cylinder + 0;
 		/* if we didn't cross a tank change and know the cylidner size as well, show SAC rate */
 		if (!crossed_tankchange && cyl->type.size.mliter) {
@@ -1660,7 +1660,7 @@ void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int 
 			int sac = lrint(volume_used / atm * 60 / delta_time);
 			memcpy(buf2, buf, bufsize);
 			volume_value = get_volume_units(sac, &volume_precision, &volume_unit);
-			snprintf(buf, bufsize, translate("gettextFromC", "%s SAC: %.*f%s"), buf2, volume_precision, volume_value, volume_unit);
+			snprintf_loc(buf, bufsize, translate("gettextFromC", "%s SAC: %.*f%s"), buf2, volume_precision, volume_value, volume_unit);
 		}
 	}
 

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -30,6 +30,8 @@
 #include <QFont>
 #include <QApplication>
 #include <QTextDocument>
+#include <cstdarg>
+#include <cstdint>
 
 #include <libxslt/documents.h>
 
@@ -1744,4 +1746,398 @@ extern "C" void lock_planner()
 extern "C" void unlock_planner()
 {
 	planLock.unlock();
+}
+
+QString asprintf_loc(const char *cformat, ...)
+{
+	va_list ap;
+	va_start(ap, cformat);
+	QString res = vasprintf_loc(cformat, ap);
+	va_end(ap);
+	return res;
+}
+
+struct vasprintf_flags {
+	bool alternate_form : 1;	// TODO: unsupported
+	bool zero : 1;
+	bool left : 1;
+	bool space : 1;
+	bool sign : 1;
+	bool thousands : 1;		// ignored
+};
+
+enum length_modifier_t {
+	LM_NONE,
+	LM_CHAR,
+	LM_SHORT,
+	LM_LONG,
+	LM_LONGLONG,
+	LM_LONGDOUBLE,
+	LM_INTMAX,
+	LM_SIZET,
+	LM_PTRDIFF
+};
+
+// Helper function to insert '+' or ' ' after last space
+static QString insert_sign(QString s, char sign)
+{
+	// For space we can take a shortcut: insert in front
+	if (sign == ' ')
+		return sign + s;
+	int size = s.size();
+	int pos;
+	for (pos = 0; pos < size && s[pos].isSpace(); ++pos)
+		;	// Pass
+	return s.left(pos) + '+' + s.mid(pos);
+}
+
+static QString fmt_string(const QString &s, vasprintf_flags flags, int field_width, int precision)
+{
+	int size = s.size();
+	if (precision >= 0 && size > precision)
+		return s.left(precision);
+	return flags.left ? s.leftJustified(field_width) :
+			    s.rightJustified(field_width);
+}
+
+// Formatting of integers and doubles using Qt's localized functions.
+// The code is somewhat complex because Qt doesn't support all stdio
+// format options, notably '+' and ' '.
+// TODO: Since this is a templated function, remove common code
+template <typename T>
+static QString fmt_int(T i, vasprintf_flags flags, int field_width, int precision, int base)
+{
+	// If precision is given, things are a bit different: we have to pad with zero *and* space.
+	// Therefore, treat this case separately.
+	if (precision > 1) {
+		// For negative numbers, increase precision by one, so that we get
+		// the correct number of printed digits
+		if (i < 0)
+			++precision;
+		QChar fillChar = '0';
+		QString res = QStringLiteral("%L1").arg(i, precision, base, fillChar);
+		if (i >= 0 && flags.space)
+			res = ' ' + res;
+		else if (i >= 0 && flags.sign)
+			res = '+' + res;
+		return fmt_string(res, flags, field_width, -1);
+	}
+
+	// If we have to prepend a '+' or a space character, remove that from the field width
+	char sign = 0;
+	if (i >= 0 && (flags.space || flags.sign) && field_width > 0) {
+		sign = flags.sign ? '+' : ' ';
+		--field_width;
+	}
+	if (flags.left)
+		field_width = -field_width;
+	QChar fillChar = flags.zero && !flags.left ? '0' : ' ';
+	QString res = QStringLiteral("%L1").arg(i, field_width, base, fillChar);
+	return sign ? insert_sign(res, sign) : res;
+}
+
+static QString fmt_float(double d, char type, vasprintf_flags flags, int field_width, int precision)
+{
+	// If we have to prepend a '+' or a space character, remove that from the field width
+	char sign = 0;
+	if (d >= 0.0 && (flags.space || flags.sign) && field_width > 0) {
+		sign = flags.sign ? '+' : ' ';
+		--field_width;
+	}
+	if (flags.left)
+		field_width = -field_width;
+	QChar fillChar = flags.zero && !flags.left ? '0' : ' ';
+	QString res = QStringLiteral("%L1").arg(d, field_width, type, precision, fillChar);
+	return sign ? insert_sign(res, sign) : res;
+}
+
+// Helper to extract integers from C-style format strings.
+// The default returned value, if no digits are found is 0.
+static int parse_fmt_int(const char **act)
+{
+	if (!isdigit(**act))
+		return 0;
+	int res = 0;
+	while (isdigit(**act)) {
+		res = res * 10 + **act - '0';
+		++(*act);
+	}
+	return res;
+}
+
+QString vasprintf_loc(const char *fmt, va_list ap)
+{
+	const char *act = fmt;
+	QString ret;
+	for (;;) {
+		// Get all bytes up to next '%' character and add them as UTF-8
+		const char *begin = act;
+		while (*act && *act != '%')
+			++act;
+		int len = act - begin;
+		if (len > 0)
+			ret += QString::fromUtf8(begin, len);
+
+		// We found either a '%' or the end of the format string
+		if (!*act)
+			break;
+		++act;	// Jump over '%'
+
+		if (*act == '%') {
+			++act;
+			ret += '%';
+			continue;
+		}
+		// Flags
+		vasprintf_flags flags = { 0 };
+		for (;; ++act) {
+			switch(*act) {
+			case '#':
+				flags.alternate_form = true;
+				continue;
+			case '0':
+				flags.zero = true;
+				continue;
+			case '-':
+				flags.left = true;
+				continue;
+			case ' ':
+				flags.space = true;
+				continue;
+			case '+':
+				flags.sign = true;
+				continue;
+			case '\'':
+				flags.thousands = true;
+				continue;
+			}
+			break;
+		}
+
+		// Field width
+		int field_width;
+		if (*act == '*') {
+			field_width = va_arg(ap, int);
+			++act;
+		} else {
+			field_width = parse_fmt_int(&act);
+		}
+
+		// Precision
+		int precision = -1;
+		if (*act == '.') {
+			++act;
+			if (*act == '*') {
+				precision = va_arg(ap, int);
+				++act;
+			} else {
+				precision = parse_fmt_int(&act);
+			}
+		}
+
+		// Length modifier
+		enum length_modifier_t length_modifier = LM_NONE;
+		switch(*act) {
+		case 'h':
+			++act;
+			length_modifier = LM_CHAR;
+			if (*act == 'h') {
+				length_modifier = LM_SHORT;
+				++act;
+			}
+			break;
+		case 'l':
+			++act;
+			length_modifier = LM_LONG;
+			if (*act == 'l') {
+				length_modifier = LM_LONGLONG;
+				++act;
+			}
+			break;
+		case 'q':
+			++act;
+			length_modifier = LM_LONGLONG;
+			break;
+		case 'L':
+			++act;
+			length_modifier = LM_LONGDOUBLE;
+			break;
+		case 'j':
+			++act;
+			length_modifier = LM_INTMAX;
+			break;
+		case 'z':
+		case 'Z':
+			++act;
+			length_modifier = LM_SIZET;
+			break;
+		case 't':
+			++act;
+			length_modifier = LM_PTRDIFF;
+			break;
+		}
+
+		char type = *act++;
+		// Bail out if we reached end of the format string
+		if (!type)
+			break;
+
+		int base = 10;
+		if (type == 'o')
+			base = 8;
+		else if (type == 'x' || type == 'X')
+			base = 16;
+
+		switch(type) {
+		case 'd': case 'i': {
+			switch(length_modifier) {
+			case LM_LONG:
+				ret += fmt_int(va_arg(ap, long), flags, field_width, precision, base);
+				break;
+			case LM_LONGLONG:
+				ret += fmt_int(va_arg(ap, long long), flags, field_width, precision, base);
+				break;
+			case LM_INTMAX:
+				ret += fmt_int(va_arg(ap, intmax_t), flags, field_width, precision, base);
+				break;
+			case LM_SIZET:
+				ret += fmt_int(va_arg(ap, ssize_t), flags, field_width, precision, base);
+				break;
+			case LM_PTRDIFF:
+				ret += fmt_int(va_arg(ap, ptrdiff_t), flags, field_width, precision, base);
+				break;
+			case LM_CHAR:
+				// char is promoted to int when passed through '...'
+				ret += fmt_int(static_cast<char>(va_arg(ap, int)), flags, field_width, precision, base);
+				break;
+			case LM_SHORT:
+				// short is promoted to int when passed through '...'
+				ret += fmt_int(static_cast<short>(va_arg(ap, int)), flags, field_width, precision, base);
+				break;
+			default:
+				ret += fmt_int(va_arg(ap, int), flags, field_width, precision, base);
+				break;
+			}
+			break;
+		}
+		case 'o': case 'u': case 'x': case 'X': {
+			QString s;
+			switch(length_modifier) {
+			case LM_LONG:
+				s = fmt_int(va_arg(ap, unsigned long), flags, field_width, precision, base);
+				break;
+			case LM_LONGLONG:
+				s = fmt_int(va_arg(ap, unsigned long long), flags, field_width, precision, base);
+				break;
+			case LM_INTMAX:
+				s = fmt_int(va_arg(ap, uintmax_t), flags, field_width, precision, base);
+				break;
+			case LM_SIZET:
+				s = fmt_int(va_arg(ap, size_t), flags, field_width, precision, base);
+				break;
+			case LM_PTRDIFF:
+				s = fmt_int(va_arg(ap, ptrdiff_t), flags, field_width, precision, base);
+				break;
+			case LM_CHAR:
+				// char is promoted to int when passed through '...'
+				s = fmt_int(static_cast<unsigned char>(va_arg(ap, int)), flags, field_width, precision, base);
+				break;
+			case LM_SHORT:
+				// short is promoted to int when passed through '...'
+				s = fmt_int(static_cast<unsigned short>(va_arg(ap, int)), flags, field_width, precision, base);
+				break;
+			default:
+				s = fmt_int(va_arg(ap, unsigned int), flags, field_width, precision, base);
+				break;
+			}
+			if (type == 'X')
+				s = s.toUpper();
+			ret += s;
+			break;
+		}
+		case 'e': case 'E': case 'f': case 'F': case 'g': case 'G': {
+			// It seems that Qt is not able to format long doubles,
+			// therefore we have to cast down to double.
+			double f = length_modifier == LM_LONGDOUBLE ?
+				static_cast<double>(va_arg(ap, long double)) :
+				va_arg(ap, double);
+			ret += fmt_float(f, type, flags, field_width, precision);
+			break;
+		}
+		case 'c':
+			if (length_modifier == LM_LONG) {
+				// Cool, on some platforms wint_t is short, on some int.
+#if WINT_MAX < UINT_MAX
+				wint_t wc = static_cast<wint_t>(va_arg(ap, int));
+#else
+				wint_t wc = va_arg(ap, wint_t);
+#endif
+				ret += QChar(wc);
+			} else {
+				ret += static_cast<char>(va_arg(ap, int));
+			}
+			break;
+		case 's': {
+			QString s = length_modifier == LM_LONG ?
+				QString::fromWCharArray(va_arg(ap, wchar_t *)) :
+				QString::fromUtf8(va_arg(ap, char *));
+			ret += fmt_string(s, flags, field_width, precision);
+			break;
+		}
+		case 'p':
+			ret += QString("0x%1").arg(reinterpret_cast<long long>(va_arg(ap, void *)), field_width, 16);
+			break;
+		}
+	}
+	return ret;
+}
+
+// Put a formated string respecting the default locale into a C-style array in UTF-8 encoding.
+// The only complication arises from the fact that we don't want to cut through multi-byte UTF-8 code points.
+extern "C" int snprintf_loc(char *dst, size_t size, const char *cformat, ...)
+{
+	va_list ap;
+	va_start(ap, cformat);
+	int res = vsnprintf_loc(dst, size, cformat, ap);
+	va_end(ap);
+	return res;
+}
+
+extern "C" int vsnprintf_loc(char *dst, size_t size, const char *cformat, va_list ap)
+{
+	QByteArray utf8 = vasprintf_loc(cformat, ap).toUtf8();
+	const char *data = utf8.constData();
+	size_t utf8_size = utf8.size();
+	if (size == 0)
+		return utf8_size;
+	if (size < utf8_size + 1) {
+		memcpy(dst, data, size - 1);
+		if ((data[size - 1] & 0xC0) == 0x80) {
+			// We truncated a multi-byte UTF-8 encoding.
+			--size;
+			// Jump to last copied byte.
+			if (size > 0)
+				--size;
+			while(size > 0 && (dst[size] & 0xC0) == 0x80)
+				--size;
+			dst[size] = 0;
+		} else {
+			dst[size - 1] = 0;
+		}
+	} else {
+		memcpy(dst, data, utf8_size + 1); // QByteArray guarantees a trailing 0
+	}
+	return utf8_size;
+}
+
+// This function is defined here instead of membuffer.c, because it needs to access QString.
+extern "C" void put_vformat_loc(struct membuffer *b, const char *fmt, va_list args)
+{
+	QByteArray utf8 = vasprintf_loc(fmt, args).toUtf8();
+	const char *data = utf8.constData();
+	size_t utf8_size = utf8.size();
+
+	make_room(b, utf8_size);
+	memcpy(b->buffer + b->len, data, utf8_size);
+	b->len += utf8_size;
 }

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -6,7 +6,13 @@
 #include "dive.h"
 #include "divelist.h"
 
-// 1) Types
+// 1) Types and macros
+
+#ifdef __GNUC__
+#define __printf(x, y) __attribute__((__format__(__printf__, x, y)))
+#else
+#define __printf(x, y)
+#endif
 
 enum inertgas {N2, HE};
 
@@ -47,6 +53,9 @@ void init_proxy();
 QString getUUID();
 QStringList imageExtensionFilters();
 char *intdup(int index);
+__printf(1, 2) QString asprintf_loc(const char *cformat, ...);
+__printf(1, 0) QString vasprintf_loc(const char *cformat, va_list ap);
+
 #endif
 
 // 3) Functions visible to C and C++
@@ -81,10 +90,11 @@ void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 void print_qt_versions();
 void lock_planner();
 void unlock_planner();
+__printf(3, 4) int snprintf_loc(char *dst, size_t size, const char *cformat, ...);
+__printf(3, 0) int vsnprintf_loc(char *dst, size_t size, const char *cformat, va_list ap);
 
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif // QTHELPER_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] Infrastructure
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at partially solving the issues raised in  #1122 and #1119. The idea is to make it as easy and natural as possible to access Qt's localize-aware formatting function from C. To this end, `snprintf_loc()` and `put_format_loc()` are introduced, which work as there standard versions, but use localized conversion. The code is based on a C++ `asprintf_loc()` function returning a `QString`, which might even be convenient in C++ code.

The code seems a bit daunting, but most of it is linear. The only complexity is in the actual formatting functions `fmt_int()` and `fmt_float()`. These had to be introduced to work around inadequacies of Qt's functions, which do not support all formatting specifiers. The '#' formatting specifier is not yet supported.

There is one semantic change compared to the standard `sprintf()` function: Since we might generate UTF-8 strings, we don't cut through UTF-8 multibyte encodings. Therefore, the rendered string might be shorter than `size - 1` in the case of overflow.

This was tested, but not extremely thoroughly. It will certainly need some adjustments / bug-fixes. Consider as experimental.

@sfuchs79: Would you mind testing this by adding `snprintf_loc` and `format_buf_loc` calls?
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
