### PR TITLE
 move prefs.dive_computer from SettingsObjectWrapper to qPrefDiveComputer

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -103,6 +103,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	settings/qPrefAnimations.cpp
 	settings/qPrefCloudStorage.cpp
 	settings/qPrefDisplay.cpp
+	settings/qPrefDiveComputer.cpp
 	settings/qPrefPrivate.cpp
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -125,13 +125,13 @@ extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *
 extern "C" int is_default_dive_computer(const char *vendor, const char *product)
 {
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	return dc->dc_vendor() == vendor && dc->dc_product() == product;
+	return dc->vendor() == vendor && dc->product() == product;
 }
 
 extern "C" int is_default_dive_computer_device(const char *name)
 {
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	return dc->dc_device() == name;
+	return dc->device() == name;
 }
 
 extern "C" void set_dc_nickname(struct dive *dive)

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -56,10 +56,10 @@ void DownloadThread::run()
 		qDebug() << "Finishing download thread:" << downloadTable.nr << "dives downloaded";
 	}
 	auto dcs = SettingsObjectWrapper::instance()->dive_computer_settings;
-	dcs->setVendor(internalData->vendor);
-	dcs->setProduct(internalData->product);
-	dcs->setDevice(internalData->devname);
-	dcs->setDeviceName(m_data->devBluetoothName());
+	dcs->set_vendor(internalData->vendor);
+	dcs->set_product(internalData->product);
+	dcs->set_device(internalData->devname);
+	dcs->set_device_name(m_data->devBluetoothName());
 }
 
 static void fill_supported_mobile_list()
