### PR TITLE
Add Cressi Leonardo to list of devices in Android

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -74,6 +74,8 @@ static void fill_supported_mobile_list()
 		QStringList({{"Mundial 2"}, {"Mundial 3"}, {"Voyager 2G"}});
 	mobileProductList["Cochran"] =
 		QStringList({{"Commander I"}, {"Commander II"}, {"Commander TM"}, {"EMC-14"}, {"EMC-16"}, {"EMC-20H"}});
+	mobileProductList["Cressi"] =
+		QStringList({{"Leonardo"}});
 	mobileProductList["Genesis"] =
 		QStringList({{"React Pro"}, {"React Pro White"}});
 	mobileProductList["Heinrichs Weikamp"] =


### PR DESCRIPTION
Adding Cressi Leonardo to the list of devices that can be selected
on Android devices.

Signed-off-by: Stephen Goodall <stephen.goodall88@googlemail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Adding Cressi Leonardo to the list of devices selectable in Android, This now works when selecting FTDI on some devices.

### Changes made:
1) Add Cressi Leonardo to the downloadfromdcthread.cpp file
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #1240 <!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
This may also work for other Cressi Devices that use the FTDI chip but I only have the Leonardo to test it with.
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
Not sure if this is something that you want to include but a few have asked for it and I have now tested this based on the latest code. Would be great if someone else could try it out aswell (using the official cable) to confirm it works on a different Android device.
Mine was a OnePlus3 using the DiveMate device.
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
@dirkhh <!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
