### PR TITLE
user-manual: add note that some Grantlee variables need '|safe'

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -5035,6 +5035,12 @@ Only a subset of the dive data is exported:
 |firstGas| (*string*) first used gas
 |=====================
 
+Please note that some of the variables like 'notes' need to be extended with '|safe' to support HTML tags:
+....
+	<p> {{ dive.notes|safe }} </p>
+....
+Otherwise tags like 'br' would not be converted to line breaks. 
+
 _Subsurface_ also exports *template_options* data. This data must be used as _CSS_ values to provide a dynamically
 editable template. The exported data is shown in the following table:
 |====================


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Grantlee variables need the '|safe' extension, so that they can use
HTML tags. Without it, tags like 'br' would not be converted to line
breaks - e.g. when exporting planned dive notes.

Add a note about that in the user manual.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- added note in manual

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

we have forum/ML reports for this

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
none

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson @dirkhh 
