### PR TITLE
core: add qPrefCloudStorage

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	# classes to manage struct preferences for QWidget and QML
 	settings/qPref.cpp
 	settings/qPrefAnimations.cpp
+	settings/qPrefCloudStorage.cpp
 	settings/qPrefDisplay.cpp
 	settings/qPrefPrivate.cpp
 

--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -3,7 +3,6 @@
 #include "pref.h"
 #include "qthelper.h"
 #include "settings/qPref.h"
-#include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <QApplication>
 
 CloudStorageAuthenticate::CloudStorageAuthenticate(QObject *parent) :
@@ -49,10 +48,10 @@ void CloudStorageAuthenticate::uploadFinished()
 
 	QString cloudAuthReply(reply->readAll());
 	qDebug() << "Completed connection with cloud storage backend, response" << cloudAuthReply;
-	CloudStorageSettings csSettings(parent());
+	qPrefCloudStorage csSettings(parent());
 
 	if (cloudAuthReply == QLatin1String("[VERIFIED]") || cloudAuthReply == QLatin1String("[OK]")) {
-		csSettings.setVerificationStatus(qPref::CS_VERIFIED);
+		csSettings.set_cloud_verification_status(qPref::CS_VERIFIED);
 		/* TODO: Move this to a correct place
 		NotificationWidget *nw = MainWindow::instance()->getNotificationWidget();
 		if (nw->getNotificationText() == myLastError)
@@ -61,7 +60,7 @@ void CloudStorageAuthenticate::uploadFinished()
 		myLastError.clear();
 	} else if (cloudAuthReply == QLatin1String("[VERIFY]") ||
 		   cloudAuthReply == QLatin1String("Invalid PIN")) {
-		csSettings.setVerificationStatus(qPref::CS_NEED_TO_VERIFY);
+		csSettings.set_cloud_verification_status(qPref::CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {
 		free((void *)prefs.cloud_storage_password);
@@ -70,7 +69,7 @@ void CloudStorageAuthenticate::uploadFinished()
 		emit passwordChangeSuccessful();
 		return;
 	} else {
-		csSettings.setVerificationStatus(qPref::CS_INCORRECT_USER_PASSWD);
+		csSettings.set_cloud_verification_status(qPref::CS_INCORRECT_USER_PASSWD);
 		myLastError = cloudAuthReply;
 		report_error("%s", qPrintable(cloudAuthReply));
 	}

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -15,6 +15,7 @@ static qPref *self = new qPref;
 
 void qPref::loadSync(bool doSync)
 {
+	qPrefCloudStorage::instance()->loadSync(doSync);
 	qPrefDisplay::instance()->loadSync(doSync);
 }
 

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -6,6 +6,7 @@
 #include "core/pref.h"
 
 #include "qPrefAnimations.h"
+#include "qPrefCloudStorage.h"
 #include "qPrefDisplay.h"
 
 class qPref : public QObject {

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPref.h"
+#include "qPrefPrivate.h"
+
+static const QString group = QStringLiteral("CloudStorage");
+
+qPrefCloudStorage::qPrefCloudStorage(QObject *parent) : QObject(parent)
+{
+}
+qPrefCloudStorage*qPrefCloudStorage::instance()
+{
+	static qPrefCloudStorage *self = new qPrefCloudStorage;
+	return self;
+}
+
+void qPrefCloudStorage::loadSync(bool doSync)
+{
+	disk_cloud_base_url(doSync);
+	disk_cloud_git_url(doSync);
+	disk_cloud_storage_email(doSync);
+	disk_cloud_storage_email_encoded(doSync);
+	disk_cloud_storage_password(doSync);
+	disk_cloud_storage_pin(doSync);
+	disk_cloud_timeout(doSync);
+	disk_cloud_verification_status(doSync);
+	disk_git_local_only(doSync);
+	disk_save_password_local(doSync);
+	disk_save_userid_local(doSync);
+	disk_userid(doSync);
+}
+
+GET_PREFERENCE_TXT(CloudStorage, cloud_base_url);
+void qPrefCloudStorage::set_cloud_base_url(const QString& value)
+{
+	if (value != prefs.cloud_base_url) {
+		// only free and set if not default
+		if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
+			COPY_TXT(cloud_base_url, value);
+			COPY_TXT(cloud_git_url, QString(prefs.cloud_base_url) + "/git");
+		}
+
+		disk_cloud_base_url(true);
+		emit cloud_base_url_changed(value);
+	}
+}
+void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
+{
+	LOADSYNC_TXT("/cloud_base_url", cloud_base_url);
+	LOADSYNC_TXT("/cloud_git_url", cloud_git_url);
+}
+
+GET_PREFERENCE_TXT(CloudStorage, cloud_git_url);
+void qPrefCloudStorage::set_cloud_git_url(const QString& value)
+{
+	if (value != prefs.cloud_git_url) {
+		// only free and set if not default
+		if (prefs.cloud_git_url != default_prefs.cloud_git_url) {
+			COPY_TXT(cloud_git_url, value);
+		}
+		disk_cloud_git_url(true);
+		emit cloud_git_url_changed(value);
+	}
+}
+DISK_LOADSYNC_TXT(CloudStorage, "/cloud_git_url", cloud_git_url)
+
+HANDLE_PREFERENCE_TXT(CloudStorage, "/email", cloud_storage_email);
+
+HANDLE_PREFERENCE_TXT(CloudStorage, "/email_encoded", cloud_storage_email_encoded);
+
+GET_PREFERENCE_TXT(CloudStorage, cloud_storage_newpassword);
+void qPrefCloudStorage::set_cloud_storage_newpassword(const QString& value)
+{
+	if (value == prefs.cloud_storage_newpassword)
+		return;
+
+	COPY_TXT(cloud_storage_newpassword, value);
+
+	// NOT saved on disk, because it is only temporary
+	emit cloud_storage_newpassword_changed(value);
+}
+
+GET_PREFERENCE_TXT(CloudStorage, cloud_storage_password);
+void qPrefCloudStorage::set_cloud_storage_password(const QString& value)
+{
+	if (value != prefs.cloud_storage_password) {
+		COPY_TXT(cloud_storage_password,value);
+		disk_cloud_storage_password(true);
+		emit cloud_storage_password_changed(value);
+	}
+}
+void qPrefCloudStorage::disk_cloud_storage_password(bool doSync)
+{
+	if (!doSync || prefs.save_password_local)
+		LOADSYNC_TXT("/password", cloud_storage_password);
+}
+
+HANDLE_PREFERENCE_TXT(CloudStorage, "/pin", cloud_storage_pin);
+
+HANDLE_PREFERENCE_INT(CloudStorage, "/timeout", cloud_timeout);
+
+HANDLE_PREFERENCE_INT(CloudStorage, "/cloud_verification_status", cloud_verification_status);
+
+HANDLE_PREFERENCE_BOOL(CloudStorage, "/git_local_only", git_local_only);
+
+HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_password_local", save_password_local);
+
+HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_userid_local", save_userid_local);
+
+GET_PREFERENCE_TXT(CloudStorage, userid);
+SET_PREFERENCE_TXT(CloudStorage, userid);
+void qPrefCloudStorage::disk_userid(bool doSync)
+{
+	//WARNING: UserId is stored outside of any group, but it belongs to Cloud Storage.
+	const QString group = QStringLiteral("");
+	LOADSYNC_TXT("subsurface_webservice_uid", userid);
+}

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREFCLOUDSTORAGE_H
+#define QPREFCLOUDSTORAGE_H
+
+#include <QObject>
+
+class qPrefCloudStorage : public QObject {
+	Q_OBJECT
+	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_url_changed);
+	Q_PROPERTY(QString cloud_git_url READ cloud_git_url WRITE set_cloud_git_url NOTIFY cloud_git_url_changed);
+	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_email_changed);
+	Q_PROPERTY(QString cloud_storage_email_encoded READ cloud_storage_email_encoded WRITE set_cloud_storage_email_encoded NOTIFY cloud_storage_email_encoded_changed);
+	Q_PROPERTY(QString cloud_storage_newpassword READ cloud_storage_newpassword WRITE set_cloud_storage_newpassword NOTIFY cloud_storage_newpassword_changed);
+	Q_PROPERTY(QString cloud_storage_password READ cloud_storage_password WRITE set_cloud_storage_password NOTIFY cloud_storage_password_changed);
+	Q_PROPERTY(QString cloud_storage_pin READ cloud_storage_pin WRITE set_cloud_storage_pin NOTIFY cloud_storage_pin_changed);
+	Q_PROPERTY(int cloud_verification_status READ cloud_verification_status WRITE set_cloud_verification_status NOTIFY cloud_verification_status_changed);
+	Q_PROPERTY(int cloud_timeout READ cloud_timeout WRITE set_cloud_timeout NOTIFY cloud_timeout_changed);
+	Q_PROPERTY(bool git_local_only READ git_local_only WRITE set_git_local_only NOTIFY git_local_only_changed);
+	Q_PROPERTY(bool save_password_local READ save_password_local WRITE set_save_password_local NOTIFY save_password_local_changed);
+	Q_PROPERTY(bool save_userid_local READ save_userid_local WRITE set_save_userid_local NOTIFY save_userid_local_changed);
+	Q_PROPERTY(QString userid READ userid WRITE set_userid NOTIFY userid_changed);
+
+public:
+	qPrefCloudStorage(QObject *parent = NULL);
+	static qPrefCloudStorage *instance();
+
+	// Load/Sync local settings (disk) and struct preference
+	void loadSync(bool doSync);
+	void load() { loadSync(false); }
+	void sync() { loadSync(true); }
+
+public:
+	const QString cloud_base_url() const;
+	const QString cloud_git_url() const;
+	const QString cloud_storage_email() const;
+	const QString cloud_storage_email_encoded() const;
+	const QString cloud_storage_newpassword() const;
+	const QString cloud_storage_password() const;
+	const QString cloud_storage_pin() const;
+	int   cloud_timeout() const;
+	int   cloud_verification_status() const;
+	bool  git_local_only() const;
+	bool  save_password_local() const;
+	bool  save_userid_local() const;
+	const QString userid() const;
+
+public slots:
+	void set_cloud_base_url(const QString& value);
+	void set_cloud_git_url(const QString& value);
+	void set_cloud_storage_email(const QString& value);
+	void set_cloud_storage_email_encoded(const QString& value);
+	void set_cloud_storage_newpassword(const QString& value);
+	void set_cloud_storage_password(const QString& value);
+	void set_cloud_storage_pin(const QString& value);
+	void set_cloud_timeout(int value);
+	void set_cloud_verification_status(int value);
+	void set_git_local_only(bool value);
+	void set_save_password_local(bool value);
+	void set_save_userid_local(bool value);
+	void set_userid(const QString& value);
+
+signals:
+	void cloud_base_url_changed(const QString& value);
+	void cloud_git_url_changed(const QString& value);
+	void cloud_storage_email_changed(const QString& value);
+	void cloud_storage_email_encoded_changed(const QString& value);
+	void cloud_storage_newpassword_changed(const QString& value);
+	void cloud_storage_password_changed(const QString& value);
+	void cloud_storage_pin_changed(const QString& value);
+	void cloud_timeout_changed(int value);
+	void cloud_verification_status_changed(int value);
+	void git_local_only_changed(bool value);
+	void save_password_local_changed(bool value);
+	void save_userid_local_changed(bool value);
+	void userid_changed(const QString& value);
+
+private:
+	// functions to load/sync variable with disk
+	void disk_cloud_base_url(bool doSync);
+	void disk_cloud_git_url(bool doSync);
+	void disk_cloud_storage_email(bool doSync);
+	void disk_cloud_storage_email_encoded(bool doSync);
+	void disk_cloud_storage_newpassword(bool doSync);
+	void disk_cloud_storage_password(bool doSync);
+	void disk_cloud_storage_pin(bool doSync);
+	void disk_cloud_timeout(bool doSync);
+	void disk_cloud_verification_status(bool doSync);
+	void disk_git_local_only(bool doSync);
+	void disk_save_password_local(bool doSync);
+	void disk_save_userid_local(bool doSync);
+	void disk_userid(bool doSync);
+};
+
+#endif

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -975,185 +975,6 @@ void ProxySettings::setPass(const QString& value)
 	emit passChanged(value);
 }
 
-CloudStorageSettings::CloudStorageSettings(QObject *parent) :
-	QObject(parent)
-{
-
-}
-
-bool CloudStorageSettings::gitLocalOnly() const
-{
-	return prefs.git_local_only;
-}
-
-QString CloudStorageSettings::password() const
-{
-	return QString(prefs.cloud_storage_password);
-}
-
-QString CloudStorageSettings::newPassword() const
-{
-	return QString(prefs.cloud_storage_newpassword);
-}
-
-QString CloudStorageSettings::email() const
-{
-	return QString(prefs.cloud_storage_email);
-}
-
-QString CloudStorageSettings::emailEncoded() const
-{
-	return QString(prefs.cloud_storage_email_encoded);
-}
-
-bool CloudStorageSettings::savePasswordLocal() const
-{
-	return prefs.save_password_local;
-}
-
-short CloudStorageSettings::verificationStatus() const
-{
-	return prefs.cloud_verification_status;
-}
-
-QString CloudStorageSettings::userId() const
-{
-	return QString(prefs.userid);
-}
-
-QString CloudStorageSettings::baseUrl() const
-{
-	return QString(prefs.cloud_base_url);
-}
-
-QString CloudStorageSettings::gitUrl() const
-{
-	return QString(prefs.cloud_git_url);
-}
-
-void CloudStorageSettings::setPassword(const QString& value)
-{
-	if (value == prefs.cloud_storage_password)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("password", value);
-	free((void *)prefs.cloud_storage_password);
-	prefs.cloud_storage_password = copy_qstring(value);
-	emit passwordChanged(value);
-}
-
-void CloudStorageSettings::setNewPassword(const QString& value)
-{
-	if (value == prefs.cloud_storage_newpassword)
-		return;
-	/*TODO: This looks like wrong, but 'new password' is not saved on disk, why it's on prefs? */
-	free((void *)prefs.cloud_storage_newpassword);
-	prefs.cloud_storage_newpassword = copy_qstring(value);
-	emit newPasswordChanged(value);
-}
-
-void CloudStorageSettings::setEmail(const QString& value)
-{
-	if (value == prefs.cloud_storage_email)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("email", value);
-	free((void *)prefs.cloud_storage_email);
-	prefs.cloud_storage_email = copy_qstring(value);
-	emit emailChanged(value);
-}
-
-void CloudStorageSettings::setUserId(const QString& value)
-{
-	if (value == prefs.userid)
-		return;
-	//WARNING: UserId is stored outside of any group, but it belongs to Cloud Storage.
-	QSettings s;
-	s.setValue("subsurface_webservice_uid", value);
-	free((void *)prefs.userid);
-	prefs.userid = copy_qstring(value);
-	emit userIdChanged(value);
-}
-
-void CloudStorageSettings::setEmailEncoded(const QString& value)
-{
-	if (value == prefs.cloud_storage_email_encoded)
-		return;
-	/*TODO: This looks like wrong, but 'email encoded' is not saved on disk, why it's on prefs? */
-	free((void *)prefs.cloud_storage_email_encoded);
-	prefs.cloud_storage_email_encoded = copy_qstring(value);
-	emit emailEncodedChanged(value);
-}
-
-void CloudStorageSettings::setSavePasswordLocal(bool value)
-{
-	if (value == prefs.save_password_local)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("save_password_local", value);
-	prefs.save_password_local = value;
-	emit savePasswordLocalChanged(value);
-}
-
-void CloudStorageSettings::setVerificationStatus(short value)
-{
-	if (value == prefs.cloud_verification_status)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("cloud_verification_status", value);
-	prefs.cloud_verification_status = value;
-	emit verificationStatusChanged(value);
-}
-
-void CloudStorageSettings::setSaveUserIdLocal(bool value)
-{
-	//TODO: this is not saved on disk?
-	if (value == prefs.save_userid_local)
-		return;
-	prefs.save_userid_local = value;
-	emit saveUserIdLocalChanged(value);
-}
-
-bool CloudStorageSettings::saveUserIdLocal() const
-{
-	return prefs.save_userid_local;
-}
-
-void CloudStorageSettings::setBaseUrl(const QString& value)
-{
-	if (value == prefs.cloud_base_url)
-		return;
-
-	// dont free data segment.
-	if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
-		free((void *)prefs.cloud_base_url);
-		free((void *)prefs.cloud_git_url);
-	}
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("cloud_base_url", value);
-	prefs.cloud_base_url = copy_qstring(value);
-	prefs.cloud_git_url = copy_qstring(QString(prefs.cloud_base_url) + "/git");
-}
-
-void CloudStorageSettings::setGitUrl(const QString&)
-{
-}
-
-void CloudStorageSettings::setGitLocalOnly(bool value)
-{
-	if (value == prefs.git_local_only)
-		return;
-	QSettings s;
-	s.beginGroup("CloudStorage");
-	s.setValue("git_local_only", value);
-	prefs.git_local_only = value;
-	emit gitLocalOnlyChanged(value);
-}
 
 DivePlannerSettings::DivePlannerSettings(QObject *parent) :
 	QObject(parent)
