### PR TITLE
Trivial: Fix typo in INSTALL: add missing backspace at end of line

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -171,7 +171,7 @@ Package names for Ubuntu 18.04
 
 sudo apt install \
 	autoconf automake cmake g++ git libcrypto++-dev libcurl4-gnutls-dev \
-	libgit2-dev libqt5qml5 libqt5quick5 libqt5svg5-dev
+	libgit2-dev libqt5qml5 libqt5quick5 libqt5svg5-dev \
 	libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libssl-dev \
 	libtool libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make \
 	pkg-config qml-module-qtlocation qml-module-qtpositioning \


### PR DESCRIPTION
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Trivial typo fix: a backspace was missing in the `apt` line for Ubuntu 18.04.