### PR TITLE
mobile: enable the map widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: enable the built-in map widget
 - Desktop: Change strategy when to allow to delete a cylinder (#869)
 - Desktop/Mobile: Format numbers according to selected Subsurface
   language (#1119)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,8 +170,10 @@ elseif(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 		set(SUBSURFACE_TARGET subsurface-mobile)
 	endif()
 	list(APPEND QT_EXTRA_COMPONENTS Quick)
+	list(APPEND QT_EXTRA_COMPONENTS Location)
 	list(APPEND QT_EXTRA_COMPONENTS QuickControls2)
 	list(APPEND QT_EXTRA_LIBRARIES Qt5::Quick)
+	list(APPEND QT_EXTRA_LIBRARIES Qt5::Location)
 	list(APPEND QT_EXTRA_LIBRARIES Qt5::QuickControls2)
 	add_definitions(-DSUBSURFACE_MOBILE)
 	message(STATUS "Building Subsurface-mobile requires BT support")
@@ -292,6 +294,7 @@ if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 		mobile-widgets/qml/kirigami/src/libkirigami/platformtheme.cpp
 		subsurface-mobile-main.cpp
 		subsurface-mobile-helper.cpp
+		map-widget/qmlmapwidgethelper.cpp
 	)
 	include_directories(${CMAKE_SOURCE_DIR}/mobile-widgets/qml/kirigami/src/libkirigami)
 	if(NOT ANDROID AND NOT iOS)

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -122,6 +122,11 @@ QString DiveObjectHelper::gps_decimal() const
 	return val;
 }
 
+QVariant DiveObjectHelper::dive_site_uuid() const
+{
+	return QVariant::fromValue(m_dive->dive_site_uuid);
+}
+
 QString DiveObjectHelper::duration() const
 {
 	return get_dive_duration_string(m_dive->duration.seconds, QObject::tr("h"), QObject::tr("min"));

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -20,6 +20,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString location READ location CONSTANT)
 	Q_PROPERTY(QString gps READ gps CONSTANT)
 	Q_PROPERTY(QString gps_decimal READ gps_decimal CONSTANT)
+	Q_PROPERTY(QVariant dive_site_uuid READ dive_site_uuid CONSTANT)
 	Q_PROPERTY(QString duration READ duration CONSTANT)
 	Q_PROPERTY(bool noDive READ noDive CONSTANT)
 	Q_PROPERTY(QString depth READ depth CONSTANT)
@@ -60,6 +61,7 @@ public:
 	QString location() const;
 	QString gps() const;
 	QString gps_decimal() const;
+	QVariant dive_site_uuid() const;
 	QString duration() const;
 	bool noDive() const;
 	QString depth() const;

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -6,13 +6,16 @@ import org.subsurfacedivelog.mobile 1.0
 
 Item {
 	id: rootItem
-	property int nSelectedDives: 0
+	property alias mapHelper: mapHelper
+	property alias map: map
+
+	signal selectedDivesChanged(var list)
 
 	MapWidgetHelper {
 		id: mapHelper
 		map: map
 		editMode: false
-		onSelectedDivesChanged: nSelectedDives = list.length
+		onSelectedDivesChanged: rootItem.selectedDivesChanged(list)
 		onEditModeChanged: editMessage.isVisible = editMode === true ? 1 : 0
 		onCoordinatesChanged: {}
 		Component.onCompleted: {

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <QApplication>
 #include <QClipboard>
-#include <QGeoCoordinate>
 #include <QDebug>
 #include <QVector>
 

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -23,6 +23,14 @@ MapWidgetHelper::MapWidgetHelper(QObject *parent) : QObject(parent)
 	        this, SLOT(selectedLocationChanged(MapLocation *)));
 }
 
+void MapWidgetHelper::centerOnDiveSiteUUID(QVariant dive_site_uuid)
+{
+	const uint32_t uuid = qvariant_cast<uint32_t>(dive_site_uuid);
+	struct dive_site *ds = get_dive_site_by_uuid(uuid);
+	if (ds)
+		centerOnDiveSite(ds);
+}
+
 void MapWidgetHelper::centerOnDiveSite(struct dive_site *ds)
 {
 	int idx;

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -22,7 +22,8 @@ public:
 	explicit MapWidgetHelper(QObject *parent = NULL);
 
 	void centerOnDiveSite(struct dive_site *);
-	void reloadMapLocations();
+	Q_INVOKABLE void centerOnDiveSiteUUID(QVariant dive_site_uuid);
+	Q_INVOKABLE void reloadMapLocations();
 	Q_INVOKABLE void copyToClipboardCoordinates(QGeoCoordinate coord, bool formatTraditional);
 	Q_INVOKABLE void calculateSmallCircleRadius(QGeoCoordinate coord);
 	Q_INVOKABLE void updateCurrentDiveSiteCoordinatesFromMap(quint32 uuid, QGeoCoordinate coord);

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -3,8 +3,9 @@
 #define QMLMAPWIDGETHELPER_H
 
 #include <QObject>
+#include <QGeoCoordinate>
+#include <QVariant>
 
-class QGeoCoordinate;
 class MapLocationModel;
 class MapLocation;
 struct dive_site;

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -170,7 +170,8 @@ Kirigami.Page {
 			name: "gps"
 		}
 		onTriggered: {
-			showMap(currentItem.modelData.dive.gps_decimal)
+			showMap()
+			mapPage.centerOnDiveSiteUUID(currentItem.modelData.dive.dive_site_uuid)
 		}
 	}
 

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -51,8 +51,8 @@ Item {
 				anchors.fill: parent
 				enabled: dive.gps_decimal !== ""
 				onClicked: {
-					if (dive.gps_decimal !== "")
-						showMap(dive.gps_decimal)
+					showMap()
+					mapPage.centerOnDiveSiteUUID(dive.dive_site_uuid)
 				}
 			}
 		}
