### PR TITLE
Cleanup: remove silly " != 0" expression

### DIFF
--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -446,7 +446,7 @@ static bool parseASF(QFile &f, metadata *metadata)
 
 		header_len -= object_len;
 		object_len -= 24;
-		if (!memcmp(data, "\xa1\xdc\xab\x8c\x47\xa9\xcf\x11\x8e\xe4\x0\xc0\xc\x20\x53\x65", 16) != 0) {
+		if (!memcmp(data, "\xa1\xdc\xab\x8c\x47\xa9\xcf\x11\x8e\xe4\x0\xc0\xc\x20\x53\x65", 16)) {
 			// This is a file properties object. The interesting data are:
 			//	quadword (64 bit) at byte 24: creation date in 100-nanoseconds since Jan. 1, 1601.
 			//	quadword (64 bit) at byte 40: duration in 100-nanoseconds.


### PR DESCRIPTION
In metadata.cpp, replace a silly
 "if (!memcmp(...) != 0)"
by the intended
 "if (!memcmp(...))"

Obviously, both have the same effect. Fixes a warning.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Trivial code cleanup.