### PR TITLE
[RFC] Video-lite

### DIFF
--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -2,6 +2,7 @@
 #ifndef IMAGEDOWNLOADER_H
 #define IMAGEDOWNLOADER_H
 
+#include "metadata.h"
 #include <QImage>
 #include <QFuture>
 #include <QNetworkReply>
@@ -48,14 +49,24 @@ public slots:
 signals:
 	void thumbnailChanged(QString filename, QImage thumbnail);
 private:
+	struct Thumbnail {
+		QImage img;
+		mediatype_t type;
+	};
+
 	Thumbnailer();
+	static void addThumbnailToCache(const Thumbnail &thumbnail, const QString &picture_filename);
 	void recalculate(QString filename);
 	void processItem(QString filename, bool tryDownload);
+	Thumbnail getThumbnailFromCache(const QString &picture_filename);
+	Thumbnail fetchImage(const QString &filename, const QString &originalFilename, bool tryDownload);
+	Thumbnail getHashedImage(const QString &filename, bool tryDownload);
 
 	mutable QMutex lock;
 	QThreadPool pool;
 	QImage failImage;		// Shown when image-fetching fails
 	QImage dummyImage;		// Shown before thumbnail is fetched
+	QImage videoImage;		// Place holder for videos
 
 	QMap<QString,QFuture<void>> workingOn;
 };

--- a/core/metadata.h
+++ b/core/metadata.h
@@ -10,10 +10,11 @@ struct metadata {
 };
 
 enum mediatype_t {
-	MEDIATYPE_IO_ERROR,	// Couldn't read file
-	MEDIATYPE_UNKNOWN,	// Couldn't identify file
+	MEDIATYPE_UNKNOWN,		// Couldn't (yet) identify file
+	MEDIATYPE_IO_ERROR,		// Couldn't read file
 	MEDIATYPE_PICTURE,
 	MEDIATYPE_VIDEO,
+	MEDIATYPE_STILL_LOADING,	// Still processing in the background
 };
 
 #ifdef __cplusplus

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1209,11 +1209,19 @@ QString localFilePath(const QString &originalFilename)
 	return localFilenameOf.value(originalFilename, originalFilename);
 }
 
+// TODO: Apparently Qt has no simple way of listing the supported video
+// codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?
+const QStringList videoExtensionsList = {
+	".avi", ".mp4", ".mpeg", ".mpg", ".wmv"
+};
+
 QStringList imageExtensionFilters() {
 	QStringList filters;
 	foreach (QString format, QImageReader::supportedImageFormats()) {
 		filters.append(QString("*.").append(format));
 	}
+	foreach (const QString &format, videoExtensionsList)
+		filters.append("*" + format);
 	return filters;
 }
 

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -42,6 +42,7 @@ QByteArray getCurrentAppState();
 void setCurrentAppState(const QByteArray &state);
 void init_proxy();
 QString getUUID();
+extern const QStringList videoExtensionsList;
 QStringList imageExtensionFilters();
 char *intdup(int index);
 char *copy_qstring(const QString &);

--- a/icons/video.svg
+++ b/icons/video.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 22 22"
+   version="1.1"
+   id="svg25756">
+  <metadata
+     id="metadata25760">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3051">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      </style>
+  </defs>
+  <path
+     style="color:#4d4d4d;fill:currentColor;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+     d="M -0.02966098,-0.02966098 V 1.3519597 2.7335805 20.69465 22.076271 H 20.694652 22.076272 V 2.7335805 1.3519597 -0.02966098 Z M 4.1152013,2.7335805 H 17.93141 V 19.313029 H 4.1152013 Z M 1.3519597,4.1152013 H 2.7335805 V 5.4968221 H 1.3519597 Z m 17.9610703,0 h 1.381622 V 5.4968221 H 19.31303 Z M 1.3519597,6.8784429 H 2.7335805 V 8.2600635 H 1.3519597 Z m 6.908104,0 v 8.2897241 l 5.5264843,-4.144862 z m 11.0529663,0 h 1.381622 V 8.2600635 H 19.31303 Z M 1.3519597,9.6416852 H 2.7335805 V 11.023305 H 1.3519597 Z m 17.9610703,0 h 1.381622 V 11.023305 H 19.31303 Z M 1.3519597,12.404926 h 1.3816208 v 1.381621 H 1.3519597 Z m 17.9610703,0 h 1.381622 v 1.381621 H 19.31303 Z M 1.3519597,15.168167 h 1.3816208 v 1.381621 H 1.3519597 Z m 17.9610703,0 h 1.381622 v 1.381621 H 19.31303 Z M 1.3519597,17.931408 h 1.3816208 v 1.381621 H 1.3519597 Z m 17.9610703,0 h 1.381622 v 1.381621 H 19.31303 Z"
+     class="ColorScheme-Text"
+     id="path25754" />
+</svg>

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -92,5 +92,6 @@
         <file alias="preferences-desktop-locale-icon">icons/language.png</file>
         <file alias="preferences-other-icon">icons/defaults.png</file>
         <file alias="camera-icon">icons/camera.svg</file>
+        <file alias="video-icon">icons/video.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Because video-playback in #1456 was received with reservations, here is the lite-version: Import videos, but only show a dummy icon. On clicking the icon, the video is shown in the system viewer.

I hope we agree that nowadays this is a must-have feature.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Import dummy video icon.
2) Add list of video extensions and recognize video files.
3) Save to thumbnail file with an appropriate flag signaling "video".
