### PR TITLE
Dive pictures: remove cache_picture() call in dive_add_picture()

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3838,7 +3838,6 @@ void dive_add_picture(struct dive *dive, struct picture *newpic)
 		pic_ptr = &(*pic_ptr)->next;
 	newpic->next = *pic_ptr;
 	*pic_ptr = newpic;
-	cache_picture(newpic);
 	return;
 }
 

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1216,12 +1216,6 @@ void learnHash(const QString &originalName, const QString &localName, const QByt
 	hashOf[originalName] = hash;
 }
 
-static bool haveHash(const QString &filename)
-{
-	QMutexLocker locker(&hashOfMutex);
-	return hashOf.contains(filename);
-}
-
 QString localFilePath(const QString &originalFilename)
 {
 	QMutexLocker locker(&hashOfMutex);
@@ -1239,13 +1233,6 @@ void hashPicture(QString filename)
 	QByteArray hash = hashFile(localFilePath(filename));
 	if (!hash.isNull() && hash != oldHash)
 		mark_divelist_changed(true);
-}
-
-extern "C" void cache_picture(struct picture *picture)
-{
-	QString filename = picture->filename;
-	if (!haveHash(filename))
-		QtConcurrent::run(hashPicture, filename);
 }
 
 QStringList imageExtensionFilters() {

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -113,7 +113,6 @@ char *hashstring(const char *filename);
 void register_hash(const char *filename, const char *hash);
 char *move_away(const char *path);
 const char *local_file_path(struct picture *picture);
-void cache_picture(struct picture *picture);
 char *cloud_url();
 char *hashfile_name_string();
 char *picturedir_string();


### PR DESCRIPTION
When adding a picture to a dive, cache_picture() was called, which
calculated the hash of the picture in a background-thread.

This made tests occasionally fail, because the tests depended on
the filename-to-localfilename being overwritten in a call running
in a different thread. Depending on which thread finished first,
the test succeeded or failed.

The easiest way to circumvent this problem is to remove the cache_picture()
call. The hash will be calculated anyway with the thumbnails. And
the only function of the hash is the "find moved images" function. Which
is not an issue here, because the user just loaded the images from
disk.

Reported-by: Jan Iversen <jani@apache.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I have a really hard time categorizing this one - but I think "cleanup" is the best fit. It also fixes random test-failures so you might say that it's a (non-user visible) bug fix. And it hashes pictures only once, which might be considered a functional change.

This should speed up addition of pictures a little bit, because every hash is only calculated once instead of twice. In my tests there was no notable difference, presumable because the image data is already in cache. I don't think the removed call should lead to any realistic failure scenario. But another pair of eyes would be most welcome.
 
### Changes made:

Remove `cache_picture()` function.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes test-failure reported in #1359 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 