@@ -2100,7 +1921,7 @@ QObject(parent),
 	facebook(new FacebookSettings(this)),
 	geocoding(new GeocodingPreferences(this)),
 	proxy(new ProxySettings(this)),
-	cloud_storage(new CloudStorageSettings(this)),
+	cloud_storage(new qPrefCloudStorage(this)),
 	planner_settings(new DivePlannerSettings(this)),
 	unit_settings(new UnitsSettings(this)),
 	general_settings(new GeneralSettingsObjectWrapper(this)),
@@ -2212,28 +2033,7 @@ void SettingsObjectWrapper::load()
 	GET_TXT("proxy_pass", proxy_pass);
 	s.endGroup();
 
-	s.beginGroup("CloudStorage");
-	GET_TXT("email", cloud_storage_email);
-#ifndef SUBSURFACE_MOBILE
-	GET_BOOL("save_password_local", save_password_local);
-#else
-	// always save the password in Subsurface-mobile
-	prefs.save_password_local = true;
-#endif
-	if (prefs.save_password_local) { // GET_TEXT macro is not a single statement
-		GET_TXT("password", cloud_storage_password);
-	}
-	GET_INT("cloud_verification_status", cloud_verification_status);
-	GET_BOOL("git_local_only", git_local_only);
-
-	// creating the git url here is simply a convenience when C code wants
-	// to compare against that git URL - it's always derived from the base URL
-	GET_TXT("cloud_base_url", cloud_base_url);
-	prefs.cloud_git_url = copy_qstring(QString(prefs.cloud_base_url) + "/git");
-	s.endGroup();
-
-	// Subsurface webservice id is stored outside of the groups
-	GET_TXT("subsurface_webservice_uid", userid);
+	qPrefCloudStorage::instance()->load();
 
 	// GeoManagement
 	s.beginGroup("geocoding");

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -326,63 +326,6 @@ private:
 	const QString group = QStringLiteral("Network");
 };
 
