### PR TITLE
desktop: fix multi-keystroke input on location

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -509,6 +509,9 @@ bool DiveLocationLineEdit::eventFilter(QObject*, QEvent *e)
 			return true;
 		}
 	}
+	else if (e->type() == QEvent::InputMethod) {
+		this->inputMethodEvent(static_cast<QInputMethodEvent *>(e));
+	}
 
 	return false;
 }


### PR DESCRIPTION
When the tooltip is hidden QInputMethodEvent is handled
by QLineEdit and works properly.
When the tooltip is visible DiveLocationListView gains
focus and receives QInputMethodEvent, without handling
them properly.

This patch just forwards the event back to the QLineEdit
object.

Fix #1405

Signed-off-by: Murillo Bernardes <mfbernardes@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
