### PR TITLE
Dive pictures: remove unnecessary check for no dives

### DIFF
--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -64,10 +64,6 @@ void DivePictureModel::updateDivePictures()
 		Thumbnailer::instance()->clearWorkQueue();
 	}
 
-	// if the dive_table is empty, quit
-	if (dive_table.nr == 0)
-		return;
-
 	int i;
 	struct dive *dive;
 	for_each_dive (i, dive) {


### PR DESCRIPTION
This fixes a bug introduced in fbe1144eaf7e800a014c7a97b846835ba9f3bc7f:
For an empty log, in DivePictureModel::updateDivePictures()
beginResetModel() would be called without a corresponding endResetModel().

It is unclear whether this can ever be hit, because in the no-dives
case, at least in the desktop version no profile is shown.
Note, that this makes the check double-unnecessary.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is in principle a bug fix, though it is unclear if the bug can be hit at all.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unnecessary check for empty log
