### PR TITLE
Make sure our libdivecomputer custom IO interfaces have sleep functions

### DIFF
--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -6,6 +6,7 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QDebug>
+#include <QThread>
 
 #include <libdivecomputer/version.h>
 #include <libdivecomputer/context.h>
@@ -395,6 +396,12 @@ static dc_status_t qt_serial_set_timeout(void *io, int timeout)
 	return DC_STATUS_SUCCESS;
 }
 
+static dc_status_t qt_custom_sleep(void *io, unsigned int timeout)
+{
+	QThread::msleep(timeout);
+	return DC_STATUS_SUCCESS;
+}
+
 #ifdef BLE_SUPPORT
 dc_status_t
 ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* devaddr, void *userdata)
@@ -415,7 +422,7 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 		qt_ble_write, /* write */
 		NULL, /* flush */
 		NULL, /* purge */
-		NULL, /* sleep */
+		qt_custom_sleep, /* sleep */
 		qt_ble_close, /* close */
 	};
 
@@ -448,7 +455,7 @@ rfcomm_stream_open(dc_iostream_t **iostream, dc_context_t *context, const char* 
 		qt_serial_write, /* write */
 		NULL, /* flush */
 		qt_serial_purge, /* purge */
-		NULL, /* sleep */
+		qt_custom_sleep, /* sleep */
 		qt_serial_close, /* close */
 	};
 

--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -98,12 +98,14 @@ static dc_status_t serial_ftdi_get_transmitted (ftdi_serial_t *device)
 	return DC_STATUS_UNSUPPORTED;
 }
 
-static dc_status_t serial_ftdi_sleep (ftdi_serial_t *device, unsigned long timeout)
+static dc_status_t serial_ftdi_sleep (void *io, unsigned int timeout)
 {
+	ftdi_serial_t *device = io;
+
 	if (device == NULL)
 		return DC_STATUS_INVALIDARGS;
 
-	INFO (device->context, "Sleep: value=%lu", timeout);
+	INFO (device->context, "Sleep: value=%u", timeout);
 
 	struct timespec ts;
 	ts.tv_sec  = (timeout / 1000);
@@ -541,7 +543,7 @@ dc_status_t ftdi_open(dc_iostream_t **iostream, dc_context_t *context)
 		serial_ftdi_write, /* write */
 		NULL, /* flush */
 		serial_ftdi_purge, /* purge */
-		NULL, /* sleep */
+		serial_ftdi_sleep, /* sleep */
 		serial_ftdi_close, /* close */
 	};
 


### PR DESCRIPTION
When I switched over from our own custom IO implementation to the new
upstream custom IO model in libdivecomputer, I completely missed the
fact that the libdivecomputer custom IO model also does a custom _sleep_
function.

I'm not entirely sure what the point was, and it broke things even in
libdivecopmputer itself when some of the new sleep functions were
broken.

Anyway, we didn't export any sleep functions at all for the bluetooth,
BLE and FTDI cases, the the libdivecomputer code didn't fall back to any
sane default sleep implementation either, so the end result was no
sleeping at all.

Which didn't matter for most divecomputers.

But it seems like at least some OSTC dive computers did care, at least
in certain situations, and both Miika and Anton had trouble downloading
with their OSTC Sport dive computers.  Using the serial line protocol
and the legacy /dev/rfcomm model worked fine, because then it used the
sleeping functions in the POSIX serial code inside libdivecomputer.

This just adds trivial sleeping functions for the affected download
protocols.  Maybe I should have just made libdivecomputer have a sane
default instead, but this wasn't hard either (the hard part was trying
to figure out why the downloads worked for some people and not for
others).

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
