### PR TITLE
core: btdiscovery, remove rediscovery() in constructor

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -72,9 +72,6 @@ BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
 		return;
 	}
 	m_instance = this;
-#if defined(BT_SUPPORT)
-	BTDiscoveryReDiscover();
-#endif
 }
 
 void BTDiscovery::BTDiscoveryReDiscover()


### PR DESCRIPTION
The btdiscovery object is created during startup, doing
a discovery at the point in time is prolonging the startup
time which is long enough (15sec on an iPhone).

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Doing a discovery when creating the btdiscovery class makes the startup phase
(at least on an iPhone) longer, and there are no need to do it, since we do not
know if the user will connect to a dc with bluetooth.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) removed call of rediscovery in btdiscovery constructor.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->