### PR TITLE
core: make stuff more readable

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -29,25 +29,45 @@ if(BLESUPPORT)
 	set(BT_CORE_SRC_FILES ${BT_CORE_SRC_FILES} qt-ble.cpp)
 endif()
 
-# compile the core library, in C.
+# compile the core library part in C, part in C++
 set(SUBSURFACE_CORE_LIB_SRCS
+	checkcloudconnection.cpp
+	cloudstorage.cpp
 	cochran.c
+	color.cpp
+	configuredivecomputer.cpp
+	configuredivecomputerthreads.cpp
+	connectionlistmodel.cpp
 	datatrak.c
 	deco.c
 	device.c
+	devicedetails.cpp
 	dive.c
+	divecomputer.cpp
+	divelogexportlogic.cpp
 	divesite.c
+	divesitehelpers.cpp
 	divesite-helper.cpp
 	divelist.c
+	downloadfromdcthread.cpp
 	equipment.c
 	errorhelper.c
+	exif.cpp
 	file.c
+	format.cpp
+	gaspressures.c
 	gas-model.c
+	gettextfromc.cpp
 	git-access.c
+	gpslocation.cpp
+	imagedownloader.cpp
+	isocialnetworkintegration.cpp
 	libdivecomputer.c
 	liquivision.c
 	load-git.c
 	membuffer.c
+	metadata.cpp
+	metrics.cpp
 	ostctools.c
 	parse-xml.c
 	parse.c
@@ -58,9 +78,10 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	import-csv.c
 	planner.c
 	plannernotes.c
+	pluginmanager.cpp
 	profile.c
-	gaspressures.c
-	worldmap-save.c
+	qthelper.cpp
+	qt-init.cpp
 	save-git.c
 	save-xml.c
 	save-html.c
@@ -68,37 +89,14 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	statistics.c
 	strtod.c
 	subsurfacestartup.c
+	subsurfacesysinfo.cpp
+	taxonomy.c
 	time.c
 	uemis.c
 	uemis-downloader.c
 	version.c
-	# gettextfrommoc should be added because we are using it on the c-code.
-	gettextfromc.cpp
-	# dirk ported some core functionality to c++.
-	qthelper.cpp
-	metadata.cpp
-	format.cpp
-	divecomputer.cpp
-	exif.cpp
-	subsurfacesysinfo.cpp
-	devicedetails.cpp
-	configuredivecomputer.cpp
-	configuredivecomputerthreads.cpp
-	divesitehelpers.cpp
-	taxonomy.c
-	checkcloudconnection.cpp
 	windowtitleupdate.cpp
-	divelogexportlogic.cpp
-	qt-init.cpp
-	metrics.cpp
-	color.cpp
-	pluginmanager.cpp
-	imagedownloader.cpp
-	isocialnetworkintegration.cpp
-	gpslocation.cpp
-	cloudstorage.cpp
-	downloadfromdcthread.cpp
-	connectionlistmodel.cpp
+	worldmap-save.c
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -98,6 +98,9 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	windowtitleupdate.cpp
 	worldmap-save.c
 
+	# classes to manage struct preferences for QWidget and QML
+	settings/qPref.cpp
+
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp
 	subsurface-qt/CylinderObjectHelper.cpp

--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -2,6 +2,7 @@
 #include "cloudstorage.h"
 #include "pref.h"
 #include "qthelper.h"
+#include "settings/qPref.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QApplication>
 

--- a/core/pref.h
+++ b/core/pref.h
@@ -223,8 +223,6 @@ enum cloud_status {
 
 extern struct preferences prefs, default_prefs, git_prefs;
 
-#define PP_GRAPHS_ENABLED (prefs.pp_graphs.po2 || prefs.pp_graphs.pn2 || prefs.pp_graphs.phe)
-
 extern const char *system_divelist_default_font;
 extern double system_divelist_default_font_size;
 

--- a/core/pref.h
+++ b/core/pref.h
@@ -59,106 +59,147 @@ typedef struct {
 	int download_mode;
 } dive_computer_prefs_t;
 
+// ********** PREFERENCES **********
+// This struct is kept global for all of ssrf
+// most of the fields are loaded from git as
+// part of the dives, but some fields are loaded
+// from local storage (QSettings)
+// The struct is divided in groups (sorted)
+// and elements within the group is sorted
+//
+// When adding items to this list, please keep
+// the list sorted (easier to find something)
 struct preferences {
-	const char *divelist_font;
-	const char *default_filename;
-	const char *default_cylinder;
+	// ********** Animations **********
+	int animation_speed;
+
+	// ********** CloudStorage **********
 	const char *cloud_base_url;
 	const char *cloud_git_url;
-	const char *time_format;
-	const char *date_format;
-	const char *date_format_short;
-	bool time_format_override;
-	bool date_format_override;
-	double font_size;
-	partial_pressure_graphs_t pp_graphs;
-	bool mod;
-	double modpO2;
-	bool ead;
-	bool dcceiling;
-	bool redceiling;
-	bool calcceiling;
-	bool calcceiling3m;
-	bool calcalltissues;
-	bool calcndltts;
-	short gflow;
-	short gfhigh;
-	int animation_speed;
-	bool gf_low_at_maxdepth;
-	bool show_ccr_setpoint;
-	bool show_ccr_sensors;
-	bool show_scr_ocpo2;
-	bool display_invalid_dives;
-	short unit_system;
-	struct units units;
-	bool coordinates_traditional;
-	bool show_sac;
-	bool display_unused_tanks;
-	bool show_average_depth;
-	bool show_icd;
-	bool zoomed_plot;
-	bool hrgraph;
-	bool percentagegraph;
-	bool rulergraph;
-	bool tankbar;
-	bool save_userid_local;
-	const char *userid;
-	int ascrate75; // All rates in mm / sec
-	int ascrate50;
-	int ascratestops;
-	int ascratelast6m;
-	int descrate;
-	int sacfactor;
-	int problemsolvingtime;
-	int bottompo2;
-	int decopo2;
-	enum deco_mode display_deco_mode;
-	depth_t bestmixend;
-	int proxy_type;
-	const char *proxy_host;
-	int proxy_port;
-	bool proxy_auth;
-	const char *proxy_user;
-	const char *proxy_pass;
-	bool doo2breaks;
-	bool drop_stone_mode;
-	bool last_stop;   // At 6m?
-	bool verbatim_plan;
-	bool display_runtime;
-	bool display_duration;
-	bool display_transitions;
-	bool display_variations;
-	bool safetystop;
-	bool switch_at_req_stop;
-	int reserve_gas;
-	int min_switch_duration; // seconds
-	int bottomsac;
-	int decosac;
-	int o2consumption; // ml per min
-	int pscr_ratio; // dump ratio times 1000
-	int defaultsetpoint; // default setpoint in mbar
-	bool show_pictures_in_profile;
-	bool use_default_file;
-	short default_file_behavior;
-	facebook_prefs_t facebook;
-	const char *cloud_storage_password;
-	const char *cloud_storage_newpassword;
 	const char *cloud_storage_email;
 	const char *cloud_storage_email_encoded;
-	bool save_password_local;
-	short cloud_verification_status;
+	const char *cloud_storage_newpassword;
+	const char *cloud_storage_password;
+	const char *cloud_storage_pin;
+	short       cloud_timeout;
+	short       cloud_verification_status;
+	bool        git_local_only;
+	bool        save_password_local;
+	bool        save_userid_local;
+	const char *userid;
+
+	// ********** DiveComputer **********
+	dive_computer_prefs_t dive_computer;
+
+	// ********** Display **********
+	bool        display_invalid_dives;
+	const char *divelist_font;
+	double      font_size;
+	bool        showDeveloper;
+ 	const char *theme;
+
+	// ********** Facebook **********
+	facebook_prefs_t facebook;
+
+	// ********** General **********
+	bool        auto_recalculate_thumbnails;
+	int         defaultsetpoint; // default setpoint in mbar
+	const char *default_cylinder;
+	const char *default_filename;
+	short       default_file_behavior;
+	int         o2consumption; // ml per min
+	int         pscr_ratio; // dump ratio times 1000
+	bool        use_default_file;
+
+	// ********** Geocoding **********
 	geocoding_prefs_t geocoding;
-	enum deco_mode planner_deco_mode;
-	short vpmb_conservatism;
+
+	// ********** Language **********
+	const char *    date_format;
+	bool            date_format_override;
+	const char *    date_format_short;
+	locale_prefs_t  locale; //: TODO: move the rest of locale based info here.
+	const char *    time_format;
+	bool            time_format_override;
+
+	// ********** LocationService **********
 	int time_threshold;
 	int distance_threshold;
-	bool git_local_only;
-	short cloud_timeout;
-	bool auto_recalculate_thumbnails;
-	locale_prefs_t locale; //: TODO: move the rest of locale based info here.
+
+	// ********** Network **********
+	bool        proxy_auth;
+	const char *proxy_host;
+	int         proxy_port;
+	int         proxy_type;
+	const char *proxy_user;
+	const char *proxy_pass;
+
+	// ********** Planner **********
+	int             ascratelast6m;
+	int             ascratestops;
+	int             ascrate50;
+	int             ascrate75; // All rates in mm / sec
+	depth_t         bestmixend;
+	int             bottompo2;
+	int             bottomsac;
+	int             decopo2;
+	int             decosac;
+	int             descrate;
+	bool            display_duration;
+	bool            display_runtime;
+	bool            display_transitions;
+	bool            display_variations;
+	bool            doo2breaks;
+	bool            drop_stone_mode;
+	bool            last_stop;   // At 6m?
+	int             min_switch_duration; // seconds
+	enum deco_mode  planner_deco_mode;
+	int             problemsolvingtime;
+	int             reserve_gas;
+	int             sacfactor;
+	bool            safetystop;
+	bool            switch_at_req_stop;
+	bool            verbatim_plan;
+
+	// ********** TecDetails **********
+	bool                        calcalltissues;
+	bool                        calcceiling;
+	bool                        calcceiling3m;
+	bool                        calcndltts;
+	bool                        dcceiling;
+	enum deco_mode              display_deco_mode;
+	bool                        display_unused_tanks;
+	bool                        ead;
+	short                       gfhigh;
+	short                       gflow;
+	bool                        gf_low_at_maxdepth;
+	bool                        hrgraph;
+	bool                        mod;
+	double                      modpO2;
+	bool                        percentagegraph;
+	partial_pressure_graphs_t   pp_graphs;
+	bool                        redceiling;
+	bool                        rulergraph;
+	bool                        show_average_depth;
+	bool                        show_ccr_sensors;
+	bool                        show_ccr_setpoint;
+	bool                        show_icd;
+	bool                        show_pictures_in_profile;
+	bool                        show_sac;
+	bool                        show_scr_ocpo2;
+	bool                        tankbar;
+	short                       vpmb_conservatism;
+	bool                        zoomed_plot;
+
+	// ********** Units **********
+	bool            coordinates_traditional;
+	short           unit_system;
+	struct units    units;
+
+	// ********** UpdateManager **********
 	update_manager_prefs_t update_manager;
-	dive_computer_prefs_t dive_computer;
 };
+
 enum unit_system_values {
 	METRIC,
 	IMPERIAL,

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -2,16 +2,15 @@
 #include "qPref_private.h"
 #include "qPref.h"
 
-
-qPref *qPref::m_instance = NULL;
+qPref::qPref(QObject *parent) : 
+	QObject(parent)
+{
+}
 qPref *qPref::instance()
 {
-	if (!m_instance)
-		m_instance = new qPref;
-	return m_instance;
+static qPref *self = new qPref;
+	return self;
 }
-
-
 
 void qPref::loadSync(bool doSync)
 {

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPref_private.h"
+#include "qPref.h"
+
+
+qPref *qPref::m_instance = NULL;
+qPref *qPref::instance()
+{
+	if (!m_instance)
+		m_instance = new qPref;
+	return m_instance;
+}
+
+
+
+void qPref::loadSync(bool doSync)
+{
+}

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -7,10 +7,10 @@
 
 class qPref : public QObject {
 	Q_OBJECT
+	Q_ENUMS(cloud_status);
 
 public:
-	qPref(QObject *parent = NULL) : QObject(parent) {};
-	~qPref() {};
+	qPref(QObject *parent = NULL);
 	static qPref *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -19,7 +19,6 @@ public:
 public:
 
 private:
-	static qPref *m_instance;
 };
 
 #endif

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREF_H
+#define QPREF_H
+
+#include <QObject>
+#include "core/pref.h"
+
+class qPref : public QObject {
+	Q_OBJECT
+
+public:
+	qPref(QObject *parent = NULL) : QObject(parent) {};
+	~qPref() {};
+	static qPref *instance();
+
+	// Load/Sync local settings (disk) and struct preference
+	void loadSync(bool doSync);
+
+public:
+
+private:
+	static qPref *m_instance;
+};
+
+#endif

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREFPRIVATE_H
+#define QPREFPRIVATE_H
+
+// Header used by all qPref<class> implementations to avoid duplicating code
+
+#include <QObject>
+#include <QSettings>
+#include <QVariant>
+#include "core/qthelper.h"
+
+#define COPY_TXT(name, string) \
+{ \
+	free((void *)prefs.name); \
+	prefs.name = copy_qstring(string); \
+}
+
+#define LOADSYNC_INT(name, field) \
+{ \
+	QSettings s; \
+	if (doSync) \
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = s.value(group + name, default_prefs.field).toInt(); \
+}
+
+#define LOADSYNC_INT_DEF(name, field, defval) \
+{ \
+	QSettings s; \
+	if (doSync)	\
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = s.value(group + name, defval).toInt(); \
+}
+
+#define LOADSYNC_ENUM(name, type, field) \
+{ \
+	QSettings s; \
+	if (doSync)	\
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = (enum type)s.value(group + name, default_prefs.field).toInt(); \
+}
+
+#define LOADSYNC_BOOL(name, field) \
+{ \
+	QSettings s; \
+	if (doSync)	\
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = s.value(group + name, default_prefs.field).toBool(); \
+}
+
+#define LOADSYNC_DOUBLE(name, field) \
+{ \
+	QSettings s; \
+	if (doSync)	\
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = s.value(group + name, default_prefs.field).toDouble(); \
+}
+
+#define LOADSYNC_TXT(name, field) \
+{ \
+	QSettings s; \
+	if (doSync)	\
+		s.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = copy_qstring(s.value(group + name, default_prefs.field).toString()); \
+}
+
+#endif

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -46,6 +46,7 @@
 #include "core/windowtitleupdate.h"
 #include "desktop-widgets/locationinformation.h"
 #include "preferences/preferencesdialog.h"
+#include "core/settings/qPref.h"
 
 #ifndef NO_USERMANUAL
 #include "usermanual.h"

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -2,8 +2,8 @@
 #include "preferences_network.h"
 #include "ui_preferences_network.h"
 #include "subsurfacewebservices.h"
-#include "core/dive.h"
 #include "core/cloudstorage.h"
+#include "core/dive.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QNetworkProxy>
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -269,12 +269,12 @@ void QMLManager::openLocalThenRemote(QString url)
 		 *    no cloud repo solves this.
 		 */
 
-		if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD)
-			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NEED_TO_VERIFY);
+		if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD)
+			QMLPrefs::instance()->setCredentialStatus(CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
-		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_UNKNOWN)
-			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+		if (QMLPrefs::instance()->credentialStatus() == CS_UNKNOWN)
+			QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
 		prefs.unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
 			git_prefs.units = IMPERIAL_units;
@@ -292,11 +292,11 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
 	}
