### PR TITLE
map-widget: improvements to context menu text and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Map-widget: try to match the zoom level in Google Maps
+- Map-widget: improve context menu texts
 - Mobile: enable the built-in map widget
 - Desktop: Change strategy when to allow to delete a cylinder (#869)
 - Desktop/Mobile: Format numbers according to selected Subsurface

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -324,10 +324,33 @@ Item {
 		}
 	}
 
+	/*
+	 * open coordinates in google maps while attempting to roughly preserve
+	 * the zoom level. the mapping between the QML map zoom level and the
+	 * Google Maps zoom level is done via exponential regression:
+	 *     y = a * exp(b * x)
+	 *
+	 * data set:
+	 *     qml (x)            gmaps (y in meters)
+	 *     21                 257
+	 *     15.313216749178913 3260
+	 *     12.553216749178931 20436
+	 *     11.11321674917894  52883
+	 *     9.313216749178952  202114
+	 *     7.51321674917896   737136
+	 *     5.593216749178958  2495529
+	 *     4.153216749178957  3895765
+	 *     1.753216749178955  18999949
+	 */
 	function openLocationInGoogleMaps(latitude, longitude) {
 		var loc = latitude + "," + longitude
-		var url = "https://www.google.com/maps/place/@" + loc + ",5000m/data=!3m1!1e3!4m2!3m1!1s0x0:0x0"
+		var x = map.zoomLevel
+		var a = 53864950.831693
+		var b = -0.60455861606547030630
+		var zoom = Math.floor(a * Math.exp(b * x))
+		var url = "https://www.google.com/maps/place/@" + loc + "," + zoom + "m/data=!3m1!1e3!4m2!3m1!1s0x0:0x0"
 		Qt.openUrlExternally(url)
+		console.log("openLocationInGoogleMaps() map.zoomLevel: " + x + ", url: " + url)
 	}
 
 	MapWidgetContextMenu {

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -325,8 +325,8 @@ Item {
 	}
 
 	function openLocationInGoogleMaps(latitude, longitude) {
-		var loc = latitude + " " + longitude
-		var url = "https://www.google.com/maps/place/" + loc + "/@" + loc + ",5000m/data=!3m1!1e3!4m2!3m1!1s0x0:0x0"
+		var loc = latitude + "," + longitude
+		var url = "https://www.google.com/maps/place/@" + loc + ",5000m/data=!3m1!1e3!4m2!3m1!1s0x0:0x0"
 		Qt.openUrlExternally(url)
 	}
 

--- a/map-widget/qml/MapWidgetContextMenu.qml
+++ b/map-widget/qml/MapWidgetContextMenu.qml
@@ -12,9 +12,9 @@ Item {
 		"SELECT_VISIBLE_LOCATIONS":     3
 	}
 	readonly property var menuItemData: [
-		{ idx: actions.OPEN_LOCATION_IN_GOOGLE_MAPS, itemText: qsTr("Open location in Google Maps") },
-		{ idx: actions.COPY_LOCATION_DECIMAL,        itemText: qsTr("Copy location to clipboard (decimal)") },
-		{ idx: actions.COPY_LOCATION_SEXAGESIMAL,    itemText: qsTr("Copy location to clipboard (sexagesimal)") },
+		{ idx: actions.OPEN_LOCATION_IN_GOOGLE_MAPS, itemText: qsTr("Open in Google Maps") },
+		{ idx: actions.COPY_LOCATION_DECIMAL,        itemText: qsTr("Copy coordinates to clipboard (decimal)") },
+		{ idx: actions.COPY_LOCATION_SEXAGESIMAL,    itemText: qsTr("Copy coordinates to clipboard (sexagesimal)") },
 		{ idx: actions.SELECT_VISIBLE_LOCATIONS,     itemText: qsTr("Select visible dive locations") }
 	]
 	readonly property real itemTextPadding: 10.0


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

@willemferguson suggested that we change the text in the map widget context menu to make it more clear that opening in gmaps or copying coordinates to the clipboard would use the current map center and not the coordinates of the current selected dive marker.

he also suggested that we hide the single marker that is shown in google maps since that is confusing.

this PR also adds a commit to attempt to roughly match the zoom level between the QML map and Gmaps.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- modify the gmaps URL so that no marker is shown
- modify context menu text
- map zoom levels between qml map and gmaps

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@willemferguson @janmulder @dirkhh 
