### PR TITLE
[WIP] mobile: temporary measure to get startup times from different devices

### DIFF
--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -19,7 +19,11 @@ extern "C" {
 #define UNUSED(x) (void)x
 #endif
 
+#ifdef ENABLE_STARTUP_TIMING
 #ifdef STARTUP_TIMER
+#define STP_SETUP() QTime stpDuration; \
+					QString stpText
+#define STP_RUN() stpDuration.start()
 // Block to help determine where time is "lost" in
 // the mobile version during startup
 #include <QTime>
@@ -30,6 +34,11 @@ extern QString stpText;
 							.append(" ms, ") \
 							.append(x) \
 							.append("\n")
+#endif // STARTUP_TIMER
+#else // Release version
+#define STP_SETUP() 
+#define STP_RUN()
+#define LOG_STP(x)
 #endif
 
 #endif // SSRF_H

--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -19,4 +19,17 @@ extern "C" {
 #define UNUSED(x) (void)x
 #endif
 
+#ifdef STARTUP_TIMER
+// Block to help determine where time is "lost" in
+// the mobile version during startup
+#include <QTime>
+extern QTime stpDuration;
+extern QString stpText;
+#define LOG_STP(x) stpText +=QString("STP ") \
+							.append(QString::number(stpDuration.elapsed())) \
+							.append(" ms, ") \
+							.append(x) \
+							.append("\n")
+#endif
+
 #endif // SSRF_H

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -362,6 +362,8 @@ void QMLManager::copyAppLogToClipboard()
 		QTextStream in(&f);
 		copyString += in.readAll();
 	}
+	copyString += "---------- startup timer ----------\n";
+	copyString += stpText;
 	copyString += "---------- finish ----------\n";
 
 	// and copy to clipboard

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -362,8 +362,10 @@ void QMLManager::copyAppLogToClipboard()
 		QTextStream in(&f);
 		copyString += in.readAll();
 	}
+#ifdef ENABLE_STARTUP_TIMING
 	copyString += "---------- startup timer ----------\n";
 	copyString += stpText;
+#endif
 	copyString += "---------- finish ----------\n";
 
 	// and copy to clipboard

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -32,6 +32,9 @@
 #include "qt-models/tankinfomodel.h"
 #include "core/downloadfromdcthread.h"
 
+#define STARTUP_TIMER
+#include "core/ssrf.h"
+
 QMLManager *QMLManager::m_instance = NULL;
 
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
@@ -138,6 +141,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	alreadySaving(false),
 	m_device_data(new DCDeviceData(this))
 {
+	LOG_STP("qmlmgr starting");
 	m_instance = this;
 	m_lastDevicePixelRatio = qApp->devicePixelRatio();
 	timer.start();
@@ -164,6 +168,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 				+ " at " + QDateTime::currentDateTime().toString());
 	}
 #endif
+	LOG_STP("qmlmgr log started");
 	set_error_cb(&showErrorFromC);
 	appendTextToLog("Starting " + getUserAgent());
 	appendTextToLog(QStringLiteral("built with libdivecomputer v%1").arg(dc_version(NULL)));
@@ -172,11 +177,13 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	git_libgit2_version(&git_maj, &git_min, &git_rev);
 	appendTextToLog(QStringLiteral("built with libgit2 %1.%2.%3").arg(git_maj).arg(git_min).arg(git_rev));
 	setStartPageText(tr("Starting..."));
+	LOG_STP("qmlmgr start page");
 
 	// ensure that we start the BTDiscovery - this should be triggered by the export of the class
 	// to QML, but that doesn't seem to always work
 	BTDiscovery *btDiscovery = BTDiscovery::instance();
 	m_btEnabled = btDiscovery->btAvailable();
+	LOG_STP("qmlmgr bt available");
 	connect(&btDiscovery->localBtDevice, &QBluetoothLocalDevice::hostModeStateChanged,
 		this, &QMLManager::btHostModeChange);
 	setShowPin(false);
@@ -185,10 +192,13 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	progress_callback = &progressCallback;
 	connect(locationProvider, SIGNAL(haveSourceChanged()), this, SLOT(hasLocationSourceChanged()));
 	setLocationServiceAvailable(locationProvider->hasLocationsSource());
+	LOG_STP("qmlmgr gps started");
 	set_git_update_cb(&gitProgressCB);
+	LOG_STP("qmlmgr git update");
 
 	// make sure we know if the current cloud repo has been successfully synced
 	syncLoadFromCloud();