@@ -62,8 +62,8 @@ Item {
 			enabled: dive.gps !== ""
 			text: qsTr("Map it")
 			onClicked: {
-				if (dive.gps_decimal !== "")
-					showMap(dive.gps_decimal)
+				showMap()
+				mapPage.centerOnDiveSiteUUID(dive.dive_site_uuid)
 			}
 		}
 		Row {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -364,4 +364,16 @@ Kirigami.ScrollablePage {
 			event.accepted = true
 		}
 	}
+
+	function setCurrentDiveListIndex(idx, noScroll) {
+		diveListView.currentIndex = idx
+		// updating the index of the ListView triggers a non-linear scroll
+		// animation that can be very slow. the fix is to stop this animation
+		// by setting contentY to itself and then using positionViewAtIndex().
+		// the downside is that the view jumps to the index immediately.
+		if (noScroll) {
+			diveListView.contentY = diveListView.contentY
+			diveListView.positionViewAtIndex(idx, ListView.Center)
+		}
+	}
 }

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -86,7 +86,8 @@ Kirigami.ScrollablePage {
 						name: "gps"
 					}
 					onTriggered: {
-						showMap(latitude + " " + longitude)
+						showMap()
+						mapPage.centerOnLocation(latitude, longitude)
 					}
 				}
 

