### PR TITLE
[RFC] Dive pictures: Make picture code more scalable

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3843,18 +3843,6 @@ void picture_free(struct picture *picture)
 	free(picture);
 }
 
-// When handling pictures in different threads, we need to copy them so we don't
-// run into problems when the main thread frees the picture.
-
-struct picture *clone_picture(struct picture *src)
-{
-	struct picture *dst;
-
-	dst = alloc_picture();
-	copy_pl(src, dst);
-	return dst;
-}
-
 // Return true if picture was found and deleted
 bool dive_remove_picture(struct dive *d, const char *filename)
 {

--- a/core/dive.h
+++ b/core/dive.h
@@ -429,7 +429,6 @@ struct picture {
 	for (struct picture *picture = (_divestruct).picture_list; picture; picture = picture->next)
 
 extern struct picture *alloc_picture();
-extern struct picture *clone_picture(struct picture *src);
 extern bool dive_check_picture_time(struct dive *d, int shift_time, timestamp_t timestamp);
 extern void dive_create_picture(struct dive *d, const char *filename, int shift_time, bool match_all);
 extern void dive_add_picture(struct dive *d, struct picture *newpic);

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -21,81 +21,71 @@ static QUrl cloudImageURL(const char *filename)
 	return QUrl::fromUserInput(QString("https://cloud.subsurface-divelog.org/images/").append(hash));
 }
 
-ImageDownloader::ImageDownloader(const QString &filename_in) : filename(filename_in)
+// Note: this is a global instead of a function-local variable on purpose.
+// We don't want this to be generated in a different thread context if
+// ImageDownloader::instance() is called from a worker thread.
+static ImageDownloader imageDownloader;
+ImageDownloader *ImageDownloader::instance()
 {
+	return &imageDownloader;
 }
 
-void ImageDownloader::load(bool fromHash)
+ImageDownloader::ImageDownloader()
 {
-	if (fromHash && loadFromUrl(cloudImageURL(qPrintable(filename))))
-		return;
-
-	// If loading from hash failed, try to load from filename
-	loadFromUrl(QUrl::fromUserInput(filename));
+	connect(&manager, &QNetworkAccessManager::finished, this, &ImageDownloader::saveImage);
 }
 
-bool ImageDownloader::loadFromUrl(const QUrl &url)
+void ImageDownloader::load(QString filename, bool fromHash)
 {
-	bool success = false;
-	if (url.isValid()) {
-		QEventLoop loop;
-		QNetworkAccessManager manager;
-		QNetworkRequest request(url);
-		connect(&manager, &QNetworkAccessManager::finished, this,
-			[this,&success] (QNetworkReply *reply) { saveImage(reply, success); });
-		connect(&manager, &QNetworkAccessManager::finished, &loop, &QEventLoop::quit);
-		qDebug() << "Downloading image from" << url;
-		QNetworkReply *reply = manager.get(request);
-		loop.exec();
-		delete reply;
+	QUrl url = fromHash ? cloudImageURL(qPrintable(filename)) : QUrl::fromUserInput(filename);
+
+	if (!url.isValid())
+		emit failed(filename);
+
+	QNetworkRequest request(url);
+	request.setAttribute(QNetworkRequest::User, filename);
+	request.setAttribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1), fromHash);
+	manager.get(request);
+}
+
+void ImageDownloader::saveImage(QNetworkReply *reply)
+{
+	QString filename = reply->request().attribute(QNetworkRequest::User).toString();
+
+	if (reply->error() != QNetworkReply::NoError) {
+		bool fromHash = reply->request().attribute(static_cast<QNetworkRequest::Attribute>(QNetworkRequest::User + 1)).toBool();
+		if (fromHash)
+			load(filename, false);
+		else
+			emit failed(filename);
+	} else {
+		QByteArray imageData = reply->readAll();
+		QCryptographicHash hash(QCryptographicHash::Sha1);
+		hash.addData(imageData);
+		QString path = QStandardPaths::standardLocations(QStandardPaths::CacheLocation).first();
+		QDir dir(path);
+		if (!dir.exists())
+			dir.mkpath(path);
+		QFile imageFile(path.append("/").append(hash.result().toHex()));
+		if (imageFile.open(QIODevice::WriteOnly)) {
+			qDebug() << "Write image to" << imageFile.fileName();
+			QDataStream stream(&imageFile);
+			stream.writeRawData(imageData.data(), imageData.length());
+			imageFile.waitForBytesWritten(-1);
+			imageFile.close();
+			learnHash(filename, imageFile.fileName(), hash.result());
+		}
+		emit loaded(filename);
 	}
-	return success;
-}
 
-void ImageDownloader::saveImage(QNetworkReply *reply, bool &success)
-{
-	success = false;
-	QByteArray imageData = reply->readAll();
-	QImage image;
-	image.loadFromData(imageData);
-	if (image.isNull())
-		return;
-	success = true;
-	QCryptographicHash hash(QCryptographicHash::Sha1);
-	hash.addData(imageData);
-	QString path = QStandardPaths::standardLocations(QStandardPaths::CacheLocation).first();
-	QDir dir(path);
-	if (!dir.exists())
-		dir.mkpath(path);
-	QFile imageFile(path.append("/").append(hash.result().toHex()));
-	if (imageFile.open(QIODevice::WriteOnly)) {
-		qDebug() << "Write image to" << imageFile.fileName();
-		QDataStream stream(&imageFile);
-		stream.writeRawData(imageData.data(), imageData.length());
-		imageFile.waitForBytesWritten(-1);
-		imageFile.close();
-		learnHash(filename, imageFile.fileName(), hash.result());
-	}
-	// This should be called to make the picture actually show.
-	// Problem is DivePictureModel is not in core.
-	// Nevertheless, the image shows when the dive is selected the next time.
-	// DivePictureModel::instance()->updateDivePictures();
-
+	reply->deleteLater();
 }
 
 static void loadPicture(QString filename, bool fromHash)
 {
-	static QSet<QString> queuedPictures;
-	static QMutex pictureQueueMutex;
-
-	QMutexLocker locker(&pictureQueueMutex);
-	if (queuedPictures.contains(filename))
-		return;
-	queuedPictures.insert(filename);
-	locker.unlock();
-
-	ImageDownloader download(filename);
-	download.load(fromHash);
+	// This has to be done in UI main thread, because QNetworkManager refuses
+	// to treat requests from other threads.
+	QMetaObject::invokeMethod(ImageDownloader::instance(), "load", Qt::AutoConnection, Q_ARG(QString, filename), Q_ARG(bool, fromHash));
 }
 
 // Overwrite QImage::load() so that we can perform better error reporting.
