### PR TITLE
[RFC] Recalculate thumbnails

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -34,6 +34,9 @@ public:
 	// via a signal later.
 	QImage fetchThumbnail(PictureEntry &entry);
 
+	// Schedule multiple thumbnails for forced recalculation
+	void calculateThumbnails(const QVector<QString> &filenames);
+
 	// If we change dive, clear all unfinished thumbnail creations
 	void clearWorkQueue();
 	static int maxThumbnailSize();
@@ -46,6 +49,7 @@ signals:
 	void thumbnailChanged(QString filename, QImage thumbnail);
 private:
 	Thumbnailer();
+	void recalculate(QString filename);
 	void processItem(QString filename, bool tryDownload);
 
 	mutable QMutex lock;

--- a/core/pref.h
+++ b/core/pref.h
@@ -154,6 +154,7 @@ struct preferences {
 	int distance_threshold;
 	bool git_local_only;
 	short cloud_timeout;
+	bool auto_recalculate_thumbnails;
 	locale_prefs_t locale; //: TODO: move the rest of locale based info here.
 	update_manager_prefs_t update_manager;
 	dive_computer_prefs_t dive_computer;

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -1802,6 +1802,11 @@ int GeneralSettingsObjectWrapper::pscrRatio() const
 	return prefs.pscr_ratio;
 }
 
+bool GeneralSettingsObjectWrapper::autoRecalculateThumbnails() const
+{
+	return prefs.auto_recalculate_thumbnails;
+}
+
 void GeneralSettingsObjectWrapper::setDefaultFilename(const QString& value)
 {
 	if (value == prefs.default_filename)
@@ -1893,6 +1898,18 @@ void GeneralSettingsObjectWrapper::setPscrRatio(int value)
 	s.setValue("pscr_ratio", value);
 	prefs.pscr_ratio = value;
 	emit pscrRatioChanged(value);
+}
+
+void GeneralSettingsObjectWrapper::setAutoRecalculateThumbnails(bool value)
+{
+	if (value == prefs.auto_recalculate_thumbnails)
+		return;
+
+	QSettings s;
+	s.beginGroup(group);
+	s.setValue("auto_recalculate_thumbnails", value);
+	prefs.auto_recalculate_thumbnails = value;
+	emit autoRecalculateThumbnailsChanged(value);
 }
 
 DisplaySettingsObjectWrapper::DisplaySettingsObjectWrapper(QObject *parent) :
@@ -2266,6 +2283,7 @@ void SettingsObjectWrapper::load()
 	GET_INT("defaultsetpoint", defaultsetpoint);
 	GET_INT("o2consumption", o2consumption);
 	GET_INT("pscr_ratio", pscr_ratio);
+	GET_BOOL("auto_recalculate_thumbnails", auto_recalculate_thumbnails);
 	s.endGroup();
 
 	s.beginGroup("Display");

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -552,13 +552,14 @@ private:
 
 class GeneralSettingsObjectWrapper : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(QString default_filename      READ defaultFilename       WRITE setDefaultFilename       NOTIFY defaultFilenameChanged)
-	Q_PROPERTY(QString default_cylinder      READ defaultCylinder       WRITE setDefaultCylinder       NOTIFY defaultCylinderChanged)
-	Q_PROPERTY(short default_file_behavior   READ defaultFileBehavior   WRITE setDefaultFileBehavior   NOTIFY defaultFileBehaviorChanged)
-	Q_PROPERTY(bool use_default_file         READ useDefaultFile        WRITE setUseDefaultFile        NOTIFY useDefaultFileChanged)
-	Q_PROPERTY(int defaultsetpoint           READ defaultSetPoint       WRITE setDefaultSetPoint       NOTIFY defaultSetPointChanged)
-	Q_PROPERTY(int o2consumption             READ o2Consumption         WRITE setO2Consumption         NOTIFY o2ConsumptionChanged)
-	Q_PROPERTY(int pscr_ratio                READ pscrRatio             WRITE setPscrRatio             NOTIFY pscrRatioChanged)
+	Q_PROPERTY(QString default_filename         READ defaultFilename           WRITE setDefaultFilename           NOTIFY defaultFilenameChanged)
+	Q_PROPERTY(QString default_cylinder         READ defaultCylinder           WRITE setDefaultCylinder           NOTIFY defaultCylinderChanged)
+	Q_PROPERTY(short default_file_behavior      READ defaultFileBehavior       WRITE setDefaultFileBehavior       NOTIFY defaultFileBehaviorChanged)
+	Q_PROPERTY(bool use_default_file            READ useDefaultFile            WRITE setUseDefaultFile            NOTIFY useDefaultFileChanged)
+	Q_PROPERTY(int defaultsetpoint              READ defaultSetPoint           WRITE setDefaultSetPoint           NOTIFY defaultSetPointChanged)
+	Q_PROPERTY(int o2consumption                READ o2Consumption             WRITE setO2Consumption             NOTIFY o2ConsumptionChanged)
+	Q_PROPERTY(int pscr_ratio                   READ pscrRatio                 WRITE setPscrRatio                 NOTIFY pscrRatioChanged)
+	Q_PROPERTY(bool auto_recalculate_thumbnails READ autoRecalculateThumbnails WRITE setAutoRecalculateThumbnails NOTIFY autoRecalculateThumbnailsChanged)
 
 public:
 	GeneralSettingsObjectWrapper(QObject *parent);
