### PR TITLE
 add qPrefUnits and remove from SettingsObjectWrapper

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	settings/qPrefFacebook.cpp
 	settings/qPrefPrivate.cpp
 	settings/qPrefProxy.cpp
+	settings/qPrefUnit.cpp
 
 	#Subsurface Qt have the Subsurface structs QObjectified for easy access via QML.
 	subsurface-qt/DiveObjectHelper.cpp

--- a/core/pref.h
+++ b/core/pref.h
@@ -59,6 +59,12 @@ typedef struct {
 	int download_mode;
 } dive_computer_prefs_t;
 
+enum unit_system_values {
+	METRIC,
+	IMPERIAL,
+	PERSONALIZE
+};
+
 // ********** PREFERENCES **********
 // This struct is kept global for all of ssrf
 // most of the fields are loaded from git as
@@ -195,18 +201,12 @@ struct preferences {
 	bool                        zoomed_plot;
 
 	// ********** Units **********
-	bool            coordinates_traditional;
-	short           unit_system;
-	struct units    units;
+	bool                    coordinates_traditional;
+	enum unit_system_values unit_system;
+	struct units            units;
 
 	// ********** UpdateManager **********
 	update_manager_prefs_t update_manager;
-};
-
-enum unit_system_values {
-	METRIC,
-	IMPERIAL,
-	PERSONALIZE
 };
 
 enum def_file_behavior {

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -20,6 +20,7 @@ void qPref::loadSync(bool doSync)
 	qPrefDiveComputer::instance()->loadSync(doSync);
 	// qPrefFaceook does not use disk.
 	qPrefProxy::instance()->loadSync(doSync);
+	qPrefUnits::instance()->loadSync(doSync);
 }
 
 const QString qPref::canonical_version() const

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -11,6 +11,7 @@
 #include "qPrefDiveComputer.h"
 #include "qPrefFacebook.h"
 #include "qPrefProxy.h"
+#include "qPrefUnit.h"
 
 class qPref : public QObject {
 	Q_OBJECT

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -20,6 +20,7 @@ public:
 	friend class qPrefDiveComputer;
 	friend class qPrefFacebook;
 	friend class qPrefProxy;
+	friend class qPrefUnits;
 
 private:
 	static qPrefPrivate *instance();

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qPref.h"
+#include "qPrefPrivate.h"
+
+
+static const QString group = QStringLiteral("Units");
+
+qPrefUnits::qPrefUnits(QObject *parent) : QObject(parent)
+{
+}
+qPrefUnits *qPrefUnits::instance()
+{
+	static qPrefUnits *self = new qPrefUnits;
+	return self;
+}
+
+
+void qPrefUnits::loadSync(bool doSync)
+{
+	disk_coordinates_traditional(doSync);
+	disk_duration_units(doSync);
+	disk_length(doSync);
+	disk_pressure(doSync);
+	disk_show_units_table(doSync);
+	disk_temperature(doSync);
+	disk_unit_system(doSync);
+	disk_vertical_speed_time(doSync);
+	disk_volume(doSync);
+	disk_weight(doSync);
+}
+
+HANDLE_PREFERENCE_BOOL(Units, "/coordinates", coordinates_traditional);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::DURATION, "/duration_units", duration_units, units.);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::LENGTH, "/length", length, units.);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, "/pressure", pressure, units.);
+
+HANDLE_PREFERENCE_BOOL_EXT(Units, "/show_units_table", show_units_table, units.);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, "/temperature", temperature, units.);
+
+QString qPrefUnits::unit_system()
+{
+	return 	prefs.unit_system == METRIC ? QStringLiteral("metric") :
+			prefs.unit_system == IMPERIAL ? QStringLiteral("imperial") :
+											QStringLiteral("personalized");
+}
+void qPrefUnits::set_unit_system(const QString& value)
+{
+	short int v = value == QStringLiteral("metric") ? METRIC :
+					value == QStringLiteral("imperial")? IMPERIAL :
+							PERSONALIZE;
+	if (v != prefs.unit_system) {
+		if (v == METRIC) {
+			prefs.unit_system = METRIC;
+			prefs.units = SI_units;
+		} else if (v == IMPERIAL) {
+			prefs.unit_system = IMPERIAL;
+			prefs.units = IMPERIAL_units;
+		} else {
+			prefs.unit_system = PERSONALIZE;
+		}
+		disk_unit_system(true);
+		emit unit_system_changed(value);
+	}
+}
+DISK_LOADSYNC_ENUM(Units, "/unit_system", unit_system_values, unit_system);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::TIME, "/vertical_speed_time", vertical_speed_time, units.);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::VOLUME, "/volume", volume, units.);
+
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, "/weight", weight, units.);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef QPREFUNIT_H
+#define QPREFUNIT_H
+#include "core/pref.h"
+
+#include <QObject>
+
+
+class qPrefUnits : public QObject {
+	Q_OBJECT
+	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditional_changed);
+	Q_PROPERTY(units::DURATION duration_units READ duration_units WRITE set_duration_units NOTIFY duration_units_changed);
+	Q_PROPERTY(units::LENGTH length READ length WRITE set_length NOTIFY length_changed);
+	Q_PROPERTY(units::PRESSURE pressure READ pressure WRITE set_pressure NOTIFY pressure_changed);
+	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_table_changed);
+	Q_PROPERTY(units::TEMPERATURE temperature READ temperature WRITE set_temperature NOTIFY temperature_changed);
+	Q_PROPERTY(QString unit_system READ unit_system WRITE set_unit_system NOTIFY unit_system_changed);
+	Q_PROPERTY(units::TIME vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_time_changed);
+	Q_PROPERTY(units::VOLUME volume READ volume WRITE set_volume NOTIFY volume_changed);
+	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weight_changed);
+
+public:
+	qPrefUnits(QObject *parent = NULL);
+	static qPrefUnits *instance();
+
+	// Load/Sync local settings (disk) and struct preference
+	void loadSync(bool doSync);
+	void inline load() { loadSync(false); }
+	void inline sync() { loadSync(true); }
+
+public:
+	static inline bool coordinates_traditional() { return prefs.coordinates_traditional; }
+	static inline units::DURATION duration_units() { return prefs.units.duration_units; }
+	static inline units::LENGTH length() { return prefs.units.length; }
+	static inline units::PRESSURE pressure() { return prefs.units.pressure; }
+	static inline bool show_units_table() { return prefs.units.show_units_table; }
+	static inline units::TEMPERATURE temperature() { return prefs.units.temperature; }
+	static QString unit_system();
+	static inline units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
+	static inline units::VOLUME volume() { return prefs.units.volume; }
+	static inline units::WEIGHT weight() { return prefs.units.weight; }
+
+public slots:
+	void set_coordinates_traditional(bool value);
+	void set_duration_units(units::DURATION value);
+	void set_length(units::LENGTH value);
+	void set_pressure(units::PRESSURE value);
+	void set_show_units_table(bool value);
+	void set_temperature(units::TEMPERATURE value);
+	void set_unit_system(const QString& value);
+	void set_vertical_speed_time(units::TIME value);
+	void set_volume(units::VOLUME value);
+	void set_weight(units::WEIGHT value);
+
+signals:
+	void coordinates_traditional_changed(bool value);
+	void duration_units_changed(int value);
+	void length_changed(int value);
+	void pressure_changed(int value);
+	void show_units_table_changed(bool value);
+	void temperature_changed(int value);
+	void unit_system_changed(const QString& value);
+	void vertical_speed_time_changed(int value);
+	void volume_changed(int value);
+	void weight_changed(int value);
+
+private:
+	void disk_coordinates_traditional(bool doSync);
+	void disk_duration_units(bool doSync);
+	void disk_length(bool doSync);
+	void disk_pressure(bool doSync);
+	void disk_show_units_table(bool doSync);
+	void disk_temperature(bool doSync);
+	void disk_unit_system(bool doSync);
+	void disk_vertical_speed_time(bool doSync);
+	void disk_volume(bool doSync);
+	void disk_weight(bool doSync);
+};
+
+#endif