-class CloudStorageSettings : public QObject {
-	Q_OBJECT
-	Q_PROPERTY(QString password          READ password           WRITE setPassword           NOTIFY passwordChanged)
-	Q_PROPERTY(QString newpassword       READ newPassword        WRITE setNewPassword        NOTIFY newPasswordChanged)
-	Q_PROPERTY(QString email             READ email              WRITE setEmail              NOTIFY emailChanged)
-	Q_PROPERTY(QString email_encoded     READ emailEncoded       WRITE setEmailEncoded       NOTIFY emailEncodedChanged)
-	Q_PROPERTY(QString userid            READ userId             WRITE setUserId             NOTIFY userIdChanged)
-	Q_PROPERTY(QString base_url          READ baseUrl            WRITE setBaseUrl            NOTIFY baseUrlChanged)
-	Q_PROPERTY(QString git_url           READ gitUrl             WRITE setGitUrl             NOTIFY gitUrlChanged)
-	Q_PROPERTY(bool save_userid_local    READ saveUserIdLocal    WRITE setSaveUserIdLocal    NOTIFY saveUserIdLocalChanged)
-	Q_PROPERTY(bool git_local_only       READ gitLocalOnly       WRITE setGitLocalOnly       NOTIFY gitLocalOnlyChanged)
-	Q_PROPERTY(bool save_password_local  READ savePasswordLocal  WRITE setSavePasswordLocal  NOTIFY savePasswordLocalChanged)
-	Q_PROPERTY(short verification_status READ verificationStatus WRITE setVerificationStatus NOTIFY verificationStatusChanged)
-public:
-	CloudStorageSettings(QObject *parent);
-	QString password() const;
-	QString newPassword() const;
-	QString email() const;
-	QString emailEncoded() const;
-	QString userId() const;
-	QString baseUrl() const;
-	QString gitUrl() const;
-	bool savePasswordLocal() const;
-	short verificationStatus() const;
-	bool gitLocalOnly() const;
-	bool saveUserIdLocal() const;
-
-public slots:
-	void setPassword(const QString& value);
-	void setNewPassword(const QString& value);
-	void setEmail(const QString& value);
-	void setEmailEncoded(const QString& value);
-	void setUserId(const QString& value);
-	void setBaseUrl(const QString& value);
-	void setGitUrl(const QString& value);
-	void setSavePasswordLocal(bool value);
-	void setVerificationStatus(short value);
-	void setGitLocalOnly(bool value);
-	void setSaveUserIdLocal(bool value);
-
-signals:
-	void passwordChanged(const QString& value);
-	void newPasswordChanged(const QString& value);
-	void emailChanged(const QString& value);
-	void emailEncodedChanged(const QString& value);
-	void userIdChanged(const QString& value);
-	void baseUrlChanged(const QString& value);
-	void gitUrlChanged(const QString& value);
-	void savePasswordLocalChanged(bool value);
-	void verificationStatusChanged(short value);
-	void gitLocalOnlyChanged(bool value);
-	void saveUserIdLocalChanged(bool value);
-
-private:
-	const QString group = QStringLiteral("CloudStorage");
-};
-
 class DivePlannerSettings : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool last_stop           READ lastStop             WRITE setLastStop             NOTIFY lastStopChanged)
