### PR TITLE
core: make qPref:cloud_status the only version of the enum

### DIFF
--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -52,7 +52,7 @@ void CloudStorageAuthenticate::uploadFinished()
 	CloudStorageSettings csSettings(parent());
 
 	if (cloudAuthReply == QLatin1String("[VERIFIED]") || cloudAuthReply == QLatin1String("[OK]")) {
-		csSettings.setVerificationStatus(CS_VERIFIED);
+		csSettings.setVerificationStatus(qPref::CS_VERIFIED);
 		/* TODO: Move this to a correct place
 		NotificationWidget *nw = MainWindow::instance()->getNotificationWidget();
 		if (nw->getNotificationText() == myLastError)
@@ -61,7 +61,7 @@ void CloudStorageAuthenticate::uploadFinished()
 		myLastError.clear();
 	} else if (cloudAuthReply == QLatin1String("[VERIFY]") ||
 		   cloudAuthReply == QLatin1String("Invalid PIN")) {
-		csSettings.setVerificationStatus(CS_NEED_TO_VERIFY);
+		csSettings.setVerificationStatus(qPref::CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {
 		free((void *)prefs.cloud_storage_password);
@@ -70,7 +70,7 @@ void CloudStorageAuthenticate::uploadFinished()
 		emit passwordChangeSuccessful();
 		return;
 	} else {
-		csSettings.setVerificationStatus(CS_INCORRECT_USER_PASSWD);
+		csSettings.setVerificationStatus(qPref::CS_INCORRECT_USER_PASSWD);
 		myLastError = cloudAuthReply;
 		report_error("%s", qPrintable(cloudAuthReply));
 	}

--- a/core/pref.h
+++ b/core/pref.h
@@ -213,14 +213,6 @@ enum def_file_behavior {
 	CLOUD_DEFAULT_FILE
 };
 
-enum cloud_status {
-	CS_UNKNOWN,
-	CS_INCORRECT_USER_PASSWD,
-	CS_NEED_TO_VERIFY,
-	CS_VERIFIED,
-	CS_NOCLOUD
-};
-
 extern struct preferences prefs, default_prefs, git_prefs;
 
 extern const char *system_divelist_default_font;

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qPref_private.h"
 #include "qPref.h"
+#include "ssrf-version.h"
 
 qPref::qPref(QObject *parent) : 
 	QObject(parent)
@@ -14,4 +15,14 @@ static qPref *self = new qPref;
 
 void qPref::loadSync(bool doSync)
 {
+}
+
+const QString qPref::canonical_version() const
+{
+	return QString(CANONICAL_VERSION_STRING);
+}
+
+const QString qPref::mobile_version() const
+{
+	return QString(MOBILE_VERSION_STRING);
 }

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -20,6 +20,14 @@ public:
 	void loadSync(bool doSync);
 
 public:
+	enum cloud_status {
+		CS_UNKNOWN,
+		CS_INCORRECT_USER_PASSWD,
+		CS_NEED_TO_VERIFY,
+		CS_VERIFIED,
+		CS_NOCLOUD
+	};
+
 
 private:
 };

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -11,6 +11,8 @@
 class qPref : public QObject {
 	Q_OBJECT
 	Q_ENUMS(cloud_status);
+	Q_PROPERTY(QString canonical_version READ canonical_version);
+	Q_PROPERTY(QString mobile_version READ mobile_version);
 
 public:
 	qPref(QObject *parent = NULL);
@@ -28,6 +30,8 @@ public:
 		CS_NOCLOUD
 	};
 
+	const QString canonical_version() const;
+	const QString mobile_version() const;
 
 private:
 };

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -442,8 +442,8 @@ void MainWindow::on_actionDiveSiteEdit_triggered() {
 
 void MainWindow::enableDisableCloudActions()
 {
-	ui.actionCloudstorageopen->setEnabled(prefs.cloud_verification_status == CS_VERIFIED);
-	ui.actionCloudstoragesave->setEnabled(prefs.cloud_verification_status == CS_VERIFIED);
+	ui.actionCloudstorageopen->setEnabled(prefs.cloud_verification_status == qPref::CS_VERIFIED);
+	ui.actionCloudstoragesave->setEnabled(prefs.cloud_verification_status == qPref::CS_VERIFIED);
 }
 
 PlannerDetails *MainWindow::plannerDetails() const {
@@ -751,7 +751,7 @@ void MainWindow::closeCurrentFile()
 
 void MainWindow::updateCloudOnlineStatus()
 {
-	bool is_cloud = existing_filename && prefs.cloud_git_url && prefs.cloud_verification_status == CS_VERIFIED &&
+	bool is_cloud = existing_filename && prefs.cloud_git_url && prefs.cloud_verification_status == qPref::CS_VERIFIED &&
 			strstr(existing_filename, prefs.cloud_git_url);
 	ui.actionCloudOnline->setEnabled(is_cloud);
 	ui.actionCloudOnline->setChecked(is_cloud && !prefs.git_local_only);

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -3,6 +3,7 @@
 #include "ui_preferences_defaults.h"
 #include "core/dive.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include "core/settings/qPref.h"
 
 #include <QFileDialog>
 
@@ -61,7 +62,7 @@ void PreferencesDefaults::refreshSettings()
 	ui->velocitySlider->setValue(prefs.animation_speed);
 	ui->btnUseDefaultFile->setChecked(prefs.use_default_file);
 
-	if (prefs.cloud_verification_status == CS_VERIFIED) {
+	if (prefs.cloud_verification_status == qPref::CS_VERIFIED) {
 		ui->cloudDefaultFile->setEnabled(true);
 	} else {
 		if (ui->cloudDefaultFile->isChecked())

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -5,6 +5,7 @@
 #include "core/cloudstorage.h"
 #include "core/dive.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include "core/settings/qPref.h"
 #include <QNetworkProxy>
 
 PreferencesNetwork::PreferencesNetwork() : AbstractPreferencesWidget(tr("Network"),QIcon(":preferences-system-network-icon"), 9), ui(new Ui::PreferencesNetwork())
@@ -62,7 +63,7 @@ void PreferencesNetwork::syncSettings()
 	QString newpassword = ui->cloud_storage_new_passwd->text();
 
 	//TODO: Change this to the Cloud Storage Stuff, not preferences.
-	if (prefs.cloud_verification_status == CS_VERIFIED && !newpassword.isEmpty()) {
+	if (prefs.cloud_verification_status == qPref::CS_VERIFIED && !newpassword.isEmpty()) {
 		// deal with password change
 		if (!email.isEmpty() && !password.isEmpty()) {
 			// connect to backend server to check / create credentials
@@ -83,14 +84,14 @@ void PreferencesNetwork::syncSettings()
 			ui->cloud_storage_new_passwd->setText("");
 			cloud->setNewPassword(newpassword);
 		}
-	} else if (prefs.cloud_verification_status == CS_UNKNOWN ||
-		   prefs.cloud_verification_status == CS_INCORRECT_USER_PASSWD ||
+	} else if (prefs.cloud_verification_status == qPref::CS_UNKNOWN ||
+		   prefs.cloud_verification_status == qPref::CS_INCORRECT_USER_PASSWD ||
 		   email != prefs.cloud_storage_email ||
 		   password != prefs.cloud_storage_password) {
 
 		// different credentials - reset verification status
 		int oldVerificationStatus = cloud->verificationStatus();
-		cloud->setVerificationStatus(CS_UNKNOWN);
+		cloud->setVerificationStatus(qPref::CS_UNKNOWN);
 		if (!email.isEmpty() && !password.isEmpty()) {
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
@@ -103,7 +104,7 @@ void PreferencesNetwork::syncSettings()
 			connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesNetwork::updateCloudAuthenticationState);
 			cloudAuth->backend(email, password);
 		}
-	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY) {
+	} else if (prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY) {
 		QString pin = ui->cloud_storage_pin->text();
 		if (!pin.isEmpty()) {
 			// connect to backend server to check / create credentials
@@ -126,19 +127,19 @@ void PreferencesNetwork::syncSettings()
 
 void PreferencesNetwork::updateCloudAuthenticationState()
 {
-	ui->cloud_storage_pin->setEnabled(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
-	ui->cloud_storage_pin->setVisible(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
-	ui->cloud_storage_pin_label->setEnabled(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
-	ui->cloud_storage_pin_label->setVisible(prefs.cloud_verification_status == CS_NEED_TO_VERIFY);
-	ui->cloud_storage_new_passwd->setEnabled(prefs.cloud_verification_status == CS_VERIFIED);
-	ui->cloud_storage_new_passwd->setVisible(prefs.cloud_verification_status == CS_VERIFIED);
-	ui->cloud_storage_new_passwd_label->setEnabled(prefs.cloud_verification_status == CS_VERIFIED);
-	ui->cloud_storage_new_passwd_label->setVisible(prefs.cloud_verification_status == CS_VERIFIED);
-	if (prefs.cloud_verification_status == CS_VERIFIED) {
+	ui->cloud_storage_pin->setEnabled(prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY);
+	ui->cloud_storage_pin->setVisible(prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY);
+	ui->cloud_storage_pin_label->setEnabled(prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY);
+	ui->cloud_storage_pin_label->setVisible(prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY);
+	ui->cloud_storage_new_passwd->setEnabled(prefs.cloud_verification_status == qPref::CS_VERIFIED);
+	ui->cloud_storage_new_passwd->setVisible(prefs.cloud_verification_status == qPref::CS_VERIFIED);
+	ui->cloud_storage_new_passwd_label->setEnabled(prefs.cloud_verification_status == qPref::CS_VERIFIED);
+	ui->cloud_storage_new_passwd_label->setVisible(prefs.cloud_verification_status == qPref::CS_VERIFIED);
+	if (prefs.cloud_verification_status == qPref::CS_VERIFIED) {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (credentials verified)"));
-	} else if (prefs.cloud_verification_status == CS_INCORRECT_USER_PASSWD) {
+	} else if (prefs.cloud_verification_status == qPref::CS_INCORRECT_USER_PASSWD) {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (incorrect password)"));
-	} else if (prefs.cloud_verification_status == CS_NEED_TO_VERIFY) {
+	} else if (prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY) {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage (PIN required)"));
 	} else {
 		ui->cloudStorageGroupBox->setTitle(tr("Subsurface cloud storage"));

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -144,7 +144,7 @@ Item {
 				text: qsTr("No cloud mode")
 				onClicked: {
 					manager.syncToCloud = false
-					prefs.credentialStatus = QMLPrefs.CS_NOCLOUD
+					prefs.credentialStatus = SsrfPrefs.CS_NOCLOUD
 					manager.saveCloudCredentials()
 					manager.openNoCloudRepo()
 				}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -23,7 +23,7 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (prefs.credentialStatus === QMLPrefs.CS_VERIFIED) {
+			if (prefs.credentialStatus === SsrfPrefs.CS_VERIFIED) {
 				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
@@ -339,8 +339,8 @@ Kirigami.ScrollablePage {
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		opacity: credentialStatus === QMLPrefs.CS_NOCLOUD ||
-									(credentialStatus === QMLPrefs.CS_VERIFIED) ? 0 : 1
+		opacity: credentialStatus === SsrfPrefs.CS_NOCLOUD ||
+									(credentialStatus === SsrfPrefs.CS_VERIFIED) ? 0 : 1
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
@@ -348,8 +348,8 @@ Kirigami.ScrollablePage {
 				page.actions.main = null
 				page.actions.right = null
 				page.title = qsTr("Cloud credentials")
-			} else if (prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
-						prefs.credentialStatus === QMLPrefs.CS_NOCLOUD) {
+			} else if (prefs.credentialStatus === SsrfPrefs.CS_VERIFIED ||
+						prefs.credentialStatus === SsrfPrefs.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")
@@ -427,7 +427,7 @@ Kirigami.ScrollablePage {
 
 	onBackRequested: {
 		if (startPage.visible && diveListView.count > 0 &&
-			prefs.credentialStatus !== QMLPrefs.CS_INCORRECT_USER_PASSWD) {
+			prefs.credentialStatus !== SsrfPrefs.CS_INCORRECT_USER_PASSWD) {
 			prefs.credentialStatus = oldStatus
 			event.accepted = true;
 		}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -42,7 +42,7 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: prefs.credentialStatus === QMLPrefs.CS_NOCLOUD ? qsTr("Not applicable") : prefs.cloudUserName
+				text: prefs.credentialStatus === SsrfPrefs.CS_NOCLOUD ? qsTr("Not applicable") : prefs.cloudUserName
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -186,10 +186,10 @@ Kirigami.ApplicationWindow {
 				text: qsTr("Dive list")
 				onTriggered: {
 					manager.appendTextToLog("requested dive list with credential status " + prefs.credentialStatus)
-					if (prefs.credentialStatus == QMLPrefs.CS_UNKNOWN) {
+					if (prefs.credentialStatus == SsrfPrefs.CS_UNKNOWN) {
 						// the user has asked to change credentials - if the credentials before that
 						// were valid, go back to dive list
-						if (oldStatus == QMLPrefs.CS_VERIFIED) {
+						if (oldStatus == SsrfPrefs.CS_VERIFIED) {
 							prefs.credentialStatus = oldStatus
 						}
 					}
@@ -216,8 +216,8 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/ic_add.svg"
 					}
 					text: qsTr("Add dive manually")
-					enabled: prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
-							prefs.credentialStatus === QMLPrefs.CS_NOCLOUD
+					enabled: prefs.credentialStatus === SsrfPrefs.CS_VERIFIED ||
+							prefs.credentialStatus === SsrfPrefs.CS_NOCLOUD
 					onTriggered: {
 						globalDrawer.close()
 						returnTopPage()  // otherwise odd things happen with the page stack
@@ -251,14 +251,14 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/cloud_sync.svg"
 					}
 					text: qsTr("Manual sync with cloud")
-					enabled: prefs.credentialStatus === QMLPrefs.CS_VERIFIED ||
-							prefs.credentialStatus === QMLPrefs.CS_NOCLOUD
+					enabled: prefs.credentialStatus === SsrfPrefs.CS_VERIFIED ||
+							prefs.credentialStatus === SsrfPrefs.CS_NOCLOUD
 					onTriggered: {
-						if (prefs.credentialStatus === QMLPrefs.CS_NOCLOUD) {
+						if (prefs.credentialStatus === SsrfPrefs.CS_NOCLOUD) {
 							returnTopPage()
 							oldStatus = prefs.credentialStatus
 							manager.startPageText = "Enter valid cloud storage credentials"
-							prefs.credentialStatus = QMLPrefs.CS_UNKNOWN
+							prefs.credentialStatus = SsrfPrefs.CS_UNKNOWN
 							globalDrawer.close()
 						} else {
 							globalDrawer.close()
@@ -273,7 +273,7 @@ Kirigami.ApplicationWindow {
 					name: syncToCloud ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
 				text: syncToCloud ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
-					enabled: prefs.credentialStatus !== QMLPrefs.CS_NOCLOUD
+					enabled: prefs.credentialStatus !== SsrfPrefs.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
 						if (!syncToCloud) {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -269,12 +269,12 @@ void QMLManager::openLocalThenRemote(QString url)
 		 *    no cloud repo solves this.
 		 */
 
-		if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD)
-			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NEED_TO_VERIFY);
+		if (QMLPrefs::instance()->credentialStatus() != qPref::CS_NOCLOUD)
+			QMLPrefs::instance()->setCredentialStatus(qPref::CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
-		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_UNKNOWN)
-			QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+		if (QMLPrefs::instance()->credentialStatus() == qPref::CS_UNKNOWN)
+			QMLPrefs::instance()->setCredentialStatus(qPref::CS_VERIFIED);
 		prefs.unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
 			git_prefs.units = IMPERIAL_units;
