### PR TITLE
Cleanup: fix column width calculation

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -26,7 +26,8 @@
 #include "core/metrics.h"
 
 DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false), sortColumn(0),
-	currentOrder(Qt::DescendingOrder), dontEmitDiveChangedSignal(false), selectionSaved(false)
+	currentOrder(Qt::DescendingOrder), dontEmitDiveChangedSignal(false), selectionSaved(false),
+	initialColumnWidths(DiveTripModel::COLUMNS, 50)	// Set up with default length 50
 {
 	setItemDelegate(new DiveListDelegate(this));
 	setUniformRowHeights(true);
@@ -43,63 +44,15 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 	setSelectionMode(ExtendedSelection);
 	header()->setContextMenuPolicy(Qt::ActionsContextMenu);
 
-	const QFontMetrics metrics(defaultModelFont());
-	int em = metrics.width('m');
-	int zw = metrics.width('0');
-
-	// Fixes for the layout needed for mac
-#ifdef Q_OS_MAC
-	int ht = metrics.height();
-	header()->setMinimumHeight(ht + 4);
-#endif
-
-	// TODO FIXME we need this to get the header names
-	// can we find a smarter way?
-	tripModel = new DiveTripModel(this);
-
-	// set the default width as a minimum between the hard-coded defaults,
-	// the header text width and the (assumed) content width, calculated
-	// based on type
-	for (int col = DiveTripModel::NR; col < DiveTripModel::COLUMNS; ++col) {
-		QString header_txt = tripModel->headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
-		int width = metrics.width(header_txt);
-		int sw = 0;
-		switch (col) {
-		case DiveTripModel::NR:
-		case DiveTripModel::DURATION:
-			sw = 8*zw;
-			break;
-		case DiveTripModel::DATE:
-			sw = 14*em;
-			break;
-		case DiveTripModel::RATING:
-			sw = static_cast<StarWidgetsDelegate*>(itemDelegateForColumn(col))->starSize().width();
-			break;
-		case DiveTripModel::SUIT:
-		case DiveTripModel::SAC:
-			sw = 7*em;
-			break;
-		case DiveTripModel::PHOTOS:
-			sw = 5*em;
-			break;
-		case DiveTripModel::LOCATION:
-			sw = 50*em;
-			break;
-		default:
-			sw = 5*em;
-		}
-		if (sw > width)
-			width = sw;
-		width += zw; // small padding
-		if (width > tripModel->columnWidth(col))
-			tripModel->setColumnWidth(col, width);
-	}
-	delete tripModel;
-
-
 	header()->setStretchLastSection(true);
 
 	installEventFilter(this);
+
+	// TODO: We use a dummy DiveTripModel to calculated column widths.
+	// Change this to a global object.
+	DiveTripModel tripModel;
+	for (int i = DiveTripModel::NR; i < DiveTripModel::COLUMNS; i++)
+		calculateInitialColumnWidth(tripModel, i);
 }
 
 DiveListView::~DiveListView()
@@ -111,13 +64,52 @@ DiveListView::~DiveListView()
 		if (isColumnHidden(i))
 			continue;
 		// we used to hardcode them all to 100 - so that might still be in the settings
-		if (columnWidth(i) == 100 || columnWidth(i) == tripModel->columnWidth(i))
+		if (columnWidth(i) == 100 || columnWidth(i) == initialColumnWidths[i])
 			settings.remove(QString("colwidth%1").arg(i));
 		else
 			settings.setValue(QString("colwidth%1").arg(i), columnWidth(i));
 	}
 	settings.remove(QString("colwidth%1").arg(DiveTripModel::COLUMNS - 1));
 	settings.endGroup();
+}
+
+void DiveListView::calculateInitialColumnWidth(const DiveTripModel &tripModel, int col)
+{
+	const QFontMetrics metrics(defaultModelFont());
+	int em = metrics.width('m');
+	int zw = metrics.width('0');
+
+	QString header_txt = tripModel.headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
+	int width = metrics.width(header_txt);
+	int sw = 0;
+	switch (col) {
+	case DiveTripModel::NR:
+	case DiveTripModel::DURATION:
+		sw = 8*zw;
+		break;
+	case DiveTripModel::DATE:
+		sw = 14*em;
+		break;
+	case DiveTripModel::RATING:
+		sw = static_cast<StarWidgetsDelegate*>(itemDelegateForColumn(col))->starSize().width();
+		break;
+	case DiveTripModel::SUIT:
+	case DiveTripModel::SAC:
+		sw = 7*em;
+		break;
+	case DiveTripModel::PHOTOS:
+		sw = 5*em;
+		break;
+	case DiveTripModel::LOCATION:
+		sw = 50*em;
+		break;
+	default:
+		sw = 5*em;
+	}
+	if (sw > width)
+		width = sw;
+	width += zw; // small padding
+	initialColumnWidths[col] = std::max(initialColumnWidths[col], width);
 }
 
 void DiveListView::setupUi()
