### PR TITLE
Plannernotes: '\0'-terminate ICD-buffer

### DIFF
--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -524,6 +524,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	/* For trimix OC dives, if an icd table header and icd data were printed to buffer, then add the ICD table here */
 	if (!icdtableheader && prefs.show_icd) {
 		put_string(&icdbuf, "</tbody></table>"); // End the ICD table
+		mb_cstring(&icdbuf);
 		put_string(&buf, icdbuf.buffer); // ..and add it to the html buffer
 		if (icdwarning) { // If necessary, add warning
 			put_format(&buf, "<span style='color: red;'>%s</span> %s",


### PR DESCRIPTION
When creating the ICD-notes the membuffer was not '\0'-terminated,
leading to output of stale data.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a formatting bug in `diveplannernotes.c`. See mailing list discussion.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) `\0` terminate the membuffer used to format ICD warnings.