### PR TITLE
mobile: revert e993d4f005e62c12765e2e45342ecf840476e3bf

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -217,13 +217,6 @@ Item {
 				border.color: subsurfaceTheme.primaryColor
 				anchors.fill: parent
 			}
-
-			onVisibleChanged: {
-				if (visible) {
-					qmlProfile.diveId = model.dive.id;
-					qmlProfile.update();
-				}
-			}
 		}
 		Controls.Label {
 			id: noProfile
@@ -404,6 +397,8 @@ Item {
 		}
 		Component.onCompleted: {
 			qmlProfile.setMargin(Kirigami.Units.smallSpacing)
+			qmlProfile.diveId = model.dive.id;
+			qmlProfile.update();
 		}
 	}
 }


### PR DESCRIPTION
The commit secured that plotDive was not called before actually being used.
However our (rather fragile) C++ qml interface did not work correctly (ony sometimes).

Revert the previous commit.

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
revert commit e993d4f005e62c12765e2e45342ecf840476e3bf
Due to a problem in our C++ qml interface this does not work as expected.

qmlprofilewidget.cpp and .h needs to be updated, but that will be after the release.
In general it seems our qml interface classes should be implemented using the
interface/implementation design pattern to avoid spurious construct/deconstruct.

currently using the onCompleted signal, which is (as the name says) too late, but works
since the page isn't visible. There are no onLoad signal which would have been logical,
this need instead to be transferred to the qmlprofilewidget constructor, and hence the need
for a interface/implementation pattern.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) revert e993d4f005e62c12765e2e45342ecf840476e3bf

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->