@@ -108,13 +98,15 @@ static QImage loadImage(const QString &fileName, const char *format = nullptr)
 	return res;
 }
 
-QImage getHashedImage(const QString &file)
+// Returns: thumbnail, still loading
+static std::pair<QImage,bool> getHashedImage(const QString &file)
 {
-	QImage res;
+	QImage thumb;
+	bool stillLoading = false;
 	QUrl url = QUrl::fromUserInput(localFilePath(file));
 	if (url.isLocalFile())
-		res = loadImage(url.toLocalFile());
-	if (res.isNull()) {
+		thumb = loadImage(url.toLocalFile());
+	if (thumb.isNull()) {
 		// This did not load anything. Let's try to get the image from other sources
 		// Let's try to load it locally via its hash
 		QString filenameLocal = localFilePath(qPrintable(file));
@@ -124,22 +116,24 @@ QImage getHashedImage(const QString &file)
 			// Try the cloud server
 			// TODO: This is dead code at the moment.
 			loadPicture(file, true);
+			stillLoading = true;
 		} else {
 			// Load locally from translated file name
-			res = loadImage(filenameLocal);
-			if (!res.isNull()) {
+			thumb = loadImage(filenameLocal);
+			if (!thumb.isNull()) {
 				// Make sure the hash still matches the image file
 				hashPicture(filenameLocal);
 			} else {
 				// Interpret filename as URL
 				loadPicture(filenameLocal, false);
+				stillLoading = true;
 			}
 		}
 	} else {
 		// We loaded successfully. Now, make sure hash is up to date.
 		hashPicture(file);
 	}
-	return res;
+	return { thumb, stillLoading };
 }
 
 static QImage renderIcon(const char *id, int size)
@@ -157,6 +151,8 @@ Thumbnailer::Thumbnailer() : failImage(renderIcon(":filter-close", maxThumbnailS
 	// Currently, we only process one image at a time. Stefan Fuchs reported problems when
 	// calculating multiple thumbnails at once and this hopefully helps.
 	pool.setMaxThreadCount(1);
+	connect(ImageDownloader::instance(), &ImageDownloader::loaded, this, &Thumbnailer::imageDownloaded);
+	connect(ImageDownloader::instance(), &ImageDownloader::failed, this, &Thumbnailer::imageDownloadFailed);
 }
 
 Thumbnailer *Thumbnailer::instance()
@@ -217,7 +213,11 @@ void Thumbnailer::processItem(QString filename)
 	QImage thumbnail = getThumbnailFromCache(filename);
 
 	if (thumbnail.isNull()) {
-		thumbnail = getHashedImage(filename);
+		auto res = getHashedImage(filename);
+		if (res.second)
+			return;
+		thumbnail = res.first;
+
 		if (thumbnail.isNull()) {
 			thumbnail = failImage;
 		} else {
@@ -229,6 +229,21 @@ void Thumbnailer::processItem(QString filename)
 
 	QMutexLocker l(&lock);
 	emit thumbnailChanged(filename, thumbnail);
+	workingOn.remove(filename);
+}
+
+void Thumbnailer::imageDownloaded(QString filename)
+{
+	// Image was downloaded and the filename connected with a hash.
+	// Try thumbnailing again.
+	QMutexLocker l(&lock);
+	workingOn[filename] = QtConcurrent::run(&pool, [this, filename]() { processItem(filename); });
+}
+
+void Thumbnailer::imageDownloadFailed(QString filename)
+{
+	emit thumbnailChanged(filename, failImage);
+	QMutexLocker l(&lock);
 	workingOn.remove(filename);
 }
 

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -16,23 +16,17 @@ static QUrl cloudImageURL(const char *filename)
 	return QUrl::fromUserInput(QString("https://cloud.subsurface-divelog.org/images/").append(hash));
 }
 
-ImageDownloader::ImageDownloader(struct picture *pic)
+ImageDownloader::ImageDownloader(const QString &filename_in) : filename(filename_in)
 {
-	picture = pic;
-}
-
-ImageDownloader::~ImageDownloader()
-{
-	picture_free(picture);
 }
 
 void ImageDownloader::load(bool fromHash)
 {
-	if (fromHash && loadFromUrl(cloudImageURL(picture->filename)))
+	if (fromHash && loadFromUrl(cloudImageURL(qPrintable(filename))))
 		return;
 
 	// If loading from hash failed, try to load from filename
-	loadFromUrl(QUrl::fromUserInput(QString(picture->filename)));
+	loadFromUrl(QUrl::fromUserInput(filename));
 }
 
 bool ImageDownloader::loadFromUrl(const QUrl &url)
@@ -75,7 +69,7 @@ void ImageDownloader::saveImage(QNetworkReply *reply, bool &success)
 		stream.writeRawData(imageData.data(), imageData.length());
 		imageFile.waitForBytesWritten(-1);
 		imageFile.close();
-		learnHash(QString(picture->filename), imageFile.fileName(), hash.result());
+		learnHash(filename, imageFile.fileName(), hash.result());
 	}
 	// This should be called to make the picture actually show.
 	// Problem is DivePictureModel is not in core.
@@ -84,22 +78,18 @@ void ImageDownloader::saveImage(QNetworkReply *reply, bool &success)
 
 }
 
