### PR TITLE
Manual: fix showing of manual

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -100,7 +100,9 @@ extern "C" void showErrorFromC(char *buf)
 MainWindow::MainWindow() : QMainWindow(),
 	actionNextDive(0),
 	actionPreviousDive(0),
+#ifndef NO_USERMANUAL
 	helpView(0),
+#endif
 	state(VIEWALL),
 	survey(0)
 {

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -191,7 +191,9 @@ private:
 	Ui::MainWindow ui;
 	QAction *actionNextDive;
 	QAction *actionPreviousDive;
+#ifndef NO_USERMANUAL
 	UserManual *helpView;
+#endif
 	CurrentState state;
 	CurrentState stateBeforeEdit;
 	QString filter_open();

--- a/desktop-widgets/usermanual.cpp
+++ b/desktop-widgets/usermanual.cpp
@@ -56,7 +56,7 @@ MyQWebEngineView::MyQWebEngineView(QWidget* parent)
 }
 #endif
 
-UserManual::UserManual(QWidget *parent) : QWidget(parent)
+UserManual::UserManual(QWidget *parent) : QDialog(parent)
 {
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
 	connect(closeKey, SIGNAL(activated()), this, SLOT(close()));

--- a/desktop-widgets/usermanual.h
+++ b/desktop-widgets/usermanual.h
@@ -8,6 +8,7 @@
 #else
 #include <QWebView>
 #endif
+#include <QDialog>
 #include "ui_searchbar.h"
 
 class SearchBar : public QWidget{
@@ -47,7 +48,7 @@ public:
 #endif
 
 
-class UserManual : public QWidget {
+class UserManual : public QDialog {
 	Q_OBJECT
 
 public:


### PR DESCRIPTION
In commit d21d42b69117aae04b68ecc9cc2139e034bde146 helpView was made
a child-object of MainWindow, which is Qt's idiomatic way of having
helpView deleted with MainWindow.

As an unintended consequence, the helpView didn't show. Therefore, as
a quick fix, replace helpView by a QScopedPointer, which has the same
effect.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug introduced in d21d42b69117aae04b68ecc9cc2139e034bde146. Apparently I still haven't understood Qt's object-hierarchy system. You can't have windows as children of other windows? Why?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson 