### PR TITLE
[RFC] Translations: unify gettextFromC::tr() and QObject::tr()

### DIFF
--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -53,7 +53,7 @@ static void exportHTMLstatisticsTotal(QTextStream &out, stats_t *total_stats)
 	out << "\"YEAR\":\"Total\",";
 	out << "\"DIVES\":\"" << total_stats->selection_size << "\",";
 	out << "\"TOTAL_TIME\":\"" << get_dive_duration_string(total_stats->total_time.seconds,
-									QObject::tr("h"), QObject::tr("min"), QObject::tr("sec"), " ") << "\",";
+									gettextFromC::tr("h"), gettextFromC::tr("min"), gettextFromC::tr("sec"), " ") << "\",";
 	out << "\"AVERAGE_TIME\":\"--\",";
 	out << "\"SHORTEST_TIME\":\"--\",";
 	out << "\"LONGEST_TIME\":\"--\",";
@@ -89,7 +89,7 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 			out << "\"YEAR\":\"" << stats_yearly[i].period << "\",";
 			out << "\"DIVES\":\"" << stats_yearly[i].selection_size << "\",";
 			out << "\"TOTAL_TIME\":\"" << get_dive_duration_string(stats_yearly[i].total_time.seconds,
-											QObject::tr("h"), QObject::tr("min"), QObject::tr("sec"), " ") << "\",";
+											gettextFromC::tr("h"), gettextFromC::tr("min"), gettextFromC::tr("sec"), " ") << "\",";
 			out << "\"AVERAGE_TIME\":\"" << get_minutes(stats_yearly[i].total_time.seconds / stats_yearly[i].selection_size) << "\",";
 			out << "\"SHORTEST_TIME\":\"" << get_minutes(stats_yearly[i].shortest_time.seconds) << "\",";
 			out << "\"LONGEST_TIME\":\"" << get_minutes(stats_yearly[i].longest_time.seconds) << "\",";

--- a/core/divesite-helper.cpp
+++ b/core/divesite-helper.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "divesite.h"
 #include "pref.h"
+#include "gettextfromc.h"
 
 QString constructLocationTags(struct dive_site *ds, bool for_maintab)
 {
@@ -17,7 +18,7 @@ QString constructLocationTags(struct dive_site *ds, bool for_maintab)
 	}
 
 	if (!prefs_set && !for_maintab) {
-		locationTag = QString("<small><small>") + QObject::tr("No dive site layout categories set in preferences!") +
+		locationTag = QString("<small><small>") + gettextFromC::tr("No dive site layout categories set in preferences!") +
 			QString("</small></small>");
 		return locationTag;
 	}
@@ -25,7 +26,7 @@ QString constructLocationTags(struct dive_site *ds, bool for_maintab)
 		return locationTag;
 
 	if (for_maintab)
-		locationTag = QString("<small><small>(") + QObject::tr("Tags") + QString(": ");
+		locationTag = QString("<small><small>(") + gettextFromC::tr("Tags") + QString(": ");
 	else 
 		locationTag = QString("<small><small>");
 	QString connector;

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -11,7 +11,7 @@
 #include <QNetworkReply>
 #include <QMap>
 