@@ -666,7 +609,7 @@ class SettingsObjectWrapper : public QObject {
 	Q_PROPERTY(FacebookSettings*           facebook         MEMBER facebook CONSTANT)
 	Q_PROPERTY(GeocodingPreferences*       geocoding        MEMBER geocoding CONSTANT)
 	Q_PROPERTY(ProxySettings*              proxy            MEMBER proxy CONSTANT)
-	Q_PROPERTY(CloudStorageSettings*       cloud_storage    MEMBER cloud_storage CONSTANT)
+	Q_PROPERTY(qPrefCloudStorage*       cloud_storage    MEMBER cloud_storage CONSTANT)
 	Q_PROPERTY(DivePlannerSettings*        planner          MEMBER planner_settings CONSTANT)
 	Q_PROPERTY(UnitsSettings*              units            MEMBER unit_settings CONSTANT)
 
@@ -686,7 +629,7 @@ public:
 	FacebookSettings *facebook;
 	GeocodingPreferences *geocoding;
 	ProxySettings *proxy;
-	CloudStorageSettings *cloud_storage;
+	qPrefCloudStorage *cloud_storage;
 	DivePlannerSettings *planner_settings;
 	UnitsSettings *unit_settings;
 	GeneralSettingsObjectWrapper *general_settings;

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -48,8 +48,8 @@ void PreferencesNetwork::syncSettings()
 	auto cloud = SettingsObjectWrapper::instance()->cloud_storage;
 	auto proxy = SettingsObjectWrapper::instance()->proxy;
 
-	cloud->setUserId(ui->default_uid->text().toUpper());
-	cloud->setSaveUserIdLocal(ui->save_uid_local->checkState());
+	cloud->set_userid(ui->default_uid->text().toUpper());
+	cloud->set_save_userid_local(ui->save_uid_local->checkState());
 
 	proxy->setType(ui->proxyType->itemData(ui->proxyType->currentIndex()).toInt());
 	proxy->setHost(ui->proxyHost->text());
@@ -82,7 +82,7 @@ void PreferencesNetwork::syncSettings()
 			connect(cloudAuth, &CloudStorageAuthenticate::passwordChangeSuccessful, this, &PreferencesNetwork::passwordUpdateSuccessful);
 			cloudAuth->backend(email, password, "", newpassword);
 			ui->cloud_storage_new_passwd->setText("");
-			cloud->setNewPassword(newpassword);
+			cloud->set_cloud_storage_newpassword(newpassword);
 		}
 	} else if (prefs.cloud_verification_status == qPref::CS_UNKNOWN ||
 		   prefs.cloud_verification_status == qPref::CS_INCORRECT_USER_PASSWD ||
@@ -90,14 +90,14 @@ void PreferencesNetwork::syncSettings()
 		   password != prefs.cloud_storage_password) {
 
 		// different credentials - reset verification status
-		int oldVerificationStatus = cloud->verificationStatus();
-		cloud->setVerificationStatus(qPref::CS_UNKNOWN);
+		int oldVerificationStatus = cloud->cloud_verification_status();
+		cloud->set_cloud_verification_status(qPref::CS_UNKNOWN);
 		if (!email.isEmpty() && !password.isEmpty()) {
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
 				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
-				cloud->setVerificationStatus(oldVerificationStatus);
+				cloud->set_cloud_verification_status(oldVerificationStatus);
 				return;
 			}
 			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
@@ -118,11 +118,11 @@ void PreferencesNetwork::syncSettings()
 			cloudAuth->backend(email, password, pin);
 		}
 	}
