### PR TITLE
desktop: use QElapsedTimer to measure time

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -33,6 +33,7 @@
 #include <QWheelEvent>
 #include <QSettings>
 #include <QMenu>
+#include <QElapsedTimer>
 
 #ifndef QT_NO_DEBUG
 #include <QTableView>
@@ -530,7 +531,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 {
 	static bool firstCall = true;
 #ifndef SUBSURFACE_MOBILE
-	QTime measureDuration; // let's measure how long this takes us (maybe we'll turn of TTL calculation later
+	QElapsedTimer measureDuration; // let's measure how long this takes us (maybe we'll turn of TTL calculation later
 	measureDuration.start();
 #else
 	Q_UNUSED(doClearPictures);


### PR DESCRIPTION
QElapsedTimer is the preferred timer for measuring time
so lets use it.

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It was pointed out in another PR, that to measure e.g. time used during startup, the
right class to use is QElapsedTimer. Profilewidget2 does exactly that but used QTimer


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Changed QTimer to QElapsedTimer

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->