### PR TITLE
mapwidget-mobile: don't start map in London

### DIFF
--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -23,6 +23,15 @@ MapWidgetHelper::MapWidgetHelper(QObject *parent) : QObject(parent)
 	        this, SLOT(selectedLocationChanged(MapLocation *)));
 }
 
+QGeoCoordinate MapWidgetHelper::getCoordinatesForUUID(QVariant dive_site_uuid)
+{
+	const uint32_t uuid = qvariant_cast<uint32_t>(dive_site_uuid);
+	struct dive_site *ds = get_dive_site_by_uuid(uuid);
+	if (!ds || !dive_site_has_gps_location(ds))
+		return QGeoCoordinate(0.0, 0.0);
+	return QGeoCoordinate(ds->latitude.udeg * 0.000001, ds->longitude.udeg * 0.000001);
+}
+
 void MapWidgetHelper::centerOnDiveSiteUUID(QVariant dive_site_uuid)
 {
 	const uint32_t uuid = qvariant_cast<uint32_t>(dive_site_uuid);

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -22,6 +22,7 @@ public:
 	explicit MapWidgetHelper(QObject *parent = NULL);
 
 	void centerOnDiveSite(struct dive_site *);
+	Q_INVOKABLE QGeoCoordinate getCoordinatesForUUID(QVariant dive_site_uuid);
 	Q_INVOKABLE void centerOnDiveSiteUUID(QVariant dive_site_uuid);
 	Q_INVOKABLE void reloadMapLocations();
 	Q_INVOKABLE void copyToClipboardCoordinates(QGeoCoordinate coord, bool formatTraditional);

--- a/mobile-widgets/qml/MapPage.qml
+++ b/mobile-widgets/qml/MapPage.qml
@@ -12,6 +12,7 @@ Kirigami.Page {
 	topPadding: 0
 	rightPadding: 0
 	bottomPadding: 0
+	property bool firstRun: true
 
 	MapWidget {
 		id: mapWidget
@@ -40,10 +41,27 @@ Kirigami.Page {
 			console.warn("main.qml: centerOnDiveSiteUUI(): uuid is undefined!")
 			return
 		}
+		// on firstRun, hard pan/center the map to the desired location so that
+		// we don't start at an arbitrary location such as [0,0] or London.
+		if (firstRun) {
+			var coord = mapWidget.mapHelper.getCoordinatesForUUID(uuid)
+			centerOnLocationHard(coord.latitude, coord.longitude)
+			firstRun = false
+		} // continue here as centerOnDiveSiteUUID() also does marker selection.
 		mapWidget.mapHelper.centerOnDiveSiteUUID(uuid)
 	}
 
 	function centerOnLocation(lat, lon) {
+		if (firstRun) {
+			centerOnLocationHard(lat, lon)
+			firstRun = false
+			return // no need to animate via centerOnCoordinate().
+		}
 		mapWidget.map.centerOnCoordinate(QtPositioning.coordinate(lat, lon))
+	}
+
+	function centerOnLocationHard(lat, lon) {
+		mapWidget.map.zoomLevel = mapWidget.map.defaultZoomIn
+		mapWidget.map.center = QtPositioning.coordinate(lat, lon)
 	}
 }

--- a/mobile-widgets/qml/MapPage.qml
+++ b/mobile-widgets/qml/MapPage.qml
@@ -30,6 +30,10 @@ Kirigami.Page {
 			}
 			diveList.setCurrentDiveListIndex(idx, true)
 		}
+		Component.onCompleted: {
+			mapWidget.map.zoomLevel = mapWidget.map.defaultZoomOut
+			mapWidget.map.center = mapWidget.map.defaultCenter
+		}
 	}
 
 	function reloadMap() {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

- on startup move the map center / zoom to [0,0] / max-zoom-out
this way if the user opens the map without a specific dive he/she would see the whole globe instead of London.
- when a dive from the dive list is selected for the first time or when a GPS location is selected for the first time, open the map centered on that location without animation. this avoids starting an animation from an arbitrary starting location such as [0,0].

i did not proceed with adding a small zoom-in (instead of the hard-center/pan) on first run because this would require changes that would affect the desktop version too.

as is, this change does not affect the desktop version.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

- added helper functions in `qmlmapwidgethelper.cpp/.h` and `MapPage.qml`
- added a `firstRun` variable in `MapPage.qml`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #1182

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

the "bigger" release note about adding the map widget support to mobile should be enough here.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh 