@@ -247,12 +247,12 @@ QStringList DCDeviceData::getProductListFromVendor(const QString &vendor)
 int DCDeviceData::getMatchingAddress(const QString &vendor, const QString &product)
 {
 	auto dcs = SettingsObjectWrapper::instance()->dive_computer_settings;
-	if (dcs->dc_vendor() == vendor &&
-	    dcs->dc_product() == product) {
+	if (dcs->vendor() == vendor &&
+	    dcs->product() == product) {
 		// we are trying to show the last dive computer selected
 		for (int i = 0; i < connectionListModel.rowCount(); i++) {
 			QString address = connectionListModel.address(i);
-			if (address.contains(dcs->dc_device()))
+			if (address.contains(dcs->device()))
 				return i;
 		}
 	}
@@ -410,10 +410,10 @@ device_data_t* DCDeviceData::internalData()
 int DCDeviceData::getDetectedVendorIndex()
 {
 	auto dcs = SettingsObjectWrapper::instance()->dive_computer_settings;
-	if (!dcs->dc_vendor().isEmpty()) {
+	if (!dcs->vendor().isEmpty()) {
 		// use the last one
 		for (int i = 0; i < vendorList.length(); i++) {
-			if (vendorList[i] == dcs->dc_vendor())
+			if (vendorList[i] == dcs->vendor())
 				return i;
 		}
 	}
@@ -431,11 +431,11 @@ int DCDeviceData::getDetectedVendorIndex()
 int DCDeviceData::getDetectedProductIndex(const QString &currentVendorText)
 {
 	auto dcs = SettingsObjectWrapper::instance()->dive_computer_settings;
-	if (!dcs->dc_vendor().isEmpty()) {
-		if (dcs->dc_vendor() == currentVendorText) {
+	if (!dcs->vendor().isEmpty()) {
+		if (dcs->vendor() == currentVendorText) {
 			// we are trying to show the last dive computer selected
 			for (int i = 0; i < productList[currentVendorText].length(); i++) {
-				if (productList[currentVendorText][i] == dcs->dc_product())
+				if (productList[currentVendorText][i] == dcs->product())
 					return i;
 			}
 		}

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -18,6 +18,7 @@ void qPref::loadSync(bool doSync)
 	qPrefAnimations::instance()->loadSync(doSync);
 	qPrefCloudStorage::instance()->loadSync(doSync);
 	qPrefDisplay::instance()->loadSync(doSync);
+	qPrefDiveComputer::instance()->loadSync(doSync);
 }
 
 const QString qPref::canonical_version() const

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -15,6 +15,7 @@ static qPref *self = new qPref;
 
 void qPref::loadSync(bool doSync)
 {
+	qPrefAnimations::instance()->loadSync(doSync);
 	qPrefCloudStorage::instance()->loadSync(doSync);
 	qPrefDisplay::instance()->loadSync(doSync);
 }

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -8,6 +8,7 @@
 #include "qPrefAnimations.h"
 #include "qPrefCloudStorage.h"
 #include "qPrefDisplay.h"
+#include "qPrefDiveComputer.h"
 
 class qPref : public QObject {
 	Q_OBJECT

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -22,8 +22,8 @@ public:
 
 	// Load/Sync local settings (disk) and struct preference
 	void loadSync(bool doSync);
-	void load() { loadSync(false); }
-	void sync() { loadSync(true); }
+	void inline load() { loadSync(false); }
+	void inline sync() { loadSync(true); }
 
 public:
 	enum cloud_status {

--- a/core/settings/qPrefAnimations.h
+++ b/core/settings/qPrefAnimations.h
@@ -15,8 +15,8 @@ public:
 
 	// Load/Sync local settings (disk) and struct preference
 	void loadSync(bool doSync);
-	void load() { loadSync(false); }
-	void sync() { loadSync(true); }
+	void inline load() { loadSync(false); }
+	void inline sync() { loadSync(true); }
 
 public:
 	static inline int animation_speed() { return prefs.animation_speed; };

--- a/core/settings/qPrefAnimations.h
+++ b/core/settings/qPrefAnimations.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #ifndef QPREFANIMATIONS_H
 #define QPREFANIMATIONS_H
+#include "core/pref.h"
 
 #include <QObject>
 
@@ -18,7 +19,7 @@ public:
 	void sync() { loadSync(true); }
 
 public:
-	int animation_speed() const;
+	static inline int animation_speed() { return prefs.animation_speed; };
 
 public slots:
 	void set_animation_speed(int value);

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -31,6 +31,7 @@ void qPrefCloudStorage::loadSync(bool doSync)
 
 void qPrefCloudStorage::set_cloud_base_url(const QString& value)
 {
+	QString valueGit = value + "/git";
 	if (value != prefs.cloud_base_url) {
 		// only free and set if not default
 		if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
@@ -39,14 +40,12 @@ void qPrefCloudStorage::set_cloud_base_url(const QString& value)
 		}
 
 		disk_cloud_base_url(true);
+		disk_cloud_git_url(true);
 		emit cloud_base_url_changed(value);
+		emit cloud_git_url_changed(valueGit);
 	}
 }
-void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
-{
-	LOADSYNC_TXT("/cloud_base_url", cloud_base_url);
-	LOADSYNC_TXT("/cloud_git_url", cloud_git_url);
-}
+DISK_LOADSYNC_TXT(CloudStorage, "/cloud_base_url", cloud_base_url)
 
 void qPrefCloudStorage::set_cloud_git_url(const QString& value)
 {
@@ -86,8 +85,12 @@ void qPrefCloudStorage::set_cloud_storage_password(const QString& value)
 }
 void qPrefCloudStorage::disk_cloud_storage_password(bool doSync)
 {
-	if (!doSync || prefs.save_password_local)
-		LOADSYNC_TXT("/password", cloud_storage_password);
+	if (doSync) {
+		if (prefs.save_password_local) 
+			qPrefPrivate::instance()->setting.setValue(group + "/password", prefs.cloud_storage_password);
+	} else {
+		prefs.cloud_storage_password = copy_qstring(qPrefPrivate::instance()->setting.value(group + "/password", default_prefs.cloud_storage_password).toString());
+	}
 }
 
 HANDLE_PREFERENCE_TXT(CloudStorage, "/pin", cloud_storage_pin);
@@ -107,5 +110,8 @@ void qPrefCloudStorage::disk_userid(bool doSync)
 {
 	//WARNING: UserId is stored outside of any group, but it belongs to Cloud Storage.
 	const QString group = QStringLiteral("");
-	LOADSYNC_TXT("subsurface_webservice_uid", userid);
+	if (doSync)
+		qPrefPrivate::instance()->setting.setValue(group + "subsurface_webservice_uid", prefs.userid);
+	else
+		prefs.userid = copy_qstring(qPrefPrivate::instance()->setting.value(group + "subsurface_webservice_uid", default_prefs.userid).toString());
 }

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -29,7 +29,6 @@ void qPrefCloudStorage::loadSync(bool doSync)
 	disk_userid(doSync);
 }
 
-GET_PREFERENCE_TXT(CloudStorage, cloud_base_url);
 void qPrefCloudStorage::set_cloud_base_url(const QString& value)
 {
 	if (value != prefs.cloud_base_url) {
@@ -49,7 +48,6 @@ void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 	LOADSYNC_TXT("/cloud_git_url", cloud_git_url);
 }
 
-GET_PREFERENCE_TXT(CloudStorage, cloud_git_url);
 void qPrefCloudStorage::set_cloud_git_url(const QString& value)
 {
 	if (value != prefs.cloud_git_url) {
@@ -67,7 +65,6 @@ HANDLE_PREFERENCE_TXT(CloudStorage, "/email", cloud_storage_email);
 
 HANDLE_PREFERENCE_TXT(CloudStorage, "/email_encoded", cloud_storage_email_encoded);
 
-GET_PREFERENCE_TXT(CloudStorage, cloud_storage_newpassword);
 void qPrefCloudStorage::set_cloud_storage_newpassword(const QString& value)
 {
 	if (value == prefs.cloud_storage_newpassword)
@@ -79,7 +76,6 @@ void qPrefCloudStorage::set_cloud_storage_newpassword(const QString& value)
 	emit cloud_storage_newpassword_changed(value);
 }
 
-GET_PREFERENCE_TXT(CloudStorage, cloud_storage_password);
 void qPrefCloudStorage::set_cloud_storage_password(const QString& value)
 {
 	if (value != prefs.cloud_storage_password) {
@@ -106,7 +102,6 @@ HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_password_local", save_password_local
 
 HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_userid_local", save_userid_local);
 
-GET_PREFERENCE_TXT(CloudStorage, userid);
 SET_PREFERENCE_TXT(CloudStorage, userid);
 void qPrefCloudStorage::disk_userid(bool doSync)
 {

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -35,8 +35,8 @@ void qPrefCloudStorage::set_cloud_base_url(const QString& value)
 	if (value != prefs.cloud_base_url) {
 		// only free and set if not default
 		if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
-			COPY_TXT(cloud_base_url, value);
-			COPY_TXT(cloud_git_url, QString(prefs.cloud_base_url) + "/git");
+			qPrefPrivate::copy_txt(&prefs.cloud_base_url, value);
+			qPrefPrivate::copy_txt(&prefs.cloud_git_url, QString(prefs.cloud_base_url) + "/git");
 		}
 
 		disk_cloud_base_url(true);
@@ -55,7 +55,7 @@ void qPrefCloudStorage::set_cloud_git_url(const QString& value)
 	if (value != prefs.cloud_git_url) {
 		// only free and set if not default
 		if (prefs.cloud_git_url != default_prefs.cloud_git_url) {
-			COPY_TXT(cloud_git_url, value);
+			qPrefPrivate::copy_txt(&prefs.cloud_git_url, value);
 		}
 		disk_cloud_git_url(true);
 		emit cloud_git_url_changed(value);
@@ -73,7 +73,7 @@ void qPrefCloudStorage::set_cloud_storage_newpassword(const QString& value)
 	if (value == prefs.cloud_storage_newpassword)
 		return;
 
-	COPY_TXT(cloud_storage_newpassword, value);
+	qPrefPrivate::copy_txt(&prefs.cloud_storage_newpassword, value);
 
 	// NOT saved on disk, because it is only temporary
 	emit cloud_storage_newpassword_changed(value);
@@ -83,7 +83,7 @@ GET_PREFERENCE_TXT(CloudStorage, cloud_storage_password);
 void qPrefCloudStorage::set_cloud_storage_password(const QString& value)
 {
 	if (value != prefs.cloud_storage_password) {
-		COPY_TXT(cloud_storage_password,value);
+		qPrefPrivate::copy_txt(&prefs.cloud_storage_password, value);
 		disk_cloud_storage_password(true);
 		emit cloud_storage_password_changed(value);
 	}

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -108,10 +108,16 @@ HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_userid_local", save_userid_local);
 SET_PREFERENCE_TXT(CloudStorage, userid);
 void qPrefCloudStorage::disk_userid(bool doSync)
 {
-	//WARNING: UserId is stored outside of any group, but it belongs to Cloud Storage.
-	const QString group = QStringLiteral("");
-	if (doSync)
+	if (doSync) {
+		// always save in new position (part of cloud storage group)
 		qPrefPrivate::instance()->setting.setValue(group + "subsurface_webservice_uid", prefs.userid);
-	else
-		prefs.userid = copy_qstring(qPrefPrivate::instance()->setting.value(group + "subsurface_webservice_uid", default_prefs.userid).toString());
+	} else {
+		//WARNING: UserId was  stored outside of any group.
+		// try to read from new location, if it fails read from old location
+		prefs.userid = copy_qstring(qPrefPrivate::instance()->setting.value(group + "subsurface_webservice_uid", "NoUserIdHere").toString());
+		if (QString(prefs.userid) == "NoUserIdHere") {
+			const QString group = QStringLiteral("");
+			prefs.userid = copy_qstring(qPrefPrivate::instance()->setting.value(group + "subsurface_webservice_uid", default_prefs.userid).toString());
+		}
+	}
 }

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -27,23 +27,23 @@ public:
 
 	// Load/Sync local settings (disk) and struct preference
 	void loadSync(bool doSync);
-	void load() { loadSync(false); }
-	void sync() { loadSync(true); }
+	void inline load() { loadSync(false); }
+	void inline sync() { loadSync(true); }
 
 public:
-	static inline const QString cloud_base_url() { return prefs.cloud_base_url; }
-	static inline const QString cloud_git_url() { return prefs.cloud_git_url; }
-	static inline const QString cloud_storage_email() { return prefs.cloud_storage_email; }
-	static inline const QString cloud_storage_email_encoded() { return prefs.cloud_storage_email_encoded; }
-	static inline const QString cloud_storage_newpassword() { return prefs.cloud_storage_newpassword; }
-	static inline const QString cloud_storage_password() { return prefs.cloud_storage_password; }
-	static inline const QString cloud_storage_pin() { return prefs.cloud_storage_pin; }
+	static inline QString cloud_base_url() { return prefs.cloud_base_url; }
+	static inline QString cloud_git_url() { return prefs.cloud_git_url; }
+	static inline QString cloud_storage_email() { return prefs.cloud_storage_email; }
+	static inline QString cloud_storage_email_encoded() { return prefs.cloud_storage_email_encoded; }
+	static inline QString cloud_storage_newpassword() { return prefs.cloud_storage_newpassword; }
+	static inline QString cloud_storage_password() { return prefs.cloud_storage_password; }
+	static inline QString cloud_storage_pin() { return prefs.cloud_storage_pin; }
 	static inline int cloud_timeout() { return prefs.cloud_timeout; }
 	static inline int cloud_verification_status() { return prefs.cloud_verification_status; }
 	static inline bool git_local_only() { return prefs.git_local_only; }
 	static inline bool save_password_local() { return prefs.save_password_local; }
 	static inline bool save_userid_local() { return prefs.save_userid_local; }
-	static inline const QString userid() { return prefs.userid; }
+	static inline QString userid() { return prefs.userid; }
 
 public slots:
 	void set_cloud_base_url(const QString& value);

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #ifndef QPREFCLOUDSTORAGE_H
 #define QPREFCLOUDSTORAGE_H
+#include "core/pref.h"
 
 #include <QObject>
 
@@ -30,19 +31,19 @@ public:
 	void sync() { loadSync(true); }
 
 public:
-	const QString cloud_base_url() const;
-	const QString cloud_git_url() const;
-	const QString cloud_storage_email() const;
-	const QString cloud_storage_email_encoded() const;
-	const QString cloud_storage_newpassword() const;
-	const QString cloud_storage_password() const;
-	const QString cloud_storage_pin() const;
-	int   cloud_timeout() const;
-	int   cloud_verification_status() const;
-	bool  git_local_only() const;
-	bool  save_password_local() const;
-	bool  save_userid_local() const;
-	const QString userid() const;
+	static inline const QString cloud_base_url() { return prefs.cloud_base_url; }
+	static inline const QString cloud_git_url() { return prefs.cloud_git_url; }
+	static inline const QString cloud_storage_email() { return prefs.cloud_storage_email; }
+	static inline const QString cloud_storage_email_encoded() { return prefs.cloud_storage_email_encoded; }
+	static inline const QString cloud_storage_newpassword() { return prefs.cloud_storage_newpassword; }
+	static inline const QString cloud_storage_password() { return prefs.cloud_storage_password; }
+	static inline const QString cloud_storage_pin() { return prefs.cloud_storage_pin; }
+	static inline int cloud_timeout() { return prefs.cloud_timeout; }
+	static inline int cloud_verification_status() { return prefs.cloud_verification_status; }
+	static inline bool git_local_only() { return prefs.git_local_only; }
+	static inline bool save_password_local() { return prefs.save_password_local; }
+	static inline bool save_userid_local() { return prefs.save_userid_local; }
+	static inline const QString userid() { return prefs.userid; }
 
 public slots:
 	void set_cloud_base_url(const QString& value);

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -35,7 +35,7 @@ void qPrefDisplay::set_divelist_font(const QString& value)
 
 	if (newValue != prefs.divelist_font &&
 		!subsurface_ignore_font(qPrintable(newValue))) {
-		COPY_TXT(divelist_font, value);
+		qPrefPrivate::copy_txt(&prefs.divelist_font, value);
 		disk_divelist_font(true);
 
 		qApp->setFont(QFont(newValue));

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -26,7 +26,6 @@ void qPrefDisplay::loadSync(bool doSync)
 	disk_theme(doSync);
 }
 
-GET_PREFERENCE_TXT(Display, divelist_font);
 void qPrefDisplay::set_divelist_font(const QString& value)
 {
 	QString newValue = value;
@@ -50,7 +49,6 @@ void qPrefDisplay::disk_divelist_font(bool doSync)
 		setCorrectFont();
 }
 
-GET_PREFERENCE_DOUBLE(Display, font_size);
 void qPrefDisplay::set_font_size(double value)
 {
 	if (value != prefs.font_size) {

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -44,7 +44,7 @@ void qPrefDisplay::set_divelist_font(const QString& value)
 void qPrefDisplay::disk_divelist_font(bool doSync)
 {
 	if (doSync)
-		LOADSYNC_TXT("/divelist_font", divelist_font)
+		qPrefPrivate::instance()->setting.setValue(group + "/divelist_font", prefs.divelist_font);
 	else
 		setCorrectFont();
 }
@@ -64,7 +64,7 @@ void qPrefDisplay::set_font_size(double value)
 void qPrefDisplay::disk_font_size(bool doSync)
 {
 	if (doSync)
-		LOADSYNC_DOUBLE("/font_size", font_size)
+		qPrefPrivate::instance()->setting.setValue(group + "/font_size", prefs.font_size);
 	else
 		setCorrectFont();
 }
@@ -78,7 +78,6 @@ HANDLE_PREFERENCE_TXT(Display, "/theme", theme);
 
 void qPrefDisplay::setCorrectFont()
 {
-	bool doSync = false;
 	QSettings s;
 	QVariant v;
 
@@ -103,5 +102,6 @@ void qPrefDisplay::setCorrectFont()
 	}
 	defaultFont.setPointSizeF(prefs.font_size);
 	qApp->setFont(defaultFont);
-	LOADSYNC_BOOL("/displayinvalid", display_invalid_dives);
+
+	prefs.display_invalid_dives = qPrefPrivate::instance()->setting.value(group + "/displayinvalid", default_prefs.display_invalid_dives).toBool();
 }

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -19,15 +19,15 @@ public:
 
 	// Load/Sync local settings (disk) and struct preference
 	void loadSync(bool doSync);
-	void load() { loadSync(false); }
-	void sync() { loadSync(true); }
+	void inline load() { loadSync(false); }
+	void inline sync() { loadSync(true); }
 
 public:
-	static inline const QString divelist_font() {return QString(prefs.divelist_font); };
+	static inline QString divelist_font() {return prefs.divelist_font; };
 	static inline double font_size() {return prefs.font_size; };
 	static inline bool display_invalid_dives() {return prefs.display_invalid_dives; };
 	static inline bool show_developer() {return prefs.show_developer; };
-	static inline const QString theme() {return QString(prefs.theme); };
+	static inline QString theme() {return prefs.theme; };
 
 public slots:
 	void set_divelist_font(const QString& value);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #ifndef QPREFDISPLAY_H
 #define QPREFDISPLAY_H
+#include "core/pref.h"
 
 #include <QObject>
 
@@ -22,11 +23,11 @@ public:
 	void sync() { loadSync(true); }
 
 public:
-	const QString divelist_font() const;
-	double font_size() const;
-	bool display_invalid_dives() const;
-	bool show_developer() const;
-	const QString theme() const;
+	static inline const QString divelist_font() {return QString(prefs.divelist_font); };
+	static inline double font_size() {return prefs.font_size; };
+	static inline bool display_invalid_dives() {return prefs.display_invalid_dives; };
+	static inline bool show_developer() {return prefs.show_developer; };
+	static inline const QString theme() {return QString(prefs.theme); };
 
 public slots:
 	void set_divelist_font(const QString& value);

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPref.h"
+#include "qPrefPrivate.h"
+
+static const QString group = QStringLiteral("DiveComputer");
+
+qPrefDiveComputer::qPrefDiveComputer(QObject *parent) : QObject(parent)
+{
+}
+qPrefDiveComputer *qPrefDiveComputer::instance()
+{
+	static qPrefDiveComputer *self = new qPrefDiveComputer;
+	return self;
+}
+
+
+void qPrefDiveComputer::loadSync(bool doSync)
+{
+	disk_device(doSync);
+	disk_device_name(doSync);
+	disk_download_mode(doSync);
+	disk_product(doSync);
+	disk_vendor(doSync);
+}
+
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_device", device, dive_computer.);
+
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_device_name", device_name, dive_computer.);
+
+HANDLE_PREFERENCE_INT_EXT(DiveComputer, "/dive_computer_download_mode", download_mode, dive_computer.);
+
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_product", product, dive_computer.);
+
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_vendor", vendor, dive_computer.);

--- a/core/settings/qPrefDiveComputer.h
+++ b/core/settings/qPrefDiveComputer.h
@@ -23,11 +23,11 @@ public:
 	void inline sync() {loadSync(true); }
 
 public:
-	static inline const QString& device() {return prefs.dive_computer.device; };
-	static inline const QString& device_name() {return prefs.dive_computer.device_name; };
+	static inline QString device() {return prefs.dive_computer.device; };
+	static inline QString device_name() {return prefs.dive_computer.device_name; };
 	static inline int download_mode() {return prefs.dive_computer.download_mode; };
-	static inline const QString& product() {return prefs.dive_computer.product; };
-	static inline const QString& vendor() {return prefs.dive_computer.vendor; };
+	static inline QString product() {return prefs.dive_computer.product; };
+	static inline QString vendor() {return prefs.dive_computer.vendor; };
 
 public slots:
 	void set_device(const QString& device);

--- a/core/settings/qPrefDiveComputer.h
+++ b/core/settings/qPrefDiveComputer.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREFSDIVECOMPUTER_H
+#define QPREFSDIVECOMPUTER_H
+#include "core/pref.h"
+
+#include <QObject>
+
+class qPrefDiveComputer : public QObject {
+	Q_OBJECT
+	Q_PROPERTY(QString device READ device WRITE set_device NOTIFY device_changed);
+	Q_PROPERTY(QString device_name READ device_name WRITE set_device_name NOTIFY device_name_changed);
+	Q_PROPERTY(int download_mode READ download_mode WRITE set_download_mode NOTIFY download_mode_changed);
+	Q_PROPERTY(QString product READ product WRITE set_product NOTIFY product_changed);
+	Q_PROPERTY(QString vendor READ vendor WRITE	set_vendor NOTIFY vendor_changed);
+
+public:
+	qPrefDiveComputer(QObject *parent = NULL);
+	static qPrefDiveComputer *instance();
+
+	// Load/Sync local settings (disk) and struct preference
+	void loadSync(bool doSync);
+	void inline load() {loadSync(false); }
+	void inline sync() {loadSync(true); }
+
+public:
+	static inline const QString& device() {return prefs.dive_computer.device; };
+	static inline const QString& device_name() {return prefs.dive_computer.device_name; };
+	static inline int download_mode() {return prefs.dive_computer.download_mode; };
+	static inline const QString& product() {return prefs.dive_computer.product; };
+	static inline const QString& vendor() {return prefs.dive_computer.vendor; };
+
+public slots:
+	void set_device(const QString& device);
+	void set_device_name(const QString& device_name);
+	void set_download_mode(int mode);
+	void set_product(const QString& product);
+	void set_vendor(const QString& vendor);
+
+signals:
+	void device_changed(const QString& device);
+	void device_name_changed(const QString& device_name);
+	void download_mode_changed(int mode);
+	void product_changed(const QString& product);
+	void vendor_changed(const QString& vendor);
+
+private:
+	// functions to load/sync variable with disk
+	void disk_device(bool doSync);
+	void disk_device_name(bool doSync);
+	void disk_download_mode(bool doSync);
+	void disk_product(bool doSync);
+	void disk_vendor(bool doSync);
+};
+
+#endif

--- a/core/settings/qPrefPrivate.cpp
+++ b/core/settings/qPrefPrivate.cpp
@@ -9,3 +9,10 @@ qPrefPrivate *qPrefPrivate::instance()
 	static qPrefPrivate *self = new qPrefPrivate;
 	return self;
 }
+
+void qPrefPrivate::copy_txt(const char **name, const QString& string)
+{
+	free((void *)*name);
+	*name = copy_qstring(string);
+}
+

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -17,6 +17,7 @@ public:
 	friend class qPrefAnimations;
 	friend class qPrefCloudStorage;
 	friend class qPrefDisplay;
+	friend class qPrefDiveComputer;
 
 private:
     static qPrefPrivate *instance();

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -3,7 +3,6 @@
 #define QPREFPRIVATE_H
 
 // Header used by all qPref<class> implementations to avoid duplicating code
-
 #include <QSettings>
 #include <QVariant>
 #include <QObject>
@@ -18,16 +17,12 @@ public:
 
 	QSettings setting;
 
+	// Helper functions
+	static void copy_txt(const char **name, const QString& string);
+
 private:
     qPrefPrivate(QObject *parent = NULL);
 };
-
-//****** Macros to be used in the set functions ******
-#define COPY_TXT(name, string) \
-{ \
-	free((void *)prefs.name); \
-	prefs.name = copy_qstring(string); \
-}
 
 //****** Macros to be used in the disk functions, which are special ******
 #define LOADSYNC_BOOL(name, field) \
@@ -191,7 +186,7 @@ void qPref ## usegroup::set_ ## field (int value) \
 void qPref ## usegroup::set_ ## field (const QString& value) \
 { \
 	if (value != prefs.field) { \
-		COPY_TXT(field, value); \
+		qPrefPrivate::instance()->copy_txt(&prefs.field, value); \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -3,6 +3,7 @@
 #define QPREFPRIVATE_H
 
 // Header used by all qPref<class> implementations to avoid duplicating code
+#include "qPref.h"
 #include <QSettings>
 #include <QVariant>
 #include <QObject>
@@ -13,6 +14,11 @@ class qPrefPrivate : public QObject {
     Q_OBJECT
 
 public:
+	friend class qPrefAnimations;
+	friend class qPrefCloudStorage;
+	friend class qPrefDisplay;
+
+private:
     static qPrefPrivate *instance();
 
 	QSettings setting;
@@ -20,7 +26,6 @@ public:
 	// Helper functions
 	static void copy_txt(const char **name, const QString& string);
 
-private:
     qPrefPrivate(QObject *parent = NULL);
 };
 

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -29,8 +29,11 @@ private:
     qPrefPrivate(QObject *parent = NULL);
 };
 
-//****** Macros to be used in the disk functions, which are special ******
-#define LOADSYNC_BOOL(name, field) \
+
+
+//******* Macros to generate disk function
+#define DISK_LOADSYNC_BOOL(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
@@ -38,7 +41,8 @@ private:
 		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toBool(); \
 }
 
-#define LOADSYNC_DOUBLE(name, field) \
+#define DISK_LOADSYNC_DOUBLE(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
@@ -46,7 +50,8 @@ private:
 		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toDouble(); \
 }
 
-#define LOADSYNC_ENUM(name, type, field) \
+#define DISK_LOADSYNC_ENUM(usegroup, name, type, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
@@ -54,7 +59,8 @@ private:
 		prefs.field = (enum type)qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
 }
 
-#define LOADSYNC_INT(name, field) \
+#define DISK_LOADSYNC_INT(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync) \
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
@@ -62,7 +68,8 @@ private:
 		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
 }
 
-#define LOADSYNC_INT_DEF(name, field, defval) \
+#define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
@@ -70,49 +77,13 @@ private:
 		prefs.field = qPrefPrivate::instance()->setting.value(group + name, defval).toInt(); \
 }
 
-#define LOADSYNC_TXT(name, field) \
+#define DISK_LOADSYNC_TXT(usegroup, name, field) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
 		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
 	else \
 		prefs.field = copy_qstring(qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toString()); \
-}
-
-//******* Macros to generate disk function
-#define DISK_LOADSYNC_BOOL(usegroup, name, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_BOOL(name, field); \
-}
-
-#define DISK_LOADSYNC_DOUBLE(usegroup, name, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_DOUBLE(name, field); \
-}
-
-#define DISK_LOADSYNC_ENUM(usegroup, name, type, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_ENUM(name, type, field); \
-}
-
-#define DISK_LOADSYNC_INT(usegroup, name, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_INT(name, field); \
-}
-
-#define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_INT_DEF(name, field, defval); \
-}
-
-#define DISK_LOADSYNC_TXT(usegroup, name, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	LOADSYNC_TXT(name, field); \
 }
 
 //******* Macros to generate set function

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -32,130 +32,162 @@ private:
 
 
 //******* Macros to generate disk function
+#define DISK_LOADSYNC_BOOL_EXT(usegroup, name, field, usestruct) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
+{ \
+	if (doSync)	\
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
+	else \
+		prefs.usestruct field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.usestruct field).toBool(); \
+}
 #define DISK_LOADSYNC_BOOL(usegroup, name, field) \
+DISK_LOADSYNC_BOOL_EXT(usegroup, name, field, )
+
+#define DISK_LOADSYNC_DOUBLE_EXT(usegroup, name, field, usestruct) \
 void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
 	else \
-		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toBool(); \
+		prefs.usestruct field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.usestruct field).toDouble(); \
 }
