### PR TITLE
Core: add all qPref macros and implement qPrefDisplay as example

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 
 	# classes to manage struct preferences for QWidget and QML
 	settings/qPref.cpp
+	settings/qPrefDisplay.cpp
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp

--- a/core/pref.h
+++ b/core/pref.h
@@ -95,7 +95,7 @@ struct preferences {
 	bool        display_invalid_dives;
 	const char *divelist_font;
 	double      font_size;
-	bool        showDeveloper;
+	bool        show_developer;
  	const char *theme;
 
 	// ********** Facebook **********

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -3,7 +3,10 @@
 #define QPREF_H
 
 #include <QObject>
+#include <QSettings>
 #include "core/pref.h"
+
+#include "qPrefDisplay.h"
 
 class qPref : public QObject {
 	Q_OBJECT

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPref.h"
+#include "qPref_private.h"
+#include "core/subsurface-string.h"
+
+#include <QApplication>
+#include <QFont>
+
+qPrefDisplay::qPrefDisplay(QObject *parent) : QObject(parent)
+{
+}
+qPrefDisplay *qPrefDisplay::instance()
+{
+	static qPrefDisplay *self = new qPrefDisplay;
+	return self;
+}
+
+void qPrefDisplay::loadSync(bool doSync)
+{
+	disk_divelist_font(doSync);
+	disk_font_size(doSync);
+	disk_display_invalid_dives(doSync);
+	disk_show_developer(doSync);
+	disk_theme(doSync);
+}
+
+const QString qPrefDisplay::divelist_font() const
+{
+	return prefs.divelist_font;
+}
+void qPrefDisplay::set_divelist_font(const QString& value)
+{
+	QString newValue = value;
+	if (value.contains(","))
+		newValue = value.left(value.indexOf(","));
+
+	if (newValue != prefs.divelist_font &&
+		!subsurface_ignore_font(qPrintable(newValue))) {
+		COPY_TXT(divelist_font, value);
+		qApp->setFont(QFont(newValue));
+		disk_divelist_font(true);
+		emit divelist_font_changed(value);
+	}
+}
+void qPrefDisplay::disk_divelist_font(bool doSync)
+{
+	LOADSYNC_TXT("/divelist_font", divelist_font);
+}
+
+double qPrefDisplay::font_size() const
+{
+	return prefs.font_size;
+}
+void qPrefDisplay::set_font_size(double value)
+{
+	if (value != prefs.font_size) {
+		prefs.font_size = value;
+		QFont defaultFont = qApp->font();
+		defaultFont.setPointSizeF(prefs.font_size);
+		qApp->setFont(defaultFont);
+		disk_font_size(true);
+		emit font_size_changed(value);
+	}
+}
+void qPrefDisplay::disk_font_size(bool doSync)
+{
+	LOADSYNC_DOUBLE("/font_size", font_size);
+}
+
+bool qPrefDisplay::display_invalid_dives() const
+{
+	return prefs.display_invalid_dives;
+}
+void qPrefDisplay::set_display_invalid_dives(bool value)
+{
+	if (value != prefs.display_invalid_dives) {
+		prefs.display_invalid_dives = value;
+		disk_display_invalid_dives(true);
+		emit display_invalid_dives_changed(value);
+	}
+}
+void qPrefDisplay::disk_display_invalid_dives(bool doSync)
+{
+	LOADSYNC_BOOL("/displayinvalid", display_invalid_dives);
+}
+
+bool qPrefDisplay::show_developer() const
+{
+	return prefs.show_developer;
+}
+void qPrefDisplay::set_show_developer(bool value)
+{
+	if (value != prefs.show_developer) {
+		prefs.show_developer = value;
+		disk_show_developer(true);
+		emit disk_show_developer(value);
+	}
+}
+void qPrefDisplay::disk_show_developer(bool doSync)
+{
+	LOADSYNC_BOOL("/showDeveloper", show_developer);
+}
+
+const QString qPrefDisplay::theme() const
+{
+	return prefs.theme;
+}
+void qPrefDisplay::set_theme(const QString& value)
+{
+	if (value != prefs.theme) {
+		COPY_TXT(theme, value);
+		disk_theme(true);
+		emit theme_changed(value);
+	}
+}
+void qPrefDisplay::disk_theme(bool doSync)
+{
+	LOADSYNC_TXT("/theme", theme);
+}

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -24,10 +24,7 @@ void qPrefDisplay::loadSync(bool doSync)
 	disk_theme(doSync);
 }
 
-const QString qPrefDisplay::divelist_font() const
-{
-	return prefs.divelist_font;
-}
+GET_PREFERENCE_TXT(Display, divelist_font);
 void qPrefDisplay::set_divelist_font(const QString& value)
 {
 	QString newValue = value;
@@ -42,15 +39,9 @@ void qPrefDisplay::set_divelist_font(const QString& value)
 		emit divelist_font_changed(value);
 	}
 }
