### PR TITLE
Add snap packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ description: |
 
 grade: stable
 confinement: strict
+base: core18
 
 apps:
   subsurface:
@@ -37,15 +38,17 @@ parts:
       mkdir -p QtHeaders/QtLocation/private QtHeaders/QtPositioning/private
       cd QtHeaders/QtLocation/private
       for HEADER in \
+          qlocationglobal \
+          maps/qabstractgeotilecache \
           maps/qcache3q \
           maps/qgeocameracapabilities \
           maps/qgeocameradata \
           maps/qgeomap \
-          maps/qgeomapcontroller \
           maps/qgeomappingmanager \
           maps/qgeomappingmanagerengine \
           maps/qgeomaptype \
-          maps/qgeotilecache \
+          maps/qgeofiletilecache \
+          maps/qgeoprojection \
           maps/qgeotiledmap \
           maps/qgeotiledmappingmanagerengine \
           maps/qgeotiledmapreply \
@@ -59,8 +62,10 @@ parts:
       cd -
       cd QtHeaders/QtPositioning/private
       for HEADER in \
+          qdoublematrix4x4 \
           qdoublevector2d \
-          qgeoprojection
+          qdoublevector3d \
+          qpositioningglobal
       do
         wget --no-verbose --content-disposition \
           http://code.qt.io/cgit/qt/qtlocation.git/plain/src/positioning/${HEADER}_p.h?h=v${QT_VERSION}
@@ -112,7 +117,7 @@ parts:
     - qtconnectivity5-dev
     - qtlocation5-dev
     - qtpositioning5-dev
