### PR TITLE
Dive pictures: adjust rowDDEnd and rowDDStart on picture deletion

### DIFF
--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -138,6 +138,14 @@ static bool removePictureFromSelectedDive(const char *fileUrl)
 	return false;
 }
 
+// Calculate how many items of a range are before the given index
+static int rangeBefore(int rangeFrom, int rangeTo, int index)
+{
+	if (rangeTo <= rangeFrom)
+		return 0;
+	return std::min(rangeTo, index) - std::min(rangeFrom, index);
+}
+
 void DivePictureModel::removePictures(const QVector<QString> &fileUrls)
 {
 	bool removed = false;
@@ -163,6 +171,12 @@ void DivePictureModel::removePictures(const QVector<QString> &fileUrls)
 		beginRemoveRows(QModelIndex(), i, j - 1);
 		pictures.erase(pictures.begin() + i, pictures.begin() + j);
 		endRemoveRows();
+
+		// After removing pictures, we have to adjust rowDDStart and rowDDEnd.
+		// Calculate the part of the range that is before rowDDStart and rowDDEnd,
+		// respectively and subtract accordingly.
+		rowDDStart -= rangeBefore(i, j, rowDDStart);
+		rowDDEnd -= rangeBefore(i, j, rowDDEnd);
 	}
 }
 


### PR DESCRIPTION
In DivePictureModel, rowDDEnd and rowDDStart specify the range of
pictures in the profile plot. Obviously, these have to be adjusted
when pictures are deleted.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug introduced when making picture deletion "smart". The fundamental problem is that we have three lists of pictures:
1) In the C-backend (all dives)
2) In DivePictureModel (all selected dives)
3) In ProfileWidget2 (currently shown dive)

Keeping these in sync is quite hard and very brittle. The old code chose the easy way: on every change recalculate 2) and 3). Ultimately, this will have to be simplified.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Keep track of changes to rowDDStart and rowDDEnd

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed - bug introduced recently.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
