### PR TITLE
(Trivial) cleanup: remove DiveListView::testSlot()

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -790,21 +790,6 @@ void DiveListView::deleteDive()
 	fixMessyQtModelBehaviour();
 }
 
-void DiveListView::testSlot()
-{
-	struct dive *d = (struct dive *)contextMenuIndex.data(DiveTripModel::DIVE_ROLE).value<void *>();
-	if (d) {
-		qDebug("testSlot called on dive #%d", d->number);
-	} else {
-		QModelIndex child = contextMenuIndex.child(0, 0);
-		d = (struct dive *)child.data(DiveTripModel::DIVE_ROLE).value<void *>();
-		if (d)
-			qDebug("testSlot called on trip including dive #%d", d->number);
-		else
-			qDebug("testSlot called on trip with no dive");
-	}
-}
-
 void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 {
 	QAction *collapseAction = NULL;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -45,7 +45,6 @@ slots:
 	void removeFromTrip();
 	void deleteDive();
 	void markDiveInvalid();
-	void testSlot();
 	void fixMessyQtModelBehaviour();
 	void mergeTripAbove();
 	void mergeTripBelow();


### PR DESCRIPTION
This debugging-slot was not linked anywhere. And especially in the
light of the impending refactoring of DiveListView/DiveTreeModel
it seems pointless to keep old debugging code.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is trivial removal of debugging code.
