### PR TITLE
save-git: allocate user_info members on the heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Cloud storage: fix potential issue with credentials on Linux [#1346]
 - Mobile/iOS: fix missing translations
 - Dive pictures: locate moved pictures based on filename and path
 - Profile: Context menu entry to manually split a dive

--- a/core/dive.h
+++ b/core/dive.h
@@ -712,8 +712,8 @@ int cylinderuse_from_text(const char *text);
 
 
 struct user_info {
-	const char *name;
-	const char *email;
+	char *name;
+	char *email;
 };
 
 extern void subsurface_user_info(struct user_info *);

--- a/core/linux.c
+++ b/core/linux.c
@@ -39,7 +39,7 @@ void subsurface_user_info(struct user_info *user)
 
 	if (pwd) {
 		if (!empty_string(pwd->pw_gecos))
-			user->name = pwd->pw_gecos;
+			user->name = strdup(pwd->pw_gecos);
 		if (!username)
 			username = pwd->pw_name;
 	}
@@ -48,8 +48,7 @@ void subsurface_user_info(struct user_info *user)
 		struct membuffer mb = {};
 		gethostname(hostname, sizeof(hostname));
 		put_format(&mb, "%s@%s", username, hostname);
-		user->email = mb_cstring(&mb);
-		free_buffer(&mb);
+		user->email = mb_cstring(&mb); // 'email' is heap allocated
 	}
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
subsurface_user_info() only works on Linux (linux.c),
but it doesn't allocate values on the heap.

Solve this ownership problem by always allocating
.name and .email on the heap in subsurface_user_info()
and freeing in the caller.

If subsurface_user_info() did not modify any of the
values from NULL, use default ones, but allocate them
on the heap too.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) make `user_info` pointers be of type `char*`
2) use heap memory for the members in `save-git.c::get_authorship()` and `linux.c::subsurface_user_info()`
3) free pointers in `save-git.c::get_authorship()` once `git_signature_now()` is done with them.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Updates #1346

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This is a definite fix for memory issues, but not sure if it fixes #1346, as well.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
```
- Cloud storage: fix potential issue with credentials on Linux [#1346]
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@exxus does this fix your issues?
