### PR TITLE
Add Cressi Giotto, Newton and Drake to list of devices

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -75,7 +75,7 @@ static void fill_supported_mobile_list()
 	mobileProductList["Cochran"] =
 		QStringList({{"Commander I"}, {"Commander II"}, {"Commander TM"}, {"EMC-14"}, {"EMC-16"}, {"EMC-20H"}});
 	mobileProductList["Cressi"] =
-		QStringList({{"Leonardo"}});
+		QStringList({{"Leonardo"}, {"Giotto"}, {"Newton"}, {"Drake"}});
 	mobileProductList["Genesis"] =
 		QStringList({{"React Pro"}, {"React Pro White"}});
 	mobileProductList["Heinrichs Weikamp"] =


### PR DESCRIPTION
Adding Cressi Giotto, Newton and Drake to the list of devices
that can be selected on Android devices.

Signed-off-by: Stephen Goodall <stephen.goodall88@googlemail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Adding Cressi Giotto, Newton and Drake to the list of devices selectable in Android, These can now be tested to check if it works when selecting FTDI on some devices.

### Changes made:
1) Add Cressi Giotto, Newton and Drake to the downloadfromdcthread.cpp file
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Extension of #1240 <!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
This should be tested by users with the specified computers, I only have the Leonardo so cannot test it myself.
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
@neolit123  <!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