--- a/core/subsurface-qt/SettingsObjectWrapper.cpp
+++ b/core/subsurface-qt/SettingsObjectWrapper.cpp
@@ -1138,191 +1138,6 @@ void DivePlannerSettings::setDecoMode(deco_mode value)
 	emit decoModeChanged(value);
 }
 
-UnitsSettings::UnitsSettings(QObject *parent) :
-	QObject(parent)
-{
-
-}
-
-int UnitsSettings::length() const
-{
-	return prefs.units.length;
-}
-
-int UnitsSettings::pressure() const
-{
-	return prefs.units.pressure;
-}
-
-int UnitsSettings::volume() const
-{
-	return prefs.units.volume;
-}
-
-int UnitsSettings::temperature() const
-{
-	return prefs.units.temperature;
-}
-
-int UnitsSettings::weight() const
-{
-	return prefs.units.weight;
-}
-
-int UnitsSettings::verticalSpeedTime() const
-{
-	return prefs.units.vertical_speed_time;
-}
-
-int UnitsSettings::durationUnits() const
-{
-	return prefs.units.duration_units;
-}
-
-bool UnitsSettings::showUnitsTable() const
-{
-	return prefs.units.show_units_table;
-}
-
-QString UnitsSettings::unitSystem() const
-{
-	return prefs.unit_system == METRIC ? QStringLiteral("metric")
-			: prefs.unit_system == IMPERIAL ? QStringLiteral("imperial")
-			: QStringLiteral("personalized");
-}
-
-bool UnitsSettings::coordinatesTraditional() const
-{
-	return prefs.coordinates_traditional;
-}
-
-void UnitsSettings::setLength(int value)
-{
-	if (value == prefs.units.length)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("length", value);
-	prefs.units.length = (units::LENGTH) value;
-	emit lengthChanged(value);
-}
-
-void UnitsSettings::setPressure(int value)
-{
-	if (value == prefs.units.pressure)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("pressure", value);
-	prefs.units.pressure = (units::PRESSURE) value;
-	emit pressureChanged(value);
-}
-
-void UnitsSettings::setVolume(int value)
-{
-	if (value == prefs.units.volume)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("volume", value);
-	prefs.units.volume = (units::VOLUME) value;
-	emit volumeChanged(value);
-}
-
-void UnitsSettings::setTemperature(int value)
-{
-	if (value == prefs.units.temperature)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("temperature", value);
-	prefs.units.temperature = (units::TEMPERATURE) value;
-	emit temperatureChanged(value);
-}
-
-void UnitsSettings::setWeight(int value)
-{
-	if (value == prefs.units.weight)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("weight", value);
-	prefs.units.weight = (units::WEIGHT) value;
-	emit weightChanged(value);
-}
-
-void UnitsSettings::setVerticalSpeedTime(int value)
-{
-	if (value == prefs.units.vertical_speed_time)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("vertical_speed_time", value);
-	prefs.units.vertical_speed_time = (units::TIME) value;
-	emit verticalSpeedTimeChanged(value);
-}
-
-void UnitsSettings::setDurationUnits(int value)
-{
-	if (value == prefs.units.duration_units)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("duration_units", value);
-	prefs.units.duration_units = (units::DURATION) value;
-	emit durationUnitChanged(value);
-}
-
-void UnitsSettings::setShowUnitsTable(bool value)
-{
-	if (value == prefs.units.show_units_table)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("show_units_table", value);
-	prefs.units.show_units_table = value;
-	emit showUnitsTableChanged(value);
-}
-
-void UnitsSettings::setCoordinatesTraditional(bool value)
-{
-	if (value == prefs.coordinates_traditional)
-		return;
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("coordinates", value);
-	prefs.coordinates_traditional = value;
-	emit coordinatesTraditionalChanged(value);
-}
-
-void UnitsSettings::setUnitSystem(const QString& value)
-{
-	short int v = value == QStringLiteral("metric") ? METRIC
-		      : value == QStringLiteral("imperial")? IMPERIAL
-		      : PERSONALIZE;
-
-	if (v == prefs.unit_system)
-		return;
-
-	QSettings s;
-	s.beginGroup(group);
-	s.setValue("unit_system", value);
-
-	if (value == QStringLiteral("metric")) {
-		prefs.unit_system = METRIC;
-		prefs.units = SI_units;
-	} else if (value == QStringLiteral("imperial")) {
-		prefs.unit_system = IMPERIAL;
-		prefs.units = IMPERIAL_units;
-	} else {
-		prefs.unit_system = PERSONALIZE;
-	}
-
-	emit unitSystemChanged(value);
-	// TODO: emit the other values here?
-}
-
 GeneralSettingsObjectWrapper::GeneralSettingsObjectWrapper(QObject *parent) :
 	QObject(parent)
 {
@@ -1714,7 +1529,7 @@ QObject(parent),
 	proxy(new qPrefProxy(this)),
 	cloud_storage(new qPrefCloudStorage(this)),
 	planner_settings(new DivePlannerSettings(this)),
-	unit_settings(new UnitsSettings(this)),
+	unit_settings(new qPrefUnits(this)),
 	general_settings(new GeneralSettingsObjectWrapper(this)),
 	display_settings(new qPrefDisplay(this)),
 	language_settings(new LanguageSettingsObjectWrapper(this)),
@@ -1731,26 +1546,9 @@ void SettingsObjectWrapper::load()
 	QVariant v;
 
 	uiLanguage(NULL);
-	s.beginGroup("Units");
-	if (s.value("unit_system").toString() == "metric") {
-		prefs.unit_system = METRIC;
-		prefs.units = SI_units;
-	} else if (s.value("unit_system").toString() == "imperial") {
-		prefs.unit_system = IMPERIAL;
-		prefs.units = IMPERIAL_units;
-	} else {
-		prefs.unit_system = PERSONALIZE;
-		GET_UNIT("length", length, units::FEET, units::METERS);
-		GET_UNIT("pressure", pressure, units::PSI, units::BAR);
-		GET_UNIT("volume", volume, units::CUFT, units::LITER);
-		GET_UNIT("temperature", temperature, units::FAHRENHEIT, units::CELSIUS);
-		GET_UNIT("weight", weight, units::LBS, units::KG);
-	}
-	GET_UNIT("vertical_speed_time", vertical_speed_time, units::MINUTES, units::SECONDS);
-	GET_UNIT3("duration_units", duration_units, units::MIXED, units::ALWAYS_HOURS, units::DURATION);
-	GET_UNIT_BOOL("show_units_table", show_units_table);
-	GET_BOOL("coordinates", coordinates_traditional);
-	s.endGroup();
+
+	qPrefUnits::instance()->load();
+
 	s.beginGroup("TecDetails");
 	GET_BOOL("po2graph", pp_graphs.po2);
 	GET_BOOL("pn2graph", pp_graphs.pn2);

--- a/core/subsurface-qt/SettingsObjectWrapper.h
+++ b/core/subsurface-qt/SettingsObjectWrapper.h
@@ -343,59 +343,6 @@ private:
 	const QString group = QStringLiteral("Planner");
 };
 
