### PR TITLE
mobile: get dive event on profile.

### DIFF
--- a/mobile-widgets/qmlprofile.cpp
+++ b/mobile-widgets/qmlprofile.cpp
@@ -15,7 +15,7 @@ QMLProfile::QMLProfile(QQuickItem *parent) :
 	setAntialiasing(true);
 	m_profileWidget = new ProfileWidget2(0);
 	m_profileWidget->setProfileState();
-	m_profileWidget->setPrintMode(true);
+	m_profileWidget->setPrintMode(false);
 	m_profileWidget->setFontPrintScale(0.8);
 	connect(QMLManager::instance(), &QMLManager::sendScreenChanged, this, &QMLProfile::screenChanged);
 	setDevicePixelRatio(QMLManager::instance()->lastDevicePixelRatio());


### PR DESCRIPTION
print mode was used to limit the functionality of the profile,
when used in ssrf-mobile.

The effect is that DC events are displayed, but not selectable

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When using your mobile to upload from DC, it is nice to see if there were critical events
in your dive.

This is the first step in making profile more mobile user friendly (zoom/move/tooltips is
on the drawing board).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) disabled print mode for profile in ssrf-mobile, no change for desktop

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->