### PR TITLE
Cleanup: replace virtual by override where appropriate

### DIFF
--- a/core/divesitehelpers.h
+++ b/core/divesitehelpers.h
@@ -10,7 +10,7 @@ Q_OBJECT
 public:
 	static ReverseGeoLookupThread *instance();
 	void lookup(struct dive_site *ds);
-	void run() Q_DECL_OVERRIDE;
+	void run() override;
 
 private:
 	ReverseGeoLookupThread(QObject *parent = 0);

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -39,8 +39,8 @@ public:
 	bool isActive() const;
 	QString errorToString() const;
 	QBluetoothDeviceDiscoveryAgent::Error error() const;
-	virtual void run();
-	virtual void stop();
+	void run() override;
+	void stop();
 
 private:
 	bool running;

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -26,9 +26,9 @@ public:
 	GasSpinBoxItemDelegate(QObject *parent = 0, column_type type = PERCENT);
 	~GasSpinBoxItemDelegate();
 
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 
 private:
 	column_type type;
@@ -46,9 +46,9 @@ public:
 	GasTypeComboBoxItemDelegate(QObject *parent = 0, computer_type type = OSTC3);
 	~GasTypeComboBoxItemDelegate();
 
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 
 private:
 	computer_type type;

--- a/desktop-widgets/divepicturewidget.h
+++ b/desktop-widgets/divepicturewidget.h
@@ -12,9 +12,9 @@ class DivePictureWidget : public QListView {
 public:
 	DivePictureWidget(QWidget *parent);
 protected:
-	void mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-	void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-	void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
+	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void mousePressEvent(QMouseEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 
 signals:
 	void photoDoubleClicked(const QString filePath);

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -67,7 +67,7 @@ class PlannerSettingsWidget : public QWidget {
 	Q_OBJECT
 public:
 	explicit PlannerSettingsWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
-	virtual ~PlannerSettingsWidget();
+	~PlannerSettingsWidget();
 public
 slots:
 	void settingsChanged();

--- a/desktop-widgets/groupedlineedit.h
+++ b/desktop-widgets/groupedlineedit.h
@@ -39,7 +39,7 @@ class GroupedLineEdit : public QPlainTextEdit {
 
 public:
 	explicit GroupedLineEdit(QWidget *parent = 0);
-	virtual ~GroupedLineEdit();
+	~GroupedLineEdit();
 
 	QString text() const;
 
@@ -55,15 +55,15 @@ public:
 
 	void addColor(QColor color);
 
-	virtual QSize sizeHint() const;
-	virtual QSize minimumSizeHint() const;
+	QSize sizeHint() const override;
+	QSize minimumSizeHint() const override;
 
 signals:
 	void editingFinished();
 
 protected:
-	virtual void paintEvent(QPaintEvent *e);
-	virtual void keyPressEvent(QKeyEvent *e);
+	void paintEvent(QPaintEvent *e) override;
+	void keyPressEvent(QKeyEvent *e) override;
 
 private:
 	struct Private;

--- a/desktop-widgets/kmessagewidget.h
+++ b/desktop-widgets/kmessagewidget.h
@@ -186,18 +186,18 @@ public:
     /**
      * Returns the preferred size of the message widget.
      */
-    QSize sizeHint() const Q_DECL_OVERRIDE;
+    QSize sizeHint() const override;
 
     /**
      * Returns the minimum size of the message widget.
      */
-    QSize minimumSizeHint() const Q_DECL_OVERRIDE;
+    QSize minimumSizeHint() const override;
 
     /**
      * Returns the required height for @p width.
      * @param width the width in pixels
      */
-    int heightForWidth(int width) const Q_DECL_OVERRIDE;
+    int heightForWidth(int width) const override;
 
     /**
      * The icon shown on the left of the text. By default, no icon is shown.
@@ -326,11 +326,11 @@ Q_SIGNALS:
     void showAnimationFinished();
 
 protected:
-    void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
+    void paintEvent(QPaintEvent *event) override;
 
-    bool event(QEvent *event) Q_DECL_OVERRIDE;
+    bool event(QEvent *event) override;
 
-    void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
     KMessageWidgetPrivate *const d;

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -11,7 +11,7 @@ class LocationInformationWidget : public QGroupBox {
 Q_OBJECT
 public:
 	LocationInformationWidget(QWidget *parent = 0);
-	virtual bool eventFilter(QObject*, QEvent*);
+	bool eventFilter(QObject*, QEvent*) override;
 
 protected:
 	void showEvent(QShowEvent *);
@@ -56,8 +56,8 @@ class DiveLocationFilterProxyModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	DiveLocationFilterProxyModel(QObject *parent = 0);
-	virtual bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;
-	virtual bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const;
+	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
 };
 
 class DiveLocationModel : public QAbstractTableModel {
@@ -79,7 +79,7 @@ class DiveLocationListView : public QListView {
 public:
 	DiveLocationListView(QWidget *parent = 0);
 protected:
-	virtual void currentChanged(const QModelIndex& current, const QModelIndex& previous);
+	void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
 signals:
 	void currentIndexChanged(const QModelIndex& current);
 };

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -59,7 +59,7 @@ public:
 	};
 
 	MainWindow();
-	virtual ~MainWindow();
+	~MainWindow();
 	static MainWindow *instance();
 	MainTab *information();
 	void loadRecentFiles();

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -19,8 +19,8 @@ class StarWidgetsDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit StarWidgetsDelegate(QWidget *parent = 0);
-	virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	const QSize& starSize() const;
 
 private:
@@ -32,10 +32,10 @@ class ComboBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit ComboBoxDelegate(QAbstractItemModel *model, QObject *parent = 0, bool allowEdit = true);
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-	virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual bool eventFilter(QObject *object, QEvent *event);
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	bool eventFilter(QObject *object, QEvent *event) override;
 public
 slots:
 	void testActivation(const QString &currString = QString());
@@ -54,8 +54,8 @@ class TankInfoDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit TankInfoDelegate(QObject *parent = 0);
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -66,17 +66,17 @@ class TankUseDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit TankUseDelegate(QObject *parent = 0);
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-	virtual void setEditorData(QWidget * editor, const QModelIndex & index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
 };
 
 class WSInfoDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit WSInfoDelegate(QObject *parent = 0);
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -86,7 +86,7 @@ class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit AirTypesDelegate(QObject *parent = 0);
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -96,7 +96,7 @@ class DiveTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit DiveTypesDelegate(QObject *parent = 0);
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -106,7 +106,7 @@ class SpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	SpinBoxDelegate(int min, int max, int step, QObject *parent = 0);
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 private:
 	int min;
 	int max;
@@ -117,7 +117,7 @@ class DoubleSpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	DoubleSpinBoxDelegate(double min, double max, double step, QObject *parent = 0);
-	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 private:
 	double min;
 	double max;
@@ -128,8 +128,8 @@ class LocationFilterDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	LocationFilterDelegate(QObject *parent = 0);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
-	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };
 
 #endif // MODELDELEGATES_H

--- a/desktop-widgets/plugins/facebook/facebook_integration.h
+++ b/desktop-widgets/plugins/facebook/facebook_integration.h
@@ -13,12 +13,12 @@ class FacebookPlugin : public ISocialNetworkIntegration {
 	Q_OBJECT
 public:
 	explicit FacebookPlugin(QObject* parent = 0);
-	virtual bool isConnected();
-	virtual void requestLogin();
-	virtual void requestLogoff();
-	virtual QString socialNetworkIcon() const;
-	virtual QString socialNetworkName() const;
-	virtual void requestUpload();
+	bool isConnected() override;
+	void requestLogin() override;
+	void requestLogoff() override;
+	QString socialNetworkIcon() const override;
+	QString socialNetworkName() const override;
+	void requestUpload() override;
 private:
 	FacebookConnectWidget *fbConnectWidget;
 };

--- a/desktop-widgets/preferences/preferences_defaults.h
+++ b/desktop-widgets/preferences/preferences_defaults.h
@@ -13,9 +13,9 @@ class PreferencesDefaults : public AbstractPreferencesWidget {
 	Q_OBJECT
 public:
 	PreferencesDefaults();
-	virtual ~PreferencesDefaults();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesDefaults();
+	void refreshSettings() override;
+	void syncSettings() override;
 public slots:
 	void on_chooseFile_clicked();
 	void on_btnUseDefaultFile_toggled(bool toggled);

--- a/desktop-widgets/preferences/preferences_georeference.h
+++ b/desktop-widgets/preferences/preferences_georeference.h
@@ -12,9 +12,9 @@ class PreferencesGeoreference : public AbstractPreferencesWidget {
 	Q_OBJECT
 public:
 	PreferencesGeoreference();
-	virtual ~PreferencesGeoreference();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesGeoreference();
+	void refreshSettings() override;
+	void syncSettings() override;
 private:
 	Ui::PreferencesGeoreference *ui;
 };

--- a/desktop-widgets/preferences/preferences_graph.h
+++ b/desktop-widgets/preferences/preferences_graph.h
@@ -12,9 +12,9 @@ class PreferencesGraph : public AbstractPreferencesWidget {
 	Q_OBJECT
 public:
 	PreferencesGraph();
-	virtual ~PreferencesGraph();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesGraph();
+	void refreshSettings() override;
+	void syncSettings() override;
 
 private slots:
 	void on_gflow_valueChanged(int gf);

--- a/desktop-widgets/preferences/preferences_language.h
+++ b/desktop-widgets/preferences/preferences_language.h
@@ -13,9 +13,9 @@ class PreferencesLanguage : public AbstractPreferencesWidget {
 	Q_OBJECT
 public:
 	PreferencesLanguage();
-	virtual ~PreferencesLanguage();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesLanguage();
+	void refreshSettings() override;
+	void syncSettings() override;
 private:
 	Ui::PreferencesLanguage *ui;
 	QMap<QString, QString> dateFormatShortMap;

--- a/desktop-widgets/preferences/preferences_network.h
+++ b/desktop-widgets/preferences/preferences_network.h
@@ -13,9 +13,9 @@ class PreferencesNetwork : public AbstractPreferencesWidget {
 
 public:
 	PreferencesNetwork();
-	virtual ~PreferencesNetwork();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesNetwork();
+	void refreshSettings() override;
+	void syncSettings() override;
 
 public slots:
 	void proxyType_changed(int i);

--- a/desktop-widgets/preferences/preferences_units.h
+++ b/desktop-widgets/preferences/preferences_units.h
@@ -12,9 +12,9 @@ class PreferencesUnits : public AbstractPreferencesWidget {
 	Q_OBJECT
 public:
 	PreferencesUnits();
-	virtual ~PreferencesUnits();
-	virtual void refreshSettings();
-	virtual void syncSettings();
+	~PreferencesUnits();
+	void refreshSettings() override;
+	void syncSettings() override;
 private:
 	Ui::PreferencesUnits *ui;
 };

--- a/desktop-widgets/preferences/preferencesdialog.h
+++ b/desktop-widgets/preferences/preferencesdialog.h
@@ -15,7 +15,7 @@ class PreferencesDialog : public QDialog {
 	Q_OBJECT
 public:
 	static PreferencesDialog* instance();
-	virtual ~PreferencesDialog();
+	~PreferencesDialog();
 	void addPreferencePage(AbstractPreferencesWidget *page);
 	void refreshPages();
 	void emitSettingsChanged();

--- a/desktop-widgets/printdialog.h
+++ b/desktop-widgets/printdialog.h
@@ -19,7 +19,7 @@ class PrintDialog : public QDialog {
 
 public:
 	explicit PrintDialog(QWidget *parent = 0, Qt::WindowFlags f = 0);
-	virtual ~PrintDialog();
+	~PrintDialog();
 
 private:
 	PrintOptions *optionsWidget;

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -172,8 +172,8 @@ protected:
 	FilterBase(FilterModelBase *model, QWidget *parent = 0);
 	FilterModelBase *model;
 	Ui::FilterWidget ui;
-	virtual void showEvent(QShowEvent *);
-	virtual void hideEvent(QHideEvent *);
+	void showEvent(QShowEvent *) override;
+	void hideEvent(QHideEvent *) override;
 	friend class MultiFilter;
 };
 
@@ -201,7 +201,7 @@ class TextHyperlinkEventFilter : public QObject {
 public:
 	explicit TextHyperlinkEventFilter(QTextEdit *txtEdit);
 
-	virtual bool eventFilter(QObject *target, QEvent *evt);
+	bool eventFilter(QObject *target, QEvent *evt) override;
 
 private:
 	void handleUrlClick(const QString &urlStr);

--- a/desktop-widgets/starwidget.h
+++ b/desktop-widgets/starwidget.h
@@ -14,7 +14,7 @@ public:
 	explicit StarWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
 	int currentStars() const;
 
-	/*reimp*/ QSize sizeHint() const;
+	QSize sizeHint() const override;
 
 	static const QImage& starActive();
 	static const QImage& starInactive();
@@ -28,11 +28,11 @@ slots:
 	void setReadOnly(bool readOnly);
 
 protected:
-	/*reimp*/ void mouseReleaseEvent(QMouseEvent *);
-	/*reimp*/ void paintEvent(QPaintEvent *);
-	/*reimp*/ void focusInEvent(QFocusEvent *);
-	/*reimp*/ void focusOutEvent(QFocusEvent *);
-	/*reimp*/ void keyPressEvent(QKeyEvent *);
+	void mouseReleaseEvent(QMouseEvent *) override;
+	void paintEvent(QPaintEvent *) override;
+	void focusInEvent(QFocusEvent *) override;
+	void focusOutEvent(QFocusEvent *) override;
+	void keyPressEvent(QKeyEvent *) override;
 
 private:
 	int current;

--- a/desktop-widgets/statistics/statisticswidget.h
+++ b/desktop-widgets/statistics/statisticswidget.h
@@ -13,7 +13,7 @@ public:
 	YearlyStatisticsWidget(QWidget *parent = 0);
 	void setModel(YearlyStatisticsModel *m);
 protected:
-	virtual void resizeEvent(QResizeEvent *event);
+	void resizeEvent(QResizeEvent *event) override;
 public slots:
 	void modelRowsInserted(const QModelIndex& index, int first, int last);
 	void modelDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);

--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -105,9 +105,9 @@ public:
 private
 slots:
 	// need to declare them as no ops or Qt4 is unhappy
-	virtual void startDownload() { }
-	virtual void startUpload() { }
-	virtual void buttonClicked(QAbstractButton *button) { Q_UNUSED(button) }
+	void startDownload() override { }
+	void startUpload() override { }
+	void buttonClicked(QAbstractButton *button) override { Q_UNUSED(button) }
 };
 
 #endif // SUBSURFACEWEBSERVICES_H

--- a/desktop-widgets/tableview.h
+++ b/desktop-widgets/tableview.h
@@ -27,7 +27,7 @@ class TableView : public QGroupBox {
 	};
 public:
 	TableView(QWidget *parent = 0);
-	virtual ~TableView();
+	~TableView();
 	/* The model is expected to have a 'remove' slot, that takes a QModelIndex as parameter.
 	 * It's also expected to have the column '1' as a trash icon. I most probably should create a
 	 * proxy model and add that column, will mark that as TODO. see? marked.
@@ -40,8 +40,8 @@ public:
 	QTableView *view();
 
 protected:
-	virtual void showEvent(QShowEvent *);
-	virtual void resizeEvent(QResizeEvent *);
+	void showEvent(QShowEvent *) override;
+	void resizeEvent(QResizeEvent *) override;
 
 signals:
 	void addButtonClicked();

--- a/desktop-widgets/undocommands.h
+++ b/desktop-widgets/undocommands.h
@@ -8,8 +8,8 @@
 class UndoDeleteDive : public QUndoCommand {
 public:
 	UndoDeleteDive(QList<struct dive*> deletedDives);
-	virtual void undo();
-	virtual void redo();
+	void undo() override;
+	void redo() override;
 
 private:
 	QList<struct dive*> diveList;
@@ -19,8 +19,8 @@ private:
 class UndoShiftTime : public QUndoCommand {
 public:
 	UndoShiftTime(QList<int> changedDives, int amount);
-	virtual void undo();
-	virtual void redo();
+	void undo() override;
+	void redo() override;
 
 private:
 	QList<int> diveList;
@@ -30,8 +30,8 @@ private:
 class UndoRenumberDives : public QUndoCommand {
 public:
 	UndoRenumberDives(QMap<int, QPair<int, int> > originalNumbers);
-	virtual void undo();
-	virtual void redo();
+	void undo() override;
+	void redo() override;
 
 private:
 	QMap<int,QPair<int, int> > oldNumbers;
@@ -40,8 +40,8 @@ private:
 class UndoRemoveDivesFromTrip : public QUndoCommand {
 public:
 	UndoRemoveDivesFromTrip(QMap<struct dive*, dive_trip*> removedDives);
-	virtual void undo();
-	virtual void redo();
+	void undo() override;
+	void redo() override;
 
 private:
 	QMap<struct dive*, dive_trip*> divesToUndo;

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -29,7 +29,7 @@ public:
 		RightToLeft
 	};
 	DiveCartesianAxis(ProfileWidget2 *widget);
-	virtual ~DiveCartesianAxis();
+	~DiveCartesianAxis();
 	void setPrintMode(bool mode);
 	void setMinimum(double minimum);
 	void setMaximum(double maximum);

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -12,7 +12,7 @@ class DiveEventItem : public DivePixmapItem {
 	Q_OBJECT
 public:
 	DiveEventItem(QGraphicsItem *parent = 0);
-	virtual ~DiveEventItem();
+	~DiveEventItem();
 	void setEvent(struct event *ev, struct gasmix *lastgasmix);
 	struct event *getEvent();
 	void eventVisibilityChanged(const QString &eventName, bool visible);

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -20,7 +20,7 @@ class CloseButtonItem : public DivePixmapItem {
 public:
 	CloseButtonItem(QGraphicsItem *parent = 0);
 protected:
-	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
+	void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 public slots:
 	void hide();
 	void show();

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -42,9 +42,6 @@ public:
 	void setHorizontalDataColumn(int column);
 	void setVerticalDataColumn(int column);
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
-	virtual void clear()
-	{
-	}
 public
 slots:
 	virtual void settingsChanged();
@@ -75,10 +72,10 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 
 public:
 	DiveProfileItem();
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void settingsToggled(bool toggled);
-	virtual void settingsChanged();
+	void settingsChanged() override;
 	void plot_depth_sample(struct plot_data *entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color);
 	int maxCeiling(int row);
 
@@ -92,8 +89,8 @@ class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveMeanDepthItem();
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
 	void createTextItem();
@@ -105,8 +102,8 @@ class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveTemperatureItem();
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
 	void createTextItem(int seconds, int mkelvin);
@@ -116,8 +113,8 @@ class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveHeartrateItem();
-	virtual void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
 	void createTextItem(int seconds, int hr);
@@ -128,8 +125,8 @@ class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DivePercentageItem(int i);
-	virtual void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
 	QString visibilityKey;
@@ -142,8 +139,8 @@ class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveAmbPressureItem();
-	virtual void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
 	QString visibilityKey;
@@ -153,8 +150,8 @@ class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveGFLineItem();
-	virtual void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
 	QString visibilityKey;
@@ -164,8 +161,8 @@ class DiveGasPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
 	void plotPressureValue(int mbar, int sec, QFlags<Qt::AlignmentFlag> align, double offset);
@@ -178,9 +175,9 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveCalculatedCeiling(ProfileWidget2 *profileWidget);
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
-	virtual void settingsChanged();
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void settingsChanged() override;
 
 public
 slots:
@@ -198,8 +195,8 @@ class DiveReportedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveReportedCeiling();
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 };
 
 class DiveCalculatedTissue : public DiveCalculatedCeiling {
@@ -207,15 +204,15 @@ class DiveCalculatedTissue : public DiveCalculatedCeiling {
 public:
 	DiveCalculatedTissue(ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
-	virtual void settingsChanged();
+	void settingsChanged() override;
 };
 
 class PartialPressureGasItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	PartialPressureGasItem();
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void setThresholdSettingsKey(double *prefPointerMin, double *prefPointerMax);
 	void setVisibilitySettingsKey(const QString &setVisibilitySettingsKey);
 	void setColors(const QColor &normalColor, const QColor &alertColor);

--- a/profile-widget/divetooltipitem.h
+++ b/profile-widget/divetooltipitem.h
@@ -30,7 +30,7 @@ public:
 	};
 
 	explicit ToolTipItem(QGraphicsItem *parent = 0);
-	virtual ~ToolTipItem();
+	~ToolTipItem();
 
 	void collapse();
 	void expand();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -84,7 +84,7 @@ public:
 	double getFontPrintScale();
 	void setFontPrintScale(double scale);
 #ifndef SUBSURFACE_MOBILE
-	virtual bool eventFilter(QObject *, QEvent *) override;
+	bool eventFilter(QObject *, QEvent *) override;
 	void clearHandlers();
 #endif
 	void recalcCeiling();
@@ -146,18 +146,18 @@ slots: // Necessary to call from QAction's signals.
 #endif
 
 protected:
-	void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+	void resizeEvent(QResizeEvent *event) override;
 #ifndef SUBSURFACE_MOBILE
-	void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
-	void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-	void contextMenuEvent(QContextMenuEvent *event) Q_DECL_OVERRIDE;
-	void mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-	void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-	void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+	void wheelEvent(QWheelEvent *event) override;
+	void mouseMoveEvent(QMouseEvent *event) override;
+	void contextMenuEvent(QContextMenuEvent *event) override;
+	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void mousePressEvent(QMouseEvent *event) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
 #endif
-	void dropEvent(QDropEvent *event) Q_DECL_OVERRIDE;
-	void dragEnterEvent(QDragEnterEvent *event) Q_DECL_OVERRIDE;
-	void dragMoveEvent(QDragMoveEvent *event) Q_DECL_OVERRIDE;
+	void dropEvent(QDropEvent *event) override;
+	void dragEnterEvent(QDragEnterEvent *event) override;
+	void dragMoveEvent(QDragMoveEvent *event) override;
 
 
 private: /*methods*/

--- a/profile-widget/ruleritem.h
+++ b/profile-widget/ruleritem.h
@@ -22,7 +22,7 @@ public:
 	void recalculate();
 
 protected:
-	virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
+	void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 private:
 	struct plot_info pInfo;
 	struct plot_data *entry;

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -22,7 +22,7 @@ public:
 signals:
 
 public slots:
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 
 private:
 	void createBar(qreal x, qreal w, struct gasmix *gas);

--- a/qt-models/cleanertablemodel.h
+++ b/qt-models/cleanertablemodel.h
@@ -20,8 +20,8 @@ class CleanerTableModel : public QAbstractTableModel {
 	Q_OBJECT
 public:
 	explicit CleanerTableModel(QObject *parent = 0);
-	virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
 protected:
 	void setHeaderDataStrings(const QStringList &headers);

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -28,10 +28,10 @@ public:
 
 	explicit CylindersModel(QObject *parent = 0);
 	static CylindersModel *instance();
-	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ Qt::ItemFlags flags(const QModelIndex &index) const;
-	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();
@@ -43,7 +43,7 @@ public:
 	void moveAtFirst(int cylid);
 	cylinder_t *cylinderAt(const QModelIndex &index);
 	bool changed;
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
 public
 slots:

--- a/qt-models/divecomputerextradatamodel.h
+++ b/qt-models/divecomputerextradatamodel.h
@@ -13,8 +13,8 @@ public:
 		VALUE
 	};
 	explicit ExtraDataModel(QObject *parent = 0);
-	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
 	void clear();
 	void updateDive();

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -15,10 +15,10 @@ public:
 		NICKNAME
 	};
 	DiveComputerModel(QObject *parent = 0);
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	void keepWorkingList();
 
 public

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -20,10 +20,10 @@ class DivePictureModel : public QAbstractTableModel {
 	Q_OBJECT
 public:
 	static DivePictureModel *instance();
-	virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual void updateDivePictures();
+	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	void updateDivePictures();
 	void removePictures(const QVector<QString> &fileUrls);
 	void updateDivePictureOffset(int diveId, const QString &filename, int offsetSeconds);
 signals:

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -26,12 +26,12 @@ public:
 		PLAN,
 		ADD
 	};
-	virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	void gasChange(const QModelIndex &index, int newcylinderid);
 	void cylinderRenumber(int mapping[]);
 	void removeSelectedPoints(const QVector<int> &rows);

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -72,10 +72,10 @@ public:
 		COLUMNS
 	};
 	explicit DivePlotDataModel(QObject *parent = 0);
