### PR TITLE
[WIP]: Incorporate bailout events in CCR & PSCR gas calculations.

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -140,6 +140,7 @@ struct event {
 		 * case, the get_cylinder_index() function will give the best
 		 * match with the cylinders in the dive based on gasmix.
 		 */
+		int divemode; // For divemode switch events during dive
 		struct {
 			int index;
 			struct gasmix mix;


### PR DESCRIPTION
RFC: Incorporating bailout into CC dive logs.

This is a request for comments. I use the existing dive structure and divemodes that are at the level of a dive, and not at the level of samples. I scan the profile for bailout events and mark the appropriate sections after bailout (or before onLoop) as OC, then calculate pO2 using OC criteria.

We start off by looking for bailout events along the dive profile.
There are two types of events:
onLoop (OC -> CC)
Bailout (CC -> OC)
At the moment they are bookmarks that were named as one of the above
two. In future, these events could be obtained directly from the
dive computer (several already store this information). Given that
we know what gas is used when doing bailout (even though this may
not mean a change of physical gas cylinder) we can then adjust the
pO2 graph to reflect OC pO2 while on bailout, and CC pO2 while on
the loop. The partial pressures of the other gases are now calculated
correctly so the the correct deco calculations are possible. This
cose accommodates an arbitary number of switches between OC and CC.
I provide much more information in the PR documentation.

Here is an image of a PSCR dive profile, indicating the equivalent OC pO2 (red), as well as the monitored pO2 (green). The onLoop and Bailout events are indicated by the red bookmarks on the profile. Before the onLoop event, the pO2 is identical to the OC equivalent pO2. After the Bailout event this is also the case. 

![bailout1](https://user-images.githubusercontent.com/5078706/37519427-b79b3976-2921-11e8-92de-07757bcab7a2.png)

Here is the same profile showing the pN2. This is correct, taking into account the OC pO2 experienced by the diver. This allows for correct calculation of decompression parameters for this dive. Beforehand the correct partial pressures were not available because of the external sensor measurements of the CC machine continued after the diver bailed out, thus giving erroneous pO2 values.

![bailout_pn2](https://user-images.githubusercontent.com/5078706/37519573-44697638-2922-11e8-9eb3-f369a115bbed.png)

Two issues:
1) I am not convinced the correct deco calculations are performed at this stage. I would appreciate it if @dotde was prepared to look at this and comment. This code need synchronisation with deco.c.

2) I am aware that @glance- and @dotde have recommended changing the internal memory representation of dives in order to allow mid-dive changes in dive mode (OC, SCR, CCR). However, I see this as changes for future development, much larger than proposed in this PR. In that case the code in this PR may be transitional.

3) This specific PR only involves code blocks around lines 1208-1258 of profile.c. The other changes indicated are associated with another PR of mine that is still under consideration, (i.e. showing OC-pO2 values as a graph for SCR). They are obviously irrelevant for the present PR.

Signed-off-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @glance- 