-	if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NEED_TO_VERIFY) {
+	if (QMLPrefs::instance()->credentialStatus() == CS_NEED_TO_VERIFY) {
 		appendTextToLog(QStringLiteral("have cloud credentials, but still needs PIN"));
 		QMLPrefs::instance()->setShowPin(true);
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD) {
 		// if we switch to credentials from CS_NOCLOUD, we take things online temporarily
 		prefs.git_local_only = false;
 		appendTextToLog(QStringLiteral("taking things online to be able to switch to cloud account"));
@@ -373,7 +373,7 @@ void QMLManager::finishSetup()
 	QMLPrefs::instance()->setCloudUserName(prefs.cloud_storage_email);
 	QMLPrefs::instance()->setCloudPassword(prefs.cloud_storage_password);
 	setSyncToCloud(!prefs.git_local_only);
-	QMLPrefs::instance()->setCredentialStatus((QMLPrefs::cloud_status_qml) prefs.cloud_verification_status);
+	QMLPrefs::instance()->setCredentialStatus((cloud_status) prefs.cloud_verification_status);
 	// if the cloud credentials are valid, we should get the GPS Webservice ID as well
 	QString url;
 	if (!QMLPrefs::instance()->cloudUserName().isEmpty() &&
@@ -384,8 +384,8 @@ void QMLManager::finishSetup()
 		alreadySaving = true;
 		openLocalThenRemote(url);
 	} else if (!empty_string(existing_filename) &&
-				QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_UNKNOWN) {
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
+				QMLPrefs::instance()->credentialStatus() != CS_UNKNOWN) {
+		QMLPrefs::instance()->setCredentialStatus(CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename);
@@ -399,7 +399,7 @@ void QMLManager::finishSetup()
 			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(existing_filename));
 		}
 	} else {
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_UNKNOWN);
+		QMLPrefs::instance()->setCredentialStatus(CS_UNKNOWN);
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}
@@ -437,7 +437,7 @@ void QMLManager::saveCloudCredentials()
 	bool cloudCredentialsChanged = false;
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
-	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD) {
 		// in case of NO_CLOUD, the email address + passwd do not care, so do not check it.
 		if (QMLPrefs::instance()->cloudPassword().isEmpty() ||
 			!regExp.match(QMLPrefs::instance()->cloudPassword()).hasMatch() ||
@@ -467,7 +467,7 @@ void QMLManager::saveCloudCredentials()
 	cloudCredentialsChanged |= !same_string(prefs.cloud_storage_password,
 								qPrintable(QMLPrefs::instance()->cloudPassword()));
 
-	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD &&
+	if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD &&
 		!cloudCredentialsChanged) {
 		// just go back to the dive list
 		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::instance()->oldStatus());
@@ -478,7 +478,7 @@ void QMLManager::saveCloudCredentials()
 		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = copy_qstring(QMLPrefs::instance()->cloudPassword());
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
+	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
 		// we came from NOCLOUD and are connecting to a cloud account;
 		// since we already have dives in the table, let's remember that so we can keep them
 		noCloudToCloud = true;
@@ -508,7 +508,7 @@ void QMLManager::saveCloudCredentials()
 		currentGitLocalOnly = prefs.git_local_only;
 		prefs.git_local_only = false;
 		openLocalThenRemote(url);
-	} else if (prefs.cloud_verification_status == QMLPrefs::CS_NEED_TO_VERIFY &&
+	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY &&
 				!QMLPrefs::instance()->cloudPin().isEmpty()) {
 		// the user entered a PIN?
 		tryRetrieveDataFromBackend();
@@ -578,7 +578,7 @@ void QMLManager::provideAuth(QNetworkReply *reply, QAuthenticator *auth)
 		// OK, credentials have been tried and didn't work, so they are invalid
 		appendTextToLog("Cloud credentials are invalid");
 		setStartPageText(RED_FONT + tr("Cloud credentials are invalid") + END_FONT);
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_INCORRECT_USER_PASSWD);
+		QMLPrefs::instance()->setCredentialStatus(CS_INCORRECT_USER_PASSWD);
 		reply->disconnect();
 		reply->abort();
 		reply->deleteLater();
