### PR TITLE
Bugfix: qthelper.cpp: pass copy of QString to hashFile()

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1161,7 +1161,7 @@ extern "C" void register_hash(const char *filename, const char *hash)
 	}
 }
 
-QByteArray hashFile(const QString &filename)
+QByteArray hashFile(QString filename)
 {
 	QCryptographicHash hash(QCryptographicHash::Sha1);
 	QFile imagefile(filename);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -33,7 +33,7 @@ QString get_divepoint_gas_string(struct dive *d, const divedatapoint& dp);
 void read_hashes();
 void write_hashes();
 void updateHash(struct picture *picture);
-QByteArray hashFile(const QString &filename);
+QByteArray hashFile(QString filename);
 QString hashString(const char *filename);
 void learnImages(const QDir dir, int max_recursions);
 void add_hash(const QString &filename, const QByteArray &hash);


### PR DESCRIPTION
This is a partial revert of e5dcd9fc161891a4e70364e1dcdf232590eb49c6,
which replaced a number of QString by-value arguments by
reference-to-QString arguments.

This introduced a bug in the case of hashFile, which is called from
a different thread context. The passed QString might be deleted in
the calling function, leading to a dangling reference.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The commit message says it all - partial revert against a bug introduced in e5dcd9fc161891a4e70364e1dcdf232590eb49c6.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
