### PR TITLE
[RFC] Profile: Fix leak in animation

### DIFF
--- a/profile-widget/animationfunctions.cpp
+++ b/profile-widget/animationfunctions.cpp
@@ -33,12 +33,12 @@ namespace Animations {
 	{
 		if (prefs.animation_speed != 0) {
 			QPropertyAnimation *animation = new QPropertyAnimation(obj, "opacity");
-			obj->connect(animation, SIGNAL(finished()), SLOT(deleteLater()));
+			obj->connect(animation, &QPropertyAnimation::finished, &QObject::deleteLater);
 			animation->setStartValue(1);
 			animation->setEndValue(0);
 			animation->start(QAbstractAnimation::DeleteWhenStopped);
 		} else {
-			obj->setProperty("opacity", 0);
+			delete obj;
 		}
 	}
 

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -128,13 +128,11 @@ void DiveCartesianAxis::setLinesVisible(bool arg1)
 }
 
 template <typename T>
-void emptyList(QList<T *> &list, double steps)
+void emptyList(QList<T *> &list, int steps)
 {
-	if (!list.isEmpty() && list.size() > steps) {
-		while (list.size() > steps) {
-			T *removedItem = list.takeLast();
-			Animations::animDelete(removedItem);
-		}
+	while (list.size() > steps) {
+		T *removedItem = list.takeLast();
+		Animations::animDelete(removedItem);
 	}
 }
 
@@ -145,7 +143,8 @@ void DiveCartesianAxis::updateTicks(color_index_t color)
 	QLineF m = line();
 	// unused so far:
 	// QGraphicsView *view = scene()->views().first();
-	double steps = (max - min) / interval;
+	double stepsInRange = (max - min) / interval;
+	int steps = (int)stepsInRange;
 	double currValueText = min;
 	double currValueLine = min;
 
@@ -155,8 +154,8 @@ void DiveCartesianAxis::updateTicks(color_index_t color)
 	emptyList(labels, steps);
 	emptyList(lines, steps);
 
-	// Move the remaining Ticks / Text to it's corerct position
-	// Regartind the possibly new values for the Axis
+	// Move the remaining ticks / text to their correct positions
+	// regarding the possible new values for the axis
 	qreal begin, stepSize;
 	if (orientation == TopToBottom) {
 		begin = m.y1();
@@ -171,7 +170,7 @@ void DiveCartesianAxis::updateTicks(color_index_t color)
 		begin = m.x2();
 		stepSize = (m.x2() - m.x1());
 	}
-	stepSize = stepSize / steps;
+	stepSize /= stepsInRange;
 
 	for (int i = 0, count = labels.size(); i < count; i++, currValueText += interval) {
 		qreal childPos = (orientation == TopToBottom || orientation == LeftToRight) ?


### PR DESCRIPTION
If animDelete() was called with prefs.animation_speed == 0, the
object would not be marked for deletion, as opposed to calling
with prefs.animation_speed != 0.

While touching this function, use the function-pointer version
of connect().

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A small leak-fix, though I'm not 100% sure about this one. I'm not happy about Qt's diffuse ownership model with owner-less objects that schedule themselves for deletion by the main-loop, etc.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Schedule object for deletion, even if animation speed is set to 0 (=infinity).
2) Use the function-pointer version of `connect` for compile-time checking.