### PR TITLE
Dive media: implement "Open folder of selected media files"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Dive media: implement "open folder of selected media files" [#1514]
 - Dive media: Change term "photos" and "images" everywhere in the UI to "media files"
 - mobile: show developer menu is now saved on disk and remebered between start of Subsurface
 - tests: add qml test harness

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -10,6 +10,7 @@
 #include <QMenu>
 #include <QUrl>
 #include <QMessageBox>
+#include <QFileInfo>
 
 //TODO: Remove those in the future.
 #include "../mainwindow.h"
@@ -54,6 +55,7 @@ void TabDivePhotos::contextMenuEvent(QContextMenuEvent *event)
 	popup.addSeparator();
 	popup.addAction(tr("Delete selected media files"), this, SLOT(removeSelectedPhotos()));
 	popup.addAction(tr("Delete all media files"), this, SLOT(removeAllPhotos()));
+	popup.addAction(tr("Open folder of selected media files"), this, SLOT(openFolderOfSelectedFiles()));
 	popup.addAction(tr("Recalculate selected thumbnails"), this, SLOT(recalculateSelectedThumbnails()));
 	popup.exec(event->globalPos());
 	event->accept();
@@ -81,6 +83,22 @@ QVector<QString> TabDivePhotos::getSelectedFilenames() const
 void TabDivePhotos::removeSelectedPhotos()
 {
 	DivePictureModel::instance()->removePictures(getSelectedFilenames());
+}
+
+void TabDivePhotos::openFolderOfSelectedFiles()
+{
+	QVector<QString> directories;
+	for (const QString &filename: getSelectedFilenames()) {
+		QFileInfo info(filename);
+		if (!info.exists())
+			continue;
+		QString path = info.absolutePath();
+		if (path.isEmpty() || directories.contains(path))
+			continue;
+		directories.append(path);
+	}
+	for (const QString &dir: directories)
+		QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
 }
 
 void TabDivePhotos::recalculateSelectedThumbnails()

--- a/desktop-widgets/tab-widgets/TabDivePhotos.h
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.h
@@ -27,6 +27,7 @@ private slots:
 	void removeAllPhotos();
 	void removeSelectedPhotos();
 	void recalculateSelectedThumbnails();
+	void openFolderOfSelectedFiles();
 	void changeZoomLevel(int delta);
 
 private:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Implements the feature suggested by @sfuchs79 in #1514: add context menu entry to open folder of selected media files.

Originally I had a commit to move the whole context menu down from TabDivePhotos to DivePictureWidget. The code had less indirections and therefore was cleaner in my opinion, but since it made zero difference for the user, I ultimately trashed it.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1514 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Too trivial?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79 @atdotde 