### PR TITLE
Dive media: transport dive-id in drag'n'drop events

### DIFF
--- a/desktop-widgets/divepicturewidget.cpp
+++ b/desktop-widgets/divepicturewidget.cpp
@@ -32,7 +32,9 @@ void DivePictureWidget::mouseDoubleClickEvent(QMouseEvent *event)
 void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 {
 	if (event->button() == Qt::LeftButton && event->modifiers() == Qt::NoModifier) {
-		QString filename = model()->data(indexAt(event->pos()), Qt::DisplayPropertyRole).toString();
+		QModelIndex index = indexAt(event->pos());
+		QString filename = model()->data(index, Qt::DisplayPropertyRole).toString();
+		int diveId = model()->data(index, Qt::UserRole).toInt();
 
 		if (!filename.isEmpty()) {
 			int dim = lrint(defaultIconMetrics().sz_pic * 0.2);
@@ -42,7 +44,7 @@ void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 			
 			QByteArray itemData;
 			QDataStream dataStream(&itemData, QIODevice::WriteOnly);
-			dataStream << filename << event->pos();
+			dataStream << filename << diveId;
 
 			QMimeData *mimeData = new QMimeData;
 			mimeData->setData("application/x-subsurfaceimagedrop", itemData);
@@ -53,11 +55,8 @@ void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 
 			drag->exec(Qt::CopyAction | Qt::MoveAction, Qt::CopyAction);
 		}
-
-		QListView::mousePressEvent(event);
-	} else {
-		QListView::mousePressEvent(event);
 	}
+	QListView::mousePressEvent(event);
 }
 
 void DivePictureWidget::wheelEvent(QWheelEvent *event)

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -96,14 +96,16 @@ QVariant DivePictureModel::data(const QModelIndex &index, int role) const
 			break;
 		case Qt::DisplayPropertyRole:
 			ret = QFileInfo(entry.filename).filePath();
+			break;
+		case Qt::UserRole:
+			ret = entry.diveId;
+			break;
 		}
 	} else if (index.column() == 1) {
 		switch (role) {
-		case Qt::UserRole:
-			ret = QVariant::fromValue(entry.offsetSeconds);
-			break;
 		case Qt::DisplayRole:
 			ret = entry.filename;
+			break;
 		}
 	}
 	return ret;


### PR DESCRIPTION
9efb56e2d43161d952efb444d1f13d87bfdd45b5 introduced rather complex
logic for picture drag'n'drop events onto the profile. Among other
things, the code had to check whether the picture actually belongs
to the displayed dive.

This can be simplified by transporting the dive-id in the drag'n'drop
event structure. The flow goes like this:
DivePictureModel--(1)-->DivePictureWidget--(2)-->ProfileWidget

For (1), we can use the Qt::UserRole role. This was used to transport
the picture-offset, but this is not needed anymore since ProfileWidget
was decoupled from DivePictureModel.

For (2), we simply replace the "position" value, which was never used.
Why would the receiver care which pixel was pressed in the media-tab?

This commit also contains a minor cleanup in DivePictureWidget:
QListView::mousePressEvent(event) was called in both branches of an
if and can therefore be removed from the if. This is so trivial,
that it doesn't warrant its own commit.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a rather small cleanup to the drag'n'drop changes in #1483. On drag & drop we should not only send the picture-filename, but also the dive it belongs to. Indeed, we should do this generally, to avoid confusion with images associated to different dives.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Transport dive-id on image drag'n'drop events.
2) Drop drag'n'drop events of images belonging to other dives immediately.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No user-visible change (hopefully)
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No user-visible change (hopefully)
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
