### PR TITLE
Cleanup: simplify dive_getUniqID()

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -454,6 +454,15 @@ double get_weight_units(unsigned int grams, int *frac, const char **units)
 	return value;
 }
 
+// we need this to be uniq. oh, and it has no meaning whatsoever
+// - that's why we have the silly initial number and increment by 3 :-)
+int dive_getUniqID()
+{
+	static int maxId = 83529;
+	maxId += 3;
+	return maxId;
+}
+
 struct dive *alloc_dive(void)
 {
 	struct dive *dive;
@@ -462,7 +471,7 @@ struct dive *alloc_dive(void)
 	if (!dive)
 		exit(1);
 	memset(dive, 0, sizeof(*dive));
-	dive->id = dive_getUniqID(dive);
+	dive->id = dive_getUniqID();
 	return dive;
 }
 
@@ -1784,7 +1793,7 @@ struct dive *fixup_dive(struct dive *dive)
 	/* we should always have a uniq ID as that gets assigned during alloc_dive(),
 	 * but we want to make sure... */
 	if (!dive->id)
-		dive->id = dive_getUniqID(dive);
+		dive->id = dive_getUniqID();
 
 	return dive;
 }

--- a/core/dive.h
+++ b/core/dive.h
@@ -757,7 +757,7 @@ extern int legacy_format_o2pressures(struct dive *dive, struct divecomputer *dc)
 extern void sort_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);
-extern int dive_getUniqID(struct dive *d);
+extern int dive_getUniqID();
 extern unsigned int dc_airtemp(struct divecomputer *dc);
 extern unsigned int dc_watertemp(struct divecomputer *dc);
 extern int split_dive(struct dive *);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -288,31 +288,6 @@ QList<int> getDivesInTrip(dive_trip_t *trip)
 	return ret;
 }
 
-// we need this to be uniq, but also make sure
-// it doesn't change during the life time of a Subsurface session
-// oh, and it has no meaning whatsoever - that's why we have the
-// silly initial number and increment by 3 :-)
-int dive_getUniqID(struct dive *d)
-{
-	static QSet<int> ids;
-	static int maxId = 83529;
-
-	int id = d->id;
-	if (id) {
-		if (!ids.contains(id)) {
-			qDebug() << "WTF - only I am allowed to create IDs";
-			ids.insert(id);
-		}
-		return id;
-	}
-	maxId += 3;
-	id = maxId;
-	Q_ASSERT(!ids.contains(id));
-	ids.insert(id);
-	return id;
-}
-
-
 static xmlDocPtr get_stylesheet_doc(const xmlChar *uri, xmlDictPtr, int, void *, xsltLoadType)
 {
 	QFile f(QLatin1String(":/xslt/") + (const char *)uri);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -982,7 +982,7 @@ void MainWindow::setupForAddAndPlan(const char *model)
 	// clean out the dive and give it an id and the correct dc model
 	clear_dive(&displayed_dive);
 	clear_dive_site(&displayed_dive_site);
-	displayed_dive.id = dive_getUniqID(&displayed_dive);
+	displayed_dive.id = dive_getUniqID();
 	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
 	displayed_dive.dc.model = strdup(model); // don't translate! this is stored in the XML file
 	dc_number = 1;


### PR DESCRIPTION
dive_getUniqID() is used to create unique dive ids, which are
stable during application lifetime. It was passed a dive, checked
that the id was not set (if it was that it is know to the application)
and set a new id (in contradiction to its name!) if it hadn't any.

There were three callers:

alloc_dive(): called the function on a zeroed dive struct.
fixup_dive(): called the function only if the dive had a 0 id.
MainWindow::setupForAddAndPlan(): called the function on a zeroed dive
struct.

Thus, in all three callers the id is guaranteed to be zero and
the whole keeping-track-of-ids logic is moot. Remove the logic,
don't pass a dive struct to dive_getUniqID() and move the function
to the C-backend.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Minor cleanup: remove the whole `dive_getUniqID()` logic, since all callers guaranteed to not have an id set. The dives where either cleared or tested for 0-id right before the call. This function might have made sense previously, but now there seems to be no point. For once, move something from C++ to C. :)
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
