### PR TITLE
Cleanup: remove reply and request member variables in QMLManager

### DIFF
--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -216,8 +216,6 @@ private:
 	GpsLocation *locationProvider;
 	bool m_loadFromCloud;
 	static QMLManager *m_instance;
-	QNetworkReply *reply;
-	QNetworkRequest request;
 	struct dive *deletedDive;
 	struct dive_trip *deletedTrip;
 	QString m_notificationText;


### PR DESCRIPTION
The reply member variable was used to access the reply in the
handleSslErrors, handleError and retrieveUserid slots. This is a
very scary proposition in the light of multi-threading. Instead,
the reply can be accessed by using the QObject::sender() function.
Thus, we can remove the member variable.

The request member was just downright weird. This was only used
locally to describe a network request. Since QNetworkAccessManager::get()
copies the request, it can be destructed right away. Nevertheless,
the data was kept as a subobject. Remove member and make it function-local.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes two ownership issues in qmlmanager.cpp. Warning: Only compile tested!