### PR TITLE
Cleanup: Split out filter-functionality

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -4202,9 +4202,9 @@ const char *get_dive_country(struct dive *dive)
 	return NULL;
 }
 
-char *get_dive_location(struct dive *dive)
+const char *get_dive_location(const struct dive *dive)
 {
-	struct dive_site *ds = get_dive_site_by_uuid(dive->dive_site_uuid);
+	const struct dive_site *ds = get_dive_site_by_uuid(dive->dive_site_uuid);
 	if (ds && ds->name)
 		return ds->name;
 	return NULL;

--- a/core/dive.h
+++ b/core/dive.h
@@ -444,7 +444,7 @@ extern struct dive *get_dive(int nr);
 extern struct dive *get_dive_from_table(int nr, struct dive_table *dt);
 extern struct dive_site *get_dive_site_for_dive(struct dive *dive);
 extern const char *get_dive_country(struct dive *dive);
-extern char *get_dive_location(struct dive *dive);
+extern const char *get_dive_location(const struct dive *dive);
 extern unsigned int number_of_computers(struct dive *dive);
 extern struct divecomputer *get_dive_dc(struct dive *dive, int nr);
 extern timestamp_t dive_endtime(const struct dive *dive);

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -132,7 +132,7 @@ int SuitsFilterModel::countDives(const char *s) const
 	return count_dives_with_suit(s);
 }
 
-bool SuitsFilterModel::doFilter(dive *d) const
+bool SuitsFilterModel::doFilter(const dive *d) const
 {
 	// rowCount() == 0 should never happen, because we have the "no suits" row
 	// let's handle it gracefully anyway.
@@ -196,7 +196,7 @@ void TagFilterModel::repopulate()
 	updateList(list);
 }
 
-bool TagFilterModel::doFilter(dive *d) const
+bool TagFilterModel::doFilter(const dive *d) const
 {
 	// If there's nothing checked, this should show everything
 	// rowCount() == 0 should never happen, because we have the "no tags" row
@@ -234,7 +234,7 @@ int BuddyFilterModel::countDives(const char *s) const
 	return count_dives_with_person(s);
 }
 
-bool BuddyFilterModel::doFilter(dive *d) const
+bool BuddyFilterModel::doFilter(const dive *d) const
 {
 	// If there's nothing checked, this should show everything
 	// rowCount() == 0 should never happen, because we have the "no tags" row
@@ -289,7 +289,7 @@ int LocationFilterModel::countDives(const char *s) const
 	return count_dives_with_location(s);
 }
 
-bool LocationFilterModel::doFilter(struct dive *d) const
+bool LocationFilterModel::doFilter(const dive *d) const
 {
 	// rowCount() == 0 should never happen, because we have the "no location" row
 	// let's handle it gracefully anyway.

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -132,7 +132,7 @@ int SuitsFilterModel::countDives(const char *s) const
 	return count_dives_with_suit(s);
 }
 
-bool SuitsFilterModel::doFilter(dive *d, QModelIndex&, QAbstractItemModel*) const
+bool SuitsFilterModel::doFilter(dive *d) const
 {
 	// rowCount() == 0 should never happen, because we have the "no suits" row
 	// let's handle it gracefully anyway.
@@ -196,7 +196,7 @@ void TagFilterModel::repopulate()
 	updateList(list);
 }
 
-bool TagFilterModel::doFilter(dive *d, QModelIndex&, QAbstractItemModel*) const
+bool TagFilterModel::doFilter(dive *d) const
 {
 	// If there's nothing checked, this should show everything
 	// rowCount() == 0 should never happen, because we have the "no tags" row
@@ -234,7 +234,7 @@ int BuddyFilterModel::countDives(const char *s) const
 	return count_dives_with_person(s);
 }
 
-bool BuddyFilterModel::doFilter(dive *d, QModelIndex&, QAbstractItemModel*) const
+bool BuddyFilterModel::doFilter(dive *d) const
 {
 	// If there's nothing checked, this should show everything
 	// rowCount() == 0 should never happen, because we have the "no tags" row
@@ -289,7 +289,7 @@ int LocationFilterModel::countDives(const char *s) const
 	return count_dives_with_location(s);
 }
 
