### PR TITLE
mobile: show last used connection in Download page

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -438,19 +438,3 @@ int DCDeviceData::getDetectedProductIndex(const QString &currentVendorText)
 #endif
 	return -1;
 }
-
-QString DCDeviceData::getDetectedDeviceAddress(const QString &currentProductText)
-{
-#if defined(BT_SUPPORT)
-	// Pull the vendor from the found devices that are possible real dive computers
-	// HACK: this assumes that dive computer names are unique across vendors
-	//       and will only give you the first of multiple identically named dive computers
-	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
-	BTDiscovery::btVendorProduct btDC;
-	Q_FOREACH(btDC, btDCs) {
-		if (currentProductText.startsWith(dc_descriptor_get_product(btDC.dcDescriptor)))
-			return btDC.btpdi.address;
-	}
-#endif
-	return QStringLiteral("cannot determine address of dive computer");
-}

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -52,7 +52,6 @@ public:
 
 	Q_INVOKABLE int getDetectedVendorIndex();
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
-	Q_INVOKABLE QString getDetectedDeviceAddress(const QString &currentProductText);
 
 public slots:
 	void setVendor(const QString& vendor);

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -67,12 +67,11 @@ Kirigami.Page {
 			}
 			columns: 2
 			Controls.Label { text: qsTr(" Vendor name: ") }
-			property var vendoridx: downloadThread.data().getDetectedVendorIndex()
 			Controls.ComboBox {
 				id: comboVendor
 				Layout.fillWidth: true
 				model: vendorList
-				currentIndex: parent.vendoridx
+				currentIndex: -1
 				delegate: Controls.ItemDelegate {
 					width: comboVendor.width
 					contentItem: Text {
@@ -100,10 +99,9 @@ Kirigami.Page {
 			Controls.Label { text: qsTr(" Dive Computer:") }
 			Controls.ComboBox {
 				id: comboProduct
-				property var productidx: downloadThread.data().getDetectedProductIndex(comboVendor.currentText)
 				Layout.fillWidth: true
 				model: null
-				currentIndex: productidx
+				currentIndex: -1
 				delegate: Controls.ItemDelegate {
 					width: comboProduct.width
 					contentItem: Text {
@@ -303,6 +301,14 @@ Kirigami.Page {
 				onClicked : {
 					importModel.selectNone()
 				}
+			}
+		}
+
+		onVisibleChanged: {
+			if (visible) {
+				comboVendor.currentIndex = downloadThread.data().getDetectedVendorIndex()
+				comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex(comboVendor.currentText)
+				comboDevice.currentIndex = downloadThread.data().getMatchingAddress(comboVendor.currentText, comboProduct.currentText)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The download page is created before the BT list is available so it is too early to
set index of connection combobox. Delayed setting until page becomes visible.

Removed unused function (+ Qt moc) in core/downloadFromComputer.*

Remark: the startup timing test, shows the BtRediscovery is not delaying the startup,
so no real need to remove that.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->