-class UnitsSettings : public QObject {
-	Q_OBJECT
-	Q_PROPERTY(int length           READ length                 WRITE setLength                 NOTIFY lengthChanged)
-	Q_PROPERTY(int pressure       READ pressure               WRITE setPressure               NOTIFY pressureChanged)
-	Q_PROPERTY(int volume           READ volume                 WRITE setVolume                 NOTIFY volumeChanged)
-	Q_PROPERTY(int temperature READ temperature            WRITE setTemperature            NOTIFY temperatureChanged)
-	Q_PROPERTY(int weight           READ weight                 WRITE setWeight                 NOTIFY weightChanged)
-	Q_PROPERTY(QString unit_system            READ unitSystem             WRITE setUnitSystem             NOTIFY unitSystemChanged)
-	Q_PROPERTY(bool coordinates_traditional   READ coordinatesTraditional WRITE setCoordinatesTraditional NOTIFY coordinatesTraditionalChanged)
-	Q_PROPERTY(int vertical_speed_time READ verticalSpeedTime    WRITE setVerticalSpeedTime    NOTIFY verticalSpeedTimeChanged)
-	Q_PROPERTY(int duration_units          READ durationUnits        WRITE setDurationUnits         NOTIFY durationUnitChanged)
-	Q_PROPERTY(bool show_units_table          READ showUnitsTable        WRITE setShowUnitsTable         NOTIFY showUnitsTableChanged)
-
-public:
-	UnitsSettings(QObject *parent = 0);
-	int length() const;
-	int pressure() const;
-	int volume() const;
-	int temperature() const;
-	int weight() const;
-	int verticalSpeedTime() const;
-	int durationUnits() const;
-	bool showUnitsTable() const;
-	QString unitSystem() const;
-	bool coordinatesTraditional() const;
-
-public slots:
-	void setLength(int value);
-	void setPressure(int value);
-	void setVolume(int value);
-	void setTemperature(int value);
-	void setWeight(int value);
-	void setVerticalSpeedTime(int value);
-	void setDurationUnits(int value);
-	void setShowUnitsTable(bool value);
-	void setUnitSystem(const QString& value);
-	void setCoordinatesTraditional(bool value);
-
-signals:
-	void lengthChanged(int value);
-	void pressureChanged(int value);
-	void volumeChanged(int value);
-	void temperatureChanged(int value);
-	void weightChanged(int value);
-	void verticalSpeedTimeChanged(int value);
-	void unitSystemChanged(const QString& value);
-	void coordinatesTraditionalChanged(bool value);
-	void durationUnitChanged(int value);
-	void showUnitsTableChanged(bool value);
-private:
-	const QString group = QStringLiteral("Units");
-};
-
 class GeneralSettingsObjectWrapper : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(QString default_filename              READ defaultFilename                WRITE setDefaultFilename                NOTIFY defaultFilenameChanged)
