### PR TITLE
Qt BLE latency improvements

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -155,6 +155,9 @@ dc_status_t BLEObject::write(const void *data, size_t size, size_t *actual)
 
 	if (!receivedPackets.isEmpty()) {
 		qDebug() << ".. write HIT with still incoming packets in queue";
+		do {
+			receivedPackets.takeFirst();
+		} while (!receivedPackets.isEmpty());
 	}
 
 	QList<QLowEnergyCharacteristic> list = preferredService()->characteristics();

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -29,17 +29,26 @@ static int debugCounter;
 #define MAXIMAL_HW_CREDIT	255
 #define MINIMAL_HW_CREDIT	32
 
-static void waitFor(int ms) {
-	Q_ASSERT(QCoreApplication::instance());
-	Q_ASSERT(QThread::currentThread());
+#define WAITFOR(expression, ms) do {					\
+	Q_ASSERT(QCoreApplication::instance());				\
+	Q_ASSERT(QThread::currentThread());				\
+									\
+	if (expression)							\
+		break;							\
+	QElapsedTimer timer;						\
+	timer.start();							\
+									\
+	do {								\
+		QCoreApplication::processEvents(QEventLoop::AllEvents, ms); \
+		if (expression)						\
+			break;						\
+		QThread::msleep(10);					\
+	} while (timer.elapsed() < (ms));				\
+} while (0)
 
-	QElapsedTimer timer;
-	timer.start();
-
-	do {
-		QCoreApplication::processEvents(QEventLoop::AllEvents, ms);
-		QThread::msleep(10);
-	} while (timer.elapsed() < ms);
+static void waitFor(int ms)
+{
+	WAITFOR(false, ms);
 }
 
 extern "C" {
@@ -176,16 +185,14 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 		if (list.isEmpty())
 			return DC_STATUS_IO;
 
-		int msec = BLE_TIMEOUT;
-		while (msec > 0 && receivedPackets.isEmpty()) {
-			waitFor(100);
-			msec -= 100;
+		qDebug() << QTime::currentTime().toString() << "packet WAIT";
+
+		WAITFOR(!receivedPackets.isEmpty(), BLE_TIMEOUT);
+		if (receivedPackets.isEmpty()) {
+			qDebug() << QTime::currentTime().toString() << "packet FAIL";
+			return DC_STATUS_IO;
 		}
 	}
-
-	// Still no packet?
-	if (receivedPackets.isEmpty())
-		return DC_STATUS_IO;
 
 	QByteArray packet = receivedPackets.takeFirst();
 


### PR DESCRIPTION
This changes how we wait for incoming packets, to improve latency.

It seems to make an enormous difference to download reliability for me - I'm not entirely sure why, but I started doing this because my packet receive traces showed behavior that implied that we would apparently sometimes miss incoming packets simply because the incoming packets would be processed much too late.

It is *possible* that this makes a difference to other dive computers too (ie the occasional timeout  issue with the Shearwater Perdix AI, for example), but that may be wishful thinking.

This also flushes the old read queue in the (now unlikely) situation where we didn't process the reads in time, decided to time out, and then write a new command. We used to warn about it - and we still do - but now we also clean up the stale old receive queue.