### PR TITLE
Dive pictures: connect DivePictureModel signals in constructor

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -151,6 +151,11 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	addActionShortcut(Qt::Key_Down, &ProfileWidget2::keyDownAction);
 	addActionShortcut(Qt::Key_Left, &ProfileWidget2::keyLeftAction);
 	addActionShortcut(Qt::Key_Right, &ProfileWidget2::keyRightAction);
+
+	connect(DivePictureModel::instance(), &DivePictureModel::dataChanged, this, &ProfileWidget2::updatePictures);
+	connect(DivePictureModel::instance(), SIGNAL(rowsInserted(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
+	connect(DivePictureModel::instance(), &DivePictureModel::rowsRemoved, this, &ProfileWidget2::removePictures);
+	connect(DivePictureModel::instance(), &DivePictureModel::modelReset, this, &ProfileWidget2::plotPictures);
 #endif // SUBSURFACE_MOBILE
 
 #if !defined(QT_NO_DEBUG) && defined(SHOW_PLOT_INFO_TABLE)
@@ -1125,12 +1130,6 @@ void ProfileWidget2::setProfileState()
 		return;
 
 	disconnectTemporaryConnections();
-#ifndef SUBSURFACE_MOBILE
-	connect(DivePictureModel::instance(), &DivePictureModel::dataChanged, this, &ProfileWidget2::updatePictures);
-	connect(DivePictureModel::instance(), SIGNAL(rowsInserted(const QModelIndex &, int, int)), this, SLOT(plotPictures()));
-	connect(DivePictureModel::instance(), &DivePictureModel::rowsRemoved, this, &ProfileWidget2::removePictures);
-	connect(DivePictureModel::instance(), &DivePictureModel::modelReset, this, &ProfileWidget2::plotPictures);
-#endif
 	/* show the same stuff that the profile shows. */
 
 	emit enableShortcuts();


### PR DESCRIPTION
The DivePictureModel signals were connected int the setProfileState()
function of ProfileWidget2. If this function was called repeatedly
(e.g. after adding a dive), multiple connections were made, which led
to multiply delivered signals. This in turn led to confusion, when
deleting pictures (i.e. multiple pictures were deleted).

Instead, connect once in ProfileWidget2's constructor. It is unclear
whether these signals should be disconnected temporarily if no pictures
are shown. In any case, the weren't, so this shouldn't introduce any
regression.

Fixes #1441

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an old problem, which was turned into an actual bug by my recent changes to `DivePictureModel`. I'm not sure, if the original code was intended that way. I.e. if the signals should be removed under certain conditions. I will make further experiments.

There is an unrelated bug which I introduced recently. Fix forthcoming.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move `connect()` calls.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1441 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed - user visible bug introduced after last release.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@tcanabrava: Please check, if this makes sense. I'm quite sure that at least it doesn't worsen things.