### PR TITLE
Fix obvious crashes in UndoCommands

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -506,6 +506,7 @@ extern void delete_single_dive(int idx);
 extern void add_single_dive(int idx, struct dive *dive);
 
 extern void insert_trip(dive_trip_t **trip);
+extern struct dive_trip *clone_empty_trip(struct dive_trip *trip);
 
 
 extern const struct units SI_units, IMPERIAL_units;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -771,6 +771,19 @@ void insert_trip(dive_trip_t **dive_trip_p)
 #endif
 }
 
+/* create a copy of a dive trip, but don't add any dives. */
+dive_trip_t *clone_empty_trip(dive_trip_t *trip)
+{
+	dive_trip_t *copy = malloc(sizeof(struct dive_trip));
+	*copy = *trip;
+	copy->location = copy_string(trip->location);
+	copy->notes = copy_string(trip->notes);
+	copy->nrdives = 0;
+	copy->next = NULL;
+	copy->dives = NULL;
+	return copy;
+}
+
 static void delete_trip(dive_trip_t *trip)
 {
 	dive_trip_t **p, *tmp;

--- a/desktop-widgets/undocommands.cpp
+++ b/desktop-widgets/undocommands.cpp
@@ -48,13 +48,7 @@ void UndoDeleteDive::redo()
 		// check for trip - if this is the last dive in the trip
 		// the trip will get deleted, so we need to remember it as well
 		if (d->divetrip && d->divetrip->nrdives == 1) {
-			struct dive_trip *undo_trip = (struct dive_trip *)calloc(1, sizeof(struct dive_trip));
-			*undo_trip = *d->divetrip;
-			undo_trip->location = copy_string(d->divetrip->location);
-			undo_trip->notes = copy_string(d->divetrip->notes);
-			undo_trip->nrdives = 0;
-			undo_trip->next = NULL;
-			undo_trip->dives = NULL;
+			dive_trip *undo_trip = clone_empty_trip(d->divetrip);
 			// update all the dives who were in this trip to point to the copy of the
 			// trip that we are about to delete implicitly when deleting its last dive below
 			Q_FOREACH(struct dive *inner_dive, newList) {
@@ -141,10 +135,15 @@ UndoRemoveDivesFromTrip::UndoRemoveDivesFromTrip(QMap<dive *, dive_trip *> remov
 
 void UndoRemoveDivesFromTrip::undo()
 {
+	// first bring back the trip(s)
+	Q_FOREACH(struct dive_trip *trip, tripList)
+		insert_trip(&trip);
+	tripList.clear();
+
 	QMapIterator<dive*, dive_trip*> i(divesToUndo);
 	while (i.hasNext()) {
 		i.next();
-		add_dive_to_trip(i.key (), i.value());
+		add_dive_to_trip(i.key(), i.value());
 	}
 	mark_divelist_changed(true);
 	MainWindow::instance()->refreshDisplay();
@@ -155,6 +154,17 @@ void UndoRemoveDivesFromTrip::redo()
 	QMapIterator<dive*, dive_trip*> i(divesToUndo);
 	while (i.hasNext()) {
 		i.next();
+		// If the trip will be deleted, remember it so that we can restore it later.
+		dive_trip *trip = i.value();
+		if (trip->nrdives == 1) {
+			dive_trip *cloned_trip = clone_empty_trip(trip);
+			tripList.append(cloned_trip);
+			// Rewrite the dive list, such that the dives will be added to the resurrected trip.
+			for (dive_trip *&old_trip: divesToUndo) {
+				if (old_trip == trip)
+					old_trip = cloned_trip;
+			}
+		}
 		remove_dive_from_trip(i.key(), false);
 	}
 	mark_divelist_changed(true);

--- a/desktop-widgets/undocommands.cpp
+++ b/desktop-widgets/undocommands.cpp
@@ -33,6 +33,7 @@ void UndoDeleteDive::undo()
 		record_dive(diveList.at(i));
 	}
 	mark_divelist_changed(true);
+	tripList.clear();
 	MainWindow::instance()->refreshDisplay();
 }
 
@@ -56,9 +57,10 @@ void UndoDeleteDive::redo()
 			undo_trip->dives = NULL;
 			// update all the dives who were in this trip to point to the copy of the
 			// trip that we are about to delete implicitly when deleting its last dive below
-			Q_FOREACH(struct dive *inner_dive, newList)
+			Q_FOREACH(struct dive *inner_dive, newList) {
 				if (inner_dive->divetrip == d->divetrip)
 					inner_dive->divetrip = undo_trip;
+			}
 			d->divetrip = undo_trip;
 			tripList.append(undo_trip);
 		}

--- a/desktop-widgets/undocommands.h
+++ b/desktop-widgets/undocommands.h
@@ -45,6 +45,7 @@ public:
 
 private:
 	QMap<struct dive*, dive_trip*> divesToUndo;
+	QList<struct dive_trip*> tripList;
 };
 
 #endif // UNDOCOMMANDS_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I looked at the "UndoCommands" and noticed that the whole thing is
1) very rudimentary
2) fundamentally broken

No offense intended, but whoever wrote this did not think it through. Multiple undo/redo levels with this scheme would mean rewriting the whole undo/redo history on every command. Can be done for now, but this does not scale for a more complete undo/redo support.

But - for better or worse - it is there and exposed to the user, so this PR fixes just two very obvious crashes. It does by no means fix the fundamental flaw and it's still trivial to crash it by using two levels of undo. This is just a temporary stop-gap measure.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Clear the list of trips on recreation of the trips to avoid double-frees.
2) Remember the deleted trips on undo of remove-from-trip. Does not consider multiple levels of undo.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I don't think we should point users to this fundamentally broken functionality.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