@@ -526,7 +473,7 @@ class SettingsObjectWrapper : public QObject {
 	Q_PROPERTY(qPrefProxy*              proxy            MEMBER proxy CONSTANT)
 	Q_PROPERTY(qPrefCloudStorage*       cloud_storage    MEMBER cloud_storage CONSTANT)
 	Q_PROPERTY(DivePlannerSettings*        planner          MEMBER planner_settings CONSTANT)
-	Q_PROPERTY(UnitsSettings*              units            MEMBER unit_settings CONSTANT)
+	Q_PROPERTY(qPrefUnits*              units            MEMBER unit_settings CONSTANT)
 
 	Q_PROPERTY(GeneralSettingsObjectWrapper*         general   MEMBER general_settings CONSTANT)
 	Q_PROPERTY(qPrefDisplay*         display   MEMBER display_settings CONSTANT)
@@ -546,7 +493,7 @@ public:
 	qPrefProxy *proxy;
 	qPrefCloudStorage *cloud_storage;
 	DivePlannerSettings *planner_settings;
-	UnitsSettings *unit_settings;
+	qPrefUnits *unit_settings;
 	GeneralSettingsObjectWrapper *general_settings;
 	qPrefDisplay *display_settings;
 	LanguageSettingsObjectWrapper *language_settings;

--- a/desktop-widgets/preferences/preferences_units.cpp
+++ b/desktop-widgets/preferences/preferences_units.cpp
@@ -51,14 +51,14 @@ void PreferencesUnits::syncSettings()
 	QString unitSystem[] = {"metric", "imperial", "personal"};
 	short unitValue = ui->metric->isChecked() ? METRIC : (ui->imperial->isChecked() ? IMPERIAL : PERSONALIZE);
 
-	units->setUnitSystem(unitSystem[unitValue]);
-	units->setTemperature(ui->fahrenheit->isChecked() ? units::FAHRENHEIT : units::CELSIUS);
-	units->setLength(ui->feet->isChecked() ? units::FEET : units::METERS);
-	units->setPressure(ui->psi->isChecked() ? units::PSI : units::BAR);
-	units->setVolume(ui->cuft->isChecked() ? units::CUFT : units::LITER);
-	units->setWeight(ui->lbs->isChecked() ? units::LBS : units::KG);
-	units->setVerticalSpeedTime(ui->vertical_speed_minutes->isChecked() ? units::MINUTES : units::SECONDS);
-	units->setCoordinatesTraditional(ui->gpsTraditional->isChecked());
-	units->setDurationUnits(ui->duration_mixed->isChecked() ? units::MIXED : (ui->duration_no_hours->isChecked() ? units::MINUTES_ONLY : units::ALWAYS_HOURS));
-	units->setShowUnitsTable(ui->show_units_table->isChecked());
+	units->set_unit_system(unitSystem[unitValue]);
+	units->set_temperature(ui->fahrenheit->isChecked() ? units::FAHRENHEIT : units::CELSIUS);
+	units->set_length(ui->feet->isChecked() ? units::FEET : units::METERS);
+	units->set_pressure(ui->psi->isChecked() ? units::PSI : units::BAR);
+	units->set_volume(ui->cuft->isChecked() ? units::CUFT : units::LITER);
+	units->set_weight(ui->lbs->isChecked() ? units::LBS : units::KG);
+	units->set_vertical_speed_time(ui->vertical_speed_minutes->isChecked() ? units::MINUTES : units::SECONDS);
+	units->set_coordinates_traditional(ui->gpsTraditional->isChecked());
+	units->set_duration_units(ui->duration_mixed->isChecked() ? units::MIXED : (ui->duration_no_hours->isChecked() ? units::MINUTES_ONLY : units::ALWAYS_HOURS));
+	units->set_show_units_table(ui->show_units_table->isChecked());
 }

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -85,6 +85,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/settings/qPrefFacebook.cpp \
 	../../core/settings/qPrefPrivate.cpp \
 	../../core/settings/qPrefProxy.cpp \
