### PR TITLE
mobile-widgets: solve cloudstatus register problem

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -269,12 +269,12 @@ void QMLManager::openLocalThenRemote(QString url)
 		 *    no cloud repo solves this.
 		 */
 
-		if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD)
-			QMLPrefs::instance()->setCredentialStatus(CS_NEED_TO_VERIFY);
+		if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD)
+			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
-		if (QMLPrefs::instance()->credentialStatus() == CS_UNKNOWN)
-			QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
+		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_UNKNOWN)
+			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
 		prefs.unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
 			git_prefs.units = IMPERIAL_units;
@@ -292,11 +292,11 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
 	}
-	if (QMLPrefs::instance()->credentialStatus() == CS_NEED_TO_VERIFY) {
+	if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NEED_TO_VERIFY) {
 		appendTextToLog(QStringLiteral("have cloud credentials, but still needs PIN"));
 		QMLPrefs::instance()->setShowPin(true);
 	}
-	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
 		// if we switch to credentials from CS_NOCLOUD, we take things online temporarily
 		prefs.git_local_only = false;
 		appendTextToLog(QStringLiteral("taking things online to be able to switch to cloud account"));
@@ -373,7 +373,7 @@ void QMLManager::finishSetup()
 	QMLPrefs::instance()->setCloudUserName(prefs.cloud_storage_email);
 	QMLPrefs::instance()->setCloudPassword(prefs.cloud_storage_password);
 	setSyncToCloud(!prefs.git_local_only);
-	QMLPrefs::instance()->setCredentialStatus((cloud_status) prefs.cloud_verification_status);
+	QMLPrefs::instance()->setCredentialStatus((QMLPrefs::cloud_status) prefs.cloud_verification_status);
 	// if the cloud credentials are valid, we should get the GPS Webservice ID as well
 	QString url;
 	if (!QMLPrefs::instance()->cloudUserName().isEmpty() &&
@@ -384,8 +384,8 @@ void QMLManager::finishSetup()
 		alreadySaving = true;
 		openLocalThenRemote(url);
 	} else if (!empty_string(existing_filename) &&
-				QMLPrefs::instance()->credentialStatus() != CS_UNKNOWN) {
-		QMLPrefs::instance()->setCredentialStatus(CS_NOCLOUD);
+				QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_UNKNOWN) {
+		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename);
@@ -399,7 +399,7 @@ void QMLManager::finishSetup()
 			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(existing_filename));
 		}
 	} else {
-		QMLPrefs::instance()->setCredentialStatus(CS_UNKNOWN);
+		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_UNKNOWN);
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}
@@ -437,7 +437,7 @@ void QMLManager::saveCloudCredentials()
 	bool cloudCredentialsChanged = false;
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
-	if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD) {
+	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD) {
 		// in case of NO_CLOUD, the email address + passwd do not care, so do not check it.
 		if (QMLPrefs::instance()->cloudPassword().isEmpty() ||
 			!regExp.match(QMLPrefs::instance()->cloudPassword()).hasMatch() ||
@@ -467,7 +467,7 @@ void QMLManager::saveCloudCredentials()
 	cloudCredentialsChanged |= !same_string(prefs.cloud_storage_password,
 								qPrintable(QMLPrefs::instance()->cloudPassword()));
 
-	if (QMLPrefs::instance()->credentialStatus() != CS_NOCLOUD &&
+	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD &&
 		!cloudCredentialsChanged) {
 		// just go back to the dive list
 		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::instance()->oldStatus());
@@ -478,7 +478,7 @@ void QMLManager::saveCloudCredentials()
 		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = copy_qstring(QMLPrefs::instance()->cloudPassword());
 	}
-	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
+	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
 		// we came from NOCLOUD and are connecting to a cloud account;
 		// since we already have dives in the table, let's remember that so we can keep them
 		noCloudToCloud = true;
@@ -508,7 +508,7 @@ void QMLManager::saveCloudCredentials()
 		currentGitLocalOnly = prefs.git_local_only;
 		prefs.git_local_only = false;
 		openLocalThenRemote(url);
-	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY &&
+	} else if (prefs.cloud_verification_status == QMLPrefs::CS_NEED_TO_VERIFY &&
 				!QMLPrefs::instance()->cloudPin().isEmpty()) {
 		// the user entered a PIN?
 		tryRetrieveDataFromBackend();
@@ -542,12 +542,12 @@ void QMLManager::tryRetrieveDataFromBackend()
 		}
 		myTimer.stop();
 		QMLPrefs::instance()->setCloudPin("");
