### PR TITLE
Fix configure bluetooth ostc's

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -1429,7 +1429,7 @@ void ConfigureDiveComputerDialog::on_DiveComputerList_currentRowChanged(int curr
 		break;
 	case 1:
 		selected_vendor = "Heinrichs Weikamp";
-		selected_product = "OSTC 3";
+		selected_product = "OSTC Plus";
 		fw_upgrade_possible = true;
 		break;
 	case 2:


### PR DESCRIPTION
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

When we introduced the whole check for supported transports code, no one
noticed that it broke configuring all ostc's over bluetooth.

The configure code just used a placeholder model of OSTC 3 to get the
right backend code. With the new supported transports model it errored
out if you where trying to connect to a bluetooth enabled device, just
because the original OSTC 3's wasn't bluetooth enabled.

This switches the placeholder model over to a OSTC Plus which is both
bluetooth, serial and ble capable, so the code works again.

@dirkh , This should go in 4.8.1.