### PR TITLE
Cleanup: remove DiveListView::fixMessyQtModelBehaviour()

### DIFF
--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -45,7 +45,8 @@ slots:
 	void removeFromTrip();
 	void deleteDive();
 	void markDiveInvalid();
-	void fixMessyQtModelBehaviour();
+	void rowsInserted(const QModelIndex &parent, int start, int end) override;
+	void reset() override;
 	void mergeTripAbove();
 	void mergeTripBelow();
 	void newTripAbove();

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -174,7 +174,6 @@ void RenumberDialog::buttonClicked(QAbstractButton *button)
 		UndoRenumberDives *undoCommand = new UndoRenumberDives(renumberedDives);
 		MainWindow::instance()->undoStack->push(undoCommand);
 
-		MainWindow::instance()->dive_list()->fixMessyQtModelBehaviour();
 		mark_divelist_changed(true);
 		MainWindow::instance()->dive_list()->restoreSelection();
 	}

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -584,10 +584,7 @@ void DiveTripModel::setupModelData()
 {
 	int i = dive_table.nr;
 
-	if (rowCount()) {
-		beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
-		endRemoveRows();
-	}
+	beginResetModel();
 
 	if (autogroup)
 		autogroup_dives();
@@ -621,10 +618,7 @@ void DiveTripModel::setupModelData()
 		tripItem->children.push_back(diveItem);
 	}
 
-	if (rowCount()) {
-		beginInsertRows(QModelIndex(), 0, rowCount() - 1);
-		endInsertRows();
-	}
+	endResetModel();
 }
 
 DiveTripModel::Layout DiveTripModel::layout() const

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -430,7 +430,6 @@ void MultiFilterSortModel::myInvalidate()
 	divesDisplayed = 0;
 
 	invalidateFilter();
-	MainWindow::instance()->dive_list()->fixMessyQtModelBehaviour();
 
 	// first make sure the trips are no longer shown as selected
 	// (but without updating the selection state of the dives... this just cleans


### PR DESCRIPTION
The function DiveListView::fixMessyQtModelBehaviour() was used to
expand the first columns of dive-trips in the dive-list view.
This function was called everytime that the dive-list was modified.
It is kind of ludicrous that external callers would have to
tell the DiveListView, when it has to update its column headers.

Instead, place this functionality in the overriden reset() and
rowsInserted() functions, as these are the only ways that
rows can be added. Change the DiveTripModel to use the proper
beginResetModel()/endResetModel() pair instead of the previous
full deletion and full repopulation using the beginRemoveRows()/
endRemoveRows() and beginInsertRows()/endInsertRows().

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a small spin-off of a (quite intimidating) monster-commit which implements proper Qt model/view semantics [`beginInsertRows()`, etc. you know what I mean] for DiveTripModel.

I hope breaking out tiny things like this will make it a bit more palatable.

This was tested with random dive-list manipulations (merge trips, delete dives) and setting/removing filters. Seemed to work as expected...
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace `fixMessyQtModelBehaviour()` and replace by the overridden `reset()` and `rowsInserted()` functions.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Nope.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
