### PR TITLE
[RFC] Cleanup: remove code related to pictures in the cloud-repository

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -13,7 +13,7 @@ public:
 	static ImageDownloader *instance();
 	ImageDownloader();
 public slots:
-	void load(QString filename, bool fromHash);
+	void load(QString filename);
 signals:
 	void loaded(QString filename);
 	void failed(QString filename);


### PR DESCRIPTION
Storing pictures in the cloud never came to be, so remove the code.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code-removal of picture related code like #1319. But whereas #1319 is pretty obvious (no plans to resurrect git-storage of pictures), this one not so much. I guess cloud-storage of pictures was planned as an alternative to git-storage of pictures. I don't know if there are plans of going forward with it.

### Mentions:

@atdotde @dirkhh 