+	../../core/settings/qPrefUnit.cpp \
 	../../core/subsurface-qt/CylinderObjectHelper.cpp \
 	../../core/subsurface-qt/DiveObjectHelper.cpp \
 	../../core/subsurface-qt/SettingsObjectWrapper.cpp \
@@ -199,6 +200,7 @@ HEADERS += \
 	../../core/settings/qPrefFacebook.h \
 	../../core/settings/qPrefPrivate.h \
 	../../core/settings/qPrefProxy.h \
+	../../core/settings/qPrefUnit.h \
 	../../core/subsurface-qt/CylinderObjectHelper.h \
 	../../core/subsurface-qt/DiveObjectHelper.h \
 	../../core/subsurface-qt/SettingsObjectWrapper.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -162,6 +162,7 @@ void register_qml_types()
 	REGISTER_TYPE(qPrefDiveComputer, "SsrfDiveComputerPrefs");
 	REGISTER_TYPE(qPrefFacebook, "SsrfFacebookPrefs");
 	REGISTER_TYPE(qPrefProxy, "SsrfProxyPrefs");
+	REGISTER_TYPE(qPrefUnits, "SsrfUnitPrefs");
 
 #ifndef SUBSURFACE_TEST_DATA
 #ifdef SUBSURFACE_MOBILE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ TEST(TestQPrefDisplay testqPrefDisplay.cpp)
 TEST(TestQPrefDiveComputer testqPrefDiveComputer.cpp)
 TEST(TestQPrefFacebook testqPrefFacebook.cpp)
 TEST(TestQPrefProxy testqPrefProxy.cpp)
+TEST(TestQPrefUnits testqPrefUnits.cpp)
 add_test(NAME TestQML COMMAND $<TARGET_FILE:TestQML> ${SUBSURFACE_SOURCE}/tests)
 
 
@@ -131,6 +132,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestQPrefDiveComputer
 	TestQPrefFacebook
 	TestQPrefProxy
+	TestQPrefUnits
 	TestQML
 )
 

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -278,42 +278,42 @@ void TestPreferences::testPreferences()
 
 	TEST(planner->decoMode(), RECREATIONAL);
 
-	auto units = pref->unit_settings;
-	units->setLength(0);
-	units->setPressure(0);
-	units->setVolume(0);
-	units->setTemperature(0);
-	units->setWeight(0);
-	units->setVerticalSpeedTime(0);
-	units->setUnitSystem(QStringLiteral("metric"));
-	units->setCoordinatesTraditional(false);
+	auto units = qPrefUnits::instance();
+	units->set_length(units::METERS);
+	units->set_pressure(units::BAR);
+	units->set_volume(units::LITER);
+	units->set_temperature(units::CELSIUS);
+	units->set_weight(units::KG);
+	units->set_vertical_speed_time(units::SECONDS);
+	units->set_unit_system(QStringLiteral("metric"));
+	units->set_coordinates_traditional(false);
 
-	TEST(units->length(), 0);
-	TEST(units->pressure(), 0);
-	TEST(units->volume(), 0);
-	TEST(units->temperature(), 0);
-	TEST(units->weight(), 0);
-	TEST(units->verticalSpeedTime(), 0);
-	TEST(units->unitSystem(), QStringLiteral("metric"));
-	TEST(units->coordinatesTraditional(), false);
+	TEST(units->length(), units::METERS);
+	TEST(units->pressure(), units::BAR);
+	TEST(units->volume(), units::LITER);
+	TEST(units->temperature(), units::CELSIUS);
+	TEST(units->weight(), units::KG);
+	TEST(units->vertical_speed_time(), units::SECONDS);
+	TEST(units->unit_system(), QStringLiteral("metric"));
+	TEST(units->coordinates_traditional(), false);
 
-	units->setLength(1);
-	units->setPressure(1);
-	units->setVolume(1);
-	units->setTemperature(1);
-	units->setWeight(1);
-	units->setVerticalSpeedTime(1);
-	units->setUnitSystem(QStringLiteral("fake-metric-system"));
-	units->setCoordinatesTraditional(true);
+	units->set_length(units::FEET);
+	units->set_pressure(units::PSI);
+	units->set_volume(units::CUFT);
+	units->set_temperature(units::FAHRENHEIT);
+	units->set_weight(units::LBS);
+	units->set_vertical_speed_time(units::MINUTES);
+	units->set_unit_system(QStringLiteral("fake-metric-system"));
+	units->set_coordinates_traditional(true);
 
-	TEST(units->length(), 1);
-	TEST(units->pressure(), 1);
-	TEST(units->volume(), 1);
-	TEST(units->temperature(), 1);
-	TEST(units->weight(), 1);
-	TEST(units->verticalSpeedTime(), 1);
-	TEST(units->unitSystem(), QStringLiteral("personalized"));
-	TEST(units->coordinatesTraditional(), true);
+	TEST(units->length(), units::FEET);
+	TEST(units->pressure(), units::PSI);
+	TEST(units->volume(), units::CUFT);
+	TEST(units->temperature(), units::FAHRENHEIT);
+	TEST(units->weight(), units::LBS);
+	TEST(units->vertical_speed_time(), units::MINUTES);
+	TEST(units->unit_system(), QStringLiteral("personalized"));
+	TEST(units->coordinates_traditional(), true);
 
 	auto general = pref->general_settings;
 	general->setDefaultFilename("filename");

--- a/tests/testpreferences.cpp
+++ b/tests/testpreferences.cpp
@@ -278,43 +278,6 @@ void TestPreferences::testPreferences()
 
 	TEST(planner->decoMode(), RECREATIONAL);
 
