### PR TITLE
desktop: better handling of progress dialog width

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -77,10 +77,13 @@ extern "C" int updateProgress(const char *text)
 	if (verbose)
 		qDebug() << "git storage:" << text;
 	if (progressDialog) {
+		// apparently we don't always get enough space to show the full label
+		// so let's manually make enough space (but don't shrink the existing size)
+		int width = QFontMetrics(qApp->font()).width(text) + 100;
+		if (width > progressDialog->width())
+			progressDialog->resize(width + 20, progressDialog->height());
 		progressDialog->setLabelText(text);
 		progressDialog->setValue(++progressCounter);
-		int width = QFontMetrics(qApp->font()).width(text) + 100;
-		progressDialog->resize(width, progressDialog->height());
 		if (progressCounter == 100)
 			progressCounter = 0; // yes this is silly, but we really don't know how long it will take
 	}


### PR DESCRIPTION
We shouldn't need to manually set it, but it appears we do. To avoid
constant resizing, let's only grow it - and let's set the size before we
update the text.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The existing code caused the dialog to shrink and expand which lead to odd visual artifacts. This looks much better.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) set the size before setting the label
2) only resize if we need more space (i.e., don't shrink the dialog)
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde this fixes something that you introduced a few months ago. Please check that things still work for you