### PR TITLE
tests: make testpreferences.h loadable independent of testdive

### DIFF
--- a/tests/testpreferences.h
+++ b/tests/testpreferences.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
-#ifndef TESTDIVESITEDUPLICATION_H
-#define TESTDIVESITEDUPLICATION_H
+#ifndef TESTPREFERENCES_H
+#define TESTPREFERENCES_H
 
 #include <QTest>
 #include <functional>
@@ -13,4 +13,4 @@ private slots:
 	void testPreferences();
 };
 
-#endif // TESTDIVESITEDUPLICATION_H
+#endif // TESTPREFERENCES_H


### PR DESCRIPTION
set #ifdef TESTPREFERENCES in testpreferences.h so it can be loaded with other header files

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Testpreferences.h used “#ifdef TESTDIVESITEDUPLICATION_H”, changed to
TESTPREFERENCES_H

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
