### PR TITLE
Fix clang override-warnings: the nuclear option

### DIFF
--- a/core/divesitehelpers.h
+++ b/core/divesitehelpers.h
@@ -10,7 +10,7 @@ Q_OBJECT
 public:
 	static ReverseGeoLookupThread *instance();
 	void lookup(struct dive_site *ds);
-	void run() override;
+	void run();
 
 private:
 	ReverseGeoLookupThread(QObject *parent = 0);

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -63,7 +63,7 @@ class DownloadThread : public QThread {
 
 public:
 	DownloadThread();
-	void run() override;
+	void run();
 
 	DCDeviceData *data();
 	QString error;

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -39,7 +39,7 @@ public:
 	bool isActive() const;
 	QString errorToString() const;
 	QBluetoothDeviceDiscoveryAgent::Error error() const;
-	void run() override;
+	void run();
 	void stop();
 
 private:

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -26,9 +26,9 @@ public:
 	GasSpinBoxItemDelegate(QObject *parent = 0, column_type type = PERCENT);
 	~GasSpinBoxItemDelegate();
 
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
 	column_type type;
@@ -46,9 +46,9 @@ public:
 	GasTypeComboBoxItemDelegate(QObject *parent = 0, computer_type type = OSTC3);
 	~GasTypeComboBoxItemDelegate();
 
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 
 private:
 	computer_type type;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -45,8 +45,8 @@ slots:
 	void removeFromTrip();
 	void deleteDive();
 	void markDiveInvalid();
-	void rowsInserted(const QModelIndex &parent, int start, int end) override;
-	void reset() override;
+	void rowsInserted(const QModelIndex &parent, int start, int end);
+	void reset();
 	void mergeTripAbove();
 	void mergeTripBelow();
 	void newTripAbove();

--- a/desktop-widgets/divepicturewidget.h
+++ b/desktop-widgets/divepicturewidget.h
@@ -12,9 +12,9 @@ class DivePictureWidget : public QListView {
 public:
 	DivePictureWidget(QWidget *parent);
 protected:
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
-	void mousePressEvent(QMouseEvent *event) override;
-	void wheelEvent(QWheelEvent *event) override;
+	void mouseDoubleClickEvent(QMouseEvent *event);
+	void mousePressEvent(QMouseEvent *event);
+	void wheelEvent(QWheelEvent *event);
 
 signals:
 	void photoDoubleClicked(const QString filePath);

--- a/desktop-widgets/groupedlineedit.h
+++ b/desktop-widgets/groupedlineedit.h
@@ -55,15 +55,15 @@ public:
 
 	void addColor(QColor color);
 
-	QSize sizeHint() const override;
-	QSize minimumSizeHint() const override;
+	QSize sizeHint() const;
+	QSize minimumSizeHint() const;
 
 signals:
 	void editingFinished();
 
 protected:
-	void paintEvent(QPaintEvent *e) override;
-	void keyPressEvent(QKeyEvent *e) override;
+	void paintEvent(QPaintEvent *e);
+	void keyPressEvent(QKeyEvent *e);
 
 private:
 	struct Private;

--- a/desktop-widgets/kmessagewidget.h
+++ b/desktop-widgets/kmessagewidget.h
@@ -186,18 +186,18 @@ public:
     /**
      * Returns the preferred size of the message widget.
      */
-    QSize sizeHint() const override;
+    QSize sizeHint() const;
 
     /**
      * Returns the minimum size of the message widget.
      */
-    QSize minimumSizeHint() const override;
+    QSize minimumSizeHint() const;
 
     /**
      * Returns the required height for @p width.
      * @param width the width in pixels
      */
-    int heightForWidth(int width) const override;
+    int heightForWidth(int width) const;
 
     /**
      * The icon shown on the left of the text. By default, no icon is shown.
@@ -326,11 +326,11 @@ Q_SIGNALS:
     void showAnimationFinished();
 
 protected:
-    void paintEvent(QPaintEvent *event) override;
+    void paintEvent(QPaintEvent *event);
 
-    bool event(QEvent *event) override;
+    bool event(QEvent *event);
 
-    void resizeEvent(QResizeEvent *event) override;
+    void resizeEvent(QResizeEvent *event);
 
 private:
     KMessageWidgetPrivate *const d;

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -11,7 +11,7 @@ class LocationInformationWidget : public QGroupBox {
 Q_OBJECT
 public:
 	LocationInformationWidget(QWidget *parent = 0);
-	bool eventFilter(QObject*, QEvent*) override;
+	bool eventFilter(QObject*, QEvent*);
 
 protected:
 	void showEvent(QShowEvent *);
@@ -56,8 +56,8 @@ class DiveLocationFilterProxyModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	DiveLocationFilterProxyModel(QObject *parent = 0);
-	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
-	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
+	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;
+	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const;
 };
 
 class DiveLocationModel : public QAbstractTableModel {
@@ -79,7 +79,7 @@ class DiveLocationListView : public QListView {
 public:
 	DiveLocationListView(QWidget *parent = 0);
 protected:
-	void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
+	void currentChanged(const QModelIndex& current, const QModelIndex& previous);
 signals:
 	void currentIndexChanged(const QModelIndex& current);
 };

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -19,8 +19,8 @@ class StarWidgetsDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit StarWidgetsDelegate(QWidget *parent = 0);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
 	const QSize& starSize() const;
 
 private:
@@ -32,10 +32,10 @@ class ComboBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit ComboBoxDelegate(QAbstractItemModel *model, QObject *parent = 0, bool allowEdit = true);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
-	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	bool eventFilter(QObject *object, QEvent *event) override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const;
+	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	bool eventFilter(QObject *object, QEvent *event);
 public
 slots:
 	void testActivation(const QString &currString = QString());
@@ -54,8 +54,8 @@ class TankInfoDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit TankInfoDelegate(QObject *parent = 0);
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -66,17 +66,17 @@ class TankUseDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit TankUseDelegate(QObject *parent = 0);
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	void setEditorData(QWidget * editor, const QModelIndex & index) const;
 };
 
 class WSInfoDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit WSInfoDelegate(QObject *parent = 0);
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -86,7 +86,7 @@ class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit AirTypesDelegate(QObject *parent = 0);
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -96,7 +96,7 @@ class DiveTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit DiveTypesDelegate(QObject *parent = 0);
-	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
 public
 slots:
 	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
@@ -106,7 +106,7 @@ class SpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	SpinBoxDelegate(int min, int max, int step, QObject *parent = 0);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 private:
 	int min;
 	int max;
@@ -117,7 +117,7 @@ class DoubleSpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	DoubleSpinBoxDelegate(double min, double max, double step, QObject *parent = 0);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 private:
 	double min;
 	double max;
@@ -128,8 +128,8 @@ class LocationFilterDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	LocationFilterDelegate(QObject *parent = 0);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
 };
 
 #endif // MODELDELEGATES_H

--- a/desktop-widgets/plugins/facebook/facebook_integration.h
+++ b/desktop-widgets/plugins/facebook/facebook_integration.h
@@ -13,12 +13,12 @@ class FacebookPlugin : public ISocialNetworkIntegration {
 	Q_OBJECT
 public:
 	explicit FacebookPlugin(QObject* parent = 0);
-	bool isConnected() override;
-	void requestLogin() override;
-	void requestLogoff() override;
-	QString socialNetworkIcon() const override;
-	QString socialNetworkName() const override;
-	void requestUpload() override;
+	bool isConnected();
+	void requestLogin();
+	void requestLogoff();
+	QString socialNetworkIcon() const;
+	QString socialNetworkName() const;
+	void requestUpload();
 private:
 	FacebookConnectWidget *fbConnectWidget;
 };

--- a/desktop-widgets/preferences/preferences_defaults.h
+++ b/desktop-widgets/preferences/preferences_defaults.h
@@ -14,8 +14,8 @@ class PreferencesDefaults : public AbstractPreferencesWidget {
 public:
 	PreferencesDefaults();
 	~PreferencesDefaults();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 public slots:
 	void on_chooseFile_clicked();
 	void on_btnUseDefaultFile_toggled(bool toggled);

--- a/desktop-widgets/preferences/preferences_georeference.h
+++ b/desktop-widgets/preferences/preferences_georeference.h
@@ -13,8 +13,8 @@ class PreferencesGeoreference : public AbstractPreferencesWidget {
 public:
 	PreferencesGeoreference();
 	~PreferencesGeoreference();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 private:
 	Ui::PreferencesGeoreference *ui;
 };

--- a/desktop-widgets/preferences/preferences_graph.h
+++ b/desktop-widgets/preferences/preferences_graph.h
@@ -13,8 +13,8 @@ class PreferencesGraph : public AbstractPreferencesWidget {
 public:
 	PreferencesGraph();
 	~PreferencesGraph();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 
 private slots:
 	void on_gflow_valueChanged(int gf);

--- a/desktop-widgets/preferences/preferences_language.h
+++ b/desktop-widgets/preferences/preferences_language.h
@@ -14,8 +14,8 @@ class PreferencesLanguage : public AbstractPreferencesWidget {
 public:
 	PreferencesLanguage();
 	~PreferencesLanguage();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 private:
 	Ui::PreferencesLanguage *ui;
 	QMap<QString, QString> dateFormatShortMap;

--- a/desktop-widgets/preferences/preferences_network.h
+++ b/desktop-widgets/preferences/preferences_network.h
@@ -14,8 +14,8 @@ class PreferencesNetwork : public AbstractPreferencesWidget {
 public:
 	PreferencesNetwork();
 	~PreferencesNetwork();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 
 public slots:
 	void proxyType_changed(int i);

--- a/desktop-widgets/preferences/preferences_units.h
+++ b/desktop-widgets/preferences/preferences_units.h
@@ -13,8 +13,8 @@ class PreferencesUnits : public AbstractPreferencesWidget {
 public:
 	PreferencesUnits();
 	~PreferencesUnits();
-	void refreshSettings() override;
-	void syncSettings() override;
+	void refreshSettings();
+	void syncSettings();
 private:
 	Ui::PreferencesUnits *ui;
 };

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -172,8 +172,8 @@ protected:
 	FilterBase(FilterModelBase *model, QWidget *parent = 0);
 	FilterModelBase *model;
 	Ui::FilterWidget ui;
-	void showEvent(QShowEvent *) override;
-	void hideEvent(QHideEvent *) override;
+	void showEvent(QShowEvent *);
+	void hideEvent(QHideEvent *);
 	friend class MultiFilter;
 };
 
@@ -201,7 +201,7 @@ class TextHyperlinkEventFilter : public QObject {
 public:
 	explicit TextHyperlinkEventFilter(QTextEdit *txtEdit);
 
-	bool eventFilter(QObject *target, QEvent *evt) override;
+	bool eventFilter(QObject *target, QEvent *evt);
 
 private:
 	void handleUrlClick(const QString &urlStr);

--- a/desktop-widgets/starwidget.h
+++ b/desktop-widgets/starwidget.h
@@ -14,7 +14,7 @@ public:
 	explicit StarWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
 	int currentStars() const;
 
-	QSize sizeHint() const override;
+	QSize sizeHint() const;
 
 	static const QImage& starActive();
 	static const QImage& starInactive();
@@ -28,11 +28,11 @@ slots:
 	void setReadOnly(bool readOnly);
 
 protected:
-	void mouseReleaseEvent(QMouseEvent *) override;
-	void paintEvent(QPaintEvent *) override;
-	void focusInEvent(QFocusEvent *) override;
-	void focusOutEvent(QFocusEvent *) override;
-	void keyPressEvent(QKeyEvent *) override;
+	void mouseReleaseEvent(QMouseEvent *);
+	void paintEvent(QPaintEvent *);
+	void focusInEvent(QFocusEvent *);
+	void focusOutEvent(QFocusEvent *);
+	void keyPressEvent(QKeyEvent *);
 
 private:
 	int current;

--- a/desktop-widgets/statistics/statisticswidget.h
+++ b/desktop-widgets/statistics/statisticswidget.h
@@ -13,7 +13,7 @@ public:
 	YearlyStatisticsWidget(QWidget *parent = 0);
 	void setModel(YearlyStatisticsModel *m);
 protected:
-	void resizeEvent(QResizeEvent *event) override;
+	void resizeEvent(QResizeEvent *event);
 public slots:
 	void modelRowsInserted(const QModelIndex& index, int first, int last);
 	void modelDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);

--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -105,9 +105,9 @@ public:
 private
 slots:
 	// need to declare them as no ops or Qt4 is unhappy
-	void startDownload() override { }
-	void startUpload() override { }
-	void buttonClicked(QAbstractButton *button) override { Q_UNUSED(button) }
+	void startDownload() { }
+	void startUpload() { }
+	void buttonClicked(QAbstractButton *button) { Q_UNUSED(button) }
 };
 
 #endif // SUBSURFACEWEBSERVICES_H

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
@@ -15,8 +15,8 @@ class TabDiveExtraInfo : public TabBase {
 public:
 	TabDiveExtraInfo(QWidget *parent = 0);
 	~TabDiveExtraInfo();
-	void updateData() override;
-	void clear() override;
+	void updateData();
+	void clear();
 private:
 	Ui::TabDiveExtraInfo *ui;
 	ExtraDataModel *extraDataModel;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -13,8 +13,8 @@ class TabDiveInformation : public TabBase {
 public:
 	TabDiveInformation(QWidget *parent = 0);
 	~TabDiveInformation();
-	void updateData() override;
-	void clear() override;
+	void updateData();
+	void clear();
 
 private:
 	Ui::TabDiveInformation *ui;

--- a/desktop-widgets/tab-widgets/TabDivePhotos.h
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.h
@@ -15,11 +15,11 @@ class TabDivePhotos : public TabBase {
 public:
 	TabDivePhotos(QWidget *parent = 0);
 	~TabDivePhotos();
-	void updateData() override;
-	void clear() override;
+	void updateData();
+	void clear();
 
 protected:
-	void contextMenuEvent(QContextMenuEvent *ev) override;
+	void contextMenuEvent(QContextMenuEvent *ev);
 
 private slots:
 	void addPhotosFromFile();

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.h
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.h
@@ -13,8 +13,8 @@ class TabDiveStatistics : public TabBase {
 public:
 	TabDiveStatistics(QWidget *parent = 0);
 	~TabDiveStatistics();
-	void updateData() override;
-	void clear() override;
+	void updateData();
+	void clear();
 
 private:
 	Ui::TabDiveStatistics *ui;

--- a/desktop-widgets/tableview.h
+++ b/desktop-widgets/tableview.h
@@ -40,8 +40,8 @@ public:
 	QTableView *view();
 
 protected:
-	void showEvent(QShowEvent *) override;
-	void resizeEvent(QResizeEvent *) override;
+	void showEvent(QShowEvent *);
+	void resizeEvent(QResizeEvent *);
 
 signals:
 	void addButtonClicked();

--- a/desktop-widgets/undocommands.h
+++ b/desktop-widgets/undocommands.h
@@ -8,8 +8,8 @@
 class UndoDeleteDive : public QUndoCommand {
 public:
 	UndoDeleteDive(QList<struct dive*> deletedDives);
-	void undo() override;
-	void redo() override;
+	void undo();
+	void redo();
 
 private:
 	QList<struct dive*> diveList;
@@ -19,8 +19,8 @@ private:
 class UndoShiftTime : public QUndoCommand {
 public:
 	UndoShiftTime(QList<int> changedDives, int amount);
-	void undo() override;
-	void redo() override;
+	void undo();
+	void redo();
 
 private:
 	QList<int> diveList;
@@ -30,8 +30,8 @@ private:
 class UndoRenumberDives : public QUndoCommand {
 public:
 	UndoRenumberDives(QMap<int, QPair<int, int> > originalNumbers);
-	void undo() override;
-	void redo() override;
+	void undo();
+	void redo();
 
 private:
 	QMap<int,QPair<int, int> > oldNumbers;
@@ -40,8 +40,8 @@ private:
 class UndoRemoveDivesFromTrip : public QUndoCommand {
 public:
 	UndoRemoveDivesFromTrip(QMap<struct dive*, dive_trip*> removedDives);
-	void undo() override;
-	void redo() override;
+	void undo();
+	void redo();
 
 private:
 	QMap<struct dive*, dive_trip*> divesToUndo;

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -20,7 +20,7 @@ class CloseButtonItem : public DivePixmapItem {
 public:
 	CloseButtonItem(QGraphicsItem *parent = 0);
 protected:
-	void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+	void mousePressEvent(QGraphicsSceneMouseEvent *event);
 public slots:
 	void hide();
 	void show();

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -72,10 +72,10 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 
 public:
 	DiveProfileItem();
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 	void settingsToggled(bool toggled);
-	void settingsChanged() override;
+	void settingsChanged();
 	void plot_depth_sample(struct plot_data *entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color);
 	int maxCeiling(int row);
 
@@ -89,8 +89,8 @@ class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveMeanDepthItem();
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
 
 private:
 	void createTextItem();
@@ -102,8 +102,8 @@ class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveTemperatureItem();
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
 
 private:
 	void createTextItem(int seconds, int mkelvin);
@@ -113,8 +113,8 @@ class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveHeartrateItem();
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 
 private:
 	void createTextItem(int seconds, int hr);
@@ -125,8 +125,8 @@ class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DivePercentageItem(int i);
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 
 private:
 	QString visibilityKey;
@@ -139,8 +139,8 @@ class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveAmbPressureItem();
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 
 private:
 	QString visibilityKey;
@@ -150,8 +150,8 @@ class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveGFLineItem();
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 
 private:
 	QString visibilityKey;
@@ -161,8 +161,8 @@ class DiveGasPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
 
 private:
 	void plotPressureValue(int mbar, int sec, QFlags<Qt::AlignmentFlag> align, double offset);
@@ -175,9 +175,9 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveCalculatedCeiling(ProfileWidget2 *profileWidget);
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void settingsChanged() override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void settingsChanged();
 
 public
 slots:
@@ -195,8 +195,8 @@ class DiveReportedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveReportedCeiling();
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
 };
 
 class DiveCalculatedTissue : public DiveCalculatedCeiling {
@@ -204,15 +204,15 @@ class DiveCalculatedTissue : public DiveCalculatedCeiling {
 public:
 	DiveCalculatedTissue(ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
-	void settingsChanged() override;
+	void settingsChanged();
 };
 
 class PartialPressureGasItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	PartialPressureGasItem();
-	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
+	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 	void setThresholdSettingsKey(double *prefPointerMin, double *prefPointerMax);
 	void setVisibilitySettingsKey(const QString &setVisibilitySettingsKey);
 	void setColors(const QColor &normalColor, const QColor &alertColor);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -84,7 +84,7 @@ public:
 	double getFontPrintScale();
 	void setFontPrintScale(double scale);
 #ifndef SUBSURFACE_MOBILE
-	bool eventFilter(QObject *, QEvent *) override;
+	bool eventFilter(QObject *, QEvent *);
 	void clearHandlers();
 #endif
 	void recalcCeiling();
@@ -146,18 +146,18 @@ slots: // Necessary to call from QAction's signals.
 #endif
 
 protected:
-	void resizeEvent(QResizeEvent *event) override;
+	void resizeEvent(QResizeEvent *event);
 #ifndef SUBSURFACE_MOBILE
-	void wheelEvent(QWheelEvent *event) override;
-	void mouseMoveEvent(QMouseEvent *event) override;
-	void contextMenuEvent(QContextMenuEvent *event) override;
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
-	void mousePressEvent(QMouseEvent *event) override;
-	void mouseReleaseEvent(QMouseEvent *event) override;
+	void wheelEvent(QWheelEvent *event);
+	void mouseMoveEvent(QMouseEvent *event);
+	void contextMenuEvent(QContextMenuEvent *event);
+	void mouseDoubleClickEvent(QMouseEvent *event);
+	void mousePressEvent(QMouseEvent *event);
+	void mouseReleaseEvent(QMouseEvent *event);
 #endif
-	void dropEvent(QDropEvent *event) override;
-	void dragEnterEvent(QDragEnterEvent *event) override;
-	void dragMoveEvent(QDragMoveEvent *event) override;
+	void dropEvent(QDropEvent *event);
+	void dragEnterEvent(QDragEnterEvent *event);
+	void dragMoveEvent(QDragMoveEvent *event);
 
 
 private: /*methods*/

--- a/profile-widget/ruleritem.h
+++ b/profile-widget/ruleritem.h
@@ -22,7 +22,7 @@ public:
 	void recalculate();
 
 protected:
-	void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+	void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
 private:
 	struct plot_info pInfo;
 	struct plot_data *entry;

--- a/qt-models/cleanertablemodel.h
+++ b/qt-models/cleanertablemodel.h
@@ -20,8 +20,8 @@ class CleanerTableModel : public QAbstractTableModel {
 	Q_OBJECT
 public:
 	explicit CleanerTableModel(QObject *parent = 0);
-	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 
 protected:
 	void setHeaderDataStrings(const QStringList &headers);

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -28,10 +28,10 @@ public:
 
 	explicit CylindersModel(QObject *parent = 0);
 	static CylindersModel *instance();
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	Qt::ItemFlags flags(const QModelIndex &index) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();
@@ -43,7 +43,7 @@ public:
 	void moveAtFirst(int cylid);
 	cylinder_t *cylinderAt(const QModelIndex &index);
 	bool changed;
-	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const;
 
 public
 slots:

--- a/qt-models/divecomputerextradatamodel.h
+++ b/qt-models/divecomputerextradatamodel.h
@@ -13,8 +13,8 @@ public:
 		VALUE
 	};
 	explicit ExtraDataModel(QObject *parent = 0);
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 
 	void clear();
 	void updateDive();

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -15,10 +15,10 @@ public:
 		NICKNAME
 	};
 	DiveComputerModel(QObject *parent = 0);
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	Qt::ItemFlags flags(const QModelIndex &index) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	void keepWorkingList();
 
 public

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -20,9 +20,9 @@ class DivePictureModel : public QAbstractTableModel {
 	Q_OBJECT
 public:
 	static DivePictureModel *instance();
-	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	void updateDivePictures();
 	void removePictures(const QVector<QString> &fileUrls);
 	void updateDivePictureOffset(int diveId, const QString &filename, int offsetSeconds);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -26,12 +26,12 @@ public:
 		PLAN,
 		ADD
 	};
-	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	Qt::ItemFlags flags(const QModelIndex &index) const;
 	void gasChange(const QModelIndex &index, int newcylinderid);
 	void cylinderRenumber(int mapping[]);
 	void removeSelectedPoints(const QVector<int> &rows);

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -72,10 +72,10 @@ public:
 		COLUMNS
 	};
 	explicit DivePlotDataModel(QObject *parent = 0);
