### PR TITLE
Profile heartrate: Nicer min/max/tics and only enable either heartrate or heatmap

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -439,7 +439,7 @@ struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer
 				maxpressure = pressure;
 			if (heartbeat > maxhr)
 				maxhr = heartbeat;
-			if (heartbeat < minhr)
+			if (heartbeat && heartbeat < minhr)
 				minhr = heartbeat;
 
 			if (depth > maxdepth)
@@ -469,7 +469,7 @@ struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer
 	if (minpressure > maxpressure)
 		minpressure = 0;
 	if (minhr > maxhr)
-		minhr = 0;
+		minhr = maxhr;
 
 	memset(&pi, 0, sizeof(pi));
 	pi.maxdepth = maxdepth;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -292,6 +292,9 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(ui.profTankbar,        &QAction::triggered, sWrapper->techDetails, &TechnicalDetailsSettings::setTankBar);
 	connect(ui.profTissues,        &QAction::triggered, sWrapper->techDetails, &TechnicalDetailsSettings::setPercentageGraph);
 
+	connect(ui.profTissues,        &QAction::triggered, this, &MainWindow::unsetProfHR);
+	connect(ui.profHR,             &QAction::triggered, this, &MainWindow::unsetProfTissues);
+
 	connect(ui.profPhe, &QAction::triggered, sWrapper->pp_gas, &PartialPressureGasSettings::setShowPhe);
 	connect(ui.profPn2, &QAction::triggered, sWrapper->pp_gas, &PartialPressureGasSettings::setShowPn2);
 	connect(ui.profPO2, &QAction::triggered, sWrapper->pp_gas, &PartialPressureGasSettings::setShowPo2);
@@ -2036,4 +2039,20 @@ void MainWindow::hideProgressBar()
 		progressDialog->deleteLater();
 		progressDialog = NULL;
 	}
+}
+
+void MainWindow::unsetProfHR()
+{
+	SettingsObjectWrapper *sWrapper = SettingsObjectWrapper::instance();
+
+	ui.profHR->setChecked(false);
+	sWrapper->techDetails->setHRgraph(false);
+}
+
+void MainWindow::unsetProfTissues()
+{
+	SettingsObjectWrapper *sWrapper = SettingsObjectWrapper::instance();
+
+	ui.profTissues->setChecked(false);
+	sWrapper->techDetails->setPercentageGraph(false);
 }

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -149,6 +149,8 @@ slots:
 	void setDefaultState();
 	void setAutomaticTitle();
 	void cancelCloudStorageOperation();
+	void unsetProfHR();
+	void unsetProfTissues();
 
 protected:
 	void closeEvent(QCloseEvent *);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -644,8 +644,20 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 
 #ifndef SUBSURFACE_MOBILE
 	if (plotInfo.maxhr) {
-		heartBeatAxis->setMinimum(plotInfo.minhr);
-		heartBeatAxis->setMaximum(plotInfo.maxhr);
+		int heartBeatAxisMin = lrint(plotInfo.minhr / 5.0 - 0.5) * 5;
+		int heartBeatAxisMax, heartBeatAxisTick;
+		if (plotInfo.maxhr - plotInfo.minhr < 40)
+			heartBeatAxisTick = 10;
+		else if (plotInfo.maxhr - plotInfo.minhr < 80)
+			heartBeatAxisTick = 20;
+		else if (plotInfo.maxhr - plotInfo.minhr < 100)
+			heartBeatAxisTick = 25;
+		else
+			heartBeatAxisTick = 50;
+		for (heartBeatAxisMax = heartBeatAxisMin; heartBeatAxisMax < plotInfo.maxhr; heartBeatAxisMax += heartBeatAxisTick);
+		heartBeatAxis->setMinimum(heartBeatAxisMin);
+		heartBeatAxis->setMaximum(heartBeatAxisMax + 1);
+		heartBeatAxis->setTickInterval(heartBeatAxisTick);
 		heartBeatAxis->updateTicks(HR_AXIS); // this shows the ticks
 	}
 	heartBeatAxis->setVisible(prefs.hrgraph && plotInfo.maxhr);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Correct a bug in finding the minimum heartrate.

Use the minimum and maximum heartrate value to set min/max and
tic distance for the heartrate axis in the profile.

Only allow to enable maximum one of both items tissue heatmap or
heartrate in profile.
This is done by always switching off the other one at the moment you
turn on one of the two items.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Closes #1162 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
I have to be fair and say that I don't understand the part of the code with the lambdas (WTF are lambdas?) at all.
I was "inspired" by reading this:
https://artandlogic.com/2013/09/qt-5-and-c11-lambdas-are-your-friend/
So you please clearly have to tell me if this is good code or if we need to do this in a different way!

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
