### PR TITLE
Update pictures in profile plot on deletion / drag & drop

### DIFF
--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -111,6 +111,7 @@ slots: // Necessary to call from QAction's signals.
 #ifndef SUBSURFACE_MOBILE
 	void plotPictures();
 	void removePictures(const QModelIndex &, int first, int last);
+	void movePictures(const QModelIndex &, int first, int last, const QModelIndex &, int to);
 	void setPlanState();
 	void setAddState();
 	void changeGas();
@@ -126,6 +127,7 @@ slots: // Necessary to call from QAction's signals.
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
 	void updatePictures(const QModelIndex &from, const QModelIndex &to);
+	void pictureOffsetChanged(int id);
 
 	/* this is called for every move on the handlers. maybe we can speed up this a bit? */
 	void recreatePlannedDive();
@@ -171,6 +173,7 @@ private: /*methods*/
 			 double *thresholdSettingsMin, double *thresholdSettingsMax);
 	void clearPictures();
 	void calculatePictureYPositions();
+	void updatePictureItem(int index, bool alwaysUpdateThumbnail);
 private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -170,6 +170,7 @@ private: /*methods*/
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 double *thresholdSettingsMin, double *thresholdSettingsMax);
 	void clearPictures();
+	void calculatePictureYPositions();
 private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -71,13 +71,21 @@ void DivePictureModel::updateDivePictures()
 	int i;
 	struct dive *dive;
 	for_each_dive (i, dive) {
-		if (dive->selected) {
-			if (dive->id == displayed_dive.id)
-				rowDDStart = pictures.count();
-			FOR_EACH_PICTURE(dive)
-				pictures.push_back({picture, picture->filename, {}, picture->offset.seconds});
-			if (dive->id == displayed_dive.id)
-				rowDDEnd = pictures.count();
+		if (!dive->selected)
+			continue;
+		int first = pictures.count();
+		FOR_EACH_PICTURE(dive)
+			pictures.push_back({ dive->id, picture, picture->filename, {}, picture->offset.seconds });
+		int last = pictures.count();
+
+		// Sort pictures of this dive by offset.
+		// Thus, the list will be sorted by (diveId, offset)
+		std::sort(pictures.begin() + first, pictures.begin() + last,
+			  [](const PictureEntry &a, const PictureEntry &b) { return a.offsetSeconds < b.offsetSeconds; });
+
+		if (dive->id == displayed_dive.id) {
+			rowDDStart = first;
+			rowDDEnd = last;
 		}
 	}
 
@@ -190,9 +198,58 @@ void DivePictureModel::updateThumbnail(QString filename, QImage thumbnail)
 
 void DivePictureModel::updateDivePictureOffset(const QString &filename, int offsetSeconds)
 {
-	int i = findPictureId(filename);
-	if (i >= 0) {
-		pictures[i].offsetSeconds = offsetSeconds;
-		emit dataChanged(createIndex(i, 0), createIndex(i, 1));
+	// Find picture with given filename, but only if it belongs to the currently displayed dive.
+	// This accounts for the facts that
+	//	1) The same picture may be associated to different dives.
+	//	2) It doesn't make sense to place a picture of a different dive to the shown profile.
+	// If such a picture doesn't exist -> return early.
+	int diveId = displayed_dive.id;
+	auto it = std::find_if(pictures.begin(), pictures.end(),
+			       [&filename, diveId](const PictureEntry &e)
+			       { return e.filename == filename && e.diveId == diveId; });
+	if (it == pictures.end())
+		return;
+
+	// Find range of pictures belonging to this picture's dive
+	auto from = it;
+	auto to = it;
+	while (from != pictures.begin() && std::prev(from)->diveId == diveId)
+		--from;
+	while (to != pictures.end() && to->diveId == diveId)
+		++to;
+
+	// Find new position in range
+	auto newPos = from;
+	for ( ; newPos != to; ++newPos)
+		if (newPos->offsetSeconds > offsetSeconds)
+			break;
+
+	// Update the offset here and in the C-part
+	it->offsetSeconds = offsetSeconds;
+	FOR_EACH_PICTURE(current_dive) {
+		if (picture->filename == filename) {
+			picture->offset.seconds = offsetSeconds;
+			mark_divelist_changed(true);
+			break;
+		}
 	}
+	copy_dive(current_dive, &displayed_dive);
+
+	// Henceforth we will work with indexes, thus turn the interators into indexes.
+	int oldIndex = it - pictures.begin();
+	int newIndex = newPos - pictures.begin();
+
+	// Qt disallows moving rows to the same place. This is unfortunate, because this would
+	// allow us to adjust the coordinates of the pictures in ProfileWidget2's movedPictures() slot.
+	// Because of this, we have to guard Qt's functions by ifs and add a custom signal/slot pair
+	// for adjusting coordinates.
+	bool actualMove = oldIndex != newIndex && oldIndex + 1 != newIndex;
+	if (actualMove)
+		beginMoveRows(QModelIndex(), oldIndex, oldIndex, QModelIndex(), newIndex);
+	int newRangeIndex = moveInVector(pictures, oldIndex, oldIndex + 1, newIndex);
+	if (actualMove)
+		endMoveRows();
+
+	// Instruct the profile plot to recalculate the coordinates of the images.
+	emit offsetChanged(newRangeIndex);
 }

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -7,6 +7,7 @@
 #include <QFuture>
 
 struct PictureEntry {
+	int diveId;
 	struct picture *picture;
 	QString filename;
 	QImage image;
@@ -25,6 +26,8 @@ public:
 	void removePictures(const QVector<QString> &fileUrls);
 	int rowDDStart, rowDDEnd;
 	void updateDivePictureOffset(const QString &filename, int offsetSeconds);
+signals:
+	void offsetChanged(int id);		// Picture offset changed.
 public slots:
 	void setZoomLevel(int level);
 	void updateThumbnail(QString filename, QImage thumbnail);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This introduces two usability changes to the picture thumbnails in the profile plot. This needed some code-reshuffling. It introduces a helper function in `qthelper.h`, which is quite useful: Move a range in a vector or vector-like container. I plan to use this more often. If there is a better place, let me know.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) When deleting a picture, update the thumbnails immediately, not only on changing the dive. But don't recalculate everything, only adjust the coordinates of the remaining pictures.

2) When drag&dropping a picture, don't recalculate the whole thumbnail list. Simply rearrange the thumbnails accordingly. To enable this, the pictures are now sorted by timestamp and the list is kept in sorted order. This is a bit tricky, since we have a list in the C-backend, a list in `DivePictureModel` and a list in `ProfileWidget2`. This PR does not touch the C-backend at all.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Needed? Perhaps something like
- Improve deletion of images / adjusting timestamp of images.

?

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