-
 #define DISK_LOADSYNC_DOUBLE(usegroup, name, field) \
+DISK_LOADSYNC_DOUBLE_EXT(usegroup, name, field, )
+
+#define DISK_LOADSYNC_ENUM_EXT(usegroup, name, type, field, usestruct) \
 void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
 	else \
-		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toDouble(); \
+		prefs.usestruct field = (enum type)qPrefPrivate::instance()->setting.value(group + name, default_prefs.usestruct field).toInt(); \
 }
-
 #define DISK_LOADSYNC_ENUM(usegroup, name, type, field) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	if (doSync)	\
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
-	else \
-		prefs.field = (enum type)qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
-}
+DISK_LOADSYNC_ENUM_EXT(usegroup, name, type, field, )
 
-#define DISK_LOADSYNC_INT(usegroup, name, field) \
+#define DISK_LOADSYNC_INT_EXT(usegroup, name, field, usestruct) \
 void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync) \
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
 	else \
-		prefs.field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toInt(); \
+		prefs.usestruct field = qPrefPrivate::instance()->setting.value(group + name, default_prefs.usestruct field).toInt(); \
 }
+#define DISK_LOADSYNC_INT(usegroup, name, field) \
+DISK_LOADSYNC_INT(usegroup, name, field, )
 
