### PR TITLE
[RFC]+[WIP] Add regulators as new equipment items

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1739,6 +1739,10 @@ struct dive *fixup_dive(struct dive *dive)
 		weightsystem_t *ws = dive->weightsystem + i;
 		add_weightsystem_description(ws);
 	}
+	for (i = 0; i < MAX_REGULATORS; i++) {
+		regulator_t *reg = dive->regulators + i;
+		add_regulator_description(reg);
+	}
 	/* we should always have a uniq ID as that gets assigned during alloc_dive(),
 	 * but we want to make sure... */
 	if (!dive->id)

--- a/core/dive.h
+++ b/core/dive.h
@@ -114,6 +114,14 @@ typedef struct
 	const char *description; /* "integrated", "belt", "ankle" */
 } weightsystem_t;
 
+typedef struct
+{
+	const char *description; /* "Regulator set", "First stage", "Second stage" */
+	timestamp_t last_service;
+	int service_interval_time_months;
+	int service_interval_number_of_dives;
+} regulator_t;
+
 struct icd_data { // This structure provides communication between function isobaric_counterdiffusion() and the calling software.
 	int dN2;      // The change in fraction (permille) of nitrogen during the change
 	int dHe;      // The change in fraction (permille) of helium during the change
@@ -323,6 +331,7 @@ struct divecomputer {
 
 #define MAX_CYLINDERS (20)
 #define MAX_WEIGHTSYSTEMS (6)
+#define MAX_REGULATORS (6)
 #define MAX_TANK_INFO (100)
 #define W_IDX_PRIMARY 0
 #define W_IDX_SECONDARY 1
@@ -366,6 +375,7 @@ struct dive {
 	int visibility; /* 0 - 5 star rating */
 	cylinder_t cylinder[MAX_CYLINDERS];
 	weightsystem_t weightsystem[MAX_WEIGHTSYSTEMS];
+	regulator_t regulators[MAX_REGULATORS];
 	char *suit;
 	int sac, otu, cns, maxcns;
 
@@ -410,6 +420,7 @@ struct dive_components {
 	unsigned int tags : 1;
 	unsigned int cylinders : 1;
 	unsigned int weights : 1;
+	unsigned int regulators : 1;
 };
 
 /* picture list and methods related to dive picture handling */
@@ -831,6 +842,7 @@ extern int nr_weightsystems(struct dive *dive);
 
 extern void add_cylinder_description(cylinder_type_t *);
 extern void add_weightsystem_description(weightsystem_t *);
+extern void add_regulator_description(regulator_t *regulator);
 extern void remember_event(const char *eventname);
 extern void invalidate_dive_cache(struct dive *dc);
 
@@ -989,13 +1001,25 @@ struct ws_info_t {
 };
 extern struct ws_info_t ws_info[100];
 
+struct reg_info_t {
+	const char *name;
+	timestamp_t last_service;
+	int service_interval_time_months;
+	int service_interval_number_of_dives;
+};
+extern struct reg_info_t reg_info[100];
+
 extern bool cylinder_nodata(const cylinder_t *cyl);
 extern bool cylinder_none(void *_data);
 extern bool weightsystem_none(void *_data);
 extern bool no_weightsystems(weightsystem_t *ws);
+extern bool regulator_none(void *_data);
+extern bool no_regulators(regulator_t *reg);
 extern void remove_cylinder(struct dive *dive, int idx);
 extern void remove_weightsystem(struct dive *dive, int idx);
+extern void remove_regulator(struct dive *dive, int idx);
 extern void reset_cylinders(struct dive *dive, bool track_gas);
+extern int get_dives_since_service(regulator_t *reg, timestamp_t stop_date);
 #ifdef DEBUG_CYL
 extern void dump_cylinders(struct dive *dive, bool verbose);
 #endif

--- a/core/helpers.h
+++ b/core/helpers.h
@@ -27,6 +27,7 @@ QString get_pressure_unit();
 QString getSubsurfaceDataPath(QString folderToFind);
 QString getPrintingTemplatePathUser();
 QString getPrintingTemplatePathBundle();
+QString get_interval_time_string(int months);
 void copyPath(QString src, QString dst);
 extern const QString get_dc_nickname(const char *model, uint32_t deviceid);
 int gettimezoneoffset(timestamp_t when = 0);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -654,6 +654,11 @@ QString get_pressure_string(pressure_t pressure, bool showunit)
 	}
 }
 
+QString get_interval_time_string(int months)
+{
+	return QString("%1 %2").arg(months).arg(translate("gettextFromC", "months"));
+}
+
 QString getSubsurfaceDataPath(QString folderToFind)
 {
 	QString execdir;
@@ -1288,6 +1293,62 @@ QString get_taglist_string(struct tag_entry *tag_list)
 	QString ret = QString::fromUtf8(buffer);
 	free(buffer);
 	return ret;
+}
+
+QDateTime string_to_date(const char *str)
+{
+	QString input = QString(str);
+	QString year, month, day;
+	QDateTime dt;
+	if (input.contains("-")) {
+		QStringList elements = input.split("-");
+		if (elements.size() == 3) {
+			/* Expected format: yyyy-MM-dd */
+			year = elements.at(0);
+			month = elements.at(1);
+			day = elements.at(2);
+		}
+	} else if (input.contains(".")) {
+		QStringList elements = input.split(".");
+		if (elements.size() == 3) {
+			/* Expected format: dd.MM.yyyy */
+			day = elements.at(0);
+			month = elements.at(1);
+			year = elements.at(2);
+		}
+	} else if (input.contains("/")) {
+		QStringList elements = input.split("/");
+		if (elements.size() == 3) {
+			/* Expected format: MM/dd/yyyy */
+			month = elements.at(0);
+			day = elements.at(1);
+			year = elements.at(2);
+		}
+	}
+	
+	if (year.length() == 2) {
+		// Only an assumption, but a likely one
+		year.prepend("20");
+	}
+	
+	if (month.length() == 1) {
+		month.prepend("0");
+	}
+	
+	if (day.length() == 1) {
+		day.prepend(("0"));
+	}
+	
+	if (year.length() == 4 && 
+	    month.length() == 2 &&
+	    day.length() == 2) {
+		QString formatedDateString = QString("%1-%2-%3")
+		                             .arg(year)
+		                             .arg(month)
+		                             .arg(day);
+		dt = QDateTime::fromString(formatedDateString, QString("yyyy-MM-dd"));
+	}
+	return dt;
 }
 
 weight_t string_to_weight(const char *str)

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -37,6 +37,7 @@ extern "C" char *hashstring(const char *filename);
 QString localFilePath(const QString &originalFilename);
 void learnHash(const QString &originalName, const QString &localName, const QByteArray &hash);
 weight_t string_to_weight(const char *str);
+QDateTime string_to_date(const char *str);
 depth_t string_to_depth(const char *str);
 pressure_t string_to_pressure(const char *str);
 volume_t string_to_volume(const char *str, pressure_t workp);

--- a/desktop-widgets/divecomponentselection.ui
+++ b/desktop-widgets/divecomponentselection.ui
@@ -137,6 +137,13 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="regulators">
+        <property name="text">
+         <string>Regulators</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -82,6 +82,17 @@ slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 };
 
