### PR TITLE
fix to qPrefCloudStorage git_url is derived from base_url

### DIFF
--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -17,7 +17,6 @@ qPrefCloudStorage *qPrefCloudStorage::instance()
 void qPrefCloudStorage::loadSync(bool doSync)
 {
 	disk_cloud_base_url(doSync);
-	disk_cloud_git_url(doSync);
 	disk_cloud_storage_email(doSync);
 	disk_cloud_storage_email_encoded(doSync);
 	disk_cloud_storage_password(doSync);
@@ -41,27 +40,18 @@ void qPrefCloudStorage::set_cloud_base_url(const QString &value)
 		}
 
 		disk_cloud_base_url(true);
-		disk_cloud_git_url(true);
 		emit cloud_base_url_changed(value);
-		emit cloud_git_url_changed(valueGit);
 	}
 }
-
-DISK_LOADSYNC_TXT(CloudStorage, "/cloud_base_url", cloud_base_url);
-
-void qPrefCloudStorage::set_cloud_git_url(const QString &value)
+void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 {
-	if (value != prefs.cloud_git_url) {
-		// only free and set if not default
-		if (prefs.cloud_git_url != default_prefs.cloud_git_url) {
-			qPrefPrivate::copy_txt(&prefs.cloud_git_url, value);
-		}
-		disk_cloud_git_url(true);
-		emit cloud_git_url_changed(value);
+	if (doSync) {
+		qPrefPrivate::instance()->setting.setValue(group + "/cloud_base_url", prefs.cloud_base_url);
+	} else {
+		prefs.cloud_base_url = copy_qstring(qPrefPrivate::instance()->setting.value(group + "/cloud_base_url", default_prefs.cloud_base_url).toString());
+		qPrefPrivate::copy_txt(&prefs.cloud_git_url, QString(prefs.cloud_base_url) + "/git");
 	}
 }
-
-DISK_LOADSYNC_TXT(CloudStorage, "/cloud_git_url", cloud_git_url);
 
 HANDLE_PREFERENCE_TXT(CloudStorage, "/email", cloud_storage_email);
 

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -8,7 +8,7 @@
 class qPrefCloudStorage : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_url_changed);
-	Q_PROPERTY(QString cloud_git_url READ cloud_git_url WRITE set_cloud_git_url NOTIFY cloud_git_url_changed);
+	Q_PROPERTY(QString cloud_git_url READ cloud_git_url);
 	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_email_changed);
 	Q_PROPERTY(QString cloud_storage_email_encoded READ cloud_storage_email_encoded WRITE set_cloud_storage_email_encoded NOTIFY cloud_storage_email_encoded_changed);
 	Q_PROPERTY(QString cloud_storage_newpassword READ cloud_storage_newpassword WRITE set_cloud_storage_newpassword NOTIFY cloud_storage_newpassword_changed);
@@ -47,7 +47,6 @@ public:
 
 public slots:
 	void set_cloud_base_url(const QString &value);
-	void set_cloud_git_url(const QString &value);
 	void set_cloud_storage_email(const QString &value);
 	void set_cloud_storage_email_encoded(const QString &value);
 	void set_cloud_storage_newpassword(const QString &value);
@@ -62,7 +61,6 @@ public slots:
 
 signals:
 	void cloud_base_url_changed(const QString &value);
-	void cloud_git_url_changed(const QString &value);
 	void cloud_storage_email_changed(const QString &value);
 	void cloud_storage_email_encoded_changed(const QString &value);
 	void cloud_storage_newpassword_changed(const QString &value);
@@ -78,7 +76,6 @@ signals:
 private:
 	// functions to load/sync variable with disk
 	void disk_cloud_base_url(bool doSync);
-	void disk_cloud_git_url(bool doSync);
 	void disk_cloud_storage_email(bool doSync);
 	void disk_cloud_storage_email_encoded(bool doSync);
 	void disk_cloud_storage_newpassword(bool doSync);

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -57,7 +57,6 @@ void TestQPrefCloudStorage::test_set_struct()
 	auto tst = qPrefCloudStorage::instance();
 
 	tst->set_cloud_base_url("t2 base");
