### PR TITLE
Cleanup: Don't defer deletion of oldModel in DiveListView::reload()

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -425,13 +425,12 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 
 	QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(model());
 	QAbstractItemModel *oldModel = m->sourceModel();
-	if (oldModel) {
-		oldModel->deleteLater();
-	}
 	tripModel = new DiveTripModel(this);
 	tripModel->setLayout(layout);
 
 	m->setSourceModel(tripModel);
+	if (oldModel)
+		delete oldModel;
 
 	if (!forceSort)
 		return;


### PR DESCRIPTION
There seems to be no point in using deleteLater() of the previous
model. Set the new model and delete the old one.

This fixes a crash with Qt 5.11.

Tested-by: Gaetan Bisson <bisson@archlinux.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This actually fixes a crash on Qt 5.11. See mailing-list discussion. The exact reason of the crash is unknown, but probably not worth further investigation.