-bool LocationFilterModel::doFilter(struct dive *d, QModelIndex&, QAbstractItemModel*) const
+bool LocationFilterModel::doFilter(struct dive *d) const
 {
 	// rowCount() == 0 should never happen, because we have the "no location" row
 	// let's handle it gracefully anyway.
@@ -412,7 +412,7 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 		return showTrip;
 	}
 	Q_FOREACH (FilterModelBase *model, models) {
-		if (!model->doFilter(d, index0, sourceModel()))
+		if (!model->doFilter(d))
 			shouldShow = false;
 	}
 

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -111,7 +111,6 @@ signals:
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 	QList<FilterModelBase *> models;
-	bool justCleared;
 	struct dive_site *curr_dive_site;
 };
 

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -97,6 +97,7 @@ public:
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 	void addFilterModel(FilterModelBase *model);
 	void removeFilterModel(FilterModelBase *model);
+	bool showDive(const struct dive *d) const;
 	int divesDisplayed;
 public
 slots:

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -7,10 +7,12 @@
 #include <stdint.h>
 #include <vector>
 
+struct dive;
+
 class FilterModelBase : public QStringListModel {
 	Q_OBJECT
 public:
-	virtual bool doFilter(struct dive *d) const = 0;
+	virtual bool doFilter(const dive *d) const = 0;
 	void clearFilter();
 	void selectAll();
 	void invertSelection();
@@ -34,7 +36,7 @@ class TagFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static TagFilterModel *instance();
-	bool doFilter(struct dive *d) const;
+	bool doFilter(const dive *d) const;
 public
 slots:
 	void repopulate();
@@ -48,7 +50,7 @@ class BuddyFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static BuddyFilterModel *instance();
-	bool doFilter(struct dive *d) const;
+	bool doFilter(const dive *d) const;
 public
 slots:
 	void repopulate();
@@ -62,7 +64,7 @@ class LocationFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static LocationFilterModel *instance();
-	bool doFilter(struct dive *d) const;
+	bool doFilter(const dive *d) const;
 public
 slots:
 	void repopulate();
@@ -78,7 +80,7 @@ class SuitsFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static SuitsFilterModel *instance();
-	bool doFilter(struct dive *d) const;
+	bool doFilter(const dive *d) const;
 public
 slots:
 	void repopulate();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -10,7 +10,7 @@
 class FilterModelBase : public QStringListModel {
 	Q_OBJECT
 public:
-	virtual bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const = 0;
+	virtual bool doFilter(struct dive *d) const = 0;
 	void clearFilter();
 	void selectAll();
 	void invertSelection();
@@ -34,7 +34,7 @@ class TagFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static TagFilterModel *instance();
-	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
+	bool doFilter(struct dive *d) const;
 public
 slots:
 	void repopulate();
@@ -48,7 +48,7 @@ class BuddyFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static BuddyFilterModel *instance();
-	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
+	bool doFilter(struct dive *d) const;
 public
 slots:
 	void repopulate();
@@ -62,7 +62,7 @@ class LocationFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static LocationFilterModel *instance();
-	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
+	bool doFilter(struct dive *d) const;
 public
 slots:
 	void repopulate();
@@ -78,7 +78,7 @@ class SuitsFilterModel : public FilterModelBase {
 	Q_OBJECT
 public:
 	static SuitsFilterModel *instance();
-	bool doFilter(struct dive *d, QModelIndex &index0, QAbstractItemModel *sourceModel) const;
+	bool doFilter(struct dive *d) const;
 public
 slots:
 	void repopulate();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is in preparation for making the undo-changes compatible with the filter. It splits out the filter functionality in a function that takes a `dive *`. Since this is independent of the undo-PR I post this as a separate PR.

There *is* one functional change: if divesite-filtering is enabled, this will now also be reflected in the `hidden_by_filter` flag. I'm not sure if the old behavior was an oversight or on purpose. There was no comment.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unused parameters
2) Constify parameters
3) Split out dive-filter function

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No user visible changes (hopefully).
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No user visible changes (hopefully).
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