-		if (prefs.cloud_verification_status == CS_INCORRECT_USER_PASSWD) {
+		if (prefs.cloud_verification_status == QMLPrefs::CS_INCORRECT_USER_PASSWD) {
 			appendTextToLog(QStringLiteral("Incorrect cloud credentials"));
 			setStartPageText(RED_FONT + tr("Incorrect cloud credentials") + END_FONT);
 			revertToNoCloudIfNeeded();
 			return;
-		} else if (prefs.cloud_verification_status != CS_VERIFIED) {
+		} else if (prefs.cloud_verification_status != QMLPrefs::CS_VERIFIED) {
 			// here we need to enter the PIN
 			appendTextToLog(QStringLiteral("Need to verify the email address - enter PIN"));
 			setStartPageText(RED_FONT + tr("Cannot connect to cloud storage - cloud account not verified") + END_FONT);
@@ -578,7 +578,7 @@ void QMLManager::provideAuth(QNetworkReply *reply, QAuthenticator *auth)
 		// OK, credentials have been tried and didn't work, so they are invalid
 		appendTextToLog("Cloud credentials are invalid");
 		setStartPageText(RED_FONT + tr("Cloud credentials are invalid") + END_FONT);
-		QMLPrefs::instance()->setCredentialStatus(CS_INCORRECT_USER_PASSWD);
+		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_INCORRECT_USER_PASSWD);
 		reply->disconnect();
 		reply->abort();
 		reply->deleteLater();
@@ -622,7 +622,7 @@ void QMLManager::retrieveUserid()
 		revertToNoCloudIfNeeded();
 		return;
 	}
