### PR TITLE
Change Desktop app dive list headers to be all 'left aligned'

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -473,7 +473,7 @@ QVariant DiveTripModel::headerData(int section, Qt::Orientation orientation, int
 
 	switch (role) {
 	case Qt::TextAlignmentRole:
-		ret = dive_table_alignment(section);
+		ret = (QVariant)(Qt::AlignLeft | Qt::AlignVCenter);
 		break;
 	case Qt::FontRole:
 		ret = defaultModelFont();


### PR DESCRIPTION
It looked strange that dive list headers were aligned inconsistently.
Having numerical values right aligned is good, but headers should still
be aligned all the same way.

Signed-off-by: Jeremie Guichard <djebrest@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix inconsistency in dive list headers alignment. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Return Qt::AlignLeft + Qt::AlignVCenter for all headers' TextAlignmentRole

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
