### PR TITLE
Add "Tags" column in Desktop app's dive list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Add Tags column in dive list view
 - Desktop: revert change that inadvertantly broke applying GPS
   coordinates to dives
 - Map-widget: try to match the zoom level in Google Maps

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -480,7 +480,8 @@ void DiveListView::reloadHeaderActions()
 						    i == DiveTripModel::TOTALWEIGHT ||
 						    i == DiveTripModel::SUIT ||
 						    i == DiveTripModel::CYLINDER ||
-						    i == DiveTripModel::SAC);
+						    i == DiveTripModel::SAC ||
+						    i == DiveTripModel::TAGS);
 			bool shown = s.value(settingName, showHeaderFirstRun).toBool();
 			a->setCheckable(true);
 			a->setChecked(shown);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -36,6 +36,7 @@ static QVariant dive_table_alignment(int column)
 	case DiveTripModel::SUIT:
 	case DiveTripModel::CYLINDER:
 	case DiveTripModel::GAS:
+	case DiveTripModel::TAGS:
 	case DiveTripModel::PHOTOS:
 	case DiveTripModel::COUNTRY:
 	case DiveTripModel::LOCATION:
@@ -136,6 +137,9 @@ QVariant DiveItem::data(int column, int role) const
 		case MAXCNS:
 			retVal = dive->maxcns;
 			break;
+		case TAGS:
+			retVal = displayTags();
+			break;
 		case PHOTOS:
 			retVal = countPhotos(dive);
 			break;
@@ -185,6 +189,9 @@ QVariant DiveItem::data(int column, int role) const
 				retVal = QString("%1%").arg(dive->maxcns);
 			else
 				retVal = dive->maxcns;
+			break;
+		case TAGS:
+			retVal = displayTags();
 			break;
 		case PHOTOS:
 			break;
@@ -264,6 +271,9 @@ QVariant DiveItem::data(int column, int role) const
 			break;
 		case MAXCNS:
 			retVal = tr("Max. CNS");
+			break;
+		case TAGS:
+			retVal = tr("Tags");
 			break;
 		case PHOTOS:
 			retVal = tr("Photos before/during/after dive");
@@ -409,6 +419,17 @@ QString DiveItem::displayWeightWithUnit() const
 	return weight_string(weight()) + ((get_units()->weight == units::KG) ? tr("kg") : tr("lbs"));
 }
 
+QString DiveItem::displayTags() const
+{
+	struct dive *dive = get_dive_by_uniq_id(diveId);
+	if (!dive->tag_list)
+		return QString();
+
+	char buf[1024];
+	taglist_get_tagstring(dive->tag_list, buf, 1024);
+	return QString(buf);
+}
+
 int DiveItem::weight() const
 {
 	struct dive *dive = get_dive_by_uniq_id(diveId);
@@ -498,6 +519,9 @@ QVariant DiveTripModel::headerData(int section, Qt::Orientation orientation, int
 		case MAXCNS:
 			ret = tr("Max CNS");
 			break;
+		case TAGS:
+			ret = tr("Tags");
+			break;
 		case PHOTOS:
 			ret = tr("Photos");
 			break;
@@ -551,6 +575,9 @@ QVariant DiveTripModel::headerData(int section, Qt::Orientation orientation, int
 			break;
 		case MAXCNS:
 			ret = tr("Max CNS");
+			break;
+		case TAGS:
+			ret = tr("Tags");
 			break;
 		case PHOTOS:
 			ret = tr("Photos before/during/after dive");

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -23,6 +23,7 @@ public:
 		SAC,
 		OTU,
 		MAXCNS,
+		TAGS,
 		PHOTOS,
 		COUNTRY,
 		LOCATION,
@@ -43,6 +44,7 @@ public:
 	QString displayWeightWithUnit() const;
 	QString displaySac() const;
 	QString displaySacWithUnit() const;
+	QString displayTags() const;
 	int countPhotos(dive *dive) const;
 	int weight() const;
 	QString icon_names[4];
@@ -72,6 +74,7 @@ public:
 		SAC,
 		OTU,
 		MAXCNS,
+		TAGS,
 		PHOTOS,
 		COUNTRY,
 		LOCATION,


### PR DESCRIPTION
Add DiveItem::displayTags helper method to return Tags as a QString
New Tags column is
 by default inserted before "Photos" column
 by default disabled

Signed-off-by: Jeremie Guichard <djebrest@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This change simply adds the possibility to display Dive's tags in the dive list view on Desktop app. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure if this kind of small change did need a CHANGELOG update, I did add one just in case.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
A new Tags column can be enabled in Desktop app's dive list view. The new column is by default inserted before Photos column. It is not enabled by default to keep current behavior.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