-void qPrefDisplay::disk_divelist_font(bool doSync)
-{
-	LOADSYNC_TXT("/divelist_font", divelist_font);
-}
+DISK_LOADSYNC_TXT(Display, "/divelist_font", divelist_font);
 
-double qPrefDisplay::font_size() const
-{
-	return prefs.font_size;
-}
+GET_PREFERENCE_DOUBLE(Display, font_size);
 void qPrefDisplay::set_font_size(double value)
 {
 	if (value != prefs.font_size) {
@@ -62,58 +53,10 @@ void qPrefDisplay::set_font_size(double value)
 		emit font_size_changed(value);
 	}
 }
-void qPrefDisplay::disk_font_size(bool doSync)
-{
-	LOADSYNC_DOUBLE("/font_size", font_size);
-}
+DISK_LOADSYNC_DOUBLE(Display, "/font_size", font_size);
 
-bool qPrefDisplay::display_invalid_dives() const
-{
-	return prefs.display_invalid_dives;
-}
-void qPrefDisplay::set_display_invalid_dives(bool value)
-{
-	if (value != prefs.display_invalid_dives) {
-		prefs.display_invalid_dives = value;
-		disk_display_invalid_dives(true);
-		emit display_invalid_dives_changed(value);
-	}
-}
-void qPrefDisplay::disk_display_invalid_dives(bool doSync)
-{
-	LOADSYNC_BOOL("/displayinvalid", display_invalid_dives);
-}
+HANDLE_PREFERENCE_BOOL(Display, "/displayinvalid", display_invalid_dives);
 
-bool qPrefDisplay::show_developer() const
-{
-	return prefs.show_developer;
-}
-void qPrefDisplay::set_show_developer(bool value)
-{
-	if (value != prefs.show_developer) {
-		prefs.show_developer = value;
-		disk_show_developer(true);
-		emit disk_show_developer(value);
-	}
-}
-void qPrefDisplay::disk_show_developer(bool doSync)
-{
-	LOADSYNC_BOOL("/showDeveloper", show_developer);
-}
+HANDLE_PREFERENCE_BOOL(Display, "/show_developer", show_developer);
 