-	cloud->setEmail(email);
-	cloud->setSavePasswordLocal(ui->save_password_local->isChecked());
-	cloud->setPassword(password);
-	cloud->setVerificationStatus(prefs.cloud_verification_status);
-	cloud->setBaseUrl(prefs.cloud_base_url);
+	cloud->set_cloud_storage_email(email);
+	cloud->set_save_password_local(ui->save_password_local->isChecked());
+	cloud->set_cloud_storage_password(password);
+	cloud->set_cloud_verification_status(prefs.cloud_verification_status);
+	cloud->set_cloud_base_url(prefs.cloud_base_url);
 }
 
 void PreferencesNetwork::updateCloudAuthenticationState()

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -2,6 +2,7 @@
 #include "desktop-widgets/subsurfacewebservices.h"
 #include "core/qthelper.h"
 #include "core/webservice.h"
+#include "core/settings/qPref.h"
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/usersurvey.h"
 #include "core/divelist.h"
@@ -9,7 +10,6 @@
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "core/display.h"
 #include "core/membuffer.h"
-#include "core/subsurface-qt/SettingsObjectWrapper.h"
 #include <errno.h>
 #include "core/cloudstorage.h"
 #include "core/subsurface-string.h"
@@ -436,7 +436,7 @@ void SubsurfaceWebServices::buttonClicked(QAbstractButton *button)
 		QSettings s;
 		QString qDialogUid = ui.userID->text().toUpper();
 		bool qSaveUid = ui.saveUidLocal->checkState();
-		SettingsObjectWrapper::instance()->cloud_storage->setSaveUserIdLocal(qSaveUid);
+		qPrefCloudStorage::instance()->set_save_userid_local(qSaveUid);
 
 		//WARN: Dirk, this seems to be wrong, I coundn't really understand the code.
 		if (qSaveUid) {

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -79,6 +79,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/qt-ble.cpp \
 	../../core/settings/qPref.cpp \
 	../../core/settings/qPrefAnimations.cpp \
+	../../core/settings/qPrefCloudStorage.cpp \
 	../../core/settings/qPrefDisplay.cpp \
 	../../core/settings/qPrefPrivate.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
@@ -189,6 +190,7 @@ HEADERS += \
 	../../core/qt-ble.h \
 	../../core/settings/qPref.h \
 	../../core/settings/qPrefAnimations.h \
+	../../core/settings/qPrefCloudStorage.h \
 	../../core/settings/qPrefDisplay.h \
 	../../core/settings/qPrefPrivate.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -148,6 +148,9 @@ void register_qml_types()
 	rc = qmlRegisterType<qPrefAnimations>("org.subsurfacedivelog.mobile", 1, 0, "SsrfAnimationsPrefs");
 	if (rc < 0)
 		qDebug() << "ERROR: Cannot register SsrfAnimationsPrefs (class qPrefAnimations), QML will not work!!";
+	rc = qmlRegisterType<qPrefCloudStorage>("org.subsurfacedivelog.mobile", 1, 0, "SsrfCloudStoragePrefs");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register SsrfCloudStoragePrefs (class qPrefCloudStorage), QML will not work!!";
 	rc = qmlRegisterType<qPrefDisplay>("org.subsurfacedivelog.mobile", 1, 0, "SsrfDisplayPrefs");
 	if (rc < 0)
 		qDebug() << "ERROR: Cannot register DisplayPrefs (class qPrefDisplay), QML will not work!!";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ TEST(TestMerge testmerge.cpp)
 TEST(TestTagList testtaglist.cpp)
 
 TEST(TestQPrefAnimations testqPrefAnimations.cpp)
+TEST(TestQPrefCloudStorage testqPrefCloudStorage.cpp)
 TEST(TestQPrefDisplay testqPrefDisplay.cpp)
 add_test(NAME TestQML COMMAND $<TARGET_FILE:TestQML> ${SUBSURFACE_SOURCE}/tests)
 
@@ -122,6 +123,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestTagList
 
 	TestQPrefAnimations
+	TestQPrefCloudStorage
 	TestQPrefDisplay
 	TestQML
 )

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -24,54 +24,6 @@ void TestPreferences::testPreferences()
 	auto pref = SettingsObjectWrapper::instance();
 	pref->load();
 
-	auto cloud = pref->cloud_storage;
-
-	cloud->set_cloud_base_url("test_one");
-	TEST(cloud->cloud_base_url(), QStringLiteral("test_one"));
-	cloud->set_cloud_base_url("test_two");
-	TEST(cloud->cloud_base_url(), QStringLiteral("test_two"));
-
-	cloud->set_cloud_storage_email("tomaz@subsurface.com");
-	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@subsurface.com"));
-	cloud->set_cloud_storage_email("tomaz@gmail.com");
-	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@gmail.com"));
-
-	cloud->set_git_local_only(true);
-	TEST(cloud->git_local_only(), true);
-	cloud->set_git_local_only(false);
-	TEST(cloud->git_local_only(), false);
-
-	// Why there's new password and password on the prefs?
-	cloud->set_cloud_storage_newpassword("ABCD");
-	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCD"));
-	cloud->set_cloud_storage_newpassword("ABCDE");
-	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCDE"));
-
-	cloud->set_cloud_storage_password("ABCDE");
-	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCDE"));
-	cloud->set_cloud_storage_password("ABCABC");
-	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCABC"));
-
-	cloud->set_save_password_local(true);
-	TEST(cloud->save_password_local(), true);
-	cloud->set_save_password_local(false);
-	TEST(cloud->save_password_local(), false);
-
-	cloud->set_save_userid_local(1);
-	TEST(cloud->save_userid_local(), true);
-	cloud->set_save_userid_local(0);
-	TEST(cloud->save_userid_local(), false);
-
-	cloud->set_userid("Tomaz");
-	TEST(cloud->userid(), QStringLiteral("Tomaz"));
-	cloud->set_userid("Zamot");
-	TEST(cloud->userid(), QStringLiteral("Zamot"));
-
-	cloud->set_cloud_verification_status(0);
-	TEST(cloud->cloud_verification_status(), (short)0);
-	cloud->set_cloud_verification_status(1);
-	TEST(cloud->cloud_verification_status(), (short)1);
-
 	auto tecDetails = pref->techDetails;
 	tecDetails->setModpO2(0.2);
 	TEST(tecDetails->modpO2(), 0.2);

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -26,51 +26,51 @@ void TestPreferences::testPreferences()
 
 	auto cloud = pref->cloud_storage;
 
-	cloud->setBaseUrl("test_one");
-	TEST(cloud->baseUrl(), QStringLiteral("test_one"));
-	cloud->setBaseUrl("test_two");
-	TEST(cloud->baseUrl(), QStringLiteral("test_two"));
+	cloud->set_cloud_base_url("test_one");
+	TEST(cloud->cloud_base_url(), QStringLiteral("test_one"));
+	cloud->set_cloud_base_url("test_two");
+	TEST(cloud->cloud_base_url(), QStringLiteral("test_two"));
 
