### PR TITLE
mobile: use full icon path - fix icon quality

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -141,7 +141,7 @@ Kirigami.Page {
 	property QtObject deleteAction: Kirigami.Action {
 		text: qsTr("Delete dive")
 		icon {
-			name: ":/icons/trash-empty"
+			name: ":/icons/trash-empty.svg"
 		}
 		onTriggered: {
 			var deletedId = currentItem.modelData.dive.id
@@ -158,7 +158,7 @@ Kirigami.Page {
 	property QtObject cancelAction: Kirigami.Action {
 		text: qsTr("Cancel edit")
 		icon {
-			name: ":/icons/dialog-cancel"
+			name: ":/icons/dialog-cancel.svg"
 		}
 		onTriggered: {
 			endEditMode()
@@ -178,7 +178,7 @@ Kirigami.Page {
 
 	actions.main: Kirigami.Action {
 		icon {
-			name: state !== "view" ? ":/icons/document-save" : ":/icons/document-edit"
+			name: state !== "view" ? ":/icons/document-save.svg" : ":/icons/document-edit.svg"
 			color: subsurfaceTheme.primaryColor
 		}
 		onTriggered: {

--- a/mobile-widgets/qml/GpsList.qml
+++ b/mobile-widgets/qml/GpsList.qml
@@ -74,7 +74,7 @@ Kirigami.ScrollablePage {
 			actions: [
 				Kirigami.Action {
 					icon {
-						name: ":/icons/trash-empty"
+						name: ":/icons/trash-empty.svg"
 					}
 					onTriggered: {
 						print("delete this!")
@@ -83,7 +83,7 @@ Kirigami.ScrollablePage {
 				},
 				Kirigami.Action {
 					icon {
-						name: ":/icons/gps"
+						name: ":/icons/gps.svg"
 					}
 					onTriggered: {
 						showMap()


### PR DESCRIPTION
For some reason Kirigami.Icon mess up icon display when filename
extension is omitted. Because of this a perfectly good, scalable svg
show up as a low resolution scaled up icon.

Signed-off-by: Murillo Bernardes <mfbernardes@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Fix some icons being displayed in very low quality even though we are using svg.

Current | New
------------ | -------------
![img_4304](https://user-images.githubusercontent.com/30494/41508439-30ae2758-7245-11e8-8bce-5fada9f85608.jpg) | ![img_4307](https://user-images.githubusercontent.com/30494/41508440-344f49e6-7245-11e8-91c1-169f1474700a.jpg)
![img_4305](https://user-images.githubusercontent.com/30494/41508511-5300e24a-7246-11e8-811d-f530acfc791d.jpg) | ![img_4306](https://user-images.githubusercontent.com/30494/41508514-5a23639a-7246-11e8-8543-1c9331d2cf96.jpg)
![img_4303](https://user-images.githubusercontent.com/30494/41508525-8b87762e-7246-11e8-9b22-c3a8e7f1431c.jpg) | ![img_4308](https://user-images.githubusercontent.com/30494/41508527-8fc2a2d6-7246-11e8-9f08-6708632a05ec.jpg)






### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->