### PR TITLE
Cleanup: Make WindowsTitleUpdate a global object

### DIFF
--- a/core/windowtitleupdate.cpp
+++ b/core/windowtitleupdate.cpp
@@ -1,33 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "windowtitleupdate.h"
 
-WindowTitleUpdate *WindowTitleUpdate::m_instance = NULL;
-
-WindowTitleUpdate::WindowTitleUpdate(QObject *parent) : QObject(parent)
-{
-	Q_ASSERT_X(m_instance == NULL, "WindowTitleUpdate", "WindowTitleUpdate recreated!");
-
-	m_instance = this;
-}
-
-WindowTitleUpdate *WindowTitleUpdate::instance()
-{
-	return m_instance;
-}
-
-WindowTitleUpdate::~WindowTitleUpdate()
-{
-	m_instance = NULL;
-}
-
-void WindowTitleUpdate::emitSignal()
-{
-	emit updateTitle();
-}
+WindowTitleUpdate windowTitleUpdate;
 
 extern "C" void updateWindowTitle()
 {
-	WindowTitleUpdate *wt = WindowTitleUpdate::instance();
-	if (wt)
-		wt->emitSignal();
+	emit windowTitleUpdate.updateTitle();
 }

--- a/core/windowtitleupdate.h
+++ b/core/windowtitleupdate.h
@@ -7,15 +7,10 @@
 class WindowTitleUpdate : public QObject
 {
 	Q_OBJECT
-public:
-	explicit WindowTitleUpdate(QObject *parent = 0);
-	~WindowTitleUpdate();
-	static WindowTitleUpdate *instance();
-	void emitSignal();
 signals:
 	void updateTitle();
-private:
-	static WindowTitleUpdate *m_instance;
 };
+
+extern WindowTitleUpdate windowTitleUpdate;
 
 #endif // WINDOWTITLEUPDATE_H

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -218,8 +218,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(information(), SIGNAL(diveSiteChanged(struct dive_site *)), mapWidget, SLOT(centerOnDiveSite(struct dive_site *)));
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
-	wtu = new WindowTitleUpdate();
-	connect(WindowTitleUpdate::instance(), SIGNAL(updateTitle()), this, SLOT(setAutomaticTitle()));
+	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);
 #ifdef NO_PRINTING
 	plannerDetails->printPlan()->hide();
 	ui.menuFile->removeAction(ui.actionPrint);

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -17,7 +17,6 @@
 #include "ui_mainwindow.h"
 #include "ui_plannerDetails.h"
 #include "desktop-widgets/notificationwidget.h"
-#include "core/windowtitleupdate.h"
 #include "core/gpslocation.h"
 
 #define NUM_RECENT_FILES 4
@@ -253,7 +252,6 @@ private:
 	QHash<QByteArray, WidgetForQuadrant> applicationState;
 	QHash<QByteArray, PropertiesForQuadrant> stateProperties;
 
-	WindowTitleUpdate *wtu;
 	GpsLocation *locationProvider;
 	QMenu *connections;
 	QAction *share_on_fb;

--- a/export-html.cpp
+++ b/export-html.cpp
@@ -13,7 +13,6 @@
 #include "git2.h"
 #include "core/subsurfacestartup.h"
 #include "core/divelogexportlogic.h"
-#include "core/windowtitleupdate.h"
 #include "core/statistics.h"
 
 int main(int argc, char **argv)
@@ -42,7 +41,6 @@ int main(int argc, char **argv)
 		qDebug() << "need --source and --output";
 		exit(1);
 	}
-	WindowTitleUpdate *wtu = new WindowTitleUpdate();
 	int ret = parse_file(qPrintable(source));
 	if (ret) {
 		fprintf(stderr, "parse_file returned %d\n", ret);


### PR DESCRIPTION
WindowsTitleUpdate is such a trivial object (a QObject with a single
signal and no own state), that it's not really understandable why
it would need all that "singleton" boiler-plate. Just make it
a default constructed/destructed global object.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
`WindowsTitleUpdate` is such a trivial object, that I don't understand why it would need all that `instance()` boiler-plate. Simply make it a global (`extern`) object.
