### PR TITLE
Cleanup: rename dive_getUniqID() and handle double ids gracefully

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -462,7 +462,7 @@ struct dive *alloc_dive(void)
 	if (!dive)
 		exit(1);
 	memset(dive, 0, sizeof(*dive));
-	dive->id = dive_getUniqID(dive);
+	dive_setUniqID(dive);
 	return dive;
 }
 
@@ -1784,7 +1784,7 @@ struct dive *fixup_dive(struct dive *dive)
 	/* we should always have a uniq ID as that gets assigned during alloc_dive(),
 	 * but we want to make sure... */
 	if (!dive->id)
-		dive->id = dive_getUniqID(dive);
+		dive_setUniqID(dive);
 
 	return dive;
 }

--- a/core/dive.h
+++ b/core/dive.h
@@ -757,7 +757,7 @@ extern int legacy_format_o2pressures(struct dive *dive, struct divecomputer *dc)
 extern void sort_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);
-extern int dive_getUniqID(struct dive *d);
+extern void dive_setUniqID(struct dive *d);
 extern unsigned int dc_airtemp(struct divecomputer *dc);
 extern unsigned int dc_watertemp(struct divecomputer *dc);
 extern int split_dive(struct dive *);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -292,24 +292,23 @@ QList<int> getDivesInTrip(dive_trip_t *trip)
 // it doesn't change during the life time of a Subsurface session
 // oh, and it has no meaning whatsoever - that's why we have the
 // silly initial number and increment by 3 :-)
-int dive_getUniqID(struct dive *d)
+void dive_setUniqID(struct dive *d)
 {
 	static QSet<int> ids;
 	static int maxId = 83529;
 
-	int id = d->id;
-	if (id) {
-		if (!ids.contains(id)) {
+	if (d->id) {
+		if (!ids.contains(d->id)) {
 			qDebug() << "WTF - only I am allowed to create IDs";
-			ids.insert(id);
+			ids.insert(d->id);
 		}
-		return id;
+		return;
 	}
-	maxId += 3;
-	id = maxId;
-	Q_ASSERT(!ids.contains(id));
-	ids.insert(id);
-	return id;
+	do {
+		maxId += 3;
+	} while (ids.contains(maxId));
+	ids.insert(maxId);
+	d->id = maxId;
 }
 
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -982,7 +982,7 @@ void MainWindow::setupForAddAndPlan(const char *model)
 	// clean out the dive and give it an id and the correct dc model
 	clear_dive(&displayed_dive);
 	clear_dive_site(&displayed_dive_site);
-	displayed_dive.id = dive_getUniqID(&displayed_dive);
+	dive_setUniqID(&displayed_dive);
 	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
 	displayed_dive.dc.model = strdup(model); // don't translate! this is stored in the XML file
 	dc_number = 1;


### PR DESCRIPTION
dive_getUniqID() actually *set* the unique id of a dive. Therefore,
rename this function to dive_setUniqID(). Weirdly, all callers of the
function used the pattern
	dive.id = dive_getUniqID(&dive);
so the dive-id was assigned twice, once inside and once outside the
function. Change this to
	dive_setUniqId(&dive)
and don't return the id. It can be read from dive.id anyway.

Finally, fix a small inconsistency:
If a dive already had an id, this id would have been registered and
a debug message written. Creation of an already-registered id would
on the other hand raise an assert(). But the latter can only happen
as a consequence of the former - so why be once graceful and once
terminate? Therefore, make both cases graceful.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is just a (very) minor cleanup, but I think the new code is more logical. Seeing something like:
```
        dive.id = dive_getUniqID(&dive);
```
you probably wouldn't have guessed that the function actually *sets* the id by itself. Changing this to
```
        dive_setUniqID(&dive);
```
makes it much more clear what happens.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) rename function `dive_getUniqID()` to `dive_setUniqID`.
2) don't return id in `dive_setUniqID`.
3) consistently handle double-ids gracefully.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
