### PR TITLE
solve error in qPrefLanguage and qPrefUpdateManager

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -55,7 +55,7 @@ typedef struct {
 	bool dont_check_for_updates;
 	bool dont_check_exists;
 	const char *last_version_used;
-	const char *next_check;
+	int next_check;
 } update_manager_prefs_t;
 
 typedef struct {

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -34,10 +34,10 @@ HANDLE_PREFERENCE_TXT(Language, "/date_format_short", date_format_short);
 
 HANDLE_PREFERENCE_TXT_EXT(Language, "/UiLanguage", language, locale.);
 
-HANDLE_PREFERENCE_TXT_EXT(Language, "/UiLang_locale", lang_locale, locale.);
+HANDLE_PREFERENCE_TXT_EXT(Language, "/UiLangLocale", lang_locale, locale.);
 
 HANDLE_PREFERENCE_TXT(Language, "/time_format", time_format);
 
 HANDLE_PREFERENCE_BOOL(Language, "/time_format_override", time_format_override);
 
-HANDLE_PREFERENCE_BOOL_EXT(Language, "/Use_system_language", use_system_language, locale.);
+HANDLE_PREFERENCE_BOOL_EXT(Language, "/UseSystemLanguage", use_system_language, locale.);

--- a/core/settings/qPrefUpdateManager.cpp
+++ b/core/settings/qPrefUpdateManager.cpp
@@ -41,12 +41,17 @@ HANDLE_PREFERENCE_TXT_EXT(UpdateManager, "/LastVersionUsed", last_version_used, 
 
 void qPrefUpdateManager::set_next_check(const QDate& value)
 {
-	QString valueString = value.toString("dd/MM/yyyy");
-	if (valueString != prefs.update_manager.next_check) {
-		qPrefPrivate::copy_txt(&prefs.update_manager.next_check, valueString);
+	long time_value = value.toJulianDay();
+	if (time_value != prefs.update_manager.next_check) {
+		prefs.update_manager.next_check = time_value;
 		disk_next_check(true);
 		emit instance()->next_check_changed(value);
 	}
 }
-DISK_LOADSYNC_TXT_EXT(UpdateManager, "/NextCheck", next_check, update_manager.);
-
+void qPrefUpdateManager::disk_next_check(bool doSync)
+{
+	if (doSync)
+		qPrefPrivate::instance()->setting.setValue(group + "/NextCheck", prefs.update_manager.next_check);
+	else
+		prefs.update_manager.next_check = qPrefPrivate::instance()->setting.value(group + "/NextCheck", 0).toInt();
+}

--- a/core/settings/qPrefUpdateManager.h
+++ b/core/settings/qPrefUpdateManager.h
@@ -26,7 +26,7 @@ public:
 	static bool dont_check_for_updates() { return prefs.update_manager.dont_check_for_updates; }
 	static bool dont_check_exists() { return prefs.update_manager.dont_check_exists; }
 	static const QString last_version_used() { return prefs.update_manager.last_version_used; }
-	static const QDate next_check() { return QDate::fromString(QString(prefs.update_manager.next_check), "dd/MM/yyyy"); }
+	static const QDate next_check() { return QDate::fromJulianDay(prefs.update_manager.next_check); }
 
 public slots:
 	static void set_dont_check_for_updates(bool value);

--- a/tests/testqPrefUpdateManager.cpp
+++ b/tests/testqPrefUpdateManager.cpp
@@ -23,7 +23,7 @@ void TestQPrefUpdateManager::test_struct_get()
 	prefs.update_manager.dont_check_for_updates = true;
 	prefs.update_manager.dont_check_exists = true;
 	prefs.update_manager.last_version_used = copy_qstring("last_version");
-	prefs.update_manager.next_check = copy_qstring(QString("11/09/1957"));
+	prefs.update_manager.next_check = QDate::fromString("11/09/1957", "dd/MM/yyyy").toJulianDay();
 
 	QCOMPARE(tst->dont_check_for_updates(), true);
 	QCOMPARE(tst->dont_check_exists(), true);
@@ -40,12 +40,12 @@ void TestQPrefUpdateManager::test_set_struct()
 	tst->set_dont_check_for_updates(false);
 	tst->set_dont_check_exists(false);
 	tst->set_last_version_used("last_version2");
-	prefs.update_manager.next_check = copy_qstring(QString("11/09/1957"));
+	tst->set_next_check(QDate::fromString("11/09/1957", "dd/MM/yyyy")); 
 
 	QCOMPARE(prefs.update_manager.dont_check_for_updates, false);
 	QCOMPARE(prefs.update_manager.dont_check_exists, false);
 	QCOMPARE(QString(prefs.update_manager.last_version_used), QString("last_version2"));
-	QCOMPARE(QDate::fromString(QString(prefs.update_manager.next_check), "dd/MM/yyyy"), QDate::fromString("11/09/1957", "dd/MM/yyyy")); 
+	QCOMPARE(QDate::fromJulianDay(prefs.update_manager.next_check), QDate::fromString("11/09/1957", "dd/MM/yyyy")); 
 }
 
 void TestQPrefUpdateManager::test_set_load_struct()
@@ -57,7 +57,7 @@ void TestQPrefUpdateManager::test_set_load_struct()
 	// secure set_ stores on disk
 	prefs.update_manager.dont_check_for_updates = true;
 	prefs.update_manager.dont_check_exists = true;
-	prefs.update_manager.next_check = copy_qstring(QString("value1"));
+	prefs.update_manager.next_check = 100;
 
 	tst->set_dont_check_for_updates(false);
 	tst->set_dont_check_exists(false);
@@ -67,12 +67,12 @@ void TestQPrefUpdateManager::test_set_load_struct()
 	prefs.update_manager.dont_check_for_updates = true;
 	prefs.update_manager.dont_check_exists = true;
 	prefs.update_manager.last_version_used = copy_qstring("last_version");
-	prefs.update_manager.next_check = copy_qstring(QString("01/01/2018"));
+	prefs.update_manager.next_check = 1000;
 
 	tst->load();
 	QCOMPARE(prefs.update_manager.dont_check_for_updates, false);
 	QCOMPARE(QString(prefs.update_manager.last_version_used), QString("last_version2"));
-	QCOMPARE(QDate::fromString(QString(prefs.update_manager.next_check),"dd/MM/yyyy"), QDate::fromString("11/09/1957", "dd/MM/yyyy")); 
+	QCOMPARE(QDate::fromJulianDay(prefs.update_manager.next_check), QDate::fromString("11/09/1957", "dd/MM/yyyy")); 
 
 	// dont_check_exists is NOT stored on disk
 	QCOMPARE(prefs.update_manager.dont_check_exists, true);
@@ -87,13 +87,13 @@ void TestQPrefUpdateManager::test_struct_disk()
 	prefs.update_manager.dont_check_for_updates = true;
 	prefs.update_manager.dont_check_exists = true;
 	prefs.update_manager.last_version_used = copy_qstring("last_version");
-	prefs.update_manager.next_check = copy_qstring("11/09/1957"); 
+	prefs.update_manager.next_check = QDate::fromString("11/09/1957", "dd/MM/yyyy").toJulianDay();
 
 	tst->sync();
 	prefs.update_manager.dont_check_for_updates = false;
 	prefs.update_manager.dont_check_exists = false;
 	prefs.update_manager.last_version_used = copy_qstring("");
-	prefs.update_manager.next_check = copy_qstring("01/09/2057"); 
+	prefs.update_manager.next_check = 1000;
 
 	tst->load();
 	QCOMPARE(tst->dont_check_for_updates(), true);
@@ -118,6 +118,16 @@ void TestQPrefUpdateManager::test_multiple()
 	QCOMPARE(tst->dont_check_for_updates(), false);
 	QCOMPARE(tst->dont_check_exists(), tst_direct->dont_check_exists());
 	QCOMPARE(tst_direct->dont_check_exists(), false);
+}
+
+void TestQPrefUpdateManager::test_next_check()
+{
+	auto tst = qPrefUpdateManager::instance();
+
+	prefs.update_manager.next_check = QDate::fromString("11/09/1957", "dd/MM/yyyy").toJulianDay();
+	prefs.update_manager.next_check++;
+
+	QCOMPARE(tst->next_check(), QDate::fromString("12/09/1957", "dd/MM/yyyy")); 
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefUpdateManager.h
+++ b/tests/testqPrefUpdateManager.h
@@ -15,6 +15,7 @@ private slots:
 	void test_struct_disk();
 	void test_multiple();
 	void test_oldPreferences();
+	void test_next_check();
 };
 
 #endif // TESTQPREFUPDATEMANAGER_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) correct wrong naming of qPrefLanguage variables on disk
2) solve next_check problem when changing locale

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh this PR conflicts with #1578 so please do not merge until I hve rebased after merge of #1578.

I still have to check what happens when upgrading from a version where next_check is a string.
