### PR TITLE
Automate ftdi

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -2,6 +2,7 @@
 #include "core/libdivecomputer.h"
 #include "core/qthelper.h"
 #include "core/subsurface-qt/SettingsObjectWrapper.h"
+#include "core/subsurface-string.h"
 #include <QDebug>
 #include <QRegularExpression>
 #if defined(Q_OS_ANDROID)
@@ -62,6 +63,27 @@ void DownloadThread::run()
 	dcs->set_product(internalData->product);
 	dcs->set_device(internalData->devname);
 	dcs->set_device_name(m_data->devBluetoothName());
+}
+
+static const QVector<dc_family_t> ftdiFamilies = {
+	DC_FAMILY_SUUNTO_SOLUTION, DC_FAMILY_SUUNTO_EON, DC_FAMILY_SUUNTO_VYPER, DC_FAMILY_SUUNTO_VYPER2, DC_FAMILY_SUUNTO_D9,
+	DC_FAMILY_OCEANIC_VTPRO, DC_FAMILY_OCEANIC_VEO250, DC_FAMILY_OCEANIC_ATOM2,
+	DC_FAMILY_HW_OSTC, DC_FAMILY_HW_OSTC3, // but careful, the OSTC 4 is DC_FAMILY_HW_OSTC3 but has no serial connector
+	DC_FAMILY_CRESSI_EDY, DC_FAMILY_CRESSI_LEONARDO,
+	DC_FAMILY_DIVERITE_NITEKQ,
+	DC_FAMILY_DIVESYSTEM_IDIVE,
+	DC_FAMILY_TECDIVING_DIVECOMPUTEREU};
+
+bool guessIfFTDI(dc_descriptor_t *descriptor)
+{
+	if (!descriptor)
+		return false;
+	dc_family_t family = dc_descriptor_get_type(descriptor);
+	if (family == DC_FAMILY_HW_OSTC3 && same_string(dc_descriptor_get_product(descriptor), "OSTC 4"))
+		return false;
+	if (ftdiFamilies.contains(family))
+		return true;
+	return false;
 }
 
 static void fill_supported_mobile_list()

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -11,6 +11,9 @@
 #if BT_SUPPORT
 #include "core/btdiscovery.h"
 #endif
+
+bool guessIfFTDI(dc_descriptor_t *descriptor);
+
 /* Helper object for access of Device Data in QML */
 class DCDeviceData {
 public:

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -75,8 +75,10 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	if (!dc->vendor().isEmpty()) {
 		ui.vendor->setCurrentIndex(ui.vendor->findText(dc->vendor()));
 		productModel.setStringList(productList[dc->vendor()]);
-		if (!dc->product().isEmpty())
+		if (!dc->product().isEmpty()) {
 			ui.product->setCurrentIndex(ui.product->findText(dc->product()));
+			updateDeviceEnabled();
+		}
 	}
 
 	updateState(INITIAL);
@@ -479,6 +481,15 @@ void DownloadFromDCWidget::updateDeviceEnabled()
 
 	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
 	if (dc_descriptor_get_transports(descriptor) & DC_TRANSPORT_SERIAL) {
+#if defined(SERIAL_FTDI)
+		if (guessIfFTDI(descriptor)) {
+			// this should be an FTDI device that we'll connect to by using
+			// the magic device name "ftdi"
+			ui.device->setEditText("ftdi");
+			ui.device->setEnabled(false);
+			return;
+		}
+#endif
 		// if the dc_transport_t is DC_TRANSPORT_SERIAL, then enable the device node box.
 		ui.device->setEnabled(true);
 	} else {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,10 @@ while [[ $# -gt 0 ]] ; do
 			# call this script with -build-deps
 			BUILD_DEPS="1"
 			;;
+		-build-with-ftdi)
+			# build against the FTDI user space library
+			BUILD_WITH_FTDI="1"
+			;;
 		-build-with-webkit)
 			# unless you build Qt from source (or at least webkit from source, you won't have webkit installed
 			# -build-with-webkit tells the script that in fact we can assume that webkit is present (it usually
@@ -211,6 +215,17 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	# when building distributable binaries on a Mac, we cannot rely on anything from Homebrew,
 	# because that always requires the latest OS (how stupid is that - and they consider it a
 	# feature). So we painfully need to build the dependencies ourselves.
+	cd $SRC
+	if [ "$BUILD_WITH_FTDI" = "1" ]; then
+		./subsurface/scripts/get-dep-lib.sh single . libftdi
+		pushd libftdi
+		mkdir -p build
+		cd build
+		cmake $OLDER_MAC_CMAKE -DCMAKE_INSTALL_PREFIX=$INSTALL_ROOT -DCMAKE_BUILD_TYPE=$DEBUGRELEASE -DFTDI_EEPROM=OFF -BUILD_TESTS=OFF -DEXAMPLES=OFF ..
+		make -j4
+		make install
+	fi
+
 	cd $SRC
 	./subsurface/scripts/get-dep-lib.sh single . libcurl
 	pushd libcurl
@@ -391,6 +406,10 @@ if [ "$BUILD_WITH_WEBKIT" = "1" ]; then
 	EXTRA_OPTS="-DNO_USERMANUAL=OFF -DFBSUPPORT=ON"
 else
 	EXTRA_OPTS="-DNO_USERMANUAL=ON -DFBSUPPORT=OFF"
+fi
+
+if [ "$BUILD_WITH_FTDI" = "1" ]; then
+	EXTRA_OPTS="$EXTRA_OPTS -DFTDISUPPORT=ON"
 fi
 
 if [ "$BUILDGRANTLEE" = "1" ] ; then

--- a/scripts/mac/before_install.sh
+++ b/scripts/mac/before_install.sh
@@ -23,7 +23,7 @@ git describe
 # takes longer than updating / installing from Homebrew
 brew update
 echo "Updated Homebrew, now get our dependencies brewed"
-brew install xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2
+brew install xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libftdi
 
 # libdivecomputer uses the wrong include path for libusb and hidapi
 # the pkgconfig file for libusb/hidapi already gives the include path as

--- a/scripts/mac/travisbuild.sh
+++ b/scripts/mac/travisbuild.sh
@@ -15,7 +15,7 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 cd ${TRAVIS_BUILD_DIR}/..
 DIR=$(pwd)
 
-bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -release
+bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -build-with-ftdi -release
 
 cd ${TRAVIS_BUILD_DIR}/build
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Clearly, picking the right device is hard. Also, FTDI drivers on the Mac appear to be a mess.
This solves both problems for people with FTDI dive computers (still the majority of them).
Build on Mac against libftdi1, try to guess if the selected dive computer uses FTDI, and then disable the device drop down and just use ftdi, period
The question becomes "what if we guess wrong?" - is it possible that there's a 3rd party non-FTDI cable for one of the typically FTDI computers? Is there a Silicon Labs cable for a Suunto Vyper?
If that was a real possibility, we might need a way to override this. But for now I assume that this would work.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Automatically detect FTDI based dive computers on Mac

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Yes, this should be mentioned in the user manual, but this should be very easy, something like "for most dive computers Subsurface automatically detects how to connect to the device, for those where it doesn't..." and then lead to the text that describes how you figure out what device name to use.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@glance- because he always is good at telling me why my ideas are stupid
@atdotde because hopefully you can test this 
@neolit123 because I wonder if this would work under Windows as well... I haven't tried to build against libftdi1 on Windows, but if that was possible, we should definitely consider it.