### PR TITLE
Cleanup: remove three instances of deleteLater() in mainwindow.cpp and one in qmlprofile.c

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1354,18 +1354,16 @@ void MainWindow::on_action_Check_for_Updates_triggered()
 void MainWindow::on_actionUserManual_triggered()
 {
 #ifndef NO_USERMANUAL
-	if (!helpView) {
-		helpView = new UserManual();
-	}
+	if (!helpView)
+		helpView = new UserManual(this);
 	helpView->show();
 #endif
 }
 
 void MainWindow::on_actionUserSurvey_triggered()
 {
-	if(!survey) {
+	if(!survey)
 		survey = new UserSurvey(this);
-	}
 	survey->show();
 }
 
@@ -1559,18 +1557,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
 		on_actionQuit_triggered();
 		event->ignore();
 		return;
-	}
-
-#ifndef NO_USERMANUAL
-	if (helpView && helpView->isVisible()) {
-		helpView->close();
-		helpView->deleteLater();
-	}
-#endif
-
-	if (survey && survey->isVisible()) {
-		survey->close();
-		survey->deleteLater();
 	}
 
 	if (unsaved_changes() && (askSaveChanges() == false)) {
@@ -2070,7 +2056,7 @@ void MainWindow::hideProgressBar()
 {
 	if (progressDialog) {
 		progressDialog->setValue(100);
-		progressDialog->deleteLater();
+		delete progressDialog;
 		progressDialog = NULL;
 	}
 }

--- a/mobile-widgets/qmlprofile.cpp
+++ b/mobile-widgets/qmlprofile.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qmlprofile.h"
 #include "qmlmanager.h"
-#include "profile-widget/profilewidget2.h"
 #include "core/subsurface-string.h"
 #include "core/metrics.h"
 #include <QTransform>
@@ -10,20 +9,15 @@
 QMLProfile::QMLProfile(QQuickItem *parent) :
 	QQuickPaintedItem(parent),
 	m_devicePixelRatio(1.0),
-	m_margin(0)
+	m_margin(0),
+	m_profileWidget(new ProfileWidget2)
 {
 	setAntialiasing(true);
-	m_profileWidget = new ProfileWidget2(0);
 	m_profileWidget->setProfileState();
 	m_profileWidget->setPrintMode(true);
 	m_profileWidget->setFontPrintScale(0.8);
 	connect(QMLManager::instance(), &QMLManager::sendScreenChanged, this, &QMLProfile::screenChanged);
 	setDevicePixelRatio(QMLManager::instance()->lastDevicePixelRatio());
-}
-
-QMLProfile::~QMLProfile()
-{
-	m_profileWidget->deleteLater();
 }
 
 void QMLProfile::paint(QPainter *painter)

--- a/mobile-widgets/qmlprofile.h
+++ b/mobile-widgets/qmlprofile.h
@@ -2,9 +2,8 @@
 #ifndef QMLPROFILE_H
 #define QMLPROFILE_H
 
+#include "profile-widget/profilewidget2.h"
 #include <QQuickPaintedItem>
-
-class ProfileWidget2;
 
 class QMLProfile : public QQuickPaintedItem
 {
@@ -14,7 +13,6 @@ class QMLProfile : public QQuickPaintedItem
 
 public:
 	explicit QMLProfile(QQuickItem *parent = 0);
-	virtual ~QMLProfile();
 
 	void paint(QPainter *painter);
 
@@ -30,7 +28,7 @@ private:
 	QString m_diveId;
 	qreal m_devicePixelRatio;
 	int m_margin;
-	ProfileWidget2 *m_profileWidget;
+	QScopedPointer<ProfileWidget2> m_profileWidget;
 
 signals:
 	void rightAlignedChanged();


### PR DESCRIPTION
deleteLater() can be dangerous. Remove were not necessary.

Analysis:

1) `helpView` was a pointer which was initialized on demand. close() and
deleteLater() were called on closure of the main window. Firstly, there's
no point in calling deleteLater(), because no references to helpView
are used later on. Secondly, the deletion (and closing) can be done
automatically in the destructor, by passing `this` as parent object.

2) `survey`: pretty much the same situation. But here, `this` was already
passed as parent object.

3) `progressDialog` is a global (not thread safe!) pointer. The object
is deleted after use. There is no point in using deleteLater(), because
the callers are not active after hideProgressBar(), which is the
place were the deleteLater() call was found.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

-------------

Cleanup: remove deleteLater() in QMLProfile

The actual profile object was destroyed with deleteLater() in the
destructor of QMLProfile. This is ominous, because the subobject
shouldn't survive the parent object.

Therefore, automatically destroy the profile by using a QScopedPointer.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removes unnecessary `deleteLater()`s. Note that I test the progressDialog and survey delete, but not the manual. Apparently I compile without user manual.

There seems to be one more questionable `deleteLater()`: in the destructor of `QMLProfile`.
EDIT: I added a commit to remove that as well. Attention: Untested! Currently my desktop-on-mobile version refuses to run:
```
INFO: QQmlApplicationEngine failed to load component
INFO: qrc:///qml/main.qml:530 Type MapPage unavailable
qrc:///qml/MapPage.qml:17 Type MapWidget unavailable
qrc:///qml/MapWidget.qml:3 module "QtLocation" is not installed

can't create window object
```