### PR TITLE
Planner: calculate last manually entered sample on demand

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -823,6 +823,18 @@ void fixup_dc_duration(struct divecomputer *dc)
 	}
 }
 
+duration_t last_manually_entered_sample(struct divecomputer *dc)
+{
+	duration_t zero_duration = { 0 };
+	if (!dc)
+		return zero_duration;
+	for (int i = dc->samples - 1; i >= 0; i--) {
+		if (dc->sample[i].manually_entered)
+			return dc->sample[i].time;
+	}
+	return zero_duration;
+}
+
 /* Which cylinders had gas used? */
 #define SOME_GAS 5000
 static unsigned int get_cylinder_used(struct dive *dive)

--- a/core/dive.h
+++ b/core/dive.h
@@ -305,7 +305,7 @@ struct extra_data {
  */
 struct divecomputer {
 	timestamp_t when;
-	duration_t duration, surfacetime, last_manual_time;
+	duration_t duration, surfacetime;
 	depth_t maxdepth, meandepth;
 	temperature_t airtemp, watertemp;
 	pressure_t surface_pressure;
@@ -800,6 +800,7 @@ extern int legacy_format_o2pressures(struct dive *dive, struct divecomputer *dc)
 extern void sort_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);
+extern duration_t last_manually_entered_sample(struct divecomputer *dc);
 extern int dive_getUniqID(struct dive *d);
 extern unsigned int dc_airtemp(struct divecomputer *dc);
 extern unsigned int dc_watertemp(struct divecomputer *dc);

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -692,9 +692,6 @@ static void parse_dc_duration(char *line, struct membuffer *str, void *_dc)
 static void parse_dc_dctype(char *line, struct membuffer *str, void *_dc)
 { (void) str; struct divecomputer *dc = _dc; dc->divemode = get_dctype(line); }
 
-static void parse_dc_lastmanualtime(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->last_manual_time = get_duration(line); }
-
 static void parse_dc_maxdepth(char *line, struct membuffer *str, void *_dc)
 { (void) str; struct divecomputer *dc = _dc; dc->maxdepth = get_depth(line); }
 
@@ -984,7 +981,7 @@ struct keyword_action dc_action[] = {
 #undef D
 #define D(x) { #x, parse_dc_ ## x }
 	D(airtemp), D(date), D(dctype), D(deviceid), D(diveid), D(duration),
-	D(event), D(keyvalue), D(lastmanualtime), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
+	D(event), D(keyvalue), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
 	D(salinity), D(surfacepressure), D(surfacetime), D(time), D(watertemp)
 };
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -735,8 +735,6 @@ static int match_dc_data_fields(struct divecomputer *dc, const char *name, char 
 		return 1;
 	if (MATCH("divetimesec", duration, &dc->duration))
 		return 1;
-	if (MATCH("last-manual-time", duration, &dc->last_manual_time))
-		return 1;
 	if (MATCH("surfacetime", duration, &dc->surfacetime))
 		return 1;
 	if (MATCH("airtemp", temperature, &dc->airtemp))

--- a/core/planner.c
+++ b/core/planner.c
@@ -259,7 +259,7 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 	struct event *ev;
 	cylinder_t *cyl;
 	int oldpo2 = 0;
-	int lasttime = 0, last_manual_point = 0;
+	int lasttime = 0;
 	depth_t lastdepth = {.mm = 0};
 	int lastcylid;
 	enum dive_comp_type type = dive->dc.divemode;
@@ -342,7 +342,6 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 		sample[-1].setpoint.mbar = po2;
 		sample->setpoint.mbar = po2;
 		sample->time.seconds = lasttime = time;
-		if (dp->entered) last_manual_point = dp->time;
 		sample->depth = lastdepth = depth;
 		sample->manually_entered = dp->entered;
 		sample->sac.mliter = dp->entered ? prefs.bottomsac : prefs.decosac;
@@ -355,7 +354,6 @@ static void create_dive_from_plan(struct diveplan *diveplan, struct dive *dive, 
 		finish_sample(dc);
 		dp = dp->next;
 	}
-	dive->dc.last_manual_time.seconds = last_manual_point;
 
 	dc->divemode = type;
 #if DEBUG_PLAN & 32

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -395,8 +395,6 @@ static void save_events(struct membuffer *b, struct dive *dive, struct event *ev
 static void save_dc(struct membuffer *b, struct dive *dive, struct divecomputer *dc)
 {
 	show_utf8(b, "model ", dc->model, "\n");
-	if (dc->last_manual_time.seconds)
-		put_duration(b, dc->last_manual_time, "lastmanualtime ", "min\n");
 	if (dc->deviceid)
 		put_format(b, "deviceid %08x\n", dc->deviceid);
 	if (dc->diveid)

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -387,8 +387,6 @@ static void save_dc(struct membuffer *b, struct dive *dive, struct divecomputer 
 {
 	put_format(b, "  <divecomputer");
 	show_utf8(b, dc->model, " model='", "'", 1);
-	if (dc->last_manual_time.seconds)
-		put_duration(b, dc->last_manual_time, " last-manual-time='", " min'");
 	if (dc->deviceid)
 		put_format(b, " deviceid='%08x'", dc->deviceid);
 	if (dc->diveid)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -107,8 +107,9 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	int j = 0;
 	int cylinderid = 0;
 	last_sp.mbar = 0;
+	duration_t last_manual_sample = last_manually_entered_sample(dc);
 	for (int i = 0; i < plansamples - 1; i++) {
-		if (dc->last_manual_time.seconds && dc->last_manual_time.seconds > 120 && lasttime.seconds >= dc->last_manual_time.seconds)
+		if (last_manual_sample.seconds && last_manual_sample.seconds > 120 && lasttime.seconds >= last_manual_sample.seconds)
 			break;
 		while (j * plansamples <= i * dc->samples) {
 			const sample &s = dc->sample[j];
@@ -132,7 +133,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 		}
 	}
 	// make sure we get the last point right so the duration is correct
-	if (!hasMarkedSamples && !dc->last_manual_time.seconds)
+	if (!hasMarkedSamples && last_manual_sample.seconds)
 		addStop(0, d->dc.duration.seconds,cylinderid, last_sp.mbar, true);
 	recalc = oldRec;
 	emitDataChanged();


### PR DESCRIPTION
Commit 9a8bab21c9996020b16f1dd140647efe8e262a42 introduced calculation
of the time of the last manually entered sample. The problem is
that the calculation was done in create_dive_from_plan(), but
samples could also be created in fake_dc(), which resulted in an
invalid last manually entered sample. This in return led to the
issue reported in #1211.

To fix this problem, and remove the complexity of keeping track
of a cached last manually entered sample, calculate this datum on
demand. There seems to be no point in keeping track of this
redundant piece of information.

This improves the issue reported in #1211 significantly, but does
not fix it completely, because the conversion duration->samples->duration
is not a no-op.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Description is in the commit-log. Improves #1211 significantly.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson, @neolit123, @atdotde, @mturkia: Please check / test. I have no idea what the original change was intended to do and therefore cannot test if the behavior is still OK.