+class RegInfoDelegate : public ComboBoxDelegate {
+	Q_OBJECT
+public:
+	explicit RegInfoDelegate(QObject *parent = 0);
+	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+public
+slots:
+	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+};
+
 class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -19,6 +19,7 @@
 #include "core/dive.h"
 
 class WeightModel;
+class RegulatorModel;
 class CylindersModel;
 class ExtraDataModel;
 class DivePictureModel;
@@ -65,6 +66,7 @@ public
 slots:
 	void addCylinder_clicked();
 	void addWeight_clicked();
+	void addRegulator_clicked();
 	void updateDiveInfo(bool clear = false);
 	void updateDepthDuration();
 	void acceptChanges();
@@ -89,6 +91,7 @@ slots:
 	void on_tagWidget_textChanged();
 	void editCylinderWidget(const QModelIndex &index);
 	void editWeightWidget(const QModelIndex &index);
+	void editRegulatorWidget(const QModelIndex &index);
 	void addDiveStarted();
 	void addMessageAction(QAction *action);
 	void hideMessage();
@@ -107,6 +110,7 @@ private:
 	Ui::MainTab ui;
 	WeightModel *weightModel;
 	CylindersModel *cylindersModel;
+	RegulatorModel *regulatorModel;
 	EditMode editMode;
 	BuddyCompletionModel buddyModel;
 	DiveMasterCompletionModel diveMasterModel;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -560,6 +560,7 @@
                 </property>
                 <widget class="TableView" name="cylinders" native="true"/>
                 <widget class="TableView" name="weights" native="true"/>