-#define GPS_CURRENT_POS QObject::tr("Waiting to aquire GPS location")
+#define GPS_CURRENT_POS gettextFromC::tr("Waiting to aquire GPS location")
 
 struct gpsTracker {
 	degrees_t latitude;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -762,9 +762,9 @@ int parseLengthToMm(const QString &text)
 	if (numOnly.isEmpty())
 		return 0;
 	double number = numOnly.toDouble();
-	if (text.contains(QObject::tr("m"), Qt::CaseInsensitive)) {
+	if (text.contains(gettextFromC::tr("m"), Qt::CaseInsensitive)) {
 		mm = lrint(number * 1000);
-	} else if (text.contains(QObject::tr("ft"), Qt::CaseInsensitive)) {
+	} else if (text.contains(gettextFromC::tr("ft"), Qt::CaseInsensitive)) {
 		mm = feet_to_mm(number);
 	} else {
 		switch (prefs.units.length) {
@@ -790,9 +790,9 @@ int parseTemperatureToMkelvin(const QString &text)
 	if (numOnly.isEmpty())
 		return 0;
 	double number = numOnly.toDouble();
-	if (text.contains(QObject::tr("C"), Qt::CaseInsensitive)) {
+	if (text.contains(gettextFromC::tr("C"), Qt::CaseInsensitive)) {
 		mkelvin = C_to_mkelvin(number);
-	} else if (text.contains(QObject::tr("F"), Qt::CaseInsensitive)) {
+	} else if (text.contains(gettextFromC::tr("F"), Qt::CaseInsensitive)) {
 		mkelvin = F_to_mkelvin(number);
 	} else {
 		switch (prefs.units.temperature) {
@@ -817,9 +817,9 @@ int parseWeightToGrams(const QString &text)
 	if (numOnly.isEmpty())
 		return 0;
 	double number = numOnly.toDouble();
-	if (text.contains(QObject::tr("kg"), Qt::CaseInsensitive)) {
+	if (text.contains(gettextFromC::tr("kg"), Qt::CaseInsensitive)) {
 		grams = lrint(number * 1000);
-	} else if (text.contains(QObject::tr("lbs"), Qt::CaseInsensitive)) {
+	} else if (text.contains(gettextFromC::tr("lbs"), Qt::CaseInsensitive)) {
 		grams = lbs_to_grams(number);
 	} else {
 		switch (prefs.units.weight) {
@@ -844,9 +844,9 @@ int parsePressureToMbar(const QString &text)
 	if (numOnly.isEmpty())
 		return 0;
 	double number = numOnly.toDouble();
-	if (text.contains(QObject::tr("bar"), Qt::CaseInsensitive)) {
+	if (text.contains(gettextFromC::tr("bar"), Qt::CaseInsensitive)) {
 		mbar = lrint(number * 1000);
-	} else if (text.contains(QObject::tr("psi"), Qt::CaseInsensitive)) {
+	} else if (text.contains(gettextFromC::tr("psi"), Qt::CaseInsensitive)) {
 		mbar = psi_to_mbar(number);
 	} else {
 		switch (prefs.units.pressure) {
@@ -867,9 +867,9 @@ int parseGasMixO2(const QString &text)
 {
 	QString gasString = text;
 	int o2, number;
-	if (gasString.contains(QObject::tr("AIR"), Qt::CaseInsensitive)) {
+	if (gasString.contains(gettextFromC::tr("AIR"), Qt::CaseInsensitive)) {
 		o2 = O2_IN_AIR;
-	} else if (gasString.contains(QObject::tr("EAN"), Qt::CaseInsensitive)) {
+	} else if (gasString.contains(gettextFromC::tr("EAN"), Qt::CaseInsensitive)) {
 		gasString.remove(QRegExp("[^0-9]"));
 		number = gasString.toInt();
 		o2 = number * 10;
@@ -1007,7 +1007,7 @@ QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 	localTime.setTimeSpec(Qt::UTC);
 	QString ret ;
 
-	QString suffix = " " + QObject::tr("(%n dive(s))", "", nr);
+	QString suffix = " " + gettextFromC::tr("(%n dive(s))", "", nr);
 	if (getday) {
 		ret = localTime.date().toString(prefs.date_format) + suffix;
 	} else {
@@ -1279,7 +1279,7 @@ extern "C" char *picturedir_string()
 QString get_gas_string(struct gasmix gas)
 {
 	uint o2 = (get_o2(&gas) + 5) / 10, he = (get_he(&gas) + 5) / 10;
-	QString result = gasmix_is_air(&gas) ? QObject::tr("AIR") : he == 0 ? (o2 == 100 ? QObject::tr("OXYGEN") : QString("EAN%1").arg(o2, 2, 10, QChar('0'))) : QString("%1/%2").arg(o2).arg(he);
+	QString result = gasmix_is_air(&gas) ? gettextFromC::tr("AIR") : he == 0 ? (o2 == 100 ? gettextFromC::tr("OXYGEN") : QString("EAN%1").arg(o2, 2, 10, QChar('0'))) : QString("%1/%2").arg(o2).arg(he);
 	return result;
 }
 
@@ -1302,8 +1302,8 @@ weight_t string_to_weight(const char *str)
 	const char *end;
 	double value = strtod_flags(str, &end, 0);
 	QString rest = QString(end).trimmed();
-	QString local_kg = QObject::tr("kg");
-	QString local_lbs = QObject::tr("lbs");
+	QString local_kg = gettextFromC::tr("kg");
+	QString local_lbs = gettextFromC::tr("lbs");
 	weight_t weight;
 
 	if (rest.startsWith("kg") || rest.startsWith(local_kg))
@@ -1326,8 +1326,8 @@ depth_t string_to_depth(const char *str)
 	const char *end;
 	double value = strtod_flags(str, &end, 0);
 	QString rest = QString(end).trimmed();
-	QString local_ft = QObject::tr("ft");
-	QString local_m = QObject::tr("m");
+	QString local_ft = gettextFromC::tr("ft");
+	QString local_m = gettextFromC::tr("m");
 	depth_t depth;
 
 	if (value < 0)
@@ -1351,8 +1351,8 @@ pressure_t string_to_pressure(const char *str)
 	const char *end;
 	double value = strtod_flags(str, &end, 0);
 	QString rest = QString(end).trimmed();
-	QString local_psi = QObject::tr("psi");
-	QString local_bar = QObject::tr("bar");
+	QString local_psi = gettextFromC::tr("psi");
+	QString local_bar = gettextFromC::tr("bar");
 	pressure_t pressure;
 
 	if (rest.startsWith("bar") || rest.startsWith(local_bar))
@@ -1374,8 +1374,8 @@ volume_t string_to_volume(const char *str, pressure_t workp)
 	const char *end;
 	double value = strtod_flags(str, &end, 0);
 	QString rest = QString(end).trimmed();
-	QString local_l = QObject::tr("l");
-	QString local_cuft = QObject::tr("cuft");
+	QString local_l = gettextFromC::tr("l");
+	QString local_cuft = gettextFromC::tr("cuft");
 	volume_t volume;
 
 	if (rest.startsWith("l") || rest.startsWith("ℓ") || rest.startsWith(local_l))

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -18,6 +18,7 @@ enum inertgas {N2, HE};
 #include <QString>
 #include <QTranslator>
 #include <QDir>
+#include "core/gettextfromc.h"
 QString weight_string(int weight_in_grams);
 QString distance_string(int distanceInMeters);
 bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_text, bool *parsed_out = 0);
@@ -76,7 +77,7 @@ int parsePressureToMbar(const QString &text);
 int parseGasMixO2(const QString &text);
 int parseGasMixHE(const QString &text);
 QString render_seconds_to_string(int seconds);
-QString get_dive_duration_string(timestamp_t when, QString hoursText, QString minutesText, QString secondsText = QObject::tr("sec"), QString separator = ":", bool isFreeDive = false);
+QString get_dive_duration_string(timestamp_t when, QString hoursText, QString minutesText, QString secondsText = gettextFromC::tr("sec"), QString separator = ":", bool isFreeDive = false);
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);
 QString get_short_dive_date_string(timestamp_t when);

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -27,7 +27,7 @@ static QString getFormattedCylinder(struct dive *dive, unsigned int idx)
 	const char *desc = cyl->type.description;
 	if (!desc && idx > 0)
 		return QString(EMPTY_DIVE_STRING);
-	QString fmt = desc ? QString(desc) : QObject::tr("unknown");
+	QString fmt = desc ? QString(desc) : gettextFromC::tr("unknown");
 	fmt += ", " + get_volume_string(cyl->type.size, true);
 	fmt += ", " + get_pressure_string(cyl->type.workingpressure, true);
 	fmt += ", " + get_pressure_string(cyl->start, false) + " - " + get_pressure_string(cyl->end, true);
@@ -129,7 +129,7 @@ QVariant DiveObjectHelper::dive_site_uuid() const
 
 QString DiveObjectHelper::duration() const
 {
-	return get_dive_duration_string(m_dive->duration.seconds, QObject::tr("h"), QObject::tr("min"));
+	return get_dive_duration_string(m_dive->duration.seconds, gettextFromC::tr("h"), gettextFromC::tr("min"));
 }
 
 bool DiveObjectHelper::noDive() const

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -62,7 +62,7 @@ void DiveHandler::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 	// don't allow removing the last point
 	if (plannerModel->rowCount() > 1) {
 		m.addSeparator();
-		m.addAction(QObject::tr("Remove this point"), this, SLOT(selfRemove()));
+		m.addAction(gettextFromC::tr("Remove this point"), this, SLOT(selfRemove()));
 		m.exec(event->screenPos());
 	}
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -632,7 +632,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 static bool saveToCloudOK()
 {
 	if (!dive_table.nr) {
-		report_error(qPrintable(QObject::tr("Don't save an empty log to the cloud")));
+		report_error(qPrintable(gettextFromC::tr("Don't save an empty log to the cloud")));
 		return false;
 	}
 	return true;

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -31,13 +31,13 @@ public:
 	{
 		avgIco = new QLabel(owner);
 		avgIco->setPixmap(QIcon(":value-average-icon").pixmap(16, 16));
-		avgIco->setToolTip(QObject::tr("Average"));
+		avgIco->setToolTip(gettextFromC::tr("Average"));
 		minIco = new QLabel(owner);
 		minIco->setPixmap(QIcon(":value-minimum-icon").pixmap(16, 16));
-		minIco->setToolTip(QObject::tr("Minimum"));
+		minIco->setToolTip(gettextFromC::tr("Minimum"));
 		maxIco = new QLabel(owner);
 		maxIco->setPixmap(QIcon(":value-maximum-icon").pixmap(16, 16));
-		maxIco->setToolTip(QObject::tr("Maximum"));
+		maxIco->setToolTip(gettextFromC::tr("Maximum"));
 		avgValue = new QLabel(owner);
 		minValue = new QLabel(owner);
 		maxValue = new QLabel(owner);

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -620,7 +620,7 @@ static DiveListResult parseDiveLogsDeDiveList(const QByteArray &xmlData)
 	 * </DiveDateReader>
 	 */
 	QXmlStreamReader reader(xmlData);
-	const QString invalidXmlError = QObject::tr("Invalid response from server");
+	const QString invalidXmlError = gettextFromC::tr("Invalid response from server");
 	bool seenDiveDates = false;
 	DiveListResult result;
 	result.idCount = 0;
@@ -628,7 +628,7 @@ static DiveListResult parseDiveLogsDeDiveList(const QByteArray &xmlData)
 	if (reader.readNextStartElement() && reader.name() != "DiveDateReader") {
 		result.errorCondition = invalidXmlError;
 		result.errorDetails =
-			QObject::tr("Expected XML tag 'DiveDateReader', got instead '%1")
+			gettextFromC::tr("Expected XML tag 'DiveDateReader', got instead '%1")
 				.arg(reader.name().toString());
 		goto out;
 	}
@@ -674,14 +674,14 @@ static DiveListResult parseDiveLogsDeDiveList(const QByteArray &xmlData)
 
 	if (!seenDiveDates) {
 		result.errorCondition = invalidXmlError;
-		result.errorDetails = QObject::tr("Expected XML tag 'DiveDates' not found");
+		result.errorDetails = gettextFromC::tr("Expected XML tag 'DiveDates' not found");
 	}
 
 out:
 	if (reader.hasError()) {
 		// if there was an XML error, overwrite the result or other error conditions
 		result.errorCondition = invalidXmlError;
-		result.errorDetails = QObject::tr("Malformed XML response. Line %1: %2")
+		result.errorDetails = gettextFromC::tr("Malformed XML response. Line %1: %2")
 						.arg(reader.lineNumber())
 						.arg(reader.errorString());
 	}

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -107,8 +107,8 @@ if (property == "year") {
 } else if (property == "max_temp") {
 	return object.year->max_temp.mkelvin == 0 ? "0" : get_temperature_string(object.year->max_temp, true);
 } else if (property == "total_time") {
-	return get_dive_duration_string(object.year->total_time.seconds, QObject::tr("h"),
-									QObject::tr("min"), QObject::tr("sec"), " ");
+	return get_dive_duration_string(object.year->total_time.seconds, gettextFromC::tr("h"),
+									gettextFromC::tr("min"), gettextFromC::tr("sec"), " ");
 } else if (property == "avg_time") {
 	return get_minutes(object.year->total_time.seconds / object.year->selection_size);
 } else if (property == "shortest_time") {


### PR DESCRIPTION
There were two catch-all classes for translations outside of class
context. gettextFromC was used exclusively from C, but C++ used
both, gettextFromC and QObject. Some of the string were even present
in both.

Unify to gettextFromC throughout the code base. This removes a
few redundant translation strings. The translation-files were unified
using a script.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This changes all `QObject:tr()` to `gettextfromC::tr()` for consistency. As a bonus it removes unnecessary doubles.

The translation files were converted by a crude script. Since I'm not familiar with the workflow, I didn't bother to sort the new entries. But doing so seems to be mostly trivial (at least sorting by ASCII - sorting by Unicode might be a bit more difficult).

Surprisingly, there were a number of inconsistent translations(!). At the moment we randomly chose one, though one might be smarter (don't choose the untranslated version). I will append them to the end of this PR.

Note that I didn't check the translations at all. This is first and foremost a RFC.

PS: en_US.ts somehow seems pointless. Can this be removed?

Inconsistent translations:

```
Convert translations_orig/subsurface_sk_SK.ts to translations/subsurface_sk_SK.ts
Convert translations_orig/subsurface_pt_PT.ts to translations/subsurface_pt_PT.ts
Warning: translations of "<source>ft</source>" differ:
          <translation>pés</translation>
vs.:
          <translation>pé</translation>
Warning: translations of "<source>lbs</source>" differ:
          <translation>libras</translation>
vs.:
          <translation>libra</translation>
Warning: translations of "<source>cuft</source>" differ:
          <translation>pés cúbicos</translation>
vs.:
          <translation>pé cúbico</translation>
Convert translations_orig/subsurface_pl_PL.ts to translations/subsurface_pl_PL.ts
Convert translations_orig/subsurface_lv_LV.ts to translations/subsurface_lv_LV.ts
Warning: translations of "<source>ft</source>" differ:
          <translation>ft</translation>
vs.:
          <translation>pēda</translation>
Warning: translations of "<source>lbs</source>" differ:
          <translation>lbs</translation>
vs.:
          <translation>mārciņa</translation>
Warning: translations of "<source>cuft</source>" differ:
          <translation>cuft</translation>
vs.:
          <translation>kub. pēda</translation>
Convert translations_orig/subsurface_de_CH.ts to translations/subsurface_de_CH.ts
Convert translations_orig/subsurface_he.ts to translations/subsurface_he.ts
Warning: translations of "<source>lbs</source>" differ:
          <translation>lbs</translation>
vs.:
          <translation>ליברה</translation>
Warning: translations of "<source>cuft</source>" differ:
          <translation>cuft</translation>
vs.:
          <translation>רגל מעוקב</translation>
Convert translations_orig/subsurface_en_GB.ts to translations/subsurface_en_GB.ts
Convert translations_orig/subsurface_da_DK.ts to translations/subsurface_da_DK.ts
Warning: translations of "<source>ft</source>" differ:
          <translation>fod</translation>
vs.:
          <translation>ft</translation>
Warning: translations of "<source>lbs</source>" differ:
          <translation>pund (lbs)</translation>
vs.:
          <translation>lbs</translation>
Convert translations_orig/subsurface_nb_NO.ts to translations/subsurface_nb_NO.ts
Convert translations_orig/subsurface_de_DE.ts to translations/subsurface_de_DE.ts
Convert translations_orig/subsurface_source.ts to translations/subsurface_source.ts
Convert translations_orig/subsurface_es_ES.ts to translations/subsurface_es_ES.ts
Warning: translations of "<source>cuft</source>" differ:
          <translation>pie³</translation>
vs.:
          <translation>cuft</translation>
Convert translations_orig/subsurface_tr.ts to translations/subsurface_tr.ts
Warning: translations of "<source>psi</source>" differ:
          <translation type="unfinished"/>
vs.:
          <translation>psi</translation>
Warning: translations of "<source>cuft</source>" differ:
          <translation type="unfinished"/>
vs.:
          <translation>fitküp</translation>
Convert translations_orig/subsurface_fi_FI.ts to translations/subsurface_fi_FI.ts
Convert translations_orig/subsurface_sv_SE.ts to translations/subsurface_sv_SE.ts
Convert translations_orig/subsurface_ca.ts to translations/subsurface_ca.ts
Warning: translations of "<source>ft</source>" differ:
          <translation>ft</translation>
vs.:
          <translation>peu</translation>
Warning: translations of "<source>cuft</source>" differ:
          <translation>cuft</translation>
vs.:
          <translation>peus</translation>
Convert translations_orig/subsurface_et_EE.ts to translations/subsurface_et_EE.ts
Convert translations_orig/subsurface_nl_NL.ts to translations/subsurface_nl_NL.ts
Convert translations_orig/subsurface_cs.ts to translations/subsurface_cs.ts
Warning: translations of "<source>lbs</source>" differ:
          <translation>libra US</translation>
vs.:
          <translation>lbs</translation>
Warning: translations of "<source>unknown</source>" differ:
          <translation>neznámý</translation>
vs.:
          <translation>neznámo</translation>
Convert translations_orig/subsurface_en_US.ts to translations/subsurface_en_US.ts
Warning: context gettextFromC not found => renaming old context
Convert translations_orig/subsurface_ru_RU.ts to translations/subsurface_ru_RU.ts
Convert translations_orig/subsurface_el_GR.ts to translations/subsurface_el_GR.ts
Convert translations_orig/subsurface_bg_BG.ts to translations/subsurface_bg_BG.ts
Convert translations_orig/subsurface_ro_RO.ts to translations/subsurface_ro_RO.ts
Convert translations_orig/subsurface_fr_FR.ts to translations/subsurface_fr_FR.ts
Convert translations_orig/subsurface_hu.ts to translations/subsurface_hu.ts
Convert translations_orig/subsurface_hr_HR.ts to translations/subsurface_hr_HR.ts
Convert translations_orig/subsurface_pt_BR.ts to translations/subsurface_pt_BR.ts
Convert translations_orig/subsurface_id.ts to translations/subsurface_id.ts
Warning: translations of "<source>kg</source>" differ:
          <translation>kg</translation>
vs.:
          <translation>kgkg</translation>
Convert translations_orig/subsurface_it_IT.ts to translations/subsurface_it_IT.ts
Convert translations_orig/subsurface_zh_TW.ts to translations/subsurface_zh_TW.ts
Convert translations_orig/subsurface_vi.ts to translations/subsurface_vi.ts
```
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