@@ -137,7 +129,7 @@ void DiveListView::setupUi()
 		if (width.isValid())
 			setColumnWidth(i, width.toInt());
 		else
-			setColumnWidth(i, tripModel->columnWidth(i));
+			setColumnWidth(i, initialColumnWidths[i]);
 	}
 	settings.endGroup();
 	if (firstRun)
@@ -424,7 +416,7 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 
 	QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(model());
 	QAbstractItemModel *oldModel = m->sourceModel();
-	tripModel = new DiveTripModel(this);
+	DiveTripModel *tripModel = new DiveTripModel(this);
 	tripModel->setLayout(layout);
 
 	m->setSourceModel(tripModel);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -77,7 +77,7 @@ private:
 	/* if dive_trip_t is null, there's no problem. */
 	QMultiHash<dive_trip_t *, int> selectedDives;
 	void merge_trip(const QModelIndex &a, const int offset);
-	void setupUi();
+	void setColumnWidths();
 	void calculateInitialColumnWidth(const DiveTripModel &tripModel, int col);
 	void backupExpandedRows();
 	void restoreExpandedRows();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -71,12 +71,14 @@ private:
 	QModelIndex contextMenuIndex;
 	bool dontEmitDiveChangedSignal;
 	bool selectionSaved;
-	DiveTripModel *tripModel;
+	// Remember the initial column widths, to avoid writing unchanged widths to the settings
+	QVector<int> initialColumnWidths;
 
 	/* if dive_trip_t is null, there's no problem. */
 	QMultiHash<dive_trip_t *, int> selectedDives;
 	void merge_trip(const QModelIndex &a, const int offset);
 	void setupUi();
+	void calculateInitialColumnWidth(const DiveTripModel &tripModel, int col);
 	void backupExpandedRows();
 	void restoreExpandedRows();
 	int lastVisibleColumn();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -442,18 +442,6 @@ DiveTripModel::DiveTripModel(QObject *parent) :
 	currentLayout(TREE)
 {
 	columns = COLUMNS;
-	// setup the default width of columns (px)
-	columnWidthMap = QVector<int>(COLUMNS);
-	// pre-fill with 50px; the rest are explicit
-	for(int i = 0; i < COLUMNS; i++)
-		columnWidthMap[i] = 50;
-	columnWidthMap[NR] = 70;
-	columnWidthMap[DATE] = 140;
-	columnWidthMap[RATING] = 90;
-	columnWidthMap[SUIT] = 70;
-	columnWidthMap[SAC] = 70;
-	columnWidthMap[PHOTOS] = 5;
-	columnWidthMap[LOCATION] = 500;
 }
 
 Qt::ItemFlags DiveTripModel::flags(const QModelIndex &index) const
@@ -657,22 +645,4 @@ bool DiveTripModel::setData(const QModelIndex &index, const QVariant &value, int
 	if (!diveItem)
 		return false;
 	return diveItem->setData(index, value, role);
-}
-
-int DiveTripModel::columnWidth(int column)
-{
-	if (column > COLUMNS - 1 || column < 0) {
-		qWarning() << "DiveTripModel::columnWidth(): not a valid column index -" << column;
-		return 50;
-	}
-	return columnWidthMap[column];
-}
-
-void DiveTripModel::setColumnWidth(int column, int width)
-{
-	if (column > COLUMNS - 1 || column < 0) {
-		qWarning() << "DiveTripModel::setColumnWidth(): not a valid column index -" << column;
-		return;
-	}
-	columnWidthMap[column] = width;
 }

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -99,13 +99,10 @@ public:
 	DiveTripModel(QObject *parent = 0);
 	Layout layout() const;
 	void setLayout(Layout layout);
-	int columnWidth(int column);
-	void setColumnWidth(int column, int width);
 
 private:
 	void setupModelData();
 	QMap<dive_trip_t *, TripItem *> trips;
-	QVector<int> columnWidthMap;
 	Layout currentLayout;
 };
 


### PR DESCRIPTION
The DiveListView constructor allocated a "tripModel" and set the
column-widths. The "tripModel" was then immediately deallocated.
Since the columnd-widths are stored in a vector of the object,
they are thus lost. Therefore, remove the whole column-setting
code. This makes the DiveTripModel::setColumnWidth() function
unused. Remove it as well.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Dead code removal. @neolit123: You were the last to touch this code, but as far as I can see - this was a no-op for a much longer time ... ?

The whole idea of storing column-widths in the model seems questionable to me. Aren't column widths very fundamentally part of the view-side?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Remove dead code.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Nope.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 