### PR TITLE
Cleanup: Don't clear WA_QuitOnClose attribute on dialogs

### DIFF
--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -28,7 +28,6 @@ void DiveComputerManagementDialog::init()
 DiveComputerManagementDialog *DiveComputerManagementDialog::instance()
 {
 	static DiveComputerManagementDialog *self = new DiveComputerManagementDialog(MainWindow::instance());
-	self->setAttribute(Qt::WA_QuitOnClose, false);
 	return self;
 }
 

--- a/desktop-widgets/diveshareexportdialog.cpp
+++ b/desktop-widgets/diveshareexportdialog.cpp
@@ -32,7 +32,6 @@ void DiveShareExportDialog::UIDFromBrowser()
 DiveShareExportDialog *DiveShareExportDialog::instance()
 {
 	static DiveShareExportDialog *self = new DiveShareExportDialog(MainWindow::instance());
-	self->setAttribute(Qt::WA_QuitOnClose, false);
 	self->ui->txtResult->setHtml("");
 	self->ui->buttonBox->setStandardButtons(QDialogButtonBox::Cancel);
 	return self;

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -691,7 +691,6 @@ out:
 DivelogsDeWebServices *DivelogsDeWebServices::instance()
 {
 	static DivelogsDeWebServices *self = new DivelogsDeWebServices(MainWindow::instance());
-	self->setAttribute(Qt::WA_QuitOnClose, false);
 	return self;
 }
 


### PR DESCRIPTION
According to Qt's documentation, the application exits if all windows
with the WA_QuitOnClose attribute are closed. This attribute was cleared
for three dialogs. This seems not necessary because:
1) The application can't be closed as long as the modal dialog is shown.
2) The flag only concerns primary windows, which these are not.

See: http://doc.qt.io/qt-5/qguiapplication.html#quitOnLastWindowClosed-prop

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes the clearing of the `WA_QuitOnClose` flag for three dialogs. To my understanding, this it not necessary. The flag is not relevant, because the dialogs have a parent and you can't close the application anyway while they are shown.

This was introduced in 880b8394d2b063c1bbd6597c2cb6c51f0a1d66c1 which has a strange commit message:
> To solve that we mark all custom windows/dialogs with the Qt::WA_QuitOnClose attribute on instance creation.

But actually the commit *clears* the flag.

> Most child windows should be closed with the main application window otherwise if left open and if making specific modifictions could potentially cause a SIGSEGV.

But - at least according to the docs - the flag in question does the *opposite*: It closes the application if the marked windows are closed, not vice-versa.

### Release note:

Not needed.

### Documentation change:

Not needed.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123: Original commit is by you. Please check