### PR TITLE
[RFC] Bluetooth: don't call deviceDiscoveryError() on scan finished

### DIFF
--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -194,11 +194,12 @@ void BtDeviceSelectionDialog::on_scan_clicked()
 
 void BtDeviceSelectionDialog::remoteDeviceScanFinished()
 {
-	if (remoteDeviceDiscoveryAgent->error() == QBluetoothDeviceDiscoveryAgent::NoError) {
+	// This check is not necessary for Qt's QBluetoothDeviceDiscoveryAgent,
+	// but with the home-brew WinBluetoothDeviceDiscoveryAgent, on error we
+	// get an error() and an finished() signal. Thus, don't overwrite the
+	// error message with a success message.
+	if (remoteDeviceDiscoveryAgent->error() == QBluetoothDeviceDiscoveryAgent::NoError)
 		ui->dialogStatus->setText(tr("Scanning finished successfully."));
-	} else {
-		deviceDiscoveryError(remoteDeviceDiscoveryAgent->error());
-	}
 
 	ui->scan->setEnabled(true);
 }


### PR DESCRIPTION
In the remoteDeviceScanFinished slot, the old code called into
the deviceDiscoveryError() in case the device discovery agent
had the error flag set. This is not necessary, since the agent will
send an error signal in such a case.

For Qt's device discovery agent, the whole check-for-error is
unnecessary, as the documentation states:
"The signal is not going to be emitted if the device discovery
finishes with an error."

But for the homebrew WinBluetoothDeviceDiscoveryAgent, which
derives from QThread, both an error() *and* a finished()
signal will be sent. Therefore keep the test, but don't call
into the slot twice.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While analyzing the Windows `WinBluetoothDeviceDiscoveryAgent` code, it occurred to me that on error we call into the error slot twice. Remove this. Note: this is not tested as I'm currently not in front of a Windows machine.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unnecessary call into error slot
2) Add comment why the error check is needed.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
