### PR TITLE
Cleanup: remove parameter from currentDiveChanged signal

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -342,7 +342,7 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 		scrollTo(idx);
 	}
 	// now that everything is up to date, update the widgets
-	Q_EMIT currentDiveChanged(selected_dive);
+	emit currentDiveChanged();
 	dontEmitDiveChangedSignal = false;
 	return;
 }
@@ -544,7 +544,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 	connect(selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)), this, SLOT(selectionChanged(QItemSelection, QItemSelection)));
 	connect(selectionModel(), SIGNAL(currentChanged(QModelIndex, QModelIndex)), this, SLOT(currentChanged(QModelIndex, QModelIndex)));
 	if (!dontEmitDiveChangedSignal)
-		Q_EMIT currentDiveChanged(selected_dive);
+		emit currentDiveChanged();
 }
 
 enum asked_user {NOTYET, MERGE, DONTMERGE};

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -59,7 +59,7 @@ slots:
 	void loadWebImages();
 
 signals:
-	void currentDiveChanged(int divenr);
+	void currentDiveChanged();
 
 private:
 	bool mouseClickSelection;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -193,7 +193,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	if (!QIcon::hasThemeIcon("window-close")) {
 		QIcon::setThemeName("subsurface");
 	}
-	connect(dive_list(), SIGNAL(currentDiveChanged(int)), this, SLOT(current_dive_changed(int)));
+	connect(dive_list(), &DiveListView::currentDiveChanged, this, &MainWindow::current_dive_changed);
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveListView, SLOT(update()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveListView, SLOT(reloadHeaderActions()));
@@ -535,11 +535,8 @@ void MainWindow::configureToolbar() {
 	}
 }
 
-void MainWindow::current_dive_changed(int divenr)
+void MainWindow::current_dive_changed()
 {
-	if (divenr >= 0) {
-		select_dive(divenr);
-	}
 	graphics()->plotDive(nullptr, false, true);
 	information()->updateDiveInfo();
 	configureToolbar();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -138,7 +138,7 @@ slots:
 	void on_action_Check_for_Updates_triggered();
 
 	void on_actionDiveSiteEdit_triggered();
-	void current_dive_changed(int divenr);
+	void current_dive_changed();
 	void initialUiSetup();
 
 	void on_actionImportDiveLog_triggered();

--- a/desktop-widgets/starwidget.cpp
+++ b/desktop-widgets/starwidget.cpp
@@ -57,7 +57,7 @@ void StarWidget::mouseReleaseEvent(QMouseEvent *event)
 	else
 		current = starClicked;
 
-	Q_EMIT valueChanged(current);
+	emit valueChanged(current);
 	update();
 }
 
@@ -88,7 +88,7 @@ void StarWidget::setCurrentStars(int value)
 {
 	current = value;
 	update();
-	Q_EMIT valueChanged(current);
+	emit valueChanged(current);
 }
 
 StarWidget::StarWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f),


### PR DESCRIPTION
The currentDiveChanged signal was emitted by the DiveListView
to inform the MainWindow of a change of current dive. The
new current dive was passed as a parameter. The slot in MainWindow
then called select_dive() on the dive.

This seems pointless because:
1) In both emits, selected_dive dive was passed as argument. But
   MainWindow can read this global variable itself.
2) Calling select_dive() again is a no-op, because obviously,
   this already *was* the selected dive.

Moreover it seems conceptually wrong to set the current dive in the
slot that is informed of the change of the current dive.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This looks like a trivial cleanup. And even if I'm missing something subtle, the old code just looks wrong from a conceptual point of view, so let's fix it.