+                <widget class="TableView" name="regulators" native="true"/>
                </widget>
               </item>
              </layout>

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -27,6 +27,8 @@ set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
 	diveplannermodel.cpp
 	divecomputerextradatamodel.cpp
 	ssrfsortfilterproxymodel.cpp
+	regulatormodel.cpp
+	regulatorinfomodel.cpp
 )
 
 # models exclusively used in mobile builds

--- a/qt-models/regulatorinfomodel.cpp
+++ b/qt-models/regulatorinfomodel.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qt-models/regulatorinfomodel.h"
+#include "core/dive.h"
+#include "core/metrics.h"
+#include "core/gettextfromc.h"
+
+RegInfoModel *RegInfoModel::instance()
+{
+	static RegInfoModel self;
+	return &self;
+}
+
+bool RegInfoModel::insertRows(int row, int count, const QModelIndex &parent)
+{
+	Q_UNUSED(row);
+	beginInsertRows(parent, rowCount(), rowCount());
+	rows += count;
+	endInsertRows();
+	return true;
+}
+
+bool RegInfoModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+	//WARN: check for Qt::EditRole
+	Q_UNUSED(role);
+	struct reg_info_t *info = &reg_info[index.row()];
+	switch (index.column()) {
+	case DESCRIPTION:
+		info->name = strdup(value.toByteArray().data());
+		break;
+	case SERVICE_INTERVAL_TIME:
+		info->service_interval_time_months = value.toInt();
+		break;
+	case SERVICE_INTERVAL_DIVES:
+		info->service_interval_number_of_dives = value.toInt();
+		break;
+	case LAST_SERVICE:
+		info->last_service = value.toLongLong();
+		break;
+	case NEXT_SERVICE:
+		// READ ONLY CELL
+		break;
+	}
+	emit dataChanged(index, index);
+	return true;
+}
+
+void RegInfoModel::clear()
+{
+}
+
+QVariant RegInfoModel::data(const QModelIndex &index, int role) const
+{
+	QVariant ret;
+	if (!index.isValid()) {
+		return ret;
+	}
+	struct reg_info_t *info = &reg_info[index.row()];
+
+	switch (role) {
+	case Qt::FontRole:
+		ret = defaultModelFont();
+		break;
+	case Qt::DisplayRole:
+	case Qt::EditRole:
+		switch (index.column()) {
+		case DESCRIPTION:
+			ret = info->name;
+			break;
+		case SERVICE_INTERVAL_TIME:
+			ret = info->service_interval_time_months;
+			break;
+		case SERVICE_INTERVAL_DIVES:
+			ret = info->service_interval_number_of_dives;
+			break;
+		case LAST_SERVICE:
+			ret = (qlonglong) info->last_service;
+			//if ()
+			//ret = QDateTime::fromMSecsSinceEpoch(info->last_service*1000).toString("yyyy-MM-dd");
+			break;
+		}
+		break;
+	}
+	return ret;
+}
+
+int RegInfoModel::rowCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return rows + 1;
+}
+
+const QString &RegInfoModel::biggerString() const
+{
+	return biggerEntry;
+}
+
+RegInfoModel::RegInfoModel() : rows(-1)
+{
+	setHeaderDataStrings(QStringList() << tr("Type") << tr("Service interval time")
+	<< tr("Dives btw. services") << tr("Last service") << tr("Next service"));
+	struct reg_info_t *info = reg_info;
+	for (info = reg_info; info->name; info++, rows++) {
+		QString regInfoName = gettextFromC::instance()->tr(info->name);
+		if (regInfoName.count() > biggerEntry.count())
+			biggerEntry = regInfoName;
+	}
+
+	if (rows > -1) {
+		beginInsertRows(QModelIndex(), 0, rows);
+		endInsertRows();
+	}
+}
+
+void RegInfoModel::updateInfo()
+{
+	struct reg_info_t *info = reg_info;
+	beginRemoveRows(QModelIndex(), 0, this->rows);
+	endRemoveRows();
+	rows = -1;
+	for (info = reg_info; info->name; info++, rows++) {
+		QString regInfoName = gettextFromC::instance()->tr(info->name);
+		if (regInfoName.count() > biggerEntry.count())
+			biggerEntry = regInfoName;
+	}
+
+	if (rows > -1) {
+		beginInsertRows(QModelIndex(), 0, rows);
+		endInsertRows();
+	}
+}
+
+void RegInfoModel::update()
+{
+	if (rows > -1) {
+		beginRemoveRows(QModelIndex(), 0, rows);
+		endRemoveRows();
+		rows = -1;
+	}
+	
+	struct reg_info_t *info = reg_info;
+	for (info = reg_info; info->name; info++, rows++)
+		;
+
+	if (rows > -1) {
+		beginInsertRows(QModelIndex(), 0, rows);
+		endInsertRows();
+	}
+	
+}
+

