### PR TITLE
mobile: measure startup time.

### DIFF
--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -13,12 +13,17 @@ extern "C" {
 
 #ifdef __cplusplus
 
+#ifdef ENABLE_STARTUP_TIMING
 // Declare generic function, will be seen only in CPP code
 // Use void parameters to avoid extra includes
 extern void log_stp(const char *ident, void *buf); 
 
 #define LOG_STP(x) log_stp(x, NULL) 
 #define LOG_STP_CLIPBOARD(x) log_stp(NULL, x) 
+#else
+#define LOG_STP(x)
+#define LOG_STP_CLIPBOARD(x)
+#endif // ENABLE_STARTUP_TIMING
 
 }
 #else

--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -13,10 +13,11 @@ extern "C" {
 
 #ifdef __cplusplus
 
+#ifdef SUBSURFACE_MOBILE
 #ifdef ENABLE_STARTUP_TIMING
 // Declare generic function, will be seen only in CPP code
 // Use void parameters to avoid extra includes
-extern void log_stp(const char *ident, void *buf); 
+extern void log_stp(const char *ident, QString *buf);
 
 #define LOG_STP(x) log_stp(x, NULL) 
 #define LOG_STP_CLIPBOARD(x) log_stp(NULL, x) 
@@ -24,6 +25,7 @@ extern void log_stp(const char *ident, void *buf);
 #define LOG_STP(x)
 #define LOG_STP_CLIPBOARD(x)
 #endif // ENABLE_STARTUP_TIMING
+#endif // SUBSURFACE_MOBILE
 
 }
 #else

--- a/core/ssrf.h
+++ b/core/ssrf.h
@@ -12,6 +12,14 @@ extern "C" {
 #endif
 
 #ifdef __cplusplus
+
+// Declare generic function, will be seen only in CPP code
+// Use void parameters to avoid extra includes
+extern void log_stp(const char *ident, void *buf); 
+
+#define LOG_STP(x) log_stp(x, NULL) 
+#define LOG_STP_CLIPBOARD(x) log_stp(NULL, x) 
+
 }
 #else
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -32,7 +32,6 @@
 #include "qt-models/tankinfomodel.h"
 #include "core/downloadfromdcthread.h"
 
-#define STARTUP_TIMER
 #include "core/ssrf.h"
 
 QMLManager *QMLManager::m_instance = NULL;
@@ -362,6 +361,7 @@ void QMLManager::copyAppLogToClipboard()
 		QTextStream in(&f);
 		copyString += in.readAll();
 	}
+	LOG_STP_CLIPBOARD(&copyString);
 	copyString += "---------- finish ----------\n";
 
 	// and copy to clipboard

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -32,6 +32,9 @@
 #include "qt-models/tankinfomodel.h"
 #include "core/downloadfromdcthread.h"
 
+#define STARTUP_TIMER
+#include "core/ssrf.h"
+
 QMLManager *QMLManager::m_instance = NULL;
 
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
@@ -138,6 +141,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	alreadySaving(false),
 	m_device_data(new DCDeviceData(this))
 {
+	LOG_STP("qmlmgr starting");
 	m_instance = this;
 	m_lastDevicePixelRatio = qApp->devicePixelRatio();
 	timer.start();
@@ -164,6 +168,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 				+ " at " + QDateTime::currentDateTime().toString());
 	}
 #endif
+	LOG_STP("qmlmgr log started");
 	set_error_cb(&showErrorFromC);
 	appendTextToLog("Starting " + getUserAgent());
 	appendTextToLog(QStringLiteral("built with libdivecomputer v%1").arg(dc_version(NULL)));
@@ -172,11 +177,13 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	git_libgit2_version(&git_maj, &git_min, &git_rev);
 	appendTextToLog(QStringLiteral("built with libgit2 %1.%2.%3").arg(git_maj).arg(git_min).arg(git_rev));
 	setStartPageText(tr("Starting..."));
+	LOG_STP("qmlmgr start page");
 
 	// ensure that we start the BTDiscovery - this should be triggered by the export of the class
 	// to QML, but that doesn't seem to always work
 	BTDiscovery *btDiscovery = BTDiscovery::instance();
 	m_btEnabled = btDiscovery->btAvailable();
+	LOG_STP("qmlmgr bt available");
 	connect(&btDiscovery->localBtDevice, &QBluetoothLocalDevice::hostModeStateChanged,
 		this, &QMLManager::btHostModeChange);
 	setShowPin(false);
@@ -185,10 +192,13 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	progress_callback = &progressCallback;
 	connect(locationProvider, SIGNAL(haveSourceChanged()), this, SLOT(hasLocationSourceChanged()));
 	setLocationServiceAvailable(locationProvider->hasLocationsSource());
+	LOG_STP("qmlmgr gps started");
 	set_git_update_cb(&gitProgressCB);
+	LOG_STP("qmlmgr git update");
 
 	// make sure we know if the current cloud repo has been successfully synced
 	syncLoadFromCloud();
