### PR TITLE
When looking for gas change events only use those

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -960,7 +960,7 @@ static inline struct gasmix *get_gasmix(struct dive *dive, struct divecomputer *
 	if (!gasmix) {
 		int cyl = explicit_first_cylinder(dive, dc);
 		gasmix = &dive->cylinder[cyl].gasmix;
-		ev = dc ? dc->events : NULL;
+		ev = dc ? get_next_event(dc->events, "gaschange") : NULL;
 	}
 	while (ev && ev->time.seconds < time) {
 		gasmix = get_gasmix_from_event(dive, ev);


### PR DESCRIPTION
This function looks for the last gas change before a
given time. We should initialize it with a gaschange
event as we might later use this event to read a
gasmix from it.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This function traverses the linked list of events to find the last gas change before a given time. To this end, it looks ahead for the next gas change event following this and keeps this event (or NULL if there is none). Once it is called with a time after this next event, it returns the gas mix from this gas change.

This patch makes sure that it is initialled with a gaschange event (or NULL), so we can at any time read a gas mix from it (otherwise, we could eventually read a wrong event and interpret it as a gas change). I am surprised this bug did not show up earlier.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->