### PR TITLE
core: qt-ble.cpp remove postEvent for all platforms

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -38,9 +38,6 @@ static void waitFor(int ms) {
 
 	do {
 		QCoreApplication::processEvents(QEventLoop::AllEvents, ms);
-#if !defined(Q_OS_IOS)
-		QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
-#endif
 		QThread::msleep(10);
 	} while (timer.elapsed() < ms);
 }


### PR DESCRIPTION
the postEvent is only called when downloading from a dc
with bluetooth, so in most it does not have an effect
on the deleteLater() in the code.

there are no reason to do special cleanup while waiting
for bluetooth

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
as discussed in #1308 there are no need for a postEvent to delete "deleteLater", since 
this is only a bluetooth loop, and postEvent are not called elsewhere.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->