### PR TITLE
Change taglist_get_tagstring to support 'unlimited' tag list size

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -264,10 +264,13 @@ struct tag_entry *taglist_added(struct tag_entry *original_list, struct tag_entr
 void dump_taglist(const char *intro, struct tag_entry *tl);
 
 /*
- * Writes all divetags in tag_list to buffer, limited by the buffer's (len)gth.
- * Returns the characters written
+ * Writes all divetags form tag_list into internally allocated buffer
+ * Function returns pointer to allocated buffer
+ * Buffer contains comma separated list of tags names or null terminated string
+ *
+ * NOTE! The returned buffer must be freed once used.
  */
-int taglist_get_tagstring(struct tag_entry *tag_list, char *buffer, int len);
+char *taglist_get_tagstring(struct tag_entry *tag_list);
 
 /* cleans up a list: removes empty tags and duplicates */
 void taglist_cleanup(struct tag_entry **tag_list);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1282,6 +1282,14 @@ QString get_divepoint_gas_string(struct dive *d, const divedatapoint &p)
 	return get_gas_string(d->cylinder[idx].gasmix);
 }
 
+QString get_taglist_string(struct tag_entry *tag_list)
+{
+	char *buffer = taglist_get_tagstring(tag_list);
+	QString ret = QString::fromUtf8(buffer);
+	free(buffer);
+	return ret;
+}
+
 weight_t string_to_weight(const char *str)
 {
 	const char *end;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -30,6 +30,7 @@ bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_te
 QList<int> getDivesInTrip(dive_trip_t *trip);
 QString get_gas_string(struct gasmix gas);
 QString get_divepoint_gas_string(struct dive *d, const divedatapoint& dp);
+QString get_taglist_string(struct tag_entry *tag_list);
 void read_hashes();
 void write_hashes();
 void updateHash(struct picture *picture);

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -192,9 +192,7 @@ QString DiveObjectHelper::notes() const
 
 QString DiveObjectHelper::tags() const
 {
-	static char buffer[256];
-	taglist_get_tagstring(m_dive->tag_list, buffer, 256);
-	return QString(buffer);
+	return get_taglist_string(m_dive->tag_list);
 }
 
 QString DiveObjectHelper::gas() const

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -417,7 +417,6 @@ void MainTab::updateDiveInfo(bool clear)
 	// for the trip in the Info tab, otherwise we show the info of the
 	// selected_dive
 	struct dive *prevd;
-	char buf[1024];
 
 	process_selected_dives();
 	process_all_dives(&displayed_dive, &prevd);
@@ -570,8 +569,7 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.equipmentTab->setEnabled(true);
 			cylindersModel->updateDive();
 			weightModel->updateDive();
-			taglist_get_tagstring(displayed_dive.tag_list, buf, 1024);
-			ui.tagWidget->setText(QString(buf));
+			ui.tagWidget->setText(get_taglist_string(displayed_dive.tag_list));
 			if (current_dive) {
 				bool isManual = same_string(current_dive->dc.model, "manually added dive");
 				ui.depth->setVisible(isManual);
@@ -1347,13 +1345,10 @@ void MainTab::diffTaggedStrings(QString currentString, QString displayedString, 
 
 void MainTab::on_tagWidget_textChanged()
 {
-	char buf[1024];
-
 	if (editMode == IGNORE || acceptingEdit == true)
 		return;
 
-	taglist_get_tagstring(displayed_dive.tag_list, buf, 1024);
-	if (same_string(buf, qPrintable(ui.tagWidget->toPlainText())))
+	if (get_taglist_string(displayed_dive.tag_list) == ui.tagWidget->toPlainText())
 		return;
 
 	markChangedWidget(ui.tagWidget);
@@ -1524,9 +1519,7 @@ void MainTab::showAndTriggerEditSelective(struct dive_components what)
 	if (what.divesite)
 		ui.location->setCurrentDiveSiteUuid(displayed_dive.dive_site_uuid);
 	if (what.tags) {
-		char buf[1024];
-		taglist_get_tagstring(displayed_dive.tag_list, buf, 1024);
-		ui.tagWidget->setText(QString(buf));
+		ui.tagWidget->setText(get_taglist_string(displayed_dive.tag_list));
 	}
 	if (what.cylinders) {
 		cylindersModel->updateDive();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -422,12 +422,7 @@ QString DiveItem::displayWeightWithUnit() const
 QString DiveItem::displayTags() const
 {
 	struct dive *dive = get_dive_by_uniq_id(diveId);
-	if (!dive->tag_list)
-		return QString();
-
-	char buf[1024];
-	taglist_get_tagstring(dive->tag_list, buf, 1024);
-	return QString(buf);
+	return get_taglist_string(dive->tag_list);
 }
 
 int DiveItem::weight() const

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ TEST(TestGitStorage testgitstorage.cpp)
 TEST(TestPreferences testpreferences.cpp)
 TEST(TestPicture testpicture.cpp)
 TEST(TestMerge testmerge.cpp)
+TEST(TestTagList testtaglist.cpp)
 
 
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
@@ -102,6 +103,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestRenumber
 	TestPicture
 	TestMerge
+	TestTagList
 )
 
 # useful for debugging CMake issues

--- a/tests/testtaglist.cpp
+++ b/tests/testtaglist.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testtaglist.h"
+#include "core/dive.h"
+
+void TestTagList::initTestCase()
+{
+	taglist_init_global();
+}
+
+void TestTagList::cleanupTestCase()
+{
+	taglist_free(g_tag_list);
+	g_tag_list = NULL;
+}
+
+void TestTagList::testGetTagstringNoTags()
+{
+	struct tag_entry *tag_list = NULL;
+	char *tagstring = taglist_get_tagstring(tag_list);
+	QVERIFY(tagstring != NULL);
+	QCOMPARE(*tagstring, '\0');
+}
+
+void TestTagList::testGetTagstringSingleTag()
+{
+	struct tag_entry *tag_list = NULL;
+	taglist_add_tag(&tag_list, "A new tag");
+	char *tagstring = taglist_get_tagstring(tag_list);
+	QVERIFY(tagstring != NULL);
+	QCOMPARE(QString::fromUtf8(tagstring), QString::fromUtf8("A new tag"));
+	free(tagstring);
+}
+
+void TestTagList::testGetTagstringMultipleTags()
+{
+	struct tag_entry *tag_list = NULL;
+	taglist_add_tag(&tag_list, "A new tag");
+	taglist_add_tag(&tag_list, "A new tag 1");
+	taglist_add_tag(&tag_list, "A new tag 2");
+	taglist_add_tag(&tag_list, "A new tag 3");
+	taglist_add_tag(&tag_list, "A new tag 4");
+	taglist_add_tag(&tag_list, "A new tag 5");
+	char *tagstring = taglist_get_tagstring(tag_list);
+	QVERIFY(tagstring != NULL);
+	QCOMPARE(QString::fromUtf8(tagstring),
+		 QString::fromUtf8(
+			 "A new tag, "
+			 "A new tag 1, "
+			 "A new tag 2, "
+			 "A new tag 3, "
+			 "A new tag 4, "
+			 "A new tag 5"));
+	free(tagstring);
+}
+
+void TestTagList::testGetTagstringWithAnEmptyTag()
+{
+	struct tag_entry *tag_list = NULL;
+	taglist_add_tag(&tag_list, "A new tag");
+	taglist_add_tag(&tag_list, "A new tag 1");
+	taglist_add_tag(&tag_list, "");
+	char *tagstring = taglist_get_tagstring(tag_list);
+	QVERIFY(tagstring != NULL);
+	QCOMPARE(QString::fromUtf8(tagstring),
+		 QString::fromUtf8(
+			 "A new tag, "
+			 "A new tag 1"));
+	free(tagstring);
+}
+
+void TestTagList::testGetTagstringEmptyTagOnly()
+{
+	struct tag_entry *tag_list = NULL;
+	taglist_add_tag(&tag_list, "");
+	char *tagstring = taglist_get_tagstring(tag_list);
+	QVERIFY(tagstring != NULL);
+	QCOMPARE(QString::fromUtf8(tagstring),
+		 QString::fromUtf8(""));
+	free(tagstring);
+}
+
+QTEST_GUILESS_MAIN(TestTagList)

--- a/tests/testtaglist.h
+++ b/tests/testtaglist.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTTAGLIST_H
+#define TESTTAGLIST_H
+
+#include <QtTest>
+
+class TestTagList : public QObject {
+	Q_OBJECT
+private slots:
+	void initTestCase();
+	void cleanupTestCase();
+
+	void testGetTagstringNoTags();
+	void testGetTagstringSingleTag();
+	void testGetTagstringMultipleTags();
+	void testGetTagstringWithAnEmptyTag();
+	void testGetTagstringEmptyTagOnly();
+};
+
+#endif


### PR DESCRIPTION
Previous taglist_get_tagstring signature/implementation did not allow
handling of cases where inputted buffer could not contain all tags.
New implementation allocates buffer based on pre-computed size allowing to
insert all tags in the returned string.

Added get_taglist_string in qthelper to handle conversion to QString
Added TestTagList with tests for taglist_get_tagstring

Signed-off-by: Jeremie Guichard <djebrest@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a follow up on our discussion regarding this issue in #1184 when user would use so many tags that generated string would not fit in the 1024 buffer. I have (more or less) followed @neolit123 implementation proposal. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
I've described all changes in the commit message.

<!-- Ensure the test cases are updated if needed. -->
Since I do not like to write code without tests, I've added some too.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Note sure if this change needs a mention in the CHANGELOG.md plus I would not know what topic to head it with, is there a place where a list of topics to be used here is maintained?

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 
