### PR TITLE
Multiple cylinder edit on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: Enable multiple cylinder editing for dives that uses more than one cylinder.
 - Mac: fix problem downloading from divelogs.de
 - Dive media: paint duration of videos on thumbnails in the dive-photo tab
 - Dive media: extract video thumbnails using ffmpeg

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -35,9 +35,9 @@ static QString getFormattedCylinder(struct dive *dive, unsigned int idx)
 	return fmt;
 }
 
-static QString getPressures(struct dive *dive, enum returnPressureSelector ret)
+static QString getPressures(struct dive *dive, int i, enum returnPressureSelector ret)
 {
-	cylinder_t *cyl = &dive->cylinder[0];
+	cylinder_t *cyl = &dive->cylinder[i];
 	QString fmt;
 	if (ret == START_PRESSURE) {
 		if (cyl->start.mbar)
@@ -405,15 +405,23 @@ QStringList DiveObjectHelper::getCylinder() const
 	return getCylinder;
 }
 
-QString DiveObjectHelper::startPressure() const
+QStringList DiveObjectHelper::startPressure() const
 {
-	QString startPressure = getPressures(m_dive, START_PRESSURE);
+	QStringList startPressure;
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		if (is_cylinder_used(m_dive, i))
+			startPressure << getPressures(m_dive, i, START_PRESSURE);
+	}
 	return startPressure;
 }
 
-QString DiveObjectHelper::endPressure() const
+QStringList DiveObjectHelper::endPressure() const
 {
-	QString endPressure = getPressures(m_dive, END_PRESSURE);
+	QStringList endPressure;
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		if (is_cylinder_used(m_dive, i))
+			endPressure << getPressures(m_dive, i, END_PRESSURE);
+	}
 	return endPressure;
 }
 

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -417,9 +417,12 @@ QString DiveObjectHelper::endPressure() const
 	return endPressure;
 }
 
-QString DiveObjectHelper::firstGas() const
+QStringList DiveObjectHelper::firstGas() const
 {
-	QString gas;
-	gas = get_gas_string(m_dive->cylinder[0].gasmix);
+	QStringList gas;
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		if (is_cylinder_used(m_dive, i))
+			gas << get_gas_string(m_dive->cylinder[i].gasmix);
+	}
 	return gas;
 }

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -395,9 +395,13 @@ QString DiveObjectHelper::sumWeight() const
 	return get_weight_string(sum, true);
 }
 
-QString DiveObjectHelper::getCylinder() const
+QStringList DiveObjectHelper::getCylinder() const
 {
-	QString getCylinder = m_dive->cylinder[0].type.description;
+	QStringList getCylinder; 
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		if (is_cylinder_used(m_dive, i))
+			getCylinder << m_dive->cylinder[i].type.description;
+	}
 	return getCylinder;
 }
 

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -45,7 +45,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
 	Q_PROPERTY(int otu READ otu CONSTANT)
 	Q_PROPERTY(QString sumWeight READ sumWeight CONSTANT)
-	Q_PROPERTY(QString getCylinder READ getCylinder CONSTANT)
+	Q_PROPERTY(QStringList getCylinder READ getCylinder CONSTANT)
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
@@ -89,7 +89,7 @@ public:
 	int maxcns() const;
 	int otu() const;
 	QString sumWeight() const;
-	QString getCylinder() const;
+	QStringList getCylinder() const;
 	QString startPressure() const;
 	QString endPressure() const;
 	QString firstGas() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -48,7 +48,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList getCylinder READ getCylinder CONSTANT)
 	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
-	Q_PROPERTY(QString firstGas READ firstGas CONSTANT)
+	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
 	~DiveObjectHelper();
@@ -92,7 +92,7 @@ public:
 	QStringList getCylinder() const;
 	QString startPressure() const;
 	QString endPressure() const;
-	QString firstGas() const;
+	QStringList firstGas() const;
 
 private:
 	struct dive *m_dive;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -46,8 +46,8 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(int otu READ otu CONSTANT)
 	Q_PROPERTY(QString sumWeight READ sumWeight CONSTANT)
 	Q_PROPERTY(QStringList getCylinder READ getCylinder CONSTANT)
-	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
-	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
+	Q_PROPERTY(QStringList startPressure READ startPressure CONSTANT)
+	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
@@ -90,8 +90,8 @@ public:
 	int otu() const;
 	QString sumWeight() const;
 	QStringList getCylinder() const;