--- a/qt-models/regulatorinfomodel.h
+++ b/qt-models/regulatorinfomodel.h
@@ -1,0 +1,39 @@
+#ifndef VEINFOMODEL_H
+#define VEINFOMODEL_H
+
+
+#include "cleanertablemodel.h"
+#include <QDateTime>
+#include <QDateEdit>
+#include <QSpinBox>
+
+/* Encapsulate ws_info */
+class RegInfoModel : public CleanerTableModel {
+	Q_OBJECT
+public:
+	static RegInfoModel *instance();
+
+	enum Column {
+		DESCRIPTION,
+		SERVICE_INTERVAL_TIME,
+		SERVICE_INTERVAL_DIVES,
+		LAST_SERVICE,
+		NEXT_SERVICE
+	};
+	RegInfoModel();
+
+	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	/*reimp*/ bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex());
+	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	const QString &biggerString() const;
+	void clear();
+	void update();
+	void updateInfo();
+
+private:
+	int rows;
+	QString biggerEntry;
+};
+
+#endif // VEINFOMODEL_H

--- a/qt-models/regulatormodel.cpp
+++ b/qt-models/regulatormodel.cpp
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qt-models/regulatormodel.h"
+#include "core/dive.h"
+#include "core/gettextfromc.h"
+#include "core/metrics.h"
+#include "core/helpers.h"
+#include "qt-models/regulatorinfomodel.h"
+
+RegulatorModel::RegulatorModel(QObject *parent) : CleanerTableModel(parent),
+changed(false),
+rows(0)
+{
+setHeaderDataStrings(QStringList() << tr("") << tr("Type") << tr("Service interval time")
+		<< tr("Dives btw. services") << tr("Last service") << tr("Next service"));
+}
+
+regulator_t *RegulatorModel::regulatorAt(const QModelIndex &index)
+{
+	return &displayed_dive.regulators[index.row()];
+}
+
+void RegulatorModel::clear()
+{
+	if (rows > 0) {
+		beginRemoveRows(QModelIndex(), 0, rows - 1);
+		endRemoveRows();
+	}
+}
+
+void RegulatorModel::remove(const QModelIndex &index)
+{
+	if (index.column() != REMOVE) {
+		return;
+	}
+	beginRemoveRows(QModelIndex(), index.row(), index.row()); // yah, know, ugly.
+	rows--;
+	remove_regulator(&displayed_dive, index.row());
+	changed = true;
+	endRemoveRows();
+}
+
+QVariant RegulatorModel::data(const QModelIndex &index, int role) const
+{
+	QVariant ret;
+	if (!index.isValid() || index.row() >= MAX_REGULATORS)
+		return ret;
+
+	regulator_t *reg = &displayed_dive.regulators[index.row()];
+
+	switch (role) {
+	case Qt::FontRole:
+		ret = defaultModelFont();
+		break;
+	case Qt::TextAlignmentRole:
+		ret = Qt::AlignCenter;
+		break;
+	case Qt::DisplayRole:
+	case Qt::EditRole:
+		switch (index.column()) {
+		case TYPE:
+			ret = gettextFromC::instance()->tr(reg->description);
+			break;
+		case SERVICE_INTERVAL_TIME:
+			ret = get_interval_time_string(reg->service_interval_time_months);
+			break;
+		case SERVICE_INTERVAL_DIVES:
+			ret = QString("%1").arg(reg->service_interval_number_of_dives);
+			break;
+		case LAST_SERVICE:
+			if (reg->last_service > 0)
+			{
+				QDateTime dt = QDateTime::fromMSecsSinceEpoch(reg->last_service*1000);
+				ret = dt.toString("yyyy-MM-dd");
+			} else {
+				ret = gettextFromC::instance()->tr("YYYY-MM-DD");
+			}
+			break;
+		case NEXT_SERVICE:
+			if (reg->last_service > 0 && reg->last_service < get_times()
+			    && reg->service_interval_number_of_dives > 0
+			    && reg->service_interval_time_months > 0)
+			{
+				/* Service prediction computable */
+				int months_left = 0, days_left = 0, dives_left = 0;
+				/* QDateTime dive_date = QDateTime::currentDateTime();
+				 * Use the time of the selected dive instead of
+				 * the current time.
+				 */
+				QDateTime dive_date = QDateTime::fromMSecsSinceEpoch(get_times() * 1000);
+				QDateTime next_service_date = QDateTime::fromMSecsSinceEpoch(reg->last_service * 1000)
+				                                        .addMonths(reg->service_interval_time_months);
+				QString time_left_string;
+				QString dives_left_string;
+				
+				dives_left = reg->service_interval_number_of_dives - get_dives_since_service(reg, get_times());
+				
+				if (dives_left  == 1) {
+					dives_left_string = QString("1 %1").arg(gettextFromC::instance()->tr("dive"));
+				} else if (dives_left > 1) {
+					dives_left_string = QString("%1 %2").arg(dives_left).arg(gettextFromC::instance()->tr("dives"));
+				}
+				
+				if (dive_date.toMSecsSinceEpoch() < next_service_date.toMSecsSinceEpoch()
+				    && dives_left > 0) {
+					days_left = dive_date.daysTo(next_service_date);
+					while (dive_date.date().month() < next_service_date.date().month() &&
+					       days_left >= dive_date.date().daysInMonth()) {
+						days_left -= dive_date.date().daysInMonth();
+						dive_date = dive_date.addMonths(1);
+						months_left++;
+					}
+					if (months_left == 1)
+						time_left_string.append(QString("1 %1").arg(gettextFromC::instance()->tr("month")));
+					else if (months_left > 1)
+						time_left_string.append(QString("%1 %2").arg(months_left).arg(gettextFromC::instance()->tr("months")));
+					if (months_left < 6) {
+						if (days_left == 1)
+							time_left_string.append(QString(" 1 %1").arg(gettextFromC::instance()->tr("day")));
+						else if (days_left > 1)
+							time_left_string.append(QString(" %1 %2").arg(days_left).arg(gettextFromC::instance()->tr("days")));
+					}
+					ret = QString("%1 / %2").arg(time_left_string).arg(dives_left_string);
+				} else {
+					ret = gettextFromC::instance()->tr("Now");
+				}
+			} else {
+				ret = tr("N/A");
+			}
+			break;
+		}
+		break;
+	case Qt::DecorationRole:
+		if (index.column() == REMOVE)
+			ret = trashIcon();
+		break;
+	case Qt::SizeHintRole:
+		if (index.column() == REMOVE)
+			ret = trashIcon().size();
+		break;
+	case Qt::ToolTipRole:
+		if (index.column() == REMOVE)
+			ret = tr("Clicking here will remove this regulator.");
+		else if (index.column() == LAST_SERVICE)
+			ret = tr("Define last service before the selected dive.");
+		else if (index.column() == NEXT_SERVICE)
+			ret = tr("Service status for the time of the selected dive.");
+		break;
+	}
+	return ret;
+}
+
+// this is our magic 'pass data in' function that allows the delegate to get
+// the data here without silly unit conversions;
+// so we only implement the two columns we care about
+void RegulatorModel::passInData(const QModelIndex &index, const QVariant &value)
+{
+	regulator_t *reg = &displayed_dive.regulators[index.row()];
+	if (index.column() == SERVICE_INTERVAL_TIME) {
+		if (reg->service_interval_time_months != value.toInt()) {
+			reg->service_interval_time_months = value.toInt();
+			dataChanged(index, index);
+		}
+	} else if (index.column() == SERVICE_INTERVAL_DIVES) {
+		if (reg->service_interval_number_of_dives != value.toInt()) {
+			reg->service_interval_number_of_dives = value.toInt();
+			dataChanged(index, index);
+		}
+	} else if (index.column() == LAST_SERVICE) {
+		if (reg->last_service != value.toLongLong()) {
+			reg->last_service = value.toLongLong();
+			dataChanged(index, index);
+		}
+	}
+}
+
+
+bool RegulatorModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+	QString vString = value.toString();
+	QRegExp rx("d(\\d+)");
+	regulator_t *reg = &displayed_dive.regulators[index.row()];
+	switch (index.column()) {
+	case TYPE:
+		if (!value.isNull()) {
+			if (!reg->description || gettextFromC::instance()->tr(reg->description) != vString) {
+				// loop over translations to see if one matches
+				int i = -1;
+				while (reg_info[++i].name) {
+					if (gettextFromC::instance()->tr(reg_info[i].name) == vString) {
+						reg->description = copy_string(reg_info[i].name);
+						break;
+					}
+				}
+				if (reg_info[i].name == NULL) // didn't find a match
+					reg->description = copy_qstring(vString);
+				changed = true;
+			}
+		}
+		break;
+	case SERVICE_INTERVAL_TIME:
+		if (CHANGED()) {
+			if (vString.contains(" "))
+				vString.split(" ")[0];
+			bool ok;
+			int months = vString.toInt(&ok);
+			if (ok && months > 0 && months <= 72) {
+				reg->service_interval_time_months = months;
+				changed = true;
+				RegInfoModel *regim = RegInfoModel::instance();
+				QModelIndexList matches = regim->match(regim->index(0, 0), Qt::DisplayRole, gettextFromC::instance()->tr(reg->description));
+				if (!matches.isEmpty()) {
+					regim->setData(regim->index(matches.first().row(), RegInfoModel::SERVICE_INTERVAL_TIME), reg->service_interval_time_months);
+				}
+			}
+		}
+		break;
+	case SERVICE_INTERVAL_DIVES:
+		if (CHANGED()) {
+			if (vString.contains(" "))
+				vString.split(" ")[0];
+			bool ok;
+			int number_of_dives = vString.toInt(&ok);
+			if (ok && number_of_dives > 0) {
+				reg->service_interval_number_of_dives = number_of_dives;
+				changed = true;
+				RegInfoModel *regim = RegInfoModel::instance();
+				QModelIndexList matches = regim->match(regim->index(0, 0), Qt::DisplayRole, gettextFromC::instance()->tr(reg->description));
+				if (!matches.isEmpty()) {
+					regim->setData(regim->index(matches.first().row(), RegInfoModel::SERVICE_INTERVAL_DIVES), reg->service_interval_number_of_dives);
+				}
+			}
+		}
+		break;
+	case LAST_SERVICE:
+		if (CHANGED()) {
+			QDateTime dt = string_to_date(qPrintable(vString));
+			reg->last_service = dt.toMSecsSinceEpoch() / 1000;
+			changed = true;
+			RegInfoModel *regim = RegInfoModel::instance();
+			QModelIndexList matches = regim->match(regim->index(0, 0), Qt::DisplayRole, gettextFromC::instance()->tr(reg->description));
+			if (!matches.isEmpty()) {
+				regim->setData(regim->index(matches.first().row(), RegInfoModel::LAST_SERVICE), (qlonglong) reg->last_service);
+			}
+		}
+		break;
+	case NEXT_SERVICE:
+		//Display only variable
+		break;
+	}
+	if (changed)
+		dataChanged(index, index);
+	return true;
+}
+
+Qt::ItemFlags RegulatorModel::flags(const QModelIndex &index) const
+{
+	if (index.column() == REMOVE)
+		return Qt::ItemIsEnabled;
+	return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
+}
+
+int RegulatorModel::rowCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return rows;
+}
+
+void RegulatorModel::add()
+{
+	if (rows >= MAX_REGULATORS)
+		return;
+
+	int row = rows;
+	beginInsertRows(QModelIndex(), row, row);
+	rows++;
+	changed = true;
+	endInsertRows();
+}
+
+void RegulatorModel::updateDive()
+{
+	clear();
+	rows = 0;
+	for (int i = 0; i < MAX_REGULATORS; i++) {
+		if (!regulator_none(&displayed_dive.regulators[i])) {
+			rows = i + 1;
+		}
+	}
+	if (rows > 0) {
+		beginInsertRows(QModelIndex(), 0, rows - 1);
+		endInsertRows();
+	}
+}