-	cloud->setEmail("tomaz@subsurface.com");
-	TEST(cloud->email(), QStringLiteral("tomaz@subsurface.com"));
-	cloud->setEmail("tomaz@gmail.com");
-	TEST(cloud->email(), QStringLiteral("tomaz@gmail.com"));
+	cloud->set_cloud_storage_email("tomaz@subsurface.com");
+	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@subsurface.com"));
+	cloud->set_cloud_storage_email("tomaz@gmail.com");
+	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@gmail.com"));
 
-	cloud->setGitLocalOnly(true);
-	TEST(cloud->gitLocalOnly(), true);
-	cloud->setGitLocalOnly(false);
-	TEST(cloud->gitLocalOnly(), false);
+	cloud->set_git_local_only(true);
+	TEST(cloud->git_local_only(), true);
+	cloud->set_git_local_only(false);
+	TEST(cloud->git_local_only(), false);
 
 	// Why there's new password and password on the prefs?
-	cloud->setNewPassword("ABCD");
-	TEST(cloud->newPassword(), QStringLiteral("ABCD"));
-	cloud->setNewPassword("ABCDE");
-	TEST(cloud->newPassword(), QStringLiteral("ABCDE"));
+	cloud->set_cloud_storage_newpassword("ABCD");
+	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCD"));
+	cloud->set_cloud_storage_newpassword("ABCDE");
+	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCDE"));
 
-	cloud->setPassword("ABCDE");
-	TEST(cloud->password(), QStringLiteral("ABCDE"));
-	cloud->setPassword("ABCABC");
-	TEST(cloud->password(), QStringLiteral("ABCABC"));
+	cloud->set_cloud_storage_password("ABCDE");
+	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCDE"));
+	cloud->set_cloud_storage_password("ABCABC");
+	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCABC"));
 
-	cloud->setSavePasswordLocal(true);
-	TEST(cloud->savePasswordLocal(), true);
-	cloud->setSavePasswordLocal(false);
-	TEST(cloud->savePasswordLocal(), false);
+	cloud->set_save_password_local(true);
+	TEST(cloud->save_password_local(), true);
+	cloud->set_save_password_local(false);
+	TEST(cloud->save_password_local(), false);
 
-	cloud->setSaveUserIdLocal(1);
-	TEST(cloud->saveUserIdLocal(), true);
-	cloud->setSaveUserIdLocal(0);
-	TEST(cloud->saveUserIdLocal(), false);
+	cloud->set_save_userid_local(1);
+	TEST(cloud->save_userid_local(), true);
+	cloud->set_save_userid_local(0);
+	TEST(cloud->save_userid_local(), false);
 
-	cloud->setUserId("Tomaz");
-	TEST(cloud->userId(), QStringLiteral("Tomaz"));
-	cloud->setUserId("Zamot");
-	TEST(cloud->userId(), QStringLiteral("Zamot"));
+	cloud->set_userid("Tomaz");
+	TEST(cloud->userid(), QStringLiteral("Tomaz"));
+	cloud->set_userid("Zamot");
+	TEST(cloud->userid(), QStringLiteral("Zamot"));
 
