### PR TITLE
iOS, set lowest deployment target to 8.0

### DIFF
--- a/packaging/ios/Subsurface-mobile/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile/Subsurface-mobile.pro
@@ -222,4 +222,5 @@ ios {
     images.files = ../../../icons/subsurface-mobile-icon.png
     QMAKE_BUNDLE_DATA += app_launch_images images
     QMAKE_INFO_PLIST = ../Info.plist
+    QMAKE_IOS_DEPLOYMENT_TARGET = 8.0
 }


### PR DESCRIPTION
Define deployment target, instead of using user default.

iOS 8.0 is the oldest supported platform

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
iOS 8.0 is currently defined as supported, but Qt Creator did not know that, so it
used the user default.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Added a variable to QtCreator that defines the min. deployment level.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->