+	LOG_STP("qmlmgr sync load cloud");
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -29,6 +29,8 @@
 
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 
+#include "core/ssrf.h"
+
 QObject *qqWindowObject = NULL;
 
 void set_non_bt_addresses() {
@@ -51,6 +53,7 @@ void init_ui()
 
 void run_ui()
 {
+	LOG_STP("run_ui starting");
 	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
 	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
 
@@ -63,6 +66,7 @@ void run_ui()
 	qmlRegisterType<MapLocation>("org.subsurfacedivelog.mobile", 1, 0, "MapLocation");
 
 	QQmlApplicationEngine engine;
+	LOG_STP("run_ui qml engine started");
 	KirigamiPlugin::getInstance().registerTypes();
 #if defined(__APPLE__) && !defined(Q_OS_IOS)
 	// when running the QML UI on a Mac the deployment of the QML Components seems
@@ -79,11 +83,13 @@ void run_ui()
 #endif
 	engine.addImportPath("qrc://imports");
 	DiveListModel diveListModel;
+	LOG_STP("run_ui diveListModel started");
 	DiveListSortModel *sortModel = new DiveListSortModel(0);
 	sortModel->setSourceModel(&diveListModel);
 	sortModel->setDynamicSortFilter(true);
 	sortModel->setSortRole(DiveListModel::DiveDateRole);
 	sortModel->sort(0, Qt::DescendingOrder);
+	LOG_STP("run_ui diveListModel sorted");
 	GpsListModel gpsListModel;
 	QSortFilterProxyModel *gpsSortModel = new QSortFilterProxyModel(0);
 	gpsSortModel->setSourceModel(&gpsListModel);
@@ -95,11 +101,13 @@ void run_ui()
 	ctxt->setContextProperty("gpsModel", gpsSortModel);
 	ctxt->setContextProperty("vendorList", vendorList);
 	set_non_bt_addresses();
+	LOG_STP("run_ui set_non_bt_adresses");
 
 	ctxt->setContextProperty("connectionListModel", &connectionListModel);
 	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
 
 	engine.load(QUrl(QStringLiteral("qrc:///qml/main.qml")));
+	LOG_STP("run_ui qml loaded");
 	qqWindowObject = engine.rootObjects().value(0);
 	if (!qqWindowObject) {
 		fprintf(stderr, "can't create window object\n");
@@ -112,8 +120,10 @@ void run_ui()
 	QScreen *screen = qml_window->screen();
 	QObject::connect(qml_window, &QQuickWindow::screenChanged, QMLManager::instance(), &QMLManager::screenChanged);
 	QMLManager *manager = QMLManager::instance();
+	LOG_STP("run_ui qmlmanager instance started");
 	// now that the log file is initialized...
 	show_computer_list();
+	LOG_STP("run_ui show_computer_list");
 
 	manager->setDevicePixelRatio(qml_window->devicePixelRatio(), qml_window->screen());
 	manager->dlSortModel = sortModel;
@@ -124,6 +134,7 @@ void run_ui()
 	qml_window->setWidth(800);
 #endif
 	qml_window->show();
+	LOG_STP("run_ui running exec");
 	qApp->exec();
 }
 

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -25,7 +25,7 @@
 #include <QElapsedTimer>
 #include <QMutex>
 #include <QMutexLocker>
-void log_stp(const char *ident, void *buf)
+void log_stp(const char *ident, QString *buf)
 {
 	static bool firstCall = true;
 	static QElapsedTimer stpDuration;

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -21,12 +21,17 @@
 
 // Implementation of STP logging 
 #include "core/ssrf.h"
+#ifdef ENABLE_STARTUP_TIMING
 #include <QElapsedTimer>
+#include <QMutex>
+#include <QMutexLocker>
 void log_stp(const char *ident, void *buf)
 {
 	static bool firstCall = true;
 	static QElapsedTimer stpDuration;
 	static QString stpText;
+
+	QMutexLocker l(&logMutex);
 
 	if (firstCall) {
 		firstCall = false;
@@ -43,6 +48,7 @@ void log_stp(const char *ident, void *buf)
 		*buf += stpText;
 	}
 }
+#endif // ENABLE_STARTUP_TIMING
 
 
 int main(int argc, char **argv)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [? ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an updated version of the closed PR. 

Even though QML is using a lot of startup time, it is still worth while to see
how other functions behave. Primarily it is important to see how this varies
across devices, and number of dives (large differences).

It is basically similar to debug printf, but is collected in a QString, and never
stored on disk. I assume that some of the log entries will prove not to be significant,
but it is made by the motto "more is better", since we cannot ask testers to do this
many times.

This PR allows us to gather this information for beta versions. Testers should mail
us the log (using the clipboard function) along with type of device and if BT is active.

As requested the functionality is default not active (macros expand to nothing), but
can be activated with the compiler flag -DENABLE_STARTUP_TIMING.

A note on the QML, had the opportunity to get a log from a version where the QML was
compiled with Qt Quick Compiler, startup time was approx. half (on iOS) so this seems 
to be worth while pursuing (maybe we can get the compiler sponsored somehow).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Please see the commits.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
@dirkhh this patch only makes sense if we make new beta, and ask the testers to send the logs. They can send the logs directly to me, if we want to keep our ML low volume.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @neolit123 @bstoeger 