### PR TITLE
map-widget: fix chronology of QML class registration

### DIFF
--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -33,6 +33,7 @@ QObject *qqWindowObject = NULL;
 void init_ui()
 {
 	init_qt_late();
+	register_qml_types();
 #ifndef SUBSURFACE_MOBILE
 	PluginManager::instance().loadPlugins();
 
@@ -97,7 +98,6 @@ void register_qml_types()
 
 void run_ui()
 {
-	register_qml_types();
 
 #ifdef SUBSURFACE_MOBILE
 	QQmlApplicationEngine engine;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The QML types needs to be registered before the MainWindow
instance is created on the desktop version, otherwise
the MapWidget instance will be created and it will fail
with a missing QML namespace.

In subsurface-helper.cpp, move register_qml_types() from run_ui()
to init_ui(), as later in init_ui(), MainWindow is instantiated
for the first time in the desktop version.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

move a function call in subsurface-helper.cpp.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #1500
https://github.com/Subsurface-divelog/subsurface/commit/ab05fe3cf83526ea63764a6c6587735e8b959527

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
NONE

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
NONE

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh @janiversen @sfuchs79 
