### PR TITLE
Dive pictures: Don't plot pictures twice when changing current dive

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -531,7 +531,7 @@ void MainWindow::current_dive_changed(int divenr)
 	if (divenr >= 0) {
 		select_dive(divenr);
 	}
-	graphics()->plotDive();
+	graphics()->plotDive(nullptr, false, true);
 	information()->updateDiveInfo();
 	configureToolbar();
 	MapWidget::instance()->reload();
@@ -1095,7 +1095,7 @@ void MainWindow::on_actionAddDive_triggered()
 	graphics()->setAddState();
 	DivePlannerPointsModel::instance()->createSimpleDive();
 	configureToolbar();
-	graphics()->plotDive();
+	graphics()->plotDive(nullptr, false, true);
 	fixup_dc_duration(&displayed_dive.dc);
 	displayed_dive.duration = displayed_dive.dc.duration;
 
@@ -1314,7 +1314,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics()->plotDive();
+	graphics()->plotDive(nullptr, false, true);
 	information()->updateDiveInfo();
 }
 
@@ -1323,7 +1323,7 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics()->plotDive();
+	graphics()->plotDive(nullptr, false, true);
 	information()->updateDiveInfo();
 }
 

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -41,7 +41,7 @@ void Printer::putProfileImage(QRect profilePlaceholder, QRect viewPort, QPainter
 	int y = profilePlaceholder.y() - viewPort.y();
 	// use the placeHolder and the viewPort position to calculate the relative position of the dive profile.
 	QRect pos(x, y, profilePlaceholder.width(), profilePlaceholder.height());
-	profile->plotDive(dive, true);
+	profile->plotDive(dive, true, true);
 
 	if (!printOptions->color_selected) {
 		QImage image(pos.width(), pos.height(), QImage::Format_ARGB32);
@@ -204,7 +204,7 @@ void Printer::render(int Pages = 0)
 	prefs.animation_speed = animationOriginal;
 
 	//replot the dive after returning the settings
-	profile->plotDive(0, true);
+	profile->plotDive(0, true, true);
 }
 
 //value: ranges from 0 : 100 and shows the progress of the templating engine

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -357,7 +357,7 @@ void ProfileWidget2::replot(struct dive *d)
 	if (!replotEnabled)
 		return;
 	dataModel->clear();
-	plotDive(d, true);
+	plotDive(d, true, false);
 }
 
 void ProfileWidget2::createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
@@ -526,7 +526,7 @@ void ProfileWidget2::resetZoom()
 }
 
 // Currently just one dive, but the plan is to enable All of the selected dives.
-void ProfileWidget2::plotDive(struct dive *d, bool force)
+void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 {
 	static bool firstCall = true;
 #ifndef SUBSURFACE_MOBILE
@@ -785,7 +785,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force)
 		DivePlannerPointsModel *model = DivePlannerPointsModel::instance();
 		model->deleteTemporaryPlan();
 	}
-	if (printMode)
+	if (doClearPictures)
 		clearPictures();
 	else
 		plotPictures();
@@ -1525,7 +1525,7 @@ void ProfileWidget2::deleteCurrentDC()
 	delete_current_divecomputer();
 	mark_divelist_changed(true);
 	// we need to force it since it's likely the same dive and same dc_number - but that's a different dive computer now
-	plotDive(0, true);
+	plotDive(0, true, false);
 
 	emit refreshDisplay(true);
 }

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -73,7 +73,7 @@ public:
 
 	ProfileWidget2(QWidget *parent = 0);
 	void resetZoom();
-	void plotDive(struct dive *d = 0, bool force = false);
+	void plotDive(struct dive *d = 0, bool force = false, bool clearPictures = false);
 	void setupItem(AbstractProfilePolygonItem *item, DiveCartesianAxis *vAxis, int vData, int hData, int zValue);
 	void setPrintMode(bool mode, bool grayscale = false);
 	bool getPrintMode();


### PR DESCRIPTION
In MainWindow::current_dive_changed() first plotDive() is called,
which replots all the pictures by calling plotPictures(). This
is pointess, because it plots the pictures of the previous dive.

Then, updateDiveInfo() is called, which resets the dive pictures
and automatically replots them. Thus, switching between dives
both with hundreds of pictures is way slower than necessary.

Switching the plotDive() and updateDiveInfo() calls doesn't work.
The reason is not 100% clear, but it doesn't make sense to plot
pictures of the new dive as long as the profile still shows the
old dive anyway.

As a quick-fix, add a flag to plotDive(), which tells the function
to clear the pictures list instead of redrawing it.
Ultimately, plotDive() should probably be split in two functions.
One for the callers who update the pictures themselves and one
for the others.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an optimization of the profile plot code: On dive-change pictures of the *old* dive were plot first, which seems quite pointless.

The fix is quite disgusting in that it introduces an additional bool-parameter to `plotDives()`, which controls its behavior. But the whole `DivePictureModel` <-> `ProfileWidget2` interface is horribly messy to begin with. I don't dare to make in-depth changes to this.

I did some quick benchmarking for the `plotDive()`/`updateDiveInfo()` pair of calls. I switched continuously between two dives:

Before patch
```
dive changed to: 15
Elapsed: 135 msec
dive changed to: 14
Elapsed: 142 msec
dive changed to: 15
Elapsed: 133 msec
dive changed to: 14
Elapsed: 147 msec
dive changed to: 15
Elapsed: 132 msec
dive changed to: 14
Elapsed: 139 msec
dive changed to: 15
Elapsed: 134 msec
dive changed to: 14
Elapsed: 147 msec
dive changed to: 15
Elapsed: 137 msec
dive changed to: 14
Elapsed: 142 msec
```

After patch
```
dive changed to: 15
Elapsed: 63 msec
dive changed to: 14
Elapsed: 135 msec
dive changed to: 15
Elapsed: 64 msec
dive changed to: 14
Elapsed: 134 msec
dive changed to: 15
Elapsed: 65 msec
dive changed to: 14
Elapsed: 135 msec
dive changed to: 15
Elapsed: 64 msec
dive changed to: 14
Elapsed: 135 msec
dive changed to: 15
Elapsed: 63 msec
dive changed to: 14
Elapsed: 136 msec
dive changed to: 15
Elapsed: 64 msec
dive changed to: 14
Elapsed: 135 msec
```

Note that the dive with internal id 14 has a bunch of pictures on the profile plot, whereas id 15 has only a few. Therefore, there is a huge improvement when switching 14->15, but only a small one for 15->14.

Looks like the data is quite convincing. :)
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