-static void loadPicture(struct picture *picture, bool fromHash)
+static void loadPicture(QString filename, bool fromHash)
 {
 	static QSet<QString> queuedPictures;
 	static QMutex pictureQueueMutex;
 
-	if (!picture)
-		return;
 	QMutexLocker locker(&pictureQueueMutex);
-	if (queuedPictures.contains(QString(picture->filename))) {
-		picture_free(picture);
+	if (queuedPictures.contains(filename))
 		return;
-	}
-	queuedPictures.insert(QString(picture->filename));
+	queuedPictures.insert(filename);
 	locker.unlock();
 
-	ImageDownloader download(picture);
+	ImageDownloader download(filename);
 	download.load(fromHash);
 }
 
@@ -113,38 +103,36 @@ static QImage loadImage(const QString &fileName, const char *format = nullptr)
 	return res;
 }
 
-QImage getHashedImage(struct picture *picture)
+QImage getHashedImage(const QString &file)
 {
 	QImage res;
-	QUrl url = QUrl::fromUserInput(localFilePath(QString(picture->filename)));
-	if(url.isLocalFile())
+	QUrl url = QUrl::fromUserInput(localFilePath(file));
+	if (url.isLocalFile())
 		res = loadImage(url.toLocalFile());
 	if (res.isNull()) {
 		// This did not load anything. Let's try to get the image from other sources
 		// Let's try to load it locally via its hash
-		QString filename = localFilePath(picture->filename);
-		qDebug() << QStringLiteral("Translated filename: %1 -> %2").arg(picture->filename, filename);
-		if (filename.isNull()) {
+		QString filenameLocal = localFilePath(qPrintable(file));
+		qDebug() << QStringLiteral("Translated filename: %1 -> %2").arg(file, filenameLocal);
+		if (filenameLocal.isNull()) {
 			// That didn't produce a local filename.
 			// Try the cloud server
 			// TODO: This is dead code at the moment.
-			QtConcurrent::run(loadPicture, clone_picture(picture), true);
+			QtConcurrent::run(loadPicture, file, true);
 		} else {
 			// Load locally from translated file name
-			res = loadImage(filename);
+			res = loadImage(filenameLocal);
 			if (!res.isNull()) {
 				// Make sure the hash still matches the image file
-				qDebug() << "Loaded picture from translated filename" << filename;
-				QtConcurrent::run(hashPicture, clone_picture(picture));
+				QtConcurrent::run(hashPicture, filenameLocal);
 			} else {
 				// Interpret filename as URL
-				qInfo() << "Failed loading picture from translated filename" << filename;
-				QtConcurrent::run(loadPicture, clone_picture(picture), false);
+				QtConcurrent::run(loadPicture, filenameLocal, false);
 			}
 		}
 	} else {
 		// We loaded successfully. Now, make sure hash is up to date.
-		QtConcurrent::run(hashPicture, clone_picture(picture));
+		QtConcurrent::run(hashPicture, file);
 	}
 	return res;
 }

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -10,6 +10,8 @@
 #include <QString>
 #include <QImageReader>
 #include <QDataStream>
+#include <QSvgRenderer>
+#include <QPainter>
 
 #include <QtConcurrent>
 
@@ -140,8 +142,17 @@ QImage getHashedImage(const QString &file)
 	return res;
 }
 
-Thumbnailer::Thumbnailer() : failImage(QImage(":filter-close").scaled(maxThumbnailSize(), maxThumbnailSize(), Qt::KeepAspectRatio)), // TODO: Don't misuse filter close icon
-			     dummyImage(QImage(":photo-icon").scaled(maxThumbnailSize(), maxThumbnailSize(), Qt::KeepAspectRatio)) // TODO: Don't misuse photo-icon
+static QImage renderIcon(const char *id, int size)
+{
+	QImage res(size, size, QImage::Format_ARGB32);
+	QSvgRenderer svg{QString(id)};
+	QPainter painter(&res);
+	svg.render(&painter);
+	return res;
+}
+
+Thumbnailer::Thumbnailer() : failImage(renderIcon(":filter-close", maxThumbnailSize())), // TODO: Don't misuse filter close icon
+			     dummyImage(renderIcon(":camera-icon", maxThumbnailSize()))
 {
 	// Currently, we only process one image at a time. Stefan Fuchs reported problems when
 	// calculating multiple thumbnails at once and this hopefully helps.

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -19,10 +19,6 @@ private:
 	struct picture *picture;
 };
 
-class SHashedImage : public QImage {
-	bool load(const QString &fileName, const char *format=nullptr);
-public:
-	SHashedImage(struct picture *picture);
-};
+QImage getHashedImage(struct picture *picture);
 
 #endif // IMAGEDOWNLOADER_H

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -10,13 +10,17 @@
 class ImageDownloader : public QObject {
 	Q_OBJECT
 public:
-	ImageDownloader(const QString &filename);
-	void load(bool fromHash);
-
+	static ImageDownloader *instance();
+	ImageDownloader();
+public slots:
+	void load(QString filename, bool fromHash);
+signals:
+	void loaded(QString filename);
+	void failed(QString filename);
 private:
-	bool loadFromUrl(const QUrl &);	// return true on success
-	void saveImage(QNetworkReply *reply, bool &success);
-	QString filename;
+	QNetworkAccessManager manager;
+	void loadFromUrl(const QString &filename, const QUrl &);
+	void saveImage(QNetworkReply *reply);
 };
 
 class PictureEntry;
