### PR TITLE
mobile: show selected dive on details view

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -209,7 +209,7 @@ Kirigami.Page {
 
 	function showDiveIndex(index) {
 		currentIndex = index;
-		//diveDetailsListView.positionViewAtIndex(index, ListView.End);
+		diveDetailsListView.positionViewAtIndex(index, ListView.End);
 	}
 
 	function endEditMode() {


### PR DESCRIPTION
Call positionViewAtIndex in order to make the selected dive
visible.

Signed-off-by: Murillo Bernardes <mfbernardes@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

As reported by Scott Ireland on the mailing list.

> Selecting a dive from the dive list does not accurately display the details for that dive.  What I'm getting (starting from a fresh app start) is something like this:
>- Select any dive from the dive list (e.g. 391 below).   Dive details from the most recent dive (e.g. 396, not the selected one) are displayed
>- Select any other dive from the list.  The most recent dive is still displayed
>- Swipe the dive details left to move to the previous dive.  The second most recent dive is displayed (e.g. 395).
>- Select another dive from the dive list.  On iPad, the dive details scroll partially (see screenshot) but still show the same dive as before.  On iPhone, the dive details appear to move to the previous dive (e.g. 394), which still does not match the selected dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->