### PR TITLE
sanitize looping over equipment arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Equipment: fix bug with the maximum number of allowed tanks [#1401]
 - Mobile: add cloud storage user name to global drawer banner
 - Mobile: add button to About page to copy logs to clipboard; this makes it
   easier to provide the required information when reporting issues

--- a/core/dive.h
+++ b/core/dive.h
@@ -275,6 +275,7 @@ struct divecomputer {
 #define MAX_CYLINDERS (20)
 #define MAX_WEIGHTSYSTEMS (6)
 #define MAX_TANK_INFO (100)
+#define MAX_WS_INFO (100)
 #define W_IDX_PRIMARY 0
 #define W_IDX_SECONDARY 1
 
@@ -943,7 +944,7 @@ struct ws_info_t {
 	const char *name;
 	int grams;
 };
-extern struct ws_info_t ws_info[100];
+extern struct ws_info_t ws_info[MAX_WS_INFO];
 
 extern bool cylinder_nodata(const cylinder_t *cyl);
 extern bool cylinder_none(void *_data);

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -43,13 +43,13 @@ void add_weightsystem_description(weightsystem_t *weightsystem)
 	desc = weightsystem->description;
 	if (!desc)
 		return;
-	for (i = 0; i < 100 && ws_info[i].name != NULL; i++) {
+	for (i = 0; i < MAX_WS_INFO && ws_info[i].name != NULL; i++) {
 		if (strcmp(ws_info[i].name, desc) == 0) {
 			ws_info[i].grams = weightsystem->weight.grams;
 			return;
 		}
 	}
-	if (i < 100) {
+	if (i < MAX_WS_INFO) {
 		// FIXME: leaked on exit
 		ws_info[i].name = strdup(desc);
 		ws_info[i].grams = weightsystem->weight.grams;
@@ -181,7 +181,7 @@ struct tank_info_t tank_info[100] = {
  * We hardcode the most common weight system types
  * This is a bit odd as the weight system types don't usually encode weight
  */
-struct ws_info_t ws_info[100] = {
+struct ws_info_t ws_info[MAX_WS_INFO] = {
 	{ QT_TRANSLATE_NOOP("gettextFromC", "integrated"), 0 },
 	{ QT_TRANSLATE_NOOP("gettextFromC", "belt"), 0 },
 	{ QT_TRANSLATE_NOOP("gettextFromC", "ankle"), 0 },

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -24,11 +24,11 @@ void add_cylinder_description(cylinder_type_t *type)
 	desc = type->description;
 	if (!desc)
 		return;
-	for (i = 0; i < 100 && tank_info[i].name != NULL; i++) {
+	for (i = 0; i < MAX_TANK_INFO && tank_info[i].name != NULL; i++) {
 		if (strcmp(tank_info[i].name, desc) == 0)
 			return;
 	}
-	if (i < 100) {
+	if (i < MAX_TANK_INFO) {
 		// FIXME: leaked on exit
 		tank_info[i].name = strdup(desc);
 		tank_info[i].ml = type->size.mliter;
@@ -120,7 +120,7 @@ bool no_weightsystems(weightsystem_t *ws)
  * we should pick up any other names from the dive
  * logs directly.
  */
-struct tank_info_t tank_info[100] = {
+struct tank_info_t tank_info[MAX_TANK_INFO] = {
 	/* Need an empty entry for the no-cylinder case */
 	{ "", },
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -209,7 +209,7 @@ void fill_default_cylinder(cylinder_t *cyl)
 
 	if (!cyl_name)
 		return;
-	while (ti->name != NULL) {
+	while (ti->name != NULL && ti < tank_info + MAX_TANK_INFO) {
 		if (strcmp(ti->name, cyl_name) == 0)
 			break;
 		ti++;

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -52,7 +52,7 @@ void PreferencesDefaults::refreshSettings()
 	ui->localDefaultFile->setChecked(prefs.default_file_behavior == LOCAL_DEFAULT_FILE);
 
 	ui->default_cylinder->clear();
-	for (int i = 0; tank_info[i].name != NULL; i++) {
+	for (int i = 0; tank_info[i].name != NULL && i < MAX_TANK_INFO; i++) {
 		ui->default_cylinder->addItem(tank_info[i].name);
 		if (prefs.default_cylinder && strcmp(tank_info[i].name, prefs.default_cylinder) == 0)
 			ui->default_cylinder->setCurrentIndex(i);

--- a/qt-models/tankinfomodel.cpp
+++ b/qt-models/tankinfomodel.cpp
@@ -91,7 +91,7 @@ TankInfoModel::TankInfoModel() : rows(-1)
 {
 	setHeaderDataStrings(QStringList() << tr("Description") << tr("ml") << tr("bar"));
 	struct tank_info_t *info = tank_info;
-	for (info = tank_info; info->name; info++, rows++) {
+	for (info = tank_info; info->name && info < tank_info + MAX_TANK_INFO; info++, rows++) {
 		QString infoName = gettextFromC::tr(info->name);
 		if (infoName.count() > biggerEntry.count())
 			biggerEntry = infoName;
@@ -111,8 +111,7 @@ void TankInfoModel::update()
 		rows = -1;
 	}
 	struct tank_info_t *info = tank_info;
-	for (info = tank_info; info->name; info++, rows++)
-		;
+	for (info = tank_info; info->name && info < tank_info + MAX_TANK_INFO; info++, rows++);
 
 	if (rows > -1) {
 		beginInsertRows(QModelIndex(), 0, rows);

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -107,7 +107,7 @@ bool WeightModel::setData(const QModelIndex &index, const QVariant &value, int r
 			if (!ws->description || gettextFromC::tr(ws->description) != vString) {
 				// loop over translations to see if one matches
 				int i = -1;
-				while (ws_info[++i].name) {
+				while (ws_info[++i].name && i < MAX_WS_INFO) {
 					if (gettextFromC::tr(ws_info[i].name) == vString) {
 						ws->description = copy_string(ws_info[i].name);
 						break;

--- a/qt-models/weightsysteminfomodel.cpp
+++ b/qt-models/weightsysteminfomodel.cpp
@@ -79,8 +79,8 @@ const QString &WSInfoModel::biggerString() const
 WSInfoModel::WSInfoModel() : rows(-1)
 {
 	setHeaderDataStrings(QStringList() << tr("Description") << tr("kg"));
-	struct ws_info_t *info = ws_info;
-	for (info = ws_info; info->name; info++, rows++) {
+	struct ws_info_t *info;
+	for (info = ws_info; info->name && info < ws_info + MAX_WS_INFO; info++, rows++) {
 		QString wsInfoName = gettextFromC::tr(info->name);
 		if (wsInfoName.count() > biggerEntry.count())
 			biggerEntry = wsInfoName;
@@ -94,11 +94,11 @@ WSInfoModel::WSInfoModel() : rows(-1)
 
 void WSInfoModel::updateInfo()
 {
-	struct ws_info_t *info = ws_info;
+	struct ws_info_t *info;
 	beginRemoveRows(QModelIndex(), 0, this->rows);
 	endRemoveRows();
 	rows = -1;
-	for (info = ws_info; info->name; info++, rows++) {
+	for (info = ws_info; info->name && info < ws_info + MAX_WS_INFO; info++, rows++) {
 		QString wsInfoName = gettextFromC::tr(info->name);
 		if (wsInfoName.count() > biggerEntry.count())
 			biggerEntry = wsInfoName;
@@ -117,9 +117,8 @@ void WSInfoModel::update()
 		endRemoveRows();
 		rows = -1;
 	}
-	struct ws_info_t *info = ws_info;
-	for (info = ws_info; info->name; info++, rows++)
-		;
+	struct ws_info_t *info;
+	for (info = ws_info; info->name && info < ws_info + MAX_WS_INFO; info++, rows++);
 
 	if (rows > -1) {
 		beginInsertRows(QModelIndex(), 0, rows);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

3 commits that sanitize loops that iterate global equipment arrays (yikes).
because reading adjacent memory can crash from time to time.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

- use MAX_TANK_INFO and MAX_WS_INFO (new) everywhere

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #1401

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

na

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

`Equipment: fix bug with the maximum number of allowed tanks [#1401]`

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

na

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh @atdotde @bstoeger @p-neves 

