### PR TITLE
QML UI: don't use anchors within Layouts

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -97,9 +97,8 @@ Item {
 		}
 
 		RowLayout {
-			anchors.left: parent.left
-			anchors.right: parent.right
-			anchors.margins: Kirigami.Units.smallSpacing
+			Layout.fillWidth: true
+			Layout.margins: Kirigami.Units.smallSpacing
 			spacing: Kirigami.Units.smallSpacing
 			visible: rootItem.showPin
 			SsrfButton {
@@ -124,9 +123,8 @@ Item {
 		}
 
 		RowLayout {
-			anchors.left: parent.left
-			anchors.right: parent.right
-			anchors.margins: Kirigami.Units.smallSpacing
+			Layout.fillWidth: true
+			Layout.margins: Kirigami.Units.smallSpacing
 			spacing: Kirigami.Units.smallSpacing
 			visible: !rootItem.showPin
 

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -49,10 +49,8 @@ Kirigami.Page {
 		Layout.fillWidth: true
 		GridLayout {
 			id: buttonGrid
-			anchors {
-				top: parent.top
-				topMargin: Kirigami.Units.smallSpacing * 4
-			}
+			Layout.alignment: Qt.AlignTop
+			Layout.topMargin: Kirigami.Units.smallSpacing * 4
 			columns: 2
 			Controls.Label { text: qsTr(" Vendor name: ") }
 			Controls.ComboBox {
@@ -163,11 +161,8 @@ Kirigami.Page {
 		}
 
 		Controls.ProgressBar {
-			anchors {
-				top: buttonGrid.bottom
-				topMargin: Kirigami.Units.smallSpacing * 4
-			}
 			id: progressBar
+			Layout.topMargin: Kirigami.Units.smallSpacing * 4
 			Layout.fillWidth: true
 			indeterminate: true
 			visible: false
@@ -175,12 +170,8 @@ Kirigami.Page {
 
 		RowLayout {
 			id: buttonBar
-			anchors {
-				left: parent.left
-				right: parent.right
-				top: progressBar.bottom
-				topMargin: Kirigami.Units.smallSpacing * 2
-			}
+			Layout.fillWidth: true
+			Layout.topMargin: Kirigami.Units.smallSpacing * 2
 			spacing: Kirigami.Units.smallSpacing
 			SsrfButton {
 				id: download
@@ -227,10 +218,7 @@ Kirigami.Page {
 
 		ListView {
 			id: dlList
-			anchors {
-				top: buttonBar.bottom
-				topMargin: Kirigami.Units.smallSpacing * 4
-			}
+			Layout.topMargin: Kirigami.Units.smallSpacing * 4
 			Layout.bottomMargin: bottomButtons.height * 1.5
 			Layout.fillWidth: true
 			Layout.fillHeight: true


### PR DESCRIPTION
Qt 5.11 adds useful warnings when code attempts to use anchors within
Layouts and even tells you how to fix things.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It seems weird to add this so late in the cycle - but I finally had enough bandwidth to update my development machine to Qt5.11
This does seem to fix an actual bug that was just silently ignored before.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
not user visible
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janiversen @mfbernardes @tcanabrava - I'd love a sanity check from people who have played with QML :-)