### PR TITLE
[RFC] Fix "unsafe" snprintfs

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -1016,7 +1016,7 @@ extern void set_userid(const char *user_id);
 extern void set_informational_units(const char *units);
 extern void set_git_prefs(const char *prefs);
 
-extern const char *get_dive_date_c_string(timestamp_t when);
+extern char *get_dive_date_c_string(timestamp_t when);
 extern void update_setpoint_events(struct dive *dive, struct divecomputer *dc);
 #ifdef __cplusplus
 }

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -618,9 +618,9 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 	}
 
 	// Parse the divetime.
-	const char *date_string = get_dive_date_c_string(dive->when);
+	char *date_string = get_dive_date_c_string(dive->when);
 	dev_info(devdata, translate("gettextFromC", "Dive %d: %s"), import_dive_number, date_string);
-	free((void *)date_string);
+	free(date_string);
 
 	unsigned int divetime = 0;
 	rc = dc_parser_get_field(parser, DC_FIELD_DIVETIME, 0, &divetime);
@@ -802,9 +802,9 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 
 	/* If we already saw this dive, abort. */
 	if (!devdata->force_download && find_dive(&dive->dc)) {
-		const char *date_string = get_dive_date_c_string(dive->when);
+		char *date_string = get_dive_date_c_string(dive->when);
 		dev_info(devdata, translate("gettextFromC", "Already downloaded dive at %s"), date_string);
-		free((void *)date_string);
+		free(date_string);
 		goto error_exit;
 	}
 

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -574,5 +574,6 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	put_string(&buf, "</div>");
 finished:
 	mb_cstring(&buf);
+	free(dive->notes);
 	dive->notes = detach_buffer(&buf);
 }

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -137,15 +137,15 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 		dive->notes = strdup(buffer);
 		goto finished;
 	} else if (diveplan->surface_interval >= 48 * 60 *60) {
-		const char *current_date = get_current_date();
+		char *current_date = get_current_date();
 		len += snprintf(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %s</b><br>",
 			translate("gettextFromC", "Subsurface"),
 			subsurface_canonical_version(),
 			translate("gettextFromC", "dive plan</b> created on"),
 			current_date);
-		free((void *)current_date);
+		free(current_date);
 	} else {
-		const char *current_date = get_current_date();
+		char *current_date = get_current_date();
 		len += snprintf_loc(buffer + len, sz_buffer - len, "<div><b>%s (%s) %s %d:%02d) %s %s<br>",
 			translate("gettextFromC", "Subsurface"),
 			subsurface_canonical_version(),
@@ -153,7 +153,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 			FRACTION(diveplan->surface_interval / 60, 60),
 			translate("gettextFromC", "created on"),
 			current_date);
-		free((void *)current_date);
+		free(current_date);
 	}
 
 	if (prefs.display_variations && decoMode() != RECREATIONAL)

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -19,7 +19,7 @@
 #include "format.h"
 #include "version.h"
 
-int diveplan_duration(struct diveplan *diveplan)
+static int diveplan_duration(struct diveplan *diveplan)
 {
 	struct divedatapoint *dp = diveplan->dp;
 	int duration = 0;
@@ -41,7 +41,7 @@ int diveplan_duration(struct diveplan *diveplan)
  *             5) Pointers to gas mixes in the gas change: gas-from and gas-to.
  * Returns:    The size of the output buffer that has been used after the new results have been added.
  */
-int add_icd_entry(char *icdbuffer, unsigned int maxsize, struct icd_data *icdvalues, bool printheader, int time_seconds, int ambientpressure_mbar, struct gasmix *gas_from, struct gasmix *gas_to)
+static int add_icd_entry(char *icdbuffer, unsigned int maxsize, struct icd_data *icdvalues, bool printheader, int time_seconds, int ambientpressure_mbar, struct gasmix *gas_from, struct gasmix *gas_to)
 {
 	int len = 0;
 	if (printheader) { // Create a table description and a table header if no icd data have been written yet.

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -976,13 +976,13 @@ QString get_short_dive_date_string(timestamp_t when)
 	return loc.toString(ts.toUTC(), QString(prefs.date_format_short) + " " + prefs.time_format);
 }
 
-const char *get_dive_date_c_string(timestamp_t when)
+char *get_dive_date_c_string(timestamp_t when)
 {
 	QString text = get_dive_date_string(when);
 	return copy_qstring(text);
 }
 
-extern "C" const char *get_current_date()
+extern "C" char *get_current_date()
 {
 	QDateTime ts(QDateTime::currentDateTime());;
 	QString current_date;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -79,7 +79,7 @@ char *picturedir_string();
 const char *subsurface_user_agent();
 enum deco_mode decoMode();
 int parse_seabear_header(const char *filename, char **params, int pnr);
-const char *get_current_date();
+char *get_current_date();
 double cache_value(int tissue, int timestep, enum inertgas gas);
 void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 void print_qt_versions();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the issue raised in #1155. Of four voices, two favored `membuffer` which constitutes a majority. So be it.

This is not perfectly consistent and one could certainly do some more cleanups/simplifications. But for a start this should suffice.

This is a bit hairy, so please test. Especially the ICD thing, which I don't even know how to trigger.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
