### PR TITLE
Dive pictures: don't attempt reading the same image twice

### DIFF
--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -115,7 +115,6 @@ static std::pair<QImage,bool> getHashedImage(const QString &file_in, bool tryDow
 		hashPicture(file);
 	} else if (tryDownload) {
 		// This did not load anything. Let's try to get the image from other sources
-		// Let's try to load it locally via its hash
 		QString filenameLocal = localFilePath(qPrintable(file));
 		qDebug() << QStringLiteral("Translated filename: %1 -> %2").arg(file, filenameLocal);
 		if (filenameLocal.isNull()) {
@@ -125,8 +124,9 @@ static std::pair<QImage,bool> getHashedImage(const QString &file_in, bool tryDow
 			loadPicture(file, true);
 			stillLoading = true;
 		} else {
-			// Load locally from translated file name
-			thumb = loadImage(filenameLocal);
+			// Load locally from translated file name if it is different
+			if (filenameLocal != file)
+				thumb = loadImage(filenameLocal);
 			if (!thumb.isNull()) {
 				// Make sure the hash still matches the image file
 				hashPicture(filenameLocal);


### PR DESCRIPTION
If loading of an image failed, we tried to see if we find a
canonical filename in the cache. There's no point in rereading
the picture if the canonical and the original filename are
the same.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a minor improvement of the picture code: Don't attempt to read an image a second time if the first time failed. This error condition is a bit hard to pull of: A picture was read once, but then corrupted. Nevertheless, this happened in my tests, so we might as well treat it gracefully.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