-	QString startPressure() const;
-	QString endPressure() const;
+	QStringList startPressure() const;
+	QStringList endPressure() const;
 	QStringList firstGas() const;
 
 private:

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -40,7 +40,7 @@ Kirigami.Page {
 	property alias cylinderIndex2: detailsEdit.cylinderIndex2
 	property alias cylinderIndex3: detailsEdit.cylinderIndex3
 	property alias cylinderIndex4: detailsEdit.cylinderIndex4
-	property alias gasmix0: detailsEdit.gasmixText0
+	property alias usedGas: detailsEdit.usedGas
 	property alias gpsCheckbox: detailsEdit.gpsCheckbox
 	property int updateCurrentIdx: manager.updateSelectedDive
 	property alias rating: detailsEdit.rating
@@ -264,7 +264,7 @@ Kirigami.Page {
 		}
 		startpressure0 = currentItem.modelData.dive.startPressure
 		endpressure0 = currentItem.modelData.dive.endPressure
-		gasmix0 = currentItem.modelData.dive.firstGas
+		usedGas = currentItem.modelData.dive.firstGas
 		usedCyl = currentItem.modelData.dive.getCylinder
 		cylinderIndex0 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[0])
 		cylinderIndex1 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[1])

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -46,7 +46,11 @@ Kirigami.Page {
 	property alias rating: detailsEdit.rating
 	property alias visibility: detailsEdit.visibility
 	property alias usedCyl: detailsEdit.usedCyl
-	property alias cylinderModel: detailsEdit.cylinderModel
+	property alias cylinderModel0: detailsEdit.cylinderModel0
+	property alias cylinderModel1: detailsEdit.cylinderModel1
+	property alias cylinderModel2: detailsEdit.cylinderModel2
+	property alias cylinderModel3: detailsEdit.cylinderModel3
+	property alias cylinderModel4: detailsEdit.cylinderModel4
 
 	title: currentItem && currentItem.modelData ? currentItem.modelData.dive.location : qsTr("Dive details")
 	state: "view"

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -33,16 +33,20 @@ Kirigami.Page {
 	property alias suitText: detailsEdit.suitText
 	property alias suitModel: detailsEdit.suitModel
 	property alias weight: detailsEdit.weightText
-	property alias startpressure: detailsEdit.startpressureText
-	property alias endpressure: detailsEdit.endpressureText
-	property alias cylinderIndex: detailsEdit.cylinderIndex
-	property alias cylinderText: detailsEdit.cylinderText
-	property alias cylinderModel: detailsEdit.cylinderModel
-	property alias gasmix: detailsEdit.gasmixText
+	property alias startpressure0: detailsEdit.startpressureText0
+	property alias endpressure0: detailsEdit.endpressureText0
+	property alias cylinderIndex0: detailsEdit.cylinderIndex0
+	property alias cylinderIndex1: detailsEdit.cylinderIndex1
+	property alias cylinderIndex2: detailsEdit.cylinderIndex2
+	property alias cylinderIndex3: detailsEdit.cylinderIndex3
+	property alias cylinderIndex4: detailsEdit.cylinderIndex4
+	property alias gasmix0: detailsEdit.gasmixText0
 	property alias gpsCheckbox: detailsEdit.gpsCheckbox
 	property int updateCurrentIdx: manager.updateSelectedDive
 	property alias rating: detailsEdit.rating
 	property alias visibility: detailsEdit.visibility
+	property alias usedCyl: detailsEdit.usedCyl
+	property alias cylinderModel: detailsEdit.cylinderModel
 
 	title: currentItem && currentItem.modelData ? currentItem.modelData.dive.location : qsTr("Dive details")
 	state: "view"
@@ -258,10 +262,15 @@ Kirigami.Page {
 			// careful when translating, this text is "magic" in DiveDetailsEdit.qml
 			weight = "cannot edit multiple weight systems"
 		}
-		startpressure = currentItem.modelData.dive.startPressure
-		endpressure = currentItem.modelData.dive.endPressure
-		gasmix = currentItem.modelData.dive.firstGas
-		cylinderIndex = currentItem.modelData.dive.cylinderList.indexOf(currentItem.modelData.dive.getCylinder)
+		startpressure0 = currentItem.modelData.dive.startPressure
+		endpressure0 = currentItem.modelData.dive.endPressure
+		gasmix0 = currentItem.modelData.dive.firstGas
+		usedCyl = currentItem.modelData.dive.getCylinder
+		cylinderIndex0 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[0])
+		cylinderIndex1 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[1])
+		cylinderIndex2 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[2])
+		cylinderIndex3 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[3])
+		cylinderIndex4 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[4])
 		rating = currentItem.modelData.dive.rating
 		visibility = currentItem.modelData.dive.visibility
 

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -33,8 +33,8 @@ Kirigami.Page {
 	property alias suitText: detailsEdit.suitText
 	property alias suitModel: detailsEdit.suitModel
 	property alias weight: detailsEdit.weightText
-	property alias startpressure0: detailsEdit.startpressureText0
-	property alias endpressure0: detailsEdit.endpressureText0
+	property alias startpressure: detailsEdit.startpressure
+	property alias endpressure: detailsEdit.endpressure
 	property alias cylinderIndex0: detailsEdit.cylinderIndex0
 	property alias cylinderIndex1: detailsEdit.cylinderIndex1
 	property alias cylinderIndex2: detailsEdit.cylinderIndex2
@@ -262,8 +262,8 @@ Kirigami.Page {
 			// careful when translating, this text is "magic" in DiveDetailsEdit.qml
 			weight = "cannot edit multiple weight systems"
 		}
-		startpressure0 = currentItem.modelData.dive.startPressure
-		endpressure0 = currentItem.modelData.dive.endPressure
+		startpressure = currentItem.modelData.dive.startPressure
+		endpressure = currentItem.modelData.dive.endPressure
 		usedGas = currentItem.modelData.dive.firstGas
 		usedCyl = currentItem.modelData.dive.getCylinder
 		cylinderIndex0 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[0])

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -38,7 +38,11 @@ Item {
 	property alias suitModel: suitBox.model
 	property alias divemasterModel: divemasterBox.model
 	property alias buddyModel: buddyBox.model
-	property alias cylinderModel: cylinderBox0.model
+	property alias cylinderModel0: cylinderBox0.model
+	property alias cylinderModel1: cylinderBox1.model
+	property alias cylinderModel2: cylinderBox2.model
+	property alias cylinderModel3: cylinderBox3.model
+	property alias cylinderModel4: cylinderBox4.model
 	property alias locationModel: locationBox.model
 	property int rating
 	property int visibility

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -73,18 +73,23 @@ Item {
 		// join cylinder info from separate string into a list.
 		if (usedCyl[0] != null) {
 			usedCyl[0] = cylinderBox0.currentText
+			usedGas[0] = txtGasMix0.text
 		}
 		if (usedCyl[1] != null) {
 			usedCyl[1] = cylinderBox1.currentText
+			usedGas[1] = txtGasMix0.text
 		}
 		if (usedCyl[2] != null) {
 			usedCyl[2] = cylinderBox2.currentText
+			usedGas[2] = txtGasMix0.text
 		}
 		if (usedCyl[3] != null) {
 			usedCyl[3] = cylinderBox3.currentText
+			usedGas[3] = txtGasMix0.text
 		}
 		if (usedCyl[4] != null) {
 			usedCyl[4] = cylinderBox4.currentText
+			usedGas[4] = txtGasMix0.text
 		}
 
 		// apply the changes to the dive_table
@@ -93,7 +98,7 @@ Item {
 				      suitBox.currentText != "" ? suitBox.currentText : suitBox.editText, buddyBox.editText,
 				      divemasterBox.currentText != "" ? divemasterBox.currentText : divemasterBox.editText,
 				      detailsEdit.weightText, detailsEdit.notesText, detailsEdit.startpressureText,
-				      detailsEdit.endpressureText, detailsEdit.gasmixText, usedCyl ,
+				      detailsEdit.endpressureText, usedGas, usedCyl ,
 				      detailsEdit.rating,
 				      detailsEdit.visibility)
 		// trigger the profile to be redrawn

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -31,9 +31,9 @@ Item {
 	property alias durationText: txtDuration.text
 	property alias depthText: txtDepth.text
 	property alias weightText: txtWeight.text
-	property alias startpressureText0: txtStartPressure0.text
-	property alias endpressureText0: txtEndPressure0.text
 	property var usedGas: []
+	property var endpressure: []
+	property var startpressure: []
 	property alias gpsCheckbox: checkboxGPS.checked
 	property alias suitModel: suitBox.model
 	property alias divemasterModel: divemasterBox.model
@@ -74,22 +74,32 @@ Item {
 		if (usedCyl[0] != null) {
 			usedCyl[0] = cylinderBox0.currentText
 			usedGas[0] = txtGasMix0.text
+			startpressure[0] = txtStartPressure0.text
+			endpressure[0] = txtEndPressure0.text
 		}
 		if (usedCyl[1] != null) {
 			usedCyl[1] = cylinderBox1.currentText
 			usedGas[1] = txtGasMix0.text
+			startpressure[1] = txtStartPressure1.text
+			endpressure[1] = txtEndPressure1.text
 		}
 		if (usedCyl[2] != null) {
 			usedCyl[2] = cylinderBox2.currentText
 			usedGas[2] = txtGasMix0.text
+			startpressure[2] = txtStartPressure2.text
+			endpressure[2] = txtEndPressure2.text
 		}
 		if (usedCyl[3] != null) {
 			usedCyl[3] = cylinderBox3.currentText
 			usedGas[3] = txtGasMix0.text
+			startpressure[3] = txtStartPressure3.text
+			endpressure[3] = txtEndPressure3.text
 		}
 		if (usedCyl[4] != null) {
 			usedCyl[4] = cylinderBox4.currentText
 			usedGas[4] = txtGasMix0.text
+			startpressure[4] = txtStartPressure4.text
+			endpressure[4] = txtEndPressure4.text
 		}
 
 		// apply the changes to the dive_table
@@ -97,8 +107,8 @@ Item {
 				      detailsEdit.depthText, detailsEdit.airtempText, detailsEdit.watertempText,
 				      suitBox.currentText != "" ? suitBox.currentText : suitBox.editText, buddyBox.editText,
 				      divemasterBox.currentText != "" ? divemasterBox.currentText : divemasterBox.editText,
-				      detailsEdit.weightText, detailsEdit.notesText, detailsEdit.startpressureText,
-				      detailsEdit.endpressureText, usedGas, usedCyl ,
+				      detailsEdit.weightText, detailsEdit.notesText, startpressure,
+				      endpressure, usedGas, usedCyl ,
 				      detailsEdit.rating,
 				      detailsEdit.visibility)
 		// trigger the profile to be redrawn
@@ -377,6 +387,7 @@ Item {
 			}
 			Controls.TextField {
 				id: txtStartPressure0
+				text: startpressure[0] != null ? startpressure[0] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -390,6 +401,7 @@ Item {
 			}
 			Controls.TextField {
 				id: txtEndPressure0
+				text: endpressure[0] != null ? endpressure[0] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -438,6 +450,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtStartPressure1
+				text: startpressure[1] != null ? startpressure[1] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -453,6 +466,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtEndPressure1
+				text: endpressure[1] != null ? endpressure[1] : null 
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -502,6 +516,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtStartPressure2
+				text: startpressure[2] != null ? startpressure[2] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -517,6 +532,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtEndPressure2
+				text: endpressure[2] != null ? endpressure[2] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -566,6 +582,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtStartPressure3
+				text: startpressure[3] != null ? startpressure[3] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -581,6 +598,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtEndPressure3
+				text: endpressure[3] != null ? endpressure[3] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -630,6 +648,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtStartPressure4
+				text: startpressure[4] != null ? startpressure[4] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -645,6 +664,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtEndPressure4
+				text: endpressure[4] != null ? endpressure[4] : null
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -22,23 +22,27 @@ Item {
 	property alias buddyText: buddyBox.editText
 	property alias divemasterIndex: divemasterBox.currentIndex
 	property alias divemasterText: divemasterBox.editText
-	property alias cylinderIndex: cylinderBox.currentIndex
-	property alias cylinderText: cylinderBox.editText
+	property alias cylinderIndex0: cylinderBox0.currentIndex
+	property alias cylinderIndex1: cylinderBox1.currentIndex
+	property alias cylinderIndex2: cylinderBox2.currentIndex
+	property alias cylinderIndex3: cylinderBox3.currentIndex
+	property alias cylinderIndex4: cylinderBox4.currentIndex
 	property alias notesText: txtNotes.text
 	property alias durationText: txtDuration.text
 	property alias depthText: txtDepth.text
 	property alias weightText: txtWeight.text
-	property alias startpressureText: txtStartPressure.text
-	property alias endpressureText: txtEndPressure.text
-	property alias gasmixText: txtGasMix.text
+	property alias startpressureText0: txtStartPressure0.text
+	property alias endpressureText0: txtEndPressure0.text
+	property alias gasmixText0: txtGasMix0.text
 	property alias gpsCheckbox: checkboxGPS.checked
 	property alias suitModel: suitBox.model
 	property alias divemasterModel: divemasterBox.model
 	property alias buddyModel: buddyBox.model
-	property alias cylinderModel: cylinderBox.model
+	property alias cylinderModel: cylinderBox0.model
 	property alias locationModel: locationBox.model
 	property int rating
 	property int visibility
+	property var usedCyl: []
 
 	function clearDetailsEdit() {
 		detailsEdit.dive_id = 0
@@ -54,7 +58,11 @@ Item {
 		suitBox.currentIndex = -1
 		buddyBox.currentIndex = -1
 		divemasterBox.currentIndex = -1
-		cylinderBox.currentIndex = -1
+		cylinderBox0.currentIndex = -1
+		cylinderBox1.currentIndex = -1
+		cylinderBox2.currentIndex = -1
+		cylinderBox3.currentIndex = -1
+		cylinderBox4.currentIndex = -1
 		detailsEdit.notesText = ""
 		detailsEdit.rating = 0
 		detailsEdit.visibility = 0
@@ -311,14 +319,15 @@ Item {
 					focus = false
 				}
 			}
-
+// all cylinder info should be able to become dynamic instead of this blob of code.
+// first cylinder
 			Controls.Label {
 				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder:")
+				text: qsTr("Cylinder1:")
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
 			Controls.ComboBox {
-				id: cylinderBox
+				id: cylinderBox0
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
@@ -332,7 +341,7 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
 			Controls.TextField {
-				id: txtGasMix
+				id: txtGasMix0
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {
@@ -346,7 +355,7 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
 			Controls.TextField {
-				id: txtStartPressure
+				id: txtStartPressure0
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false
@@ -359,7 +368,258 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
 			Controls.TextField {
-				id: txtEndPressure
+				id: txtEndPressure0
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+//second cylinder
+			Controls.Label {
+				visible: usedCyl[1] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Cylinder2:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.ComboBox {
+				visible: usedCyl[1] != null ? true : false
+				id: cylinderBox1
+				flat: true
+				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+				inputMethodHints: Qt.ImhNoPredictiveText
+				Layout.fillWidth: true
+			}
+
+			Controls.Label {
+				visible: usedCyl[1] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Gas mix:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[1] != null ? true : false
+				id: txtGasMix1
+				Layout.fillWidth: true
+				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[1] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Start Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[1] != null ? true : false
+				id: txtStartPressure1
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[1] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("End Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[1] != null ? true : false
+				id: txtEndPressure1
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+// third cylinder
+			Controls.Label {
+				visible: usedCyl[2] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Cylinder3:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.ComboBox {
+				visible: usedCyl[2] != null ? true : false
+				id: cylinderBox2
+				currentIndex: find(usedCyl[2])
+				flat: true
+				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+				inputMethodHints: Qt.ImhNoPredictiveText
+				Layout.fillWidth: true
+			}
+
+			Controls.Label {
+				visible: usedCyl[2] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Gas mix:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[2] != null ? true : false
+				id: txtGasMix2
+				Layout.fillWidth: true
+				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[2] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Start Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[2] != null ? true : false
+				id: txtStartPressure2
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[2] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("End Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[2] != null ? true : false
+				id: txtEndPressure2
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+// fourth cylinder
+			Controls.Label {
+				visible: usedCyl[3] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Cylinder4:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.ComboBox {
+				visible: usedCyl[3] != null ? true : false
+				id: cylinderBox3
+				currentIndex: find(usedCyl[3])
+				flat: true
+				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+				inputMethodHints: Qt.ImhNoPredictiveText
+				Layout.fillWidth: true
+			}
+
+			Controls.Label {
+				visible: usedCyl[3] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Gas mix:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[3] != null ? true : false
+				id: txtGasMix3
+				Layout.fillWidth: true
+				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[3] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Start Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[3] != null ? true : false
+				id: txtStartPressure3
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[3] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("End Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[3] != null ? true : false
+				id: txtEndPressure3
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+// fifth cylinder
+			Controls.Label {
+				visible: usedCyl[4] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Cylinder5:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.ComboBox {
+				visible: usedCyl[4] != null ? true : false
+				id: cylinderBox4
+				currentIndex: find(usedCyl[4])
+				flat: true
+				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+				inputMethodHints: Qt.ImhNoPredictiveText
+				Layout.fillWidth: true
+			}
+
+			Controls.Label {
+				visible: usedCyl[4] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Gas mix:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[4] != null ? true : false
+				id: txtGasMix4
+				Layout.fillWidth: true
+				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[4] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Start Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[4] != null ? true : false
+				id: txtStartPressure4
+				Layout.fillWidth: true
+				onEditingFinished: {
+					focus = false
+				}
+			}
+
+			Controls.Label {
+				visible: usedCyl[4] != null ? true : false
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("End Pressure:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.TextField {
+				visible: usedCyl[4] != null ? true : false
+				id: txtEndPressure4
 				Layout.fillWidth: true
 				onEditingFinished: {
 					focus = false

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -33,7 +33,7 @@ Item {
 	property alias weightText: txtWeight.text
 	property alias startpressureText0: txtStartPressure0.text
 	property alias endpressureText0: txtEndPressure0.text
-	property alias gasmixText0: txtGasMix0.text
+	property var usedGas: []
 	property alias gpsCheckbox: checkboxGPS.checked
 	property alias suitModel: suitBox.model
 	property alias divemasterModel: divemasterBox.model
@@ -357,6 +357,7 @@ Item {
 			}
 			Controls.TextField {
 				id: txtGasMix0
+				text: usedGas[0] != null ? usedGas[0] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {
@@ -415,6 +416,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtGasMix1
+				text: usedGas[1] != null ? usedGas[1] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {
@@ -478,6 +480,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtGasMix2
+				text: usedGas[2] != null ? usedGas[2] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {
@@ -541,6 +544,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtGasMix3
+				text: usedGas[3] != null ? usedGas[3] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {
@@ -604,6 +608,7 @@ Item {
 			Controls.TextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtGasMix4
+				text: usedGas[4] != null ? usedGas[4] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 				onEditingFinished: {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -70,14 +70,30 @@ Item {
 
 	function saveData() {
 		diveDetailsPage.state = "view" // run the transition
+		// join cylinder info from separate string into a list.
+		if (usedCyl[0] != null) {
+			usedCyl[0] = cylinderBox0.currentText
+		}
+		if (usedCyl[1] != null) {
+			usedCyl[1] = cylinderBox1.currentText
+		}
+		if (usedCyl[2] != null) {
+			usedCyl[2] = cylinderBox2.currentText
+		}
+		if (usedCyl[3] != null) {
+			usedCyl[3] = cylinderBox3.currentText
+		}
+		if (usedCyl[4] != null) {
+			usedCyl[4] = cylinderBox4.currentText
+		}
+
 		// apply the changes to the dive_table
 		manager.commitChanges(dive_id, detailsEdit.dateText, locationBox.editText, detailsEdit.gpsText, detailsEdit.durationText,
 				      detailsEdit.depthText, detailsEdit.airtempText, detailsEdit.watertempText,
 				      suitBox.currentText != "" ? suitBox.currentText : suitBox.editText, buddyBox.editText,
 				      divemasterBox.currentText != "" ? divemasterBox.currentText : divemasterBox.editText,
 				      detailsEdit.weightText, detailsEdit.notesText, detailsEdit.startpressureText,
-				      detailsEdit.endpressureText, detailsEdit.gasmixText,
-				      cylinderBox.currentText != "" ? cylinderBox.currentText : cylinderBox.editText,
+				      detailsEdit.endpressureText, detailsEdit.gasmixText, usedCyl ,
 				      detailsEdit.rating,
 				      detailsEdit.visibility)
 		// trigger the profile to be redrawn
@@ -97,7 +113,6 @@ Item {
 		diveDetailsListView.currentItem.modelData.suit = suitBox.currentText
 		diveDetailsListView.currentItem.modelData.buddy = buddyBox.currentText
 		diveDetailsListView.currentItem.modelData.divemaster = divemasterBox.currentText
-		diveDetailsListView.currentItem.modelData.cylinder = cylinderBox.currentText
 		diveDetailsListView.currentItem.modelData.notes = detailsEdit.notesText
 		diveDetailsListView.currentItem.modelData.rating = detailsEdit.rating
 		diveDetailsListView.currentItem.modelData.visibility = detailsEdit.visibility

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -73,6 +73,7 @@ Item {
 	}
 
 	function saveData() {
+		var state =  diveDetailsPage.state
 		diveDetailsPage.state = "view" // run the transition
 		// join cylinder info from separate string into a list.
 		if (usedCyl[0] != null) {
@@ -114,7 +115,7 @@ Item {
 				      detailsEdit.weightText, detailsEdit.notesText, startpressure,
 				      endpressure, usedGas, usedCyl ,
 				      detailsEdit.rating,
-				      detailsEdit.visibility)
+				      detailsEdit.visibility, state)
 		// trigger the profile to be redrawn
 		QMLProfile.diveId = dive_id
 

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -306,7 +306,7 @@ Item {
 		//------------
 		Controls.Label {
 			id: txtCylinder
-			text: dive.getCylinder
+			text: dive.getCylinder.join(', ')
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 		}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -95,13 +95,17 @@ Kirigami.ApplicationWindow {
 		detailsWindow.suitModel = manager.suitList
 		detailsWindow.suitIndex = -1
 		detailsWindow.suitText = ""
-		detailsWindow.cylinderModel = manager.cylinderInit
-		detailsWindow.cylinderIndex = -1
-		detailsWindow.cylinderText = ""
+		detailsWindow.cylinderModel0 = manager.cylinderInit
+		detailsWindow.cylinderModel1 = manager.cylinderInit
+		detailsWindow.cylinderModel2 = manager.cylinderInit
+		detailsWindow.cylinderModel3 = manager.cylinderInit
+		detailsWindow.cylinderModel4 = manager.cylinderInit
+		detailsWindow.cylinderIndex0 = -1
+		detailsWindow.usedCyl = ["",]
 		detailsWindow.weight = ""
-		detailsWindow.gasmix = ""
-		detailsWindow.startpressure = ""
-		detailsWindow.endpressure = ""
+		detailsWindow.usedGas = []
+		detailsWindow.startpressure = []
+		detailsWindow.endpressure = []
 		detailsWindow.gpsCheckbox = false
 		stackView.push(detailsWindow)
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1003,7 +1003,7 @@ bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
 // update the dive and return the notes field, stripped of the HTML junk
 void QMLManager::commitChanges(QString diveId, QString date, QString location, QString gps, QString duration, QString depth,
 			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveMaster, QString weight, QString notes,
-			       QString startpressure, QString endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility)
+			       QStringList startpressure, QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility)
 {
 	struct dive *d = get_dive_by_uniq_id(diveId.toInt());
 
@@ -1049,10 +1049,17 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	// start and end pressures for first cylinder only
 	if (myDive->startPressure() != startpressure || myDive->endPressure() != endpressure) {
 		diveChanged = true;
-		d->cylinder[0].start.mbar = parsePressureToMbar(startpressure);
-		d->cylinder[0].end.mbar = parsePressureToMbar(endpressure);
-		if (d->cylinder[0].end.mbar > d->cylinder[0].start.mbar)
-			d->cylinder[0].end.mbar = d->cylinder[0].start.mbar;
+		for ( int i = 0, j = 0 ; j < startpressure.length() && j < endpressure.length() ; i++ ) {
+			if (!is_cylinder_used(d, i))
+				continue;
+
+			d->cylinder[i].start.mbar = parsePressureToMbar(startpressure[j]);
+			d->cylinder[i].end.mbar = parsePressureToMbar(endpressure[j]);
+			if (d->cylinder[i].end.mbar > d->cylinder[i].start.mbar)
+				d->cylinder[i].end.mbar = d->cylinder[i].start.mbar;
+
+			j++;
+		}
 	}
 	// gasmix for first cylinder
 	if (myDive->firstGas() != gasmix) {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1003,7 +1003,7 @@ bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
 // update the dive and return the notes field, stripped of the HTML junk
 void QMLManager::commitChanges(QString diveId, QString date, QString location, QString gps, QString duration, QString depth,
 			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveMaster, QString weight, QString notes,
-			       QStringList startpressure, QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility)
+			       QStringList startpressure, QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state)
 {
 	struct dive *d = get_dive_by_uniq_id(diveId.toInt());
 
@@ -1050,7 +1050,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	if (myDive->startPressure() != startpressure || myDive->endPressure() != endpressure) {
 		diveChanged = true;
 		for ( int i = 0, j = 0 ; j < startpressure.length() && j < endpressure.length() ; i++ ) {
-			if (!is_cylinder_used(d, i))
+			if (state != "add" && !is_cylinder_used(d, i))
 				continue;
 
 			d->cylinder[i].start.mbar = parsePressureToMbar(startpressure[j]);
@@ -1064,7 +1064,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	// gasmix for first cylinder
 	if (myDive->firstGas() != gasmix) {
 		for ( int i = 0, j = 0 ; j < gasmix.length() ; i++ ) {
-			if (!is_cylinder_used(d, i))
+			if (state != "add" && !is_cylinder_used(d, i))
 				continue;
 
 			int o2 = parseGasMixO2(gasmix[j]);
@@ -1085,8 +1085,8 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		diveChanged = true;
 		unsigned long i;
 		int size = 0, wp = 0, j = 0, k = 0;
-		for (j = 0; k < usedCylinder.length() ; j++) {
-			if (!is_cylinder_used(d, j))
+		for (j = 0; k < usedCylinder.length() && j < MAX_CYLINDERS; j++) {
+			if (state != "add" && !is_cylinder_used(d, j))
 				continue;
 
 			for (i = 0; i < MAX_TANK_INFO && tank_info[i].name != NULL; i++) {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1611,6 +1611,14 @@ QStringList QMLManager::cylinderInit() const
 				cylinders << d->cylinder[j].type.description;
 		}
 	}
+
+	for (unsigned long ti = 0; ti < MAX_TANK_INFO && tank_info[ti].name != NULL; ti++) {
+		QString cyl = tank_info[ti].name;
+		if (cyl == "")
+			continue;
+		cylinders << cyl;
+	}
+
 	cylinders.removeDuplicates();
 	cylinders.sort();
 	return cylinders;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1003,7 +1003,7 @@ bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
 // update the dive and return the notes field, stripped of the HTML junk
 void QMLManager::commitChanges(QString diveId, QString date, QString location, QString gps, QString duration, QString depth,
 			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveMaster, QString weight, QString notes,
-			       QString startpressure, QString endpressure, QString gasmix, QStringList usedCylinder, int rating, int visibility)
+			       QString startpressure, QString endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility)
 {
 	struct dive *d = get_dive_by_uniq_id(diveId.toInt());
 
@@ -1056,15 +1056,21 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	}
 	// gasmix for first cylinder
 	if (myDive->firstGas() != gasmix) {
-		int o2 = parseGasMixO2(gasmix);
-		int he = parseGasMixHE(gasmix);
-		// the QML code SHOULD only accept valid gas mixes, but just to make sure
-		if (o2 >= 0 && o2 <= 1000 &&
-		    he >= 0 && he <= 1000 &&
-		    o2 + he <= 1000) {
-			diveChanged = true;
-			d->cylinder[0].gasmix.o2.permille = o2;
-			d->cylinder[0].gasmix.he.permille = he;
+		for ( int i = 0, j = 0 ; j < gasmix.length() ; i++ ) {
+			if (!is_cylinder_used(d, i))
+				continue;
+
+			int o2 = parseGasMixO2(gasmix[j]);
+			int he = parseGasMixHE(gasmix[j]);
+			// the QML code SHOULD only accept valid gas mixes, but just to make sure
+			if (o2 >= 0 && o2 <= 1000 &&
+				he >= 0 && he <= 1000 &&
+				o2 + he <= 1000) {
+				diveChanged = true;
+				d->cylinder[i].gasmix.o2.permille = o2;
+				d->cylinder[i].gasmix.he.permille = he;
+			}
+			j++;
 		}
 	}
 	// info for first cylinder

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1003,7 +1003,7 @@ bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
 // update the dive and return the notes field, stripped of the HTML junk
 void QMLManager::commitChanges(QString diveId, QString date, QString location, QString gps, QString duration, QString depth,
 			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveMaster, QString weight, QString notes,
-			       QString startpressure, QString endpressure, QString gasmix, QString cylinder, int rating, int visibility)
+			       QString startpressure, QString endpressure, QString gasmix, QStringList usedCylinder, int rating, int visibility)
 {
 	struct dive *d = get_dive_by_uniq_id(diveId.toInt());
 
@@ -1068,26 +1068,31 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// info for first cylinder
-	if (myDive->getCylinder() != cylinder) {
+	if (myDive->getCylinder() != usedCylinder) {
 		diveChanged = true;
 		unsigned long i;
-		int size = 0, wp = 0;
-		for (i = 0; i < MAX_TANK_INFO && tank_info[i].name != NULL; i++) {
-			if (tank_info[i].name == cylinder ) {
-				if (tank_info[i].ml > 0){
-					size = tank_info[i].ml;
-					wp = tank_info[i].bar * 1000;
-				} else {
-					size = (int) (cuft_to_l(tank_info[i].cuft) * 1000 / bar_to_atm(psi_to_bar(tank_info[i].psi)));
-					wp = psi_to_mbar(tank_info[i].psi);
-				}
-				break;
-			}
+		int size = 0, wp = 0, j = 0, k = 0;
+		for (j = 0; k < usedCylinder.length() ; j++) {
+			if (!is_cylinder_used(d, j))
+				continue;
 
+			for (i = 0; i < MAX_TANK_INFO && tank_info[i].name != NULL; i++) {
+				if (tank_info[i].name == usedCylinder[k] ) {
+					if (tank_info[i].ml > 0){
+						size = tank_info[i].ml;
+						wp = tank_info[i].bar * 1000;
+					} else {
+						size = (int) (cuft_to_l(tank_info[i].cuft) * 1000 / bar_to_atm(psi_to_bar(tank_info[i].psi)));
+						wp = psi_to_mbar(tank_info[i].psi);
+					}
+					break;
+				}
+			}
+			d->cylinder[j].type.description = copy_qstring(usedCylinder[k]);
+			d->cylinder[j].type.size.mliter = size;
+			d->cylinder[j].type.workingpressure.mbar = wp;
+			k++;
 		}
-		d->cylinder[0].type.description = copy_qstring(cylinder);
-		d->cylinder[0].type.size.mliter = size;
-		d->cylinder[0].type.workingpressure.mbar = wp;
 	}
 	if (myDive->suit() != suit) {
 		diveChanged = true;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -156,7 +156,7 @@ public slots:
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
 			   QString diveMaster, QString weight, QString notes, QString startpressure,
-			   QString endpressure, QString gasmix, QString cylinder, int rating, int visibility);
+			   QString endpressure, QString gasmix, QStringList usedCylinder, int rating, int visibility);
 	void changesNeedSaving();
 	void openNoCloudRepo();
 	void saveChangesLocal();

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -155,8 +155,8 @@ public slots:
 	void commitChanges(QString diveId, QString date, QString location, QString gps,
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
-			   QString diveMaster, QString weight, QString notes, QString startpressure,
-			   QString endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility);
+			   QString diveMaster, QString weight, QString notes, QStringList startpressure,
+			   QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility);
 	void changesNeedSaving();
 	void openNoCloudRepo();
 	void saveChangesLocal();

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -156,7 +156,7 @@ public slots:
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
 			   QString diveMaster, QString weight, QString notes, QStringList startpressure,
-			   QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility);
+			   QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state);
 	void changesNeedSaving();
 	void openNoCloudRepo();
 	void saveChangesLocal();

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -156,7 +156,7 @@ public slots:
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
 			   QString diveMaster, QString weight, QString notes, QString startpressure,
-			   QString endpressure, QString gasmix, QStringList usedCylinder, int rating, int visibility);
+			   QString endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility);
 	void changesNeedSaving();
 	void openNoCloudRepo();
 	void saveChangesLocal();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
We have had multiple requests both here #547 and on the ML to support editing multiple gas mixes and cylinders on the mobile app.
This PR is a stab at enabling that functionality without cluttering the UI.
The solution is to display multiple cylinders as comma separated list on the dive details page.

When editing a dive with multiple cylinders only the used cylinders are displayed on the edit page.

When adding a new dive manually on the mobile app there is a limit to a single cylinder as we don't yet have the option to insert a gas switch event.

### Changes made:
1) Displays all used cylinders when viewing info for a dive.
2) Allow the user the user to edit multiple cylinders using the current GUI, in order not to clutter the UI only the cylinders that are in use are displayed.

### Related issues:
Fixes #547

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
- Mobile: enable editing of multiple cylinders in a dive

### Documentation change:
The user can edit cylinder information for a dive that uses multiple cylinders on the mobile app.
Adding a dive manually is restricted to a single cylinder since we can not create gas switch events in the mobile app.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
