### PR TITLE
Dive pictures: Make failure of loading images less noisy

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -13,7 +13,7 @@ public:
 	static ImageDownloader *instance();
 	ImageDownloader();
 public slots:
-	void load(QString filename);
+	void load(QUrl url, QString filename);
 signals:
 	void loaded(QString filename);
 	void failed(QString filename);


### PR DESCRIPTION
For debug reasons, failure to load the original image was spilled
to the console, even if the local file was then found.

Only print a message, when also the local image failed loading.
This needed a bit of code reshuffling. To know when to print a
failed-loading message, the URL is now checked at the Thumbnailer
level, not the ImageDownloader level. The ImageDownloader is
passed the URL and the original filename (if different). The
image is loaded from the URL, but the signals send the original
filename, so that the thumbnail can be associated to the proper
image.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This makes loading of images with a local file name less noisy. It also contains a borderline bugfix. If a remote image had a translated filename, the thumbnails would not have been associated correctly. Though it is not clear how such a situation could arise currently. In the future (find moved images in remote storage?) it might very well do.

Tested briefly. Seems to work.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Verbose messages are discussed in #1349 