### PR TITLE
core: remove prefs-macros.h where unused

### DIFF
--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "divecomputer.h"
+#include "dive.h"
 #include "subsurface-string.h"
 #include "subsurface-qt/SettingsObjectWrapper.h"
 

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -7,6 +7,7 @@
 #include <QNetworkProxy>
 
 #include "core/qthelper.h"
+#include "core/prefs-macros.h"
 
 DiveComputerSettings::DiveComputerSettings(QObject *parent):
 	QObject(parent)

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -5,8 +5,7 @@
 #include <QObject>
 #include <QDate>
 
-#include "../pref.h"
-#include "../prefs-macros.h"
+#include "core/pref.h"
 
 /* Wrapper class for the Settings. This will allow
  * seamlessy integration of the settings with the QML

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "preferences_defaults.h"
 #include "ui_preferences_defaults.h"
-#include "core/prefs-macros.h"
+#include "core/dive.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 
 #include <QFileDialog>

--- a/desktop-widgets/preferences/preferences_georeference.cpp
+++ b/desktop-widgets/preferences/preferences_georeference.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "preferences_georeference.h"
 #include "ui_preferences_georeference.h"
-#include "core/prefs-macros.h"
 #include "core/qthelper.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include "qt-models/divelocationmodel.h"

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "preferences_graph.h"
 #include "ui_preferences_graph.h"
-#include "core/prefs-macros.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QMessageBox>
 

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -2,7 +2,7 @@
 #include "preferences_network.h"
 #include "ui_preferences_network.h"
 #include "subsurfacewebservices.h"
-#include "core/prefs-macros.h"
+#include "core/dive.h"
 #include "core/cloudstorage.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QNetworkProxy>

--- a/desktop-widgets/preferences/preferences_units.cpp
+++ b/desktop-widgets/preferences/preferences_units.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "preferences_units.h"
 #include "ui_preferences_units.h"
-#include "core/prefs-macros.h"
 #include "core/qthelper.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 


### PR DESCRIPTION
move #include prefs-macros from SettingsObjectWrapper.h to SettingsObjectWrapper.cpp
include dive.h directly (only part of prefs-macros.h used) in preference classes

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
prefs-macros.h is included in many files where not needed due to being include
in SettingsObjectWrapper.h

classes in desktop-widget/preferences did not need prefs-macros.h but dive.h, corrected

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->