### PR TITLE
When BT_SUPPORT is not enabled, don't default to "true" for using blu…

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -216,7 +216,11 @@ DCDeviceData::DCDeviceData()
 	data.download_table = nullptr;
 	data.diveid = 0;
 	data.deviceid = 0;
+#if defined(BT_SUPPORT)
 	data.bluetooth_mode = true;
+#else
+	data.bluetooth_mode = false;
+#endif
 	data.force_download = false;
 	data.create_new_trip = false;
 	data.libdc_dump = false;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

BT_SUPPORT, if undefined, also needs the bluetooth_mode value in DCDeviceData to be false by default.  Otherwise, it's never changed from true due to the ifdef in DownloadFromDCWidget, which results in the system trying to use bluetooth even if it's not there!

With this patch, I can download dives on OpenBSD 6.3 with the current codebase.

This was originally noted at https://github.com/Subsurface-divelog/subsurface/issues/1541.