### PR TITLE
Don't repopulate DivePictureModel on deletion of pictures

### DIFF
--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -60,23 +60,21 @@ void TabDivePhotos::contextMenuEvent(QContextMenuEvent *event)
 
 void TabDivePhotos::removeSelectedPhotos()
 {
-	bool last = false;
 	if (!ui->photosView->selectionModel()->hasSelection())
 		return;
 	QModelIndexList indexes =  ui->photosView->selectionModel()->selectedRows();
 	if (indexes.count() == 0)
 		indexes = ui->photosView->selectionModel()->selectedIndexes();
-	QModelIndex photo = indexes.first();
-	do {
-		photo = indexes.first();
-		last = indexes.count() == 1;
+	QVector<QString> photosToDelete;
+	photosToDelete.reserve(indexes.count());
+	for (const auto &photo: indexes) {
 		if (photo.isValid()) {
 			QString fileUrl = photo.data(Qt::DisplayPropertyRole).toString();
-			if (fileUrl.length() > 0)
-				DivePictureModel::instance()->removePicture(fileUrl, last);
+			if (!fileUrl.isEmpty())
+				photosToDelete.push_back(fileUrl);
 		}
-		indexes.removeFirst();
-	} while(!indexes.isEmpty());
+	}
+	DivePictureModel::instance()->removePictures(photosToDelete);
 }
 
 //TODO: This looks overly wrong. We shouldn't call MainWindow to retrieve the DiveList to add Images.

--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -116,6 +116,6 @@ void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 void DivePictureItem::removePicture()
 {
 #ifndef SUBSURFACE_MOBILE
-	DivePictureModel::instance()->removePicture(fileUrl, true);
+	DivePictureModel::instance()->removePictures({ fileUrl });
 #endif
 }

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1117,6 +1117,7 @@ void ProfileWidget2::setProfileState()
 	connect(DivePictureModel::instance(), &DivePictureModel::dataChanged, this, &ProfileWidget2::updatePictures);
 	connect(DivePictureModel::instance(), SIGNAL(rowsInserted(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
 	connect(DivePictureModel::instance(), SIGNAL(rowsRemoved(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
+	connect(DivePictureModel::instance(), &DivePictureModel::modelReset, this, &ProfileWidget2::plotPictures);
 #endif
 	/* show the same stuff that the profile shows. */
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1116,7 +1116,7 @@ void ProfileWidget2::setProfileState()
 #ifndef SUBSURFACE_MOBILE
 	connect(DivePictureModel::instance(), &DivePictureModel::dataChanged, this, &ProfileWidget2::updatePictures);
 	connect(DivePictureModel::instance(), SIGNAL(rowsInserted(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
-	connect(DivePictureModel::instance(), SIGNAL(rowsRemoved(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
+	connect(DivePictureModel::instance(), &DivePictureModel::rowsRemoved, this, &ProfileWidget2::removePictures);
 	connect(DivePictureModel::instance(), &DivePictureModel::modelReset, this, &ProfileWidget2::plotPictures);
 #endif
 	/* show the same stuff that the profile shows. */
@@ -2087,6 +2087,19 @@ void ProfileWidget2::plotPictures()
 		item->setPos(x, y);
 	}
 }
+
+void ProfileWidget2::removePictures(const QModelIndex &, int first, int last)
+{
+	DivePictureModel *m = DivePictureModel::instance();
+	first = std::max(0, first - m->rowDDStart);
+	// Note that last points *to* the last item and not *past* the last item,
+	// therefore we add 1 to achieve conventional C++ semantics.
+	last = std::min((int)pictures.size(), last + 1 - m->rowDDStart);
+	if (first >= (int)pictures.size() || last <= first)
+		return;
+	pictures.erase(pictures.begin() + first, pictures.begin() + last);
+}
+
 #endif
 
 void ProfileWidget2::dropEvent(QDropEvent *event)

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -110,6 +110,7 @@ slots: // Necessary to call from QAction's signals.
 	void replot(dive *d = 0);
 #ifndef SUBSURFACE_MOBILE
 	void plotPictures();
+	void removePictures(const QModelIndex &, int first, int last);
 	void setPlanState();
 	void setAddState();
 	void changeGas();

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -57,10 +57,9 @@ void DivePictureModel::updateThumbnails()
 
 void DivePictureModel::updateDivePictures()
 {
+	beginResetModel();
 	if (!pictures.isEmpty()) {
-		beginRemoveRows(QModelIndex(), 0, pictures.count() - 1);
 		pictures.clear();
-		endRemoveRows();
 		rowDDStart = rowDDEnd = 0;
 		Thumbnailer::instance()->clearWorkQueue();
 	}
@@ -83,11 +82,7 @@ void DivePictureModel::updateDivePictures()
 	}
 
 	updateThumbnails();
-
-	if (!pictures.isEmpty()) {
-		beginInsertRows(QModelIndex(), 0, pictures.count() - 1);
-		endInsertRows();
-	}
+	endResetModel();
 }
 
 int DivePictureModel::columnCount(const QModelIndex &parent) const

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -149,7 +149,22 @@ void DivePictureModel::removePictures(const QVector<QString> &fileUrls)
 	copy_dive(current_dive, &displayed_dive);
 	mark_divelist_changed(true);
 
-	updateDivePictures();
+	for (int i = 0; i < pictures.size(); ++i) {
+		// Find range [i j) of pictures to remove
+		if (std::find(fileUrls.begin(), fileUrls.end(), pictures[i].filename) == fileUrls.end())
+			continue;
+		int j;
+		for (j = i + 1; j < pictures.size(); ++j) {
+			if (std::find(fileUrls.begin(), fileUrls.end(), pictures[j].filename) == fileUrls.end())
+				break;
+		}
+
+		// Qt's model-interface is surprisingly idiosyncratic: you don't pass [first last), but [first last] ranges.
+		// For example, an empty list would be [0 -1].
+		beginRemoveRows(QModelIndex(), i, j - 1);
+		pictures.erase(pictures.begin() + i, pictures.begin() + j);
+		endRemoveRows();
+	}
 }
 
 int DivePictureModel::rowCount(const QModelIndex &parent) const

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -30,7 +30,7 @@ public slots:
 	void updateThumbnail(QString filename, QImage thumbnail);
 private:
 	DivePictureModel();
-	QList<PictureEntry> pictures;
+	QVector<PictureEntry> pictures;
 	int findPictureId(const QString &filename);	// Return -1 if not found
 	double zoomLevel;	// -1.0: minimum, 0.0: standard, 1.0: maximum
 	int size;

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -22,7 +22,7 @@ public:
 	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	virtual void updateDivePictures();
 	void updateDivePicturesWhenDone(QList<QFuture<void>>);
-	void removePicture(const QString& fileUrl, bool last);
+	void removePictures(const QVector<QString> &fileUrls);
 	int rowDDStart, rowDDEnd;
 	void updateDivePictureOffset(const QString &filename, int offsetSeconds);
 public slots:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Deletion of pictures repopulated the whole DivePictureModel, which looked ugly in the UI (all pictures in the profile plot regenerated).

Make this smarter, by starting the implementing of proper model-semantics. This is a bit hairy, so testing would be appreciated (@sfuchs79?)

Drag/drop and picture addition will be harder, therefore postpone until this works properly.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) On reset, don't do a `removeRows()`/`addRows()` pair.
2) Change the interface of `removePicture()` to not take a `last` parameter, but a list of pictures. This part actually fixes a bug.
3) Implement `removePicture` with proper model-semantics.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79 