+	LOG_STP("qmlmgr sync load cloud");
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -29,6 +29,9 @@
 
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 
+#define STARTUP_TIMER
+#include "core/ssrf.h"
+
 QObject *qqWindowObject = NULL;
 
 void set_non_bt_addresses() {
@@ -51,6 +54,7 @@ void init_ui()
 
 void run_ui()
 {
+	LOG_STP("run_ui starting");
 	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
 	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
 
@@ -63,6 +67,7 @@ void run_ui()
 	qmlRegisterType<MapLocation>("org.subsurfacedivelog.mobile", 1, 0, "MapLocation");
 
 	QQmlApplicationEngine engine;
+	LOG_STP("run_ui qml engine started");
 	KirigamiPlugin::getInstance().registerTypes();
 #if defined(__APPLE__) && !defined(Q_OS_IOS)
 	// when running the QML UI on a Mac the deployment of the QML Components seems
@@ -79,11 +84,13 @@ void run_ui()
 #endif
 	engine.addImportPath("qrc://imports");
 	DiveListModel diveListModel;
+	LOG_STP("run_ui diveListModel started");
 	DiveListSortModel *sortModel = new DiveListSortModel(0);
 	sortModel->setSourceModel(&diveListModel);
 	sortModel->setDynamicSortFilter(true);
 	sortModel->setSortRole(DiveListModel::DiveDateRole);
 	sortModel->sort(0, Qt::DescendingOrder);
+	LOG_STP("run_ui diveListModel sorted");
 	GpsListModel gpsListModel;
 	QSortFilterProxyModel *gpsSortModel = new QSortFilterProxyModel(0);
 	gpsSortModel->setSourceModel(&gpsListModel);
@@ -95,11 +102,13 @@ void run_ui()
 	ctxt->setContextProperty("gpsModel", gpsSortModel);
 	ctxt->setContextProperty("vendorList", vendorList);
 	set_non_bt_addresses();
+	LOG_STP("run_ui set_non_bt_adresses");
 
 	ctxt->setContextProperty("connectionListModel", &connectionListModel);
 	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
 
 	engine.load(QUrl(QStringLiteral("qrc:///qml/main.qml")));
+	LOG_STP("run_ui qml loaded");
 	qqWindowObject = engine.rootObjects().value(0);
 	if (!qqWindowObject) {
 		fprintf(stderr, "can't create window object\n");
@@ -112,8 +121,10 @@ void run_ui()
 	QScreen *screen = qml_window->screen();
 	QObject::connect(qml_window, &QQuickWindow::screenChanged, QMLManager::instance(), &QMLManager::screenChanged);
 	QMLManager *manager = QMLManager::instance();
+	LOG_STP("run_ui qmlmanager instance started");
 	// now that the log file is initialized...
 	show_computer_list();
+	LOG_STP("run_ui show_computer_list");
 
 	manager->setDevicePixelRatio(qml_window->devicePixelRatio(), qml_window->screen());
 	manager->dlSortModel = sortModel;
@@ -124,6 +135,7 @@ void run_ui()
 	qml_window->setWidth(800);
 #endif
 	qml_window->show();
+	LOG_STP("run_ui running exec");
 	qApp->exec();
 }
 

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -19,14 +19,23 @@
 #include <QLocale>
 #include <git2.h>
 
+#define STARTUP_TIMER
+#include "core/ssrf.h"
+QTime stpDuration;
+QString stpText;
+
 int main(int argc, char **argv)
 {
+	stpDuration.start();
+	LOG_STP("main starting");
+
 	int i;
 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 
 	// Start application
 	new QApplication(argc, argv);
+	LOG_STP("main Qt started");
 
 	// and get comand line arguments
 	QStringList arguments = QCoreApplication::arguments();
@@ -41,6 +50,7 @@ int main(int argc, char **argv)
 		}
 	}
 	git_libgit2_init();
+	LOG_STP("main git loaded");
 	setup_system_prefs();
 	if (QLocale().measurementSystem() == QLocale::MetricSystem)
 		default_prefs.units = SI_units;
@@ -51,8 +61,11 @@ int main(int argc, char **argv)
 	fill_computer_list();
 
 	parse_xml_init();
+	LOG_STP("main xml parsed");
 	taglist_init_global();
+	LOG_STP("main taglist done");
 	init_ui();
+	LOG_STP("main init_ui done");
 	if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE)
 		set_filename(prefs.default_filename);
 	else
@@ -66,6 +79,7 @@ int main(int argc, char **argv)
 
 	init_proxy();
 
+	LOG_STP("main call run_ui (continue in qmlmanager)");
 	if (!quit)
 		run_ui();
 	exit_ui();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 /* main.c */
-#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -21,12 +20,11 @@
 
 #define STARTUP_TIMER
 #include "core/ssrf.h"
-QTime stpDuration;
-QString stpText;
+STP_SETUP();
 
 int main(int argc, char **argv)
 {
-	stpDuration.start();
+	STP_RUN();
 	LOG_STP("main starting");
 
 	int i;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] Test

### Pull request long description:
<!-- Describe your pull request in detail. -->
There is a timer object started in subsurface-mobile-main.cpp (main)
and with the help of a macro, different steps in
first main
then qmlmanager
is added to the clipboard (as a sort of log extension).

This allows us to publish a new TestFlight (and whatever it is called in android), so
we. can ask the testers, to mail us their logs after startup. That way we can look for a
consistent pattern (on my iPhone it is run_ui, that causes the biggest delay).

the following is from and iPhone 6s:
---------- startup timer ----------
STP 0 ms, main starting
STP 306 ms, main Qt started
STP 311 ms, main git loaded
STP 313 ms, main xml parsed
STP 313 ms, main taglist done
STP 353 ms, main init_ui done
STP 353 ms, main call run_ui (continue in qmlmanager)
STP 3372 ms, qmlmgr starting
STP 3376 ms, qmlmgr log started
STP 3378 ms, qmlmgr start page
STP 3381 ms, qmlmgr bt available
STP 3388 ms, qmlmgr gps started
STP 3388 ms, qmlmgr git update
STP 3389 ms, qmlmgr sync load cloud
---------- finish ----------

Once the analysis is done, the code can be removed again.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->