### PR TITLE
[RFC] Prepare for video thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 - Dive media: implement "open folder of selected media files" [#1514]
+- Dive media: show play-time of videos on the profile plot
+- Dive media: draw thumbnails on top of deco-ceilings
 - Dive media: Change term "photos" and "images" everywhere in the UI to "media files"
 - mobile: show developer menu is now saved on disk and remebered between start of Subsurface
 - tests: add qml test harness

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -47,7 +47,7 @@ public slots:
 	void imageDownloaded(QString filename);
 	void imageDownloadFailed(QString filename);
 signals:
-	void thumbnailChanged(QString filename, QImage thumbnail);
+	void thumbnailChanged(QString filename, QImage thumbnail, duration_t duration);
 private:
 	struct Thumbnail {
 		QImage img;
@@ -56,9 +56,9 @@ private:
 	};
 
 	Thumbnailer();
-	static void addPictureThumbnailToCache(const QString &picture_filename, const QImage &thumbnail);
-	static void addVideoThumbnailToCache(const QString &picture_filename, duration_t duration);
-	static void addUnknownThumbnailToCache(const QString &picture_filename);
+	Thumbnail addPictureThumbnailToCache(const QString &picture_filename, const QImage &thumbnail);
+	Thumbnail addVideoThumbnailToCache(const QString &picture_filename, duration_t duration);
+	Thumbnail addUnknownThumbnailToCache(const QString &picture_filename);
 	void recalculate(QString filename);
 	void processItem(QString filename, bool tryDownload);
 	Thumbnail getThumbnailFromCache(const QString &picture_filename);

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -52,13 +52,18 @@ private:
 	struct Thumbnail {
 		QImage img;
 		mediatype_t type;
+		duration_t duration;
 	};
 
 	Thumbnailer();
-	static void addThumbnailToCache(const Thumbnail &thumbnail, const QString &picture_filename);
+	static void addPictureThumbnailToCache(const QString &picture_filename, const QImage &thumbnail);
+	static void addVideoThumbnailToCache(const QString &picture_filename, duration_t duration);
+	static void addUnknownThumbnailToCache(const QString &picture_filename);
 	void recalculate(QString filename);
 	void processItem(QString filename, bool tryDownload);
 	Thumbnail getThumbnailFromCache(const QString &picture_filename);
+	Thumbnail getPictureThumbnailFromStream(QDataStream &stream);
+	Thumbnail getVideoThumbnailFromStream(QDataStream &stream);
 	Thumbnail fetchImage(const QString &filename, const QString &originalFilename, bool tryDownload);
 	Thumbnail getHashedImage(const QString &filename, bool tryDownload);
 

--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -42,7 +42,8 @@ void CloseButtonItem::show()
 DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
 	canvas(new QGraphicsRectItem(this)),
 	shadow(new QGraphicsRectItem(this)),
-	button(new CloseButtonItem(this))
+	button(new CloseButtonItem(this)),
+	baseZValue(0.0)
 {
 	setFlag(ItemIgnoresTransformations);
 	setAcceptHoverEvents(true);
@@ -67,6 +68,14 @@ DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
 	button->hide();
 }
 
+// The base z-value is used for correct paint-order of the thumbnails. On hoverEnter the z-value is raised
+// so that the thumbnail is drawn on top of all other thumbnails and on hoverExit it is restored to the base value.
+void DivePictureItem::setBaseZValue(double z)
+{
+	baseZValue = z;
+	setZValue(z);
+}
+
 void DivePictureItem::settingsChanged()
 {
 	setVisible(prefs.show_pictures_in_profile);
@@ -85,7 +94,7 @@ void DivePictureItem::setPixmap(const QPixmap &pix)
 void DivePictureItem::hoverEnterEvent(QGraphicsSceneHoverEvent*)
 {
 	Animations::scaleTo(this, 1.0);
-	setZValue(5);
+	setZValue(baseZValue + 5.0);
 
 	button->setOpacity(0);
 	button->show();
@@ -100,7 +109,7 @@ void DivePictureItem::setFileUrl(const QString &s)
 void DivePictureItem::hoverLeaveEvent(QGraphicsSceneHoverEvent*)
 {
 	Animations::scaleTo(this, 0.2);
-	setZValue(0);
+	setZValue(baseZValue);
 	Animations::hide(button);
 }
 

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -32,6 +32,7 @@ class DivePictureItem : public DivePixmapItem {
 public:
 	DivePictureItem(QGraphicsItem *parent = 0);
 	void setPixmap(const QPixmap& pix);
+	void setBaseZValue(double z);
 public slots:
 	void settingsChanged();
 	void removePicture();
@@ -45,6 +46,7 @@ private:
 	QGraphicsRectItem *canvas;
 	QGraphicsRectItem *shadow;
 	CloseButtonItem *button;
+	double baseZValue;
 };
 
 #endif // DIVEPIXMAPITEM_H

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -74,6 +74,7 @@ public:
 
 	ProfileWidget2(QWidget *parent = 0);
 	void resetZoom();
+	void scale(qreal sx, qreal sy);
 	void plotDive(struct dive *d = 0, bool force = false, bool clearPictures = false);
 	void setupItem(AbstractProfilePolygonItem *item, DiveCartesianAxis *vAxis, int vData, int hData, int zValue);
 	void setPrintMode(bool mode, bool grayscale = false);
@@ -127,7 +128,7 @@ slots: // Necessary to call from QAction's signals.
 	void deleteCurrentDC();
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
-	void updateThumbnail(QString filename, QImage thumbnail);
+	void updateThumbnail(QString filename, QImage thumbnail, duration_t duration);
 
 	/* this is called for every move on the handlers. maybe we can speed up this a bit? */
 	void recreatePlannedDive();
@@ -234,14 +235,19 @@ private:
 	// Pictures that are outside of the dive time are not shown.
 	struct PictureEntry {
 		offset_t offset;
+		duration_t duration;
 		QString filename;
 		std::unique_ptr<DivePictureItem> thumbnail;
+		// For videos with known duration, we represent the duration of the video by a line
+		std::unique_ptr<QGraphicsRectItem> durationLine;
 		PictureEntry (offset_t offsetIn, const QString &filenameIn, QGraphicsScene *scene);
 		bool operator< (const PictureEntry &e) const;
 	};
 	void updateThumbnailXPos(PictureEntry &e);
 	std::vector<PictureEntry> pictures;
 	void calculatePictureYPositions();
+	void updateDurationLine(PictureEntry &e);
+	void updateThumbnailPaintOrder();
 
 	QList<DiveHandler *> handles;
 	void repositionDiveHandlers();

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -165,7 +165,7 @@ int DivePictureModel::findPictureId(const QString &filename)
 	return -1;
 }
 
-void DivePictureModel::updateThumbnail(QString filename, QImage thumbnail)
+void DivePictureModel::updateThumbnail(QString filename, QImage thumbnail, duration_t)
 {
 	int i = findPictureId(filename);
 	if (i >= 0) {

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -2,6 +2,8 @@
 #ifndef DIVEPICTUREMODEL_H
 #define DIVEPICTUREMODEL_H
 
+#include "core/units.h"
+
 #include <QAbstractTableModel>
 #include <QImage>
 #include <QFuture>
@@ -28,7 +30,7 @@ signals:
 	void picturesRemoved(const QVector<QString> &fileUrls);
 public slots:
 	void setZoomLevel(int level);
-	void updateThumbnail(QString filename, QImage thumbnail);
+	void updateThumbnail(QString filename, QImage thumbnail, duration_t duration);
 private:
 	DivePictureModel();
 	QVector<PictureEntry> pictures;

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -31,10 +31,12 @@
 #ifndef SUBSURFACE_TEST_DATA
 QObject *qqWindowObject = NULL;
 
+static void register_meta_types();
 void init_ui()
 {
 	init_qt_late();
 	register_qml_types();
+	register_meta_types();
 #ifndef SUBSURFACE_MOBILE
 	PluginManager::instance().loadPlugins();
 
@@ -136,6 +138,12 @@ void run_ui()
 	MainWindow::instance()->show();
 #endif // SUBSURFACE_MOBILE
 	qApp->exec();
+}
+
+Q_DECLARE_METATYPE(duration_t)
+static void register_meta_types()
+{
+	qRegisterMetaType<duration_t>();
 }
 #endif // not SUBSURFACE_TEST_DATA
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This prepares for video thumbnails. What this basically does is move the thumbnail-writing down in the call chain to where the thumbnails are created and defines a rather general format for thumbnails, which supports multiple images at different locations (@atdotde: this might be interesting to you - are you fine with this format?).

Here's the commit message of the relevant commit:
Video thumbnails are more complex than simple picture thumbnails.
We store a duration and might want to store multiple images.

Therefore, refactor the thumbnailing in imagedownloader.cpp. Move
the thumbnail-writing down in the call chain to where the thumbnails
are created, since we have more information there (i.e. could we
parse the file but not extract an image, etc.).

Split the write-to-cache function into three versions:
  - pictures
  - videos
  - unknown

Define the video-thumbnail on-disk format as
  - uint32  MEDIATYPE_VIDEO
  - uint32  duration of video in seconds
  - uint32  number of pictures
  for each picture:
        - uint32  offset in msec from begining of video
        - QImage  frame

Currently, we write 0 pictures. This will be filled in newer commits.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move down thumbnail-writing in the call-chain to where thumbnails are generated.
2) Split thumbnail-writing functions into 3 versions (pictures, videos, unknown).
3) Define an on-disk format for video-thumbnails.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1494 #1486
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
When this becomes ready.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Needs a general change mentioning videos
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 