### PR TITLE
Planner: Unify final ascent rates in plan() and fake_dc()

### DIFF
--- a/core/device.c
+++ b/core/device.c
@@ -146,7 +146,7 @@ void fake_dc(struct divecomputer *dc)
 	if (avg_d == 0) {
 		/* we try for a sane slope, but bow to the insanity of
 		 * the user supplied data */
-		fill_samples_no_avg(fake, max_d, max_t, MAX(2.0 * max_d / max_t, 5000.0 / 60));
+		fill_samples_no_avg(fake, max_d, max_t, MAX(2.0 * max_d / max_t, (double)prefs.ascratelast6m));
 		if (fake[3].time.seconds == 0) { // just a 4 point profile
 			dc->samples = 4;
 			fake[3].time.seconds = max_t;
@@ -165,7 +165,7 @@ void fake_dc(struct divecomputer *dc)
 	 * Ok, first we try a basic profile with a specific ascent
 	 * rate (5 meters per minute) and d_frac (1/3).
 	 */
-	if (fill_samples(fake, max_d, avg_d, max_t, 5000.0 / 60, 0.33))
+	if (fill_samples(fake, max_d, avg_d, max_t, (double)prefs.ascratelast6m, 0.33))
 		return;
 
 	/*

--- a/core/planner.c
+++ b/core/planner.c
@@ -732,7 +732,10 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 
 	/* if all we wanted was the dive just get us back to the surface */
 	if (!is_planner) {
-		transitiontime = depth / 75; /* this still needs to be made configurable */
+		/* Attn: for manually entered dives, we depend on the last segment having the
+		 * same ascent rate as in fake_dc(). If you change it here, also change it there.
+		 */
+		transitiontime = lrint(depth / (double)prefs.ascratelast6m);
 		plan_add_segment(diveplan, transitiontime, 0, current_cylinder, po2, false);
 		create_dive_from_plan(diveplan, dive, is_planner);
 		return false;


### PR DESCRIPTION
When generating fake profiles for manually entered dives, fake_dc() and
plan() used different final ascent rates of 5 m/min and 4.5 m/min,
respectively. This led to dives that were 6 seconds longer than entered
by the user and to confusion. See #554.

Therefore, use the same ascent rate taken from the preferences field
flag.ascratelast6m in both cases.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This (partially?) fixes the long-standing bug #554.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#554 #1211
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
