### PR TITLE
core: remove qml ui properties

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -277,16 +277,19 @@ QString DCDeviceData::devBluetoothName() const
 	return m_devBluetoothName;
 }
 
+#ifdef SUBSURFACE_MOBILE
 QString DCDeviceData::descriptor() const
 {
 	return "";
 }
+#endif // SUBSURFACE_MOBILE
 
 bool DCDeviceData::bluetoothMode() const
 {
 	return data.bluetooth_mode;
 }
 
+#ifdef SUBSURFACE_MOBILE
 bool DCDeviceData::forceDownload() const
 {
 	return data.force_download;
@@ -306,6 +309,7 @@ int DCDeviceData::diveId() const
 {
 	return data.diveid;
 }
+#endif // SUBSURFACE_MOBILE
 
 void DCDeviceData::setVendor(const QString& vendor)
 {
@@ -358,6 +362,7 @@ void DCDeviceData::setCreateNewTrip(bool create)
 	data.create_new_trip = create;
 }
 
+#ifdef SUBSURFACE_MOBILE
 void DCDeviceData::setDeviceId(int deviceId)
 {
 	data.deviceid = deviceId;
@@ -367,6 +372,7 @@ void DCDeviceData::setDiveId(int diveId)
 {
 	data.diveid = diveId;
 }
+#endif // SUBSURFACE_MOBILE
 
 void DCDeviceData::setSaveDump(bool save)
 {
@@ -383,10 +389,13 @@ void DCDeviceData::setSaveLog(bool saveLog)
 	data.libdc_log = saveLog;
 }
 
+#ifdef SUBSURFACE_MOBILE
 bool DCDeviceData::saveLog() const
 {
 	return data.libdc_log;
 }
+#endif // SUBSURFACE_MOBILE
+
 
 device_data_t* DCDeviceData::internalData()
 {

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -205,7 +205,7 @@ void show_computer_list()
 }
 DCDeviceData *DCDeviceData::m_instance = NULL;
 
-DCDeviceData::DCDeviceData(QObject *parent) : QObject(parent)
+DCDeviceData::DCDeviceData()
 {
 	memset(&data, 0, sizeof(data));
 	data.trip = nullptr;
@@ -227,7 +227,7 @@ DCDeviceData::DCDeviceData(QObject *parent) : QObject(parent)
 DCDeviceData *DCDeviceData::instance()
 {
 	if (!m_instance)
-		m_instance = new DCDeviceData();
+		m_instance = new DCDeviceData;
 	return m_instance;
 }
 
@@ -282,19 +282,16 @@ QString DCDeviceData::devBluetoothName() const
 	return m_devBluetoothName;
 }
 
-#ifdef SUBSURFACE_MOBILE
 QString DCDeviceData::descriptor() const
 {
 	return "";
 }
-#endif // SUBSURFACE_MOBILE
 
 bool DCDeviceData::bluetoothMode() const
 {
 	return data.bluetooth_mode;
 }
 
-#ifdef SUBSURFACE_MOBILE
 bool DCDeviceData::forceDownload() const
 {
 	return data.force_download;
@@ -314,7 +311,6 @@ int DCDeviceData::diveId() const
 {
 	return data.diveid;
 }
-#endif // SUBSURFACE_MOBILE
 
 void DCDeviceData::setVendor(const QString& vendor)
 {
@@ -367,7 +363,6 @@ void DCDeviceData::setCreateNewTrip(bool create)
 	data.create_new_trip = create;
 }
 
-#ifdef SUBSURFACE_MOBILE
 void DCDeviceData::setDeviceId(int deviceId)
 {
 	data.deviceid = deviceId;
@@ -377,7 +372,6 @@ void DCDeviceData::setDiveId(int diveId)
 {
 	data.diveid = diveId;
 }
-#endif // SUBSURFACE_MOBILE
 
 void DCDeviceData::setSaveDump(bool save)
 {
@@ -394,12 +388,10 @@ void DCDeviceData::setSaveLog(bool saveLog)
 	data.libdc_log = saveLog;
 }
 
-#ifdef SUBSURFACE_MOBILE
 bool DCDeviceData::saveLog() const
 {
 	return data.libdc_log;
 }
-#endif // SUBSURFACE_MOBILE
 
 
 device_data_t* DCDeviceData::internalData()

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -212,6 +212,11 @@ DCDeviceData::DCDeviceData(QObject *parent) : QObject(parent)
 	data.download_table = nullptr;
 	data.diveid = 0;
 	data.deviceid = 0;
+	data.bluetooth_mode = true;
+	data.force_download = false;
+	data.create_new_trip = false;
+	data.libdc_dump = false;
+	data.libdc_log = false;
 	if (m_instance) {
 		qDebug() << "already have an instance of DCDevieData";
 		return;

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -99,11 +99,7 @@ public:
 	DownloadThread();
 	void run() override;
 
-#ifdef SUBSURFACE_MOBILE
-	Q_INVOKABLE DCDeviceData *data();
-#else
 	DCDeviceData *data();
-#endif // SUBSURFACE_MOBILE
 	QString error;
 
 private:

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -14,6 +14,7 @@
 /* Helper object for access of Device Data in QML */
 class DCDeviceData : public QObject {
 	Q_OBJECT
+#ifdef SUBSURFACE_MOBILE
 	Q_PROPERTY(QString vendor READ vendor WRITE setVendor)
 	Q_PROPERTY(QString product READ product WRITE setProduct)
 	Q_PROPERTY(bool bluetoothMode READ bluetoothMode WRITE setBluetoothMode)
@@ -26,6 +27,7 @@ class DCDeviceData : public QObject {
 	Q_PROPERTY(int diveId READ diveId WRITE setDiveId)
 	Q_PROPERTY(bool saveDump READ saveDump WRITE setSaveDump)
 	Q_PROPERTY(bool saveLog READ saveLog WRITE setSaveLog)
+#endif // SUBSURFACE_MOBILE
 
 public:
 	DCDeviceData(QObject *parent = nullptr);
@@ -34,26 +36,42 @@ public:
 	QString vendor() const;
 	QString product() const;
 	QString devName() const;
-	QString devBluetoothName() const;
-	QString descriptor() const;
 	bool bluetoothMode() const;
+	bool saveDump() const;
+	QString devBluetoothName() const;
+#ifdef SUBSURFACE_MOBILE
+	QString descriptor() const;
 	bool forceDownload() const;
 	bool createNewTrip() const;
-	bool saveDump() const;
 	bool saveLog() const;
 	int deviceId() const;
 	int diveId() const;
+#endif // SUBSURFACE_MOBILE
 
 	/* this needs to be a pointer to make the C-API happy */
 	device_data_t* internalData();
 
+#ifdef SUBSURFACE_MOBILE
 	Q_INVOKABLE QStringList getProductListFromVendor(const QString& vendor);
 	Q_INVOKABLE int getMatchingAddress(const QString &vendor, const QString &product);
 
 	Q_INVOKABLE int getDetectedVendorIndex();
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
+#else
+	QStringList getProductListFromVendor(const QString& vendor);
+	int getMatchingAddress(const QString &vendor, const QString &product);
 
+	int getDetectedVendorIndex();
+	int getDetectedProductIndex(const QString &currentVendorText);
+#endif // SUBSURFACE_MOBILE
+
+#ifdef SUBSURFACE_MOBILE
 public slots:
+	void setDeviceId(int deviceId);
+	void setDiveId(int diveId);
+#else
+public:
+#endif // SUBSURFACE_MOBILE
 	void setVendor(const QString& vendor);
 	void setProduct(const QString& product);
 	void setDevName(const QString& devName);
@@ -61,8 +79,6 @@ public slots:
 	void setBluetoothMode(bool mode);
 	void setForceDownload(bool force);
 	void setCreateNewTrip(bool create);
-	void setDeviceId(int deviceId);
-	void setDiveId(int diveId);
 	void setSaveDump(bool dumpMode);
 	void setSaveLog(bool saveLog);
 private:
@@ -75,13 +91,19 @@ private:
 
 class DownloadThread : public QThread {
 	Q_OBJECT
+#ifdef SUBSURFACE_MOBILE
 	Q_PROPERTY(DCDeviceData* deviceData MEMBER m_data)
+#endif // SUBSURFACE_MOBILE
 
 public:
 	DownloadThread();
 	void run() override;
 
+#ifdef SUBSURFACE_MOBILE
 	Q_INVOKABLE DCDeviceData *data();
+#else
+	DCDeviceData *data();
+#endif // SUBSURFACE_MOBILE
 	QString error;
 
 private:

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -12,25 +12,9 @@
 #include "core/btdiscovery.h"
 #endif
 /* Helper object for access of Device Data in QML */
-class DCDeviceData : public QObject {
-	Q_OBJECT
-#ifdef SUBSURFACE_MOBILE
-	Q_PROPERTY(QString vendor READ vendor WRITE setVendor)
-	Q_PROPERTY(QString product READ product WRITE setProduct)
-	Q_PROPERTY(bool bluetoothMode READ bluetoothMode WRITE setBluetoothMode)
-	Q_PROPERTY(QString devName READ devName WRITE setDevName)
-	Q_PROPERTY(QString devBluetoothName READ devBluetoothName WRITE setDevBluetoothName)
-	Q_PROPERTY(QString descriptor READ descriptor)
-	Q_PROPERTY(bool forceDownload READ forceDownload WRITE setForceDownload)
-	Q_PROPERTY(bool createNewTrip READ createNewTrip WRITE setCreateNewTrip)
-	Q_PROPERTY(int deviceId READ deviceId WRITE setDeviceId)
-	Q_PROPERTY(int diveId READ diveId WRITE setDiveId)
-	Q_PROPERTY(bool saveDump READ saveDump WRITE setSaveDump)
-	Q_PROPERTY(bool saveLog READ saveLog WRITE setSaveLog)
-#endif // SUBSURFACE_MOBILE
-
+class DCDeviceData {
 public:
-	DCDeviceData(QObject *parent = nullptr);
+	DCDeviceData();
 	static DCDeviceData *instance();
 
 	QString vendor() const;
@@ -39,39 +23,24 @@ public:
 	bool bluetoothMode() const;
 	bool saveDump() const;
 	QString devBluetoothName() const;
-#ifdef SUBSURFACE_MOBILE
 	QString descriptor() const;
 	bool forceDownload() const;
 	bool createNewTrip() const;
 	bool saveLog() const;
 	int deviceId() const;
 	int diveId() const;
-#endif // SUBSURFACE_MOBILE
 
 	/* this needs to be a pointer to make the C-API happy */
 	device_data_t* internalData();
 
-#ifdef SUBSURFACE_MOBILE
-	Q_INVOKABLE QStringList getProductListFromVendor(const QString& vendor);
-	Q_INVOKABLE int getMatchingAddress(const QString &vendor, const QString &product);
-
-	Q_INVOKABLE int getDetectedVendorIndex();
-	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
-#else
 	QStringList getProductListFromVendor(const QString& vendor);
 	int getMatchingAddress(const QString &vendor, const QString &product);
 
 	int getDetectedVendorIndex();
 	int getDetectedProductIndex(const QString &currentVendorText);
-#endif // SUBSURFACE_MOBILE
 
-#ifdef SUBSURFACE_MOBILE
-public slots:
 	void setDeviceId(int deviceId);
 	void setDiveId(int diveId);
-#else
-public:
-#endif // SUBSURFACE_MOBILE
 	void setVendor(const QString& vendor);
 	void setProduct(const QString& product);
 	void setDevName(const QString& devName);
@@ -91,9 +60,6 @@ private:
 
 class DownloadThread : public QThread {
 	Q_OBJECT
-#ifdef SUBSURFACE_MOBILE
-	Q_PROPERTY(DCDeviceData* deviceData MEMBER m_data)
-#endif // SUBSURFACE_MOBILE
 
 public:
 	DownloadThread();

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -23,18 +23,6 @@ Kirigami.Page {
 
 	DCDownloadThread {
 		id: downloadThread
-		deviceData.vendor : comboVendor.currentText
-		deviceData.product : comboProduct.currentText
-		deviceData.devName : comboConnection.currentText
-
-		//TODO: Make this the default on the C++
-		deviceData.bluetoothMode : true
-		deviceData.forceDownload : false
-		deviceData.createNewTrip : false
-		deviceData.deviceId : 0
-		deviceData.diveId : 0
-		deviceData.saveDump : false
-		deviceData.saveLog : true
 
 		onFinished : {
 			importModel.repopulate()
@@ -164,10 +152,10 @@ Kirigami.Page {
 						btAddr = /\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}/;
 
 					if (btAddr.test(currentText))
-						downloadThread.deviceData.bluetoothMode = true
+						downloadThread.manager.DC_bluetoothMode = true
 					else
-						downloadThread.deviceData.bluetoothMode = false
-					downloadThread.deviceData.devName = comboConnection.currentText
+						downloadThread.manager.DC_bluetoothMode = false
+					downloadThread.manager.DC_devName = comboConnection.currentText
 				}
 			}
 		}
@@ -198,9 +186,9 @@ Kirigami.Page {
 				onClicked: {
 					text = qsTr("Retry")
 					// strip any BT Name from the address
-					var devName = downloadThread.deviceData.devName
-					downloadThread.deviceData.devName = devName.replace(/^(.*) /, "")
-					manager.appendTextToLog("DCDownloadThread started for " + downloadThread.deviceData.product + " on "+ downloadThread.deviceData.devName)
+					var devName = downloadThread.manager.devName
+					downloadThread.manager.devName = devName.replace(/^(.*) /, "")
+					manager.appendTextToLog("DCDownloadThread started for " + downloadThread.manager.product + " on "+ downloadThread.manager.devName)
 					progressBar.visible = true
 					downloadThread.start()
 				}
@@ -309,6 +297,9 @@ Kirigami.Page {
 				comboVendor.currentIndex = downloadThread.data().getDetectedVendorIndex()
 				comboProduct.currentIndex = downloadThread.data().getDetectedProductIndex(comboVendor.currentText)
 				comboDevice.currentIndex = downloadThread.data().getMatchingAddress(comboVendor.currentText, comboProduct.currentText)
+				manager.DC_vendor = comboVendor.currentText
+				manager.DC_product = comboProduct.currentText
+				manager.DC_devName = comboConnection.currentText
 			}
 		}
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -138,7 +138,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_selectedDiveTimestamp(0),
 	m_credentialStatus(CS_UNKNOWN),
 	alreadySaving(false),
-	m_device_data(new DCDeviceData(this))
+	m_device_data(new DCDeviceData)
 {
 	LOG_STP("qmlmgr starting");
 	m_instance = this;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1723,3 +1723,138 @@ void QMLManager::setStatusbarColor(QColor)
 }
 
 #endif
+
+QString QMLManager::DC_vendor() const
+{
+	return m_device_data->vendor();
+}
+
+QString QMLManager::DC_product() const
+{
+	return m_device_data->product();
+}
+
+QString QMLManager::DC_devName() const
+{
+	return m_device_data->devName();
+}
+
+QString QMLManager::DC_devBluetoothName() const
+{
+	return m_device_data->devBluetoothName();
+}
+
+QString QMLManager::DC_descriptor() const
+{
+	return m_device_data->descriptor();
+}
+
+bool QMLManager::DC_forceDownload() const
+{
+	return m_device_data->forceDownload();
+}
+
+bool QMLManager::DC_bluetoothMode() const
+{
+	return m_device_data->bluetoothMode();
+}
+
+bool QMLManager::DC_createNewTrip() const
+{
+	return m_device_data->createNewTrip();
+}
+
+bool QMLManager::DC_saveDump() const
+{
+	return m_device_data->saveDump();
+}
+
+bool QMLManager::DC_saveLog() const
+{
+	return m_device_data->saveLog();
+}
+
+int QMLManager::DC_deviceId() const
+{
+	return m_device_data->deviceId();
+}
+
+int QMLManager::DC_diveId() const
+{
+	return m_device_data->diveId();
+}
+
+void QMLManager::DC_setDeviceId(int deviceId)
+{
+	m_device_data->setDeviceId(deviceId);
+}
+
+void QMLManager::DC_setDiveId(int diveId)
+{
+	m_device_data->setDiveId(diveId);
+}
+
+void QMLManager::DC_setVendor(const QString& vendor)
+{
+	m_device_data->setVendor(vendor);
+}
+
+void QMLManager::DC_setProduct(const QString& product)
+{
+	m_device_data->setProduct(product);
+}
+
+void QMLManager::DC_setDevName(const QString& devName)
+{
+	m_device_data->setDevName(devName);
+}
+
+void QMLManager::DC_setDevBluetoothName(const QString& devBluetoothName)
+{
+	m_device_data->setDevBluetoothName(devBluetoothName);
+}
+
+void QMLManager::DC_setBluetoothMode(bool mode)
+{
+	m_device_data->setBluetoothMode(mode);
+}
+
+void QMLManager::DC_setForceDownload(bool force)
+{
+	m_device_data->setForceDownload(force);
+}
+
+void QMLManager::DC_setCreateNewTrip(bool create)
+{
+	m_device_data->setCreateNewTrip(create);
+}
+
+void QMLManager::DC_setSaveDump(bool dumpMode)
+{
+	m_device_data->setSaveDump(dumpMode);
+}
+
+void QMLManager::DC_setSaveLog(bool saveLog)
+{
+	m_device_data->setSaveLog(saveLog);
+}
+
+QStringList QMLManager::getProductListFromVendor(const QString &vendor)
+{
+	return m_device_data->getProductListFromVendor(vendor);
+}
+
+int QMLManager::getMatchingAddress(const QString &vendor, const QString &product)
+{
+	return m_device_data->getMatchingAddress(vendor, product);
+}
+
+int QMLManager::getDetectedVendorIndex()
+{
+	return m_device_data->getDetectedVendorIndex();
+}
+
+int QMLManager::getDetectedProductIndex(const QString &currentVendorText)
+{
+	return m_device_data->getDetectedProductIndex(currentVendorText);
+}

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -48,10 +48,62 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool developer MEMBER m_developer WRITE setDeveloper NOTIFY developerChanged)
 	Q_PROPERTY(bool btEnabled MEMBER m_btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
 
+	Q_PROPERTY(QString DC_vendor READ DC_vendor WRITE DC_setVendor)
+	Q_PROPERTY(QString DC_product READ DC_product WRITE DC_setProduct)
+	Q_PROPERTY(QString DC_devName READ DC_devName WRITE DC_setDevName)
+	Q_PROPERTY(QString DC_devBluetoothName READ DC_devBluetoothName WRITE DC_setDevBluetoothName)
+	Q_PROPERTY(QString descriptor READ DC_descriptor)
+	Q_PROPERTY(bool DC_forceDownload READ DC_forceDownload WRITE DC_setForceDownload)
+	Q_PROPERTY(bool DC_bluetoothMode READ DC_bluetoothMode WRITE DC_setBluetoothMode)
+	Q_PROPERTY(bool DC_createNewTrip READ DC_createNewTrip WRITE DC_setCreateNewTrip)
+	Q_PROPERTY(bool DC_saveDump READ DC_saveDump WRITE DC_setSaveDump)
+	Q_PROPERTY(bool DC_saveLog READ DC_saveLog WRITE DC_setSaveLog)
+	Q_PROPERTY(int DC_deviceId READ DC_deviceId WRITE DC_setDeviceId)
+	Q_PROPERTY(int DC_diveId READ DC_diveId WRITE DC_setDiveId)
 public:
 	QMLManager();
 	~QMLManager();
 
+	QString DC_vendor() const;
+	void DC_setVendor(const QString& vendor);
+
+	QString DC_product() const;
+	void DC_setProduct(const QString& product);
+
+	QString DC_devName() const;
+	void DC_setDevName(const QString& devName);
+
+	QString DC_devBluetoothName() const;
+	void DC_setDevBluetoothName(const QString& devBluetoothName);
+
+	QString DC_descriptor() const;
+
+	bool DC_forceDownload() const;
+	void DC_setForceDownload(bool force);
+
+	bool DC_bluetoothMode() const;
+	void DC_setBluetoothMode(bool mode);
+
+	bool DC_createNewTrip() const;
+	void DC_setCreateNewTrip(bool create);
+
+	bool DC_saveDump() const;
+	void DC_setSaveDump(bool dumpMode);
+
+	bool DC_saveLog() const;
+	void DC_setSaveLog(bool saveLog);
+
+	int DC_deviceId() const;
+	void DC_setDeviceId(int deviceId);
+
+	int DC_diveId() const;
+	void DC_setDiveId(int diveId);
+
+	Q_INVOKABLE QStringList getProductListFromVendor(const QString& vendor);
+	Q_INVOKABLE int getMatchingAddress(const QString &vendor, const QString &product);
+	Q_INVOKABLE int getDetectedVendorIndex();
+	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
+public:
 	enum cloud_status_qml {
 		CS_UNKNOWN,
 		CS_INCORRECT_USER_PASSWD,
@@ -234,7 +286,7 @@ private:
 	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
 	bool m_showPin;
-	DCDeviceData *m_device_data;
+	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;
 	bool m_developer;
 	bool m_btEnabled;

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -57,7 +57,6 @@ void run_ui()
 	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
 	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
 
-	qmlRegisterType<DCDeviceData>("org.subsurfacedivelog.mobile", 1, 0, "DCDeviceData");
 	qmlRegisterType<DownloadThread>("org.subsurfacedivelog.mobile", 1, 0, "DCDownloadThread");
 	qmlRegisterType<DiveImportedModel>("org.subsurfacedivelog.mobile", 1, 0, "DCImportModel");
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
downloadFromComputer contained qml properties which should not be in core and 
also not be compiled as part of the desktop.

The properties are added to qmlmanager

With the PR core is clean from qml properties.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
the commits are made in a sequence in order not to make a "Big Bang" change, but
show the logical change flow.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->