### PR TITLE
Cleanup: fix warning in unix.c

### DIFF
--- a/core/unix.c
+++ b/core/unix.c
@@ -48,7 +48,8 @@ void subsurface_user_info(struct user_info *user)
 		struct membuffer mb = {};
 		gethostname(hostname, sizeof(hostname));
 		put_format(&mb, "%s@%s", username, hostname);
-		user->email = mb_cstring(&mb); // 'email' is heap allocated
+		mb_cstring(&mb);
+		user->email = detach_buffer(&mb);
 	}
 }
 


### PR DESCRIPTION
The compiler complained about assigning the "const char *" returned by
mb_cstring() to a "char *". The warning is correct, as the returned
buffer still belongs to the membuffer. The code only worked because
destruction of the membuffer was "forgotten".

Fix this by using the "detach_buffer()" function, which passes ownership
to the caller and accordingly returns a "char *".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This warning has bothered me for the longest time...

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use `detach_buffer()` to silence a warning.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No user visible change.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No user visible change.