### PR TITLE
core: qPrefDisplay correct font setting (solve #1511)

### DIFF
--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -34,15 +34,17 @@ void qPrefDisplay::set_divelist_font(const QString& value)
 	if (newValue != prefs.divelist_font &&
 		!subsurface_ignore_font(qPrintable(newValue))) {
 		COPY_TXT(divelist_font, value);
-		qApp->setFont(QFont(newValue));
 		disk_divelist_font(true);
+
+		qApp->setFont(QFont(newValue));
 		emit divelist_font_changed(value);
 	}
 }
 void qPrefDisplay::disk_divelist_font(bool doSync)
 {
-	LOADSYNC_TXT("/divelist_font", divelist_font);
-	if (!doSync)
+	if (doSync)
+		LOADSYNC_TXT("/divelist_font", divelist_font)
+	else
 		setCorrectFont();
 }
 
@@ -51,17 +53,19 @@ void qPrefDisplay::set_font_size(double value)
 {
 	if (value != prefs.font_size) {
 		prefs.font_size = value;
+		disk_font_size(true);
+
 		QFont defaultFont = qApp->font();
 		defaultFont.setPointSizeF(prefs.font_size);
 		qApp->setFont(defaultFont);
-		disk_font_size(true);
 		emit font_size_changed(value);
 	}
 }
 void qPrefDisplay::disk_font_size(bool doSync)
 {
-	LOADSYNC_DOUBLE("/font_size", font_size);
-	if (!doSync)
+	if (doSync)
+		LOADSYNC_DOUBLE("/font_size", font_size)
+	else
 		setCorrectFont();
 }
 
@@ -74,21 +78,30 @@ HANDLE_PREFERENCE_TXT(Display, "/theme", theme);
 
 void qPrefDisplay::setCorrectFont()
 {
+	bool doSync = false;
+	QSettings s;
+	QVariant v;
+
 	// get the font from the settings or our defaults
 	// respect the system default font size if none is explicitly set
-	QFont defaultFont(prefs.divelist_font);
+	QFont defaultFont = s.value(group + "/divelist_font", prefs.divelist_font).value<QFont>();
 	if (IS_FP_SAME(system_divelist_default_font_size, -1.0)) {
 		prefs.font_size = qApp->font().pointSizeF();
 		system_divelist_default_font_size = prefs.font_size; // this way we don't save it on exit
 	}
+
+	prefs.font_size = s.value(group + "/font_size", prefs.font_size).toFloat();
 	// painful effort to ignore previous default fonts on Windows - ridiculous
 	QString fontName = defaultFont.toString();
 	if (fontName.contains(","))
 		fontName = fontName.left(fontName.indexOf(","));
-	if (subsurface_ignore_font(qPrintable(fontName)))
+	if (subsurface_ignore_font(qPrintable(fontName))) {
 		defaultFont = QFont(prefs.divelist_font);
-	else
-		COPY_TXT(divelist_font, fontName);
+	} else {
+		free((void *)prefs.divelist_font);
+		prefs.divelist_font = copy_qstring(fontName);
+	}
 	defaultFont.setPointSizeF(prefs.font_size);
 	qApp->setFont(defaultFont);
+	LOADSYNC_BOOL("/displayinvalid", display_invalid_dives);
 }

--- a/core/settings/qPref_private.h
+++ b/core/settings/qPref_private.h
@@ -87,7 +87,7 @@ void qPref ## usegroup::disk_ ## field(bool doSync) \
 #define DISK_LOADSYNC_INT(usegroup, name, field) \
 void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
-	LOADSYNC_DOUBLE(name, field); \
+	LOADSYNC_INT(name, field); \
 }
 
 #define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \


### PR DESCRIPTION
SettingsObjectWrapper contained some delicate font handling mixing font and
font_size, breaking that into 2 parts broke font handling on some platforms

Copy font + font_size handling 1-1 from SettingsObjectWrapper

Signed-off-by: Jan Iversen <jani@apache.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The way we load font and size, seems in need for an update, but for now just redid what was.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger please test on your system.

fixes #1511