### PR TITLE
profile: make it self contained

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,6 @@ endif()
 if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 	set(MOBILE_SRC
 		mobile-widgets/qmlmanager.cpp
-		mobile-widgets/qmlprofile.cpp
 		mobile-widgets/qml/kirigami/src/kirigamiplugin.cpp
 		mobile-widgets/qml/kirigami/src/settings.cpp
 		mobile-widgets/qml/kirigami/src/enums.cpp
@@ -298,6 +297,7 @@ if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 		mobile-widgets/qml/kirigami/src/libkirigami/platformtheme.cpp
 		subsurface-mobile-main.cpp
 		subsurface-mobile-helper.cpp
+		profile-widget/qmlprofile.cpp
 		map-widget/qmlmapwidgethelper.cpp
 	)
 	include_directories(${CMAKE_SOURCE_DIR}/mobile-widgets/qml/kirigami/src/libkirigami)

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -116,31 +116,31 @@ Item {
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: ratingText.verticalCenter 
+				anchors.verticalCenter: ratingText.verticalCenter
 				source: (dive.rating >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: ratingText.verticalCenter 
+				anchors.verticalCenter: ratingText.verticalCenter
 				source: (dive.rating >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: ratingText.verticalCenter 
+				anchors.verticalCenter: ratingText.verticalCenter
 				source: (dive.rating >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: ratingText.verticalCenter 
+				anchors.verticalCenter: ratingText.verticalCenter
 				source: (dive.rating >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: ratingText.verticalCenter 
+				anchors.verticalCenter: ratingText.verticalCenter
 				source: (dive.rating === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 		}
@@ -159,31 +159,31 @@ Item {
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: visibilityText.verticalCenter 
+				anchors.verticalCenter: visibilityText.verticalCenter
 				source: (dive.visibility >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: visibilityText.verticalCenter 
+				anchors.verticalCenter: visibilityText.verticalCenter
 				source: (dive.visibility >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
-			}	
+			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: visibilityText.verticalCenter 
+				anchors.verticalCenter: visibilityText.verticalCenter
 				source: (dive.visibility >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: visibilityText.verticalCenter 
+				anchors.verticalCenter: visibilityText.verticalCenter
 				source: (dive.visibility >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
-				anchors.verticalCenter: visibilityText.verticalCenter 
+				anchors.verticalCenter: visibilityText.verticalCenter
 				source: (dive.visibility === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 			}
 		}

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -217,6 +217,13 @@ Item {
 				border.color: subsurfaceTheme.primaryColor
 				anchors.fill: parent
 			}
+
+			onVisibleChanged: {
+				if (visible) {
+					qmlProfile.diveId = model.dive.id;
+					qmlProfile.update();
+				}
+			}
 		}
 		Controls.Label {
 			id: noProfile
@@ -397,8 +404,6 @@ Item {
 		}
 		Component.onCompleted: {
 			qmlProfile.setMargin(Kirigami.Units.smallSpacing)
-			qmlProfile.diveId = model.dive.id;
-			qmlProfile.update();
 		}
 	}
 }

--- a/mobile-widgets/qmlprofile.h
+++ b/mobile-widgets/qmlprofile.h
@@ -8,7 +8,7 @@
 class QMLProfile : public QQuickPaintedItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString diveId READ diveId WRITE setDiveId NOTIFY diveIdChanged)
+	Q_PROPERTY(QString diveId MEMBER m_diveId WRITE setDiveId)
 	Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio NOTIFY devicePixelRatioChanged)
 
 public:
@@ -32,7 +32,6 @@ private:
 
 signals:
 	void rightAlignedChanged();
-	void diveIdChanged();
 	void devicePixelRatioChanged();
 };
 

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -81,7 +81,6 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
 	../../mobile-widgets/qmlmanager.cpp \
-	../../mobile-widgets/qmlprofile.cpp \
 	../../qt-models/divelistmodel.cpp \
 	../../qt-models/diveplotdatamodel.cpp \
 	../../qt-models/gpslistmodel.cpp \
@@ -90,6 +89,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../qt-models/maplocationmodel.cpp \
 	../../qt-models/diveimportedmodel.cpp \
 	../../qt-models/messagehandlermodel.cpp \
+	../../profile-widget/qmlprofile.cpp \
 	../../profile-widget/divecartesianaxis.cpp \
 	../../profile-widget/diveeventitem.cpp \
 	../../profile-widget/diveprofileitem.cpp \
@@ -183,7 +183,6 @@ HEADERS += \
 	../../core/subsurface-qt/DiveObjectHelper.h \
 	../../core/subsurface-qt/SettingsObjectWrapper.h \
 	../../mobile-widgets/qmlmanager.h \
-	../../mobile-widgets/qmlprofile.h \
 	../../map-widget/qmlmapwidgethelper.h \
 	../../qt-models/divelistmodel.h \
 	../../qt-models/diveplotdatamodel.h \
@@ -194,6 +193,7 @@ HEADERS += \
 	../../qt-models/maplocationmodel.h \
 	../../qt-models/diveimportedmodel.h \
 	../../qt-models/messagehandlermodel.h \
+	../../profile-widget/qmlprofile.h \
 	../../profile-widget/diveprofileitem.h \
 	../../profile-widget/profilewidget2.h \
 	../../profile-widget/ruleritem.h \

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -391,19 +391,21 @@ void ProfileWidget2::setupItemSizes()
 	itemPos.depth.pos.off.setX(-2);
 	itemPos.depth.pos.off.setY(3);
 	itemPos.depth.expanded.setP1(QPointF(0, 0));
+#ifndef SUBSURFACE_MOBILE
 	itemPos.depth.expanded.setP2(QPointF(0, 85));
+#else
+	itemPos.depth.expanded.setP2(QPointF(0, 65));
+#endif
 	itemPos.depth.shrinked.setP1(QPointF(0, 0));
 	itemPos.depth.shrinked.setP2(QPointF(0, 55));
 	itemPos.depth.intermediate.setP1(QPointF(0, 0));
 	itemPos.depth.intermediate.setP2(QPointF(0, 65));
-#ifdef SUBSURFACE_MOBILE
-	itemPos.depth.expanded.setP2(QPointF(0, 65));
-#endif
 
 	// Time Axis Config
 	itemPos.time.pos.on.setX(3);
+#ifndef SUBSURFACE_MOBILE
 	itemPos.time.pos.on.setY(95);
-#ifdef SUBSURFACE_MOBILE
+#else
 	itemPos.time.pos.on.setY(89.5);
 #endif
 	itemPos.time.pos.off.setX(3);
@@ -413,15 +415,17 @@ void ProfileWidget2::setupItemSizes()
 
 	// Partial Gas Axis Config
 	itemPos.partialPressure.pos.on.setX(97);
+#ifndef SUBSURFACE_MOBILE
 	itemPos.partialPressure.pos.on.setY(75);
-#ifdef SUBSURFACE_MOBILE
+#else
 	itemPos.partialPressure.pos.on.setY(70);
 #endif
 	itemPos.partialPressure.pos.off.setX(110);
 	itemPos.partialPressure.pos.off.setY(63);
 	itemPos.partialPressure.expanded.setP1(QPointF(0, 0));
+#ifndef SUBSURFACE_MOBILE
 	itemPos.partialPressure.expanded.setP2(QPointF(0, 19));
-#ifdef SUBSURFACE_MOBILE
+#else
 	itemPos.partialPressure.expanded.setP2(QPointF(0, 20));
 #endif
 	itemPos.partialPressureWithTankBar = itemPos.partialPressure;
@@ -445,21 +449,20 @@ void ProfileWidget2::setupItemSizes()
 
 	// Temperature axis config
 	itemPos.temperature.pos.on.setX(3);
-	itemPos.temperature.pos.on.setY(60);
-	itemPos.temperatureAll.pos.on.setY(51);
 	itemPos.temperature.pos.off.setX(-10);
 	itemPos.temperature.pos.off.setY(40);
 	itemPos.temperature.expanded.setP1(QPointF(0, 20));
 	itemPos.temperature.expanded.setP2(QPointF(0, 33));
 	itemPos.temperature.shrinked.setP1(QPointF(0, 2));
 	itemPos.temperature.shrinked.setP2(QPointF(0, 12));
+#ifndef SUBSURFACE_MOBILE
+	itemPos.temperature.pos.on.setY(60);
+	itemPos.temperatureAll.pos.on.setY(51);
 	itemPos.temperature.intermediate.setP1(QPointF(0, 2));
 	itemPos.temperature.intermediate.setP2(QPointF(0, 12));
-#ifdef SUBSURFACE_MOBILE
+#else
 	itemPos.temperature.pos.on.setY(51);
 	itemPos.temperatureAll.pos.on.setY(47);
-	itemPos.temperature.expanded.setP1(QPointF(0, 20));
-	itemPos.temperature.expanded.setP2(QPointF(0, 33));
 	itemPos.temperature.intermediate.setP1(QPointF(0, 2));
 	itemPos.temperature.intermediate.setP2(QPointF(0, 12));
 #endif
@@ -486,8 +489,9 @@ void ProfileWidget2::setupItemSizes()
 	itemPos.dcLabel.off.setY(100);
 
 	itemPos.tankBar.on.setX(0);
+#ifndef SUBSURFACE_MOBILE
 	itemPos.tankBar.on.setY(91.95);
-#ifdef SUBSURFACE_MOBILE
+#else
 	itemPos.tankBar.on.setY(86.4);
 #endif
 }
@@ -1107,11 +1111,9 @@ void ProfileWidget2::setEmptyState()
 #ifndef SUBSURFACE_MOBILE
 	hideAll(allTissues);
 	hideAll(allPercentages);
-#endif
-	hideAll(eventItems);
-#ifndef SUBSURFACE_MOBILE
 	hideAll(handles);
 #endif
+	hideAll(eventItems);
 	hideAll(gases);
 }
 

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qmlprofile.h"
-#include "qmlmanager.h"
+#include "mobile-widgets/qmlmanager.h"
 #include "core/subsurface-string.h"
 #include "core/metrics.h"
 #include <QTransform>

--- a/profile-widget/qmlprofile.h
+++ b/profile-widget/qmlprofile.h
@@ -2,7 +2,7 @@
 #ifndef QMLPROFILE_H
 #define QMLPROFILE_H
 
-#include "profile-widget/profilewidget2.h"
+#include "profilewidget2.h"
 #include <QQuickPaintedItem>
 
 class QMLProfile : public QQuickPaintedItem

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -19,7 +19,7 @@
 #include "mobile-widgets/qmlmanager.h"
 #include "qt-models/divelistmodel.h"
 #include "qt-models/gpslistmodel.h"
-#include "mobile-widgets/qmlprofile.h"
+#include "profile-widget/qmlprofile.h"
 #include "core/downloadfromdcthread.h"
 #include "core/connectionlistmodel.h"
 #include "qt-models/diveimportedmodel.h"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
move the code for profile widget to profile widget, in order to make it 
self contained.
Make the needed changed in pro/cmake files

update qml to not call plot dive before the widget is visible. With this PR
plotDive is not longer called during startup, but for some (still) unknown reason
QMLProfile is instantiated 2+ times with every dive change, leading to side effects,
like that the dive id never matches.

All code relating to making (not using) profile should be in the same directory, to
make code searches easier.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->