-	cloud->setVerificationStatus(0);
-	TEST(cloud->verificationStatus(), (short)0);
-	cloud->setVerificationStatus(1);
-	TEST(cloud->verificationStatus(), (short)1);
+	cloud->set_cloud_verification_status(0);
+	TEST(cloud->cloud_verification_status(), (short)0);
+	cloud->set_cloud_verification_status(1);
+	TEST(cloud->cloud_verification_status(), (short)1);
 
 	auto tecDetails = pref->techDetails;
 	tecDetails->setModpO2(0.2);

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testqPrefCloudStorage.h"
+
+#include "core/settings/qPref.h"
+#include "core/pref.h"
+#include "core/qthelper.h"
+
+#include <QTest>
+
+void TestQPrefCloudStorage::initTestCase()
+{
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("SubsurfaceTestQPrefCloudStorage");
+}
+
+void TestQPrefCloudStorage::test_struct_get()
+{
+	// Test struct pref -> get func.
+
+	auto tst = qPrefCloudStorage::instance();
+
+	prefs.animation_speed = 17;
+	prefs.cloud_base_url = copy_qstring("new url");
+	prefs.cloud_git_url = copy_qstring("new again url");
+	prefs.cloud_storage_email = copy_qstring("myEmail");
+	prefs.cloud_storage_email_encoded = copy_qstring("encodedMyEMail");
+	prefs.cloud_storage_newpassword = copy_qstring("secret");
+	prefs.cloud_storage_password = copy_qstring("more secret");
+	prefs.cloud_storage_pin = copy_qstring("a pin");
+	prefs.cloud_timeout = 117;
+	prefs.cloud_verification_status = qPref::CS_NOCLOUD;
+	prefs.git_local_only = true;
+	prefs.save_password_local = true;
+	prefs.save_userid_local = true;
+	prefs.userid = copy_qstring("my user");
+
+	QCOMPARE(tst->cloud_base_url(), QString(prefs.cloud_base_url));
+	QCOMPARE(tst->cloud_git_url(), QString(prefs.cloud_git_url));
+	QCOMPARE(tst->cloud_storage_email(), QString(prefs.cloud_storage_email));
+	QCOMPARE(tst->cloud_storage_email_encoded(), QString(prefs.cloud_storage_email_encoded));
+	QCOMPARE(tst->cloud_storage_newpassword(), QString(prefs.cloud_storage_newpassword));
+	QCOMPARE(tst->cloud_storage_password(), QString(prefs.cloud_storage_password));
+	QCOMPARE(tst->cloud_storage_pin(), QString(prefs.cloud_storage_pin));
+	QCOMPARE(tst->cloud_timeout(), (int)prefs.cloud_timeout);
+	QCOMPARE(tst->cloud_verification_status(), (int)prefs.cloud_verification_status);
+	QCOMPARE(tst->git_local_only(), prefs.git_local_only);
+	QCOMPARE(tst->save_password_local(), prefs.save_password_local);
+	QCOMPARE(tst->save_userid_local(), prefs.save_userid_local);
+	QCOMPARE(tst->userid(), QString(prefs.userid));
+
+}
+
+void TestQPrefCloudStorage::test_set_struct()
+{
+	// Test set func -> struct pref
+
+	auto tst = qPrefCloudStorage::instance();
+
+	tst->set_cloud_base_url("t2 base");
+	tst->set_cloud_git_url("t2 git");
+	tst->set_cloud_storage_email("t2 email");
+	tst->set_cloud_storage_email_encoded("t2 email2");
+	tst->set_cloud_storage_newpassword("t2 pass1");
+	tst->set_cloud_storage_password("t2 pass2");
+	tst->set_cloud_storage_pin("t2 pin");
+	tst->set_cloud_timeout(123);
+	tst->set_cloud_verification_status(qPref::CS_VERIFIED);
+	tst->set_git_local_only(false);
+	tst->set_save_password_local(false);
+	tst->set_save_userid_local(false);
+	tst->set_userid("t2 user");
+
+	QCOMPARE(QString(prefs.cloud_base_url), QString("t2 base"));
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t2 git"));
+	QCOMPARE(QString(prefs.cloud_storage_email), QString("t2 email"));
+	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t2 email2"));
+	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("t2 pass1"));
+	QCOMPARE(QString(prefs.cloud_storage_password), QString("t2 pass2"));
+	QCOMPARE(QString(prefs.cloud_storage_pin), QString("t2 pin"));
+	QCOMPARE((int)prefs.cloud_timeout, 123);
+	QCOMPARE((int)prefs.cloud_verification_status, (int)qPref::CS_VERIFIED);
+	QCOMPARE(prefs.git_local_only, false);
+	QCOMPARE(prefs.save_password_local, false);
+	QCOMPARE(prefs.save_userid_local, false);
+	QCOMPARE(QString(prefs.userid), QString("t2 user"));
+}
+
+void TestQPrefCloudStorage::test_set_load_struct()
+{
+	// test set func -> load -> struct pref 
+
+	auto tst = qPrefCloudStorage::instance();
+
+	tst->set_cloud_base_url("t3 base");
+	tst->set_cloud_git_url("t3 git");
+	tst->set_cloud_storage_email("t3 email");
+	tst->set_cloud_storage_email_encoded("t3 email2");
+	tst->set_cloud_storage_newpassword("t3 pass1");
+	tst->set_save_password_local(true);
+	tst->set_cloud_storage_password("t3 pass2");
+	tst->set_cloud_storage_pin("t3 pin");
+	tst->set_cloud_timeout(321);
+	tst->set_cloud_verification_status(qPref::CS_NOCLOUD);
+	tst->set_git_local_only(true);
+	tst->set_save_userid_local(true);
+	tst->set_userid("t3 user");
+
+	prefs.cloud_base_url = copy_qstring("error1");
+	prefs.cloud_git_url = copy_qstring("error1");
+	prefs.cloud_storage_email = copy_qstring("error1");
+	prefs.cloud_storage_email_encoded = copy_qstring("error1");
+	prefs.cloud_storage_newpassword = copy_qstring("my new password");
+	prefs.cloud_storage_password = copy_qstring("error1");
+	prefs.cloud_storage_pin = copy_qstring("error1");
+	prefs.cloud_timeout = 324;
+	prefs.cloud_verification_status = qPref::CS_VERIFIED;
+	prefs.git_local_only = false;
+	prefs.save_password_local = false;
+	prefs.save_userid_local = false;
+	prefs.userid = copy_qstring("error1");
+
+	tst->load();
+	QCOMPARE(QString(prefs.cloud_base_url), QString("t3 base"));
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t3 git"));
+	QCOMPARE(QString(prefs.cloud_storage_email), QString("t3 email"));
+	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t3 email2"));
+	QCOMPARE(QString(prefs.cloud_storage_password), QString("t3 pass2"));
+	QCOMPARE(QString(prefs.cloud_storage_pin), QString("t3 pin"));
+	QCOMPARE((int)prefs.cloud_timeout, 321);
+	QCOMPARE((int)prefs.cloud_verification_status, (int)qPref::CS_NOCLOUD);
+	QCOMPARE(prefs.git_local_only, true);
+	QCOMPARE(prefs.save_password_local, true);
+	QCOMPARE(prefs.save_userid_local, true);
+	QCOMPARE(QString(prefs.userid), QString("t3 user"));
+
+	// warning new password is not saved on disk
+	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("my new password"));
+}
+
+void TestQPrefCloudStorage::test_struct_disk()
+{
+	// test struct prefs -> disk
+
+	auto tst = qPrefCloudStorage::instance();
+
+	prefs.cloud_base_url = copy_qstring("t4 base");
+	prefs.cloud_git_url = copy_qstring("t4 git");
+	prefs.cloud_storage_email = copy_qstring("t4 email");
+	prefs.cloud_storage_email_encoded = copy_qstring("t4 email2");
+	prefs.cloud_storage_newpassword = copy_qstring("t4 pass1");
+	prefs.save_password_local = true;
+	prefs.cloud_storage_password = copy_qstring("t4 pass2");
+	prefs.cloud_storage_pin = copy_qstring("t4 pin");
+	prefs.cloud_timeout = 123;
+	prefs.cloud_verification_status = qPref::CS_VERIFIED;
+	prefs.git_local_only = true;
+	prefs.save_userid_local = true;
+	prefs.userid = copy_qstring("t4 user");
+
+	tst->sync();
+
+	prefs.cloud_base_url = copy_qstring("error1");
+	prefs.cloud_git_url = copy_qstring("error1");
+	prefs.cloud_storage_email = copy_qstring("error1");
+	prefs.cloud_storage_email_encoded = copy_qstring("error1");
+	prefs.cloud_storage_newpassword = copy_qstring("my new password");
+	prefs.cloud_storage_password = copy_qstring("error1");
+	prefs.cloud_storage_pin = copy_qstring("error1");
+	prefs.cloud_timeout = 324;
+	prefs.cloud_verification_status = qPref::CS_VERIFIED;
+	prefs.git_local_only = false;
+	prefs.save_password_local = false;
+	prefs.save_userid_local = false;
+	prefs.userid = copy_qstring("error1");
+
+	tst->load();
+
+	QCOMPARE(QString(prefs.cloud_base_url), QString("t4 base"));
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t4 git"));
+	QCOMPARE(QString(prefs.cloud_storage_email), QString("t4 email"));
+	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t4 email2"));
+	QCOMPARE(QString(prefs.cloud_storage_password), QString("t4 pass2"));
+	QCOMPARE(QString(prefs.cloud_storage_pin), QString("t4 pin"));
+	QCOMPARE((int)prefs.cloud_timeout, 123);
+	QCOMPARE((int)prefs.cloud_verification_status, (int)qPref::CS_VERIFIED);
+	QCOMPARE(prefs.git_local_only, true);
+	QCOMPARE(prefs.save_password_local, true);
+	QCOMPARE(prefs.save_userid_local, true);
+	QCOMPARE(QString(prefs.userid), QString("t4 user"));
+
+	// warning new password not stored on disk
+	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("my new password"));
+}
+
+void TestQPrefCloudStorage::test_multiple()
+{
+	// test multiple instances have the same information
+
+	prefs.animation_speed = 37;
+	auto tst_direct = new qPrefCloudStorage;
+
+	prefs.cloud_timeout = 25;
+	auto tst = qPrefCloudStorage::instance();
+
+	QCOMPARE(tst->cloud_timeout(), tst_direct->cloud_timeout());
+}
+
+QTEST_MAIN(TestQPrefCloudStorage)

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -206,4 +206,61 @@ void TestQPrefCloudStorage::test_multiple()
 	QCOMPARE(tst->cloud_timeout(), tst_direct->cloud_timeout());
 }
 
