### PR TITLE
[RFC] Dive pictures: Derive thumbnail file from picture filename

### DIFF
--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -167,7 +167,6 @@ Thumbnailer *Thumbnailer::instance()
 
 static QImage getThumbnailFromCache(const QString &picture_filename)
 {
-	// First, check if we know a hash for this filename
 	QString filename = thumbnailFileName(picture_filename);
 	if (filename.isEmpty())
 		return QImage();
@@ -192,14 +191,6 @@ static void addThumbnailToCache(const QImage &thumbnail, const QString &picture_
 		return;
 
 	QString filename = thumbnailFileName(picture_filename);
-
-	// If we got a thumbnail, we are guaranteed to have its hash and therefore
-	// thumbnailFileName() should return a filename.
-	if (filename.isEmpty()) {
-		qWarning() << "Internal error: can't get filename of recently created thumbnail";
-		return;
-	}
-
 	QSaveFile file(filename);
 	if (!file.open(QIODevice::WriteOnly))
 		return;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1088,12 +1088,14 @@ static QString thumbnailDir()
 	return QString(system_default_directory()) + "/thumbnails/";
 }
 
-// Return filename of thumbnail if it is known to us.
-// If this is an unknown thumbnail, return an empty string.
+// Calculate thumbnail filename by hashing name of file.
 QString thumbnailFileName(const QString &filename)
 {
-	QString hash = getHash(filename).toHex();
-	return hash.isEmpty() ? QString() : thumbnailDir() + hash;
+	if (filename.isEmpty())
+		return QString();
+	QCryptographicHash hash(QCryptographicHash::Sha1);
+	hash.addData(filename.toUtf8());
+	return thumbnailDir() + hash.result().toHex();
 }
 
 extern "C" char *hashfile_name_string()


### PR DESCRIPTION
Since commit 6618c9ebfc6a7cebbef687fcb3aa74c70f504ff2, thumbnails
are saved in individual files. The filename was simply the picture-hash.
In a mailing-list discussion it turned out that in the future we might
not hash images or change the hash. Therefore, derive the thumbnail
filename from the image filename, using the SHA1 algorithm.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This changes the way the thumbnail filenames are generated: Instead of using the image hash, derive it from the image filename. The reason is that according to a mailing-list discussion, we might change or even remove the hash.

The thumbnail filename is generating by SHA1ing the (canonical, not local) picture filename. I wonder if a less heavy hash-function would suffice. After all, all we want to avoid is collisions, isn't it?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