@@ -569,15 +570,17 @@ public:
 	int defaultSetPoint() const;
 	int o2Consumption() const;
 	int pscrRatio() const;
+	bool autoRecalculateThumbnails() const;
 
 public slots:
-	void setDefaultFilename       (const QString& value);
-	void setDefaultCylinder       (const QString& value);
-	void setDefaultFileBehavior   (short value);
-	void setUseDefaultFile        (bool value);
-	void setDefaultSetPoint       (int value);
-	void setO2Consumption         (int value);
-	void setPscrRatio             (int value);
+	void setDefaultFilename           (const QString& value);
+	void setDefaultCylinder           (const QString& value);
+	void setDefaultFileBehavior       (short value);
+	void setUseDefaultFile            (bool value);
+	void setDefaultSetPoint           (int value);
+	void setO2Consumption             (int value);
+	void setPscrRatio                 (int value);
+	void setAutoRecalculateThumbnails (bool value);
 
 signals:
 	void defaultFilenameChanged(const QString& value);
@@ -587,6 +590,7 @@ signals:
 	void defaultSetPointChanged(int value);
 	void o2ConsumptionChanged(int value);
 	void pscrRatioChanged(int value);
+	void autoRecalculateThumbnailsChanged(int value);
 private:
 	const QString group = QStringLiteral("GeneralSettings");
 };

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -99,6 +99,7 @@ struct preferences default_prefs = {
 #else
 	.cloud_timeout = 5,
 #endif
+	.auto_recalculate_thumbnails = true,
 };
 
 int run_survey;

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -47,6 +47,7 @@ void PreferencesGraph::refreshSettings()
 
 	ui->display_unused_tanks->setChecked(prefs.display_unused_tanks);
 	ui->show_average_depth->setChecked(prefs.show_average_depth);
+	ui->auto_recalculate_thumbnails->setChecked(prefs.auto_recalculate_thumbnails);
 	ui->show_icd->setChecked(prefs.show_icd);
 }
 
@@ -56,6 +57,7 @@ void PreferencesGraph::syncSettings()
 	general->setDefaultSetPoint(lrint(ui->defaultSetpoint->value() * 1000.0));
 	general->setO2Consumption(lrint(ui->psro2rate->value() *1000.0));
 	general->setPscrRatio(lrint(1000.0 / ui->pscrfactor->value()));
+	general->setAutoRecalculateThumbnails(ui->auto_recalculate_thumbnails->isChecked());
 
 	auto pp_gas = SettingsObjectWrapper::instance()->pp_gas;
 	pp_gas->setPheThreshold(ui->pheThreshold->value());

--- a/desktop-widgets/preferences/preferences_graph.ui
+++ b/desktop-widgets/preferences/preferences_graph.ui
@@ -368,6 +368,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="auto_recalculate_thumbnails">
+        <property name="text">
+         <string>Recalculate thumbnails if older than image</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/desktop-widgets/tab-widgets/TabDivePhotos.h
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.h
@@ -26,11 +26,13 @@ private slots:
 	void addPhotosFromURL();
 	void removeAllPhotos();
 	void removeSelectedPhotos();
+	void recalculateSelectedThumbnails();
 	void changeZoomLevel(int delta);
 
 private:
 	Ui::TabDivePhotos *ui;
 	DivePictureModel *divePictureModel;
+	QVector<QString> getSelectedFilenames() const;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We calculate file-hashes of pictures to (among other things) be able to tell when a picture changed. Yet, in routine-operation, the hashes never were checked against image data, thus stale thumbnails would not be recalculated.

Therefore, two methods of thumbnail-recalculations are added in this PR:

1) Manual. The user can choose "update thumbnails of selected images".
2) Automatic. If a thumbnail is detected that is older than the local version of the image, a thumbnail recalculation is performed. This does not check the source of downloaded images, thus a manual control is still necessary. Since this does more disk-IO (access timestamp of original picture) and may have strange side effects with messed up file-timestamps or computer clocks, it can be turned off in the preferences.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Implement manual updating of thumbnails
2) Add preferences option "automatic recalculation of thumbnails"
3) Implement automatic recalculation of thumbnails

I tested this by editing local pictures and it recalculated them when changing to the respective dive. Currently, no recalculation is performed without changing dive. I feel that hooking into the file-change-notification-thing of the OS would be overkill.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Should probably be present in the release notes - I will make a PR of the recent changes before release.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 