@@ -35,6 +39,9 @@ public:
 	static int maxThumbnailSize();
 	static int defaultThumbnailSize();
 	static int thumbnailSize(double zoomLevel);
+public slots:
+	void imageDownloaded(QString filename);
+	void imageDownloadFailed(QString filename);
 signals:
 	void thumbnailChanged(QString filename, QImage thumbnail);
 private:
@@ -48,7 +55,5 @@ private:
 
 	QMap<QString,QFuture<void>> workingOn;
 };
-
-QImage getHashedImage(const QString &filename);
 
 #endif // IMAGEDOWNLOADER_H

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -5,6 +5,7 @@
 #include <QImage>
 #include <QFuture>
 #include <QNetworkReply>
+#include <QThreadPool>
 
 class ImageDownloader : public QObject {
 	Q_OBJECT
@@ -16,6 +17,31 @@ private:
 	bool loadFromUrl(const QUrl &);	// return true on success
 	void saveImage(QNetworkReply *reply, bool &success);
 	QString filename;
+};
+
+class PictureEntry;
+class Thumbnailer : public QObject {
+	Q_OBJECT
+public:
+	static Thumbnailer *instance();
+
+	// Schedule a thumbnail for fetching or calculation.
+	// Returns a placehlder thumbnail. The actual thumbnail will be sent
+	// via a signal later.
+	QImage fetchThumbnail(PictureEntry &entry, int size);
+
+	// If we change dive, clear all unfinished thumbnail creations
+	void clearWorkQueue();
+signals:
+	void thumbnailChanged(QString filename, QImage thumbnail);
+private:
+	Thumbnailer();
+	void processItem(QString filename, int size);
+
+	mutable QMutex lock;
+	QThreadPool pool;
+
+	QMap<QString,QFuture<void>> workingOn;
 };
 
 QImage getHashedImage(const QString &filename);

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -9,16 +9,15 @@
 class ImageDownloader : public QObject {
 	Q_OBJECT
 public:
-	ImageDownloader(struct picture *picture);
-	~ImageDownloader();
+	ImageDownloader(const QString &filename);
 	void load(bool fromHash);
 
 private:
 	bool loadFromUrl(const QUrl &);	// return true on success
 	void saveImage(QNetworkReply *reply, bool &success);
-	struct picture *picture;
+	QString filename;
 };
 
-QImage getHashedImage(struct picture *picture);
+QImage getHashedImage(const QString &filename);
 
 #endif // IMAGEDOWNLOADER_H

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -28,18 +28,23 @@ public:
 	// Schedule a thumbnail for fetching or calculation.
 	// Returns a placehlder thumbnail. The actual thumbnail will be sent
 	// via a signal later.
-	QImage fetchThumbnail(PictureEntry &entry, int size);
+	QImage fetchThumbnail(PictureEntry &entry);
 
 	// If we change dive, clear all unfinished thumbnail creations
 	void clearWorkQueue();
+	static int maxThumbnailSize();
+	static int defaultThumbnailSize();
+	static int thumbnailSize(double zoomLevel);
 signals:
 	void thumbnailChanged(QString filename, QImage thumbnail);
 private:
 	Thumbnailer();
-	void processItem(QString filename, int size);
+	void processItem(QString filename);
 
 	mutable QMutex lock;
 	QThreadPool pool;
+	QImage failImage;		// Shown when image-fetching fails
+	QImage dummyImage;		// Shown before thumbnail is fetched
 
 	QMap<QString,QFuture<void>> workingOn;
 };

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1240,23 +1240,20 @@ QString localFilePath(const QString &originalFilename)
 		return originalFilename;
 }
 
