### PR TITLE
Planner: Enable CCR gas use calculations with bailout

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -198,6 +198,8 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 	} else if (value) {
 		if (type == SAMPLE_EVENT_PO2 && same_string(internalEvent->name, "SP change")) {
 			name += QString(": %1bar").arg((double)value / 1000, 0, 'f', 1);
+		// this is a bad idea - we are abusing an existing event type that is supposed to
+		// warn of high or low pO₂ and are turning it into a setpoint change event
 		} else if (type == SAMPLE_EVENT_CEILING && same_string(internalEvent->name, "planned waypoint above ceiling")) {
 			const char *depth_unit;
 			double depth_value = get_depth_units(value*1000, NULL, &depth_unit);
@@ -205,11 +207,8 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 		} else {
 			name += QString(": %1").arg(value);
 		}
-	} else if (type == SAMPLE_EVENT_PO2 && same_string(internalEvent->name, "SP change")) {
-		// this is a bad idea - we are abusing an existing event type that is supposed to
-		// warn of high or low pO₂ and are turning it into a setpoint change event
-		name += ":\n" + tr("Manual switch to OC");
-	} else {
+	} 
+	else {
 		name += internalEvent->flags & SAMPLE_FLAGS_BEGIN ? tr(" begin", "Starts with space!") :
 								    internalEvent->flags & SAMPLE_FLAGS_END ? tr(" end", "Starts with space!") : "";
 	}


### PR DESCRIPTION
As the title says. Gas use during CCR dives is normally not
calculated in the planner. However, if the divemode of a segment
is NOT CCR, then the gas consumption should be calculated for all
non-CCR segments.

This change leaves the previous mechanism in place where CCR bailout is
initiated when a segments has a setpoint of zero. Eventually we will
probably standardise on only the first mechanism, but for now we leave
both mechanisms in place.

Signed-off-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 