### PR TITLE
Disable the WindowContextHelpButtonHint for Qt >=5.10

### DIFF
--- a/core/qt-init.cpp
+++ b/core/qt-init.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <QApplication>
+#include <Qt>
 #include <QNetworkProxy>
 #include <QLibraryInfo>
 #include <QTextCodec>
@@ -42,6 +43,11 @@ void init_qt_late()
 		QCoreApplication::setApplicationName("Subsurface");
 #endif
 	}
+	// Disables the WindowContextHelpButtonHint by default on Qt::Sheet and Qt::Dialog widgets.
+	// This hides the ? button on Windows, which only makes sense if you use QWhatsThis functionality.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+	QCoreApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
+#endif
 	// find plugins installed in the application directory (without this SVGs don't work on Windows)
 	SettingsObjectWrapper::instance()->load();
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Disables the WindowContextHelpButtonHint by default on Qt::Sheet and
Qt::Dialog widgets. This hides the ? button on Windows, which only
makes sense if you use QWhatsThis functionality.
This value has been added in Qt 5.10.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 