@@ -622,7 +622,7 @@ void QMLManager::retrieveUserid()
 		revertToNoCloudIfNeeded();
 		return;
 	}
-	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
 	QString userid(prefs.userid);
 	if (userid.isEmpty()) {
 		if (empty_string(prefs.cloud_storage_email) || empty_string(prefs.cloud_storage_password)) {
@@ -641,7 +641,7 @@ void QMLManager::retrieveUserid()
 		s.setValue("subsurface_webservice_uid", prefs.userid);
 		s.sync();
 	}
-	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
 	setStartPageText(tr("Cloud credentials valid, loading dives..."));
 	// this only gets called with "alreadySaving" already locked
 	loadDivesWithValidCredentials();
@@ -726,7 +726,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		currentGitLocalOnly = false;
 		prefs.git_local_only = true;
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD) {
 		// we tried to switch to a cloud account and had previously used local data,
 		// but connecting to the cloud account (and subsequently merging the local
 		// and cloud data) failed - so let's delete the cloud credentials and go
@@ -742,7 +742,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		prefs.cloud_storage_password = NULL;
 		QMLPrefs::instance()->setCloudUserName("");
 		QMLPrefs::instance()->setCloudPassword("");
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
+		QMLPrefs::instance()->setCredentialStatus(CS_NOCLOUD);
 		set_filename(NOCLOUD_LOCALSTORAGE);
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}
@@ -1202,7 +1202,7 @@ void QMLManager::openNoCloudRepo()
 void QMLManager::saveChangesLocal()
 {
 	if (unsaved_changes()) {
-		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NOCLOUD) {
+		if (QMLPrefs::instance()->credentialStatus() == CS_NOCLOUD) {
 			if (empty_string(existing_filename)) {
 				char *filename = NOCLOUD_LOCALSTORAGE;
 				git_create_local_repo(filename);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -69,12 +69,12 @@ void QMLPrefs::setCloudUserName(const QString &cloudUserName)
 	emit cloudUserNameChanged();
 }
 
-QMLPrefs::cloud_status_qml QMLPrefs::credentialStatus() const
+cloud_status QMLPrefs::credentialStatus() const
 {
 	return m_credentialStatus;
 }
 
-void QMLPrefs::setCredentialStatus(const cloud_status_qml value)
+void QMLPrefs::setCredentialStatus(const cloud_status value)
 {
 	if (m_credentialStatus != value) {
 		setOldStatus(m_credentialStatus);
@@ -105,12 +105,12 @@ void QMLPrefs::setDistanceThreshold(int distance)
 	emit distanceThresholdChanged();
 }
 
-QMLPrefs::cloud_status_qml QMLPrefs::oldStatus() const
+cloud_status QMLPrefs::oldStatus() const
 {
 	return m_oldStatus;
 }
 
-void QMLPrefs::setOldStatus(const cloud_status_qml value)
+void QMLPrefs::setOldStatus(const cloud_status value)
 {
 	if (m_oldStatus != value) {
 		m_oldStatus = value;

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -3,11 +3,12 @@
 #define QMLPREFS_H
 
 #include <QObject>
+#include "core/settings/qPref.h"
 
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
-	Q_ENUMS(cloud_status_qml)
+	Q_ENUMS(cloud_status)
 	Q_PROPERTY(QString cloudPassword
 				MEMBER m_cloudPassword
 				WRITE setCloudPassword
@@ -20,7 +21,7 @@ class QMLPrefs : public QObject {
 				MEMBER m_cloudUserName
 				WRITE setCloudUserName
 				NOTIFY cloudUserNameChanged)
-	Q_PROPERTY(cloud_status_qml credentialStatus
+	Q_PROPERTY(cloud_status credentialStatus
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
 				NOTIFY credentialStatusChanged)
@@ -36,7 +37,7 @@ class QMLPrefs : public QObject {
 				MEMBER m_showPin
 				WRITE setShowPin
 				NOTIFY showPinChanged)
-	Q_PROPERTY(cloud_status_qml oldStatus
+	Q_PROPERTY(cloud_status oldStatus
 				MEMBER m_oldStatus
 				WRITE setOldStatus
 				NOTIFY oldStatusChanged)
@@ -55,14 +56,6 @@ public:
 
 	static QMLPrefs *instance();
 
-	enum cloud_status_qml {
-		CS_UNKNOWN,
-		CS_INCORRECT_USER_PASSWD,
-		CS_NEED_TO_VERIFY,
-		CS_VERIFIED,
-		CS_NOCLOUD
-	};
-
 	const QString cloudPassword() const;
 	void setCloudPassword(const QString &cloudPassword);
 
@@ -72,16 +65,16 @@ public:
 	const QString cloudUserName() const;
 	void setCloudUserName(const QString &cloudUserName);
 
-	cloud_status_qml credentialStatus() const;
-	void setCredentialStatus(const cloud_status_qml value);
+	cloud_status credentialStatus() const;
+	void setCredentialStatus(const cloud_status value);
 
 	void setDeveloper(bool value);
 
 	int distanceThreshold() const;
 	void setDistanceThreshold(int distance);
 
-	cloud_status_qml oldStatus() const;
-	void setOldStatus(const cloud_status_qml value);
+	cloud_status oldStatus() const;
+	void setOldStatus(const cloud_status value);
 
 	bool showPin() const;
 	void setShowPin(bool enable);
@@ -100,11 +93,11 @@ private:
 	QString m_cloudPassword;
 	QString m_cloudPin;
 	QString m_cloudUserName;
-	cloud_status_qml m_credentialStatus;
+	cloud_status m_credentialStatus;
 	bool m_developer;
 	int m_distanceThreshold;
 	static QMLPrefs *m_instance;
-	cloud_status_qml m_oldStatus;
+	cloud_status m_oldStatus;
 	bool m_showPin;
 	int m_timeThreshold;
 

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -77,6 +77,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/btdiscovery.cpp \
 	../../core/connectionlistmodel.cpp \
 	../../core/qt-ble.cpp \
+	../../core/settings/qPref.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
@@ -183,6 +184,8 @@ HEADERS += \
 	../../core/btdiscovery.h \
 	../../core/connectionlistmodel.h \
 	../../core/qt-ble.h \
+	../../core/settings/qPref.h \
+	../../core/settings/qPref_private.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \
 	../../core/subsurface-qt/DiveObjectHelper.h \
 	../../core/subsurface-qt/SettingsObjectWrapper.h \

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -44,6 +44,8 @@
 #endif
 #include <QtWidgets>
 
+#define PP_GRAPHS_ENABLED (prefs.pp_graphs.po2 || prefs.pp_graphs.pn2 || prefs.pp_graphs.phe)
+
 // a couple of helpers we need
 extern bool haveFilesOnCommandLine();
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Isolate first part of #1423 in this PR, since these 5 commits make a standalone change.

Sorting/grouping can always be discussed, but having names randomly distributed is not a good starting point for a new developer trying to learn.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) sort/group struct preferences in pref.h making it easier to locate variables (when you do not know the name)
2) move PP_GRAPHS_ENABLED from pref.h, since it is only used in 1 cpp file
3) sort CMakeLists.txt, to make it faster to look if a file is included or not (did this after I mistakenly added the same file twice)
4) add qPref.h and qPrefprivate.h, this is the fundament of #1423
5) remove double definition of enum cloud_storage_status, having the same enum defined in several places is error prone.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->