### PR TITLE
In dive picture shift time dialog suppress double triggering of timeEdit

### DIFF
--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -412,10 +412,15 @@ void ShiftImageTimesDialog::updateInvalid()
 
 void ShiftImageTimesDialog::timeEditChanged(const QTime &time)
 {
+	QDateTimeEdit::Section timeEditSection = ui.timeEdit->currentSection();
+	ui.timeEdit->setEnabled(false);
 	m_amount = time.hour() * 3600 + time.minute() * 60;
 	if (ui.backwards->isChecked())
 		m_amount *= -1;
 	updateInvalid();
+	ui.timeEdit->setEnabled(true);
+	ui.timeEdit->setFocus();
+	ui.timeEdit->setSelectedSection(timeEditSection);
 }
 
 void ShiftImageTimesDialog::timeEditChanged()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In dive picture shift time dialog when pressing the up or down arrow
of the timeEdit widged there is some risk of double triggering because
the function called after this UI action ("updateInvalid()") can have
quite some runtime.

Suppress any potential double triggering by disabling the timeEdit
widget after each change until the code is processed.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
