### PR TITLE
(Trivial) cleanup: remove DiveItem::icon_names member array

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -82,11 +82,16 @@ QVariant TripItem::data(int column, int role) const
 	return ret;
 }
 
+static const QString icon_names[4] = {
+	QStringLiteral(":zero"),
+	QStringLiteral(":photo-in-icon"),
+	QStringLiteral(":photo-out-icon"),
+	QStringLiteral(":photo-in-out-icon")
+};
 
 QVariant DiveItem::data(int column, int role) const
 {
 	QVariant retVal;
-	QString icon_names[4] = {":zero",":photo-in-icon", ":photo-out-icon", ":photo-in-out-icon" };
 	struct dive *dive = get_dive_by_uniq_id(diveId);
 	if (!dive)
 		return QVariant();

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -47,7 +47,6 @@ public:
 	QString displayTags() const;
 	int countPhotos(dive *dive) const;
 	int weight() const;
-	QString icon_names[4];
 };
 
 struct TripItem : public TreeItem {


### PR DESCRIPTION
Each DiveItem (which is a wrapper around diveId with some virtual
functions), had a member icon_names, which is an array of
four QStrings. These were not used anywhere and must be an obscure
oversight and was probably planned as a static cons array?.
In any case, remove it.

There *was* a function-local analogous icon_names array in
DiveItem::data() though. This array would initialize four
QStrings from C-string literals on every invocation. Make
this array static, local to the translation unit and use
the QStringLiteral macro to construct the QString object at
compile-time.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup. The whole `DiveTripModel` code makes my head spin. Quite a  set-back for my undo-ambitions. This will be significantly more work than expected. :(