### PR TITLE
Cleanup: make lastUsedDir() functions static and non-slot, respectively

### DIFF
--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -35,6 +35,7 @@ public:
 	void restoreSelection();
 	void contextMenuEvent(QContextMenuEvent *event);
 	QList<dive_trip_t *> selectedTrips();
+	static QString lastUsedImageDir();
 public
 slots:
 	void toggleColumnVisibilityByIndex();
@@ -56,7 +57,6 @@ slots:
 	void shiftTimes();
 	void loadImages();
 	void loadWebImages();
-	static QString lastUsedImageDir();
 
 signals:
 	void currentDiveChanged(int divenr);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -544,6 +544,18 @@ void MainWindow::on_actionNew_triggered()
 	on_actionClose_triggered();
 }
 
+static QString lastUsedDir()
+{
+	QSettings settings;
+	QString lastDir = QDir::homePath();
+
+	settings.beginGroup("FileDialog");
+	if (settings.contains("LastDir"))
+		if (QDir(settings.value("LastDir").toString()).exists())
+			lastDir = settings.value("LastDir").toString();
+	return lastDir;
+}
+
 void MainWindow::on_actionOpen_triggered()
 {
 	if (!okToClose(tr("Please save or cancel the current dive edit before opening a new file.")))
@@ -782,18 +794,6 @@ void MainWindow::on_actionClose_triggered()
 		ui.multiFilter->closeFilter();
 		recreateDiveList();
 	}
-}
-
-QString MainWindow::lastUsedDir()
-{
-	QSettings settings;
-	QString lastDir = QDir::homePath();
-
-	settings.beginGroup("FileDialog");
-	if (settings.contains("LastDir"))
-		if (QDir(settings.value("LastDir").toString()).exists())
-			lastDir = settings.value("LastDir").toString();
-	return lastDir;
 }
 
 void MainWindow::updateLastUsedDir(const QString &dir)

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -213,7 +213,6 @@ private:
 	void beginChangeState(CurrentState s);
 	void saveSplitterSizes();
 	void toggleCollapsible(bool toggle);
-	QString lastUsedDir();
 	void updateLastUsedDir(const QString &s);
 	void registerApplicationState(const QByteArray& state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight);
 	void enterState(CurrentState);

--- a/smtk-import/smrtk2ssrfc_window.cpp
+++ b/smtk-import/smrtk2ssrfc_window.cpp
@@ -35,7 +35,7 @@ Smrtk2ssrfcWindow::~Smrtk2ssrfcWindow()
 	delete ui;
 }
 
-QString Smrtk2ssrfcWindow::lastUsedDir()
+static QString lastUsedDir()
 {
 	QSettings settings;
 	QString lastDir = QDir::homePath();

--- a/smtk-import/smrtk2ssrfc_window.h
+++ b/smtk-import/smrtk2ssrfc_window.h
@@ -22,7 +22,6 @@ public:
 
 private:
 	Ui::Smrtk2ssrfcWindow *ui;
-	QString lastUsedDir();
 	QString filter();
 	void updateLastUsedDir(const QString &s);
 	void closeCurrentFile();


### PR DESCRIPTION
The lastUsedDir() functions of MainWindow and Smrtk2ssrfcWindow don't
use any member-objects and are only used in their respective translation
units. Therefore, remove them from the class and made of static linkage.

The lastUsedImageDir() function was declared as a slog, which makes
no sense. Make it a normal static function (though one might argue
why it is assiociated with the DiveListView class in the first place).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Very minor code cleanup. The `Smrtk2ssrfcWindow` is not tested. I hope Travis compiles this?
