### PR TITLE
mobile: add "Copy log to clipboard" button

### DIFF
--- a/mobile-widgets/qml/About.qml
+++ b/mobile-widgets/qml/About.qml
@@ -56,5 +56,14 @@ Kirigami.ScrollablePage {
 			anchors.horizontalCenter: parent.Center
 			horizontalAlignment: Text.AlignHCenter
 		}
+		SsrfButton {
+			id: copyAppLogToClipboard
+			Layout.alignment: Qt.AlignHCenter
+			text: qsTr("Copy app log to clipboard")
+			onClicked: {
+				manager.copyAppLogToClipboard()
+				rootItem.returnTopPage()
+				}
+		}
 	}
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -12,12 +12,14 @@
 #include <QElapsedTimer>
 #include <QTimer>
 #include <QDateTime>
+#include <QClipboard>
 
 #include <QBluetoothLocalDevice>
 
 #include "qt-models/divelistmodel.h"
 #include "qt-models/gpslistmodel.h"
 #include "qt-models/completionmodels.h"
+#include "qt-models/messagehandlermodel.h"
 #include "core/divelist.h"
 #include "core/device.h"
 #include "core/pref.h"
@@ -330,6 +332,16 @@ void QMLManager::cancelCredentialsPinSetup()
 	setStartPageText(tr("Starting..."));
 
 	setShowPin(false);
+}
+
+void QMLManager::copyAppLogToClipboard()
+{
+	/*
+	 * The user clicked the button, so copy the log file
+	 * to the clipboard for easy access
+	 */
+	QString copyString =  MessageHandlerModel::self()->logAsString();
+	QApplication::clipboard()->setText(copyString, QClipboard::Clipboard);
 }
 
 void QMLManager::finishSetup()

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -178,6 +178,7 @@ public slots:
 	void clearGpsData();
 	void clearCredentials();
 	void cancelCredentialsPinSetup();
+	void copyAppLogToClipboard();
 	void finishSetup();
 	void openLocalThenRemote(QString url);
 	void mergeLocalRepo();

--- a/qt-models/messagehandlermodel.cpp
+++ b/qt-models/messagehandlermodel.cpp
@@ -51,6 +51,15 @@ void MessageHandlerModel::addLog(QtMsgType type, const QString& message)
 #endif
 }
 
+const QString MessageHandlerModel::logAsString()
+{
+	QString copyString;
+
+	// Loop through m_data and build big string to be put on the clipboard
+	for(const MessageData &data: m_data)
+		copyString += data.message + "\n";
+	return copyString;
+}
 QVariant MessageHandlerModel::data(const QModelIndex& idx, int role) const
 {
 	switch(role) {

--- a/qt-models/messagehandlermodel.h
+++ b/qt-models/messagehandlermodel.h
@@ -14,6 +14,7 @@ public:
 	QVariant data(const QModelIndex& idx, int role) const override;
 	QHash<int, QByteArray> roleNames() const override;
 	void addLog(QtMsgType type, const QString& message);
+	const QString logAsString();
 
 	/* call this to clear the debug data */
 	Q_INVOKABLE void reset();


### PR DESCRIPTION
on iOS it is practically impossible to copy the App log
to e.g. a mail! in iOS 11 the log file is stored within
the subsurface container and you first need to copy (actually
using the clipboard) out from there to the "normal" document
shared space, before it can be used.

At least iOS users (and I believe Android users) are not really
used to work with files, so the process is not easy to document
in an understandable way.

The alternative is to provide a button, which simply puts the
log on the general clipboard, allowing it to be pasted in a
multitud of applications.

Documentation will be updated in a seperate commit.

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit text. It is important that users can easily mail the app log in case of problems,
the current solution (at least on iOS) is not at all user friendly.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Added button to mobile about window
2) Added function in MessageHandlermodel to return the log as string
3) Added function in qmlmanager to respond to button.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
