### PR TITLE
mobile: prevent Action buttons hijack after delete

### DIFF
--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -80,6 +80,10 @@ sed -i -e "s/visible: root.action/visible: root.action \&\& \!Qt.inputMethod.vis
 sed -i -e "s/visible: root.leftAction/visible: root.leftAction \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
 sed -i -e "s/visible: root.rightAction/visible: root.rightAction \&\& \!Qt.inputMethod.visible/g" src/controls/private/ActionButton.qml
 
+# kirigami hack: passive notification hijacks area even after disabled.
+# https://bugs.kde.org/show_bug.cgi?id=394204
+sed -i -e "s/width: backgroundRect/enabled: root.enabled;    width: backgroundRect/g" src/controls/templates/private/PassiveNotification.qml
+
 # another hack. Do not include the Kirigami resources (on static build). It causes
 # double defined symbols in our setting. I would like a nicer fix for this
 # issue, but failed to find one. For example, not adding the resource in


### PR DESCRIPTION
This gets delete dive working properly.

Kirigami passive notification ends up hijacking area where the
"Add dive" or "Delete" or "Discard" buttons are shown. So after
deleting a dive the "Undo" button from the notification
keeps handling the touch events even when not visible.

Signed-off-by: Murillo Bernardes <mfbernardes@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

After deleting a dive a notification with Undo button is displayed. After 3s the notification disappear.

Any subsequent event intended to the right action button (either "Add dive" or "Delete" or "Discard", depending on the page) are actually handled by the invisible Undo button. This makes the first click to undelete the dive and all other clicks get "Trying to undo delete but can't find the deleted dive" into the log.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->