--- a/mobile-widgets/qml/MapPage.qml
+++ b/mobile-widgets/qml/MapPage.qml
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import QtPositioning 5.3
+import org.subsurfacedivelog.mobile 1.0
+import org.kde.kirigami 2.2 as Kirigami
+
+Kirigami.Page {
+	id: mapPage
+	objectName: "MapPage"
+	title: qsTr("Map")
+	leftPadding: 0
+	topPadding: 0
+	rightPadding: 0
+	bottomPadding: 0
+
+	MapWidget {
+		id: mapWidget
+		anchors.fill: parent
+		onSelectedDivesChanged: {
+			if (list.length === 0) {
+				console.warn("main.qml: onSelectedDivesChanged(): received empty list!")
+				return
+			}
+			var id = list[0] // only single dive selection is supported
+			var idx = diveModel.getIdxForId(id)
+			if (idx === -1) {
+				console.warn("main.qml: onSelectedDivesChanged(): cannot find list index for dive id:", id)
+				return
+			}
+			diveList.setCurrentDiveListIndex(idx, true)
+		}
+	}
+
+	function reloadMap() {
+		mapWidget.mapHelper.reloadMapLocations()
+	}
+
+	function centerOnDiveSiteUUID(uuid) {
+		if (!uuid) {
+			console.warn("main.qml: centerOnDiveSiteUUI(): uuid is undefined!")
+			return
+		}
+		mapWidget.mapHelper.centerOnDiveSiteUUID(uuid)
+	}
+
+	function centerOnLocation(lat, lon) {
+		mapWidget.map.centerOnCoordinate(QtPositioning.coordinate(lat, lon))
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -133,6 +133,15 @@ Kirigami.ApplicationWindow {
 			},
 			Kirigami.Action {
 				icon {
+					name: "icons/map-globe.svg"
+				}
+				text: mapPage.title
+				onTriggered: {
+					showMap()
+				}
+			},
+			Kirigami.Action {
+				icon {
 					name: "icons/ic_sync.svg"
 				}
 				text: qsTr("Dive management")

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -476,6 +476,14 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	pageStack.onCurrentItemChanged: {
 	// This is called whenever the user navigates using the breadcrumbs in the header
 
+		// disable the left swipe to go back when on the map page
+		stackView.interactive = pageStack.currentItem.objectName !== mapPage.objectName
+
+		// is there a better way to reload the map markers instead of doing that
+		// every time the map page is shown - e.g. link to the dive list model somehow?
+		if (pageStack.currentItem.objectName === mapPage.objectName)
+			mapPage.reloadMap()
+
 		// In case we land on any page, not being the DiveDetails (which can be
 		// in multiple states, such as add, edit or view), just end the edit/add mode
 		if (pageStack.currentItem.objectName !== "DiveDetails" &&

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -512,6 +512,12 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		visible: false
 	}
 
+	MapPage {
+		id: mapPage
+		visible: false
+		anchors.fill: parent
+	}
+
 	ThemeTest {
 		id: themetest
 		visible: false

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -67,12 +67,10 @@ Kirigami.ApplicationWindow {
 		diveList.scrollToTop()
 	}
 
-	function showMap(location) {
-		var urlPrefix = "https://www.google.com/maps/place/"
-		var locationPair = location + "/@" + location
-		var urlSuffix = ",5000m/data=!3m1!1e3!4m2!3m1!1s0x0:0x0"
-		Qt.openUrlExternally(urlPrefix + locationPair + urlSuffix)
-
+	function showMap() {
+		globalDrawer.close()
+		returnTopPage()
+		stackView.push(mapPage)
 	}
 
 	function startAddDive() {

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -25,11 +25,25 @@
 		<file>SsrfSwitch.qml</file>
 		<file>SsrfCheckBox.qml</file>
 		<file>SsrfButton.qml</file>
+		<file>MapPage.qml</file>
+		<file alias="MapWidget.qml">../../map-widget/qml/MapWidget.qml</file>
+		<file alias="MapWidgetContextMenu.qml">../../map-widget/qml/MapWidgetContextMenu.qml</file>
+	</qresource>
+	<qresource prefix="/">
+		<file alias="mapwidget-context-menu.png">../../map-widget/qml/icons/mapwidget-context-menu.png</file>
+		<file alias="mapwidget-marker.png">../../map-widget/qml/icons/mapwidget-marker.png</file>
+		<file alias="mapwidget-marker-gray.png">../../map-widget/qml/icons/mapwidget-marker-gray.png</file>
+		<file alias="mapwidget-marker-selected.png">../../map-widget/qml/icons/mapwidget-marker-selected.png</file>
+		<file alias="mapwidget-toggle-satellite.png">../../map-widget/qml/icons/mapwidget-toggle-satellite.png</file>
+		<file alias="mapwidget-toggle-street.png">../../map-widget/qml/icons/mapwidget-toggle-street.png</file>
+		<file alias="mapwidget-zoom-in.png">../../map-widget/qml/icons/mapwidget-zoom-in.png</file>
+		<file alias="mapwidget-zoom-out.png">../../map-widget/qml/icons/mapwidget-zoom-out.png</file>
 	</qresource>
 	<qresource prefix="/">
 		<file>qtquickcontrols2.conf</file>
 	</qresource>
 	<qresource prefix="/org/kde/kirigami">
+		<file alias="icons/map-globe.svg">kirigami/icons/map-globe.svg</file>
 		<file alias="icons/go-next-symbolic.svg">kirigami/icons/go-next.svg</file>
 		<file alias="icons/go-previous-symbolic.svg">kirigami/icons/go-previous.svg</file>
 		<file alias="icons/go-up.svg">kirigami/icons/go-up.svg</file>

--- a/packaging/android/build.sh
+++ b/packaging/android/build.sh
@@ -104,7 +104,7 @@ if [ "$PLATFORM" = "Darwin" ] ; then
 	export ANDROID_NDK_HOST=darwin-x86_64
 else
 	export ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT-$SUBSURFACE_SOURCE/../android-sdk-linux}
-	export ANDROID_NDK_HOST=linux-x86
+	export ANDROID_NDK_HOST=linux-x86_64
 fi
 
 # Which versions are we building against?
@@ -161,6 +161,32 @@ if [ "$PLATFORM" = "Darwin" ] ; then
 else
 	export JAVA_HOME=/usr
 fi
+
+
+# find qmake
+QMAKE=$QT5_ANDROID/android_armv7/bin/qmake
+$QMAKE -query
+
+# build google maps plugin
+if [ ! -e googlemaps ] ; then
+	git clone https://github.com/Subsurface-divelog/googlemaps.git
+fi
+cd googlemaps
+git checkout master
+git pull --rebase
+mkdir -p build-"$ARCH"
+cd build-"$ARCH"
+$QMAKE ../googlemaps.pro
+# on Travis the compiler doesn't support c++1z, yet qmake adds that flag;
+# since things compile fine with c++11, let's just hack that away
+# similarly, don't use -Wdata-time
+mv Makefile Makefile.bak
+cat Makefile.bak | sed -e 's/std=c++1z/std=c++11/g ; s/-Wdate-time//' > Makefile
+make -j4
+QT_PLUGINS_PATH=`$QMAKE -query QT_INSTALL_PLUGINS`
+GOOGLEMAPS_BIN=libqtgeoservices_googlemaps.so
+$QMAKE -install qinstall -exe $GOOGLEMAPS_BIN $QT_PLUGINS_PATH/geoservices/$GOOGLEMAPS_BIN
+cd ../../
 
 if [ ! -e sqlite-autoconf-${SQLITE_VERSION}.tar.gz ] ; then
 	wget http://www.sqlite.org/2017/sqlite-autoconf-${SQLITE_VERSION}.tar.gz

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SUBSURFACE_MOBILE_MODELS_LIB_SRCS
 	divelistmodel.cpp
 	messagehandlermodel.cpp
 	gpslistmodel.cpp
+	maplocationmodel.cpp
 )
 
 if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "DesktopExecutable")

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -54,6 +54,7 @@ rm -rf $MC
 mkdir -p $MC/icons
 cp -R $PMMC/* $MC/
 
+cp $BREEZE/icons/actions/22/map-globe.svg $MC/icons
 cp $BREEZE/icons/actions/24/dialog-cancel.svg $MC/icons
 cp $BREEZE/icons/actions/24/distribute-horizontal-x.svg $MC/icons
 cp $BREEZE/icons/actions/24/document-edit.svg $MC/icons

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -25,6 +25,8 @@
 #include "core/connectionlistmodel.h"
 #include "qt-models/diveimportedmodel.h"
 #include "qt-models/messagehandlermodel.h"
+#include "map-widget/qmlmapwidgethelper.h"
+#include "qt-models/maplocationmodel.h"
 
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 
@@ -56,6 +58,10 @@ void run_ui()
 	qmlRegisterType<DCDeviceData>("org.subsurfacedivelog.mobile", 1, 0, "DCDeviceData");
 	qmlRegisterType<DownloadThread>("org.subsurfacedivelog.mobile", 1, 0, "DCDownloadThread");
 	qmlRegisterType<DiveImportedModel>("org.subsurfacedivelog.mobile", 1, 0, "DCImportModel");
+
+	qmlRegisterType<MapWidgetHelper>("org.subsurfacedivelog.mobile", 1, 0, "MapWidgetHelper");
+	qmlRegisterType<MapLocationModel>("org.subsurfacedivelog.mobile", 1, 0, "MapLocationModel");
+	qmlRegisterType<MapLocation>("org.subsurfacedivelog.mobile", 1, 0, "MapLocation");
 
 	QQmlApplicationEngine engine;
 	KirigamiPlugin::getInstance().registerTypes();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

this PR enables the map widget on mobile. it is placed in a Kirigami Page and it's possible to
navigate to the page using these methods:
- open left drawer -> Map
- open dive details -> Map it
- open GPS fix -> Show on map

the map is the same as on the desktop version with a few limitations, like:
1) not being able to click on cluster of dives and select all of them in the dive list.
the mobile version does not allow multi-selection, thus only a clicked marker is selected.
2) since selecting multiple dives in the dive list is not possible on mobile, the map always zooms to
a single dive, rather than zooming on a rectangle of dives.
3) the map widget context menu action to "select visible dive locations" does not work (no multi-selection) and always the first dive location is selected.
4) when selecting dive markers on the map the dive list moves the selection without animation, as otherwise this can take minutes for a huge dive list. there seems to be no way to control the speed of this animation.
5) editing from the map by dragging markers is not supported as we don't have the UX for that. editing by entering coordinates in the dive details works.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added small `ifdef` wrapped modifications in `mapwidgethelper` to comply with the limits of the mobile version.
2) use a Breeze icon for the map in the drawer on mobile.
3) add a Kirigami Page for the map.
4) expose signals and functions to make it possible to select dives in the dive list from the map and open a map location from the dive details or from a gps fix.
5) update CMake and QRC
6) make the view stack behave slightly differently when `MapPage` is active

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #1037

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
- untested on an actual mobile device by me for the time being.
- i'm not sure if the `QtLocation`, `QtPositioning` modules need extra deployment steps.
- **not sure how the packaging of the google maps plugin would work? ideas?**

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
`- Mobile: enable the built-in map widget`

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Requires work flow updates in the documentation to include the map widget navigation - e.g. 
screenshots.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @janmulder @atdotde @glance- @willemferguson 
