### PR TITLE
Dive pictures: render icons with white instead of transparent background

### DIFF
--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -121,7 +121,8 @@ static std::pair<QImage, bool> getHashedImage(const QString &filename, bool tryD
 
 static QImage renderIcon(const char *id, int size)
 {
-	QImage res(size, size, QImage::Format_ARGB32);
+	QImage res(size, size, QImage::Format_RGB32);
+	res.fill(Qt::white);
 	QSvgRenderer svg{QString(id)};
 	QPainter painter(&res);
 	svg.render(&painter);


### PR DESCRIPTION
The SVG icons for failed / still-loading pictures were rendered with an
alpha channel. This lead to strange behavior when hovering over the
icon in the profile plot: When hitting a "hole" the icon would be
minimized again.

Therefore, render the SVGs onto a white background.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a backport from my video branch. It fixes a usability bug: If you had a "failed loading" or a "not yet loaded" thumbnail in the profile, clicking on the delete button was very tricky, because moving the mouse out of the opaque parts of the SVG would minimize the thumbnail.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
