### PR TITLE
Bugfix: Load PSC dive logs

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -45,7 +45,7 @@ const char *divemode_text_ui[] = {
 };
 
 // For writing/reading files.
-const char *divemode_text[] = {"OC", "CCR", "pSCR", "Freedive"};
+const char *divemode_text[] = {"OC", "CCR", "PSCR", "Freedive"};
 
 /*
  * Adding a cylinder pressure sample field is not quite as trivial as it


### PR DESCRIPTION
The code changes to standardise the named of divemodes and to
separate internal divemode names and UI divemode names introduced
a bug that caused non-backward compatability with existing
dive logs. The reason for this is the definition of the
divemode_text strings in dive.c

This change reverses that definition and brings about correct
loading of PSCR dive logs as well as correct parsing of bailout
events involving PSCR.

Signed-off-by: Willem Ferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @sfuchs79 