### PR TITLE
Configure ostc3: Remove obsoleted setting

### DIFF
--- a/core/configuredivecomputerthreads.cpp
+++ b/core/configuredivecomputerthreads.cpp
@@ -902,7 +902,7 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	dc_status_t rc;
 	dc_event_progress_t progress;
 	progress.current = 0;
-	progress.maximum = 57;
+	progress.maximum = 56;
 	unsigned char hardware[1];
 
 	//Read hardware type
@@ -1128,7 +1128,6 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	READ_SETTING(OSTC3_AGF_LOW, aGFLow);
 	READ_SETTING(OSTC3_CALIBRATION_GAS_O2, calibrationGas);
 	READ_SETTING(OSTC3_FLIP_SCREEN, flipScreen);
-	READ_SETTING(OSTC3_SETPOINT_FALLBACK, setPointFallback);
 	READ_SETTING(OSTC3_LEFT_BUTTON_SENSIVITY, leftButtonSensitivity);
 	READ_SETTING(OSTC3_RIGHT_BUTTON_SENSIVITY, rightButtonSensitivity);
 	READ_SETTING(OSTC3_BOTTOM_GAS_CONSUMPTION, bottomGasConsumption);
@@ -1178,7 +1177,7 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 	dc_status_t rc;
 	dc_event_progress_t progress;
 	progress.current = 0;
-	progress.maximum = 56;
+	progress.maximum = 55;
 
 	//write gas values
 	unsigned char gas1Data[4] = {
@@ -1395,7 +1394,6 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 	WRITE_SETTING(OSTC3_AGF_LOW, aGFLow);
 	WRITE_SETTING(OSTC3_CALIBRATION_GAS_O2, calibrationGas);
 	WRITE_SETTING(OSTC3_FLIP_SCREEN, flipScreen);
-	WRITE_SETTING(OSTC3_SETPOINT_FALLBACK, setPointFallback);
 	WRITE_SETTING(OSTC3_LEFT_BUTTON_SENSIVITY, leftButtonSensitivity);
 	WRITE_SETTING(OSTC3_RIGHT_BUTTON_SENSIVITY, rightButtonSensitivity);
 	WRITE_SETTING(OSTC3_BOTTOM_GAS_CONSUMPTION, bottomGasConsumption);

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -463,7 +463,6 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 	deviceDetails->aGFLow = ui.aGFLowSpinBox->value();
 	deviceDetails->calibrationGas = ui.calibrationGasSpinBox->value();
 	deviceDetails->flipScreen = ui.flipScreenCheckBox->isChecked();
-	deviceDetails->setPointFallback = ui.setPointFallbackCheckBox->isChecked();
 	deviceDetails->leftButtonSensitivity = ui.leftButtonSensitivity->value();
 	deviceDetails->rightButtonSensitivity = ui.rightButtonSensitivity->value();
 	deviceDetails->bottomGasConsumption = ui.bottomGasConsumption->value();
@@ -1000,7 +999,6 @@ void ConfigureDiveComputerDialog::reloadValuesOSTC3()
 	ui.aGFLowSpinBox->setValue(deviceDetails->aGFLow);
 	ui.calibrationGasSpinBox->setValue(deviceDetails->calibrationGas);
 	ui.flipScreenCheckBox->setChecked(deviceDetails->flipScreen);
-	ui.setPointFallbackCheckBox->setChecked(deviceDetails->setPointFallback);
 	ui.leftButtonSensitivity->setValue(deviceDetails->leftButtonSensitivity);
 	ui.rightButtonSensitivity->setValue(deviceDetails->rightButtonSensitivity);
 	ui.bottomGasConsumption->setValue(deviceDetails->bottomGasConsumption);

--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -2415,16 +2415,6 @@
               </item>
              </widget>
             </item>
-            <item row="3" column="3">
-             <widget class="QCheckBox" name="setPointFallbackCheckBox">
-              <property name="text">
-               <string>Setpoint fallback</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
             <item row="6" column="2">
              <spacer>
               <property name="orientation">


### PR DESCRIPTION
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

In firmware version 2.97 the setting 0x38, SETPOINT FALLBACK, has bin
obsoleted and we get a error when trying to write to it.

This removes this setting.