+#define DISK_LOADSYNC_INT_DEF_EXT(usegroup, name, field, defval, usestruct) \
+void qPref ## usegroup::disk_ ## field(bool doSync) \
+{ \
+	if (doSync)	\
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
+	else \
+		prefs.usestruct field = qPrefPrivate::instance()->setting.value(group + name, defval).toInt(); \
+}
 #define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \
-void qPref ## usegroup::disk_ ## field(bool doSync) \
-{ \
-	if (doSync)	\
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
-	else \
-		prefs.field = qPrefPrivate::instance()->setting.value(group + name, defval).toInt(); \
-}
+DISK_LOADSYNC_INT_DEF_EXT(usegroup, name, field, defval, )
 
-#define DISK_LOADSYNC_TXT(usegroup, name, field) \
+#define DISK_LOADSYNC_TXT_EXT(usegroup, name, field, usestruct) \
 void qPref ## usegroup::disk_ ## field(bool doSync) \
 { \
 	if (doSync)	\
-		qPrefPrivate::instance()->setting.setValue(group + name, prefs.field); \
+		qPrefPrivate::instance()->setting.setValue(group + name, prefs.usestruct field); \
 	else \
-		prefs.field = copy_qstring(qPrefPrivate::instance()->setting.value(group + name, default_prefs.field).toString()); \
+		prefs.usestruct field = copy_qstring(qPrefPrivate::instance()->setting.value(group + name, default_prefs.usestruct field).toString()); \
 }
+#define DISK_LOADSYNC_TXT(usegroup, name, field) \
+DISK_LOADSYNC_TXT_EXT(usegroup, name, field, )
 
 //******* Macros to generate set function