--- a/qt-models/regulatormodel.h
+++ b/qt-models/regulatormodel.h
@@ -1,0 +1,41 @@
+#ifndef REGULATORMODEL_H
+#define REGULATORMODEL_H
+
+#include "cleanertablemodel.h"
+#include "core/dive.h"
+
+class RegulatorModel : public CleanerTableModel {
+	Q_OBJECT
+public:
+	enum Column {
+		REMOVE,
+		TYPE,
+		SERVICE_INTERVAL_TIME,
+		SERVICE_INTERVAL_DIVES,
+		LAST_SERVICE,
+		NEXT_SERVICE,
+		REMARKS
+	};
+	
+	explicit RegulatorModel(QObject *parent = 0);
+	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	/*reimp*/ Qt::ItemFlags flags(const QModelIndex &index) const;
+	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	
+	void passInData(const QModelIndex &index, const QVariant &value);
+	void add();
+	void clear();
+	void updateDive();
+	regulator_t *regulatorAt(const QModelIndex &index);
+	bool changed;
+	
+	public
+	slots:
+	void remove(const QModelIndex &index);
+	
+private:
+	int rows;
+};
+
+#endif // REGULATORMODEL_H


### PR DESCRIPTION
Added regulators as a new type of equipment to the log featuring basic tracking functionality.
Work in progress! The current commit lacks the following features:
- Extended import and export
- Dive planner integration
- Local and cloud save/load