-	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	void clear();
 	void setDive(struct dive *d, const plot_info &pInfo);
 	const plot_info &data() const;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -30,10 +30,10 @@ public:
 		COLUMNS
 	};
 
-	QVariant data(int column, int role) const override;
+	QVariant data(int column, int role) const;
 	int diveId;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QString displayDate() const;
 	QString displayDuration() const;
 	QString displayDepth() const;
@@ -52,7 +52,7 @@ public:
 struct TripItem : public TreeItem {
 	Q_DECLARE_TR_FUNCTIONS(TripItem)
 public:
-	QVariant data(int column, int role) const override;
+	QVariant data(int column, int role) const;
 	dive_trip_t *trip;
 };
 
@@ -94,8 +94,8 @@ public:
 	};
 
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	DiveTripModel(QObject *parent = 0);
 	Layout layout() const;
 	void setLayout(Layout layout);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -92,7 +92,7 @@ class MultiFilterSortModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	static MultiFilterSortModel *instance();
-	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
+	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 	void addFilterModel(FilterModelBase *model);
 	void removeFilterModel(FilterModelBase *model);
 	int divesDisplayed;

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -56,8 +56,8 @@ public:
 	~MapLocationModel();
 
 	Q_INVOKABLE MapLocation *get(int row);
-	QVariant data(const QModelIndex &index, int role) const override;
-	int rowCount(const QModelIndex &parent) const override;
+	QVariant data(const QModelIndex &index, int role) const;
+	int rowCount(const QModelIndex &parent) const;
 	int count();
 	void add(MapLocation *);
 	void addList(QVector<MapLocation *>);
