### PR TITLE
 core: update of qPref_private.h

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	settings/qPref.cpp
 	settings/qPrefAnimations.cpp
 	settings/qPrefDisplay.cpp
+	settings/qPrefPrivate.cpp
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-#include "qPref_private.h"
+#include "qPrefPrivate.h"
 #include "qPref.h"
 #include "ssrf-version.h"
 

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -3,7 +3,6 @@
 #define QPREF_H
 
 #include <QObject>
-#include <QSettings>
 #include "core/pref.h"
 
 #include "qPrefAnimations.h"

--- a/core/settings/qPrefAnimations.cpp
+++ b/core/settings/qPrefAnimations.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qPref.h"
-#include "qPref_private.h"
-#include "qPrefAnimations.h"
+#include "qPrefPrivate.h"
+
+static const QString group = QStringLiteral("Animations");
 
 qPrefAnimations::qPrefAnimations(QObject *parent) : QObject(parent)
 {

--- a/core/settings/qPrefAnimations.h
+++ b/core/settings/qPrefAnimations.h
@@ -3,7 +3,6 @@
 #define QPREFANIMATIONS_H
 
 #include <QObject>
-#include <QSettings>
 
 class qPrefAnimations : public QObject {
 	Q_OBJECT
@@ -28,9 +27,6 @@ signals:
 	void animation_speed_changed(int value);
 
 private:
-	const QString group = QStringLiteral("Animations");
-	QSettings setting;
-
 	// functions to load/sync variable with disk
 	void disk_animation_speed(bool doSync);
 };

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qPref.h"
-#include "qPref_private.h"
+#include "qPrefPrivate.h"
 #include "core/subsurface-string.h"
 
 #include <QApplication>
 #include <QFont>
+
+static const QString group = QStringLiteral("Display");
 
 qPrefDisplay::qPrefDisplay(QObject *parent) : QObject(parent)
 {

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -3,7 +3,6 @@
 #define QPREFDISPLAY_H
 
 #include <QObject>
-#include <QSettings>
 
 class qPrefDisplay : public QObject {
 	Q_OBJECT
@@ -44,9 +43,6 @@ signals:
 	void theme_changed(const QString& value);
 
 private:
-	const QString group = QStringLiteral("Display");
-	QSettings setting;
-
 	// functions to load/sync variable with disk
 	void disk_divelist_font(bool doSync);
 	void disk_font_size(bool doSync);

--- a/core/settings/qPrefPrivate.cpp
+++ b/core/settings/qPrefPrivate.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h"
+
+qPrefPrivate::qPrefPrivate(QObject *parent) : QObject(parent)
+{
+}
+qPrefPrivate *qPrefPrivate::instance()
+{
+	static qPrefPrivate *self = new qPrefPrivate;
+	return self;
+}

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -9,6 +9,19 @@
 #include <QObject>
 #include "core/qthelper.h"
 
+// implementation class of the interface classes
+class qPrefPrivate : public QObject {
+    Q_OBJECT
+
+public:
+    static qPrefPrivate *instance();
+
+	QSettings setting;
+
+private:
+    qPrefPrivate(QObject *parent = NULL);
+};
+
 //****** Macros to be used in the set functions ******
 #define COPY_TXT(name, string) \
 { \
@@ -20,49 +33,49 @@
 #define LOADSYNC_BOOL(name, field) \
 { \
 	if (doSync)	\
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = setting.value(group + name, default_prefs.field).toBool(); \
+		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toBool(); \
 }
 
 #define LOADSYNC_DOUBLE(name, field) \
 { \
 	if (doSync)	\
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = setting.value(group + name, default_prefs.field).toDouble(); \
+		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toDouble(); \
 }
 
 #define LOADSYNC_ENUM(name, type, field) \
 { \
 	if (doSync)	\
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = (enum type)setting.value(group + name, default_prefs.field).toInt(); \
+		prefs.field = (enum type)qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
 }
 
 #define LOADSYNC_INT(name, field) \
 { \
 	if (doSync) \
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = setting.value(group + name, default_prefs.field).toInt(); \
+		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
 }
 
 #define LOADSYNC_INT_DEF(name, field, defval) \
 { \
 	if (doSync)	\
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = setting.value(group + name, defval).toInt(); \
+		prefs.field = qPrefPrivate::instance()->setting.value(group + name, defval).toInt(); \
 }
 
 #define LOADSYNC_TXT(name, field) \
 { \
 	if (doSync)	\
-		setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
-		prefs.field = copy_qstring(setting.value(group + name, default_prefs.field).toString()); \
+		prefs.field = copy_qstring(qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toString()); \
 }
 
 //******* Macros to generate disk function

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -80,6 +80,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/settings/qPref.cpp \
 	../../core/settings/qPrefAnimations.cpp \
 	../../core/settings/qPrefDisplay.cpp \
+	../../core/settings/qPrefPrivate.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
@@ -189,7 +190,7 @@ HEADERS += \
 	../../core/settings/qPref.h \
 	../../core/settings/qPrefAnimations.h \
 	../../core/settings/qPrefDisplay.h \
-	../../core/settings/qPref_private.h \
+	../../core/settings/qPrefPrivate.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \
 	../../core/subsurface-qt/DiveObjectHelper.h \
 	../../core/subsurface-qt/SettingsObjectWrapper.h \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,11 +97,12 @@ TEST(TestDiveSiteDuplication testdivesiteduplication.cpp)
 TEST(TestRenumber testrenumber.cpp)
 TEST(TestGitStorage testgitstorage.cpp)
 TEST(TestPreferences testpreferences.cpp)
-TEST(TestQPrefDisplay testqPrefDisplay.cpp)
-TEST(TestQPrefAnimations testqPrefAnimations.cpp)
 TEST(TestPicture testpicture.cpp)
 TEST(TestMerge testmerge.cpp)
 TEST(TestTagList testtaglist.cpp)
+
+TEST(TestQPrefAnimations testqPrefAnimations.cpp)
+TEST(TestQPrefDisplay testqPrefDisplay.cpp)
 add_test(NAME TestQML COMMAND $<TARGET_FILE:TestQML> ${SUBSURFACE_SOURCE}/tests)
 
 
@@ -114,12 +115,14 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestGitStorage
 	TestPlan
 	TestDiveSiteDuplication
-	TestQPrefDisplay
 	TestPreferences
 	TestRenumber
 	TestPicture
 	TestMerge
 	TestTagList
+
+	TestQPrefAnimations
+	TestQPrefDisplay
 	TestQML
 )
 

--- a/tests/testqPrefAnimations.cpp
+++ b/tests/testqPrefAnimations.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testqPrefAnimations.h"
 
-#include "core/settings/qPrefAnimations.h"
+#include "core/settings/qPref.h"
 #include "core/pref.h"
 #include "core/qthelper.h"
 
 #include <QDate>
+#include <QTest>
 
 void TestQPrefAnimations::initTestCase()
 {

--- a/tests/testqPrefAnimations.h
+++ b/tests/testqPrefAnimations.h
@@ -2,7 +2,7 @@
 #ifndef TESTQPREFANIMATIONS_H
 #define TESTQPREFANIMATIONS_H
 
-#include <QtTest>
+#include <QObject>
 
 class TestQPrefAnimations : public QObject
 {

--- a/tests/testqPrefDisplay.cpp
+++ b/tests/testqPrefDisplay.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testqPrefDisplay.h"
 
-#include "core/settings/qPrefDisplay.h"
+#include "core/settings/qPref.h"
 #include "core/pref.h"
 #include "core/qthelper.h"
 
 #include <QDate>
+#include <QTest>
 
 void TestQPrefDisplay::initTestCase()
 {
@@ -40,13 +41,13 @@ void TestQPrefDisplay::test_set_struct()
 	auto display = qPrefDisplay::instance();
 
 	display->set_display_invalid_dives(true);
-	display->set_divelist_font("comic");
+	display->set_divelist_font("doNotCareAtAll");
 	display->set_font_size(12.0);
 	display->set_show_developer(false);
  	display->set_theme("myTheme");
 
 	QCOMPARE(prefs.display_invalid_dives, true);
-	QCOMPARE(prefs.divelist_font, "comic");
+	QCOMPARE(prefs.divelist_font, "doNotCareAtAll");
 	QCOMPARE(prefs.font_size, 12.0);
 	QCOMPARE(prefs.show_developer, false);
 	QCOMPARE(prefs.theme, "myTheme");
@@ -59,20 +60,20 @@ void TestQPrefDisplay::test_set_load_struct()
 	auto display = qPrefDisplay::instance();
 
 	display->set_display_invalid_dives(false);
-	display->set_divelist_font("helvitica");
+	display->set_divelist_font("doNotCareString");
 	display->set_font_size(15.0);
 	display->set_show_developer(true);
  	display->set_theme("myTheme2");
 
 	prefs.display_invalid_dives = true;
-	prefs.divelist_font = copy_qstring("comic");
+	prefs.divelist_font = copy_qstring("doNotCareAtAll");
 	prefs.font_size = 12.0;
 	prefs.show_developer = false;
  	prefs.theme = copy_qstring("myTheme");
 
 	display->load();
 	QCOMPARE(prefs.display_invalid_dives, false);
-	QCOMPARE(prefs.divelist_font, "helvitica");
+	QCOMPARE(prefs.divelist_font, "doNotCareString");
 	QCOMPARE(prefs.font_size, 15.0);
 	QCOMPARE(prefs.show_developer, true);
 	QCOMPARE(prefs.theme, "myTheme2");
@@ -85,21 +86,21 @@ void TestQPrefDisplay::test_struct_disk()
 	auto display = qPrefDisplay::instance();
 
 	prefs.display_invalid_dives = true;
-	prefs.divelist_font = copy_qstring("helvitica");
+	prefs.divelist_font = copy_qstring("doNotCareAtAll");
 	prefs.font_size = 17.0;
 	prefs.show_developer = false;
  	prefs.theme = copy_qstring("myTheme3");
 
 	display->sync();
 	prefs.display_invalid_dives = false;
-	prefs.divelist_font = copy_qstring("comic");
+	prefs.divelist_font = copy_qstring("noString");
 	prefs.font_size = 11.0;
 	prefs.show_developer = true;
  	prefs.theme = copy_qstring("myTheme");
 
 	display->load();
 	QCOMPARE(prefs.display_invalid_dives, true);
-	QCOMPARE(prefs.divelist_font, "helvitica");
+	QCOMPARE(prefs.divelist_font, "doNotCareAtAll");
 	QCOMPARE(prefs.font_size, 17.0);
 	QCOMPARE(prefs.show_developer, false);
 	QCOMPARE(prefs.theme, "myTheme3");
@@ -117,7 +118,7 @@ void TestQPrefDisplay::test_multiple()
 	auto display_direct = new qPrefDisplay;
 
 	prefs.display_invalid_dives = true;
-	prefs.divelist_font = copy_qstring("helvetica");
+	prefs.divelist_font = copy_qstring("multipleCharsInString");
 	prefs.font_size = 15.0;
 	prefs.show_developer = false;
  	prefs.theme = copy_qstring("myTheme8");

--- a/tests/testqPrefDisplay.h
+++ b/tests/testqPrefDisplay.h
@@ -2,7 +2,7 @@
 #ifndef TESTQPREFDISPLAY_H
 #define TESTQPREFDISPLAY_H
 
-#include <QtTest>
+#include <QObject>
 
 class TestQPrefDisplay : public QObject
 {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
QSettings header was exposed to the whole system, and each qPref* instance contained a QSettings object.

Change to have 1 global Qsettings variable (qPrefPrivate) and no Qsettings include in the public header files.

tests files had a mismtch between including QtTest and QTest

Clean includes in header files.

This PR could have waited, but it is my preference to make the change mow so the comming 7 PR (one pr class) will have it included.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh I am leaving #1515 as WIP until this one is merged.