-	virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	void clear();
 	void setDive(struct dive *d, const plot_info &pInfo);
 	const plot_info &data() const;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -30,10 +30,10 @@ public:
 		COLUMNS
 	};
 
-	virtual QVariant data(int column, int role) const;
+	QVariant data(int column, int role) const override;
 	int diveId;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	QString displayDate() const;
 	QString displayDuration() const;
 	QString displayDepth() const;
@@ -52,7 +52,7 @@ public:
 struct TripItem : public TreeItem {
 	Q_DECLARE_TR_FUNCTIONS(TripItem)
 public:
-	virtual QVariant data(int column, int role) const;
+	QVariant data(int column, int role) const override;
 	dive_trip_t *trip;
 };
 
@@ -94,8 +94,8 @@ public:
 	};
 
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	DiveTripModel(QObject *parent = 0);
 	Layout layout() const;
 	void setLayout(Layout layout);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -92,7 +92,7 @@ class MultiFilterSortModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	static MultiFilterSortModel *instance();
-	virtual bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
+	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 	void addFilterModel(FilterModelBase *model);
 	void removeFilterModel(FilterModelBase *model);
 	int divesDisplayed;

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -27,7 +27,7 @@ class GasSelectionModel : public QStringListModel {
 public:
 	static GasSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	virtual QVariant data(const QModelIndex &index, int role) const;
+	QVariant data(const QModelIndex &index, int role) const override;
 public
 slots:
 	void repopulate();
@@ -38,7 +38,7 @@ class DiveTypeSelectionModel : public QStringListModel {
 public:
 	static DiveTypeSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	virtual QVariant data(const QModelIndex &index, int role) const;
+	QVariant data(const QModelIndex &index, int role) const override;
 public
 slots:
 	void repopulate();
@@ -49,8 +49,8 @@ class LanguageModel : public QAbstractListModel {
 	Q_OBJECT
 public:
 	static LanguageModel *instance();
-	virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
 private:
 	LanguageModel(QObject *parent = 0);

--- a/qt-models/ssrfsortfilterproxymodel.h
+++ b/qt-models/ssrfsortfilterproxymodel.h
@@ -17,9 +17,9 @@ class SsrfSortFilterProxyModel : public QSortFilterProxyModel {
 
 public:
 	SsrfSortFilterProxyModel(QObject *parent = 0);
-	virtual bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const;
-	virtual bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;
-	virtual bool filterAcceptsColumn(int source_column, const QModelIndex& source_parent) const;
+	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
+	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+	bool filterAcceptsColumn(int source_column, const QModelIndex& source_parent) const override;
 
 	void setLessThan(less_than_cb func);
 	void setFilterRow(filter_accepts_row_cb func);

--- a/qt-models/tankinfomodel.h
+++ b/qt-models/tankinfomodel.h
@@ -18,10 +18,10 @@ public:
 	};
 	TankInfoModel();
 
-	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex());
-	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	const QString &biggerString() const;
 	void clear();
 public

--- a/qt-models/treemodel.h
+++ b/qt-models/treemodel.h
@@ -25,12 +25,12 @@ class TreeModel : public QAbstractItemModel {
 	Q_OBJECT
 public:
 	TreeModel(QObject *parent = 0);
-	virtual ~TreeModel();
-	virtual QVariant data(const QModelIndex &index, int role) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ int columnCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ QModelIndex parent(const QModelIndex &child) const;
+	~TreeModel();
+	QVariant data(const QModelIndex &index, int role) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+	QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+	QModelIndex parent(const QModelIndex &child) const override;
 
 protected:
 	int columns;

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -17,10 +17,10 @@ public:
 	};
 
 	explicit WeightModel(QObject *parent = 0);
-	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ Qt::ItemFlags flags(const QModelIndex &index) const;
-	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();

--- a/qt-models/weightsysteminfomodel.h
+++ b/qt-models/weightsysteminfomodel.h
@@ -16,10 +16,10 @@ public:
 	};
 	WSInfoModel();
 
-	/*reimp*/ QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	/*reimp*/ int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	/*reimp*/ bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex());
-	/*reimp*/ bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	const QString &biggerString() const;
 	void clear();
 	void update();