@@ -292,11 +292,11 @@ void QMLManager::openLocalThenRemote(QString url)
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
 	}
-	if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NEED_TO_VERIFY) {
+	if (QMLPrefs::instance()->credentialStatus() == qPref::CS_NEED_TO_VERIFY) {
 		appendTextToLog(QStringLiteral("have cloud credentials, but still needs PIN"));
 		QMLPrefs::instance()->setShowPin(true);
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == qPref::CS_NOCLOUD) {
 		// if we switch to credentials from CS_NOCLOUD, we take things online temporarily
 		prefs.git_local_only = false;
 		appendTextToLog(QStringLiteral("taking things online to be able to switch to cloud account"));
@@ -373,7 +373,7 @@ void QMLManager::finishSetup()
 	QMLPrefs::instance()->setCloudUserName(prefs.cloud_storage_email);
 	QMLPrefs::instance()->setCloudPassword(prefs.cloud_storage_password);
 	setSyncToCloud(!prefs.git_local_only);
-	QMLPrefs::instance()->setCredentialStatus((QMLPrefs::cloud_status) prefs.cloud_verification_status);
+	QMLPrefs::instance()->setCredentialStatus((qPref::cloud_status) prefs.cloud_verification_status);
 	// if the cloud credentials are valid, we should get the GPS Webservice ID as well
 	QString url;
 	if (!QMLPrefs::instance()->cloudUserName().isEmpty() &&
@@ -384,8 +384,8 @@ void QMLManager::finishSetup()
 		alreadySaving = true;
 		openLocalThenRemote(url);
 	} else if (!empty_string(existing_filename) &&
-				QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_UNKNOWN) {
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
+				QMLPrefs::instance()->credentialStatus() != qPref::CS_UNKNOWN) {
+		QMLPrefs::instance()->setCredentialStatus(qPref::CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename);
@@ -399,7 +399,7 @@ void QMLManager::finishSetup()
 			appendTextToLog(QString("working in no-cloud mode, finished loading %1 dives from %2").arg(dive_table.nr).arg(existing_filename));
 		}
 	} else {
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_UNKNOWN);
+		QMLPrefs::instance()->setCredentialStatus(qPref::CS_UNKNOWN);
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}
@@ -437,7 +437,7 @@ void QMLManager::saveCloudCredentials()
 	bool cloudCredentialsChanged = false;
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
-	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->credentialStatus() != qPref::CS_NOCLOUD) {
 		// in case of NO_CLOUD, the email address + passwd do not care, so do not check it.
 		if (QMLPrefs::instance()->cloudPassword().isEmpty() ||
 			!regExp.match(QMLPrefs::instance()->cloudPassword()).hasMatch() ||
@@ -467,7 +467,7 @@ void QMLManager::saveCloudCredentials()
 	cloudCredentialsChanged |= !same_string(prefs.cloud_storage_password,
 								qPrintable(QMLPrefs::instance()->cloudPassword()));
 
-	if (QMLPrefs::instance()->credentialStatus() != QMLPrefs::CS_NOCLOUD &&
+	if (QMLPrefs::instance()->credentialStatus() != qPref::CS_NOCLOUD &&
 		!cloudCredentialsChanged) {
 		// just go back to the dive list
 		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::instance()->oldStatus());
@@ -478,7 +478,7 @@ void QMLManager::saveCloudCredentials()
 		free((void *)prefs.cloud_storage_password);
 		prefs.cloud_storage_password = copy_qstring(QMLPrefs::instance()->cloudPassword());
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
+	if (QMLPrefs::instance()->oldStatus() == qPref::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
 		// we came from NOCLOUD and are connecting to a cloud account;
 		// since we already have dives in the table, let's remember that so we can keep them
 		noCloudToCloud = true;
@@ -508,7 +508,7 @@ void QMLManager::saveCloudCredentials()
 		currentGitLocalOnly = prefs.git_local_only;
 		prefs.git_local_only = false;
 		openLocalThenRemote(url);
-	} else if (prefs.cloud_verification_status == QMLPrefs::CS_NEED_TO_VERIFY &&
+	} else if (prefs.cloud_verification_status == qPref::CS_NEED_TO_VERIFY &&
 				!QMLPrefs::instance()->cloudPin().isEmpty()) {
 		// the user entered a PIN?
 		tryRetrieveDataFromBackend();
@@ -542,12 +542,12 @@ void QMLManager::tryRetrieveDataFromBackend()
 		}
 		myTimer.stop();
 		QMLPrefs::instance()->setCloudPin("");
-		if (prefs.cloud_verification_status == QMLPrefs::CS_INCORRECT_USER_PASSWD) {
+		if (prefs.cloud_verification_status == qPref::CS_INCORRECT_USER_PASSWD) {
 			appendTextToLog(QStringLiteral("Incorrect cloud credentials"));
 			setStartPageText(RED_FONT + tr("Incorrect cloud credentials") + END_FONT);
 			revertToNoCloudIfNeeded();
 			return;
-		} else if (prefs.cloud_verification_status != QMLPrefs::CS_VERIFIED) {
+		} else if (prefs.cloud_verification_status != qPref::CS_VERIFIED) {
 			// here we need to enter the PIN
 			appendTextToLog(QStringLiteral("Need to verify the email address - enter PIN"));
 			setStartPageText(RED_FONT + tr("Cannot connect to cloud storage - cloud account not verified") + END_FONT);
@@ -578,7 +578,7 @@ void QMLManager::provideAuth(QNetworkReply *reply, QAuthenticator *auth)
 		// OK, credentials have been tried and didn't work, so they are invalid
 		appendTextToLog("Cloud credentials are invalid");
 		setStartPageText(RED_FONT + tr("Cloud credentials are invalid") + END_FONT);
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_INCORRECT_USER_PASSWD);
+		QMLPrefs::instance()->setCredentialStatus(qPref::CS_INCORRECT_USER_PASSWD);
 		reply->disconnect();
 		reply->abort();
 		reply->deleteLater();
@@ -622,7 +622,7 @@ void QMLManager::retrieveUserid()
 		revertToNoCloudIfNeeded();
 		return;
 	}
-	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(qPref::CS_VERIFIED);
 	QString userid(prefs.userid);
 	if (userid.isEmpty()) {
 		if (empty_string(prefs.cloud_storage_email) || empty_string(prefs.cloud_storage_password)) {
@@ -641,7 +641,7 @@ void QMLManager::retrieveUserid()
 		s.setValue("subsurface_webservice_uid", prefs.userid);
 		s.sync();
 	}
-	QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_VERIFIED);
+	QMLPrefs::instance()->setCredentialStatus(qPref::CS_VERIFIED);
 	setStartPageText(tr("Cloud credentials valid, loading dives..."));
 	// this only gets called with "alreadySaving" already locked
 	loadDivesWithValidCredentials();
@@ -726,7 +726,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		currentGitLocalOnly = false;
 		prefs.git_local_only = true;
 	}
-	if (QMLPrefs::instance()->oldStatus() == QMLPrefs::CS_NOCLOUD) {
+	if (QMLPrefs::instance()->oldStatus() == qPref::CS_NOCLOUD) {
 		// we tried to switch to a cloud account and had previously used local data,
 		// but connecting to the cloud account (and subsequently merging the local
 		// and cloud data) failed - so let's delete the cloud credentials and go
@@ -742,7 +742,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		prefs.cloud_storage_password = NULL;
 		QMLPrefs::instance()->setCloudUserName("");
 		QMLPrefs::instance()->setCloudPassword("");
-		QMLPrefs::instance()->setCredentialStatus(QMLPrefs::CS_NOCLOUD);
+		QMLPrefs::instance()->setCredentialStatus(qPref::CS_NOCLOUD);
 		set_filename(NOCLOUD_LOCALSTORAGE);
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}
@@ -1202,7 +1202,7 @@ void QMLManager::openNoCloudRepo()
 void QMLManager::saveChangesLocal()
 {
 	if (unsaved_changes()) {
-		if (QMLPrefs::instance()->credentialStatus() == QMLPrefs::CS_NOCLOUD) {
+		if (QMLPrefs::instance()->credentialStatus() == qPref::CS_NOCLOUD) {
 			if (empty_string(existing_filename)) {
 				char *filename = NOCLOUD_LOCALSTORAGE;
 				git_create_local_repo(filename);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -11,10 +11,10 @@
 QMLPrefs *QMLPrefs::m_instance = NULL;
 
 QMLPrefs::QMLPrefs() :
-	m_credentialStatus(QMLPrefs::CS_UNKNOWN),
+	m_credentialStatus(qPref::CS_UNKNOWN),
 	m_developer(false),
 	m_distanceThreshold(1000),
-	m_oldStatus(QMLPrefs::CS_UNKNOWN),
+	m_oldStatus(qPref::CS_UNKNOWN),
 	m_showPin(false),
 	m_timeThreshold(60)
 {
@@ -69,16 +69,16 @@ void QMLPrefs::setCloudUserName(const QString &cloudUserName)
 	emit cloudUserNameChanged();
 }
 
-QMLPrefs::cloud_status QMLPrefs::credentialStatus() const
+qPref::cloud_status QMLPrefs::credentialStatus() const
 {
 	return m_credentialStatus;
 }
 
-void QMLPrefs::setCredentialStatus(const QMLPrefs::cloud_status value)
+void QMLPrefs::setCredentialStatus(const qPref::cloud_status value)
 {
 	if (m_credentialStatus != value) {
 		setOldStatus(m_credentialStatus);
-		if (value == QMLPrefs::CS_NOCLOUD) {
+		if (value == qPref::CS_NOCLOUD) {
 			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE);
 			clearCredentials();
@@ -105,12 +105,12 @@ void QMLPrefs::setDistanceThreshold(int distance)
 	emit distanceThresholdChanged();
 }
 
-QMLPrefs::cloud_status QMLPrefs::oldStatus() const
+qPref::cloud_status QMLPrefs::oldStatus() const
 {
 	return m_oldStatus;
 }
 
-void QMLPrefs::setOldStatus(const QMLPrefs::cloud_status value)
+void QMLPrefs::setOldStatus(const qPref::cloud_status value)
 {
 	if (m_oldStatus != value) {
 		m_oldStatus = value;
@@ -177,7 +177,7 @@ void QMLPrefs::cancelCredentialsPinSetup()
 	 */
 	QSettings s;
 	
-	setCredentialStatus(QMLPrefs::CS_UNKNOWN);
+	setCredentialStatus(qPref::CS_UNKNOWN);
 	s.beginGroup("CloudStorage");
 	s.setValue("email", m_cloudUserName);
 	s.setValue("password", m_cloudPassword);

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -8,7 +8,6 @@
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
-	Q_ENUM(cloud_status)
 	Q_PROPERTY(QString cloudPassword
 				MEMBER m_cloudPassword
 				WRITE setCloudPassword
@@ -21,7 +20,7 @@ class QMLPrefs : public QObject {
 				MEMBER m_cloudUserName
 				WRITE setCloudUserName
 				NOTIFY cloudUserNameChanged)
-	Q_PROPERTY(cloud_status credentialStatus
+	Q_PROPERTY(qPref::cloud_status credentialStatus
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
 				NOTIFY credentialStatusChanged)
@@ -37,7 +36,7 @@ class QMLPrefs : public QObject {
 				MEMBER m_showPin
 				WRITE setShowPin
 				NOTIFY showPinChanged)
-	Q_PROPERTY(cloud_status oldStatus
+	Q_PROPERTY(qPref::cloud_status oldStatus
 				MEMBER m_oldStatus
 				WRITE setOldStatus
 				NOTIFY oldStatusChanged)
@@ -51,14 +50,6 @@ class QMLPrefs : public QObject {
 				NOTIFY timeThresholdChanged)
 
 public:
-	enum cloud_status {
-		CS_UNKNOWN,
-		CS_INCORRECT_USER_PASSWD,
-		CS_NEED_TO_VERIFY,
-		CS_VERIFIED,
-		CS_NOCLOUD
-	};
-
 	QMLPrefs();
 	~QMLPrefs();
 
@@ -73,16 +64,16 @@ public:
 	const QString cloudUserName() const;
 	void setCloudUserName(const QString &cloudUserName);
 
-	cloud_status credentialStatus() const;
-	void setCredentialStatus(const cloud_status value);
+	qPref::cloud_status credentialStatus() const;
+	void setCredentialStatus(const qPref::cloud_status value);
 
 	void setDeveloper(bool value);
 
 	int distanceThreshold() const;
 	void setDistanceThreshold(int distance);
 
-	cloud_status oldStatus() const;
-	void setOldStatus(const cloud_status value);
+	qPref::cloud_status oldStatus() const;
+	void setOldStatus(const qPref::cloud_status value);
 
 	bool showPin() const;
 	void setShowPin(bool enable);
@@ -101,11 +92,11 @@ private:
 	QString m_cloudPassword;
 	QString m_cloudPin;
 	QString m_cloudUserName;
-	cloud_status m_credentialStatus;
+	qPref::cloud_status m_credentialStatus;
 	bool m_developer;
 	int m_distanceThreshold;
 	static QMLPrefs *m_instance;
-	cloud_status m_oldStatus;
+	qPref::cloud_status m_oldStatus;
 	bool m_showPin;
 	int m_timeThreshold;
 

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -55,18 +55,37 @@ void init_ui()
 
 void run_ui()
 {
+	int rc;
 	LOG_STP("run_ui starting");
-	qmlRegisterType<qPref>("org.subsurfacedivelog.mobile", 1, 0, "SsrfPrefs");
-	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
-	qmlRegisterType<QMLPrefs>("org.subsurfacedivelog.mobile", 1, 0, "QMLPrefs");
-	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
+	rc = qmlRegisterType<qPref>("org.subsurfacedivelog.mobile", 1, 0, "SsrfPrefs");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register Prefs (class qPref), QML will not work!!";
+	rc = qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register QMLManager, QML will not work!!";
+	rc = qmlRegisterType<QMLPrefs>("org.subsurfacedivelog.mobile", 1, 0, "QMLPrefs");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register QMLPrefs, QML will not work!!";
+	rc = qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register QMLProfile, QML will not work!!";
 
-	qmlRegisterType<DownloadThread>("org.subsurfacedivelog.mobile", 1, 0, "DCDownloadThread");
-	qmlRegisterType<DiveImportedModel>("org.subsurfacedivelog.mobile", 1, 0, "DCImportModel");
+	rc = qmlRegisterType<DownloadThread>("org.subsurfacedivelog.mobile", 1, 0, "DCDownloadThread");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register DCDownloadThread, QML will not work!!";
+	rc = qmlRegisterType<DiveImportedModel>("org.subsurfacedivelog.mobile", 1, 0, "DCImportModel");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register DCImportModel, QML will not work!!";
 
-	qmlRegisterType<MapWidgetHelper>("org.subsurfacedivelog.mobile", 1, 0, "MapWidgetHelper");
-	qmlRegisterType<MapLocationModel>("org.subsurfacedivelog.mobile", 1, 0, "MapLocationModel");
-	qmlRegisterType<MapLocation>("org.subsurfacedivelog.mobile", 1, 0, "MapLocation");
+	rc = qmlRegisterType<MapWidgetHelper>("org.subsurfacedivelog.mobile", 1, 0, "MapWidgetHelper");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register MapWidgetHelper, QML will not work!!";
+	rc = qmlRegisterType<MapLocationModel>("org.subsurfacedivelog.mobile", 1, 0, "MapLocationModel");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register MapLocationModel, QML will not work!!";
+	rc = qmlRegisterType<MapLocation>("org.subsurfacedivelog.mobile", 1, 0, "MapLocation");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register MapLocation, QML will not work!!";
 
 	QQmlApplicationEngine engine;
 	LOG_STP("run_ui qml engine started");

--- a/subsurface-mobile-helper.cpp
+++ b/subsurface-mobile-helper.cpp
@@ -27,6 +27,7 @@
 #include "qt-models/messagehandlermodel.h"
 #include "map-widget/qmlmapwidgethelper.h"
 #include "qt-models/maplocationmodel.h"
+#include "core/settings/qPref.h"
 
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 
@@ -55,6 +56,7 @@ void init_ui()
 void run_ui()
 {
 	LOG_STP("run_ui starting");
+	qmlRegisterType<qPref>("org.subsurfacedivelog.mobile", 1, 0, "SsrfPrefs");
 	qmlRegisterType<QMLManager>("org.subsurfacedivelog.mobile", 1, 0, "QMLManager");
 	qmlRegisterType<QMLPrefs>("org.subsurfacedivelog.mobile", 1, 0, "QMLPrefs");
 	qmlRegisterType<QMLProfile>("org.subsurfacedivelog.mobile", 1, 0, "QMLProfile");


### PR DESCRIPTION
add enum to qPref and remove elsewhere
update source core to reference qPref.

the enum cannot be in pref.h because it is to be used in qml and Q_ENUM
need the enum to be defined as part of the class

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This extends the release bug fix in #1462 and present a final solution.

cloud_storage is only defined in the qPref class, and referenced elsewhere.

I have an idea on how to make QML test cases as well, but will do that later in another PR.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