-	auto units = qPrefUnits::instance();
-	units->set_length(units::METERS);
-	units->set_pressure(units::BAR);
-	units->set_volume(units::LITER);
-	units->set_temperature(units::CELSIUS);
-	units->set_weight(units::KG);
-	units->set_vertical_speed_time(units::SECONDS);
-	units->set_unit_system(QStringLiteral("metric"));
-	units->set_coordinates_traditional(false);
-
-	TEST(units->length(), units::METERS);
-	TEST(units->pressure(), units::BAR);
-	TEST(units->volume(), units::LITER);
-	TEST(units->temperature(), units::CELSIUS);
-	TEST(units->weight(), units::KG);
-	TEST(units->vertical_speed_time(), units::SECONDS);
-	TEST(units->unit_system(), QStringLiteral("metric"));
-	TEST(units->coordinates_traditional(), false);
-
-	units->set_length(units::FEET);
-	units->set_pressure(units::PSI);
-	units->set_volume(units::CUFT);
-	units->set_temperature(units::FAHRENHEIT);
-	units->set_weight(units::LBS);
-	units->set_vertical_speed_time(units::MINUTES);
-	units->set_unit_system(QStringLiteral("fake-metric-system"));
-	units->set_coordinates_traditional(true);
-
-	TEST(units->length(), units::FEET);
-	TEST(units->pressure(), units::PSI);
-	TEST(units->volume(), units::CUFT);
-	TEST(units->temperature(), units::FAHRENHEIT);
-	TEST(units->weight(), units::LBS);
-	TEST(units->vertical_speed_time(), units::MINUTES);
-	TEST(units->unit_system(), QStringLiteral("personalized"));
-	TEST(units->coordinates_traditional(), true);
-
 	auto general = pref->general_settings;
 	general->setDefaultFilename("filename");
 	general->setDefaultCylinder("cylinder_2");

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testqPrefUnits.h"
+
+#include "core/pref.h"
+#include "core/qthelper.h"
+#include "core/settings/qPref.h"
+
+#include <QTest>
+
+void TestQPrefUnits::initTestCase()
+{
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("SubsurfaceTestQPrefUnits");
+}
+
+void TestQPrefUnits::test_struct_get()
+{
+	// Test struct pref -> get func.
+
+	auto tst = qPrefUnits::instance();
+
+	prefs.coordinates_traditional = true;
+	prefs.units.duration_units = units::MIXED;
+	prefs.units.length = units::METERS;
+	prefs.units.pressure = units::BAR;
+	prefs.units.show_units_table = true;
+	prefs.units.temperature = units::CELSIUS;
+	prefs.units.vertical_speed_time = units::SECONDS;
+	prefs.units.volume = units::LITER;
+	prefs.units.weight = units::KG;
+
+	QCOMPARE(tst->coordinates_traditional(), true);
+	QCOMPARE(tst->duration_units(), units::MIXED);
+	QCOMPARE(tst->length(), units::METERS);
+	QCOMPARE(tst->pressure(), units::BAR);
+	QCOMPARE(tst->show_units_table(), true);
+	QCOMPARE(tst->temperature(), units::CELSIUS);
+	QCOMPARE(tst->vertical_speed_time(), units::SECONDS);
+	QCOMPARE(tst->volume(), units::LITER);
+	QCOMPARE(tst->weight(), units::KG);
+}
+
+void TestQPrefUnits::test_set_struct()
+{
+	// Test set func -> struct pref
+
+	auto tst = qPrefUnits::instance();
+
+	tst->set_coordinates_traditional(false);
+	tst->set_duration_units(units::MINUTES_ONLY);
+	tst->set_length(units::FEET);
+	tst->set_pressure(units::PSI);
+	tst->set_show_units_table(false);
+	tst->set_temperature(units::FAHRENHEIT);
+	tst->set_vertical_speed_time(units::MINUTES);
+	tst->set_volume(units::CUFT);
+	tst->set_weight(units::LBS);
+
+	QCOMPARE(prefs.coordinates_traditional, false);
+	QCOMPARE(prefs.units.duration_units, units::MINUTES_ONLY);
+	QCOMPARE(prefs.units.length, units::FEET);
+	QCOMPARE(prefs.units.pressure, units::PSI);
+	QCOMPARE(prefs.units.show_units_table, false);
+	QCOMPARE(prefs.units.temperature, units::FAHRENHEIT);
+	QCOMPARE(prefs.units.vertical_speed_time, units::MINUTES);
+	QCOMPARE(prefs.units.volume, units::CUFT);
+	QCOMPARE(prefs.units.weight, units::LBS);
+}
+
+void TestQPrefUnits::test_set_load_struct()
+{
+	// test set func -> load -> struct pref
+
+	auto tst = qPrefUnits::instance();
+
+	tst->set_coordinates_traditional(false);
+	tst->set_duration_units(units::MINUTES_ONLY);
+	tst->set_length(units::FEET);
+	tst->set_pressure(units::PSI);
+	tst->set_show_units_table(false);
+	tst->set_temperature(units::FAHRENHEIT);
+	tst->set_vertical_speed_time(units::MINUTES);
+	tst->set_volume(units::CUFT);
+	tst->set_weight(units::LBS);
+
+	tst->sync();
+	prefs.coordinates_traditional = true;
+	prefs.units.duration_units = units::MIXED;
+	prefs.units.length = units::METERS;
+	prefs.units.pressure = units::BAR;
+	prefs.units.show_units_table = true;
+	prefs.units.temperature = units::CELSIUS;
+	prefs.units.vertical_speed_time = units::SECONDS;
+	prefs.units.volume = units::LITER;
+	prefs.units.weight = units::KG;
+
+	tst->load();
+	QCOMPARE(prefs.coordinates_traditional, false);
+	QCOMPARE(prefs.units.duration_units, units::MINUTES_ONLY);
+	QCOMPARE(prefs.units.length, units::FEET);
+	QCOMPARE(prefs.units.pressure, units::PSI);
+	QCOMPARE(prefs.units.show_units_table, false);
+	QCOMPARE(prefs.units.temperature, units::FAHRENHEIT);
+	QCOMPARE(prefs.units.vertical_speed_time, units::MINUTES);
+	QCOMPARE(prefs.units.volume, units::CUFT);
+	QCOMPARE(prefs.units.weight, units::LBS);
+}
+
+void TestQPrefUnits::test_struct_disk()
+{
+	// test struct prefs -> disk
+
+	auto tst = qPrefUnits::instance();
+
+	prefs.coordinates_traditional = true;
+	prefs.units.duration_units = units::MIXED;
+	prefs.units.length = units::METERS;
+	prefs.units.pressure = units::BAR;
+	prefs.units.show_units_table = true;
+	prefs.units.temperature = units::CELSIUS;
+	prefs.units.vertical_speed_time = units::SECONDS;
+	prefs.units.volume = units::LITER;
+	prefs.units.weight = units::KG;
+
+	tst->sync();
+	prefs.coordinates_traditional = false;
+	prefs.units.duration_units = units::MINUTES_ONLY;
+	prefs.units.length = units::FEET;
+	prefs.units.pressure = units::PSI;
+	prefs.units.show_units_table = false;
+	prefs.units.temperature = units::FAHRENHEIT;
+	prefs.units.vertical_speed_time = units::MINUTES;
+	prefs.units.volume = units::CUFT;
+	prefs.units.weight = units::LBS;
+
+	tst->load();
+	QCOMPARE(prefs.coordinates_traditional, true);
+	QCOMPARE(prefs.units.duration_units, units::MIXED);
+	QCOMPARE(prefs.units.length, units::METERS);
+	QCOMPARE(prefs.units.pressure, units::BAR);
+	QCOMPARE(prefs.units.show_units_table, true);
+	QCOMPARE(prefs.units.temperature, units::CELSIUS);
+	QCOMPARE(prefs.units.vertical_speed_time, units::SECONDS);
+	QCOMPARE(prefs.units.volume, units::LITER);
+	QCOMPARE(prefs.units.weight, units::KG);
+}
+
+void TestQPrefUnits::test_multiple()
+{
+	// test multiple instances have the same information
+
+	prefs.units.length = units::METERS;
+	auto tst_direct = new qPrefUnits;
+
+	prefs.units.pressure = units::BAR;
+	auto tst = qPrefUnits::instance();
+
+	QCOMPARE(tst->length(), tst_direct->length());
+	QCOMPARE(tst->length(), units::METERS);
+	QCOMPARE(tst->pressure(), tst_direct->pressure());
+	QCOMPARE(tst->pressure(), units::BAR);
+}
+
+void TestQPrefUnits::test_unit_system()
+{
+	// test struct prefs <->  set/get unit_system
+
+	auto tst = qPrefUnits::instance();
+
+	tst->set_unit_system("metric");
+	QCOMPARE(prefs.unit_system, METRIC);
+	QCOMPARE(tst->unit_system(), QString("metric"));
+	tst->set_unit_system("imperial");
+	QCOMPARE(prefs.unit_system, IMPERIAL);
+	QCOMPARE(tst->unit_system(), QString("imperial"));
+	tst->set_unit_system("personalized");
+	QCOMPARE(prefs.unit_system, PERSONALIZE);
+	QCOMPARE(tst->unit_system(), QString("personalized"));
+
+	prefs.unit_system = METRIC;
+	QCOMPARE(tst->unit_system(), QString("metric"));
+	prefs.unit_system = IMPERIAL;
+	QCOMPARE(tst->unit_system(), QString("imperial"));
+	prefs.unit_system = PERSONALIZE;
+	QCOMPARE(tst->unit_system(), QString("personalized"));
+}
+
+QTEST_MAIN(TestQPrefUnits)

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -53,7 +53,7 @@ void TestQPrefUnits::test_set_struct()
 	tst->set_pressure(units::PSI);
 	tst->set_show_units_table(false);
 	tst->set_temperature(units::FAHRENHEIT);
