### PR TITLE
cmake: add the GCC_OPTIMIZATION_FLAGS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(LIBGRANTLEE_FROM_PKGCONFIG "use pkg-config to retrieve grantlee" OFF)
 option(FORCE_LIBSSH "force linking with libssh to workaround libgit2 bug" ON)
 option(LIBGIT2_DYNAMIC "search for libgit2.so before libgit2.a" OFF)
 
+option(GCC_OPTIMIZATION_FLAGS "optimization flags in debug builds" -O2)
+
 #Options regarding disabling parts of subsurface.
 option(NO_DOCS "disable the docs" OFF)
 option(NO_PRINTING "disable the printing support" OFF)
@@ -105,9 +107,10 @@ endif()
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-# optimize -O2 even for debug builds
-set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O2")
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
+# by detault optimize with -O2 even for debug builds
+message (STATUS "GCC optimization flags: " ${GCC_OPTIMIZATION_FLAGS})
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${GCC_OPTIMIZATION_FLAGS}")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_OPTIMIZATION_FLAGS}")
 
 # pkgconfig for required libraries
 find_package(PkgConfig)


### PR DESCRIPTION
Instead of always adding -O2 for CMAKE_C_FLAGS_DEBUG and
CMAKE_CXX_FLAGS_DEBUG allow the user to pass a custom value
via GCC_OPTIMIZATION_FLAGS.

Passing -DGCC_OPTIMIZATION_FLAGS:STRING=-O0 would disable
all optimizations.

This can be set in ccmake

Suggested-by: Robert C. Helling <helling@atdotde.de>
Signed-off-by: Lubomir I. Ivanov <neolit123@gmail.com>
Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Allow for local configuration using cmake. I would do this rather than #1224 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->