### PR TITLE
[RFC] Extract timestamp from MP4 and related file formats

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	gettextfromc.cpp
 	# dirk ported some core functionality to c++.
 	qthelper.cpp
+	metadata.cpp
 	divecomputer.cpp
 	exif.cpp
 	subsurfacesysinfo.cpp

--- a/core/dive.c
+++ b/core/dive.c
@@ -11,6 +11,7 @@
 #include "device.h"
 #include "divelist.h"
 #include "qthelper.h"
+#include "metadata.h"
 
 /* one could argue about the best place to have this variable -
  * it's used in the UI, but it seems to make the most sense to have it

--- a/core/dive.c
+++ b/core/dive.c
@@ -3780,16 +3780,18 @@ bool picture_check_valid(const char *filename, int shift_time)
 
 void dive_create_picture(struct dive *dive, const char *filename, int shift_time, bool match_all)
 {
-	timestamp_t timestamp = picture_get_timestamp(filename);
+	struct metadata metadata;
+	get_metadata(filename, &metadata);
 	if (!new_picture_for_dive(dive, filename))
 		return;
-	if (!match_all && !dive_check_picture_time(dive, shift_time, timestamp))
+	if (!match_all && !dive_check_picture_time(dive, shift_time, metadata.timestamp))
 		return;
 
 	struct picture *picture = alloc_picture();
 	picture->filename = strdup(filename);
-	picture->offset.seconds = timestamp - dive->when + shift_time;
-	picture_load_exif_data(picture);
+	picture->offset.seconds = metadata.timestamp - dive->when + shift_time;
+	picture->longitude = metadata.longitude;
+	picture->latitude = metadata.latitude;
 
 	dive_add_picture(dive, picture);
 	dive_set_geodata_from_picture(dive, picture);

--- a/core/dive.h
+++ b/core/dive.h
@@ -433,8 +433,6 @@ extern void dive_add_picture(struct dive *d, struct picture *newpic);
 extern bool dive_remove_picture(struct dive *d, const char *filename);
 extern unsigned int dive_get_picture_count(struct dive *d);
 extern bool picture_check_valid(const char *filename, int shift_time);
-extern void picture_load_exif_data(struct picture *p);
-extern timestamp_t picture_get_timestamp(const char *filename);
 extern void dive_set_geodata_from_picture(struct dive *d, struct picture *pic);
 extern void picture_free(struct picture *picture);
 

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -6,22 +6,47 @@
 #include <QFile>
 #include <QDateTime>
 
-// Fetch quint16 in big endian mode from QFile and return 0 on error.
-// This is a very specialized function for parsing JPEGs, therefore we can get away with such an in-band error code.
-static inline quint16 getShortBE(QFile &f)
+// Weirdly, android builds fail owing to undefined UINT64_MAX
+#ifndef UINT64_MAX
+#define UINT64_MAX (~0ULL)
+#endif
+
+// The following two functions fetch an arbitrary-length _unsigned_ integer from either
+// a file or a memory location in big-endian mode. The size of the integer is passed
+// via a template argument [e.g. getBE<uint16_t>(...)].
+// The function doing file access returns a default value on IO error or end-of-file.
+// Warning: This code works properly only for unsigned integers. The template parameter
+// is not checked and passing a signed integer will silently fail!
+template <typename T>
+static inline T getBE(const char *buf_in)
 {
-	unsigned char buf[2];
-	if (f.read(reinterpret_cast<char *>(buf), 2) != 2)
-		return 0;
-	return (buf[0] << 8) | buf[1];
+	constexpr size_t size = sizeof(T);
+	// Interpret raw bytes as unsigned char to avoid sign extension for
+	// characters in the 0x80...0xff range.
+	auto buf = (unsigned const char *)buf_in;
+	T ret = 0;
+	for (size_t i = 0; i < size; ++i)
+		ret = (ret << 8) | buf[i];
+	return ret;
+}
+
+template <typename T>
+static inline T getBE(QFile &f, T def=0)
+{
+	constexpr size_t size = sizeof(T);
+	char buf[size];
+	if (f.read(buf, size) != size)
+		return def;
+	return getBE<T>(buf);
 }
 
 static bool parseExif(QFile &f, struct metadata *metadata)
 {
-	if (getShortBE(f) != 0xffd8)
+	f.seek(0);
+	if (getBE<uint16_t>(f) != 0xffd8)
 		return false;
 	for (;;) {
-		switch (getShortBE(f)) {
+		switch (getBE<uint16_t>(f)) {
 		case 0xffc0:
 		case 0xffc2:
 		case 0xffc4:
@@ -31,14 +56,14 @@ static bool parseExif(QFile &f, struct metadata *metadata)
 		case 0xffe0:
 		case 0xffe2 ... 0xffef:
 		case 0xfffe: {
-			quint16 len = getShortBE(f);
+			uint16_t len = getBE<uint16_t>(f);
 			if (len < 2)
 				return false;
 			f.seek(f.pos() + len - 2); // TODO: switch to QFile::skip()
 			break;
 		}
 		case 0xffe1: {
-			quint16 len = getShortBE(f);
+			uint16_t len = getBE<uint16_t>(f);
 			if (len < 2)
 				return false;
 			len -= 2;
@@ -63,10 +88,107 @@ static bool parseExif(QFile &f, struct metadata *metadata)
 	}
 }
 
-static bool parseMP4(QFile &, metadata *)
+static bool parseMP4(QFile &f, metadata *metadata)
 {
-	// TODO: Implement MP4 parsing
-	return false;
+	f.seek(0);
+
+	// MP4s and related formats are hierarchical, being made up of "atoms", which can
+	// contain other atoms (an interesting interpretation of the term atom).
+	// To parse the file, the remaining to-be-parsed bytes of the upper atoms in
+	// the parse-tree are tracked in a stack-like structure. This is not strictly
+	// necessary, since the level at which an atom is found is insubstantial.
+	// Nevertheless, it is an effective and simple way of sanity-checking the file and the
+	// parsing routine.
+	std::vector<uint64_t> atom_stack;
+	atom_stack.reserve(10);
+
+	// For the outmost level, set the atom-size the the maximum value representable in
+	// 64-bits, which effectively means parse to the end of file.
+	atom_stack.push_back(UINT64_MAX);
+
+	// The first atom of an MP4 or related video is supposed to be of the "ftyp" kind.
+	// If such an atom is found as first atom, this function will return true, indicating
+	// that the file is a video.
+	bool found_ftyp = false;
+
+	while (!f.atEnd() && !atom_stack.empty()) {
+		// Parse atom header. The header can have two forms (each character stands for a byte):
+		//	lllltttt
+		// or
+		// 	0001ttttllllllll
+		// where "l" stands for length in big-endian mode and "t" for type of the atom.
+		// The length includes the 8- or 16-bytes header.
+		uint64_t atom_size = getBE<uint32_t>(f, 2);
+		int atom_header_size = 8;
+		if (atom_size > 1 && atom_size < 8)
+			break;
+		char type[4];
+		if (f.read(type, 4) != 4)
+			break;
+		if (atom_size == 1) {
+			atom_size = getBE<uint64_t>(f);
+			atom_header_size = 16;
+			if (atom_size < 16)
+			       break;
+		}
+		if (atom_size == 0)
+			atom_size = atom_stack.back();
+		if (atom_size > atom_stack.back())
+			break;
+		atom_stack.back() -= atom_size;
+		atom_size -= atom_header_size;
+
+		// The first atom must be "ftyp"
+		if (!found_ftyp) {
+			found_ftyp = !memcmp(type, "ftyp", 4);
+			if (!found_ftyp)
+				break;
+		}
+
+		if (!memcmp(type, "moov", 4) ||
+		    !memcmp(type, "trak", 4) ||
+		    !memcmp(type, "mdia", 4)) {
+			// Recurse into "moov", "trak" and "mdia" atoms
+			atom_stack.push_back(atom_size);
+			continue;
+		} else if (!memcmp(type, "mdhd", 4) && atom_size >= 24 && atom_size < 4096) {
+			// Parse "mdhd" (media header).
+			// Sanity check: size between 24 and 4096
+			std::vector<char> data(atom_size);
+			if (f.read(&data[0], atom_size) != static_cast<int>(atom_size))
+				break;
+			uint64_t timestamp = 0;
+			// First byte is version. We know version 0 and 1
+			switch (data[0]) {
+			case 0:
+				timestamp = getBE<uint32_t>(&data[4]);
+				break;
+			case 1:
+				timestamp = getBE<uint64_t>(&data[4]);
+				break;
+			default:
+				// For unknown versions: ignore -> maybe we find a parseable "mdhd" atom later in this file
+				break;
+			}
+			// Timestamp is given as seconds since midnight 1904/1/1. To be convertible to the UNIX epoch
+			// it must be larger than 2082844800.
+			if (timestamp >= 2082844800) {
+				metadata->timestamp = timestamp - 2082844800;
+				// Currently, we only know how to extract timestamps, so we might just quit parsing here.
+				break;
+			}
+		} else {
+			// Jump over unknown atom
+			if (!f.seek(f.pos() + atom_size)) // TODO: switch to QFile::skip()
+				break;
+		}
+
+		// If end of atom is reached, return to outer atom
+		while (!atom_stack.empty() && atom_stack.back() == 0)
+			atom_stack.pop_back();
+	}
+
+	return found_ftyp;
 }
 
 extern "C" mediatype_t get_metadata(const char *filename_in, metadata *data)

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "metadata.h"
+#include "exif.h"
+#include "qthelper.h"
+#include <QString>
+#include <QFile>
+#include <QDateTime>
+
+// Fetch quint16 in big endian mode from QFile and return 0 on error.
+// This is a very specialized function for parsing JPEGs, therefore we can get away with such an in-band error code.
+static inline quint16 getShortBE(QFile &f)
+{
+	unsigned char buf[2];
+	if (f.read(reinterpret_cast<char *>(buf), 2) != 2)
+		return 0;
+	return (buf[0] << 8) | buf[1];
+}
+
+static bool parseExif(QFile &f, struct metadata *metadata)
+{
+	if (getShortBE(f) != 0xffd8)
+		return false;
+	for (;;) {
+		switch (getShortBE(f)) {
+		case 0xffc0:
+		case 0xffc2:
+		case 0xffc4:
+		case 0xffd0 ... 0xffd7:
+		case 0xffdb:
+		case 0xffdd:
+		case 0xffe0:
+		case 0xffe2 ... 0xffef:
+		case 0xfffe: {
+			quint16 len = getShortBE(f);
+			if (len < 2)
+				return false;
+			f.seek(f.pos() + len - 2); // TODO: switch to QFile::skip()
+			break;
+		}
+		case 0xffe1: {
+			quint16 len = getShortBE(f);
+			if (len < 2)
+				return false;
+			len -= 2;
+			QByteArray data = f.read(len);
+			if (data.size() != len)
+				return false;
+			easyexif::EXIFInfo exif;
+			if (exif.parseFromEXIFSegment(reinterpret_cast<const unsigned char *>(data.constData()), len) != PARSE_EXIF_SUCCESS)
+				return false;
+			metadata->longitude.udeg = lrint(1000000.0 * exif.GeoLocation.Longitude);
+			metadata->latitude.udeg = lrint(1000000.0 * exif.GeoLocation.Latitude);
+			metadata->timestamp = exif.epoch();
+			return true;
+		}
+		case 0xffda:
+		case 0xffd9:
+			// We expect EXIF data before any scan data
+			return false;
+		default:
+			return false;
+		}
+	}
+}
+
+static bool parseMP4(QFile &, metadata *)
+{
+	// TODO: Implement MP4 parsing
+	return false;
+}
+
+extern "C" mediatype_t get_metadata(const char *filename_in, metadata *data)
+{
+	data->timestamp = 0;
+	data->latitude.udeg = 0;
+	data->longitude.udeg = 0;
+
+	QString filename = localFilePath(QString(filename_in));
+	QFile f(filename);
+	if (!f.open(QIODevice::ReadOnly))
+		return MEDIATYPE_IO_ERROR;
+
+	if (parseExif(f, data)) {
+		return MEDIATYPE_PICTURE;
+	} else if(parseMP4(f, data)) {
+		return MEDIATYPE_VIDEO;
+	} else {
+		// If we couldn't parse EXIF or MP4 data, use file creation date.
+		// TODO: QFileInfo::created is deprecated in newer Qt versions.
+		data->timestamp = QFileInfo(filename).created().toMSecsSinceEpoch() / 1000;
+		return MEDIATYPE_UNKNOWN;
+	}
+}
+
+extern "C" timestamp_t picture_get_timestamp(const char *filename)
+{
+	struct metadata data;
+	get_metadata(filename, &data);
+	return data.timestamp;
+}
+
+extern "C" void picture_load_exif_data(struct picture *p)
+{
+	struct metadata data;
+	if (get_metadata(p->filename, &data) == MEDIATYPE_IO_ERROR)
+		return;
+	p->longitude = data.longitude;
+	p->latitude = data.latitude;
+}

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -98,12 +98,3 @@ extern "C" timestamp_t picture_get_timestamp(const char *filename)
 	get_metadata(filename, &data);
 	return data.timestamp;
 }
-
-extern "C" void picture_load_exif_data(struct picture *p)
-{
-	struct metadata data;
-	if (get_metadata(p->filename, &data) == MEDIATYPE_IO_ERROR)
-		return;
-	p->longitude = data.longitude;
-	p->latitude = data.latitude;
-}

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -22,7 +22,6 @@ extern "C" {
 
 enum mediatype_t get_metadata(const char *filename, struct metadata *data);
 timestamp_t picture_get_timestamp(const char *filename);
-void picture_load_exif_data(struct picture *p);
 
 #ifdef __cplusplus
 }

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -1,0 +1,31 @@
+#ifndef METADATA_H
+#define METADATA_H
+
+#include "units.h"
+
+struct metadata {
+	timestamp_t	timestamp;
+	degrees_t	latitude;
+	degrees_t	longitude;
+};
+
+enum mediatype_t {
+	MEDIATYPE_IO_ERROR,	// Couldn't read file
+	MEDIATYPE_UNKNOWN,	// Couldn't identify file
+	MEDIATYPE_PICTURE,
+	MEDIATYPE_VIDEO,
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum mediatype_t get_metadata(const char *filename, struct metadata *data);
+timestamp_t picture_get_timestamp(const char *filename);
+void picture_load_exif_data(struct picture *p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // METADATA_H

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -20,6 +20,7 @@
 #include "profile-widget/profilewidget2.h"
 #include "desktop-widgets/undocommands.h"
 #include "core/qthelper.h"
+#include "core/metadata.h"
 
 class MinMaxAvgWidgetPrivate {
 public:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is another step in preparation of video support. The meta-data extractor now knows about MP4s and other Quicktime-derived formats. Tested on .mov and .mp4 files generated by a Nikon and a GoPro, respectively.

The whole thing feels a bit over-engineered. For example, the `get_metadata()` function returns a rather complex enum, which differentiates between videos and pictures. Currently, this information is unused. Please have a look if this is acceptable or should be simplified.

Extraction of big-endians from file or memory is done with hacky templates. If someone has a better idea, let me know.

Example videos containing GPS data would be very welcome. Though this would mean parsing an embedded XML (which also may contain timestamp with ms resolution). Qt has an XML-parse, so hopefully no big deal.

Testing: on dive-picture import, simply remove the filter in the file requester. 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
