### PR TITLE
build-system: download libzip from our own server

### DIFF
--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -151,8 +151,8 @@ if [[ "$BUILD" = *"libxslt"* && ! -d libxslt ]]; then
 fi
 
 if [[ "$BUILD" = *"libzip"* && ! -d libzip ]]; then
-	${CURL} https://libzip.org/download/libzip-${CURRENT_LIBZIP}.tar.gz
-	tar xzf libzip-${CURRENT_LIBZIP}.tar.gz
+	${CURL} https://subsurface-divelog.org/downloads/libzip-${CURRENT_LIBZIP}.tar.xz
+	tar xJf libzip-${CURRENT_LIBZIP}.tar.xz
 	mv libzip-${CURRENT_LIBZIP} libzip
 fi
 


### PR DESCRIPTION
The libzip.org server often times out and causes build failures.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I repackaged the two versions that we currently use as .xz (since my server tends to be fairly slow for downloads - compared to GCS or S3 at least).
