### PR TITLE
[RFC] Localization: simplify gettextfromc functions

### DIFF
--- a/CodingStyle.md
+++ b/CodingStyle.md
@@ -135,7 +135,7 @@ other editors that implement this coding style, please add them here.
 * text strings
   The default language of subsurface is US English so please use US English
   spelling and terminology.
-  Where at all possible strings should be passed to the tr() function to enable
+  User-visible strings should be passed to the tr() function to enable
   translation into other languages.
 
  * like this
@@ -146,6 +146,56 @@ other editors that implement this coding style, please add them here.
 ```
 	QString msgTitle = "Submit user survey.";
 ```
+
+  This works by default in classes (indirectly) derived from QObject. Each
+  string to be translated is associated with a context, which corresponds
+  to the class name. Classes that are not derived from QObject can generate
+  the tr() functions by using the Q_DECLARE_FUNCTIONS macro:
+```
+	#include <QCoreApplication>
+
+	class myClass {
+		Q_DECLARE_TR_FUNCTIONS(gettextfromC)
+		...
+	};
+```
+
+  As an alternative, which also works outside of class context, the tr()
+  function of a different class can be called. This avoids creating multiple
+  translations for the same string:
+```
+	gettextFromC::tr("%1km")
+```
+
+  The gettextFromC class in the above example was created as a catch-all
+  context for translations accessed in C code. But it can also be used
+  from C++ helper functions. To use it from C, include the "core/gettext.h"
+  header and invoke the translate() macro:
+```
+	#include "core/gettext.h"
+
+	report_error(translate("gettextFromC", "Remote storage and local data diverged"));
+```
+  It is crucial to pass "gettextFromC" as a first macro argument so that Qt
+  is able to associate the string with the correct context.
+  The translate macro returns a cached C-style string, which is generated at runtime
+  when the particular translation string is encountered for the first time.
+  It remains valid during the whole application's life time.
+
+  Outside of function context, the QT_TRANSLATE_NOOP macro can be used as in
+```
+struct ws_info_t ws_info[100] = {
+	{ QT_TRANSLATE_NOOP("gettextFromC", "integrated"), 0 },
+	{ QT_TRANSLATE_NOOP("gettextFromC", "belt"), 0 },
+	{ QT_TRANSLATE_NOOP("gettextFromC", "ankle"), 0 },
+	{ QT_TRANSLATE_NOOP("gettextFromC", "backplate"), 0 },
+	{ QT_TRANSLATE_NOOP("gettextFromC", "clip-on"), 0 },
+};
+```
+  Note that here, the texts will be scheduled for translation with the "gettextFromC"
+  context, but the array is only initialized with the original text. The actual
+  translation has to be performed later in code. For C-code, the QT_TRANSLATE_NOOP
+  macro is defined in the "core/gettext.h" header.
 
 * UI text style
   These guidelines are designed to ensure consistency in presentation within

--- a/core/gettextfromc.cpp
+++ b/core/gettextfromc.cpp
@@ -1,28 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
-#include <QCoreApplication>
-#include <QString>
 #include "gettextfromc.h"
+#include <QHash>
 
-const char *gettextFromC::trGettext(const char *text)
-{
-	QByteArray &result = translationCache[QByteArray(text)];
-	if (result.isEmpty())
-		result = translationCache[QByteArray(text)] = trUtf8(text).toUtf8();
-	return result.constData();
-}
-
-void gettextFromC::reset(void)
-{
-	translationCache.clear();
-}
-
-gettextFromC *gettextFromC::instance()
-{
-	static gettextFromC self;
-	return &self;
-}
+static QHash<QByteArray, QByteArray> translationCache;
 
 extern "C" const char *trGettext(const char *text)
 {
-	return gettextFromC::instance()->trGettext(text);
+	QByteArray &result = translationCache[QByteArray(text)];
+	if (result.isEmpty())
+		result = gettextFromC::tr(text).toUtf8();
+	return result.constData();
 }

--- a/core/gettextfromc.cpp
+++ b/core/gettextfromc.cpp
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "gettextfromc.h"
 #include <QHash>
+#include <QMutex>
 
 static QHash<QByteArray, QByteArray> translationCache;
+static QMutex lock;
 
 extern "C" const char *trGettext(const char *text)
 {
-	QByteArray &result = translationCache[QByteArray(text)];
-	if (result.isEmpty())
-		result = gettextFromC::tr(text).toUtf8();
-	return result.constData();
+	QByteArray key(text);
+	QMutexLocker l(&lock);
+	auto it = translationCache.find(key);
+	if (it == translationCache.end())
+		it = translationCache.insert(key, gettextFromC::tr(text).toUtf8());
+	return it->constData();
 }

--- a/core/gettextfromc.h
+++ b/core/gettextfromc.h
@@ -2,18 +2,12 @@
 #ifndef GETTEXTFROMC_H
 #define GETTEXTFROMC_H
 
