### PR TITLE
core: bug in alloc_samples ?

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -747,7 +747,7 @@ void copy_samples(struct divecomputer *s, struct divecomputer *d)
 void alloc_samples(struct divecomputer *dc, int num)
 {
 	if (num > dc->alloc_samples) {
-		dc->alloc_samples = (dc->alloc_samples * 3) / 2 + 10;
+		dc->alloc_samples = (num * 3) / 2 + 10;
 		dc->sample = realloc(dc->sample, dc->alloc_samples * sizeof(struct sample));
 		if (!dc->sample)
 			dc->samples = dc->alloc_samples = 0;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -927,6 +927,7 @@ bool QMLManager::checkDuration(DiveObjectHelper *myDive, struct dive *d, QString
 			free(d->dc.sample);
 			d->dc.sample = 0;
 			d->dc.samples = 0;
+			d->dc.alloc_samples = 0;
 		} else {
 			appendTextToLog("Cannot change the duration on a dive that wasn't manually added");
 		}
@@ -949,6 +950,7 @@ bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
 				free(d->dc.sample);
 				d->dc.sample = 0;
 				d->dc.samples = 0;
+				d->dc.alloc_samples = 0;
 			}
 			return true;
 		}


### PR DESCRIPTION
When num > dc->alloc_samples we whould allocate space for num

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
alloc_samples does not use the parameter num, and dc->alloc_samples start with 0,
so change to realloc using num (if > dc->alloc_samples). I saw this problem while debugging #1408

Please this code is completely new land, so please check if my assumptions are correct.

The second commit for qmlmanager.cpp corrects the problem in #1408, but I am not sure it
is the correct way.

solves #1408

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->