### PR TITLE
QML UI: correctly update the model

### DIFF
--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -94,8 +94,10 @@ void DiveListModel::removeDiveById(int id)
 void DiveListModel::updateDive(int i, dive *d)
 {
 	DiveObjectHelper *newDive = new DiveObjectHelper(d);
-	m_dives.replace(i, newDive);
-	emit dataChanged(createIndex(i, 0), createIndex(i, 0));
+	// we need to make sure that QML knows that this dive has changed -
+	// the only reliable way I've found is to remove and re-insert it
+	removeDive(i);
+	insertDive(i, newDive);
 }
 
 void DiveListModel::clear()


### PR DESCRIPTION
In order to trigger the redraw of an edited dive we need to make sure
the model realizes that it has been updated. So far the only way to make
sure this happens reliably appears to be to remove the item and
re-insert it. Seems weird, but with this the bug of not redrawing the
profile after an edit appears fixed.

Fixes #1419

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This has been bugging me for a while - trying the big hammer worked.
The trick is to make sure that the model realizes that the dive has changed. The only thing that seems to reliably work is to remove the dive and immediately re-add it.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1419
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I have locally already moved the CHANGELOG to the ReleaseNotes (but haven't pushed that yet), so while this needs to go into the ReleaseNotes I didn't add that here as it will just create a merge conflict later
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janiversen @mfbernardes @tcanabrava - I'd love a sanity check from people who have played with QML :-)