### PR TITLE
Split and merge

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3562,7 +3562,7 @@ int split_dive(struct dive *dive)
 		// the surface start.
 		if (!surface_start)
 			continue;
-		if (!should_split(dc, dc->sample[surface_start].time.seconds, sample[i - 1].time.seconds))
+		if (!should_split(dc, dc->sample[surface_start].time.seconds, sample[-1].time.seconds))
 			continue;
 
 		return split_dive_at(dive, surface_start, i-1);

--- a/core/dive.c
+++ b/core/dive.c
@@ -2701,7 +2701,7 @@ int match_one_dc(struct divecomputer *a, struct divecomputer *b)
 	 * If they have different dive ID's on the same
 	 * dive computer, that's a definite "same or not"
 	 */
-	return a->diveid == b->diveid ? 1 : -1;
+	return a->diveid == b->diveid && a->when == b->when ? 1 : -1;
 }
 
 /*
@@ -3456,6 +3456,7 @@ static int split_dive_at(struct dive *dive, int a, int b)
 	 */
 	t = dc2->sample[0].time.seconds;
 	d2->when += t;
+	dc2->when += t;
 	for (i = 0; i < dc2->samples; i++)
 		dc2->sample[i].time.seconds -= t;
 


### PR DESCRIPTION
This fixes dive splitting and merging.

There were two independent bugs in here: one stupid sample pointer arithmetic error (introduced back in 2015 by commit a39038a902: "In free dive mode split dives with only a 10 second surface interval"), and one situation where we incorrectly then considered the two (or more) parts of a dive that had been split to be the exact same dive, so we merged not the parts back into one longer dive, but tried to merge the parts back as if they were two copies of the same (short) dive.

This fixes the dive case that Alberto had with several surface intervals: the his dive now splits into four distinct segments, and you can merge them back again however you like.