### PR TITLE
Fixes / improvements to video-lite PR [#1463]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Dive pictures: support addition of videos
 - Cloud storage: fix potential issue with credentials on Linux [#1346]
 - Mobile/iOS: fix missing translations
 - Dive pictures: locate moved pictures based on filename and path

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -98,7 +98,7 @@ Thumbnailer::Thumbnail Thumbnailer::fetchImage(const QString &filename, const QS
 		else if (type == MEDIATYPE_VIDEO)
 			return { videoImage, MEDIATYPE_VIDEO };
 
-		// Try if Qt can parse this image
+		// Try if Qt can parse this image. If it does, use this as a thumbnail.
 		QImage thumb(filename);
 		if (!thumb.isNull())
 			return { thumb, MEDIATYPE_PICTURE };
@@ -130,14 +130,16 @@ Thumbnailer::Thumbnail Thumbnailer::getHashedImage(const QString &filename, bool
 {
 	QString localFilename = localFilePath(filename);
 
-	// If there is a translated filename, try that first
-	Thumbnail thumbnail { QImage(), MEDIATYPE_UNKNOWN };
+	// If there is a translated filename, try that first.
+	// Note that we set the default type to io-error, so that if we didn't try
+	// the local filename first, we will load the file from the canonical filename.
+	Thumbnail thumbnail { QImage(), MEDIATYPE_IO_ERROR };
 	if (localFilename != filename)
 		thumbnail = fetchImage(localFilename, filename, tryDownload);
 
-	// Note that the translated filename should never be a remote file and therefore checking for
-	// still-loading is currently not necessary. But in the future, we might support such a use case
-	// (e.g. images stored in the cloud).
+	// If fetching from the local filename failed (or we didn't even try),
+	// use the canonical filename. This might for example happen if we downloaded
+	// a file, but for some reason lost the cached file.
 	if (thumbnail.type == MEDIATYPE_IO_ERROR)
 		thumbnail = fetchImage(filename, filename, tryDownload);
 

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -67,6 +67,7 @@ private:
 	QImage failImage;		// Shown when image-fetching fails
 	QImage dummyImage;		// Shown before thumbnail is fetched
 	QImage videoImage;		// Place holder for videos
+	QImage unknownImage;		// Place holder for files where we couldn't determine the type
 
 	QMap<QString,QFuture<void>> workingOn;
 };

--- a/icons/unknown.svg
+++ b/icons/unknown.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg30031"
+   height="22"
+   version="1.1"
+   width="22">
+  <defs
+     id="defs3871" />
+  <metadata
+     id="metadata3874">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1 0 0 1 -326 -534.3622)"
+     id="layer1">
+    <rect
+       id="rect4035"
+       style="fill:#6c7a89"
+       height="10.999983"
+       y="535.98694"
+       x="326.49567"
+       width="0" />
+    <rect
+       id="rect4035-7"
+       style="fill:#6c7a89"
+       height="10.999983"
+       y="538.50604"
+       x="321.94366"
+       width="0" />
+    <rect
+       id="rect4035-9"
+       style="fill:#6c7a89"
+       height="10.999983"
+       y="526.08746"
+       x="317.43588"
+       width="0" />
+    <path
+       d="m 326.55607,534.89106 v 5.23559 14.39784 1.3089 h 13.08896 7.85338 v -1.3089 -6.54448 -7.85336 -5.23559 z m 1.3089,5.23559 h 18.32454 v 7.85336 6.54448 h -6.54448 -11.78006 z"
+       id="rect4138"
+       style="fill:#1a1a1a;stroke-width:1" />
+    <path
+       d="m 337.02658,541.43554 c -1.09037,0 -2.10865,0.33473 -2.82601,0.96252 -0.7175,0.62779 -1.10001,1.51912 -1.10001,2.4733 h 2.24321 c 0,-0.51813 0.17887,-0.85405 0.44291,-1.08494 0.26387,-0.23131 0.64823,-0.38757 1.2399,-0.38757 0.59277,0 0.97604,0.15629 1.2406,0.38757 0.26419,0.23088 0.44222,0.5668 0.44222,1.08494 0,0.45 -0.0995,0.64142 -0.2363,0.81111 -0.58495,0.5165 -1.29193,0.95765 -1.86023,1.38043 -0.64173,0.42128 -1.26837,0.97376 -1.26837,1.73518 v 0.4908 h 2.24349 v -0.4908 c 0.79773,-0.7143 1.98561,-1.33725 2.72577,-1.99215 0.39059,-0.48982 0.64016,-1.15709 0.64016,-1.93491 0,-0.95419 -0.38272,-1.84517 -1.09979,-2.47296 -0.71758,-0.62779 -1.73654,-0.96252 -2.82709,-0.96252 z m -1.68208,9.81708 v 1.96297 h 2.24349 v -1.96297 z"
+       id="rect4169-4"
+       style="fill:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round" />
+  </g>
+</svg>

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -93,5 +93,6 @@
         <file alias="preferences-other-icon">icons/defaults.png</file>
         <file alias="camera-icon">icons/camera.svg</file>
         <file alias="video-icon">icons/video.svg</file>
+        <file alias="unknown-icon">icons/unknown.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A last-minute change in the video-lite PR introduced a bug (of course), which would lead to thumbnails not being properly created if local and original filename were the same (i.e. all newly added images).

Moreover, @neolit123 noted that we do not properly recognize videos that are not based on the QuickTime / MP4 formats.

Fix this and refine the icons: differentiate between "we can't read that file (io error)" and "we can't understand that file (parse error)".

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add "unknown type" icon (LGPL from KDE breeze)
2) If we couldn't parse the video or read as image, look for video file extension
3) If all that fails, show the "unknown type" icon
4) Fix bug where thumbnails would not be properly created
5) Add changelog entry
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1463
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
