### PR TITLE
Fetch sqlite from https:// site

### DIFF
--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -182,7 +182,7 @@ for package in "${PACKAGES[@]}" ; do
 			curl_download_library libftdi1 https://www.intra2net.com/en/developer/libftdi/download/ libftdi1-${CURRENT_LIBFTDI}.tar.bz2
 			;;
 		sqlite)
-			curl_download_library sqlite http://www.sqlite.org/2017/ sqlite-autoconf-${CURRENT_SQLITE}.tar.gz
+			curl_download_library sqlite https://www.sqlite.org/2017/ sqlite-autoconf-${CURRENT_SQLITE}.tar.gz
 			;;
 		*)
 			echo "unknown package \"$package\""


### PR DESCRIPTION
The http:// version is down an makes Travis fail.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Change `http://www.sqlite.org` to `https://www.sqlite.org`. The former makes Travis fail, because it can't be reached.