### PR TITLE
Dive picture: fix toggling of picture-visibility

### DIFF
--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -50,7 +50,6 @@ DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
 #ifndef SUBSURFACE_MOBILE
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
 #endif
-	setVisible(prefs.show_pictures_in_profile);
 
 	canvas->setPen(Qt::NoPen);
 	canvas->setBrush(QColor(Qt::white));

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -2077,6 +2077,7 @@ void ProfileWidget2::plotPictures()
 			pictures[picItemNr].reset(item);
 			scene()->addItem(item);
 		}
+		item->setVisible(prefs.show_pictures_in_profile);
 		item->setPixmap(m->index(i, 0).data(Qt::UserRole).value<QPixmap>());
 		item->setFileUrl(m->index(i, 1).data().toString());
 		// let's put the picture at the correct time, but at a fixed "depth" on the profile


### PR DESCRIPTION
In a recent commit, the profile widget was changed to reuse
DivePictureItems. This made toggling of picture-visibility
disfunctional, because the visibility was set in the constructor.
Only on change of dive would the setting take effect.

Therefore, move the setting of the visibility up to the
ProfileWidget2::plotPictures() call. This is more consistent
anyway, since at this level pixmap and fileUrl are set.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a functional change / fix of a regression, which I introduced recently. With this fix, toggling of the "view pictures" setting takes effect immediately.
