### PR TITLE
RFC:  Showing po2 graphs with pscr dives using active o2 monitoring

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1031,7 +1031,7 @@ void update_setpoint_events(struct dive *dive, struct divecomputer *dc)
 				gasmix = get_gasmix_from_event(dive, ev);
 				next = get_next_event(ev, "gaschange");
 			}
-			fill_pressures(&pressures, calculate_depth_to_mbar(dc->sample[i].depth.mm, dc->surface_pressure, 0), gasmix ,0, OC);
+			fill_pressures(&pressures, calculate_depth_to_mbar(dc->sample[i].depth.mm, dc->surface_pressure, 0), gasmix ,0, dc->divemode);
 			if (abs(dc->sample[i].setpoint.mbar - (int)(1000 * pressures.o2)) <= 50)
 				dc->sample[i].setpoint.mbar = 0;
 		}
@@ -2007,47 +2007,36 @@ int gasmix_distance(const struct gasmix *a, const struct gasmix *b)
 	return delta_he + delta_o2;
 }
 
-/* fill_pressures(): Compute partial gas pressures in bar from gasmix and ambient pressures, possibly for OC or CCR, to be
- * extended to PSCT. This function does the calculations of gas pressures applicable to a single point on the dive profile.
+/* fill_pressures(): Compute partial gas pressures in bar from gasmix and ambient pressures
+ * for OC, PSCR or CCR. This function calculates gas pressures for a single point on the dive profile.
  * The structure "pressures" is used to return calculated gas pressures to the calling software.
  * Call parameters:	po2 = po2 value applicable to the record in calling function
  *			amb_pressure = ambient pressure applicable to the record in calling function
  *			*pressures = structure for communicating o2 sensor values from and gas pressures to the calling function.
  *			*mix = structure containing cylinder gas mixture information.
- * This function called by: calculate_gas_information_new() in profile.c; add_segment() in deco.c.
+ * This function called by: calculate_gas_information_new() in profile.c; add_segment() in deco.c as well as plannernotes.c.
  */
 extern void fill_pressures(struct gas_pressures *pressures, const double amb_pressure, const struct gasmix *mix, double po2, enum dive_comp_type divemode)
 {
-	if (po2) {	// This is probably a CCR dive where pressures->o2 is defined
-		if (po2 >= amb_pressure) {
+	if (po2) {	// This is a CCR or PSCR dive where pO2 values result from external O2 sensor(s)
+		if (po2 >= amb_pressure || get_o2(mix) == 1000) {
 			pressures->o2 = amb_pressure;
 			pressures->n2 = pressures->he = 0.0;
 		} else {
-			pressures->o2 = po2;
-			if (get_o2(mix) == 1000) {
-				pressures->he = pressures->n2 = 0;
+			if (pressures->o2 < 0) { // He's dead, Jim.
+				pressures->o2 = 0;
 			} else {
+				pressures->o2 = po2;
 				pressures->he = (amb_pressure - pressures->o2) * (double)get_he(mix) / (1000 - get_o2(mix));
 				pressures->n2 = amb_pressure - pressures->o2 - pressures->he;
 			}
 		}
-	} else {
-		if (divemode == PSCR) { /* The steady state approximation should be good enough */
-			pressures->o2 = get_o2(mix) / 1000.0 * amb_pressure - (1.0 - get_o2(mix) / 1000.0) * prefs.o2consumption / (prefs.bottomsac * prefs.pscr_ratio / 1000.0);
-			if (pressures->o2 < 0) // He's dead, Jim.
-				pressures->o2 = 0;
-			if (get_o2(mix) != 1000) {
-				pressures->he = (amb_pressure - pressures->o2) * get_he(mix) / (1000.0 - get_o2(mix));
-				pressures->n2 = (amb_pressure - pressures->o2) * (1000 - get_o2(mix) - get_he(mix)) / (1000.0 - get_o2(mix));
-			} else {
-				pressures->he = pressures->n2 = 0;
-			}
-		} else {
-			// Open circuit dives: no gas pressure values available, they need to be calculated
-			pressures->o2 = get_o2(mix) / 1000.0 * amb_pressure; // These calculations are also used if the CCR calculation above..
-			pressures->he = get_he(mix) / 1000.0 * amb_pressure; // ..returned a po2 of zero (i.e. o2 sensor data not resolvable)
-			pressures->n2 = (1000 - get_o2(mix) - get_he(mix)) / 1000.0 * amb_pressure;
-		}
+	} else { // Open circuit or PSCR dives without O2 sensor: no gas pressure values available, they need to be calculated
+		pressures->o2 = get_o2(mix) / 1000.0 * amb_pressure; 
+		if (divemode == PSCR) // For PSCR the steady state approximation should be good enough
+			pressures->o2 = pressures->o2 - (1.0 - get_o2(mix) / 1000.0) * prefs.o2consumption / (prefs.bottomsac * prefs.pscr_ratio / 1000.0);
+		pressures->he = get_he(mix) / 1000.0 * amb_pressure; // ..returned a po2 of zero (i.e. o2 sensor data not resolvable)
+		pressures->n2 = (1000 - get_o2(mix) - get_he(mix)) / 1000.0 * amb_pressure;
 	}
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -592,7 +592,9 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 		currentdc = fake_dc(currentdc, false);
 	}
 
-	bool setpointflag = (currentdc->divemode == CCR) && prefs.pp_graphs.po2 && current_dive;
+	bool pscr_o2 = (currentdc->divemode == PSCR);
+	bool ccr_o2 = (currentdc->divemode == CCR) && prefs.pp_graphs.po2 && current_dive;
+	bool setpointflag = pscr_o2 || ccr_o2;
 	bool sensorflag = setpointflag && prefs.show_ccr_sensors;
 	o2SetpointGasItem->setVisible(setpointflag && prefs.show_ccr_setpoint);
 	ccrsensor1GasItem->setVisible(sensorflag);
@@ -700,8 +702,8 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 		pn2GasItem->setVisible(false);
 		po2GasItem->setVisible(false);
 		pheGasItem->setVisible(false);
-		o2SetpointGasItem->setVisible(false);
-		ccrsensor1GasItem->setVisible(false);
+		o2SetpointGasItem->setVisible(currentdc->divemode == PSCR && currentdc->no_o2sensors);
+		ccrsensor1GasItem->setVisible(currentdc->divemode == PSCR && currentdc->no_o2sensors);
 		ccrsensor2GasItem->setVisible(false);
 		ccrsensor3GasItem->setVisible(false);
 	}


### PR DESCRIPTION
This is a first step to provide po2 values for pscr dives where
there is active po2 monitoring using a dive computer. The present
implementation is based on using a Petrel 2 with external o2
sensor. Currently, the display of pscr dives shows a computed po2
graph, based on a steady state approximation. See image below

![existing profile](https://user-images.githubusercontent.com/5078706/36778665-176250dc-1c76-11e8-8448-d5b9741297cd.jpg)

There is no provision for the display of pscr dives that use an oxygen
sensor to monitor po2. There are a few issues or question that I have
numbered in the notes below.

**What is new:**
This PR implements display of po2 graph based on an external oxygen
sensor. See image below:

![new_po2](https://user-images.githubusercontent.com/5078706/36778694-33672834-1c76-11e8-85bb-f32e7ca5c0f8.jpg)

In addition, the CCR setpoint preference is used to show the normal
OC po2 values for the dive. Just as the setpoint is the reference value against which
ccr dive po2 values are judged, so the OC po2 value is the one against which pscr
po2 values are judged. they have an exact analogous use in dive interpretation.
Consequently, if one checks the box "Show setpoints when viewing po2" in the
Preferences tab, the OC po2 values are shown in red for pscr profiles. See image below:

![setpoint](https://user-images.githubusercontent.com/5078706/36778900-d340991c-1c76-11e8-80c0-130c9df6b067.jpg)

ISSUE 1. I am not sure how the divecomputer->no_o2sensors information gets into
Subsurface. In this case I scan sample->o2sensor[0] and if any positive values are found
I set the divecomputer->no_o2sensors to 1. I am not convinced this is the most
efficient way of doing this.

ISSUE 2: In function fill_pressures (dive.c) I fill the setpoint array to the
OC po2 values. but I cannot find an easy way to access the fraction of O2 in the
gasmix. Therefore I added an additional parameter to that function header. This
propagated into the calls to this function in deco.c and plannernotes.c. My solution
does not appear particularly elegant.

ISSUE 3: Currently the po2 graph for scr dives with o2 sensors only covers the period
when the diver is on the loop (part of dive between red flags on dive profile images above).
One would like
to extend this by adding the OC po2 values for parts of the dive that are off the loop
(typically at the start and at the end of the dive). This requires that one can see the
events for going onto the loop and going off the loop. I do not think this works for the
Petrel 2. One can fix this with a piece of duct tape by inferring these events from the po2
sensor values (po2 is not recorder when off the loop). There must be a much better
way of doing this. Therefore I do not have a clear idea of how to add this this to the current
implementation.

Any comments or suggestions are extremely valuable.

Signed-off-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 
@sfuchs79 
@glance- 