### PR TITLE
Two very minor cleanups

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -25,6 +25,7 @@
  * void mark_divelist_changed(int changed)
  * int unsaved_changes()
  * void remove_autogen_trips()
+ * void sort_table(struct dive_table *table)
  */
 #include <unistd.h>
 #include <stdio.h>
@@ -1385,7 +1386,6 @@ int get_dive_id_closest_to(timestamp_t when)
 		return dive_table.dives[i]->id;
 }
 
-
 void clear_dive_file_data()
 {
 	while (dive_table.nr)
@@ -1398,4 +1398,21 @@ void clear_dive_file_data()
 
 	reset_min_datafile_version();
 	saved_git_id = "";
+}
+
+static int sortfn(const void *_a, const void *_b)
+{
+	const struct dive *a = (const struct dive *)*(void **)_a;
+	const struct dive *b = (const struct dive *)*(void **)_b;
+
+	if (a->when < b->when)
+		return -1;
+	if (a->when > b->when)
+		return 1;
+	return 0;
+}
+
+void sort_table(struct dive_table *table)
+{
+	qsort(table->dives, table->nr, sizeof(struct dive *), sortfn);
 }

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -112,23 +112,6 @@ struct units *get_units()
 }
 
 /* random helper functions, used here or elsewhere */
-static int sortfn(const void *_a, const void *_b)
-{
-	const struct dive *a = (const struct dive *)*(void **)_a;
-	const struct dive *b = (const struct dive *)*(void **)_b;
-
-	if (a->when < b->when)
-		return -1;
-	if (a->when > b->when)
-		return 1;
-	return 0;
-}
-
-void sort_table(struct dive_table *table)
-{
-	qsort(table->dives, table->nr, sizeof(struct dive *), sortfn);
-}
-
 const char *monthname(int mon)
 {
 	static const char month_array[12][7] = {

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -114,8 +114,7 @@ struct units *get_units()
 /* random helper functions, used here or elsewhere */
 const char *monthname(int mon)
 {
-	static const char month_array[12][7] = {
-		/*++GETTEXT: these are three letter months - we allow up to six code bytes*/
+	static const char month_array[12][4] = {
 		QT_TRANSLATE_NOOP("gettextFromC", "Jan"), QT_TRANSLATE_NOOP("gettextFromC", "Feb"), QT_TRANSLATE_NOOP("gettextFromC", "Mar"), QT_TRANSLATE_NOOP("gettextFromC", "Apr"), QT_TRANSLATE_NOOP("gettextFromC", "May"), QT_TRANSLATE_NOOP("gettextFromC", "Jun"),
 		QT_TRANSLATE_NOOP("gettextFromC", "Jul"), QT_TRANSLATE_NOOP("gettextFromC", "Aug"), QT_TRANSLATE_NOOP("gettextFromC", "Sep"), QT_TRANSLATE_NOOP("gettextFromC", "Oct"), QT_TRANSLATE_NOOP("gettextFromC", "Nov"), QT_TRANSLATE_NOOP("gettextFromC", "Dec"),
 	};


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are two very minor cleanups of code that I stumbled upon.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move `sort_table` from `subsurface_startup.c` to `divelist.c`
2) Only use 4 (3+1) instead of 7 (2*3+1) chars for three-char month names. Apparently, the old code used to translate once in-place, but now it is done dynamically and the array doesn't change.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Nope.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
