### PR TITLE
[Build Fix] Remove non-trivial designated initializers

### DIFF
--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -54,31 +54,32 @@ static dc_status_t ble_serial_purge(dc_custom_io_t *io, dc_direction_t queue);
 static dc_status_t ble_serial_get_available(dc_custom_io_t *io, size_t *available);
 static dc_status_t ble_serial_set_timeout(dc_custom_io_t *io, long timeout);
 
-static dc_custom_io_t ble_serial_ops = {
-	.userdata = NULL,
-	.user_device = NULL,
+static dc_custom_io_t ble_serial_ops = []() -> dc_custom_io_t {
+	auto self = dc_custom_io_t{};
+    self.userdata = NULL;
+	self.user_device = NULL;
 
-	.serial_open = ble_serial_open,
-	.serial_close = ble_serial_close,
-	.serial_read = ble_serial_read,
-	.serial_write = ble_serial_write,
-	.serial_purge = ble_serial_purge,
-	.serial_get_available = ble_serial_get_available,
-	.serial_set_timeout = ble_serial_set_timeout,
+	self.serial_open = ble_serial_open;
+	self.serial_close = ble_serial_close;
+	self.serial_read = ble_serial_read;
+	self.serial_write = ble_serial_write;
+	self.serial_purge = ble_serial_purge;
+	self.serial_get_available = ble_serial_get_available;
+	self.serial_set_timeout = ble_serial_set_timeout;
 // These doesn't make sense over bluetooth
 // NULL means NOP
-	.serial_configure = NULL,
-	.serial_set_dtr = NULL,
-	.serial_set_rts = NULL,
-	.serial_set_break = NULL,
+	self.serial_configure = NULL;
+	self.serial_set_dtr = NULL;
+	self.serial_set_rts = NULL;
+	self.serial_set_break = NULL;
 
-	.packet_size  = 20,
-	.packet_open  = qt_ble_open,
-	.packet_close = qt_ble_close,
-	.packet_read  = qt_ble_read,
-	.packet_write = qt_ble_write,
-};
-
+	self.packet_size  = 20;
+	self.packet_open  = qt_ble_open;
+	self.packet_close = qt_ble_close;
+	self.packet_read  = qt_ble_read;
+	self.packet_write = qt_ble_write;
+    return self;
+}();
 
 static dc_status_t ble_serial_open(dc_custom_io_t *io, dc_context_t *context, const char* devaddr)
 {
@@ -589,31 +590,33 @@ static dc_status_t qt_serial_set_timeout(dc_custom_io_t *io, long timeout)
 	return DC_STATUS_SUCCESS;
 }
 
-dc_custom_io_t qt_serial_ops = {
-	.userdata = NULL,
-	.user_device = NULL,
-	.serial_open = qt_serial_open,
-	.serial_close = qt_serial_close,
-	.serial_read = qt_serial_read,
-	.serial_write = qt_serial_write,
-	.serial_purge = qt_serial_purge,
-	.serial_get_available = qt_serial_get_available,
-	.serial_set_timeout = qt_serial_set_timeout,
+dc_custom_io_t qt_serial_ops = []() -> dc_custom_io_t {
+    auto self = dc_custom_io_t{};
+	self.userdata = NULL;
+	self.user_device = NULL;
+	self.serial_open = qt_serial_open;
+	self.serial_close = qt_serial_close;
+	self.serial_read = qt_serial_read;
+	self.serial_write = qt_serial_write;
+	self.serial_purge = qt_serial_purge;
+	self.serial_get_available = qt_serial_get_available;
+	self.serial_set_timeout = qt_serial_set_timeout;
 // These doesn't make sense over bluetooth
 // NULL means NOP
-	.serial_configure = NULL,
-	.serial_set_dtr = NULL,
-	.serial_set_rts = NULL,
-	.serial_set_break = NULL,
+	self.serial_configure = NULL;
+	self.serial_set_dtr = NULL;
+	self.serial_set_rts = NULL;
+	self.serial_set_break = NULL;
 
 #ifdef BLE_SUPPORT
-	.packet_size  = 20,
-	.packet_open  = qt_ble_open,
-	.packet_close = qt_ble_close,
-	.packet_read  = qt_ble_read,
-	.packet_write = qt_ble_write,
+	self.packet_size  = 20;
+	self.packet_open  = qt_ble_open;
+	self.packet_close = qt_ble_close;
+	self.packet_read  = qt_ble_read;
+	self.packet_write = qt_ble_write;
 #endif
-};
+    return self;
+}();
 
 dc_custom_io_t* get_qt_serial_ops() {
 	return (dc_custom_io_t*) &qt_serial_ops;


### PR DESCRIPTION
Some C++ compillers (like g++) don't have non-trivial
designated initializers, we can replace that with a lambda
with just a bit more verbosity in the code.

The actual error:
core/qtserialbluetooth.cpp:617:1: sorry, unimplemented:
non-trivial designated initializers not supported

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
