### PR TITLE
Dive media: add ".mov" to list of known video extensions

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1212,7 +1212,7 @@ QString localFilePath(const QString &originalFilename)
 // TODO: Apparently Qt has no simple way of listing the supported video
 // codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?
 const QStringList videoExtensionsList = {
-	".avi", ".mp4", ".mpeg", ".mpg", ".wmv"
+	".avi", ".mp4", ".mov", ".mpeg", ".mpg", ".wmv"
 };
 
 QStringList imageExtensionFilters() {


### PR DESCRIPTION
This was an oversight in b28dba6087f0433af8ece176b64fcac54ca370a4.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not really a bug fix, but still an embarrassing oversight in b28dba6087f0433af8ece176b64fcac54ca370a4. Notably my Nikon produces .mov files.
I think this should go in 4.8.1.
### Changes made:
1) Add ".mov" to list of known video extensions.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed.