-// This needs to operate on a copy of picture as it frees it after finishing!
-void hashPicture(struct picture *picture)
+// This works on a copy of the string, because it runs in asynchronous context
+void hashPicture(QString filename)
 {
-	if (!picture)
-		return;
-	QByteArray oldHash = getHash(QString(picture->filename));
-	QByteArray hash = hashFile(localFilePath(picture->filename));
+	QByteArray oldHash = getHash(filename);
+	QByteArray hash = hashFile(localFilePath(filename));
 	if (!hash.isNull() && hash != oldHash)
 		mark_divelist_changed(true);
-	picture_free(picture);
 }
 
 extern "C" void cache_picture(struct picture *picture)
 {
 	QString filename = picture->filename;
 	if (!haveHash(filename))
-		QtConcurrent::run(hashPicture, clone_picture(picture));
+		QtConcurrent::run(hashPicture, filename);
 }
 
 QStringList imageExtensionFilters() {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -11,6 +11,9 @@
 #include "gettextfromc.h"
 #include "metadata.h"
 #include <sys/time.h>
+#include "exif.h"
+#include "file.h"
+#include "imagedownloader.h"
 #include "prefs-macros.h"
 #include <QFile>
 #include <QRegExp>

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -30,6 +30,7 @@ void write_hashes();
 void updateHash(struct picture *picture);
 QByteArray hashFile(const QString &filename);
 QString hashString(const char *filename);
+QString thumbnailFileName(const QString &filename);
 void learnImages(const QDir dir, int max_recursions);
 void add_hash(const QString &filename, const QByteArray &hash);
 void hashPicture(struct picture *picture);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -33,7 +33,7 @@ QString hashString(const char *filename);
 QString thumbnailFileName(const QString &filename);
 void learnImages(const QDir dir, int max_recursions);
 void add_hash(const QString &filename, const QByteArray &hash);
-void hashPicture(struct picture *picture);
+void hashPicture(QString filename);
 extern "C" char *hashstring(const char *filename);
 QString localFilePath(const QString &originalFilename);
 void learnHash(const QString &originalName, const QString &localName, const QByteArray &hash);

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDivePhotos.h"
 #include "ui_TabDivePhotos.h"
+#include "core/imagedownloader.h"
 
 #include <qt-models/divepicturemodel.h>
 

--- a/icons/camera.svg
+++ b/icons/camera.svg
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg12285"
+   version="1.1"
+   viewBox="0 0 12.7 12.7"
+   height="48"
+   width="48">
+  <defs
+     id="defs12279">
+    <linearGradient
+       gradientTransform="matrix(0.39813267,0,0,0.24500942,-156.30132,161.8335)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="543.79797"
+       y1="541.79797"
+       id="linearGradient4784-5-7"
+       xlink:href="#linearGradient4159-5" />
+    <linearGradient
+       id="linearGradient4159-5">
+      <stop
+         id="stop4161-5"
+         style="stop-color:#1d1e1e" />
+      <stop
+         id="stop4163-7"
+         style="stop-color:#44484c"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.39813267,0,0,0.24500942,-156.30132,153.50334)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="543.79797"
+       y1="541.79797"
+       id="linearGradient4784-5"
+       xlink:href="#linearGradient4159-5" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="23.000019"
+       y1="41.000019"
+       id="linearGradient4861"
+       xlink:href="#linearGradient4199"
+       gradientTransform="matrix(0.24500478,0,0,0.24500478,-1.4757969,282.81888)" />
+    <linearGradient
+       id="linearGradient4199">
+      <stop
+         id="stop4201"
+         style="stop-color:#2f3943" />
+      <stop
+         id="stop4203"
+         style="stop-color:#4d5662"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.14700275,0,0,0.14700275,-55.411801,214.254)"
+       gradientUnits="userSpaceOnUse"
+       x2="415.57144"
+       x1="386.061"
+       y2="527.79797"
+       y1="498.28754"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4356-7-7" />
+    <linearGradient
+       id="linearGradient5002">
+      <stop
+         id="stop5004"
+         style="stop-color:#2e5d89" />
+      <stop
+         id="stop5006"
+         style="stop-color:#1b92f4"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.19600339,0,0,0.19600339,-75.432066,188.78356)"
+       gradientUnits="userSpaceOnUse"
+       x2="415.57144"
+       x1="397.47784"
+       y2="527.79797"
+       y1="509.70438"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4356-76" />
+    <linearGradient
+       gradientTransform="matrix(0.24500478,0,0,0.24500478,-95.452627,163.31274)"
+       x2="415.57144"
+       gradientUnits="userSpaceOnUse"
+       x1="402.40549"
+       y2="527.79797"
+       y1="514.63202"
+       xlink:href="#linearGradient5002"
+       id="linearGradient4327-2" />
+    <linearGradient
+       gradientTransform="matrix(0.19250391,0,0,0.19250391,-74.002274,190.60256)"
+       x2="419.77139"
+       gradientUnits="userSpaceOnUse"
+       x1="398.30478"
+       y2="530.99805"
+       y1="509.53143"
+       xlink:href="#linearGradient4191"
+       id="linearGradient4510-8-2" />
+    <linearGradient
+       id="linearGradient4191">
+      <stop
+         id="stop4193"
+         style="stop-color:#18222a" />
+      <stop
+         id="stop4195"
+         style="stop-color:#566069"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.24500478,0,0,-0.24500478,104.75128,418.01871)"
+       x2="418.57147"
+       gradientUnits="userSpaceOnUse"
+       x1="398.5715"
+       y2="528.79797"
+       y1="508.798"
+       xlink:href="#linearGradient4199"
+       id="linearGradient4510-5" />
+    <linearGradient
+       gradientTransform="matrix(0.24500478,0,0,0.24500478,-95.452627,163.31274)"
+       x2="398.57144"
+       gradientUnits="userSpaceOnUse"
+       x1="421.57144"
+       y2="507.798"
+       y1="530.79797"
+       xlink:href="#linearGradient4722"
+       id="linearGradient4609-6" />
+    <linearGradient
+       id="linearGradient4722">
+      <stop
+         id="stop4724"
+         style="stop-color:#a1adb3" />
+      <stop
+         id="stop4726"
+         style="stop-color:#bfc7cb"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.17324454,-0.17324454,0.17324454,0.17324454,-156.18561,271.39634)"
+       x2="0"
+       gradientUnits="userSpaceOnUse"
+       y2="541.01117"
+       y1="519.79797"
+       xlink:href="#linearGradient4770-8"
+       id="linearGradient4735-2" />
+    <linearGradient
+       id="linearGradient4770-8">
+      <stop
+         id="stop4772-3" />
+      <stop
+         id="stop4774-6"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.36750715,0,0,0.36750715,-138.39847,93.137876)"
+       x2="0"
+       gradientUnits="userSpaceOnUse"
+       y2="528.79797"
+       y1="530.79797"
+       xlink:href="#linearGradient4347"
+       id="linearGradient4749" />
+    <linearGradient
+       id="linearGradient4347">
+      <stop
+         id="stop4349"
+         style="stop-color:#f33777" />
+      <stop
+         id="stop4351"
+         style="stop-color:#fd2d65"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.26542152,0,0,0.32723158,-102.07929,120.5647)"
+       x2="0"
+       gradientUnits="userSpaceOnUse"
+       y2="501.69922"
+       y1="531.79797"
+       xlink:href="#linearGradient4303"
+       id="linearGradient4617" />
+    <linearGradient
+       id="linearGradient4303">
+      <stop
+         id="stop4305"
+         style="stop-color:#c6cdd1" />
+      <stop
+         id="stop4307"
+         style="stop-color:#e0e5e7"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.24500478,0,0,0.24500478,-93.737593,162.81601)"
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="499.798"
+       y1="504.798"
+       id="linearGradient4208"
+       xlink:href="#linearGradient4159-5" />
+  </defs>
+  <metadata
+     id="metadata12282">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-284.3)"
+     id="layer1">
+    <rect
+       id="rect4200"
+       style="fill:url(#linearGradient4208);stroke-width:0.26458332"
+       height="0.73501676"
+       y="285.75891"
+       x="10.284432"
+       width="1.4700249" />
+    <rect
+       id="rect4288"
+       style="fill:url(#linearGradient4617);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       height="7.8535523"
+       rx="0"
+       y="286.73227"
+       x="-0.0057678986"
+       width="12.740248" />
+    <path
+       d="m 10.651934,287.47492 a 0.36750715,0.36750715 0 0 0 -0.367507,0.36751 0.36750715,0.36750715 0 0 0 0.367507,0.3675 0.36750715,0.36750715 0 0 0 0.367508,-0.3675 0.36750715,0.36750715 0 0 0 -0.367508,-0.36751 z"
+       id="path4715"
+       style="fill:url(#linearGradient4749);stroke-width:0.02645834;stroke-linecap:square" />
+    <path
+       d="m 7.4214142,287.89363 -5.5441886,5.54419 0.1679607,0.16797 h 7.9942377 v -2.60413 z"
+       id="rect4727-1"
+       style="opacity:0.2;fill:url(#linearGradient4735-2);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round" />
+    <circle
+       r="3.9200759"
+       id="path4286-2"
+       style="fill:url(#linearGradient4609-6);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <path
+       d="m 1.219263,290.66572 a 3.4300602,3.4300602 0 0 1 3.4300593,-3.43005 3.4300602,3.4300602 0 0 1 3.4300595,3.43005 3.4300602,3.4300602 0 0 1 -3.4300595,3.43007 3.4300602,3.4300602 0 0 1 -3.4300593,-3.43007 z"
+       id="path4286-9-6"
+       style="fill:url(#linearGradient4510-5);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round" />
+    <circle
+       r="2.6950498"
+       id="path4286-9-4-4"
+       style="fill:url(#linearGradient4510-8-2);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <circle
+       r="2.4500451"
+       id="circle4309-9"
+       style="fill:url(#linearGradient4327-2);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <circle
+       id="circle4354-3"
+       r="1.9600316"
+       style="fill:url(#linearGradient4356-76);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <circle
+       id="circle4354-5-3"
+       r="1.4700259"
+       style="fill:url(#linearGradient4356-7-7);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <circle
+       id="circle4354-5-1-8"
+       r="0.98001617"
+       style="fill:#2c3e50;stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="290.66574"
+       cx="4.649323" />
+    <circle
+       r="0.24500474"
+       id="path4786-1"
+       style="fill:#84cbfe;stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       cy="289.93069"
+       cx="3.9143083" />
+    <ellipse
+       id="path4786-6-8"
+       style="fill:#84cbfe;stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       ry="0.36750397"
+       rx="0.3675057"
+       cy="289.4407"
+       cx="3.4242916" />
+    <path
+       d="m 11.999466,288.45398 c -0.271469,0 -0.490011,0.21854 -0.490011,0.49001 v 3.43007 c 0,0.27147 0.218542,0.49 0.490011,0.49 h 0.245004 0.490011 v -0.49 -3.43007 -0.49001 H 12.24447 Z"
+       id="rect4850"
+       style="fill:url(#linearGradient4861);stroke-width:0.26458332;stroke-linecap:round" />
+    <rect
+       id="rect4290"
+       style="fill:url(#linearGradient4784-5);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       height="0.49001199"
+       y="286.24893"
+       x="-0.0057678986"
+       width="12.740248" />
+    <rect
+       id="rect4290-6"
+       style="fill:url(#linearGradient4784-5-7);stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:round"
+       height="0.49001199"
+       y="294.57913"
+       x="-0.0057678986"
+       width="12.740248" />
+  </g>
+</svg>

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -12,7 +12,7 @@
 extern struct ev_select *ev_namelist;
 extern int evn_used;
 
