### PR TITLE
Remove implicit conversion warnings from units.h and dive.h

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -151,7 +151,7 @@ static inline int interpolate(int a, int b, int part, int whole)
 	/* It is doubtful that we actually need floating point for this, but whatever */
 	if (whole) {
 		double x = (double)a * (whole - part) + (double)b * part;
-		return lrint(x / whole);
+		return (int)lrint(x / whole);
 	}
 	return (a+b)/2;
 }
@@ -452,7 +452,7 @@ static inline int rel_mbar_to_depth(int mbar, struct dive *dive)
 	if (dive->dc.salinity)
 		specific_weight = dive->dc.salinity / 10000.0 * 0.981;
 	/* whole mbar gives us cm precision */
-	cm = lrint(mbar / specific_weight);
+	cm = (int)lrint(mbar / specific_weight);
 	return cm * 10;
 }
 
@@ -471,7 +471,7 @@ static inline depth_t gas_mod(struct gasmix *mix, pressure_t po2_limit, struct d
 	depth_t rounded_depth;
 
 	double depth = (double) mbar_to_depth(po2_limit.mbar * 1000 / get_o2(mix), dive);
-	rounded_depth.mm = lrint(depth / roundto) * roundto;
+	rounded_depth.mm = (int)lrint(depth / roundto) * roundto;
 	return rounded_depth;
 }
 
@@ -481,8 +481,8 @@ static inline depth_t gas_mnd(struct gasmix *mix, depth_t end, struct dive *dive
 	pressure_t ppo2n2;
 	ppo2n2.mbar = depth_to_mbar(end.mm, dive);
 
-	int maxambient = lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0));
-	rounded_depth.mm = lrint(((double)mbar_to_depth(maxambient, dive)) / roundto) * roundto;
+	int maxambient = (int)lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0));
+	rounded_depth.mm = (int)lrint(((double)mbar_to_depth(maxambient, dive)) / roundto) * roundto;
 	return rounded_depth;
 }
 

--- a/core/units.h
+++ b/core/units.h
@@ -146,7 +146,7 @@ static inline double grams_to_lbs(int grams)
 
 static inline int lbs_to_grams(double lbs)
 {
-	return lrint(lbs * 453.6);
+	return (int)lrint(lbs * 453.6);
 }
 
 static inline double ml_to_cuft(int ml)
@@ -176,7 +176,7 @@ static inline unsigned long feet_to_mm(double feet)
 
 static inline int to_feet(depth_t depth)
 {
-	return lrint(mm_to_feet(depth.mm));
+	return (int)lrint(mm_to_feet(depth.mm));
 }
 
 static inline double mkelvin_to_C(int mkelvin)
@@ -211,7 +211,7 @@ static inline long psi_to_mbar(double psi)
 
 static inline int to_PSI(pressure_t pressure)
 {
-	return lrint(pressure.mbar * 0.0145037738);
+	return (int)lrint(pressure.mbar * 0.0145037738);
 }
 
 static inline double bar_to_atm(double bar)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When generating iOS, there are 2.400 warnings, mostly from implicit conversions.
Just sometimes an implicit conversion is wrong, but will surely be overlooked in the
mist of warnings.

This PR removes the implicit conversion warnings originating in header files (and therefore
multiplying the number of warnings).

Having a function that returns an int but uses a long function to generate the int, calls for
an explicit cast, to inform other developers that this is intentionally.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) update units.h
2) update dive.h

NO functional changes.
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->