-	QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
 	QString userid(prefs.userid);
 	if (userid.isEmpty()) {
 		if (empty_string(prefs.cloud_storage_email) || empty_string(prefs.cloud_storage_password)) {
@@ -641,7 +641,7 @@ void QMLManager::retrieveUserid()
 		s.setValue("subsurface_webservice_uid", prefs.userid);
 		s.sync();
 	}
-	QMLPrefs::instance()->setCredentialStatus(CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
 	setStartPageText(tr("Cloud credentials valid, loading dives..."));
 	// this only gets called with "alreadySaving" already locked
 	loadDivesWithValidCredentials();
@@ -726,7 +726,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		currentGitLocalOnly = false;
 		prefs.git_local_only = true;
 	}
-	if (QMLPrefs::instance()->oldStatus() == CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
 		// we tried to switch to a cloud account and had previously used local data,
 		// but connecting to the cloud account (and subsequently merging the local
 		// and cloud data) failed - so let's delete the cloud credentials and go
@@ -742,7 +742,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		prefs.cloud_storage_password = NULL;
 		QMLPrefs::instance()->setCloudUserName("");
 		QMLPrefs::instance()->setCloudPassword("");
-		QMLPrefs::instance()->setCredentialStatus(CS_NOCLOUD);
+		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
 		set_filename(NOCLOUD_LOCALSTORAGE);
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}
@@ -1202,7 +1202,7 @@ void QMLManager::openNoCloudRepo()
 void QMLManager::saveChangesLocal()
 {
 	if (unsaved_changes()) {
-		if (QMLPrefs::instance()->credentialStatus() == CS_NOCLOUD) {
+		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NOCLOUD) {
 			if (empty_string(existing_filename)) {
 				char *filename = NOCLOUD_LOCALSTORAGE;
 				git_create_local_repo(filename);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -11,10 +11,10 @@
 QMLPrefs *QMLPrefs::m_instance = NULL;
 
 QMLPrefs::QMLPrefs() :
-	m_credentialStatus(CS_UNKNOWN),
+	m_credentialStatus(QMLPrefs::CS_UNKNOWN),
 	m_developer(false),
 	m_distanceThreshold(1000),
-	m_oldStatus(CS_UNKNOWN),
+	m_oldStatus(QMLPrefs::CS_UNKNOWN),
 	m_showPin(false),
 	m_timeThreshold(60)
 {
@@ -69,16 +69,16 @@ void QMLPrefs::setCloudUserName(const QString &cloudUserName)
 	emit cloudUserNameChanged();
 }
 
-cloud_status QMLPrefs::credentialStatus() const
+QMLPrefs::cloud_status QMLPrefs::credentialStatus() const
 {
 	return m_credentialStatus;
 }
 
-void QMLPrefs::setCredentialStatus(const cloud_status value)
+void QMLPrefs::setCredentialStatus(const QMLPrefs::cloud_status value)
 {
 	if (m_credentialStatus != value) {
 		setOldStatus(m_credentialStatus);
-		if (value == CS_NOCLOUD) {
+		if (value == QMLPrefs::CS_NOCLOUD) {
 			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE);
 			clearCredentials();
@@ -105,12 +105,12 @@ void QMLPrefs::setDistanceThreshold(int distance)
 	emit distanceThresholdChanged();
 }
 
-cloud_status QMLPrefs::oldStatus() const
+QMLPrefs::cloud_status QMLPrefs::oldStatus() const
 {
 	return m_oldStatus;
 }
 
-void QMLPrefs::setOldStatus(const cloud_status value)
+void QMLPrefs::setOldStatus(const QMLPrefs::cloud_status value)
 {
 	if (m_oldStatus != value) {
 		m_oldStatus = value;
@@ -177,7 +177,7 @@ void QMLPrefs::cancelCredentialsPinSetup()
 	 */
 	QSettings s;
 	
-	setCredentialStatus(CS_UNKNOWN);
+	setCredentialStatus(QMLPrefs::CS_UNKNOWN);
 	s.beginGroup("CloudStorage");
 	s.setValue("email", m_cloudUserName);
 	s.setValue("password", m_cloudPassword);

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -8,7 +8,7 @@
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
-	Q_ENUMS(cloud_status)
+	Q_ENUM(cloud_status)
 	Q_PROPERTY(QString cloudPassword
 				MEMBER m_cloudPassword
 				WRITE setCloudPassword
@@ -51,6 +51,14 @@ class QMLPrefs : public QObject {
 				NOTIFY timeThresholdChanged)
 
 public:
+	enum cloud_status {
+		CS_UNKNOWN,
+		CS_INCORRECT_USER_PASSWD,
+		CS_NEED_TO_VERIFY,
+		CS_VERIFIED,
+		CS_NOCLOUD
+	};
+
 	QMLPrefs();
 	~QMLPrefs();
 


### PR DESCRIPTION
Use Q_ENUM instad of Q_ENUMS (which is depreciated) since it does the
meta registration for all Qt platforms.

Q_ENUM require the enum to be defined in the class and cannot refer to
a global class, therefore copied enum to class.

This commit is made to get the release to work, with minimal changes,
this class will be moved to qPref and the double definition solved

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Using Q_ENUMS works even though depreciated on some MAC development setups, however not all. As a temporary fix (for the release) the enum is again added to QMLPref and Q_ENUM is used.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh I do not know why it works (I run with the old code active on my ipad) when building on my mac, and not when you build, but this should solve the problem. 

Remark: This patch is currently NOT tested on iOS, as I work remote and cannot upload to my iPad.
