### PR TITLE
iOS: Allow change of bundle identifier

### DIFF
--- a/packaging/ios/README
+++ b/packaging/ios/README
@@ -13,7 +13,8 @@ Follow the instruction in:
 and then continue here:
 
 1) cd <repo>/packaging/ios
-2) ./build.sh
+2) export IOS_BUNDLE_PRODUCT_IDENTIFIER="<your apple id>.subsurface-divelog.subsurface-mobile"
+3) ./build.sh
 note: this builds all dependencies and is only needed first time
       it currently build for armv7 arm64 and x86_64 (simulator)
 
@@ -41,4 +42,8 @@ build.sh script so that the Info.plist used by QtCreator (well, by Xcode under
 the hood) gets updated. Otherwise you will continue to see the old version
 number, even though the sources have been recompiled which can be very
 confusing.
+
+Do a simply version update by running:
+build.sh version
+and then rebuilding in Qt Creator
 

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -4,7 +4,7 @@
 set -x
 set -e
 
-PRODUCT_BUNDLE_IDENTIFIER="\$(PRODUCT_BUNDLE_IDENTIFIER)"
+doVersion=$1
 DEBUGRELEASE="Release"
 DRCONFIG="release"
 ARCHS="armv7 arm64 x86_64"
@@ -14,12 +14,6 @@ TARGET2="Device"
 while [[ $# -gt 0 ]] ; do
 	arg="$1"
 	case $arg in
-		-official)
-			# build an app identified as org.subsurface-divelog.subsurface-mobile
-			# without having to set this explicitly in Xcode (this way this works,
-			# e.g., in Travis)
-			PRODUCT_BUNDLE_IDENTIFIER="org.subsurface-divelog.subsurface-mobile"
-			;;
 		-debug)
 			# build for debugging
 			DEBUGRELEASE="Debug"
@@ -86,10 +80,15 @@ echo "#define GIT_VERSION_STRING \"$GITVERSION\"" > subsurface-mobile/ssrf-versi
 echo "#define CANONICAL_VERSION_STRING \"$CANONICALVERSION\"" >> subsurface-mobile/ssrf-version.h
 echo "#define MOBILE_VERSION_STRING \"$MOBILEVERSION\"" >> subsurface-mobile/ssrf-version.h
 
-# create Info.plist with the correct versions
-cat Info.plist.in | sed "s/@MOBILE_VERSION@/$MOBILEVERSION/;s/@CANONICAL_VERSION@/$CANONICALVERSION/;s/@PRODUCT_BUNDLE_IDENTIFIER@/$PRODUCT_BUNDLE_IDENTIFIER/" > Info.plist
+BUNDLE=org.subsurface-divelog.subsurface-mobile
+if [ "${IOS_BUNDLE_PRODUCT_IDENTIFIER}" != "" ] ; then
+  BUNDLE=${IOS_BUNDLE_PRODUCT_IDENTIFIER}
+fi
 
-if [ "$1" = "version" ] ; then
+# create Info.plist with the correct versions
+cat Info.plist.in | sed "s/@MOBILE_VERSION@/$MOBILEVERSION/;s/@CANONICAL_VERSION@/$CANONICALVERSION/;s/@PRODUCT_BUNDLE_IDENTIFIER@/$BUNDLE/" > Info.plist
+
+if [ "$doVersion" = "version" ] ; then
 	exit 0
 fi
 


### PR DESCRIPTION
This patch allows users to set a bundle identifier,
without opening Xcode (set as env. variable).

If the env. variable is not set (like e.g. on Travis) it defaults
to org....

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ x] Build system change
- [ x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Current master, requires you open the generated Xcode project to change the bundle identifier or
do xcconfig magic.

This solution uses the env variable IOS_BUNDLE_PRODUCT_IDENTIFIER if set, otherwise
defaults to the product org...

This correspond to the way normally used for code signing iOS projects.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->