-DiveEventItem::DiveEventItem(QObject *parent) : DivePixmapItem(parent),
+DiveEventItem::DiveEventItem(QGraphicsItem *parent) : DivePixmapItem(parent),
 	vAxis(NULL),
 	hAxis(NULL),
 	dataModel(NULL),

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -11,7 +11,7 @@ struct event;
 class DiveEventItem : public DivePixmapItem {
 	Q_OBJECT
 public:
-	DiveEventItem(QObject *parent = 0);
+	DiveEventItem(QGraphicsItem *parent = 0);
 	virtual ~DiveEventItem();
 	void setEvent(struct event *ev, struct gasmix *lastgasmix);
 	struct event *getEvent();

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -12,15 +12,33 @@ class DivePixmapItem : public QObject, public QGraphicsPixmapItem {
 	Q_PROPERTY(qreal x WRITE setX READ x)
 	Q_PROPERTY(qreal y WRITE setY READ y)
 public:
-	DivePixmapItem(QObject *parent = 0);
+	DivePixmapItem(QGraphicsItem *parent = 0);
+};
+
+class DiveButtonItem : public DivePixmapItem {
+	Q_OBJECT
+public:
+	DiveButtonItem(QGraphicsItem *parent = 0);
+protected:
+	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
+signals:
+	void clicked();
+};
+
+class CloseButtonItem : public DiveButtonItem {
+	Q_OBJECT
+public:
+	CloseButtonItem(QGraphicsItem *parent = 0);
+public slots:
+	void hide();
+	void show();
 };
 
 class DivePictureItem : public DivePixmapItem {
 	Q_OBJECT
 	Q_PROPERTY(qreal scale WRITE setScale READ scale)
 public:
-	DivePictureItem(QObject *parent = 0);
-	virtual ~DivePictureItem();
+	DivePictureItem(QGraphicsItem *parent = 0);
 	void setPixmap(const QPixmap& pix);
 public slots:
 	void settingsChanged();
@@ -36,25 +54,7 @@ private:
 	QString fileUrl;
 	QGraphicsRectItem *canvas;
 	QGraphicsRectItem *shadow;
-};
-
-class DiveButtonItem : public DivePixmapItem {
-	Q_OBJECT
-public:
-	DiveButtonItem(QObject *parent = 0);
-protected:
-	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
-signals:
-	void clicked();
-};
-
-class CloseButtonItem : public DiveButtonItem {
-	Q_OBJECT
-public:
-	CloseButtonItem(QObject *parent = 0);
-public slots:
-	void hide();
-	void show();
+	DiveButtonItem *button;
 };
 
 #endif // DIVEPIXMAPITEM_H

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -2060,14 +2060,14 @@ void ProfileWidget2::dropEvent(QDropEvent *event)
 			if (QString(picture->filename) == filename) {
 				picture->offset.seconds = lrint(timeAxis->valueAt(mappedPos));
 				mark_divelist_changed(true);
+#ifndef SUBSURFACE_MOBILE
+				DivePictureModel::instance()->updateDivePictureOffset(filename, picture->offset.seconds);
+				plotPictures();
+#endif
 				break;
 			}
 		}
 		copy_dive(current_dive, &displayed_dive);