-	tst->set_vertical_speed_time(units::MINUTES);
+	tst->set_vertical_speed_time(units::SECONDS);
 	tst->set_volume(units::CUFT);
 	tst->set_weight(units::LBS);
 
@@ -63,7 +63,7 @@ void TestQPrefUnits::test_set_struct()
 	QCOMPARE(prefs.units.pressure, units::PSI);
 	QCOMPARE(prefs.units.show_units_table, false);
 	QCOMPARE(prefs.units.temperature, units::FAHRENHEIT);
-	QCOMPARE(prefs.units.vertical_speed_time, units::MINUTES);
+	QCOMPARE(prefs.units.vertical_speed_time, units::SECONDS);
 	QCOMPARE(prefs.units.volume, units::CUFT);
 	QCOMPARE(prefs.units.weight, units::LBS);
 }
@@ -184,6 +184,53 @@ void TestQPrefUnits::test_unit_system()
 	QCOMPARE(tst->unit_system(), QString("imperial"));
 	prefs.unit_system = PERSONALIZE;
 	QCOMPARE(tst->unit_system(), QString("personalized"));
+}
+
+#define TEST(METHOD, VALUE)      \
+	QCOMPARE(METHOD, VALUE); \
+	units->sync();           \
+	units->load();           \
+	QCOMPARE(METHOD, VALUE);
+
+void TestQPrefUnits::test_oldPreferences()
+{
+	auto units = qPrefUnits::instance();
+
+	units->set_length(units::METERS);
+	units->set_pressure(units::BAR);
+	units->set_volume(units::LITER);
+	units->set_temperature(units::CELSIUS);
+	units->set_weight(units::KG);
+	units->set_unit_system(QStringLiteral("metric"));
+	units->set_coordinates_traditional(false);
+	units->set_vertical_speed_time(units::SECONDS);
+
+	TEST(units->length(), units::METERS);
+	TEST(units->pressure(), units::BAR);
+	TEST(units->volume(), units::LITER);
+	TEST(units->temperature(), units::CELSIUS);
+	TEST(units->weight(), units::KG);
+	TEST(units->vertical_speed_time(), units::SECONDS);
+	TEST(units->unit_system(), QStringLiteral("metric"));
+	TEST(units->coordinates_traditional(), false);
+
+	units->set_length(units::FEET);
+	units->set_pressure(units::PSI);
+	units->set_volume(units::CUFT);
+	units->set_temperature(units::FAHRENHEIT);
+	units->set_weight(units::LBS);
+	units->set_vertical_speed_time(units::MINUTES);
+	units->set_unit_system(QStringLiteral("fake-metric-system"));
+	units->set_coordinates_traditional(true);
+
+	TEST(units->length(), units::FEET);
+	TEST(units->pressure(), units::PSI);
+	TEST(units->volume(), units::CUFT);
+	TEST(units->temperature(), units::FAHRENHEIT);
+	TEST(units->weight(), units::LBS);
+	TEST(units->vertical_speed_time(), units::MINUTES);
+	TEST(units->unit_system(), QStringLiteral("personalized"));
+	TEST(units->coordinates_traditional(), true);
 }
 
 QTEST_MAIN(TestQPrefUnits)

