### PR TITLE
[RFC][Alternative to #1381]Turn dive computer map into sorted vector

### DIFF
--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -5,14 +5,6 @@
 
 DiveComputerList dcList;
 
-DiveComputerList::DiveComputerList()
-{
-}
-
-DiveComputerList::~DiveComputerList()
-{
-}
-
 bool DiveComputerNode::operator==(const DiveComputerNode &a) const
 {
 	return model == a.model &&
@@ -89,8 +81,7 @@ void DiveComputerList::addDC(QString m, uint32_t d, QString n, QString s, QStrin
 		dcMap.remove(m, *existNode);
 	}
 
-	DiveComputerNode newNode(m, d, s, f, n);
-	dcMap.insert(m, newNode);
+	dcMap.insert(m, { m, d, s, f, n });
 }
 
 extern "C" void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname)

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -8,8 +8,6 @@
 
 class DiveComputerNode {
 public:
-	DiveComputerNode(QString m, uint32_t d, QString s, QString f, QString n)
-	    : model(m), deviceId(d), serialNumber(s), firmware(f), nickName(n) {};
 	bool operator==(const DiveComputerNode &a) const;
 	bool operator!=(const DiveComputerNode &a) const;
 	bool changesValues(const DiveComputerNode &b) const;
@@ -23,15 +21,12 @@ public:
 
 class DiveComputerList {
 public:
-	DiveComputerList();
-	~DiveComputerList();
 	const DiveComputerNode *getExact(const QString &m, uint32_t d);
 	const DiveComputerNode *get(const QString &m);
 	void addDC(QString m, uint32_t d, QString n = QString(), QString s = QString(), QString f = QString());
 	DiveComputerNode matchDC(const QString &m, uint32_t d);
 	DiveComputerNode matchModel(const QString &m);
 	QMultiMap<QString, DiveComputerNode> dcMap;
-	QMultiMap<QString, DiveComputerNode> dcWorkingMap;
 };
 
 extern DiveComputerList dcList;

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -3,13 +3,14 @@
 #define DIVECOMPUTER_H
 
 #include <QString>
-#include <QMap>
+#include <QVector>
 #include <stdint.h>
 
 class DiveComputerNode {
 public:
 	bool operator==(const DiveComputerNode &a) const;
 	bool operator!=(const DiveComputerNode &a) const;
+	bool operator<(const DiveComputerNode &a) const;
 	bool changesValues(const DiveComputerNode &b) const;
 	void showchanges(const QString &n, const QString &s, const QString &f) const;
 	QString model;
@@ -26,7 +27,9 @@ public:
 	void addDC(QString m, uint32_t d, QString n = QString(), QString s = QString(), QString f = QString());
 	DiveComputerNode matchDC(const QString &m, uint32_t d);
 	DiveComputerNode matchModel(const QString &m);
-	QMultiMap<QString, DiveComputerNode> dcMap;
+
+	// Keep the dive computers in a vector sorted by (model, deviceId)
+	QVector<DiveComputerNode> dcs;
 };
 
 extern DiveComputerList dcList;

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -20,21 +20,17 @@ DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::
 void DiveComputerManagementDialog::init()
 {
 	model.reset(new DiveComputerModel(dcList.dcMap));
+	model->update();
 	ui.tableView->setModel(model.data());
+	ui.tableView->resizeColumnsToContents();
+	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
+	layout()->activate();
 }
 
 DiveComputerManagementDialog *DiveComputerManagementDialog::instance()
 {
 	static DiveComputerManagementDialog *self = new DiveComputerManagementDialog(MainWindow::instance());
 	return self;
-}
-
-void DiveComputerManagementDialog::update()
-{
-	model->update();
-	ui.tableView->resizeColumnsToContents();
-	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
-	layout()->activate();
 }
 
 void DiveComputerManagementDialog::tryRemove(const QModelIndex &index)

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -6,8 +6,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 
-DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f),
-	model(0)
+DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
 {
 	ui.setupUi(this);
 	init();
@@ -20,9 +19,8 @@ DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::
 
 void DiveComputerManagementDialog::init()
 {
-	delete model;
-	model = new DiveComputerModel(dcList.dcMap);
-	ui.tableView->setModel(model);
+	model.reset(new DiveComputerModel(dcList.dcMap));
+	ui.tableView->setModel(model.data());
 }
 
 DiveComputerManagementDialog *DiveComputerManagementDialog::instance()

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -19,8 +19,7 @@ DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::
 
 void DiveComputerManagementDialog::init()
 {
-	model.reset(new DiveComputerModel(dcList.dcMap));
-	model->update();
+	model.reset(new DiveComputerModel);
 	ui.tableView->setModel(model.data());
 	ui.tableView->resizeColumnsToContents();
 	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
@@ -57,7 +56,6 @@ void DiveComputerManagementDialog::accept()
 
 void DiveComputerManagementDialog::reject()
 {
-	model->dropWorkingList();
 	hide();
 	close();
 }

--- a/desktop-widgets/divecomputermanagementdialog.h
+++ b/desktop-widgets/divecomputermanagementdialog.h
@@ -3,9 +3,9 @@
 #define DIVECOMPUTERMANAGEMENTDIALOG_H
 #include <QDialog>
 #include "ui_divecomputermanagementdialog.h"
+#include "qt-models/divecomputermodel.h"
 
 class QModelIndex;
-class DiveComputerModel;
 
 class DiveComputerManagementDialog : public QDialog {
 	Q_OBJECT
@@ -24,7 +24,7 @@ slots:
 private:
 	explicit DiveComputerManagementDialog(QWidget *parent = 0, Qt::WindowFlags f = 0);
 	Ui::DiveComputerManagementDialog ui;
-	DiveComputerModel *model;
+	QScopedPointer<DiveComputerModel> model;
 };
 
 #endif // DIVECOMPUTERMANAGEMENTDIALOG_H

--- a/desktop-widgets/divecomputermanagementdialog.h
+++ b/desktop-widgets/divecomputermanagementdialog.h
@@ -12,7 +12,6 @@ class DiveComputerManagementDialog : public QDialog {
 
 public:
 	static DiveComputerManagementDialog *instance();
-	void update();
 	void init();
 
 public

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -889,7 +889,6 @@ void MainWindow::on_actionDivelogs_de_triggered()
 void MainWindow::on_actionEditDeviceNames_triggered()
 {
 	DiveComputerManagementDialog::instance()->init();
-	DiveComputerManagementDialog::instance()->update();
 	DiveComputerManagementDialog::instance()->show();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -767,7 +767,7 @@ void MainWindow::closeCurrentFile()
 
 	clear_events();
 
-	dcList.dcMap.clear();
+	dcList.dcs.clear();
 }
 
 void MainWindow::updateCloudOnlineStatus()

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -14,14 +14,12 @@ public:
 		ID,
 		NICKNAME
 	};
-	DiveComputerModel(QMultiMap<QString, DiveComputerNode> &dcMap, QObject *parent = 0);
+	DiveComputerModel(QObject *parent = 0);
 	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
 	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	void update();
 	void keepWorkingList();
-	void dropWorkingList();
 
 public
 slots:
@@ -29,7 +27,7 @@ slots:
 
 private:
 	int numRows;
-	QMultiMap<QString, DiveComputerNode> dcWorkingMap;
+	QVector<DiveComputerNode> dcs;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a more radical alternative to #1381: Turn the map of dive computers into a sorted list. Thus conversions map<->list or awkward stepping through the map are avoided. As opposed to #1381, this does not use any template magic, so that might be perceived as an advantage. On the flip side, it uses binary search instead of associative arrays to access the dive computers, which might be unfamiliar to some.

I tested it only lightly, because I'm mostly interested in comments. 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turns the dive computer map into list
2) Implement a proper Qt-style model/view interface for the `DiveComputerModel`
3) Remove unnecessary constructors, use a `QScopedPointer` and other minor cleanups
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Might address #1278 
Alternative to #1381

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