-    - qttools5-dev-tools
+    - qttools5-dev
     override-build: |
       mkdir -p ../install-root
       ln -sf ../../../stage/usr/lib/*/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so \
@@ -120,9 +125,11 @@ parts:
       sed -i 's@^Icon=.*@Icon=${SNAP}/share/icons/hicolor/scalable/apps/subsurface-icon.svg@' ../src/subsurface.desktop
       snapcraftctl build
     stage-packages:
+    - libcap2
     - libcurl3-gnutls
+    - libdb5.3
     - libftdi1-2
-    - libgit2-24
+    - libgit2-26
     - libgrantlee-templates5
     - libqt5bluetooth5
     - libqt5concurrent5

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ apps:
     - home
     - network
     - opengl
+    - raw-usb
     - unity7
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,151 @@
+name: subsurface
+version: git
+version-script: |
+  git describe
+icon: icons/subsurface-icon.svg
+summary: Open source divelog program for recreational, tech, and free-divers
+description: |
+  Subsurface can plan and track single- and multi-tank dives using air, Nitrox
+  or TriMix. It allows tracking of dive locations including GPS coordinates
+  (which can also conveniently be entered using a map interface), logging of
+  equipment used and names of other divers, and lets users rate dives and
+  provide additional notes.
+
+grade: stable
+confinement: strict
+
+apps:
+  subsurface:
+    command: desktop-launch $SNAP/bin/subsurface
+    desktop: share/applications/subsurface.desktop
+    plugs:
+    - bluez
+    - home
+    - network
+    - opengl
+    - unity7
+
+parts:
+  googlemaps:
+    source: git://github.com/Subsurface-divelog/googlemaps.git
+    build-packages:
+    - wget
+    override-pull: |
+      snapcraftctl pull
+      export QT_SELECT=5
+      export QT_VERSION=$( qmake -query QT_VERSION )
+      mkdir -p QtHeaders/QtLocation/private QtHeaders/QtPositioning/private
+      cd QtHeaders/QtLocation/private
+      for HEADER in \
+          maps/qcache3q \
+          maps/qgeocameracapabilities \
+          maps/qgeocameradata \
+          maps/qgeomap \
+          maps/qgeomapcontroller \
+          maps/qgeomappingmanager \
+          maps/qgeomappingmanagerengine \
+          maps/qgeomaptype \
+          maps/qgeotilecache \
+          maps/qgeotiledmap \
+          maps/qgeotiledmappingmanagerengine \
+          maps/qgeotiledmapreply \
+          maps/qgeotilefetcher \
+          maps/qgeotilespec \
+          places/unsupportedreplies
+      do
+        wget --no-verbose --content-disposition \
+          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/location/${HEADER}_p.h?h=v${QT_VERSION}
+      done
+      cd -
+      cd QtHeaders/QtPositioning/private
+      for HEADER in \
+          qdoublevector2d \
+          qgeoprojection
+      do
+        wget --no-verbose --content-disposition \
+          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/positioning/${HEADER}_p.h?h=v${QT_VERSION}
+      done
+    plugin: qmake
+    options:
+    - INCLUDEPATH+=QtHeaders
+
+  libdc:
+    plugin: autotools
+    source-subdir: libdivecomputer
+    build-packages:
+    - libbluetooth-dev
+    - libhidapi-dev
+    - libusb-dev
+    override-build: |
+      sed -i 's/\[HIDAPI\], \[hidapi\]/[HIDAPI], [hidapi-libusb]/' libdivecomputer/configure.ac
+      snapcraftctl build
+    stage-packages:
+    - libbluetooth3
+    - libftdi1-2
+    - libhidapi-libusb0
+    - libusb-1.0-0
+
+  subsurface:
+    after: [desktop-qt5, googlemaps, libdc]
+    plugin: cmake
+    configflags:
+    - -DMAKE_TESTS=OFF
+    - -DLIBGIT2_DYNAMIC=ON
+    - -DFTDISUPPORT=ON
+    - -DLIBDIVECOMPUTER_LIBRARIES=../../../stage/lib/libdivecomputer.so
+    source-type: git
+    build-packages:
+    - build-essential
+    - libcurl4-gnutls-dev
+    - libftdi1-dev
+    - libgrantlee5-dev
+    - libgit2-dev
+    - libqt5svg5-dev
+    - libqt5webkit5-dev
+    - libsqlite3-dev
+    - libssh2-1-dev
+    - libssl-dev
+    - libxml2-dev
+    - libxslt-dev
+    - libzip-dev
+    - pkg-config
+    - qtconnectivity5-dev
+    - qtlocation5-dev
+    - qtpositioning5-dev
+    - qttools5-dev-tools
+    override-build: |
+      mkdir -p ../install-root
+      ln -sf ../../../stage/usr/lib/*/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so \
+        ../install-root/
+      sed -i 's@^Icon=.*@Icon=${SNAP}/share/icons/hicolor/scalable/apps/subsurface-icon.svg@' ../src/subsurface.desktop
+      snapcraftctl build
+    stage-packages:
+    - libcurl3-gnutls
+    - libftdi1-2
+    - libgit2-24
+    - libgrantlee-templates5
+    - libqt5bluetooth5
+    - libqt5concurrent5
+    - libqt5core5a
+    - libqt5gui5
+    - libqt5location5
+    - libqt5network5
+    - libqt5positioning5
+    - libqt5printsupport5
+    - libqt5qml5
+    - libqt5quick5
+    - libqt5quickwidgets5
+    - libqt5svg5
+    - libqt5webkit5
+    - libqt5widgets5
+    - libsqlite3-0
+    - libssh2-1
+    - libssl1.0.0
+    - libusb-1.0-0
+    - libxml2
+    - libxslt1.1
+    - libzip4
+    - qml-module-qtlocation
+    - qml-module-qtpositioning
+    - qml-module-qtquick2
+    - zlib1g


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This adds [`snap`](https://snapcraft.io/) packaging to subsurface. Its previous iteration was #1230.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added `snap/snapcraft.yaml`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
See [this forum post](https://forum.snapcraft.io/t/call-for-testing-subsurface/5249) for more information on where to get the snap.
The placement of `snapcraft.yaml` in a top-level `snap` directory is required to use automated builds and releases from the Git repository.
The snaps are [being built on Launchpad](https://code.launchpad.net/~saviq/+snap/subsurface) from [an automatic import](https://code.launchpad.net/~saviq/subsurface/+git/subsurface/) temporarily from [my repository](https://github.com/Saviq/subsurface). I'd like to transfer ownership of the `subsurface` name in the [snap store](https://snapcraft.io/store), but I can also carry on maintaining the builds until [build.snapcraft.io](https://build.snapcraft.io) gains support for `core18` builds.
With the next stable version of [snapd](https://github.com/snapcore/snapd/) it will be possible to communicate with computers over `/dev/ttyUSB*` after connecting the `raw-usb` interface:

```
snap refresh core --beta
snap connect subsurface:raw-usb
```

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Subsurface is now also available as a snap (https://snapcraft.io/subsurface).
> the link above will start working once the snap is released in the `stable` channel

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
A mention of the snap should be added to the website.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