-	tst->set_cloud_git_url("t2 git");
 	tst->set_cloud_storage_email("t2 email");
 	tst->set_cloud_storage_email_encoded("t2 email2");
 	tst->set_cloud_storage_newpassword("t2 pass1");
@@ -71,7 +70,6 @@ void TestQPrefCloudStorage::test_set_struct()
 	tst->set_userid("t2 user");
 
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t2 base"));
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t2 git"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t2 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t2 email2"));
 	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("t2 pass1"));
@@ -83,6 +81,9 @@ void TestQPrefCloudStorage::test_set_struct()
 	QCOMPARE(prefs.save_password_local, false);
 	QCOMPARE(prefs.save_userid_local, false);
 	QCOMPARE(QString(prefs.userid), QString("t2 user"));
+
+	// remark is set with set_base_url
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t2 base/git"));
 }
 
 void TestQPrefCloudStorage::test_set_load_struct()
@@ -92,7 +93,6 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	auto tst = qPrefCloudStorage::instance();
 
 	tst->set_cloud_base_url("t3 base");
-	tst->set_cloud_git_url("t3 git");
 	tst->set_cloud_storage_email("t3 email");
 	tst->set_cloud_storage_email_encoded("t3 email2");
 	tst->set_cloud_storage_newpassword("t3 pass1");
@@ -121,7 +121,6 @@ void TestQPrefCloudStorage::test_set_load_struct()
 
 	tst->load();
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t3 base"));
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t3 git"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t3 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t3 email2"));
 	QCOMPARE(QString(prefs.cloud_storage_password), QString("t3 pass2"));
@@ -132,6 +131,9 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	QCOMPARE(prefs.save_password_local, true);
 	QCOMPARE(prefs.save_userid_local, true);
 	QCOMPARE(QString(prefs.userid), QString("t3 user"));
+
+	// remark is set with set_base_url
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t3 base/git"));
 
 	// warning new password is not saved on disk
 	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("my new password"));
@@ -144,7 +146,6 @@ void TestQPrefCloudStorage::test_struct_disk()
 	auto tst = qPrefCloudStorage::instance();
 
 	prefs.cloud_base_url = copy_qstring("t4 base");
-	prefs.cloud_git_url = copy_qstring("t4 git");
 	prefs.cloud_storage_email = copy_qstring("t4 email");
 	prefs.cloud_storage_email_encoded = copy_qstring("t4 email2");
 	prefs.cloud_storage_newpassword = copy_qstring("t4 pass1");
@@ -176,7 +177,6 @@ void TestQPrefCloudStorage::test_struct_disk()
 	tst->load();
 
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t4 base"));
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t4 git"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t4 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t4 email2"));
 	QCOMPARE(QString(prefs.cloud_storage_password), QString("t4 pass2"));
@@ -187,6 +187,9 @@ void TestQPrefCloudStorage::test_struct_disk()
 	QCOMPARE(prefs.save_password_local, true);
 	QCOMPARE(prefs.save_userid_local, true);
 	QCOMPARE(QString(prefs.userid), QString("t4 user"));
+
+	// remark is set with set_base_url
+	QCOMPARE(QString(prefs.cloud_git_url), QString("t4 base/git"));
 
 	// warning new password not stored on disk
 	QCOMPARE(QString(prefs.cloud_storage_newpassword), QString("my new password"));

--- a/tests/tst_qPrefCloudStorage.qml
+++ b/tests/tst_qPrefCloudStorage.qml
@@ -20,8 +20,7 @@ TestCase {
 		compare(tst.cloud_base_url, "my url")
 
 		var x2 = tst.cloud_git_url
-		tst.cloud_git_url= "my url"
-		compare(tst.cloud_git_url, "my url")
+		compare(tst.cloud_git_url, "my url/git")
 
 		var x3 = tst.cloud_storage_email
 		tst.cloud_storage_email = "my email"


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
old version of qPrefCloudStorage loaded/saved git_url from/to disk, whereas 
SettingsObjectWrapper derived git_url from base_url (kind of ugly, but)

Code changed to derive git_url from base_url,
test cases updated to test the relationship between base_url and git_url.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->·
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh please test that all your multipke issues are solved
@sfuchs79 I am not sure this solves your case, so please test (I still fo not have a valid local profile).