Signed-off-by: Oliver Schwaneberg <oliver.schwaneberg@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Adding regulators to the dive log. I used the weightsystems as a template.
The main difference to the existing managers for cylinders and weightsystems
is that I also introduced data fields for equipment tracking.
Each regulator has a descriptor, a service interval and the date of the last
service. There is a service information automatically rendered into the table showing the
remaining time and number of dives until the regulator must be serviced again.
![regulators_01](https://user-images.githubusercontent.com/35252661/39752782-c44d72f0-52bc-11e8-98b6-4f4233d4a041.png)

I like to integrate the regulators into the dive planner as well so you can see
if the selected regulator will require service before that dive. I did not implement
it yet because I like to get some feedback on the current work before.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Added class RegulatorModel using WeightModel as template
2) Added class RegInfoModel using WeightInfoModel as template
3) Changing divecomponentselection.ui and maintab.ui to display a new table for regulators
4) Adding the most important hooks to equipment.c, qthelper.cpp, modeldelegates.cpp and maintab.cpp to implement basic functionality (save, load, import and export are not yet implemented)

### Related issues:
If we start introducting equipment tracking functionality into Subsurface, we should also
consider cylinder inspections.
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Each regulator only stores one date for the last service. Therefore, service status information is only available for dives logged after the last service.
It would probably be better to keep the full history of service dates for each regulator.
Comments are welcome!

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I did not wrote to the changelog yet because there is still a lot of work to do.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 
See the conversation "New feature recommendation for equipment tracking" in Google groups.
