### PR TITLE
Planner: don't return static data in fake_dc()

### DIFF
--- a/core/device.c
+++ b/core/device.c
@@ -133,6 +133,9 @@ void fake_dc(struct divecomputer *dc)
 		return;
 	}
 
+	/* Set last manually entered time to the total dive length */
+	dc->last_manual_time = dc->duration;
+
 	/*
 	 * We want to fake the profile so that the average
 	 * depth ends up correct. However, in the absence of

--- a/core/device.h
+++ b/core/device.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-extern struct divecomputer *fake_dc(struct divecomputer *dc, bool alloc);
+extern void fake_dc(struct divecomputer *dc);
 extern void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid);
 extern void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
 extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uint32_t,

--- a/core/dive.h
+++ b/core/dive.h
@@ -792,6 +792,7 @@ extern struct dive *clone_dive(struct dive *s);
 
 extern void clear_table(struct dive_table *table);
 
+extern void alloc_samples(struct divecomputer *dc, int num);
 extern struct sample *prepare_sample(struct divecomputer *dc);
 extern void finish_sample(struct divecomputer *dc);
 extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1089,9 +1089,9 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 			// so we have depth > 0, a manually added dive and no samples
 			// let's create an actual profile so the desktop version can work it
 			// first clear out the mean depth (or the fake_dc() function tries
-			// to be too clever
+			// to be too clever)
 			d->meandepth.mm = d->dc.meandepth.mm = 0;
-			d->dc = *fake_dc(&d->dc, true);
+			fake_dc(&d->dc);
 		}
 		fixup_dive(d);
 		DiveListModel::instance()->updateDive(modelIdx, d);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -592,9 +592,8 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 	// data that we have
 	struct divecomputer *currentdc = select_dc(&displayed_dive);
 	Q_ASSERT(currentdc);
-	if (!currentdc || !currentdc->samples) {
-		currentdc = fake_dc(currentdc, false);
-	}
+	if (!currentdc || !currentdc->samples)
+		fake_dc(currentdc);
 
 	bool setpointflag = (currentdc->divemode == CCR) && prefs.pp_graphs.po2 && current_dive;
 	bool sensorflag = setpointflag && prefs.show_ccr_sensors;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -99,7 +99,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	if (dc->samples)
 		hasMarkedSamples = dc->sample[0].manually_entered;
 	else
-		dc = fake_dc(dc, true);
+		fake_dc(dc);
 
 	// if this dive has more than 100 samples (so it is probably a logged dive),
 	// average samples so we end up with a total of 100 samples.


### PR DESCRIPTION
fake_dc() used to return a statically allocated dc with statically
allocated samples. This is of course a questionable practice in
the light of multi-threading / resource ownership. Once these
problems were recognized, the parameter "alloc" was added. If set
to true, the function would still return a statically allocated
dc, but heap-allocated samples, which could then be copied in
a different dc.

All in all an ownership nightmare and a recipie for disaster.
The returned static dc was only used as a pointer to the samples
anyway. There are four callers of fake_dc() and they all have access
to a dc-structure without samples. Therefore, change the semantics
of fake_dc() to fill out the passed in dc. If the caller does
not care about the samples, it can simply reset the sample number
to zero after work.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code cleanup, which gives the `fake_dc()` functions sane semantics (no static buffers, please!): The samples of the passed-in dc structure are filled out. If the caller wants to throw them away later, it is free to do so by setting `dc->samples` to 0. I was able to hit 3 of the 4 occurrences of `fake_dc()`. The fourth is in the mobile code, which I can't compile at the moment:

```
[ 56%] Linking CXX executable subsurface-mobile
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status
CMakeFiles/subsurface-mobile.dir/build.make:86: recipe for target 'subsurface-mobile' failed
make[2]: *** [subsurface-mobile] Error 1
CMakeFiles/Makefile2:288: recipe for target 'CMakeFiles/subsurface-mobile.dir/all' failed
make[1]: *** [CMakeFiles/subsurface-mobile.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```

In a second commit, `last_manual_time` is set properly, to fix the problem described in #1211.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Don't return static-allocation data in fake_dc()
2) Correctly fill out `last_manual_time`
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