--- a/qt-models/yearlystatisticsmodel.h
+++ b/qt-models/yearlystatisticsmodel.h
@@ -26,7 +26,7 @@ public:
 		COLUMNS
 	};
 
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 	YearlyStatisticsModel(QObject *parent = 0);
 	void update_yearly_stats();
 };


### PR DESCRIPTION
The keyword "virtual" signalizes that the function is virtual,
i.e. the function of the derived class is called, even if the
call is on the parent class.

It is not necessary to repeat the "virtual" keyword in derived
classes. To highlight derived virtual functions, the keyword
"override" should be used instead. It results in a hard compile-
error, if no function is overridden, thus avoiding subtle bugs.

Replace "virtual" by "override" where appropriate. Moreover,
replace Q_DECL_OVERRIDE by override, since we require reasonably
recent compilers anyway.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a purely code-hygiene thing. It *is* a bit dangerous and I hope I didn't unvirtualize a function that's supposed to be virtual, notably `TankItem::modelDataChanged()` and `DivePictureModel::updatePictures()`. But it doesn't look like these classes are inherited from?

BTW: inlining virtual functions as in
```
	void startDownload() override { }
	void startUpload() override { }
	void buttonClicked(QAbstractButton *button) override { Q_UNUSED(button) }
```
seems a bit pointless...
### Changes made:
1) Replace `virtual` by `override` where appropriate.
2) Replace `Q_DECL_OVERRIDE` by `override`.
3) Replace `/*reimp*/` by `override`.