### PR TITLE
Minor fixes MXE Windows build script: googlemaps and MXE comment

### DIFF
--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -108,6 +108,7 @@ export CXXFLAGS=-std=c++11
 if [[ "$1" == "debug" ]] ; then
 	RELEASE="Debug"
 	RELEASE_MAIN="Debug"
+	RELEASE_GM="debug"
 	DLL_SUFFIX="d"
 	shift
 	if [[ -f Release ]] ; then
@@ -117,6 +118,7 @@ if [[ "$1" == "debug" ]] ; then
 else
 	RELEASE="Release"
 	RELEASE_MAIN="RelWithDebInfo"
+	RELEASE_GM="release"
 	DLL_SUFFIX=""
 	if [[ -f Debug ]] ; then
 		rm -rf *
@@ -202,8 +204,8 @@ if [[ ! -d googlemaps || -f build.googlemaps ]] ; then
 	mkdir -p googlemaps
 	cd googlemaps
 	"$BASEDIR"/"$MXEDIR"/usr/i686-w64-mingw32.shared/qt5/bin/qmake PREFIX=$"$BASEDIR"/"$MXEDIR"/usr/i686-w64-mingw32.shared "$BASEDIR"/googlemaps/googlemaps.pro
-	make $JOBS
-	make install
+	make $JOBS $RELEASE_GM
+	make "$RELEASE_GM"-install
 fi
 
 ###############

--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -27,7 +27,7 @@
 #
 # now you can start the build
 #
-# make libxml2 libxslt libusb1 libzip qt5 nsis
+# make libxml2 libxslt libusb1 libzip libssh2 curl qt5 nsis
 #
 # After quite a while (depending on your machine anywhere from 15-20
 # minutes to several hours) you should have a working MXE install in


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
MXE Windows build script: Do right build flavor also for googlemaps
Do the right build flavor also for the googlemaps plugin.


MXE Windows build script: Chance MXE make call in comment
In the comment/instruction how to build MXE add "libssh2" and "curl"
to the make call. This seems to be needed in newer versions of MXE.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
