### PR TITLE
Profile: open pictures using local file path

### DIFF
--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -3,6 +3,7 @@
 #include "profile-widget/animationfunctions.h"
 #include "qt-models/divepicturemodel.h"
 #include "core/pref.h"
+#include "core/qthelper.h"
 #ifndef SUBSURFACE_MOBILE
 #include "desktop-widgets/preferences/preferencesdialog.h"
 #endif
@@ -106,9 +107,8 @@ void DivePictureItem::hoverLeaveEvent(QGraphicsSceneHoverEvent*)
 
 void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-	if (event->button() == Qt::LeftButton) {
-		QDesktopServices::openUrl(QUrl::fromLocalFile(fileUrl));
-	}
+	if (event->button() == Qt::LeftButton)
+		QDesktopServices::openUrl(QUrl::fromLocalFile(localFilePath(fileUrl)));
 }
 
 void DivePictureItem::removePicture()


### PR DESCRIPTION
Make the behavior of the profile-pictures consistent with the pictures
in the photos-tab: Use the local file path to open the picture in the
system viewer instead of the canonical filename (which might point to
a non-existing location).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a tiny bug: If the pictures are not located at their original place, double-clicking in the photo-tab works, but clicking on the profile image fails. Make both behave consistently.