@@ -68,7 +68,7 @@ public:
 	quint32 selectedUuid();
 
 protected:
-	QHash<int, QByteArray> roleNames() const override;
+	QHash<int, QByteArray> roleNames() const;
 
 private:
 	QVector<MapLocation *> m_mapLocations;

--- a/qt-models/messagehandlermodel.h
+++ b/qt-models/messagehandlermodel.h
@@ -10,9 +10,9 @@ class MessageHandlerModel : public QAbstractListModel {
 public:
 	static MessageHandlerModel *self();
 	enum MsgTypes {Message = Qt::UserRole + 1, Severity};
-	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-	QVariant data(const QModelIndex& idx, int role) const override;
-	QHash<int, QByteArray> roleNames() const override;
+	int rowCount(const QModelIndex& parent = QModelIndex()) const;
+	QVariant data(const QModelIndex& idx, int role) const;
+	QHash<int, QByteArray> roleNames() const;
 	void addLog(QtMsgType type, const QString& message);
 	const QString logAsString();
 

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -27,7 +27,7 @@ class GasSelectionModel : public QStringListModel {
 public:
 	static GasSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	QVariant data(const QModelIndex &index, int role) const override;
+	QVariant data(const QModelIndex &index, int role) const;
 public
 slots:
 	void repopulate();
@@ -38,7 +38,7 @@ class DiveTypeSelectionModel : public QStringListModel {
 public:
 	static DiveTypeSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
-	QVariant data(const QModelIndex &index, int role) const override;
+	QVariant data(const QModelIndex &index, int role) const;
 public
 slots:
 	void repopulate();
@@ -49,8 +49,8 @@ class LanguageModel : public QAbstractListModel {
 	Q_OBJECT
 public:
 	static LanguageModel *instance();
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 
 private:
 	LanguageModel(QObject *parent = 0);

--- a/qt-models/ssrfsortfilterproxymodel.h
+++ b/qt-models/ssrfsortfilterproxymodel.h
@@ -17,9 +17,9 @@ class SsrfSortFilterProxyModel : public QSortFilterProxyModel {
 
 public:
 	SsrfSortFilterProxyModel(QObject *parent = 0);
-	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
-	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
-	bool filterAcceptsColumn(int source_column, const QModelIndex& source_parent) const override;
+	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const;
+	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;
+	bool filterAcceptsColumn(int source_column, const QModelIndex& source_parent) const;
 
 	void setLessThan(less_than_cb func);
 	void setFilterRow(filter_accepts_row_cb func);

--- a/qt-models/tankinfomodel.h
+++ b/qt-models/tankinfomodel.h
@@ -18,10 +18,10 @@ public:
 	};
 	TankInfoModel();
 
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex());
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	const QString &biggerString() const;
 	void clear();
 public

--- a/qt-models/treemodel.h
+++ b/qt-models/treemodel.h
@@ -26,11 +26,11 @@ class TreeModel : public QAbstractItemModel {
 public:
 	TreeModel(QObject *parent = 0);
 	~TreeModel();
-	QVariant data(const QModelIndex &index, int role) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-	QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
-	QModelIndex parent(const QModelIndex &child) const override;
+	QVariant data(const QModelIndex &index, int role) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	int columnCount(const QModelIndex &parent = QModelIndex()) const;
+	QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
+	QModelIndex parent(const QModelIndex &child) const;
 
 protected:
 	int columns;

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -17,10 +17,10 @@ public:
 	};
 
 	explicit WeightModel(QObject *parent = 0);
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	Qt::ItemFlags flags(const QModelIndex &index) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();

--- a/qt-models/weightsysteminfomodel.h
+++ b/qt-models/weightsysteminfomodel.h
@@ -16,10 +16,10 @@ public:
 	};
 	WSInfoModel();
 
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const;
+	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex());
+	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 	const QString &biggerString() const;
 	void clear();
 	void update();

--- a/qt-models/yearlystatisticsmodel.h
+++ b/qt-models/yearlystatisticsmodel.h
@@ -26,7 +26,7 @@ public:
 		COLUMNS
 	};
 
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 	YearlyStatisticsModel(QObject *parent = 0);
 	void update_yearly_stats();
 };


### PR DESCRIPTION
Commit df156a56c08a56eb380711a507ef739d8150a71f replaced "virtual"
by "override" where appropriate. Unfortunately, this had the
unintended consequence of producing numerous clang warnings. If
clang finds a override-modified function in a class definition,
it warns for *all* overriden virtual functions without the override
modifier.

To solve this, go the easy route and remove all overrides. At least
it is consistent.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This would be the easy way of fixing the clang override warnings: simply remove them all. I'm not saying that this is the right thing to do - I'm just throwing that as an option out there.
Three other possibilities:
- Suppress the warning.
- Add the missing overrides.
- Revert df156a56c08a56eb380711a507ef739d8150a71f and go back to the previous messy - but warning-free - state.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove all overrides modifiers.