### PR TITLE
Move configure dive computer to be called from Download dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Dive computer configuration: remove from main menu and trigger from download dialog instead,
+  but only for dive computers that are actually supported for configuration
 - Android: switch to Download page when dive computer is plugged in and try to
   populate vendor / device / connection based on the information we get
 - Mobile: enable multiple cylinder editing for dives that uses more than one cylinder 

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -14,21 +14,41 @@
 #include <QProgressDialog>
 #include <QSettings>
 
+static int getTypeFromVendorProduct(QString vendor, QString product)
+{
+	if (vendor == "Heinrichs Weikamp") {
+		if (product == "OSTC Mk2" ||
+		    product == "OSTC 2N" ||
+		    product == "OSTC 2C") {
+			return 0;
+		}
+		if (product == "OSTC 2" ||
+		    product == "OSTC 3" ||
+		    product == "OSTC Sport" ||
+		    product == "OSTC Plus" ||
+		    product == "OSTC cR") {
+			return 1;
+		}
+		if (product == "OSTC 4") {
+			return 2;
+		}
+		return -1;
+	}
+	if (vendor == "Suunto" &&
+	    (product == "Vyper" ||
+	     product == "Stinger" ||
+	     product == "Mosquito" ||
+	     product == "D3" ||
+	     product == "Vytec" ||
+	     product == "Cobra" ||
+	     product == "Gekko" ||
+	     product == "Zoop"))
+		return 3;
+	return -1;
+}
 bool diveComputerConfigurable(QString vendor, QString product)
 {
-	if ((vendor == "Heinrichs Weikamp" &&
-	     product != "OSTC") ||
-	    (vendor == "Suunto" &&
-	     (product == "Vyper" ||
-	      product == "Stinger" ||
-	      product == "Mosquito" ||
-	      product == "D3" ||
-	      product = "Vytec" ||
-	      product == "Cobra" ||
-	      product == "Gekko" ||
-	      product == "Zoop")
-		return true;
-	return false;
+	return getTypeFromVendorProduct(vendor, product) >= 0;
 }
 
 GasSpinBoxItemDelegate::GasSpinBoxItemDelegate(QObject *parent, column_type type) : QStyledItemDelegate(parent), type(type)
@@ -116,7 +136,7 @@ void GasTypeComboBoxItemDelegate::setModelData(QWidget *editor, QAbstractItemMod
 		QStyledItemDelegate::setModelData(editor, model, index);
 }
 
-ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDialog(parent),
+ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent, QString vendor, QString product) : QDialog(parent),
 	config(0),
 #ifdef BT_SUPPORT
 	deviceDetails(0),
@@ -154,8 +174,9 @@ ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDia
 	if (!dc->device().isEmpty())
 		ui.device->setEditText(dc->device());
 
-	ui.DiveComputerList->setCurrentRow(0);
-	on_DiveComputerList_currentRowChanged(0);
+	int selected = getTypeFromVendorProduct(vendor, product);
+	ui.DiveComputerList->setCurrentRow(selected);
+	on_DiveComputerList_currentRowChanged(selected);
 
 	ui.ostc3GasTable->setItemDelegateForColumn(1, new GasSpinBoxItemDelegate(this, GasSpinBoxItemDelegate::PERCENT));
 	ui.ostc3GasTable->setItemDelegateForColumn(2, new GasSpinBoxItemDelegate(this, GasSpinBoxItemDelegate::PERCENT));

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -14,9 +14,27 @@
 #include <QProgressDialog>
 #include <QSettings>
 
+bool diveComputerConfigurable(QString vendor, QString product)
+{
+	if ((vendor == "Heinrichs Weikamp" &&
+	     product != "OSTC") ||
+	    (vendor == "Suunto" &&
+	     (product == "Vyper" ||
+	      product == "Stinger" ||
+	      product == "Mosquito" ||
+	      product == "D3" ||
+	      product = "Vytec" ||
+	      product == "Cobra" ||
+	      product == "Gekko" ||
+	      product == "Zoop")
+		return true;
+	return false;
+}
+
 GasSpinBoxItemDelegate::GasSpinBoxItemDelegate(QObject *parent, column_type type) : QStyledItemDelegate(parent), type(type)
 {
 }
+
 GasSpinBoxItemDelegate::~GasSpinBoxItemDelegate()
 {
 }

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -60,7 +60,7 @@ class ConfigureDiveComputerDialog : public QDialog {
 	Q_OBJECT
 
 public:
-	explicit ConfigureDiveComputerDialog(QWidget *parent = 0);
+	explicit ConfigureDiveComputerDialog(QWidget *parent = 0, QString vendor = QString(), QString product = QString());
 	~ConfigureDiveComputerDialog();
 
 protected:

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -13,6 +13,8 @@
 #include "desktop-widgets/btdeviceselectiondialog.h"
 #endif
 
+extern bool diveComputerConfigurable(QString vendor, QString product);
+
 class GasSpinBoxItemDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -345,7 +345,7 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 
 void DownloadFromDCWidget::on_configureDiveComputerButton_clicked()
 {
-	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(this);
+	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(this, ui.vendor->currentText(), ui.product->currentText());
 	dcConfig->show();
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "desktop-widgets/downloadfromdivecomputer.h"
+#include "desktop-widgets/configuredivecomputerdialog.h"
 #include "core/display.h"
 #include "core/qthelper.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
@@ -235,14 +236,16 @@ void DownloadFromDCWidget::on_vendor_currentIndexChanged(const QString &vendor)
 	int dcType = DC_TYPE_SERIAL;
 	productModel.setStringList(productList[vendor]);
 	ui.product->setCurrentIndex(0);
+	ui.configureDiveComputerButton->setEnabled(diveComputerConfigurable(vendor, productList[vendor][0]));
 
 	if (vendor == QString("Uemis"))
 		dcType = DC_TYPE_UEMIS;
 	fill_device_list(dcType);
 }
 
-void DownloadFromDCWidget::on_product_currentIndexChanged(const QString &)
+void DownloadFromDCWidget::on_product_currentIndexChanged(const QString &product)
 {
+	ui.configureDiveComputerButton->setEnabled(diveComputerConfigurable(ui.vendor->currentText(), product));
 	updateDeviceEnabled();
 }
 
@@ -338,6 +341,12 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	    !data->saveDump()) {
 		ostcFirmwareCheck = new OstcFirmwareCheck(product);
 	}
+}
+
+void DownloadFromDCWidget::on_configureDiveComputerButton_clicked()
+{
+	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(this);
+	dcConfig->show();
 }
 
 bool DownloadFromDCWidget::preferDownloaded()

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -38,6 +38,7 @@ public:
 public
 slots:
 	void on_downloadCancelRetryButton_clicked();
+	void on_configureDiveComputerButton_clicked();
 	void on_ok_clicked();
 	void on_cancel_clicked();
 	void on_search_clicked();

--- a/desktop-widgets/downloadfromdivecomputer.ui
+++ b/desktop-widgets/downloadfromdivecomputer.ui
@@ -161,6 +161,19 @@
           <number>0</number>
          </property>
          <item>
+          <widget class="QPushButton" name="configureDiveComputerButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Configure dive computer</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1922,12 +1922,6 @@ void MainWindow::on_actionExport_triggered()
 	diveLogExport.exec();
 }
 
-void MainWindow::on_actionConfigure_Dive_Computer_triggered()
-{
-	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(this);
-	dcConfig->show();
-}
-
 void MainWindow::setEnabledToolbar(bool arg1)
 {
 	Q_FOREACH (QAction *b, profileToolbarActions)

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -147,7 +147,6 @@ slots:
 	void on_copy_triggered();
 	void on_paste_triggered();
 	void on_actionFilterTags_triggered();
-	void on_actionConfigure_Dive_Computer_triggered();
 	void setDefaultState();
 	void setAutomaticTitle();
 	void cancelCloudStorageOperation();

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -74,7 +74,6 @@
     <addaction name="actionPreferences"/>
     <addaction name="separator"/>
     <addaction name="actionHash_images"/>
-    <addaction name="actionConfigure_Dive_Computer"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuLog">

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,10 @@ while [[ $# -gt 0 ]] ; do
 			# call this script with -build-deps
 			BUILD_DEPS="1"
 			;;
+		-build-with-ftdi)
+			# build against the FTDI user space library
+			BUILD_WITH_FTDI="1"
+			;;
 		-build-with-webkit)
 			# unless you build Qt from source (or at least webkit from source, you won't have webkit installed
 			# -build-with-webkit tells the script that in fact we can assume that webkit is present (it usually
@@ -211,6 +215,17 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	# when building distributable binaries on a Mac, we cannot rely on anything from Homebrew,
 	# because that always requires the latest OS (how stupid is that - and they consider it a
 	# feature). So we painfully need to build the dependencies ourselves.
+	cd $SRC
+	if [ "$BUILD_WITH_FTDI" = "1" ]; then
+		./subsurface/scripts/get-dep-lib.sh single . libftdi
+		pushd libftdi
+		mkdir -p build
+		cd build
+		cmake $OLDER_MAC_CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT -DCMAKE_BUILD_TYPE=$DEBUGRELEASE -DFTDI_EEPROM=OFF -BUILD_TESTS=OFF -DEXAMPLES=OFF ..
+		make -j4
+		make install
+	fi
+
 	cd $SRC
 	./subsurface/scripts/get-dep-lib.sh single . libcurl
 	pushd libcurl
@@ -391,6 +406,10 @@ if [ "$BUILD_WITH_WEBKIT" = "1" ]; then
 	EXTRA_OPTS="-DNO_USERMANUAL=OFF -DFBSUPPORT=ON"
 else
 	EXTRA_OPTS="-DNO_USERMANUAL=ON -DFBSUPPORT=OFF"
+fi
+
+if [ "$BUILD_WITH_FTDI" = "1" ]; then
+	EXTRA_OPTS="$EXTRA_OPTS -DFTDISUPPORT=ON"
 fi
 
 if [ "$BUILDGRANTLEE" = "1" ] ; then


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was a suggestion from Linus when quite a few users ended up trying to configure dive computers instead of downloading from them.
This way the entry is gone from the main menu, and the button is grayed out unless a dive computer that we actually CAN configure is selected.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I guess I need to add a CHANGELOG.md entry. Oops :-)

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
This requires changes to the user manual. We need to update the screenshots for the download dialog and change the text to explain that that's from where you can start the configuration.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@glance- do I list all the supported dive computers? That's now important to get right...
