### PR TITLE
Dive pictures: Fix crash on picture delete

### DIFF
--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -16,31 +16,26 @@ DivePixmapItem::DivePixmapItem(QGraphicsItem *parent) : QGraphicsPixmapItem(pare
 {
 }
 
-DiveButtonItem::DiveButtonItem(QGraphicsItem *parent): DivePixmapItem(parent)
-{
-}
-
-void DiveButtonItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
-{
-	QGraphicsItem::mousePressEvent(event);
-	emit clicked();
-}
-
-CloseButtonItem::CloseButtonItem(QGraphicsItem *parent): DiveButtonItem(parent)
+CloseButtonItem::CloseButtonItem(QGraphicsItem *parent): DivePixmapItem(parent)
 {
 	static QPixmap p = QPixmap(":list-remove-icon");
 	setPixmap(p);
 	setFlag(ItemIgnoresTransformations);
 }
 
+void CloseButtonItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
+{
+	qgraphicsitem_cast<DivePictureItem*>(parentItem())->removePicture();
+}
+
 void CloseButtonItem::hide()
 {
-	DiveButtonItem::hide();
+	DivePixmapItem::hide();
 }
 
 void CloseButtonItem::show()
 {
-	DiveButtonItem::show();
+	DivePixmapItem::show();
 }
 
 DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
@@ -96,7 +91,6 @@ void DivePictureItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 	button->setOpacity(0);
 	button->show();
 	Animations::show(button);
-	connect(button, SIGNAL(clicked()), this, SLOT(removePicture()));
 }
 
 void DivePictureItem::setFileUrl(const QString &s)
@@ -119,9 +113,9 @@ void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	}
 }
 
-#ifndef SUBSURFACE_MOBILE
 void DivePictureItem::removePicture()
 {
+#ifndef SUBSURFACE_MOBILE
 	DivePictureModel::instance()->removePicture(fileUrl, true);
-}
 #endif
+}

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -15,20 +15,12 @@ public:
 	DivePixmapItem(QGraphicsItem *parent = 0);
 };
 
-class DiveButtonItem : public DivePixmapItem {
-	Q_OBJECT
-public:
-	DiveButtonItem(QGraphicsItem *parent = 0);
-protected:
-	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
-signals:
-	void clicked();
-};
-
-class CloseButtonItem : public DiveButtonItem {
+class CloseButtonItem : public DivePixmapItem {
 	Q_OBJECT
 public:
 	CloseButtonItem(QGraphicsItem *parent = 0);
+protected:
+	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
 public slots:
 	void hide();
 	void show();
@@ -42,9 +34,7 @@ public:
 	void setPixmap(const QPixmap& pix);
 public slots:
 	void settingsChanged();
-#ifndef SUBSURFACE_MOBILE
 	void removePicture();
-#endif
 	void setFileUrl(const QString& s);
 protected:
 	void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
@@ -54,7 +44,7 @@ private:
 	QString fileUrl;
 	QGraphicsRectItem *canvas;
 	QGraphicsRectItem *shadow;
-	DiveButtonItem *button;
+	CloseButtonItem *button;
 };
 
 #endif // DIVEPIXMAPITEM_H


### PR DESCRIPTION
The recent simplification of the close button code introduced a crash:
Deletion of pictures caused an invalid memory access, because the
CloseButtonItem was deleted with the parent DivePicture item.
For some (not fully understood!) reason, a reference to this button
was stored in the depths of Qt.

Empirically, it was found out that removing the first line of the pair
       QGraphicsItem::mousePressEvent(event);
       emit clicked();
fixed the crash.

It seemed therefore prudent to remove the whole questionable signal/slot
mechanism and directly call the removePicture() function of the parent.
Thus, the intermediate DiveButtonItem class became unnecessary and was
removed, leading to a shallower class hierarchy.

Unfortunately, CloseButtonItem must still be derived from QObject owing
to the Q_PROPERTY machinery, which is in turn needed for animation.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a crash and is at the same time a code cleanup. The reason for the original crash is not fully understood. Qt's object model is mad.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't use signal/slot system in CloseButtonItem.
2) Remove unnecessary DiveButtonItem class.