### PR TITLE
Last round of Q_UNUSED / UNUSED updates

### DIFF
--- a/core/cochran.c
+++ b/core/cochran.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -592,7 +593,7 @@ static void cochran_parse_samples(struct dive *dive, const unsigned char *log,
 		offset += config.sample_size;
 		sample_cnt++;
 	}
-	(void)ascent_rate; // mark the variable as unused
+	UNUSED(ascent_rate); // mark the variable as unused
 
 	if (sample_cnt > 0)
 		*duration = sample_cnt * profile_period - 1;
@@ -792,7 +793,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 
 int try_to_open_cochran(const char *filename, struct memblock *mem)
 {
-	(void) filename;
+	UNUSED(filename);
 	unsigned int i;
 	unsigned int mod;
 	unsigned int *offsets, dive1, dive2;

--- a/core/deco.c
+++ b/core/deco.c
@@ -17,6 +17,7 @@
  * restore_deco_state()
  * dump_tissues()
  */
+#include "ssrf.h"
 #include <math.h>
 #include <string.h>
 #include "dive.h"
@@ -480,7 +481,7 @@ void calc_crushing_pressure(struct deco_state *ds, double pressure)
 /* add period_in_seconds at the given pressure and gas to the deco calculation */
 void add_segment(struct deco_state *ds, double pressure, const struct gasmix *gasmix, int period_in_seconds, int ccpo2, enum divemode_t divemode, int sac)
 {
-	(void) sac;
+	UNUSED(sac);
 	int ci;
 	struct gas_pressures pressures;
 	bool icd = false;

--- a/core/device.c
+++ b/core/device.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "ssrf.h"
 #include <string.h>
 #include "dive.h"
 #include "subsurface-string.h"
@@ -192,7 +193,7 @@ static void match_id(void *_dc, const char *model, uint32_t deviceid,
 		     const char *nickname, const char *serial, const char *firmware)
 {
 	// here nickname is unused
-	(void)nickname;
+	UNUSED(nickname);
 
 	struct divecomputer *dc = _dc;
 

--- a/core/file.c
+++ b/core/file.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "ssrf.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -118,9 +119,9 @@ int try_to_open_zip(const char *filename)
 
 static int db_test_func(void *param, int columns, char **data, char **column)
 {
-	(void) param;
-	(void) columns;
-	(void) column;
+	UNUSED(param);
+	UNUSED(columns);
+	UNUSED(column);
 	return *data[0] == '0';
 }
 

--- a/core/gaspressures.c
+++ b/core/gaspressures.c
@@ -18,6 +18,7 @@
  *  pr_track_t is defined in gaspressures.h
  */
 
+#include "ssrf.h"
 #include "dive.h"
 #include "display.h"
 #include "profile.h"
@@ -343,7 +344,7 @@ static void debug_print_pressures(struct plot_info *pi)
  */
 void populate_pressure_information(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, int sensor)
 {
-	(void) dc;
+	UNUSED(dc);
 	int first, last, cyl;
 	cylinder_t *cylinder = dive->cylinder + sensor;
 	pr_track_t *track = NULL;

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -66,8 +67,8 @@ int git_storage_update_progress(const char *text)
 // map the git progress to 20% of overall progress
 static void progress_cb(const char *path, size_t completed_steps, size_t total_steps, void *payload)
 {
-	(void) path;
-	(void) payload;
+	UNUSED(path);
+	UNUSED(payload);
 	char buf[80];
 	snprintf(buf, sizeof(buf),  translate("gettextFromC", "Checkout from storage (%lu/%lu)"), completed_steps, total_steps);
 	(void)git_storage_update_progress(buf);
@@ -78,7 +79,7 @@ static void progress_cb(const char *path, size_t completed_steps, size_t total_s
 // if the user cancels the dialog this is passed back to libgit2
 static int transfer_progress_cb(const git_transfer_progress *stats, void *payload)
 {
-	(void) payload;
+	UNUSED(payload);
 
 	static int last_done = -1;
 	char buf[80];
@@ -109,8 +110,8 @@ static int transfer_progress_cb(const git_transfer_progress *stats, void *payloa
 // the initial push to sync the repos is mapped to 10% of overall progress
 static int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void *payload)
 {
-	(void) bytes;
-	(void) payload;
+	UNUSED(bytes);
+	UNUSED(payload);
 	char buf[80];
 	snprintf(buf, sizeof(buf), translate("gettextFromC", "Transfer to storage (%d/%d)"), current, total);
 	return git_storage_update_progress(buf);
@@ -143,7 +144,7 @@ static char *move_local_cache(const char *remote, const char *branch)
 
 static int check_clean(const char *path, unsigned int status, void *payload)
 {
-	(void) payload;
+	UNUSED(payload);
 	status &= ~GIT_STATUS_CURRENT | GIT_STATUS_IGNORED;
 	if (!status)
 		return 0;
@@ -220,9 +221,9 @@ int credential_ssh_cb(git_cred **out,
 		  unsigned int allowed_types,
 		  void *payload)
 {
-	(void) url;
-	(void) payload;
-	(void) username_from_url;
+	UNUSED(url);
+	UNUSED(payload);
+	UNUSED(username_from_url);
 
 	const char *username = prefs.cloud_storage_email_encoded;
 	const char *passphrase = prefs.cloud_storage_password ? prefs.cloud_storage_password : "";
@@ -259,10 +260,10 @@ int credential_https_cb(git_cred **out,
 			unsigned int allowed_types,
 			void *payload)
 {
-	(void) url;
-	(void) username_from_url;
-	(void) payload;
-	(void) allowed_types;
+	UNUSED(url);
+	UNUSED(username_from_url);
+	UNUSED(payload);
+	UNUSED(allowed_types);
 
 	if (exceeded_auth_attempts())
 		return GIT_EUSER;
@@ -276,7 +277,7 @@ int credential_https_cb(git_cred **out,
 #define KNOWN_CERT "\xfd\xb8\xf7\x73\x76\xe2\x75\x53\x93\x37\xdc\xfe\x1e\x55\x43\x3d\xf2\x2c\x18\x2c"
 int certificate_check_cb(git_cert *cert, int valid, const char *host, void *payload)
 {
-	(void) payload;
+	UNUSED(payload);
 	if (same_string(host, "cloud.subsurface-divelog.org") && cert->cert_type == GIT_CERT_X509) {
 		SHA_CTX ctx;
 		unsigned char hash[21];
@@ -297,8 +298,8 @@ int certificate_check_cb(git_cert *cert, int valid, const char *host, void *payl
 
 static int update_remote(git_repository *repo, git_remote *origin, git_reference *local, git_reference *remote, enum remote_transport rt)
 {
-	(void) repo;
-	(void) remote;
+	UNUSED(repo);
+	UNUSED(remote);
 
 	git_push_options opts = GIT_PUSH_OPTIONS_INIT;
 	git_strarray refspec;
@@ -331,7 +332,7 @@ extern int update_git_checkout(git_repository *repo, git_object *parent, git_tre
 
 static int try_to_git_merge(git_repository *repo, git_reference **local_p, git_reference *remote, git_oid *base, const git_oid *local_id, const git_oid *remote_id)
 {
-	(void) remote;
+	UNUSED(remote);
 	git_tree *local_tree, *remote_tree, *base_tree;
 	git_commit *local_commit, *remote_commit, *base_commit;
 	git_index *merged_index;
@@ -683,7 +684,7 @@ static git_repository *update_local_repo(const char *localdir, const char *remot
 
 static int repository_create_cb(git_repository **out, const char *path, int bare, void *payload)
 {
-	(void) payload;
+	UNUSED(payload);
 	char *proxy_string;
 	git_config *conf;
 

--- a/core/import-cobalt.c
+++ b/core/import-cobalt.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include "dive.h"
 #include "subsurface-string.h"
 #include "parse.h"
@@ -14,9 +15,9 @@
 
 extern int cobalt_profile_sample(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	sample_start();
 	if (data[0])
@@ -33,9 +34,9 @@ extern int cobalt_profile_sample(void *handle, int columns, char **data, char **
 
 extern int cobalt_cylinders(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	cylinder_start();
 	if (data[0])
@@ -57,9 +58,9 @@ extern int cobalt_cylinders(void *handle, int columns, char **data, char **colum
 
 extern int cobalt_buddies(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	if (data[0])
 		utf8_string(data[0], &cur_dive->buddy);
@@ -74,18 +75,18 @@ extern int cobalt_buddies(void *handle, int columns, char **data, char **column)
 
 extern int cobalt_visibility(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
-	(void) data;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
+	UNUSED(data);
 	return 0;
 }
 
 extern int cobalt_location(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	static char *location = NULL;
 	if (data[0]) {
@@ -108,8 +109,8 @@ extern int cobalt_location(void *handle, int columns, char **data, char **column
 
 extern int cobalt_dive(void *param, int columns, char **data, char **column)
 {
-	(void) columns;
-	(void) column;
+	UNUSED(columns);
+	UNUSED(column);
 
 	int retval = 0;
 	sqlite3 *handle = (sqlite3 *)param;
@@ -217,8 +218,8 @@ extern int cobalt_dive(void *param, int columns, char **data, char **column)
 int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
 			    struct dive_table *table)
 {
-	(void) buffer;
-	(void) size;
+	UNUSED(buffer);
+	UNUSED(size);
 
 	int retval;
 	char *err = NULL;

--- a/core/import-divinglog.c
+++ b/core/import-divinglog.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include "dive.h"
 #include "subsurface-string.h"
 #include "parse.h"
@@ -14,9 +15,9 @@
 
 extern int divinglog_cylinder(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	short dbl = 1;
 	//char get_cylinder_template[] = "select TankID,TankSize,PresS,PresE,PresW,O2,He,DblTank from Tank where LogID = %d";
@@ -60,9 +61,9 @@ extern int divinglog_cylinder(void *handle, int columns, char **data, char **col
 
 extern int divinglog_profile(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	int sinterval = 0;
 	unsigned long time;
@@ -197,7 +198,7 @@ extern int divinglog_profile(void *handle, int columns, char **data, char **colu
 			int ppo2_2 = atoi_n(ptr5 + 3, 3);
 			int ppo2_3 = atoi_n(ptr5 + 6, 3);
 			int otu = atoi_n(ptr5 + 9, 4);
-			(void) otu; // we seem to not store this? Do we understand its format?
+			UNUSED(otu); // we seem to not store this? Do we understand its format?
 			int cns = atoi_n(ptr5 + 13, 4);
 			int setpoint = atoi_n(ptr5 + 17, 2);
 
@@ -267,8 +268,8 @@ extern int divinglog_profile(void *handle, int columns, char **data, char **colu
 
 extern int divinglog_dive(void *param, int columns, char **data, char **column)
 {
-	(void) columns;
-	(void) column;
+	UNUSED(columns);
+	UNUSED(column);
 
 	int retval = 0;
 	sqlite3 *handle = (sqlite3 *)param;
@@ -397,8 +398,8 @@ extern int divinglog_dive(void *param, int columns, char **data, char **column)
 int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
 			    struct dive_table *table)
 {
-	(void) buffer;
-	(void) size;
+	UNUSED(buffer);
+	UNUSED(size);
 
 	int retval;
 	char *err = NULL;

--- a/core/import-shearwater.c
+++ b/core/import-shearwater.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include "dive.h"
 #include "subsurface-string.h"
 #include "parse.h"
@@ -14,9 +15,9 @@
 
 extern int shearwater_cylinders(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	int o2 = lrint(strtod_flags(data[0], NULL, 0) * 1000);
 	int he = lrint(strtod_flags(data[1], NULL, 0) * 1000);
@@ -36,9 +37,9 @@ extern int shearwater_cylinders(void *handle, int columns, char **data, char **c
 
 extern int shearwater_changes(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	if (columns != 3) {
 		return 1;
@@ -78,9 +79,9 @@ extern int shearwater_changes(void *handle, int columns, char **data, char **col
 
 extern int shearwater_profile_sample(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	sample_start();
 	if (data[0])
@@ -111,9 +112,9 @@ extern int shearwater_profile_sample(void *handle, int columns, char **data, cha
 
 extern int shearwater_ai_profile_sample(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	sample_start();
 	if (data[0])
@@ -146,9 +147,9 @@ extern int shearwater_ai_profile_sample(void *handle, int columns, char **data, 
 
 extern int shearwater_mode(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	if (data[0])
 		cur_dive->dc.divemode = atoi(data[0]) == 0 ? CCR : OC;
@@ -158,8 +159,8 @@ extern int shearwater_mode(void *handle, int columns, char **data, char **column
 
 extern int shearwater_dive(void *param, int columns, char **data, char **column)
 {
-	(void) columns;
-	(void) column;
+	UNUSED(columns);
+	UNUSED(column);
 
 	int retval = 0;
 	sqlite3 *handle = (sqlite3 *)param;
@@ -278,8 +279,8 @@ extern int shearwater_dive(void *param, int columns, char **data, char **column)
 int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
 			    struct dive_table *table)
 {
-	(void) buffer;
-	(void) size;
+	UNUSED(buffer);
+	UNUSED(size);
 
 	int retval;
 	char *err = NULL;

--- a/core/import-suunto.c
+++ b/core/import-suunto.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include "dive.h"
 #include "subsurface-string.h"
 #include "parse.h"
@@ -14,9 +15,9 @@
 
 extern int dm4_events(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	event_start();
 	if (data[1])
@@ -147,9 +148,9 @@ extern int dm4_events(void *handle, int columns, char **data, char **column)
 
 extern int dm4_tags(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	if (data[0])
 		taglist_add_tag(&cur_dive->tag_list, data[0]);
@@ -159,8 +160,8 @@ extern int dm4_tags(void *handle, int columns, char **data, char **column)
 
 extern int dm4_dive(void *param, int columns, char **data, char **column)
 {
-	(void) columns;
-	(void) column;
+	UNUSED(columns);
+	UNUSED(column);
 	int i;
 	int interval, retval = 0;
 	sqlite3 *handle = (sqlite3 *)param;
@@ -289,8 +290,8 @@ extern int dm4_dive(void *param, int columns, char **data, char **column)
 int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
 		     struct dive_table *table)
 {
-	(void) buffer;
-	(void) size;
+	UNUSED(buffer);
+	UNUSED(size);
 
 	int retval;
 	char *err = NULL;
@@ -312,9 +313,9 @@ int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int s
 
 extern int dm5_cylinders(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	cylinder_start();
 	if (data[7] && atoi(data[7]) > 0 && atoi(data[7]) < 350000)
@@ -340,9 +341,9 @@ extern int dm5_cylinders(void *handle, int columns, char **data, char **column)
 
 extern int dm5_gaschange(void *handle, int columns, char **data, char **column)
 {
-	(void) handle;
-	(void) columns;
-	(void) column;
+	UNUSED(handle);
+	UNUSED(columns);
+	UNUSED(column);
 
 	event_start();
 	if (data[0])
@@ -362,8 +363,8 @@ extern int dm5_gaschange(void *handle, int columns, char **data, char **column)
 
 extern int dm5_dive(void *param, int columns, char **data, char **column)
 {
-	(void) columns;
-	(void) column;
+	UNUSED(columns);
+	UNUSED(column);
 	int i;
 	int tempformat = 0;
 	int interval, retval = 0, block_size;
@@ -546,8 +547,8 @@ extern int dm5_dive(void *param, int columns, char **data, char **column)
 int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
 		     struct dive_table *table)
 {
-	(void) buffer;
-	(void) size;
+	UNUSED(buffer);
+	UNUSED(size);
 
 	int retval;
 	char *err = NULL;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include <stdio.h>
 #include <unistd.h>
 #include <inttypes.h>
@@ -429,7 +430,7 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 
 static void dev_info(device_data_t *devdata, const char *fmt, ...)
 {
-	(void) devdata;
+	UNUSED(devdata);
 	static char buffer[1024];
 	va_list ap;
 
@@ -445,7 +446,7 @@ static int import_dive_number = 0;
 
 static int parse_samples(device_data_t *devdata, struct divecomputer *dc, dc_parser_t *parser)
 {
-	(void) devdata;
+	UNUSED(devdata);
 	// Parse the sample data.
 	return dc_parser_samples_foreach(parser, sample_cb, dc);
 }
@@ -549,8 +550,8 @@ static uint32_t calculate_string_hash(const char *str)
  */
 static void dc_match_serial(void *_dc, const char *model, uint32_t deviceid, const char *nickname, const char *serial, const char *firmware)
 {
-	(void)nickname;
-	(void)firmware;
+	UNUSED(nickname);
+	UNUSED(firmware);
 
 	struct divecomputer *dc = _dc;
 
@@ -1060,7 +1061,7 @@ static void lookup_fingerprint(dc_device_t *device, device_data_t *devdata)
 
 static void event_cb(dc_device_t *device, dc_event_type_t event, const void *data, void *userdata)
 {
-	(void) device;
+	UNUSED(device);
 	const dc_event_progress_t *progress = data;
 	const dc_event_devinfo_t *devinfo = data;
 	const dc_event_clock_t *clock = data;
@@ -1140,7 +1141,7 @@ int import_thread_cancelled;
 
 static int cancel_cb(void *userdata)
 {
-	(void) userdata;
+	UNUSED(userdata);
 	return import_thread_cancelled;
 }
 
@@ -1190,7 +1191,7 @@ static const char *do_device_import(device_data_t *data)
 
 void logfunc(dc_context_t *context, dc_loglevel_t loglevel, const char *file, unsigned int line, const char *function, const char *msg, void *userdata)
 {
-	(void) context;
+	UNUSED(context);
 	const char *loglevels[] = { "NONE", "ERROR", "WARNING", "INFO", "DEBUG", "ALL" };
 
 	FILE *fp = (FILE *)userdata;

--- a/core/linux.c
+++ b/core/linux.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 /* linux.c */
 /* implements Linux specific functions */
+#include "ssrf.h"
 #include "dive.h"
 #include "subsurface-string.h"
 #include "display.h"
@@ -22,7 +23,7 @@ double system_divelist_default_font_size = -1.0;
 bool subsurface_ignore_font(const char *font)
 {
 	// there are no old default fonts to ignore
-	(void)font;
+	UNUSED(font);
 	return false;
 }
 

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <string.h>
 
+#include "ssrf.h"
 #include "dive.h"
 #include "divelist.h"
 #include "file.h"
@@ -36,10 +37,10 @@ struct lv_sensor_ids sensor_ids;
 
 static int handle_event_ver2(int code, const unsigned char *ps, unsigned int ps_ptr, struct lv_event *event)
 {
-	(void) code;
-	(void) ps;
-	(void) ps_ptr;
-	(void) event;
+	UNUSED(code);
+	UNUSED(ps);
+	UNUSED(ps_ptr);
+	UNUSED(event);
 
 	// Skip 4 bytes
 	return 4;
@@ -288,9 +289,9 @@ static void parse_dives (int log_version, const unsigned char *buf, unsigned int
 			break;
 		}
 		// we aren't using the start_cns, dive_mode, and algorithm, yet
-		(void)start_cns;
-		(void)dive_mode;
-		(void)algorithm;
+		UNUSED(start_cns);
+		UNUSED(dive_mode);
+		UNUSED(algorithm);
 
 		ptr += 4;
 
@@ -443,7 +444,7 @@ static void parse_dives (int log_version, const unsigned char *buf, unsigned int
 
 int try_to_open_liquivision(const char *filename, struct memblock *mem)
 {
-	(void) filename;
+	UNUSED(filename);
 	const unsigned char *buf = mem->buffer;
 	unsigned int buf_size = mem->size;
 	unsigned int ptr;

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-#ifdef __clang__
-// Clang has a bug on zero-initialization of C structs.
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
+#include "ssrf.h"
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -179,7 +175,7 @@ static int get_hex(const char *line)
 
 static void parse_dive_gps(char *line, struct membuffer *str, void *_dive)
 {
-	(void) str;
+	UNUSED(str);
 	uint32_t uuid;
 	degrees_t latitude = parse_degrees(line, &line);
 	degrees_t longitude = parse_degrees(line, &line);
@@ -206,7 +202,7 @@ static void parse_dive_gps(char *line, struct membuffer *str, void *_dive)
 
 static void parse_dive_location(char *line, struct membuffer *str, void *_dive)
 {
-	(void) line;
+	UNUSED(line);
 	uint32_t uuid;
 	char *name = get_utf8(str);
 	struct dive *dive = _dive;
@@ -230,19 +226,19 @@ static void parse_dive_location(char *line, struct membuffer *str, void *_dive)
 }
 
 static void parse_dive_divemaster(char *line, struct membuffer *str, void *_dive)
-{ (void) line; struct dive *dive = _dive; dive->divemaster = get_utf8(str); }
+{ UNUSED(line); struct dive *dive = _dive; dive->divemaster = get_utf8(str); }
 
 static void parse_dive_buddy(char *line, struct membuffer *str, void *_dive)
-{ (void) line; struct dive *dive = _dive; dive->buddy = get_utf8(str); }
+{ UNUSED(line); struct dive *dive = _dive; dive->buddy = get_utf8(str); }
 
 static void parse_dive_suit(char *line, struct membuffer *str, void *_dive)
-{ (void) line; struct dive *dive = _dive; dive->suit = get_utf8(str); }
+{ UNUSED(line); struct dive *dive = _dive; dive->suit = get_utf8(str); }
 
 static void parse_dive_notes(char *line, struct membuffer *str, void *_dive)
-{ (void) line; struct dive *dive = _dive; dive->notes = get_utf8(str); }
+{ UNUSED(line); struct dive *dive = _dive; dive->notes = get_utf8(str); }
 
 static void parse_dive_divesiteid(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->dive_site_uuid = get_hex(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->dive_site_uuid = get_hex(line); }
 
 /*
  * We can have multiple tags in the membuffer. They are separated by
@@ -250,7 +246,7 @@ static void parse_dive_divesiteid(char *line, struct membuffer *str, void *_dive
  */
 static void parse_dive_tags(char *line, struct membuffer *str, void *_dive)
 {
-	(void) line;
+	UNUSED(line);
 	struct dive *dive = _dive;
 	const char *tag;
 	int len = str->len;
@@ -273,40 +269,40 @@ static void parse_dive_tags(char *line, struct membuffer *str, void *_dive)
 }
 
 static void parse_dive_airtemp(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->airtemp = get_temperature(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->airtemp = get_temperature(line); }
 
 static void parse_dive_watertemp(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->watertemp = get_temperature(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->watertemp = get_temperature(line); }
 
 static void parse_dive_duration(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->duration = get_duration(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->duration = get_duration(line); }
 
 static void parse_dive_rating(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->rating = get_index(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->rating = get_index(line); }
 
 static void parse_dive_visibility(char *line, struct membuffer *str, void *_dive)
-{ (void) str; struct dive *dive = _dive; dive->visibility = get_index(line); }
+{ UNUSED(str); struct dive *dive = _dive; dive->visibility = get_index(line); }
 
 static void parse_dive_notrip(char *line, struct membuffer *str, void *_dive)
 {
-	(void) str;
-	(void) line;
+	UNUSED(str);
+	UNUSED(line);
 	struct dive *dive = _dive; dive->tripflag = NO_TRIP;
 }
 
 static void parse_site_description(char *line, struct membuffer *str, void *_ds)
-{ (void) line; struct dive_site *ds = _ds; ds->description = strdup(mb_cstring(str)); }
+{ UNUSED(line); struct dive_site *ds = _ds; ds->description = strdup(mb_cstring(str)); }
 
 static void parse_site_name(char *line, struct membuffer *str, void *_ds)
-{ (void) line; struct dive_site *ds = _ds; ds->name = strdup(mb_cstring(str)); }
+{ UNUSED(line); struct dive_site *ds = _ds; ds->name = strdup(mb_cstring(str)); }
 
 static void parse_site_notes(char *line, struct membuffer *str, void *_ds)
-{ (void) line; struct dive_site *ds = _ds; ds->notes = strdup(mb_cstring(str)); }
+{ UNUSED(line); struct dive_site *ds = _ds; ds->notes = strdup(mb_cstring(str)); }
 
 extern degrees_t parse_degrees(char *buf, char **end);
 static void parse_site_gps(char *line, struct membuffer *str, void *_ds)
 {
-	(void) str;
+	UNUSED(str);
 	struct dive_site *ds = _ds;
 
 	ds->latitude = parse_degrees(line, &line);
@@ -676,52 +672,52 @@ static void sample_parser(char *line, struct divecomputer *dc)
 }
 
 static void parse_dc_airtemp(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->airtemp = get_temperature(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->airtemp = get_temperature(line); }
 
 static void parse_dc_date(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; update_date(&dc->when, line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; update_date(&dc->when, line); }
 
 static void parse_dc_deviceid(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; set_dc_deviceid(dc, get_hex(line)); }
+{ UNUSED(str); struct divecomputer *dc = _dc; set_dc_deviceid(dc, get_hex(line)); }
 
 static void parse_dc_diveid(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->diveid = get_hex(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->diveid = get_hex(line); }
 
 static void parse_dc_duration(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->duration = get_duration(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->duration = get_duration(line); }
 
 static void parse_dc_dctype(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->divemode = get_dctype(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->divemode = get_dctype(line); }
 
 static void parse_dc_lastmanualtime(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->last_manual_time = get_duration(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->last_manual_time = get_duration(line); }
 
 static void parse_dc_maxdepth(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->maxdepth = get_depth(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->maxdepth = get_depth(line); }
 
 static void parse_dc_meandepth(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->meandepth = get_depth(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->meandepth = get_depth(line); }
 
 static void parse_dc_model(char *line, struct membuffer *str, void *_dc)
-{ (void) line; struct divecomputer *dc = _dc; dc->model = get_utf8(str); }
+{ UNUSED(line); struct divecomputer *dc = _dc; dc->model = get_utf8(str); }
 
 static void parse_dc_numberofoxygensensors(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->no_o2sensors = get_index(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->no_o2sensors = get_index(line); }
 
 static void parse_dc_surfacepressure(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->surface_pressure = get_pressure(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->surface_pressure = get_pressure(line); }
 
 static void parse_dc_salinity(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->salinity = get_salinity(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->salinity = get_salinity(line); }
 
 static void parse_dc_surfacetime(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->surfacetime = get_duration(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->surfacetime = get_duration(line); }
 
 static void parse_dc_time(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; update_time(&dc->when, line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; update_time(&dc->when, line); }
 
 static void parse_dc_watertemp(char *line, struct membuffer *str, void *_dc)
-{ (void) str; struct divecomputer *dc = _dc; dc->watertemp = get_temperature(line); }
+{ UNUSED(str); struct divecomputer *dc = _dc; dc->watertemp = get_temperature(line); }
 
 
 int get_divemode(const char *divemodestring) {
@@ -832,37 +828,37 @@ static void parse_dc_event(char *line, struct membuffer *str, void *_dc)
 }
 
 static void parse_trip_date(char *line, struct membuffer *str, void *_trip)
-{ (void) str; dive_trip_t *trip = _trip; update_date(&trip->when, line); }
+{ UNUSED(str); dive_trip_t *trip = _trip; update_date(&trip->when, line); }
 
 static void parse_trip_time(char *line, struct membuffer *str, void *_trip)
-{ (void) str; dive_trip_t *trip = _trip; update_time(&trip->when, line); }
+{ UNUSED(str); dive_trip_t *trip = _trip; update_time(&trip->when, line); }
 
 static void parse_trip_location(char *line, struct membuffer *str, void *_trip)
-{ (void) line; dive_trip_t *trip = _trip; trip->location = get_utf8(str); }
+{ UNUSED(line); dive_trip_t *trip = _trip; trip->location = get_utf8(str); }
 
 static void parse_trip_notes(char *line, struct membuffer *str, void *_trip)
-{ (void) line; dive_trip_t *trip = _trip; trip->notes = get_utf8(str); }
+{ UNUSED(line); dive_trip_t *trip = _trip; trip->notes = get_utf8(str); }
 
 static void parse_settings_autogroup(char *line, struct membuffer *str, void *_unused)
 {
-	(void) line;
-	(void) str;
-	(void) _unused;
+	UNUSED(line);
+	UNUSED(str);
+	UNUSED(_unused);
 	set_autogroup(true);
 }
 
 static void parse_settings_units(char *line, struct membuffer *str, void *unused)
 {
-	(void) str;
-	(void) unused;
+	UNUSED(str);
+	UNUSED(unused);
 	if (line)
 		set_informational_units(line);
 }
 
 static void parse_settings_userid(char *line, struct membuffer *str, void *_unused)
 {
-	(void) str;
-	(void) _unused;
+	UNUSED(str);
+	UNUSED(_unused);
 	if (line) {
 		prefs.save_userid_local = true;
 		set_userid(line);
@@ -871,8 +867,8 @@ static void parse_settings_userid(char *line, struct membuffer *str, void *_unus
 
 static void parse_settings_prefs(char *line, struct membuffer *str, void *unused)
 {
-	(void) str;
-	(void) unused;
+	UNUSED(str);
+	UNUSED(unused);
 	if (line)
 		set_git_prefs(line);
 }
@@ -886,8 +882,8 @@ static void parse_settings_prefs(char *line, struct membuffer *str, void *unused
  */
 static void parse_settings_version(char *line, struct membuffer *str, void *_unused)
 {
-	(void) str;
-	(void) _unused;
+	UNUSED(str);
+	UNUSED(_unused);
 	int version = atoi(line);
 	report_datafile_version(version);
 	if (version > DATAFORMAT_VERSION)
@@ -897,9 +893,9 @@ static void parse_settings_version(char *line, struct membuffer *str, void *_unu
 /* The string in the membuffer is the version string of subsurface that saved things, just FYI */
 static void parse_settings_subsurface(char *line, struct membuffer *str, void *_unused)
 {
-	(void) line;
-	(void) str;
-	(void) _unused;
+	UNUSED(line);
+	UNUSED(str);
+	UNUSED(_unused);
 }
 
 struct divecomputerid {
@@ -947,7 +943,7 @@ static void parse_divecomputerid_keyvalue(void *_cid, const char *key, const cha
  */
 static void parse_settings_divecomputerid(char *line, struct membuffer *str, void *_unused)
 {
-	(void) _unused;
+	UNUSED(_unused);
 	struct divecomputerid id = { mb_cstring(str) };
 
 	id.cstr = id.model + strlen(id.model) + 1;
@@ -968,14 +964,14 @@ static void parse_settings_divecomputerid(char *line, struct membuffer *str, voi
 
 static void parse_picture_filename(char *line, struct membuffer *str, void *_pic)
 {
-	(void) line;
+	UNUSED(line);
 	struct picture *pic = _pic;
 	pic->filename = get_utf8(str);
 }
 
 static void parse_picture_gps(char *line, struct membuffer *str, void *_pic)
 {
-	(void) str;
+	UNUSED(str);
 	struct picture *pic = _pic;
 
 	pic->latitude = parse_degrees(line, &line);
@@ -984,7 +980,7 @@ static void parse_picture_gps(char *line, struct membuffer *str, void *_pic)
 
 static void parse_picture_hash(char *line, struct membuffer *str, void *_pic)
 {
-	(void) line;
+	UNUSED(line);
 	struct picture *pic = _pic;
 	char *hash = get_utf8(str);
 	register_hash(pic->filename, get_utf8(str));
@@ -1056,7 +1052,7 @@ static struct keyword_action settings_action[] = {
 
 static void settings_parser(char *line, struct membuffer *str, void *_unused)
 {
-	(void) _unused;
+	UNUSED(_unused);
 	match_action(line, str, NULL, settings_action, ARRAY_SIZE(settings_action));
 }
 
@@ -1383,8 +1379,8 @@ static int dive_directory(const char *root, const git_tree_entry *entry, const c
 
 static int picture_directory(const char *root, const char *name)
 {
-	(void) root;
-	(void) name;
+	UNUSED(root);
+	UNUSED(name);
 	if (!active_dive)
 		return GIT_WALK_SKIP;
 	return GIT_WALK_OK;
@@ -1521,7 +1517,7 @@ static struct divecomputer *create_new_dc(struct dive *dive)
  */
 static int parse_divecomputer_entry(git_repository *repo, const git_tree_entry *entry, const char *suffix)
 {
-	(void) suffix;
+	UNUSED(suffix);
 	git_blob *blob = git_tree_entry_blob(repo, entry);
 
 	if (!blob)

--- a/core/macos.c
+++ b/core/macos.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 /* macos.c */
 /* implements Mac OS X specific functions */
+#include "ssrf.h"
 #include <stdlib.h>
 #include <dirent.h>
 #include <fnmatch.h>
@@ -19,7 +20,7 @@
 
 void subsurface_user_info(struct user_info *info)
 {
-	(void) info;
+	UNUSED(info);
 	/* Nothing, let's use libgit2-20 on MacOS */
 }
 
@@ -46,7 +47,7 @@ void subsurface_OS_pref_setup(void)
 
 bool subsurface_ignore_font(const char *font)
 {
-	(void) font;
+	UNUSED(font);
 	// there are no old default fonts to ignore
 	return false;
 }

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -404,8 +405,8 @@ static void gasmix(char *buffer, fraction_t *fraction)
 
 static void gasmix_nitrogen(char *buffer, struct gasmix *gasmix)
 {
-	(void) buffer;
-	(void) gasmix;
+	UNUSED(buffer);
+	UNUSED(gasmix);
 	/* Ignore n2 percentages. There's no value in them. */
 }
 
@@ -925,7 +926,7 @@ static void try_to_fill_sample(struct sample *sample, const char *name, char *bu
 
 static void try_to_fill_userid(const char *name, char *buf)
 {
-	(void) name;
+	UNUSED(name);
 	if (prefs.save_userid_local)
 		set_userid(buf);
 }
@@ -1606,7 +1607,7 @@ static const char *preprocess_divelog_de(const char *buffer)
 int parse_xml_buffer(const char *url, const char *buffer, int size,
 		      struct dive_table *table, const char **params)
 {
-	(void) size;
+	UNUSED(size);
 	xmlDoc *doc;
 	const char *res = preprocess_divelog_de(buffer);
 	int ret = 0;

--- a/core/parse.c
+++ b/core/parse.c
@@ -1,3 +1,4 @@
+#include "ssrf.h"
 #include <stdio.h>
 #include <assert.h>
 #include <stdarg.h>
@@ -195,7 +196,7 @@ bool is_dive(void)
 void reset_dc_info(struct divecomputer *dc)
 {
 	/* WARN: reset dc info does't touch the dc? */
-	(void) dc;
+	UNUSED(dc);
 	lastcylinderindex = 0;
 }
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -5,6 +5,7 @@
  *
  * (c) Dirk Hohndel 2013
  */
+#include "ssrf.h"
 #include <assert.h>
 #include <unistd.h>
 #include <ctype.h>
@@ -533,7 +534,7 @@ static int *sort_stops(int *dstops, int dnr, struct gaschanges *gstops, int gnr)
 
 int ascent_velocity(int depth, int avg_depth, int bottom_time)
 {
-	(void) bottom_time;
+	UNUSED(bottom_time);
 	/* We need to make this configurable */
 
 	/* As an example (and possibly reasonable default) this is the Tech 1 provedure according

--- a/core/profile.c
+++ b/core/profile.c
@@ -2,6 +2,7 @@
 /* profile.c */
 /* creates all the necessary data for drawing the dive profile
  */
+#include "ssrf.h"
 #include "gettext.h"
 #include <limits.h>
 #include <string.h>
@@ -373,9 +374,9 @@ static int set_setpoint(struct plot_info *pi, int i, int setpoint, int end)
 
 static void check_setpoint_events(struct dive *dive, struct divecomputer *dc, struct plot_info *pi)
 {
+	UNUSED(dive);
 	int i = 0;
 	pressure_t setpoint;
-	(void) dive;
 	setpoint.mbar = 0;
 	struct event *ev = get_next_event(dc->events, "SP change");
 
@@ -502,12 +503,11 @@ struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer
 
 struct plot_data *populate_plot_entries(struct dive *dive, struct divecomputer *dc, struct plot_info *pi)
 {
-
+	UNUSED(dive);
 	int idx, maxtime, nr, i;
 	int lastdepth, lasttime, lasttemp = 0;
 	struct plot_data *plot_data;
 	struct event *ev = dc->events;
-	(void) dive;
 	maxtime = pi->maxtime;
 
 	/*
@@ -793,8 +793,8 @@ static void calculate_sac(struct dive *dive, struct divecomputer *dc, struct plo
 
 static void populate_secondary_sensor_data(struct divecomputer *dc, struct plot_info *pi)
 {
-	(void) dc;
-	(void) pi;
+	UNUSED(dc);
+	UNUSED(pi);
 	/* We should try to see if it has interesting pressure data here */
 }
 
@@ -1322,7 +1322,7 @@ void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plo
 	struct deco_state plot_deco_state;
 	init_decompression(&plot_deco_state, dive);
 #else
-	(void)planner_ds;
+	UNUSED(planner_ds);
 #endif
 	/* Create the new plot data */
 	free((void *)last_pi_entry_new);

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -327,11 +327,10 @@ static dc_status_t qt_serial_write(void *io, const void* data, size_t size, size
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t qt_serial_purge(void *io, dc_direction_t queue)
+static dc_status_t qt_serial_purge(void *io, dc_direction_t)
 {
 	qt_serial_t *device = (qt_serial_t*) io;
 
-	(void)queue;
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
 #if !defined(Q_OS_WIN)

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include "ssrf.h"
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -1035,11 +1036,11 @@ static int notify_cb(git_checkout_notify_t why,
 	const git_diff_file *workdir,
 	void *payload)
 {
-	(void) baseline;
-	(void) target;
-	(void) workdir;
-	(void) payload;
-	(void) why;
+	UNUSED(baseline);
+	UNUSED(target);
+	UNUSED(workdir);
+	UNUSED(payload);
+	UNUSED(why);
 	report_error("File '%s' does not match in working tree", path);
 	return 0; /* Continue with checkout */
 }

--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef SSRF_H
+#define SSRF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+}
+#else
+
+// Macro to be used for silencing unused parameters
+#define UNUSED(x) (void)x
+#endif
+
+#endif // SSRF_H

--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -6,6 +6,10 @@
 extern "C" {
 #endif
 
+#ifdef __clang__
+// Clang has a bug on zero-initialization of C structs.
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
 #ifdef __cplusplus
 }

--- a/core/windows.c
+++ b/core/windows.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 /* windows.c */
 /* implements Windows specific functions */
+#include "ssrf.h"
 #include <io.h>
 #include "dive.h"
 #include "display.h"
@@ -391,7 +392,7 @@ static struct {
 
 void subsurface_console_init(void)
 {
-	(void)console_desc;
+	UNUSED(console_desc);
 	/* if this is a console app already, do nothing */
 #ifndef WIN32_CONSOLE_APP
 

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -1043,8 +1043,7 @@ void DiveListView::updateLastImageTimeOffset(const int offset)
 	s.setValue("LastImageTimeOffset", offset);
 }
 
-void DiveListView::mouseDoubleClickEvent(QMouseEvent * event)
+void DiveListView::mouseDoubleClickEvent(QMouseEvent*)
 {
-	(void) event;
 	return;
 }

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -415,7 +415,6 @@ void SubsurfaceWebServices::buttonClicked(QAbstractButton *button)
 		struct dive *d;
 		struct dive_site *ds;
 		bool changed = false;
-		(void)changed;
 		clear_table(&gps_location_table);
 		QByteArray url = tr("Webservice").toUtf8();
 		parse_xml_buffer(url.data(), downloadedData.data(), downloadedData.length(), &gps_location_table, NULL);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -163,7 +163,6 @@ int DiveProfileItem::maxCeiling(int row)
 void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
 	bool eventAdded = false;
-	(void)eventAdded;
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
 
@@ -175,7 +174,9 @@ void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelI
 	reported_ceiling_in_red = prefs.redceiling;
 	profileColor = getColor(DEPTH_BOTTOM);
 
-#ifndef SUBSURFACE_MOBILE
+#ifdef SUBSURFACE_MOBILE
+	Q_UNUSED(eventAdded);
+#else
 	int currState = qobject_cast<ProfileWidget2 *>(scene()->views().first())->currentState;
 	if (currState == ProfileWidget2::PLAN) {
 		plot_data *entry = dataModel->data().entry;

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -40,8 +40,7 @@ int main(int argc, char **argv)
 	int i;
 	bool no_filenames = true;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
-	QApplication *application = new QApplication(argc, argv);
-	(void)application;
+	new QApplication(argc, argv);
 	QStringList files;
 	QStringList importedFiles;
 	QStringList arguments = QCoreApplication::arguments();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -24,8 +24,11 @@ int main(int argc, char **argv)
 	int i;
 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
-	QApplication *application = new QApplication(argc, argv);
-	(void)application;
+
+	// Start application
+	new QApplication(argc, argv);
+
+	// and get comand line arguments
 	QStringList arguments = QCoreApplication::arguments();
 
 	subsurface_console_init();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
cleanup how to silence not used parameters

added ssrf.h as a global product header in contrast to
dive.h that are the global dive header.

ssrf.h should slowly be extended with common macros, includes etc.
for now it contains UNUSED(x)

added a #pragma to silence missing initialisers, due to a clang bug.

with this are source should be consistent (apart from the few I have not catched).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) replaced (void)x with Q_UNUSED(x) or remove parameter name in cpp files
2) added ssrf.h
3) replaced (void)x with UNUSED(x) in C files

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->