### PR TITLE
core: solved PictureEntry defined as class and struct.

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -23,7 +23,7 @@ private:
 	void saveImage(QNetworkReply *reply);
 };
 
-class PictureEntry;
+struct PictureEntry;
 class Thumbnailer : public QObject {
 	Q_OBJECT
 public:


### PR DESCRIPTION
PictureEntry was defined as class in imagedownloader.h and
as struct in divepicturemodel.h

A class has a vptr in front, so the difference is real at least
for the clang compiler.

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
class or struct is another example of where a warning is important.

I had some "Interesting" debugging effects due to a vptr expected or too much.
 
Disclaimer: I am not as such doing a lot with the picture code (for now).
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) changed forward declaration from "class" to "struct"

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->