### PR TITLE
Mobile: pass QString as value to registerError()

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -89,7 +89,7 @@ extern "C" int gitProgressCB(const char *text)
 	return 0;
 }
 
-void QMLManager::registerError(const QString &error)
+void QMLManager::registerError(QString error)
 {
 	appendTextToLog(error);
 	if (!m_lastError.isEmpty())

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -61,7 +61,7 @@ public:
 	};
 
 	static QMLManager *instance();
-	Q_INVOKABLE void registerError(const QString &error);
+	Q_INVOKABLE void registerError(QString error);
 	QString consumeError();
 
 	QString cloudUserName() const;


### PR DESCRIPTION
registerError() may be called from a different thread context. Passing
the message as a const-reference may lead to a dangling reference.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a potential crash-fix. When passed an error from a different thread (e.g. BT download), this would create a dangling reference (at least that's how I understand it, but perhaps `invokeMethod` does some magic which makes passing references OK?).
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
