### PR TITLE
Dive pictures: Don't enter infinity loop on invalid pictures

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -46,7 +46,7 @@ signals:
 	void thumbnailChanged(QString filename, QImage thumbnail);
 private:
 	Thumbnailer();
-	void processItem(QString filename);
+	void processItem(QString filename, bool tryDownload);
 
 	mutable QMutex lock;
 	QThreadPool pool;


### PR DESCRIPTION
The recently committed refactoring of the dive-picture code introduced
a severe bug:

If an image couldn't be loaded from disk owing to an invalid file, the
filename was interpreted as an url and loaded in the background. This
succeeded, because the file actually exists. After download, the file
would then still be invalid and the whole thing restarted, leading to
an infinity loop.

To fix this, do two things:

1) Don't even try to download local files.
2) If interpreting a downloaded file fails, don't try the downloading
business again.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This fixes a severe bug introduced in the recent dive-picture refactoring: An invalid image file lead to an infinite loop. Hopefully, this was the worst bomb that I introduced!
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Don't try to download local files.
2) If interpreting a downloaded file fails, don't try the downloading business again.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