-const QString qPrefDisplay::theme() const
-{
-	return prefs.theme;
-}
-void qPrefDisplay::set_theme(const QString& value)
-{
-	if (value != prefs.theme) {
-		COPY_TXT(theme, value);
-		disk_theme(true);
-		emit theme_changed(value);
-	}
-}
-void qPrefDisplay::disk_theme(bool doSync)
-{
-	LOADSYNC_TXT("/theme", theme);
-}
+HANDLE_PREFERENCE_TXT(Display, "/theme", theme);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREFDISPLAY_H
+#define QPREFDISPLAY_H
+
+#include <QObject>
+#include <QSettings>
+
+class qPrefDisplay : public QObject {
+	Q_OBJECT
+	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_font_changed);
+	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_size_changed);
+	Q_PROPERTY(bool display_invalid_dives READ display_invalid_dives WRITE set_display_invalid_dives NOTIFY display_invalid_dives_changed);
+	Q_PROPERTY(bool show_developer READ show_developer WRITE set_show_developer NOTIFY show_developer_changed);
+	Q_PROPERTY(QString theme READ theme WRITE set_theme NOTIFY theme_changed);
+
+public:
+	qPrefDisplay(QObject *parent = NULL);
+	static qPrefDisplay *instance();
+
+	// Load/Sync local settings (disk) and struct preference
+	void loadSync(bool doSync);
+
+public:
+	const QString divelist_font() const;
+	double font_size() const;
+	bool display_invalid_dives() const;
+	bool show_developer() const;
+	const QString theme() const;
+
+public slots:
+	void set_divelist_font(const QString& value);
+	void set_font_size(double value);
+	void set_display_invalid_dives(bool value);
+	void set_show_developer(bool value);
+	void set_theme(const QString& value);
+
+signals:
+	void divelist_font_changed(const QString& value);
+	void font_size_changed(double value);
+	void display_invalid_dives_changed(bool value);
+	void show_developer_changed(bool value);
+	void theme_changed(const QString& value);
+
+private:
+	const QString group = QStringLiteral("Display");
+	QSettings setting;
+
+	// functions to load/sync variable with disk
+	void disk_divelist_font(bool doSync);
+	void disk_font_size(bool doSync);
+	void disk_display_invalid_dives(bool doSync);
+	void disk_show_developer(bool doSync);
+	void disk_theme(bool doSync);
+};
+#endif

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -66,76 +66,76 @@
 }
 
 //******* Macros to generate disk function
-#define DISK_LOADSYNC_BOOL(class, name, field) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_BOOL(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_BOOL(name, field); \
 }
 
-#define DISK_LOADSYNC_DOUBLE(class, name, field) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_DOUBLE(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_DOUBLE(name, field); \
 }
 
-#define DISK_LOADSYNC_ENUM(class, name, type, field) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_ENUM(usegroup, name, type, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_ENUM(name, type, field); \
 }
 
-#define DISK_LOADSYNC_INT(class, name, field) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_INT(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_DOUBLE(name, field); \
 }
 
-#define DISK_LOADSYNC_INT_DEF(class, name, field, defval) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_INT_DEF(name, field, defval); \
 }
 
-#define DISK_LOADSYNC_TXT(class, name, field) \
-void qPref ## class::disk_ ## field(bool doSync) \
+#define DISK_LOADSYNC_TXT(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_TXT(name, field); \
 }
 
 //******* Macros to generate get function
-#define GET_PREFERENCE_BOOL(class, field) \
-bool qPref ## class::field () const \
+#define GET_PREFERENCE_BOOL(usegroup, field) \
+bool qPref ## usegroup::field () const \
 { \
 	return prefs.field; \
 }
 
-#define GET_PREFERENCE_DOUBLE(class, field) \
-double  qPref ## class::field () const \
+#define GET_PREFERENCE_DOUBLE(usegroup, field) \
+double  qPref ## usegroup::field () const \
 { \
 	return prefs.field; \
 }
 
-#define GET_PREFERENCE_ENUM(class, type, field) \
-struct type  qPref ## class:: ## field () const \
+#define GET_PREFERENCE_ENUM(usegroup, type, field) \
+struct type  qPref ## usegroup:: ## field () const \
 { \
 	return prefs.field; \
 }
 
-#define GET_PREFERENCE_INT(class, field) \
-int qPref ## class::field () const \
+#define GET_PREFERENCE_INT(usegroup, field) \
+int qPref ## usegroup::field () const \
 { \
 	return prefs.field; \
 }
 
-#define GET_PREFERENCE_TXT(class, field) \
-const QString qPref ## class::field () const \
+#define GET_PREFERENCE_TXT(usegroup, field) \
+const QString qPref ## usegroup::field () const \
 { \
 	return prefs.field; \
 }
 
 //******* Macros to generate set function
