### PR TITLE
Replace QDateTime::toSecsSinceEpoch() by toMSecsSinceEpoch()

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -406,7 +406,7 @@ extern "C" timestamp_t picture_get_timestamp(const char *filename)
 		// If we couldn't parse EXIF data, use file creation date.
 		// TODO: QFileInfo::created is deprecated in newer Qt versions.
 		QDateTime created = QFileInfo(QString(filename)).created();
-		return created.toSecsSinceEpoch();
+		return created.toMSecsSinceEpoch() / 1000;
 	}
 	return exif.epoch();
 }


### PR DESCRIPTION
Commit c896938f7a5f1cf99a9792233ab1164cb7cd8585 introduced a
QDateTime::toSecsSinceEpoch() function call, which needs Qt >5.8.
Remove this requirement by using QDateTime::toMSecsSinceEpoch()
instead.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Commit message says it all: remove dependency on Qt 5.8. From now on, I will try to keep this in mind. Hard to say if this is a bug fix or code cleanup?
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