-#ifndef SUBSURFACE_MOBILE
-		DivePictureModel::instance()->updateDivePictures();
-#endif
-
 
 		if (event->source() == this) {
 			event->setDropAction(Qt::MoveAction);

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -21,6 +21,8 @@ DivePictureModel::DivePictureModel() : rowDDStart(0),
 				       zoomLevel(0.0),
 				       defaultSize(defaultIconMetrics().sz_pic)
 {
+	connect(Thumbnailer::instance(), &Thumbnailer::thumbnailChanged,
+		this, &DivePictureModel::updateThumbnail, Qt::QueuedConnection);
 }
 
 void DivePictureModel::updateDivePicturesWhenDone(QList<QFuture<void>> futures)
@@ -159,4 +161,14 @@ int DivePictureModel::rowCount(const QModelIndex &parent) const
 {
 	Q_UNUSED(parent);
 	return pictures.count();
+}
+
+void DivePictureModel::updateThumbnail(QString filename, QImage thumbnail)
+{
+	for (int i = 0; i < pictures.size(); ++i) {
+		if (pictures[i].filename != filename)
+			continue;
+		pictures[i].image = thumbnail;
+		emit dataChanged(createIndex(i, 0), createIndex(i, 1));
+	}
 }

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -65,7 +65,7 @@ static void scaleImages(PictureEntry &entry, int maxSize)
 	// Rescale in such a case to avoid resizing artifacts.
 	if (thumbnail.isNull() || (thumbnail.size().width() < maxSize && thumbnail.size().height() < maxSize)) {
 		qDebug() << "No thumbnail in cache for" << entry.filename;
-		thumbnail = getHashedImage(entry.picture).scaled(maxSize, maxSize, Qt::KeepAspectRatio);
+		thumbnail = getHashedImage(QString(entry.picture->filename));
 		addThumbnailToCache(thumbnail, entry);
 	}
 

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -65,7 +65,7 @@ static void scaleImages(PictureEntry &entry, int maxSize)
 	// Rescale in such a case to avoid resizing artifacts.
 	if (thumbnail.isNull() || (thumbnail.size().width() < maxSize && thumbnail.size().height() < maxSize)) {
 		qDebug() << "No thumbnail in cache for" << entry.filename;
-		thumbnail = SHashedImage(entry.picture).scaled(maxSize, maxSize, Qt::KeepAspectRatio);
+		thumbnail = getHashedImage(entry.picture).scaled(maxSize, maxSize, Qt::KeepAspectRatio);
 		addThumbnailToCache(thumbnail, entry);
 	}
 

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -8,8 +8,6 @@
 
 #include <QFileInfo>
 
-static const int maxZoom = 3;	// Maximum zoom: thrice of standard size
-
 DivePictureModel *DivePictureModel::instance()
 {
 	static DivePictureModel *self = new DivePictureModel();
@@ -19,7 +17,7 @@ DivePictureModel *DivePictureModel::instance()
 DivePictureModel::DivePictureModel() : rowDDStart(0),
 				       rowDDEnd(0),
 				       zoomLevel(0.0),
-				       defaultSize(defaultIconMetrics().sz_pic)
+				       defaultSize(Thumbnailer::defaultThumbnailSize())
 {
 	connect(Thumbnailer::instance(), &Thumbnailer::thumbnailChanged,
 		this, &DivePictureModel::updateThumbnail, Qt::QueuedConnection);
@@ -47,22 +45,14 @@ void DivePictureModel::setZoomLevel(int level)
 
 void DivePictureModel::updateZoom()
 {
-	// Calculate size of thumbnails. The standard size is defaultIconMetrics().sz_pic.
-	// We use exponential scaling so that the central point is the standard
-	// size and the minimum and maximum extreme points are a third respectively
-	// three times the standard size.
-	// Naturally, these three zoom levels are then represented by
-	// -1.0 (minimum), 0 (standard) and 1.0 (maximum). The actual size is
-	// calculated as standard_size*3.0^zoomLevel.
-	size = static_cast<int>(round(defaultSize * pow(maxZoom, zoomLevel)));
+	size = Thumbnailer::thumbnailSize(zoomLevel);
 }
 
 void DivePictureModel::updateThumbnails()
 {
-	int maxSize = defaultSize * maxZoom;
 	updateZoom();
 	for (PictureEntry &entry: pictures)
-		entry.image = Thumbnailer::instance()->fetchThumbnail(entry, maxSize);
+		entry.image = Thumbnailer::instance()->fetchThumbnail(entry);
 }
 
 void DivePictureModel::updateDivePictures()

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -153,12 +153,28 @@ int DivePictureModel::rowCount(const QModelIndex &parent) const
 	return pictures.count();
 }
 
+int DivePictureModel::findPictureId(const QString &filename)
+{
+	for (int i = 0; i < pictures.size(); ++i)
+		if (pictures[i].filename == filename)
+			return i;
+	return -1;
+}
+
 void DivePictureModel::updateThumbnail(QString filename, QImage thumbnail)
 {
-	for (int i = 0; i < pictures.size(); ++i) {
-		if (pictures[i].filename != filename)
-			continue;
+	int i = findPictureId(filename);
+	if (i >= 0) {
 		pictures[i].image = thumbnail;
+		emit dataChanged(createIndex(i, 0), createIndex(i, 1));
+	}
+}
+
+void DivePictureModel::updateDivePictureOffset(const QString &filename, int offsetSeconds)
+{
+	int i = findPictureId(filename);
+	if (i >= 0) {
+		pictures[i].offsetSeconds = offsetSeconds;
 		emit dataChanged(createIndex(i, 0), createIndex(i, 1));
 	}
 }

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -24,12 +24,14 @@ public:
 	void updateDivePicturesWhenDone(QList<QFuture<void>>);
 	void removePicture(const QString& fileUrl, bool last);
 	int rowDDStart, rowDDEnd;
+	void updateDivePictureOffset(const QString &filename, int offsetSeconds);
 public slots:
 	void setZoomLevel(int level);
 	void updateThumbnail(QString filename, QImage thumbnail);
 private:
 	DivePictureModel();
 	QList<PictureEntry> pictures;
+	int findPictureId(const QString &filename);	// Return -1 if not found
 	double zoomLevel;	// -1.0: minimum, 0.0: standard, 1.0: maximum
 	int size;
 	int defaultSize;

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -10,7 +10,6 @@ struct PictureEntry {
 	struct picture *picture;
 	QString filename;
 	QImage image;
-	QImage imageProfile;	// For the profile widget keep a copy of a constant sized image
 	int offsetSeconds;
 };
 
@@ -31,7 +30,10 @@ private:
 	DivePictureModel();
 	QList<PictureEntry> pictures;
 	double zoomLevel;	// -1.0: minimum, 0.0: standard, 1.0: maximum
+	int defaultSize;
+	int size;
 	void updateThumbnails();
+	void updateZoom();
 };
 
 #endif

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -31,8 +31,8 @@ private:
 	DivePictureModel();
 	QList<PictureEntry> pictures;
 	double zoomLevel;	// -1.0: minimum, 0.0: standard, 1.0: maximum
-	int defaultSize;
 	int size;
+	int defaultSize;
 	void updateThumbnails();
 	void updateZoom();
 };

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -26,6 +26,7 @@ public:
 	int rowDDStart, rowDDEnd;
 public slots:
 	void setZoomLevel(int level);
+	void updateThumbnail(QString filename, QImage thumbnail);
 private:
 	DivePictureModel();
 	QList<PictureEntry> pictures;

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -100,5 +100,6 @@
         <file alias="photo-in-out-icon">icons/inAndOutPhoto.png</file>
         <file alias="preferences-desktop-locale-icon">icons/language.png</file>
         <file alias="preferences-other-icon">icons/defaults.png</file>
+        <file alias="camera-icon">icons/camera.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
To potentially conserve memory, don't keep copies of scaled thumbnails.
Scale the thumbnails on demand.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Currently, all thumbnails are loaded into memory on startup and are saved to disk on exit. For big divelogs this can amount to a substantial memory-consumption. Moreover, at least three references of the thumbnails of the currently selected dive(s) are kept by the application:
1) In `thumbnailCache` with maximum size.
2) In `DivePictureModel`, according to current `zoomLevel` (for photo-tab).
3) In `DivePictureModel`, default size for the profile plot.

This commit attempts to make the dive picture code more scalable, by loading thumbnails on demand. Since the thumbnails are loaded from disk, displaying thumbnails now takes longer than previously. Therefore, this is now done in a background thread to avoid blocking the UI. Switching between dives with many pictures should now be "snappier".

Currently, there is only a single background thread, i.e. all thumbnailing code is serialized. This can be configured owing to the use of a `QThreadPool`.

As an added bonus of the new code, when adding an image from a remote URL, the image is shown after loading without having to switch between dives.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Store thumbnails in individual files
2) Convert old thumbnail hash to individual files
3) Load thumbnails on demand
4) Do thumbnail processing in background thread
5) Update thumbnails after download
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