-#define SET_PREFERENCE_BOOL(usegroup, field) \
+#define SET_PREFERENCE_BOOL_EXT(usegroup, field, usestruct) \
 void qPref ## usegroup::set_ ## field (bool value) \
 { \
-	if (value != prefs.field) { \
-		prefs.field = value; \
+	if (value != prefs.usestruct field) { \
+		prefs.usestruct field = value; \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \
 }
+#define SET_PREFERENCE_BOOL(usegroup, field) \
+SET_PREFERENCE_BOOL_EXT(usegroup, field, ) \
 
-#define SET_PREFERENCE_DOUBLE(usegroup, field) \
+#define SET_PREFERENCE_DOUBLE_EXT(usegroup, field, usestruct) \
 void qPref ## usegroup::set_ ## field (double value) \
 { \
-	if (value != prefs.field) { \
-		prefs.field = value; \
+	if (value != prefs.usestruct field) { \
+		prefs.usestruct field = value; \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \
 }
+#define SET_PREFERENCE_DOUBLE(usegroup, field) \
+SET_PREFERENCE_DOUBLE_EXT(usegroup, field, ) \
 
-#define SET_PREFERENCE_ENUM(usegroup, type, field) \
+#define SET_PREFERENCE_ENUM_EXT(usegroup, type, field, usestruct) \
 void qPref ## usegroup::set_ ## field (type value) \
 { \
-	if (value != prefs.field) { \
-		prefs.field = value; \
+	if (value != prefs.usestruct field) { \
+		prefs.usestruct field = value; \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \
 }
+#define SET_PREFERENCE_ENUM(usegroup, type, field) \
+SET_PREFERENCE_ENUM_EXT(usegroup, type, field, )
 
-#define SET_PREFERENCE_INT(usegroup, field) \
+#define SET_PREFERENCE_INT_EXT(usegroup, field, usestruct) \
 void qPref ## usegroup::set_ ## field (int value) \
 { \
-	if (value != prefs.field) { \
-		prefs.field = value; \
+	if (value != prefs.usestruct field) { \
+		prefs.usestruct field = value; \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \
 }
+#define SET_PREFERENCE_INT(usegroup, field) \
+SET_PREFERENCE_INT_EXT(usegroup, field, ) \
 
-#define SET_PREFERENCE_TXT(usegroup, field) \
+#define SET_PREFERENCE_TXT_EXT(usegroup, field, usestruct) \
 void qPref ## usegroup::set_ ## field (const QString& value) \
 { \
-	if (value != prefs.field) { \
-		qPrefPrivate::instance()->copy_txt(&prefs.field, value); \
+	if (value != prefs.usestruct field) { \
+		qPrefPrivate::instance()->copy_txt(&prefs.usestruct field, value); \
 		disk_ ## field(true); \
 		emit field ## _changed(value); \
 	} \
 }
+#define SET_PREFERENCE_TXT(usegroup, field) \
+SET_PREFERENCE_TXT_EXT(usegroup, field, ) \
 
 //******* Macros to generate set/set/loadsync combined
+#define HANDLE_PREFERENCE_BOOL_EXT(usegroup, name, field, usestruct) \
+SET_PREFERENCE_BOOL_EXT(usegroup, field, usestruct); \
+DISK_LOADSYNC_BOOL_EXT(usegroup, name, field, usestruct);
 #define HANDLE_PREFERENCE_BOOL(usegroup, name, field) \
-SET_PREFERENCE_BOOL(usegroup, field); \
-DISK_LOADSYNC_BOOL(usegroup, name, field);
+HANDLE_PREFERENCE_BOOL_EXT(usegroup, name, field, )
 
+#define HANDLE_PREFERENCE_DOUBLE_EXT(usegroup, name, field, usestruct) \
+SET_PREFERENCE_DOUBLE_EXT(usegroup, field, usestruct); \
+DISK_LOADSYNC_DOUBLE_EXT(usegroup, name, field, usestruct);
 #define HANDLE_PREFERENCE_DOUBLE(usegroup, name, field) \
-SET_PREFERENCE_DOUBLE(usegroup, field); \
-DISK_LOADSYNC_DOUBLE(usegroup, name, field);
+HANDLE_PREFERENCE_DOUBLE_EXT(usegroup, name, field, )
 
+#define HANDLE_PREFERENCE_ENUM_EXT(usegroup, type, name, field, usestruct) \
+SET_PREFERENCE_ENUM_EXT(usegroup, type, field, usestruct); \
+DISK_LOADSYNC_ENUM_EXT(usegroup, name, type, field, usestruct);
 #define HANDLE_PREFERENCE_ENUM(usegroup, type, name, field) \
-SET_PREFERENCE_ENUM(usegroup, type, field); \
-DISK_LOADSYNC_ENUM(usegroup, name, type, field);
+HANDLE_PREFERENCE_ENUM_EXT(usegroup, type, name, field, )
 
+#define HANDLE_PREFERENCE_INT_EXT(usegroup, name, field, usestruct) \
+SET_PREFERENCE_INT_EXT(usegroup, field, usestruct); \
+DISK_LOADSYNC_INT_EXT(usegroup, name, field, usestruct);
 #define HANDLE_PREFERENCE_INT(usegroup, name, field) \
-SET_PREFERENCE_INT(usegroup, field); \
-DISK_LOADSYNC_INT(usegroup, name, field);
+HANDLE_PREFERENCE_INT_EXT(usegroup, name, field, )
 
+#define HANDLE_PREFERENCE_TXT_EXT(usegroup, name, field, usestruct) \
+SET_PREFERENCE_TXT_EXT(usegroup, field, usestruct); \
+DISK_LOADSYNC_TXT_EXT(usegroup, name, field, usestruct);
 #define HANDLE_PREFERENCE_TXT(usegroup, name, field) \
-SET_PREFERENCE_TXT(usegroup, field); \
-DISK_LOADSYNC_TXT(usegroup, name, field);
+HANDLE_PREFERENCE_TXT_EXT(usegroup, name, field, )
 
 #endif

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -115,37 +115,6 @@ void qPref ## usegroup::disk_ ## field(bool doSync) \
 	LOADSYNC_TXT(name, field); \
 }
 
-//******* Macros to generate get function
-#define GET_PREFERENCE_BOOL(usegroup, field) \
-bool qPref ## usegroup::field () const \
-{ \
-	return prefs.field; \
-}
-
-#define GET_PREFERENCE_DOUBLE(usegroup, field) \
-double  qPref ## usegroup::field () const \
-{ \
-	return prefs.field; \
-}
-
-#define GET_PREFERENCE_ENUM(usegroup, type, field) \
-struct type  qPref ## usegroup:: ## field () const \
-{ \
-	return prefs.field; \
-}
-
-#define GET_PREFERENCE_INT(usegroup, field) \
-int qPref ## usegroup::field () const \
-{ \
-	return prefs.field; \
-}
-
-#define GET_PREFERENCE_TXT(usegroup, field) \
-const QString qPref ## usegroup::field () const \
-{ \
-	return prefs.field; \
-}
-
 //******* Macros to generate set function
 #define SET_PREFERENCE_BOOL(usegroup, field) \
 void qPref ## usegroup::set_ ## field (bool value) \
@@ -199,27 +168,22 @@ void qPref ## usegroup::set_ ## field (const QString& value) \
 
 //******* Macros to generate set/set/loadsync combined
 #define HANDLE_PREFERENCE_BOOL(usegroup, name, field) \
-GET_PREFERENCE_BOOL(usegroup, field); \
 SET_PREFERENCE_BOOL(usegroup, field); \
 DISK_LOADSYNC_BOOL(usegroup, name, field);
 
 #define HANDLE_PREFERENCE_DOUBLE(usegroup, name, field) \
-GET_PREFERENCE_DOUBLE(usegroup, field); \
 SET_PREFERENCE_DOUBLE(usegroup, field); \
 DISK_LOADSYNC_DOUBLE(usegroup, name, field);
 
 #define HANDLE_PREFERENCE_ENUM(usegroup, type, name, field) \
-GET_PREFERENCE_ENUM(usegroup, type, field); \
 SET_PREFERENCE_ENUM(usegroup, type, field); \
 DISK_LOADSYNC_ENUM(usegroup, name, type, field);
 
 #define HANDLE_PREFERENCE_INT(usegroup, name, field) \
-GET_PREFERENCE_INT(usegroup, field); \
 SET_PREFERENCE_INT(usegroup, field); \
 DISK_LOADSYNC_INT(usegroup, name, field);
 
 #define HANDLE_PREFERENCE_TXT(usegroup, name, field) \
-GET_PREFERENCE_TXT(usegroup, field); \
 SET_PREFERENCE_TXT(usegroup, field); \
 DISK_LOADSYNC_TXT(usegroup, name, field);
 

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -2020,9 +2020,7 @@ void SettingsObjectWrapper::load()
 
 	qPrefDisplay::instance()->load();
 
-	s.beginGroup("Animations");
-	GET_INT("animation_speed", animation_speed);
-	s.endGroup();
+	qPrefAnimations::instance()->load();
 
 	s.beginGroup("Network");
 	GET_INT_DEF("proxy_type", proxy_type, QNetworkProxy::DefaultProxy);

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -9,95 +9,6 @@
 #include "core/qthelper.h"
 #include "core/prefs-macros.h"
 
-DiveComputerSettings::DiveComputerSettings(QObject *parent):
-	QObject(parent)
-{
-}
-
-QString DiveComputerSettings::dc_vendor() const
-{
-	return prefs.dive_computer.vendor;
-}
-
-QString DiveComputerSettings::dc_product() const
-{
-	return prefs.dive_computer.product;
-}
-
-QString DiveComputerSettings::dc_device() const
-{
-	return prefs.dive_computer.device;
-}
-
-QString DiveComputerSettings::dc_device_name() const
-{
-	return prefs.dive_computer.device_name;
-}
-
-int DiveComputerSettings::downloadMode() const
-{
-	return prefs.dive_computer.download_mode;
-}
-
-void DiveComputerSettings::setVendor(const QString& vendor)
-{
-	if (vendor == prefs.dive_computer.vendor)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("dive_computer_vendor", vendor);
-	free((void *)prefs.dive_computer.vendor);
-	prefs.dive_computer.vendor = copy_qstring(vendor);
-}
-
-void DiveComputerSettings::setProduct(const QString& product)
-{
-	if (product == prefs.dive_computer.product)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("dive_computer_product", product);
-	free((void *)prefs.dive_computer.product);
-	prefs.dive_computer.product = copy_qstring(product);
-}
-
-void DiveComputerSettings::setDevice(const QString& device)
-{
-	if (device == prefs.dive_computer.device)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("dive_computer_device", device);
-	free((void *)prefs.dive_computer.device);
-	prefs.dive_computer.device = copy_qstring(device);
-}
-
-void DiveComputerSettings::setDeviceName(const QString& device_name)
-{
-	if (device_name == prefs.dive_computer.device_name)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("dive_computer_device_name", device_name);
-	free((void *)prefs.dive_computer.device_name);
-	prefs.dive_computer.device_name = copy_qstring(device_name);
-}
-
-void DiveComputerSettings::setDownloadMode(int mode)
-{
-	if (mode == prefs.dive_computer.download_mode)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("dive_computer_download_mode", mode);
-	prefs.dive_computer.download_mode = mode;
-}
-
 UpdateManagerSettings::UpdateManagerSettings(QObject *parent) : QObject(parent)
 {
 
@@ -1930,7 +1841,7 @@ QObject(parent),
 	animation_settings(new qPrefAnimations(this)),
 	location_settings(new LocationServiceSettingsObjectWrapper(this)),
 	update_manager_settings(new UpdateManagerSettings(this)),
-	dive_computer_settings(new DiveComputerSettings(this))
+	dive_computer_settings(new qPrefDiveComputer(this))
 {
 }
 
@@ -2077,13 +1988,7 @@ void SettingsObjectWrapper::load()
 	prefs.planner_deco_mode = deco_mode(s.value("deco_mode", default_prefs.planner_deco_mode).toInt());
 	s.endGroup();
 
-	s.beginGroup("DiveComputer");
-	GET_TXT("dive_computer_vendor",dive_computer.vendor);
-	GET_TXT("dive_computer_product", dive_computer.product);
-	GET_TXT("dive_computer_device", dive_computer.device);
-	GET_TXT("dive_computer_device_name", dive_computer.device_name);
-	GET_INT("dive_computer_download_mode", dive_computer.download_mode);
-	s.endGroup();
+	qPrefDiveComputer::instance()->load();
 
 	s.beginGroup("UpdateManager");
 	prefs.update_manager.dont_check_exists = s.contains("DontCheckForUpdates");

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -13,39 +13,6 @@
  * and QWidget frontends. This class will be huge, since
  * I need tons of properties, one for each option. */
 
-class DiveComputerSettings : public QObject {
-	Q_OBJECT
-	Q_PROPERTY(QString vendor READ dc_vendor WRITE setVendor NOTIFY vendorChanged)
-	Q_PROPERTY(QString product READ dc_product WRITE setProduct NOTIFY productChanged)
-	Q_PROPERTY(QString device READ dc_device WRITE setDevice NOTIFY deviceChanged)
-	Q_PROPERTY(QString device_name READ dc_device_name WRITE setDeviceName NOTIFY deviceNameChanged)
-	Q_PROPERTY(int download_mode READ downloadMode WRITE setDownloadMode NOTIFY downloadModeChanged)
-public:
-	DiveComputerSettings(QObject *parent);
-	QString dc_vendor() const;
-	QString dc_product() const;
-	QString dc_device() const;
-	QString dc_device_name() const;
-	int downloadMode() const;
-
-public slots:
-	void setVendor(const QString& vendor);
-	void setProduct(const QString& product);
-	void setDevice(const QString& device);
-	void setDeviceName(const QString& device_name);
-	void setDownloadMode(int mode);
-
-signals:
-	void vendorChanged(const QString& vendor);
-	void productChanged(const QString& product);
-	void deviceChanged(const QString& device);
-	void deviceNameChanged(const QString& device_name);
-	void downloadModeChanged(int mode);
-private:
-	const QString group = QStringLiteral("DiveComputer");
-
-};
-
 class UpdateManagerSettings : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool dont_check_for_updates READ dontCheckForUpdates WRITE setDontCheckForUpdates NOTIFY dontCheckForUpdatesChanged)
@@ -620,7 +587,7 @@ class SettingsObjectWrapper : public QObject {
 	Q_PROPERTY(LocationServiceSettingsObjectWrapper* Location  MEMBER location_settings CONSTANT)
 
 	Q_PROPERTY(UpdateManagerSettings* update MEMBER update_manager_settings CONSTANT)
-	Q_PROPERTY(DiveComputerSettings* dive_computer MEMBER dive_computer_settings CONSTANT)
+	Q_PROPERTY(qPrefDiveComputer* dive_computer MEMBER dive_computer_settings CONSTANT)
 public:
 	static SettingsObjectWrapper *instance();
 
@@ -638,7 +605,7 @@ public:
 	qPrefAnimations *animation_settings;
 	LocationServiceSettingsObjectWrapper *location_settings;
 	UpdateManagerSettings *update_manager_settings;
-	DiveComputerSettings *dive_computer_settings;
+	qPrefDiveComputer *dive_computer_settings;
 
 	void sync();
 	void load();

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -133,8 +133,8 @@ ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDia
 	memset(&device_data, 0, sizeof(device_data));
 	fill_computer_list();
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	if (!dc->dc_device().isEmpty())
-		ui.device->setEditText(dc->dc_device());
+	if (!dc->device().isEmpty())
+		ui.device->setEditText(dc->device());
 
 	ui.DiveComputerList->setCurrentRow(0);
 	on_DiveComputerList_currentRowChanged(0);
@@ -912,10 +912,10 @@ void ConfigureDiveComputerDialog::getDeviceData()
 	device_data.deviceid = device_data.diveid = 0;
 
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	dc->setDevice(device_data.devname);
+	dc->set_device(device_data.devname);
 #ifdef BT_SUPPORT
 	if (ui.bluetoothMode && btDeviceSelectionDialog)
-		dc->setDeviceName(btDeviceSelectionDialog->getSelectedDeviceName());
+		dc->set_device_name(btDeviceSelectionDialog->getSelectedDeviceName());
 #endif
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -72,11 +72,11 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	connect(&thread, SIGNAL(finished()), w, SLOT(refreshDisplay()));
 
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	if (!dc->dc_vendor().isEmpty()) {
-		ui.vendor->setCurrentIndex(ui.vendor->findText(dc->dc_vendor()));
-		productModel.setStringList(productList[dc->dc_vendor()]);
-		if (!dc->dc_product().isEmpty())
-			ui.product->setCurrentIndex(ui.product->findText(dc->dc_product()));
+	if (!dc->vendor().isEmpty()) {
+		ui.vendor->setCurrentIndex(ui.vendor->findText(dc->vendor()));
+		productModel.setStringList(productList[dc->vendor()]);
+		if (!dc->product().isEmpty())
+			ui.product->setCurrentIndex(ui.product->findText(dc->product()));
 	}
 
 	updateState(INITIAL);
@@ -84,16 +84,16 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	ui.downloadCancelRetryButton->setEnabled(true);
 	ui.downloadCancelRetryButton->setText(tr("Download"));
 
-	QString deviceText = dc->dc_device();
+	QString deviceText = dc->device();
 #if defined(BT_SUPPORT)
 	ui.bluetoothMode->setText(tr("Choose Bluetooth download mode"));
-	ui.bluetoothMode->setChecked(dc->downloadMode() == DC_TRANSPORT_BLUETOOTH);
+	ui.bluetoothMode->setChecked(dc->download_mode() == DC_TRANSPORT_BLUETOOTH);
 	btDeviceSelectionDialog = 0;
 	connect(ui.bluetoothMode, SIGNAL(stateChanged(int)), this, SLOT(enableBluetoothMode(int)));
 	connect(ui.chooseBluetoothDevice, SIGNAL(clicked()), this, SLOT(selectRemoteBluetoothDevice()));
 	ui.chooseBluetoothDevice->setEnabled(ui.bluetoothMode->isChecked());
 	if (ui.bluetoothMode->isChecked())
-		deviceText = BtDeviceSelectionDialog::formatDeviceText(dc->dc_device(), dc->dc_device_name());
+		deviceText = BtDeviceSelectionDialog::formatDeviceText(dc->device(), dc->device_name());
 #else
 	ui.bluetoothMode->hide();
 	ui.chooseBluetoothDevice->hide();
@@ -289,8 +289,8 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 			data->setDevBluetoothName(btDeviceSelectionDialog->getSelectedDeviceName());
 		} else {
 			auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-			data->setDevName(dc->dc_device());
-			data->setDevBluetoothName(dc->dc_device_name());
+			data->setDevName(dc->device());
+			data->setDevBluetoothName(dc->device_name());
 		}
 	} else
 		// this breaks an "else if" across lines... not happy...
@@ -314,12 +314,12 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	data->setSaveDump(ui.dumpToFile->isChecked());
 
 	auto dc = SettingsObjectWrapper::instance()->dive_computer_settings;
-	dc->setVendor(data->vendor());
-	dc->setProduct(data->product());
-	dc->setDevice(data->devName());
+	dc->set_vendor(data->vendor());
+	dc->set_product(data->product());
+	dc->set_device(data->devName());
 
 #if defined(BT_SUPPORT)
-	dc->setDownloadMode(ui.bluetoothMode->isChecked() ? DC_TRANSPORT_BLUETOOTH : DC_TRANSPORT_SERIAL);
+	dc->set_download_mode(ui.bluetoothMode->isChecked() ? DC_TRANSPORT_BLUETOOTH : DC_TRANSPORT_SERIAL);
 #endif
 
 	// before we start, remember where the dive_table ended

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -81,6 +81,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/settings/qPrefAnimations.cpp \
 	../../core/settings/qPrefCloudStorage.cpp \
 	../../core/settings/qPrefDisplay.cpp \
+	../../core/settings/qPrefDiveComputer.cpp \
 	../../core/settings/qPrefPrivate.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
@@ -192,6 +193,7 @@ HEADERS += \
 	../../core/settings/qPrefAnimations.h \
 	../../core/settings/qPrefCloudStorage.h \
 	../../core/settings/qPrefDisplay.h \
+	../../core/settings/qPrefDiveComputer.h \
 	../../core/settings/qPrefPrivate.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \
 	../../core/subsurface-qt/DiveObjectHelper.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -154,6 +154,9 @@ void register_qml_types()
 	rc = qmlRegisterType<qPrefDisplay>("org.subsurfacedivelog.mobile", 1, 0, "SsrfDisplayPrefs");
 	if (rc < 0)
 		qDebug() << "ERROR: Cannot register DisplayPrefs (class qPrefDisplay), QML will not work!!";
+	rc = qmlRegisterType<qPrefDiveComputer>("org.subsurfacedivelog.mobile", 1, 0, "SsrfDiveComputerPrefs");
+	if (rc < 0)
+		qDebug() << "ERROR: Cannot register DiveComputerPrefs (class qPrefDiveComputer), QML will not work!!";
 
 #ifndef SUBSURFACE_TEST_DATA
 #ifdef SUBSURFACE_MOBILE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ TEST(TestTagList testtaglist.cpp)
 TEST(TestQPrefAnimations testqPrefAnimations.cpp)
 TEST(TestQPrefCloudStorage testqPrefCloudStorage.cpp)
 TEST(TestQPrefDisplay testqPrefDisplay.cpp)
+TEST(TestQPrefDiveComputer testqPrefDiveComputer.cpp)
 add_test(NAME TestQML COMMAND $<TARGET_FILE:TestQML> ${SUBSURFACE_SOURCE}/tests)
 
 
@@ -125,6 +126,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestQPrefAnimations
 	TestQPrefCloudStorage
 	TestQPrefDisplay
+	TestQPrefDiveComputer
 	TestQML
 )
 

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -466,27 +466,6 @@ void TestPreferences::testPreferences()
 	TEST(update->dontCheckForUpdates(), false);
 	TEST(update->lastVersionUsed(), QStringLiteral("tomaz-2"));
 	TEST(update->nextCheck(), date);
-
-	auto dc = pref->dive_computer_settings;
-	dc->set_device("TomazComputer");
-	TEST(dc->device(), QStringLiteral("TomazComputer"));
-	dc->set_device("Deepwater");
-	TEST(dc->device(), QStringLiteral("Deepwater"));
-
-	dc->set_download_mode(0);
-	TEST(dc->download_mode(), 0);
-	dc->set_download_mode(1);
-	TEST(dc->download_mode(), 1);
-
-	dc->set_product("Thingy1");
-	TEST(dc->product(), QStringLiteral("Thingy1"));
-	dc->set_product("Thingy2");
-	TEST(dc->product(), QStringLiteral("Thingy2"));
-
-	dc->set_vendor("Sharewater");
-	TEST(dc->vendor(), QStringLiteral("Sharewater"));
-	dc->set_vendor("OSTS");
-	TEST(dc->vendor(), QStringLiteral("OSTS"));
 }
 
 QTEST_MAIN(TestPreferences)

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -468,25 +468,25 @@ void TestPreferences::testPreferences()
 	TEST(update->nextCheck(), date);
 
 	auto dc = pref->dive_computer_settings;
-	dc->setDevice("TomazComputer");
-	TEST(dc->dc_device(), QStringLiteral("TomazComputer"));
-	dc->setDevice("Deepwater");
-	TEST(dc->dc_device(), QStringLiteral("Deepwater"));
+	dc->set_device("TomazComputer");
+	TEST(dc->device(), QStringLiteral("TomazComputer"));
+	dc->set_device("Deepwater");
+	TEST(dc->device(), QStringLiteral("Deepwater"));
 
-	dc->setDownloadMode(0);
-	TEST(dc->downloadMode(), 0);
-	dc->setDownloadMode(1);
-	TEST(dc->downloadMode(), 1);
+	dc->set_download_mode(0);
+	TEST(dc->download_mode(), 0);
+	dc->set_download_mode(1);
+	TEST(dc->download_mode(), 1);
 
-	dc->setProduct("Thingy1");
-	TEST(dc->dc_product(), QStringLiteral("Thingy1"));
-	dc->setProduct("Thingy2");
-	TEST(dc->dc_product(), QStringLiteral("Thingy2"));
+	dc->set_product("Thingy1");
+	TEST(dc->product(), QStringLiteral("Thingy1"));
+	dc->set_product("Thingy2");
+	TEST(dc->product(), QStringLiteral("Thingy2"));
 
-	dc->setVendor("Sharewater");
-	TEST(dc->dc_vendor(), QStringLiteral("Sharewater"));
-	dc->setVendor("OSTS");
-	TEST(dc->dc_vendor(), QStringLiteral("OSTS"));
+	dc->set_vendor("Sharewater");
+	TEST(dc->vendor(), QStringLiteral("Sharewater"));
+	dc->set_vendor("OSTS");
+	TEST(dc->vendor(), QStringLiteral("OSTS"));
 }
 
 QTEST_MAIN(TestPreferences)

--- a/tests/testqPrefDiveComputer.cpp
+++ b/tests/testqPrefDiveComputer.cpp
@@ -120,5 +120,36 @@ void TestQPrefDiveComputer::test_multiple()
 	QCOMPARE(tst->download_mode(), tst_direct->download_mode());
 }
 
+#define TEST(METHOD, VALUE) \
+QCOMPARE(METHOD, VALUE); \
+dc->sync(); \
+dc->load(); \
+QCOMPARE(METHOD, VALUE);
+
+void TestQPrefDiveComputer::test_oldPreferences()
+{
+	auto dc = qPrefDiveComputer::instance();
+
+	dc->set_device("TomazComputer");
+	TEST(dc->device(), QStringLiteral("TomazComputer"));
+	dc->set_device("Deepwater");
+	TEST(dc->device(), QStringLiteral("Deepwater"));
+
+	dc->set_download_mode(0);
+	TEST(dc->download_mode(), 0);
+	dc->set_download_mode(1);
+	TEST(dc->download_mode(), 1);
+
+	dc->set_product("Thingy1");
+	TEST(dc->product(), QStringLiteral("Thingy1"));
+	dc->set_product("Thingy2");
+	TEST(dc->product(), QStringLiteral("Thingy2"));
+
+	dc->set_vendor("Sharewater");
+	TEST(dc->vendor(), QStringLiteral("Sharewater"));
+	dc->set_vendor("OSTS");
+	TEST(dc->vendor(), QStringLiteral("OSTS"));
+}
+
 QTEST_MAIN(TestQPrefDiveComputer)
 

--- a/tests/testqPrefDiveComputer.cpp
+++ b/tests/testqPrefDiveComputer.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testqPrefDiveComputer.h"
+
+#include "core/settings/qPref.h"
+#include "core/pref.h"
+#include "core/qthelper.h"
+
+#include <QTest>
+
+void TestQPrefDiveComputer::initTestCase()
+{
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("SubsurfaceTestQPrefDiveComputer");
+}
+
+void TestQPrefDiveComputer::test_struct_get()
+{
+	// Test struct pref -> get func.
+
+	auto tst = qPrefDiveComputer::instance();
+
+	prefs.dive_computer.device = copy_qstring("my device");
+	prefs.dive_computer.device_name = copy_qstring("my device name");
+	prefs.dive_computer.download_mode = 17;
+	prefs.dive_computer.product = copy_qstring("my product");
+	prefs.dive_computer.vendor = copy_qstring("my vendor");
+
+	QCOMPARE(tst->device(), QString(prefs.dive_computer.device));
+	QCOMPARE(tst->device_name(), QString(prefs.dive_computer.device_name));
+	QCOMPARE(tst->download_mode(), prefs.dive_computer.download_mode);
+	QCOMPARE(tst->product(), QString(prefs.dive_computer.product));
+	QCOMPARE(tst->vendor(), QString(prefs.dive_computer.vendor));
+}
+
+void TestQPrefDiveComputer::test_set_struct()
+{
+	// Test set func -> struct pref
+
+	auto tst = qPrefDiveComputer::instance();
+
+	tst->set_device("t2 device");
+	tst->set_device_name("t2 device name");
+	tst->set_download_mode(27);
+	tst->set_product("t2 product");
+	tst->set_vendor("t2 vendor");
+
+	QCOMPARE(QString(prefs.dive_computer.device), QString("t2 device"));
+	QCOMPARE(QString(prefs.dive_computer.device_name), QString("t2 device name"));
+	QCOMPARE(prefs.dive_computer.download_mode, 27);
+	QCOMPARE(QString(prefs.dive_computer.product), QString("t2 product"));
+	QCOMPARE(QString(prefs.dive_computer.vendor), QString("t2 vendor"));
+}
+
+void TestQPrefDiveComputer::test_set_load_struct()
+{
+	// test set func -> load -> struct pref 
+
+	auto tst = qPrefDiveComputer::instance();
+
+	tst->set_device("t3 device");
+	tst->set_device_name("t3 device name");
+	tst->set_download_mode(37);
+	tst->set_product("t3 product");
+	tst->set_vendor("t3 vendor");
+
+	prefs.dive_computer.device = copy_qstring("error1");
+	prefs.dive_computer.device_name = copy_qstring("error2");
+	prefs.dive_computer.download_mode = 38;
+	prefs.dive_computer.product = copy_qstring("error3");
+	prefs.dive_computer.vendor = copy_qstring("error4");
+
+	tst->load();
+	QCOMPARE(QString(prefs.dive_computer.device), QString("t3 device"));
+	QCOMPARE(QString(prefs.dive_computer.device_name), QString("t3 device name"));
+	QCOMPARE(prefs.dive_computer.download_mode, 37);
+	QCOMPARE(QString(prefs.dive_computer.product), QString("t3 product"));
+	QCOMPARE(QString(prefs.dive_computer.vendor), QString("t3 vendor"));
+}
+
+void TestQPrefDiveComputer::test_struct_disk()
+{
+	// test struct prefs -> disk
+
+	auto tst = qPrefDiveComputer::instance();
+
+	prefs.dive_computer.device = copy_qstring("t4 device");
+	prefs.dive_computer.device_name = copy_qstring("t4 device name");
+	prefs.dive_computer.download_mode = 47;
+	prefs.dive_computer.product = copy_qstring("t4 product");
+	prefs.dive_computer.vendor = copy_qstring("t4 vendor");
+
+	tst->sync();
+
+	prefs.dive_computer.device = copy_qstring("error");
+	prefs.dive_computer.device_name = copy_qstring("error");
+	prefs.dive_computer.download_mode = 48;
+	prefs.dive_computer.product = copy_qstring("error");
+	prefs.dive_computer.vendor = copy_qstring("error");
+
+	tst->load();
+
+	QCOMPARE(QString(prefs.dive_computer.device), QString("t4 device"));
+	QCOMPARE(QString(prefs.dive_computer.device_name), QString("t4 device name"));
+	QCOMPARE(prefs.dive_computer.download_mode, 47);
+	QCOMPARE(QString(prefs.dive_computer.product), QString("t4 product"));
+	QCOMPARE(QString(prefs.dive_computer.vendor), QString("t4 vendor"));
+}
+
+void TestQPrefDiveComputer::test_multiple()
+{
+	// test multiple instances have the same information
+	prefs.dive_computer.download_mode = 57;
+
+	auto tst_direct = new qPrefDiveComputer;
+
+	prefs.dive_computer.download_mode = 25;
+	auto tst = qPrefDiveComputer::instance();
+
+	QCOMPARE(tst->download_mode(), tst_direct->download_mode());
+}
+
+QTEST_MAIN(TestQPrefDiveComputer)
+

--- a/tests/testqPrefDiveComputer.h
+++ b/tests/testqPrefDiveComputer.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTQPREFDIVECOMPUTER_H
+#define TESTQPREFDIVECOMPUTER_H
+
+#include <QObject>
+
+class TestQPrefDiveComputer : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase();
+	void test_struct_get();
+	void test_set_struct();
+	void test_set_load_struct();
+	void test_struct_disk();
+	void test_multiple();
+};
+
+#endif // TESTQPREFDIVECOMPUTER_H

--- a/tests/testqPrefDiveComputer.h
+++ b/tests/testqPrefDiveComputer.h
@@ -15,6 +15,7 @@ private slots:
 	void test_set_load_struct();
 	void test_struct_disk();
 	void test_multiple();
+	void test_oldPreferences();
 };
 
 #endif // TESTQPREFDIVECOMPUTER_H

--- a/tests/tst_qPrefDiveComputer.qml
+++ b/tests/tst_qPrefDiveComputer.qml
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import QtTest 1.2
+import org.subsurfacedivelog.mobile 1.0
+
+TestCase {
+	name: "qPrefDiveComputer"
+
+	SsrfDiveComputerPrefs {
+		id: tst
+	}
+
+	SsrfPrefs {
+		id: prefs
+	}
+
+	function test_variables() {
+		var x1 = tst.device
+		tst.device = "my device"
+		compare(tst.device, "my device")
+
+		var x1 = tst.device_name
+		tst.device_name = "my device name"
+		compare(tst.device_name, "my device name")
+
+		var x1 = tst.download_mode
+		tst.download_mode = 19
+		compare(tst.download_mode, 19)
+
+		var x1 = tst.product
+		tst.product = "my product"
+		compare(tst.product, "my product")
+
+		var x1 = tst.vendor
+		tst.vendor = "my vendor"
+		compare(tst.vendor, "my vendor")
+	}
+}
+


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add qPrefDivecomputer with test cases.

This is a sub struct in struct preferences so the macros are modified to handle that effect.

getters as functions are overkill, but needed for QML, made these static inline, which saves code, and lines of code to write.

Removed LOADSYNC* macroes in order to reduce the number of macros.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