-#include <QHash>
 #include <QCoreApplication>
 
 extern "C" const char *trGettext(const char *text);
 
 class gettextFromC {
 	Q_DECLARE_TR_FUNCTIONS(gettextFromC)
-public:
-	static gettextFromC *instance();
-	const char *trGettext(const char *text);
-	void reset(void);
-	QHash<QByteArray, QByteArray> translationCache;
 };
 
 #endif // GETTEXTFROMC_H

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -42,7 +42,6 @@
 const char *existing_filename;
 static QLocale loc;
 
-#define translate(_context, arg) trGettext(arg)
 static const QString DEGREE_SIGNS("dD" UTF8_DEGREE);
 
 QString weight_string(int weight_in_grams)
@@ -63,15 +62,15 @@ QString distance_string(int distanceInMeters)
 	QString str;
 	if(get_units()->length == units::METERS) {
 		if (distanceInMeters >= 1000)
-			str = QString(translate("gettextFromC", "%1km")).arg(distanceInMeters / 1000);
+			str = gettextFromC::tr("%1km").arg(distanceInMeters / 1000);
 		else
-			str = QString(translate("gettextFromC", "%1m")).arg(distanceInMeters);
+			str = gettextFromC::tr("%1m").arg(distanceInMeters);
 	} else {
 		double miles = m_to_mile(distanceInMeters);
 		if (miles >= 1.0)
-			str = QString(translate("gettextFromC", "%1mi")).arg((int)miles);
+			str = gettextFromC::tr("%1mi").arg((int)miles);
 		else
-			str = QString(translate("gettextFromC", "%1yd")).arg((int)(miles * 1760));
+			str = gettextFromC::tr("%1yd").arg((int)(miles * 1760));
 	}
 	return str;
 }
