### PR TITLE
Profile: On dataChanged() only update pictures that actually changed

### DIFF
--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -3,6 +3,8 @@
 #define PROFILEWIDGET2_H
 
 #include <QGraphicsView>
+#include <vector>
+#include <memory>
 
 // /* The idea of this widget is to display and edit the profile.
 //  * It has:
@@ -121,6 +123,7 @@ slots: // Necessary to call from QAction's signals.
 	void deleteCurrentDC();
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
+	void updatePictures(const QModelIndex &from, const QModelIndex &to);
 
 	/* this is called for every move on the handlers. maybe we can speed up this a bit? */
 	void recreatePlannedDive();
@@ -164,6 +167,7 @@ private: /*methods*/
 	void addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)());
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 double *thresholdSettingsMin, double *thresholdSettingsMax);
+	void clearPictures();
 private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;
@@ -217,7 +221,9 @@ private:
 	bool printMode;
 
 	QList<QGraphicsSimpleTextItem *> gases;
-	QList<DivePictureItem *> pictures;
+
+	// Use std::vector<> and std::unique_ptr<>, because QVector<QScopedPointer<...>> is unsupported.
+	std::vector<std::unique_ptr<DivePictureItem>> pictures;
 
 	//specifics for ADD and PLAN
 #ifndef SUBSURFACE_MOBILE


### PR DESCRIPTION
Only update those pictures of the DivePictureModel that actually changed.
This will be useful once pictures are loaded incrementally.

To do so, replace the pictures array by an array with stable ids. Before
this commit, not-shown pictures are left out of the pictures array, which
makes the mapping from DivePictureModel-ids to the picture array index
non-trivial.

Replace the QList<DivePictureItem *> by a std::vector<std::unique_ptr<DivePictureItem>>
to easy memory management. Sadly, owing to COW semantics, QVector is incompatible
with QScopedPointer.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Only update changed pictures in the profile plot. For discussion, see #1179.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