-#define SET_PREFERENCE_BOOL(class, field) \
-void qPref ## class::set_ ## field (bool value) \
+#define SET_PREFERENCE_BOOL(usegroup, field) \
+void qPref ## usegroup::set_ ## field (bool value) \
 { \
 	if (value != prefs.field) { \
 		prefs.field = value; \
@@ -144,8 +144,8 @@ void qPref ## class::set_ ## field (bool value) \
 	} \
 }
 
-#define SET_PREFERENCE_DOUBLE(class, field) \
-void qPref ## class::set_ ## field (double value) \
+#define SET_PREFERENCE_DOUBLE(usegroup, field) \
+void qPref ## usegroup::set_ ## field (double value) \
 { \
 	if (value != prefs.field) { \
 		prefs.field = value; \
@@ -154,8 +154,8 @@ void qPref ## class::set_ ## field (double value) \
 	} \
 }
 
-#define SET_PREFERENCE_ENUM(class, type, field) \
-void qPref ## class::set_ ## field (type value) \
+#define SET_PREFERENCE_ENUM(usegroup, type, field) \
+void qPref ## usegroup::set_ ## field (type value) \
 { \
 	if (value != prefs.field) { \
 		prefs.field = value; \
@@ -164,8 +164,8 @@ void qPref ## class::set_ ## field (type value) \
 	} \
 }
 
-#define SET_PREFERENCE_INT(class, field) \
-void qPref ## class::set_ ## field (int value) \
+#define SET_PREFERENCE_INT(usegroup, field) \
+void qPref ## usegroup::set_ ## field (int value) \
 { \
 	if (value != prefs.field) { \
 		prefs.field = value; \
@@ -174,8 +174,8 @@ void qPref ## class::set_ ## field (int value) \
 	} \
 }
 
-#define SET_PREFERENCE_TXT(class, field) \
-void qPref ## class::set_ ## field (const QString& value) \
+#define SET_PREFERENCE_TXT(usegroup, field) \
+void qPref ## usegroup::set_ ## field (const QString& value) \
 { \
 	if (value != prefs.field) { \
 		COPY_TXT(field, value); \
@@ -183,4 +183,31 @@ void qPref ## class::set_ ## field (const QString& value) \
 		emit field ## _changed(value); \
 	} \
 }
+
+//******* Macros to generate set/set/loadsync combined
+#define HANDLE_PREFERENCE_BOOL(usegroup, name, field) \
+GET_PREFERENCE_BOOL(usegroup, field); \
+SET_PREFERENCE_BOOL(usegroup, field); \
+DISK_LOADSYNC_BOOL(usegroup, name, field);
+
+#define HANDLE_PREFERENCE_DOUBLE(usegroup, name, field) \
+GET_PREFERENCE_DOUBLE(usegroup, field); \
+SET_PREFERENCE_DOUBLE(usegroup, field); \
+DISK_LOADSYNC_DOUBLE(usegroup, name, field);
+
+#define HANDLE_PREFERENCE_ENUM(usegroup, type, name, field) \
+GET_PREFERENCE_ENUM(usegroup, type, field); \
+SET_PREFERENCE_ENUM(usegroup, type, field); \
+DISK_LOADSYNC_ENUM(usegroup, name, type, field);
+
+#define HANDLE_PREFERENCE_INT(usegroup, name, field) \
+GET_PREFERENCE_INT(usegroup, field); \
+SET_PREFERENCE_INT(usegroup, field); \
+DISK_LOADSYNC_INT(usegroup, name, field);
+
+#define HANDLE_PREFERENCE_TXT(usegroup, name, field) \
+GET_PREFERENCE_TXT(usegroup, field); \
+SET_PREFERENCE_TXT(usegroup, field); \
+DISK_LOADSYNC_TXT(usegroup, name, field);
+
 #endif

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -4,69 +4,101 @@
 
 // Header used by all qPref<class> implementations to avoid duplicating code
 
-#include <QObject>
 #include <QSettings>
 #include <QVariant>
+#include <QObject>
 #include "core/qthelper.h"
 