@@ -87,8 +86,8 @@ extern "C" const char *printGPSCoords(int lat, int lon)
 		return strdup("");
 
 	if (prefs.coordinates_traditional) {
-		lath = lat >= 0 ? translate("gettextFromC", "N") : translate("gettextFromC", "S");
-		lonh = lon >= 0 ? translate("gettextFromC", "E") : translate("gettextFromC", "W");
+		lath = lat >= 0 ? gettextFromC::tr("N") : gettextFromC::tr("S");
+		lonh = lon >= 0 ? gettextFromC::tr("E") : gettextFromC::tr("W");
 		lat = abs(lat);
 		lon = abs(lon);
 		latdeg = lat / 1000000U;
@@ -222,10 +221,10 @@ static bool parseSpecialCoords(const QString& txt, double& latitude, double& lon
 
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude)
 {
-	static const QString POS_LAT = QString("+N") + translate("gettextFromC", "N");
-	static const QString NEG_LAT = QString("-S") + translate("gettextFromC", "S");
-	static const QString POS_LON = QString("+E") + translate("gettextFromC", "E");
-	static const QString NEG_LON = QString("-W") + translate("gettextFromC", "W");
+	static const QString POS_LAT = QString("+N") + gettextFromC::tr("N");
+	static const QString NEG_LAT = QString("-S") + gettextFromC::tr("S");
+	static const QString POS_LON = QString("+E") + gettextFromC::tr("E");
+	static const QString NEG_LON = QString("-W") + gettextFromC::tr("W");
 
 	//remove the useless spaces (but keep the ones separating numbers)
 	static const QRegExp SPACE_CLEANER("\\s*([" + POS_LAT + NEG_LAT + POS_LON +
@@ -569,10 +568,10 @@ QString get_depth_string(int mm, bool showunit, bool showdecimal)
 {
 	if (prefs.units.length == units::METERS) {
 		double meters = mm / 1000.0;
-		return QString("%L1%2").arg(meters, 0, 'f', (showdecimal && meters < 20.0) ? 1 : 0).arg(showunit ? translate("gettextFromC", "m") : "");
+		return QString("%L1%2").arg(meters, 0, 'f', (showdecimal && meters < 20.0) ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
 	} else {
 		double feet = mm_to_feet(mm);
-		return QString("%L1%2").arg(feet, 0, 'f', 0).arg(showunit ? translate("gettextFromC", "ft") : "");
+		return QString("%L1%2").arg(feet, 0, 'f', 0).arg(showunit ? gettextFromC::tr("ft") : QString());
 	}
 }
 
@@ -584,18 +583,18 @@ QString get_depth_string(depth_t depth, bool showunit, bool showdecimal)
 QString get_depth_unit()
 {
 	if (prefs.units.length == units::METERS)
-		return QString("%1").arg(translate("gettextFromC", "m"));
+		return gettextFromC::tr("m");
 	else
-		return QString("%1").arg(translate("gettextFromC", "ft"));
+		return gettextFromC::tr("ft");
 }
 
 QString get_weight_string(weight_t weight, bool showunit)
 {
 	QString str = weight_string(weight.grams);
 	if (get_units()->weight == units::KG) {
-		str = QString("%1%2").arg(str).arg(showunit ? translate("gettextFromC", "kg") : "");
+		str = QString("%1%2").arg(str, showunit ? gettextFromC::tr("kg") : QString());
 	} else {
-		str = QString("%1%2").arg(str).arg(showunit ? translate("gettextFromC", "lbs") : "");
+		str = QString("%1%2").arg(str, showunit ? gettextFromC::tr("lbs") : QString());
 	}
 	return str;
 }
@@ -603,9 +602,9 @@ QString get_weight_string(weight_t weight, bool showunit)
 QString get_weight_unit()
 {
 	if (prefs.units.weight == units::KG)
-		return QString("%1").arg(translate("gettextFromC", "kg"));
+		return gettextFromC::tr("kg");
 	else
-		return QString("%1").arg(translate("gettextFromC", "lbs"));
+		return gettextFromC::tr("lbs");
 }
 
 QString get_temperature_string(temperature_t temp, bool showunit)
@@ -614,10 +613,10 @@ QString get_temperature_string(temperature_t temp, bool showunit)
 		return ""; //temperature not defined
 	} else if (prefs.units.temperature == units::CELSIUS) {
 		double celsius = mkelvin_to_C(temp.mkelvin);
-		return QString("%L1%2%3").arg(celsius, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? translate("gettextFromC", "C") : "");
+		return QString("%L1%2%3").arg(celsius, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? gettextFromC::tr("C") : QString());
 	} else {
 		double fahrenheit = mkelvin_to_F(temp.mkelvin);
-		return QString("%L1%2%3").arg(fahrenheit, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? translate("gettextFromC", "F") : "");
+		return QString("%L1%2%3").arg(fahrenheit, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? gettextFromC::tr("F") : QString());
 	}
 }
 
@@ -653,10 +652,10 @@ QString get_pressure_string(pressure_t pressure, bool showunit)
 {
 	if (prefs.units.pressure == units::BAR) {
 		double bar = pressure.mbar / 1000.0;
-		return QString("%L1%2").arg(bar, 0, 'f', 1).arg(showunit ? translate("gettextFromC", "bar") : "");
+		return QString("%L1%2").arg(bar, 0, 'f', 1).arg(showunit ? gettextFromC::tr("bar") : QString());
 	} else {
 		double psi = mbar_to_PSI(pressure.mbar);
-		return QString("%L1%2").arg(psi, 0, 'f', 0).arg(showunit ? translate("gettextFromC", "psi") : "");
+		return QString("%L1%2").arg(psi, 0, 'f', 0).arg(showunit ? gettextFromC::tr("psi") : QString());
 	}
 }
 
@@ -945,7 +944,7 @@ QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hour
 	mins = (when + 30 - days * 3600 * 24 - hrs * 3600) / 60;
 
 	QString displayInt;
-	if (maxdays && days > maxdays) displayInt = QString(translate("gettextFromC", "more than %1 days")).arg(maxdays);
+	if (maxdays && days > maxdays) displayInt = gettextFromC::tr("more than %1 days").arg(maxdays);
 	else if (days) displayInt = QString("%1%2%3%4%5%6%7%8").arg(days).arg(daysText).arg(separator)
 		.arg(hrs).arg(hoursText).arg(separator)
 		.arg(mins).arg(minutesText);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include <QToolBar>
 #include <QStatusBar>
 
+#include "core/gettextfromc.h"
 #include "core/version.h"
 #include "core/subsurface-string.h"
 #include "desktop-widgets/divelistview.h"

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -301,7 +301,7 @@ QWidget *TankUseDelegate::createEditor(QWidget * parent, const QStyleOptionViewI
 {
 	QComboBox *comboBox = new QComboBox(parent);
 	for (int i = 0; i < NUM_GAS_USE; i++)
-		comboBox->addItem(gettextFromC::instance()->trGettext(cylinderuse_text[i]));
+		comboBox->addItem(gettextFromC::tr(cylinderuse_text[i]));
 	return comboBox;
 }
 

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -222,7 +222,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 				ret = get_depth_string(gas_mnd(&cyl->gasmix, prefs.bestmixend, &displayed_dive, M_OR_FT(1,1)), true);
 			break;
 		case USE:
-			ret = gettextFromC::instance()->trGettext(cylinderuse_text[cyl->cylinder_use]);
+			ret = gettextFromC::tr(cylinderuse_text[cyl->cylinder_use]);
 			break;
 		}
 		break;

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -176,7 +176,7 @@ GeoReferencingOptionsModel::GeoReferencingOptionsModel(QObject *parent) : QStrin
 	QStringList list;
 	int i;
 	for (i = 0; i < TC_NR_CATEGORIES; i++)
-		list << gettextFromC::instance()->trGettext(taxonomy_category_names[i]);
+		list << gettextFromC::tr(taxonomy_category_names[i]);
 	setStringList(list);
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Admittedly, this is a bit of a brutal cleanup. But at the end of the day, there seems to be no reason for having an instance of the `gettextFromC` class. C++ callers can simply use the `static` `tr()` function. C callers (or C++ callers wanting a persistent C-string) use the function `trGettext()`, which is the only user of the translation-cache. Thus, the translation cache can be made local to this function.

PS: This obviously is not (and never was) thread safe! I'm not positive that this is only called from GUI-thread context.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Only use C++-translation functions from C++.
2) Remove the `gettextFromC` instance.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
