### PR TITLE
Cloud-storage: consistently don't save empty file on desktop version

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -609,13 +609,21 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 	refreshDisplay();
 }
 
+// Return whether saving to cloud is OK. If it isn't, show an error return false.
+static bool saveToCloudOK()
+{
+	if (!dive_table.nr) {
+		report_error(qPrintable(QObject::tr("Don't save an empty log to the cloud")));
+		return false;
+	}
+	return true;
+}
+
 void MainWindow::on_actionCloudstoragesave_triggered()
 {
 	QString filename;
-	if (!dive_table.nr) {
-		report_error(qPrintable(tr("Don't save an empty log to the cloud")));
+	if (!saveToCloudOK())
 		return;
-	}
 	if (getCloudURL(filename))
 		return;
 
@@ -1724,6 +1732,8 @@ int MainWindow::file_save(void)
 		return file_save_as();
 
 	is_cloud = (strncmp(existing_filename, "http", 4) == 0);
+	if (is_cloud && !saveToCloudOK())
+		return -1;
 
 	if (information()->isEditing())
 		information()->acceptChanges();


### PR DESCRIPTION
Make the behavior consistent: Don't save an empty file to the cloud,
neither on selection of "Save to cloud" nor on "Save". The latter
was not the case. It was a bit hard to trigger: Open cloud, delete
all dives, save.

Fixes #1228

Reported-by: Jan Iversen <jani@apache.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes an UI inconsistency reported in #1228. Originally I planned to move the "Divelog empty" check into the IO layer, but then it would have also hit general git repositories. And users of those should know what they are doing. I have a rather big patch set, which tries to abstract the file handling and which can bother about this kind of things. But this will have to wait (among other things eg for #1097).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