+//****** Macros to be used in the set functions ******
 #define COPY_TXT(name, string) \
 { \
 	free((void *)prefs.name); \
 	prefs.name = copy_qstring(string); \
 }
 
-#define LOADSYNC_INT(name, field) \
-{ \
-	QSettings s; \
-	if (doSync) \
-		s.setValue(group + name, prefs.field); \
-	else \
-		prefs.field = s.value(group + name, default_prefs.field).toInt(); \
-}
-
-#define LOADSYNC_INT_DEF(name, field, defval) \
-{ \
-	QSettings s; \
-	if (doSync)	\
-		s.setValue(group + name, prefs.field); \
-	else \
-		prefs.field = s.value(group + name, defval).toInt(); \
-}
-
-#define LOADSYNC_ENUM(name, type, field) \
-{ \
-	QSettings s; \
-	if (doSync)	\
-		s.setValue(group + name, prefs.field); \
-	else \
-		prefs.field = (enum type)s.value(group + name, default_prefs.field).toInt(); \
-}
-
+//****** Macros to be used in the disk functions, which are special ******
 #define LOADSYNC_BOOL(name, field) \
 { \
-	QSettings s; \
 	if (doSync)	\
-		s.setValue(group + name, prefs.field); \
+		setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = s.value(group + name, default_prefs.field).toBool(); \
+		prefs.field = setting.value(group + name, default_prefs.field).toBool(); \
 }
 
 #define LOADSYNC_DOUBLE(name, field) \
 { \
-	QSettings s; \
 	if (doSync)	\
-		s.setValue(group + name, prefs.field); \
+		setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = s.value(group + name, default_prefs.field).toDouble(); \
+		prefs.field = setting.value(group + name, default_prefs.field).toDouble(); \
+}
+
+#define LOADSYNC_ENUM(name, type, field) \
+{ \
+	if (doSync)	\
+		setting.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = (enum type)setting.value(group + name, default_prefs.field).toInt(); \
+}
+
+#define LOADSYNC_INT(name, field) \
+{ \
+	if (doSync) \
+		setting.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = setting.value(group + name, default_prefs.field).toInt(); \
+}
+
+#define LOADSYNC_INT_DEF(name, field, defval) \
+{ \
+	if (doSync)	\
+		setting.setValue(group + name, prefs.field); \
+	else \
+		prefs.field = setting.value(group + name, defval).toInt(); \
 }
 
 #define LOADSYNC_TXT(name, field) \
 { \
-	QSettings s; \
 	if (doSync)	\
-		s.setValue(group + name, prefs.field); \
+		setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = copy_qstring(s.value(group + name, default_prefs.field).toString()); \
+		prefs.field = copy_qstring(setting.value(group + name, default_prefs.field).toString()); \
 }
 
+//******* Macros to generate disk function
+#define DISK_LOADSYNC_BOOL(class, name, field) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_BOOL(name, field); \
+}
+
+#define DISK_LOADSYNC_DOUBLE(class, name, field) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_DOUBLE(name, field); \
+}
+
+#define DISK_LOADSYNC_ENUM(class, name, type, field) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_ENUM(name, type, field); \
+}
+
+#define DISK_LOADSYNC_INT(class, name, field) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_DOUBLE(name, field); \
+}
+
+#define DISK_LOADSYNC_INT_DEF(class, name, field, defval) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_INT_DEF(name, field, defval); \
+}
+
+#define DISK_LOADSYNC_TXT(class, name, field) \
+void qPref ## class::disk_ ## field(bool doSync) \
+{ \
+	LOADSYNC_TXT(name, field); \
+}
 #endif

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -101,4 +101,36 @@ void qPref ## class::disk_ ## field(bool doSync) \
 { \
 	LOADSYNC_TXT(name, field); \
 }
