### PR TITLE
mobile: "isolate" QML variables used in Settings from QMLManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ endif()
 if(${SUBSURFACE_TARGET_EXECUTABLE} MATCHES "MobileExecutable")
 	set(MOBILE_SRC
 		mobile-widgets/qmlmanager.cpp
+		mobile-widgets/qmlprefs.cpp
 		mobile-widgets/qml/kirigami/src/kirigamiplugin.cpp
 		mobile-widgets/qml/kirigami/src/settings.cpp
 		mobile-widgets/qml/kirigami/src/enums.cpp

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -15,9 +15,9 @@ Item {
 	property string password: password.text;
 
 	function saveCredentials() {
-		manager.cloudUserName = login.text
-		manager.cloudPassword = password.text
-		manager.cloudPin = pin.text
+		prefs.cloudUserName = login.text
+		prefs.cloudPassword = password.text
+		prefs.cloudPin = pin.text
 		manager.saveCloudCredentials()
 	}
 
@@ -60,7 +60,7 @@ Item {
 
 		Controls.TextField {
 			id: login
-			text: manager.cloudUserName
+			text: prefs.cloudUserName
 			visible: !rootItem.showPin
 			Layout.fillWidth: true
 			inputMethodHints: Qt.ImhEmailCharactersOnly |
@@ -76,7 +76,7 @@ Item {
 
 		Controls.TextField {
 			id: password
-			text: manager.cloudPassword
+			text: prefs.cloudPassword
 			visible: !rootItem.showPin
 			echoMode: TextInput.PasswordEchoOnEdit
 			inputMethodHints: Qt.ImhSensitiveData |
@@ -146,7 +146,7 @@ Item {
 				text: qsTr("No cloud mode")
 				onClicked: {
 					manager.syncToCloud = false
-					manager.credentialStatus = QMLManager.CS_NOCLOUD
+					manager.credentialStatus = QMLPrefs.CS_NOCLOUD
 					manager.saveCloudCredentials()
 					manager.openNoCloudRepo()
 				}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -13,7 +13,7 @@ Kirigami.ScrollablePage {
 	title: qsTr("Dive list")
 	verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
 	width: subsurfaceTheme.columnWidth
-	property int credentialStatus: manager.credentialStatus
+	property int credentialStatus: prefs.credentialStatus
 	property int numDives: diveListView.count
 	property color textColor: subsurfaceTheme.textColor
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor
@@ -23,14 +23,14 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (manager.credentialStatus === QMLManager.CS_VERIFIED) {
+			if (prefs.credentialStatus === QMLPrefs.CS_VERIFIED) {
 				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
 				console.log("done syncing, turn off spinner")
 				refreshing = false
 			} else {
-				console.log("sync with cloud storage requested, but credentialStatus is " + manager.credentialStatus)
+				console.log("sync with cloud storage requested, but credentialStatus is " + prefs.credentialStatus)
 				console.log("no syncing, turn off spinner")
 				refreshing = false
 			}
@@ -339,7 +339,8 @@ Kirigami.ScrollablePage {
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		opacity: credentialStatus === QMLManager.CS_NOCLOUD || (credentialStatus === QMLManager.CS_VERIFIED) ? 0 : 1
+		opacity: credentialStatus === QMLPrefs.CS_NOCLOUD ||
+									(credentialStatus === QMLPrefs.CS_VERIFIED) ? 0 : 1
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
@@ -347,7 +348,8 @@ Kirigami.ScrollablePage {
 				page.actions.main = null
 				page.actions.right = null
 				page.title = qsTr("Cloud credentials")
-			} else if (manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD) {
+			} else if (prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
+						prefs.credentialStatus === QMLPrefs.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")
@@ -424,8 +426,9 @@ Kirigami.ScrollablePage {
 	}
 
 	onBackRequested: {
-		if (startPage.visible && diveListView.count > 0 && manager.credentialStatus !== QMLManager.CS_INCORRECT_USER_PASSWD) {
-			manager.credentialStatus = oldStatus
+		if (startPage.visible && diveListView.count > 0 &&
+			prefs.credentialStatus !== QMLPrefs.CS_INCORRECT_USER_PASSWD) {
+			prefs.credentialStatus = oldStatus
 			event.accepted = true;
 		}
 		if (!startPage.visible) {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -42,7 +42,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: manager.credentialStatus === QMLManager.CS_NOCLOUD ? qsTr("Not applicable") : manager.cloudUserName
+				text: prefs.credentialStatus === QMLPrefs.CS_NOCLOUD ? qsTr("Not applicable") :
+																		prefs.cloudUserName
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
@@ -63,7 +64,7 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: describe[manager.credentialStatus]
+				text: describe[prefs.credentialStatus]
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
@@ -136,8 +137,8 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Blue"
 				onClicked: {
 					blueTheme()
-					manager.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					prefs.theme = subsurfaceTheme.currentTheme
+					prefs.savePreferences()
 				}
 			}
 
@@ -189,8 +190,8 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Pink"
 				onClicked: {
 					pinkTheme()
-					manager.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					prefs.theme = subsurfaceTheme.currentTheme
+					prefs.savePreferences()
 				}
 			}
 
@@ -241,8 +242,8 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Dark"
 				onClicked: {
 					darkTheme()
-					manager.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					prefs.theme = subsurfaceTheme.currentTheme
+					prefs.savePreferences()
 				}
 			}
 		}
@@ -275,11 +276,11 @@ Kirigami.ScrollablePage {
 
 			Controls.TextField {
 				id: distanceThreshold
-				text: manager.distanceThreshold
+				text: prefs.distanceThreshold
 				Layout.preferredWidth: gridWidth * 0.25
 				onEditingFinished: {
-					manager.distanceThreshold = distanceThreshold.text
-					manager.savePreferences()
+					prefs.distanceThreshold = distanceThreshold.text
+					prefs.savePreferences()
 				}
 			}
 
@@ -291,11 +292,11 @@ Kirigami.ScrollablePage {
 
 			Controls.TextField {
 				id: timeThreshold
-				text: manager.timeThreshold
+				text: prefs.timeThreshold
 				Layout.preferredWidth: gridWidth * 0.25
 				onEditingFinished: {
-					manager.timeThreshold = timeThreshold.text
-					manager.savePreferences()
+					prefs.timeThreshold = timeThreshold.text
+					prefs.savePreferences()
 				}
 			}
 
@@ -325,10 +326,10 @@ Kirigami.ScrollablePage {
 			}
 			SsrfSwitch {
 				id: developerButton
-				checked: manager.developer
+				checked: prefs.developer
 				Layout.preferredWidth: gridWidth * 0.25
 				onClicked: {
-					manager.developer = checked
+					prefs.developer = checked
 				}
 			}
 		}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -20,11 +20,11 @@ Kirigami.ApplicationWindow {
 		maximumHeight: Kirigami.Units.gridUnit * 2
 		background: Rectangle { color: subsurfaceTheme.primaryColor }
 	}
-	property alias oldStatus: manager.oldStatus
+	property alias oldStatus: prefs.oldStatus
 	property alias notificationText: manager.notificationText
 	property alias syncToCloud: manager.syncToCloud
 	property alias locationServiceEnabled: manager.locationServiceEnabled
-	property alias showPin: manager.showPin
+	property alias showPin: prefs.showPin
 	onNotificationTextChanged: {
 		if (notificationText != "") {
 			// there's a risk that we have a >5 second gap in update events;
@@ -119,12 +119,12 @@ Kirigami.ApplicationWindow {
 				}
 				text: qsTr("Dive list")
 				onTriggered: {
-					manager.appendTextToLog("requested dive list with credential status " + manager.credentialStatus)
-					if (manager.credentialStatus == QMLManager.CS_UNKNOWN) {
+					manager.appendTextToLog("requested dive list with credential status " + prefs.credentialStatus)
+					if (prefs.credentialStatus == QMLPrefs.CS_UNKNOWN) {
 						// the user has asked to change credentials - if the credentials before that
 						// were valid, go back to dive list
-						if (oldStatus == QMLManager.CS_VERIFIED) {
-							manager.credentialStatus = oldStatus
+						if (oldStatus == QMLPrefs.CS_VERIFIED) {
+							prefs.credentialStatus = oldStatus
 						}
 					}
 					returnTopPage()
@@ -150,7 +150,8 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/ic_add.svg"
 					}
 					text: qsTr("Add dive manually")
-					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
+					enabled: prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
+							prefs.credentialStatus === QMLPrefs.CS_NOCLOUD
 					onTriggered: {
 						globalDrawer.close()
 						returnTopPage()  // otherwise odd things happen with the page stack
@@ -184,13 +185,14 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/cloud_sync.svg"
 					}
 					text: qsTr("Manual sync with cloud")
-					enabled: manager.credentialStatus === QMLManager.CS_VERIFIED || manager.credentialStatus === QMLManager.CS_NOCLOUD
+					enabled: prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
+							prefs.credentialStatus === QMLPrefs.CS_NOCLOUD
 					onTriggered: {
-						if (manager.credentialStatus === QMLManager.CS_NOCLOUD) {
+						if (prefs.credentialStatus === QMLPrefs.CS_NOCLOUD) {
 							returnTopPage()
-							oldStatus = manager.credentialStatus
+							oldStatus = prefs.credentialStatus
 							manager.startPageText = "Enter valid cloud storage credentials"
-							manager.credentialStatus = QMLManager.CS_UNKNOWN
+							prefs.credentialStatus = QMLPrefs.CS_UNKNOWN
 							globalDrawer.close()
 						} else {
 							globalDrawer.close()
@@ -205,7 +207,7 @@ Kirigami.ApplicationWindow {
 					name: syncToCloud ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
 				text: syncToCloud ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
-					enabled: manager.credentialStatus !== QMLManager.CS_NOCLOUD
+					enabled: prefs.credentialStatus !== QMLPrefs.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
 						if (!syncToCloud) {
@@ -307,7 +309,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					name: ":/icons/ic_adb.svg"
 				}
 				text: qsTr("Developer")
-				visible: manager.developer
+				visible: prefs.developer
 				Kirigami.Action {
 					text: qsTr("App log")
 					onTriggered: {
@@ -452,7 +454,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		property int columnWidth: Math.round(rootItem.width/(Kirigami.Units.gridUnit*28)) > 0 ? Math.round(rootItem.width / Math.round(rootItem.width/(Kirigami.Units.gridUnit*28))) : rootItem.width
 		Component.onCompleted: {
 			// this needs to pick the theme from persistent preference settings
-			var theme = manager.theme
+			var theme = prefs.theme
 			if (theme == "Blue")
 				blueTheme()
 			else if (theme == "Pink")

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -492,6 +492,10 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		}
 	}
 
+	QMLPrefs {
+		id: prefs
+	}
+
 	QMLManager {
 		id: manager
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -39,8 +39,6 @@ QMLManager *QMLManager::m_instance = NULL;
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
 #define END_FONT QLatin1Literal("</font>")
 
-#define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
-
 extern "C" void showErrorFromC(char *buf)
 {
 	QString error(buf);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -21,21 +21,12 @@
 
 class QMLManager : public QObject {
 	Q_OBJECT
-	Q_ENUMS(cloud_status_qml)
-	Q_PROPERTY(QString cloudUserName MEMBER m_cloudUserName WRITE setCloudUserName NOTIFY cloudUserNameChanged)
-	Q_PROPERTY(QString cloudPassword MEMBER m_cloudPassword WRITE setCloudPassword NOTIFY cloudPasswordChanged)
-	Q_PROPERTY(QString cloudPin MEMBER m_cloudPin WRITE setCloudPin NOTIFY cloudPinChanged)
 	Q_PROPERTY(QString logText READ logText WRITE setLogText NOTIFY logTextChanged)
 	Q_PROPERTY(bool locationServiceEnabled MEMBER m_locationServiceEnabled WRITE setLocationServiceEnabled NOTIFY locationServiceEnabledChanged)
 	Q_PROPERTY(bool locationServiceAvailable MEMBER m_locationServiceAvailable WRITE setLocationServiceAvailable NOTIFY locationServiceAvailableChanged)
-	Q_PROPERTY(int distanceThreshold MEMBER m_distanceThreshold WRITE setDistanceThreshold NOTIFY distanceThresholdChanged)
-	Q_PROPERTY(int timeThreshold MEMBER m_timeThreshold WRITE setTimeThreshold NOTIFY timeThresholdChanged)
-	Q_PROPERTY(QString theme READ theme WRITE setTheme NOTIFY themeChanged)
 	Q_PROPERTY(bool loadFromCloud MEMBER m_loadFromCloud WRITE setLoadFromCloud NOTIFY loadFromCloudChanged)
 	Q_PROPERTY(QString startPageText MEMBER m_startPageText WRITE setStartPageText NOTIFY startPageTextChanged)
 	Q_PROPERTY(bool verboseEnabled MEMBER m_verboseEnabled WRITE setVerboseEnabled NOTIFY verboseEnabledChanged)
-	Q_PROPERTY(cloud_status_qml credentialStatus MEMBER m_credentialStatus WRITE setCredentialStatus NOTIFY credentialStatusChanged)
-	Q_PROPERTY(cloud_status_qml oldStatus MEMBER m_oldStatus WRITE setOldStatus NOTIFY oldStatusChanged)
 	Q_PROPERTY(QString notificationText MEMBER m_notificationText WRITE setNotificationText NOTIFY notificationTextChanged)
 	Q_PROPERTY(bool syncToCloud MEMBER m_syncToCloud WRITE setSyncToCloud NOTIFY syncToCloudChanged)
 	Q_PROPERTY(int updateSelectedDive MEMBER m_updateSelectedDive WRITE setUpdateSelectedDive NOTIFY updateSelectedDiveChanged)
@@ -45,9 +36,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
 	Q_PROPERTY(QStringList locationList READ locationList NOTIFY locationListChanged)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
-	Q_PROPERTY(bool showPin MEMBER m_showPin WRITE setShowPin NOTIFY showPinChanged)
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
-	Q_PROPERTY(bool developer MEMBER m_developer WRITE setDeveloper NOTIFY developerChanged)
 	Q_PROPERTY(bool btEnabled MEMBER m_btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
 
 	Q_PROPERTY(QString DC_vendor READ DC_vendor WRITE DC_setVendor)
@@ -106,26 +95,9 @@ public:
 	Q_INVOKABLE int getDetectedVendorIndex();
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
 public:
-	enum cloud_status_qml {
-		CS_UNKNOWN,
-		CS_INCORRECT_USER_PASSWD,
-		CS_NEED_TO_VERIFY,
-		CS_VERIFIED,
-		CS_NOCLOUD
-	};
-
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);
 	QString consumeError();
-
-	QString cloudUserName() const;
-	void setCloudUserName(const QString &cloudUserName);
-
-	QString cloudPassword() const;
-	void setCloudPassword(const QString &cloudPassword);
-
-	QString cloudPin() const;
-	void setCloudPin(const QString &cloudPin);
 
 	bool locationServiceEnabled() const;
 	void setLocationServiceEnabled(bool locationServiceEnable);
@@ -136,27 +108,12 @@ public:
 	bool verboseEnabled() const;
 	void setVerboseEnabled(bool verboseMode);
 
-	int distanceThreshold() const;
-	void setDistanceThreshold(int distance);
-
-	int timeThreshold() const;
-	void setTimeThreshold(int time);
-
-	QString theme() const;
-	void setTheme(QString theme);
-
 	bool loadFromCloud() const;
 	void setLoadFromCloud(bool done);
 	void syncLoadFromCloud();
 
 	QString startPageText() const;
 	void setStartPageText(const QString& text);
-
-	cloud_status_qml credentialStatus() const;
-	void setCredentialStatus(const cloud_status_qml value);
-
-	cloud_status_qml oldStatus() const;
-	void setOldStatus(const cloud_status_qml value);
 
 	QString logText() const;
 	void setLogText(const QString &logText);
@@ -176,9 +133,6 @@ public:
 	QString progressMessage() const;
 	void setProgressMessage(QString text);
 
-	bool developer() const;
-	void setDeveloper(bool value);
-
 	bool btEnabled() const;
 	void setBtEnabled(bool value);
 
@@ -189,8 +143,6 @@ public:
 	QStringList divemasterList() const;
 	QStringList locationList() const;
 	QStringList cylinderInit() const;
-	bool showPin() const;
-	void setShowPin(bool enable);
 	Q_INVOKABLE void setStatusbarColor(QColor color);
 	void btHostModeChange(QBluetoothLocalDevice::HostMode state);
 
@@ -227,8 +179,6 @@ public slots:
 	void populateGpsData();
 	void cancelDownloadDC();
 	void clearGpsData();
-	void clearCredentials();
-	void cancelCredentialsPinSetup();
 	void copyAppLogToClipboard();
 	void finishSetup();
 	void openLocalThenRemote(QString url);
@@ -256,9 +206,6 @@ private:
 	SuitCompletionModel suitModel;
 	DiveMasterCompletionModel divemasterModel;
 	LocationInformationModel locationModel;
-	QString m_cloudUserName;
-	QString m_cloudPassword;
-	QString m_cloudPin;
 	QString m_ssrfGpsWebUserid;
 	QString m_startPageText;
 	QString m_logText;
@@ -266,8 +213,6 @@ private:
 	bool m_locationServiceEnabled;
 	bool m_locationServiceAvailable;
 	bool m_verboseEnabled;
-	int m_distanceThreshold;
-	int m_timeThreshold;
 	GpsLocation *locationProvider;
 	bool m_loadFromCloud;
 	static QMLManager *m_instance;
@@ -277,8 +222,6 @@ private:
 	bool m_syncToCloud;
 	int m_updateSelectedDive;
 	int m_selectedDiveTimestamp;
-	cloud_status_qml m_credentialStatus;
-	cloud_status_qml m_oldStatus;
 	qreal m_lastDevicePixelRatio;
 	QElapsedTimer timer;
 	bool alreadySaving;
@@ -287,10 +230,8 @@ private:
 	bool checkDuration(DiveObjectHelper *myDive, struct dive *d, QString duration);
 	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
-	bool m_showPin;
 	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;
-	bool m_developer;
 	bool m_btEnabled;
 	void updateAllGlobalLists();
 
@@ -301,28 +242,18 @@ private:
 #endif
 
 signals:
-	void cloudUserNameChanged();
-	void cloudPasswordChanged();
-	void cloudPinChanged();
 	void locationServiceEnabledChanged();
 	void locationServiceAvailableChanged();
 	void verboseEnabledChanged();
 	void logTextChanged();
-	void timeThresholdChanged();
-	void themeChanged();
-	void distanceThresholdChanged();
 	void loadFromCloudChanged();
 	void startPageTextChanged();
-	void credentialStatusChanged();
-	void oldStatusChanged();
 	void notificationTextChanged();
 	void syncToCloudChanged();
 	void updateSelectedDiveChanged();
 	void selectedDiveTimestampChanged();
-	void showPinChanged();
 	void sendScreenChanged(QScreen *screen);
 	void progressMessageChanged();
-	void developerChanged();
 	void btEnabledChanged();
 	void suitListChanged();
 	void buddyListChanged();

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -17,6 +17,8 @@
 #include "qt-models/completionmodels.h"
 #include "qt-models/divelocationmodel.h"
 
+#define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
+
 class QMLManager : public QObject {
 	Q_OBJECT
 	Q_ENUMS(cloud_status_qml)

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qmlprefs.h"
+
+QMLPrefs *QMLPrefs::m_instance = NULL;
+
+
+QMLPrefs::QMLPrefs()
+{
+	if (!m_instance)
+		m_instance = this;
+}
+
+QMLPrefs::~QMLPrefs()
+{
+	m_instance = NULL;
+}
+
+QMLPrefs *QMLPrefs::instance()
+{
+	return m_instance;
+}

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -1,11 +1,25 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qmlprefs.h"
+#include "qmlmanager.h"
 
+#include "core/membuffer.h"
+#include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include "core/gpslocation.h"
+
+
+/*** Global and constructors ***/
 QMLPrefs *QMLPrefs::m_instance = NULL;
 
-
-QMLPrefs::QMLPrefs()
+QMLPrefs::QMLPrefs() :
+	m_credentialStatus(CS_UNKNOWN),
+	m_developer(false),
+	m_distanceThreshold(1000),
+	m_oldStatus(CS_UNKNOWN),
+	m_showPin(false),
+	m_timeThreshold(60)
 {
+	// This strange construct is needed because QMLEngine calls new and that
+	// cannot be overwritten
 	if (!m_instance)
 		m_instance = this;
 }
@@ -18,4 +32,165 @@ QMLPrefs::~QMLPrefs()
 QMLPrefs *QMLPrefs::instance()
 {
 	return m_instance;
+}
+
+
+/*** public functions ***/
+const QString QMLPrefs::cloudPassword() const
+{
+	return m_cloudPassword;
+}
+
+void QMLPrefs::setCloudPassword(const QString &cloudPassword)
+{
+	m_cloudPassword = cloudPassword;
+	emit cloudPasswordChanged();
+}
+
+const QString QMLPrefs::cloudPin() const
+{
+	return m_cloudPin;
+}
+
+void QMLPrefs::setCloudPin(const QString &cloudPin)
+{
+	m_cloudPin = cloudPin;
+	emit cloudPinChanged();
+}
+
+const QString QMLPrefs::cloudUserName() const
+{
+	return m_cloudUserName;
+}
+
+void QMLPrefs::setCloudUserName(const QString &cloudUserName)
+{
+	m_cloudUserName = cloudUserName.toLower();
+	emit cloudUserNameChanged();
+}
+
+QMLPrefs::cloud_status_qml QMLPrefs::credentialStatus() const
+{
+	return m_credentialStatus;
+}
+
+void QMLPrefs::setCredentialStatus(const cloud_status_qml value)
+{
+	if (m_credentialStatus != value) {
+		setOldStatus(m_credentialStatus);
+		if (value == CS_NOCLOUD) {
+			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
+			set_filename(NOCLOUD_LOCALSTORAGE);
+			clearCredentials();
+		}
+		m_credentialStatus = value;
+		emit credentialStatusChanged();
+	}
+}
+
+void QMLPrefs::setDeveloper(bool value)
+{
+	m_developer = value;
+	emit developerChanged();
+}
+
+int QMLPrefs::distanceThreshold() const
+{
+	return m_distanceThreshold;
+}
+
+void QMLPrefs::setDistanceThreshold(int distance)
+{
+	m_distanceThreshold = distance;
+	emit distanceThresholdChanged();
+}
+
+QMLPrefs::cloud_status_qml QMLPrefs::oldStatus() const
+{
+	return m_oldStatus;
+}
+
+void QMLPrefs::setOldStatus(const cloud_status_qml value)
+{
+	if (m_oldStatus != value) {
+		m_oldStatus = value;
+		emit oldStatusChanged();
+	}
+}
+
+bool QMLPrefs::showPin() const
+{
+	return m_showPin;
+}
+
+void QMLPrefs::setShowPin(bool enable)
+{
+	m_showPin = enable;
+	emit showPinChanged();
+}
+
+int QMLPrefs::timeThreshold() const
+{
+	return m_timeThreshold;
+}
+
+void QMLPrefs::setTimeThreshold(int time)
+{
+	m_timeThreshold = time;
+	GpsLocation::instance()->setGpsTimeThreshold(m_timeThreshold * 60);
+	emit timeThresholdChanged();
+}
+
+const QString QMLPrefs::theme() const
+{
+	QSettings s;
+	s.beginGroup("Theme");
+	return s.value("currentTheme", "Blue").toString();
+}
+
+void QMLPrefs::setTheme(QString theme)
+{
+	QSettings s;
+	s.beginGroup("Theme");
+	s.setValue("currentTheme", theme);
+	emit themeChanged();
+}
+
+
+
+/*** public slot functions ***/
+void QMLPrefs::cancelCredentialsPinSetup()
+{   
+	/* 
+	 * The user selected <cancel> on the final stage of the
+	 * cloud account generation (entering the emailed PIN).
+	 * 
+	 * Resets the cloud credential status to CS_UNKNOWN, resulting
+	 * in a return to the first crededentials page, with the
+	 * email and passwd still filled in. In case of a cancel
+	 * of registration (from the PIN page), the email address
+	 * was probably misspelled, so the user never received a PIN to
+	 * complete the process.
+	 * 
+	 * Notice that this function is also used to switch to a different
+	 * cloud account, so the name is not perfect.
+	 */
+	QSettings s;
+	
+	setCredentialStatus(CS_UNKNOWN);
+	s.beginGroup("CloudStorage");
+	s.setValue("email", m_cloudUserName);
+	s.setValue("password", m_cloudPassword);
+	s.setValue("cloud_verification_status", m_credentialStatus);
+	s.sync();
+	QMLManager::instance()->setStartPageText(tr("Starting..."));
+	
+	setShowPin(false);
+}
+
+void QMLPrefs::clearCredentials()
+{
+	setCloudUserName(NULL);
+	setCloudPassword(NULL);
+	setCloudPin(NULL);
 }

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -7,6 +7,47 @@
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
+	Q_ENUMS(cloud_status_qml)
+	Q_PROPERTY(QString cloudPassword
+				MEMBER m_cloudPassword
+				WRITE setCloudPassword
+				NOTIFY cloudPasswordChanged)
+	Q_PROPERTY(QString cloudPin
+				MEMBER m_cloudPin
+				WRITE setCloudPin
+				NOTIFY cloudPinChanged)
+	Q_PROPERTY(QString cloudUserName
+				MEMBER m_cloudUserName
+				WRITE setCloudUserName
+				NOTIFY cloudUserNameChanged)
+	Q_PROPERTY(cloud_status_qml credentialStatus
+				MEMBER m_credentialStatus
+				WRITE setCredentialStatus
+				NOTIFY credentialStatusChanged)
+	Q_PROPERTY(bool developer
+				MEMBER m_developer
+				WRITE setDeveloper
+				NOTIFY developerChanged)
+	Q_PROPERTY(int distanceThreshold
+				MEMBER m_distanceThreshold
+				WRITE setDistanceThreshold
+				NOTIFY distanceThresholdChanged)
+	Q_PROPERTY(bool showPin
+				MEMBER m_showPin
+				WRITE setShowPin
+				NOTIFY showPinChanged)
+	Q_PROPERTY(cloud_status_qml oldStatus
+				MEMBER m_oldStatus
+				WRITE setOldStatus
+				NOTIFY oldStatusChanged)
+	Q_PROPERTY(QString theme
+				READ theme
+				WRITE setTheme
+				NOTIFY themeChanged)
+	Q_PROPERTY(int timeThreshold
+				MEMBER m_timeThreshold
+				WRITE setTimeThreshold
+				NOTIFY timeThresholdChanged)
 
 public:
 	QMLPrefs();
@@ -14,12 +55,70 @@ public:
 
 	static QMLPrefs *instance();
 
+	enum cloud_status_qml {
+		CS_UNKNOWN,
+		CS_INCORRECT_USER_PASSWD,
+		CS_NEED_TO_VERIFY,
+		CS_VERIFIED,
+		CS_NOCLOUD
+	};
+
+	const QString cloudPassword() const;
+	void setCloudPassword(const QString &cloudPassword);
+
+	const QString cloudPin() const;
+	void setCloudPin(const QString &cloudPin);
+
+	const QString cloudUserName() const;
+	void setCloudUserName(const QString &cloudUserName);
+
+	cloud_status_qml credentialStatus() const;
+	void setCredentialStatus(const cloud_status_qml value);
+
+	void setDeveloper(bool value);
+
+	int distanceThreshold() const;
+	void setDistanceThreshold(int distance);
+
+	cloud_status_qml oldStatus() const;
+	void setOldStatus(const cloud_status_qml value);
+
+	bool showPin() const;
+	void setShowPin(bool enable);
+
+	int  timeThreshold() const;
+	void setTimeThreshold(int time);
+
+	const QString theme() const;
+	void setTheme(QString theme);
+
 public slots:
+	void cancelCredentialsPinSetup();
+	void clearCredentials();
 
 private:
+	QString m_cloudPassword;
+	QString m_cloudPin;
+	QString m_cloudUserName;
+	cloud_status_qml m_credentialStatus;
+	bool m_developer;
+	int m_distanceThreshold;
 	static QMLPrefs *m_instance;
+	cloud_status_qml m_oldStatus;
+	bool m_showPin;
+	int m_timeThreshold;
 
 signals:
+	void cloudPasswordChanged();
+	void cloudPinChanged();
+	void cloudUserNameChanged();
+	void credentialStatusChanged();
+	void distanceThresholdChanged();
+	void developerChanged();
+	void oldStatusChanged();
+	void showPinChanged();
+	void themeChanged();
+	void timeThresholdChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QMLPREFS_H
+#define QMLPREFS_H
+
+#include <QObject>
+
+
+class QMLPrefs : public QObject {
+	Q_OBJECT
+
+public:
+	QMLPrefs();
+	~QMLPrefs();
+
+	static QMLPrefs *instance();
+
+public slots:
+
+private:
+	static QMLPrefs *m_instance;
+
+signals:
+};
+
+#endif

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -81,6 +81,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
 	../../mobile-widgets/qmlmanager.cpp \
+	../../mobile-widgets/qmlprefs.cpp \
 	../../qt-models/divelistmodel.cpp \
 	../../qt-models/diveplotdatamodel.cpp \
 	../../qt-models/gpslistmodel.cpp \
@@ -183,6 +184,7 @@ HEADERS += \
 	../../core/subsurface-qt/DiveObjectHelper.h \
 	../../core/subsurface-qt/SettingsObjectWrapper.h \
 	../../mobile-widgets/qmlmanager.h \
+	../../mobile-widgets/qmlprefs.h \
 	../../map-widget/qmlmapwidgethelper.h \
 	../../qt-models/divelistmodel.h \
 	../../qt-models/diveplotdatamodel.h \

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -17,6 +17,7 @@
 #include <QQmlContext>
 #include <QSortFilterProxyModel>
 #include "mobile-widgets/qmlmanager.h"
+#include "mobile-widgets/qmlprefs.h"
 #include "qt-models/divelistmodel.h"
 #include "qt-models/gpslistmodel.h"
 #include "profile-widget/qmlprofile.h"
@@ -55,6 +56,7 @@ void run_ui()
 {
 	LOG_STP("run_ui starting");
 	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
+	qmlRegisterType<QMLPrefs>("org.subsurfacedivelog.mobile", 1, 0, "QMLPrefs");
 	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
 
 	qmlRegisterType<DownloadThread>("org.subsurfacedivelog.mobile", 1, 0, "DCDownloadThread");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add class QMLPrefs that contain the variables used on the Settings page, in order to reduce the size of QMLManager.

This is the first step in direction of making 1 class the covers the user settings for both desktop and mobile (mobile will still not allow all settings to be set). QMLPrefs and settings.qml will be amended with extra settings for the mobile.

Currently preferences/settings are distributed over 3 places, core/pref.h core/subsurface-qt and mobile-widgets. Q_Property in core/subsurface-qt is compiled into the desktop version, and more importantly the classes are never registred in the mobile version. a second step is to unify these places e.g. use pref.h as base (since it is also used in C code) have a core/settings where all settings are kept (registred as classes in mobile).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->