+#define TEST(METHOD, VALUE) \
+QCOMPARE(METHOD, VALUE); \
+cloud->sync(); \
+cloud->load(); \
+QCOMPARE(METHOD, VALUE);
+
+void TestQPrefCloudStorage::test_oldPreferences()
+{
+	auto cloud = qPrefCloudStorage::instance();
+
+	cloud->set_cloud_base_url("test_one");
+	TEST(cloud->cloud_base_url(), QStringLiteral("test_one"));
+	cloud->set_cloud_base_url("test_two");
+	TEST(cloud->cloud_base_url(), QStringLiteral("test_two"));
+
+	cloud->set_cloud_storage_email("tomaz@subsurface.com");
+	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@subsurface.com"));
+	cloud->set_cloud_storage_email("tomaz@gmail.com");
+	TEST(cloud->cloud_storage_email(), QStringLiteral("tomaz@gmail.com"));
+
+	cloud->set_git_local_only(true);
+	TEST(cloud->git_local_only(), true);
+	cloud->set_git_local_only(false);
+	TEST(cloud->git_local_only(), false);
+
+	// Why there's new password and password on the prefs?
+	cloud->set_cloud_storage_newpassword("ABCD");
+	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCD"));
+	cloud->set_cloud_storage_newpassword("ABCDE");
+	TEST(cloud->cloud_storage_newpassword(), QStringLiteral("ABCDE"));
+
+	cloud->set_cloud_storage_password("ABCDE");
+	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCDE"));
+	cloud->set_cloud_storage_password("ABCABC");
+	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCABC"));
+
+	cloud->set_save_password_local(true);
+	TEST(cloud->save_password_local(), true);
+	cloud->set_save_password_local(false);
+	TEST(cloud->save_password_local(), false);
+
+	cloud->set_save_userid_local(1);
+	TEST(cloud->save_userid_local(), true);
+	cloud->set_save_userid_local(0);
+	TEST(cloud->save_userid_local(), false);
+
+	cloud->set_userid("Tomaz");
+	TEST(cloud->userid(), QStringLiteral("Tomaz"));
+	cloud->set_userid("Zamot");
+	TEST(cloud->userid(), QStringLiteral("Zamot"));
+
+	cloud->set_cloud_verification_status(0);
+	TEST(cloud->cloud_verification_status(), 0);
+	cloud->set_cloud_verification_status(1);
+	TEST(cloud->cloud_verification_status(), 1);
+}
+
 QTEST_MAIN(TestQPrefCloudStorage)

--- a/tests/testqPrefCloudStorage.h
+++ b/tests/testqPrefCloudStorage.h
@@ -15,6 +15,7 @@ private slots:
 	void test_set_load_struct();
 	void test_struct_disk();
 	void test_multiple();
+	void test_oldPreferences();
 };
 
 #endif // TESTQPREFCLOUDSTORAGE_H

--- a/tests/testqPrefCloudStorage.h
+++ b/tests/testqPrefCloudStorage.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTQPREFCLOUDSTORAGE_H
+#define TESTQPREFCLOUDSTORAGE_H
+
+#include <QObject>
+
+class TestQPrefCloudStorage : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase();
+	void test_struct_get();
+	void test_set_struct();
+	void test_set_load_struct();
+	void test_struct_disk();
+	void test_multiple();
+};
+
+#endif // TESTQPREFCLOUDSTORAGE_H

--- a/tests/tst_qPrefCloudStorage.qml
+++ b/tests/tst_qPrefCloudStorage.qml
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import QtTest 1.2
+import org.subsurfacedivelog.mobile 1.0
+
+TestCase {
+	name: "qPrefCloudStorage"
+
+	SsrfCloudStoragePrefs {
+		id: tst
+	}
+
+	SsrfPrefs {
+		id: prefs
+	}
+
+	function test_variables() {
+		var x1 = tst.cloud_base_url
+		tst.cloud_base_url = "my url"
+		compare(tst.cloud_base_url, "my url")
+
+		var x2 = tst.cloud_git_url
+		tst.cloud_git_url= "my url"
+		compare(tst.cloud_git_url, "my url")
+
+		var x3 = tst.cloud_storage_email
+		tst.cloud_storage_email = "my email"
+		compare(tst.cloud_storage_email, "my email")
+
+		var x4 = tst.cloud_storage_email_encoded
+		tst.cloud_storage_email_encoded= "my email enc"
+		compare(tst.cloud_storage_email_encoded, "my email enc")
+
+		var x5 = tst.cloud_storage_newpassword
+		tst.cloud_storage_newpassword = "my new password"
+		compare(tst.cloud_storage_newpassword, "my new password")
+
+		var x6 = tst.cloud_storage_password
+		tst.cloud_storage_password = "my url"
+		compare(tst.cloud_storage_password, "my url")
+
+		var x7 = tst.cloud_storage_pin
+		tst.cloud_storage_pin= "my pin"
+		compare(tst.cloud_storage_pin, "my pin")
+
+		var x8 = tst.cloud_timeout
+		tst.cloud_timeout = 137
+		compare(tst.cloud_timeout, 137)
+
+		var x9 = tst.cloud_verification_status
+		tst.cloud_verification_status = SsrfPrefs.CS_VERIFIED
+		compare(tst.cloud_verification_status, SsrfPrefs.CS_VERIFIED)
+
+		var x10 = tst.git_local_only
+		tst.git_local_only = true 
+		compare(tst.git_local_only, true)
+
+		var x11 = tst.save_password_local
+		tst.save_password_local = true
+		compare(tst.save_password_local, true)
+
+		var x12 = tst.save_userid_local
+		tst.save_userid_local = true
+		compare(tst.save_userid_local, true)
+
+		var x13 = tst.userid
+		tst.userid = "my user"
+		compare(tst.userid, "my user")
+	}
+}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Following qPrefDisplay and qPrefAnimations are qPrefCloudStorage, same schema

There are several special test cases to test e.g. that newpassword is not saved on disk.

remark qmlprefs and the qml files are not changed in this PR, as the preference is to deal with qmlPrefs in a single PR.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