+
+
+//******* Macros to generate get function
+#define GET_PREFERENCE_BOOL(class, field) \
+bool qPref ## class::field () const \
+{ \
+	return prefs.field; \
+}
+
+#define GET_PREFERENCE_DOUBLE(class, field) \
+double  qPref ## class::field () const \
+{ \
+	return prefs.field; \
+}
+
+#define GET_PREFERENCE_ENUM(class, type, field) \
+struct type  qPref ## class:: ## field () const \
+{ \
+	return prefs.field; \
+}
+
+#define GET_PREFERENCE_INT(class, field) \
+int qPref ## class::field () const \
+{ \
+	return prefs.field; \
+}
+
+#define GET_PREFERENCE_TXT(class, field) \
+const QString qPref ## class::field () const \
+{ \
+	return prefs.field; \
+}
 #endif

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -102,7 +102,6 @@ void qPref ## class::disk_ ## field(bool doSync) \
 	LOADSYNC_TXT(name, field); \
 }
 
-
 //******* Macros to generate get function
 #define GET_PREFERENCE_BOOL(class, field) \
 bool qPref ## class::field () const \
@@ -132,5 +131,56 @@ int qPref ## class::field () const \
 const QString qPref ## class::field () const \
 { \
 	return prefs.field; \
+}
+
+//******* Macros to generate set function
+#define SET_PREFERENCE_BOOL(class, field) \
+void qPref ## class::set_ ## field (bool value) \
+{ \
+	if (value != prefs.field) { \
+		prefs.field = value; \
+		disk_ ## field(true); \
+		emit field ## _changed(value); \
+	} \
+}
+
+#define SET_PREFERENCE_DOUBLE(class, field) \
+void qPref ## class::set_ ## field (double value) \
+{ \
+	if (value != prefs.field) { \
+		prefs.field = value; \
+		disk_ ## field(true); \
+		emit field ## _changed(value); \
+	} \
+}
+
+#define SET_PREFERENCE_ENUM(class, type, field) \
+void qPref ## class::set_ ## field (type value) \
+{ \
+	if (value != prefs.field) { \
+		prefs.field = value; \
+		disk_ ## field(true); \
+		emit field ## _changed(value); \
+	} \
+}
+
+#define SET_PREFERENCE_INT(class, field) \
+void qPref ## class::set_ ## field (int value) \
+{ \
+	if (value != prefs.field) { \
+		prefs.field = value; \
+		disk_ ## field(true); \
+		emit field ## _changed(value); \
+	} \
+}
+
+#define SET_PREFERENCE_TXT(class, field) \
+void qPref ## class::set_ ## field (const QString& value) \
+{ \
+	if (value != prefs.field) { \
+		COPY_TXT(field, value); \
+		disk_ ## field(true); \
+		emit field ## _changed(value); \
+	} \
 }
 #endif

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -78,6 +78,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/connectionlistmodel.cpp \
 	../../core/qt-ble.cpp \
 	../../core/settings/qPref.cpp \
+	../../core/settings/qPrefDisplay.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
@@ -185,6 +186,7 @@ HEADERS += \
 	../../core/connectionlistmodel.h \
 	../../core/qt-ble.h \
 	../../core/settings/qPref.h \
+	../../core/settings/qPrefDisplay.h \
 	../../core/settings/qPref_private.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \
 	../../core/subsurface-qt/DiveObjectHelper.h \


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR extend qPref_private with macros for:
The whole get function (when the get function is standard)
The whole set function (when the set function is standard)
The whole get/set/loadsync functions (in case the variable is all standard)

LOADSYNC is updated to use a private QSetting variable instead of making a new instance in 
Every call.

The first commit shows qPrefDisplay using the low level LOADSYNC macros, this will only be used
Where the load/sync does not follow a standard pattern.

The last commit shows qPrefDisplay using the higher level LOADSYNC macros, depending on how
Standarzied the variable is.

REMARK: qPrefDisplay is NOT connected to SettingsObjectWrapper and thus not part of an executable. This is on purpose for 2 reasons:
- We can freely discuss and update the use pattern, without side effects.
- There are no test cases, which needs to be part of every class conversion.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
