### PR TITLE
Cleanup: Make DiveComputerModel more sensible

### DIFF
--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -21,6 +21,9 @@ void DiveComputerManagementDialog::init()
 {
 	model.reset(new DiveComputerModel(dcList.dcMap));
 	ui.tableView->setModel(model.data());
+	ui.tableView->resizeColumnsToContents();
+	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
+	layout()->activate();
 }
 
 DiveComputerManagementDialog *DiveComputerManagementDialog::instance()
@@ -28,13 +31,6 @@ DiveComputerManagementDialog *DiveComputerManagementDialog::instance()
 	static DiveComputerManagementDialog *self = new DiveComputerManagementDialog(MainWindow::instance());
 	self->setAttribute(Qt::WA_QuitOnClose, false);
 	return self;
-}
-
-void DiveComputerManagementDialog::update()
-{
-	ui.tableView->resizeColumnsToContents();
-	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
-	layout()->activate();
 }
 
 void DiveComputerManagementDialog::tryRemove(const QModelIndex &index)

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -32,7 +32,6 @@ DiveComputerManagementDialog *DiveComputerManagementDialog::instance()
 
 void DiveComputerManagementDialog::update()
 {
-	model->update();
 	ui.tableView->resizeColumnsToContents();
 	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
 	layout()->activate();
@@ -62,7 +61,6 @@ void DiveComputerManagementDialog::accept()
 
 void DiveComputerManagementDialog::reject()
 {
-	model->dropWorkingList();
 	hide();
 	close();
 }

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -6,8 +6,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 
-DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f),
-	model(0)
+DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
 {
 	ui.setupUi(this);
 	init();
@@ -20,9 +19,8 @@ DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::
 
 void DiveComputerManagementDialog::init()
 {
-	delete model;
-	model = new DiveComputerModel(dcList.dcMap);
-	ui.tableView->setModel(model);
+	model.reset(new DiveComputerModel(dcList.dcMap));
+	ui.tableView->setModel(model.data());
 }
 
 DiveComputerManagementDialog *DiveComputerManagementDialog::instance()

--- a/desktop-widgets/divecomputermanagementdialog.h
+++ b/desktop-widgets/divecomputermanagementdialog.h
@@ -3,9 +3,9 @@
 #define DIVECOMPUTERMANAGEMENTDIALOG_H
 #include <QDialog>
 #include "ui_divecomputermanagementdialog.h"
+#include "qt-models/divecomputermodel.h"
 
 class QModelIndex;
-class DiveComputerModel;
 
 class DiveComputerManagementDialog : public QDialog {
 	Q_OBJECT
@@ -24,7 +24,7 @@ slots:
 private:
 	explicit DiveComputerManagementDialog(QWidget *parent = 0, Qt::WindowFlags f = 0);
 	Ui::DiveComputerManagementDialog ui;
-	DiveComputerModel *model;
+	QScopedPointer<DiveComputerModel> model;
 };
 
 #endif // DIVECOMPUTERMANAGEMENTDIALOG_H

--- a/desktop-widgets/divecomputermanagementdialog.h
+++ b/desktop-widgets/divecomputermanagementdialog.h
@@ -12,7 +12,6 @@ class DiveComputerManagementDialog : public QDialog {
 
 public:
 	static DiveComputerManagementDialog *instance();
-	void update();
 	void init();
 
 public

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -889,7 +889,6 @@ void MainWindow::on_actionDivelogs_de_triggered()
 void MainWindow::on_actionEditDeviceNames_triggered()
 {
 	DiveComputerManagementDialog::instance()->init();
-	DiveComputerManagementDialog::instance()->update();
 	DiveComputerManagementDialog::instance()->show();
 }
 

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -19,16 +19,13 @@ public:
 	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	void update();
 	void keepWorkingList();
-	void dropWorkingList();
 
 public
 slots:
 	void remove(const QModelIndex &index);
 
 private:
-	int numRows;
 	QMultiMap<QString, DiveComputerNode> dcWorkingMap;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
`DiveComputerModel` is a mess. This PR tries to make it at least somewhat sane by implementing proper `QtModel` semantics and removing the `QMultiMap`->`QMap` conversions.
Moreover, a naked pointer is replaced by a `QScopedPointer` to remove a `delete`. 

Note that since I possess only one DC, this is only very lightly tested.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement `QtModel` semantics in `DiveComputerModel`
2) Remove the quasi-noop function `DiveComputerModel::update`
3) Replace a naked pointer by a `QScopedPointer`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
I didn't find an outright bug, but perhaps this indirectly addresses #1278
 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
