### PR TITLE
Look for actual isobaric counter diffusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Profile: Add information about actual isobaric counter diffusion happening
 - Suunto DM import: improved temperature parsing in special cases
 # Always add new entries at the very top of this file above other
 # existing entries.

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -2356,6 +2356,13 @@ the narcotic gases nitrogen and oxygen as the current trimix dive. A
 trimix diver can expect the same narcotic effect as a diver breathing
 air diving at a depth equaling the END.
 
+If at some point a isobaric counter diffusion situation is encountered
+in the leading tissue (defined to be a moment in time where helium is
+off-gassing while nitrogen is on-gassing and the net effect is
+on-gassing) this is indicated in the infobox as well. Note that this
+condition not only depends on the gas that is currently breathed but
+on the tissue loadings as well.
+
 Figure (*B*) above shows an information box with a nearly complete set of data.
 
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -896,6 +896,7 @@ struct deco_state {
 	int ci_pointing_to_guiding_tissue;
 	double gf_low_pressure_this_dive;
 	int deco_time;
+	bool icd_warning;
 };
 
 extern void add_segment(struct deco_state *ds, double pressure, const struct gasmix *gasmix, int period_in_seconds, int setpoint, const struct dive *dive, int sac);

--- a/core/profile.c
+++ b/core/profile.c
@@ -1036,7 +1036,8 @@ void calculate_deco_information(struct deco_state *ds, struct deco_state *planne
 			for (j = t0 + time_stepsize; j <= t1; j += time_stepsize) {
 				int depth = interpolate(entry[-1].depth, entry[0].depth, j - t0, t1 - t0);
 				add_segment(ds, depth_to_bar(depth, dive),
-					gasmix, time_stepsize, entry->o2pressure.mbar, dive, entry->sac);
+					    gasmix, time_stepsize, entry->o2pressure.mbar, dive, entry->sac);
+				entry->icd_warning = ds->icd_warning;
 				if ((t1 - j < time_stepsize) && (j < t1))
 					time_stepsize = t1 - j;
 			}
@@ -1498,6 +1499,8 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 			}
 		}
 	}
+	if (entry->icd_warning)
+		put_format(b, "%s", translate("gettextFromC", "ICD in leading tissue\n"));
 	if (entry->heartbeat && prefs.hrgraph)
 		put_format_loc(b, translate("gettextFromC", "heart rate: %d\n"), entry->heartbeat);
 	if (entry->bearing >= 0)

--- a/core/profile.h
+++ b/core/profile.h
@@ -63,6 +63,7 @@ struct plot_data {
 	double ambpressure;
 	double gfline;
 	double density;
+	bool icd_warning;
 };
 
 struct ev_select {


### PR DESCRIPTION
Identify segements that fullfill the folllowing criteria for
the leading compartment:

He is off-gasing while N2 is on-gasing
Overall there is on-gasing

Add a line to the info box for those segments

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Our previous criterium for ICD is used by others but not very well justified (I ranted about it on https://thetheoreticaldiver.org/wordpress/index.php/2018/01/24/isobaric-counter-diffusion-criteria/ )

The advantage of that criterium is though, that it only depends on the gas switch, i.e. on the two gases breathed before and after the switch, so it is easy to check even in a mental calculation.

This PR introduces a different criterium motivated by what the OSTCs do (according to Matthias Heinrichs): It looks at the leading compartment and checks for two conditions:

* He is off-gassing while N2 is on-gassing 
* The net-effect is on-gassing

This has to know about the current state of the tissues (to decide about on/off-gassinfg) and it only depends on the gas currently in use (not a previous one, at least not directly).

This criterium is now checked for in deco.c add_segemnt() which returns now a bool.

To the user, this is displayed as a line in the info box (but one could as well add an icon if required).

I should say, I have been unable to plan a dive that actually triggers this condition (bit I have not really tried). Dropping either the "only in leading compartment" or the "net-on-gassing" criteria this is however triggered.

I believe, in the long run, we should adopt this criterium in place of the other.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->@willemferguson