--- a/tests/testqPrefUnits.h
+++ b/tests/testqPrefUnits.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTQPREFUNITS_H
+#define TESTQPREFUNITS_H
+
+#include <QObject>
+
+class TestQPrefUnits : public QObject {
+	Q_OBJECT
+
+private slots:
+	void initTestCase();
+	void test_struct_get();
+	void test_set_struct();
+	void test_set_load_struct();
+	void test_struct_disk();
+	void test_multiple();
+	void test_unit_system();
+};
+
+#endif // TESTQPREFUNITS_H

--- a/tests/testqPrefUnits.h
+++ b/tests/testqPrefUnits.h
@@ -15,6 +15,7 @@ private slots:
 	void test_struct_disk();
 	void test_multiple();
 	void test_unit_system();
+	void test_oldPreferences();
 };
 
 #endif // TESTQPREFUNITS_H

--- a/tests/tst_qPrefUnits.qml
+++ b/tests/tst_qPrefUnits.qml
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import QtTest 1.2
+import org.subsurfacedivelog.mobile 1.0
+
+TestCase {
+	name: "qPrefUnits"
+
+	SsrfUnitPrefs {
+		id: tst
+	}
+
+	SsrfPrefs {
+		id: prefs
+	}
+
+	function test_variables() {
+		var x1 = tst.coordinates_traditional
+		tst.coordinates_traditional = true
+		compare(tst.coordinates_traditional, true)
+
+		var x2 = tst.duration_units
+//TBD		tst.duration_units = ??
+//TBD		compare(tst.duration_units,  ??)
+
+		var x3 = tst.length
+//TBD		tst.=length = ??
+//TBD		compare(tst.length,  ??)
+
+		var x4 = tst.pressure
+//TBD		tst.pressure = ??
+//TBD		compare(tst.pressure, ??)
+
+		var x5 = tst.show_units_table
+		tst.show_units_table = true
+		compare(tst.show_units_table, true)
+
+		var x6 = tst.temperature
+//TBD		tst.temperature = ??
+//TBD		compare(tst.temperature, ??)
+
+		var x7 = tst.unit_system
+		tst.unit_system = "metric" 
+		compare(tst.unit_system, "metric")
+
+		var x8 = tst.vertical_speed_time
+//TBD		tst.vertical_speed_time = ??
+//TBD		compare(tst.vertical_speed_time, ??)
+
+		var x9 = tst.volume
+//TBD		tst.volume = ??
+//TBD		compare(tst.volume, ??)
+
+		var x10 = tst.weight
+//TBD		tst.weight = ??
+//TBD		compare(tst.weight, ??)
+	}
+}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
next class in the qPref series.

This one caused and are still causing problems.

unit_system was defined as a short, but was in reality an enum, instead of adding extra macros, this is corrected in the first commit.

Many if the units are not (and was not) available to qml, due to the enums, which are used in C code as well and cannot be transferred to qPrefUnits. However the ui needs strings, so all set/get functions should accept and retrieve a string.

I need to make an array or similar to store the relatinship string-enum, and then update unitspreferences. I have however decided to make that in another PR, not to mix things.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh if you are unhappy with the ui changes being in another PR, then of course I can append the commits here.
@tcanabrava suggestions as to how we can secure strings and enums stays synchronized are welcome.
