### PR TITLE
Cleanup: const-ify numerous functions

### DIFF
--- a/core/deco.c
+++ b/core/deco.c
@@ -479,7 +479,7 @@ void calc_crushing_pressure(struct deco_state *ds, double pressure)
 }
 
 /* add period_in_seconds at the given pressure and gas to the deco calculation */
-void add_segment(struct deco_state *ds, double pressure, const struct gasmix *gasmix, int period_in_seconds, int ccpo2, enum divemode_t divemode, int sac)
+void add_segment(struct deco_state *ds, double pressure, struct gasmix gasmix, int period_in_seconds, int ccpo2, enum divemode_t divemode, int sac)
 {
 	UNUSED(sac);
 	int ci;

--- a/core/deco.c
+++ b/core/deco.c
@@ -581,7 +581,7 @@ void restore_deco_state(struct deco_state *data, struct deco_state *target, bool
 
 }
 
-int deco_allowed_depth(double tissues_tolerance, double surface_pressure, struct dive *dive, bool smooth)
+int deco_allowed_depth(double tissues_tolerance, double surface_pressure, const struct dive *dive, bool smooth)
 {
 	int depth;
 	double pressure_delta;

--- a/core/deco.h
+++ b/core/deco.h
@@ -8,7 +8,7 @@ extern "C" {
 
 extern double buehlmann_N2_t_halflife[];
 
-extern int deco_allowed_depth(double tissues_tolerance, double surface_pressure, struct dive *dive, bool smooth);
+extern int deco_allowed_depth(double tissues_tolerance, double surface_pressure, const struct dive *dive, bool smooth);
 
 double get_gf(struct deco_state *ds, double ambpressure_bar, const struct dive *dive);
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -3858,7 +3858,7 @@ static bool new_picture_for_dive(struct dive *d, const char *filename)
 // only add pictures that have timestamps between 30 minutes before the dive and
 // 30 minutes after the dive ends
 #define D30MIN (30 * 60)
-bool dive_check_picture_time(struct dive *d, int shift_time, timestamp_t timestamp)
+bool dive_check_picture_time(const struct dive *d, int shift_time, timestamp_t timestamp)
 {
 	offset_t offset;
 	if (timestamp) {
@@ -4025,7 +4025,7 @@ void delete_current_divecomputer(void)
 
 /* helper function to make it easier to work with our structures
  * we don't interpolate here, just use the value from the last sample up to that time */
-int get_depth_at_time(struct divecomputer *dc, unsigned int time)
+int get_depth_at_time(const struct divecomputer *dc, unsigned int time)
 {
 	int depth = 0;
 	if (dc && dc->sample)
@@ -4038,7 +4038,7 @@ int get_depth_at_time(struct divecomputer *dc, unsigned int time)
 }
 
 //Calculate O2 in best mix
-fraction_t best_o2(depth_t depth, struct dive *dive)
+fraction_t best_o2(depth_t depth, const struct dive *dive)
 {
 	fraction_t fo2;
 
@@ -4050,7 +4050,7 @@ fraction_t best_o2(depth_t depth, struct dive *dive)
 }
 
 //Calculate He in best mix. O2 is considered narcopic
-fraction_t best_he(depth_t depth, struct dive *dive)
+fraction_t best_he(depth_t depth, const struct dive *dive)
 {
 	fraction_t fhe;
 	int pnarcotic, ambient;
@@ -4107,17 +4107,17 @@ int calculate_depth_to_mbar(int depth, pressure_t surface_pressure, int salinity
 	return mbar;
 }
 
-int depth_to_mbar(int depth, struct dive *dive)
+int depth_to_mbar(int depth, const struct dive *dive)
 {
 	return calculate_depth_to_mbar(depth, dive->surface_pressure, dive->salinity);
 }
 
-double depth_to_bar(int depth, struct dive *dive)
+double depth_to_bar(int depth, const struct dive *dive)
 {
 	return depth_to_mbar(depth, dive) / 1000.0;
 }
 
-double depth_to_atm(int depth, struct dive *dive)
+double depth_to_atm(int depth, const struct dive *dive)
 {
 	return mbar_to_atm(depth_to_mbar(depth, dive));
 }
@@ -4126,7 +4126,7 @@ double depth_to_atm(int depth, struct dive *dive)
  * (that's the one that some dive computers like the Uemis Zurich
  * provide - for the other models that do this libdivecomputer has to
  * take care of this, but the Uemis we support natively */
-int rel_mbar_to_depth(int mbar, struct dive *dive)
+int rel_mbar_to_depth(int mbar, const struct dive *dive)
 {
 	int cm;
 	double specific_weight = 1.03 * 0.981;
@@ -4137,7 +4137,7 @@ int rel_mbar_to_depth(int mbar, struct dive *dive)
 	return cm * 10;
 }
 
-int mbar_to_depth(int mbar, struct dive *dive)
+int mbar_to_depth(int mbar, const struct dive *dive)
 {
 	pressure_t surface_pressure;
 	if (dive->surface_pressure.mbar)
@@ -4148,7 +4148,7 @@ int mbar_to_depth(int mbar, struct dive *dive)
 }
 
 /* MOD rounded to multiples of roundto mm */
-depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, struct dive *dive, int roundto)
+depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct dive *dive, int roundto)
 {
 	depth_t rounded_depth;
 
@@ -4158,7 +4158,7 @@ depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, struct dive *dive, int 
 }
 
 /* Maximum narcotic depth rounded to multiples of roundto mm */
-depth_t gas_mnd(struct gasmix mix, depth_t end, struct dive *dive, int roundto)
+depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto)
 {
 	depth_t rounded_depth;
 	pressure_t ppo2n2;
@@ -4183,14 +4183,14 @@ struct dive *get_dive_from_table(int nr, struct dive_table *dt)
 	return dt->dives[nr];
 }
 
-struct dive_site *get_dive_site_for_dive(struct dive *dive)
+struct dive_site *get_dive_site_for_dive(const struct dive *dive)
 {
 	if (dive)
 		return get_dive_site_by_uuid(dive->dive_site_uuid);
 	return NULL;
 }
 
-const char *get_dive_country(struct dive *dive)
+const char *get_dive_country(const struct dive *dive)
 {
 	struct dive_site *ds = get_dive_site_by_uuid(dive->dive_site_uuid);
 	if (ds) {
@@ -4201,7 +4201,7 @@ const char *get_dive_country(struct dive *dive)
 	return NULL;
 }
 
-char *get_dive_location(struct dive *dive)
+const char *get_dive_location(const struct dive *dive)
 {
 	struct dive_site *ds = get_dive_site_by_uuid(dive->dive_site_uuid);
 	if (ds && ds->name)
@@ -4209,10 +4209,10 @@ char *get_dive_location(struct dive *dive)
 	return NULL;
 }
 
-unsigned int number_of_computers(struct dive *dive)
+unsigned int number_of_computers(const struct dive *dive)
 {
 	unsigned int total_number = 0;
-	struct divecomputer *dc = &dive->dc;
+	const struct divecomputer *dc = &dive->dc;
 
 	if (!dive)
 		return 1;
@@ -4275,12 +4275,12 @@ int get_idx_by_uniq_id(int id)
 	return i;
 }
 
-bool dive_site_has_gps_location(struct dive_site *ds)
+bool dive_site_has_gps_location(const struct dive_site *ds)
 {
 	return ds && (ds->latitude.udeg || ds->longitude.udeg);
 }
 
-int dive_has_gps_location(struct dive *dive)
+int dive_has_gps_location(const struct dive *dive)
 {
 	if (!dive)
 		return false;

--- a/core/dive.c
+++ b/core/dive.c
@@ -4308,3 +4308,11 @@ struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, s
 	*evp = ev;
 	return res;
 }
+
+/* get the gas at a certain time during the dive */
+struct gasmix get_gasmix_at_time(struct dive *d, struct divecomputer *dc, duration_t time)
+{
+	struct event *ev = NULL;
+	struct gasmix gasmix = { 0 };
+	return get_gasmix(d, dc, time.seconds, &ev, &gasmix);
+}

--- a/core/dive.h
+++ b/core/dive.h
@@ -718,11 +718,14 @@ extern void printdecotable(struct decostop *table);
 
 extern struct event *get_next_event(struct event *event, const char *name);
 
-/* Get gasmix at increasing timestamps.
+/* Get gasmixes at increasing timestamps.
  * In "evp", pass a pointer to a "struct event *" which is NULL-initialized on first invocation.
  * On subsequent calls, pass the same "evp" and the "gasmix" from previous calls.
  */
 extern struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix *gasmix);
+
+/* Get gasmix at a given time */
+extern struct gasmix get_gasmix_at_time(struct dive *dive, struct divecomputer *dc, duration_t time);
 
 /* these structs holds the information that
  * describes the cylinders / weight systems.

--- a/core/dive.h
+++ b/core/dive.h
@@ -585,7 +585,7 @@ extern void update_event_name(struct dive *d, struct event* event, const char *n
 extern void add_extra_data(struct divecomputer *dc, const char *key, const char *value);
 extern void per_cylinder_mean_depth(struct dive *dive, struct divecomputer *dc, int *mean, int *duration);
 extern int get_cylinder_index(struct dive *dive, struct event *ev);
-extern struct gasmix *get_gasmix_from_event(struct dive *, struct event *ev);
+extern struct gasmix get_gasmix_from_event(struct dive *, struct event *ev);
 extern int nr_cylinders(struct dive *dive);
 extern int nr_weightsystems(struct dive *dive);
 
@@ -718,7 +718,11 @@ extern void printdecotable(struct decostop *table);
 
 extern struct event *get_next_event(struct event *event, const char *name);
 
-extern struct gasmix *get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix *gasmix);
+/* Get gasmix at increasing timestamps.
+ * In "evp", pass a pointer to a "struct event *" which is NULL-initialized on first invocation.
+ * On subsequent calls, pass the same "evp" and the "gasmix" from previous calls.
+ */
+extern struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix *gasmix);
 
 /* these structs holds the information that
  * describes the cylinders / weight systems.

--- a/core/dive.h
+++ b/core/dive.h
@@ -71,7 +71,7 @@ struct icd_data { // This structure provides communication between function isob
 	int dHe;      // The change in fraction (permille) of helium during the change
 };
 
-extern bool isobaric_counterdiffusion(struct gasmix *oldgasmix, struct gasmix *newgasmix, struct icd_data *results);
+extern bool isobaric_counterdiffusion(struct gasmix oldgasmix, struct gasmix newgasmix, struct icd_data *results);
 
 /*
  * Events are currently based straight on what libdivecomputer gives us.
@@ -114,32 +114,32 @@ extern int units_to_sac(double volume);
 
 /* Volume in mliter of a cylinder at pressure 'p' */
 extern int gas_volume(cylinder_t *cyl, pressure_t p);
-extern double gas_compressibility_factor(struct gasmix *gas, double bar);
-extern double isothermal_pressure(struct gasmix *gas, double p1, int volume1, int volume2);
-extern double gas_density(struct gasmix *gas, int pressure);
-extern int same_gasmix(struct gasmix *a, struct gasmix *b);
+extern double gas_compressibility_factor(struct gasmix gas, double bar);
+extern double isothermal_pressure(struct gasmix gas, double p1, int volume1, int volume2);
+extern double gas_density(struct gasmix gas, int pressure);
+extern int same_gasmix(struct gasmix a, struct gasmix b);
 
-static inline int get_o2(const struct gasmix *mix)
+static inline int get_o2(struct gasmix mix)
 {
-	return mix->o2.permille ?: O2_IN_AIR;
+	return mix.o2.permille ?: O2_IN_AIR;
 }
 
-static inline int get_he(const struct gasmix *mix)
+static inline int get_he(struct gasmix mix)
 {
-	return mix->he.permille;
+	return mix.he.permille;
 }
 
 struct gas_pressures {
 	double o2, n2, he;
 };
 
-extern void fill_pressures(struct gas_pressures *pressures, const double amb_pressure, const struct gasmix *mix, double po2, enum divemode_t dctype);
+extern void fill_pressures(struct gas_pressures *pressures, const double amb_pressure, struct gasmix mix, double po2, enum divemode_t dctype);
 
 extern void sanitize_gasmix(struct gasmix *mix);
-extern int gasmix_distance(const struct gasmix *a, const struct gasmix *b);
-extern int find_best_gasmix_match(struct gasmix *mix, cylinder_t array[], unsigned int used);
+extern int gasmix_distance(struct gasmix a, struct gasmix b);
+extern int find_best_gasmix_match(struct gasmix mix, cylinder_t array[], unsigned int used);
 
-extern bool gasmix_is_air(const struct gasmix *gasmix);
+extern bool gasmix_is_air(struct gasmix gasmix);
 
 /* Linear interpolation between 'a' and 'b', when we are 'part'way into the 'whole' distance from a to b */
 static inline int interpolate(int a, int b, int part, int whole)
@@ -152,8 +152,8 @@ static inline int interpolate(int a, int b, int part, int whole)
 	return (a+b)/2;
 }
 
-void get_gas_string(const struct gasmix *gasmix, char *text, int len);
-const char *gasname(const struct gasmix *gasmix);
+void get_gas_string(struct gasmix gasmix, char *text, int len);
+const char *gasname(struct gasmix gasmix);
 
 #define MAX_SENSORS 2
 struct sample                         // BASE TYPE BYTES  UNITS    RANGE               DESCRIPTION
@@ -396,8 +396,8 @@ extern double depth_to_bar(int depth, struct dive *dive);
 extern double depth_to_atm(int depth, struct dive *dive);
 extern int rel_mbar_to_depth(int mbar, struct dive *dive);
 extern int mbar_to_depth(int mbar, struct dive *dive);
-extern depth_t gas_mod(struct gasmix *mix, pressure_t po2_limit, struct dive *dive, int roundto);
-extern depth_t gas_mnd(struct gasmix *mix, depth_t end, struct dive *dive, int roundto);
+extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, struct dive *dive, int roundto);
+extern depth_t gas_mnd(struct gasmix mix, depth_t end, struct dive *dive, int roundto);
 
 #define SURFACE_THRESHOLD 750 /* somewhat arbitrary: only below 75cm is it really diving */
 
@@ -663,7 +663,7 @@ struct deco_state {
 	bool icd_warning;
 };
 
-extern void add_segment(struct deco_state *ds, double pressure, const struct gasmix *gasmix, int period_in_seconds, int setpoint, enum divemode_t divemode, int sac);
+extern void add_segment(struct deco_state *ds, double pressure, struct gasmix gasmix, int period_in_seconds, int setpoint, enum divemode_t divemode, int sac);
 extern void clear_deco(struct deco_state *ds, double surface_pressure);
 extern void dump_tissues(struct deco_state *ds);
 extern void set_gf(short gflow, short gfhigh);
@@ -722,7 +722,7 @@ extern struct event *get_next_event(struct event *event, const char *name);
  * In "evp", pass a pointer to a "struct event *" which is NULL-initialized on first invocation.
  * On subsequent calls, pass the same "evp" and the "gasmix" from previous calls.
  */
-extern struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix *gasmix);
+extern struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix gasmix);
 
 /* Get gasmix at a given time */
 extern struct gasmix get_gasmix_at_time(struct dive *dive, struct divecomputer *dc, duration_t time);

--- a/core/dive.h
+++ b/core/dive.h
@@ -373,7 +373,7 @@ struct picture {
 	for (struct picture *picture = (_divestruct).picture_list; picture; picture = picture->next)
 
 extern struct picture *alloc_picture();
-extern bool dive_check_picture_time(struct dive *d, int shift_time, timestamp_t timestamp);
+extern bool dive_check_picture_time(const struct dive *d, int shift_time, timestamp_t timestamp);
 extern void dive_create_picture(struct dive *d, const char *filename, int shift_time, bool match_all);
 extern void dive_add_picture(struct dive *d, struct picture *newpic);
 extern bool dive_remove_picture(struct dive *d, const char *filename);
@@ -384,20 +384,20 @@ extern void picture_free(struct picture *picture);
 
 extern bool has_gaschange_event(struct dive *dive, struct divecomputer *dc, int idx);
 extern int explicit_first_cylinder(struct dive *dive, struct divecomputer *dc);
-extern int get_depth_at_time(struct divecomputer *dc, unsigned int time);
+extern int get_depth_at_time(const struct divecomputer *dc, unsigned int time);
 
-extern fraction_t best_o2(depth_t depth, struct dive *dive);
-extern fraction_t best_he(depth_t depth, struct dive *dive);
+extern fraction_t best_o2(depth_t depth, const struct dive *dive);
+extern fraction_t best_he(depth_t depth, const struct dive *dive);
 
 extern int get_surface_pressure_in_mbar(const struct dive *dive, bool non_null);
 extern int calculate_depth_to_mbar(int depth, pressure_t surface_pressure, int salinity);
-extern int depth_to_mbar(int depth, struct dive *dive);
-extern double depth_to_bar(int depth, struct dive *dive);
-extern double depth_to_atm(int depth, struct dive *dive);
-extern int rel_mbar_to_depth(int mbar, struct dive *dive);
-extern int mbar_to_depth(int mbar, struct dive *dive);
-extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, struct dive *dive, int roundto);
-extern depth_t gas_mnd(struct gasmix mix, depth_t end, struct dive *dive, int roundto);
+extern int depth_to_mbar(int depth, const struct dive *dive);
+extern double depth_to_bar(int depth, const struct dive *dive);
+extern double depth_to_atm(int depth, const struct dive *dive);
+extern int rel_mbar_to_depth(int mbar, const struct dive *dive);
+extern int mbar_to_depth(int mbar, const struct dive *dive);
+extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct dive *dive, int roundto);
+extern depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto);
 
 #define SURFACE_THRESHOLD 750 /* somewhat arbitrary: only below 75cm is it really diving */
 
@@ -442,10 +442,10 @@ extern unsigned int dc_number;
 
 extern struct dive *get_dive(int nr);
 extern struct dive *get_dive_from_table(int nr, struct dive_table *dt);
-extern struct dive_site *get_dive_site_for_dive(struct dive *dive);
-extern const char *get_dive_country(struct dive *dive);
-extern char *get_dive_location(struct dive *dive);
-extern unsigned int number_of_computers(struct dive *dive);
+extern struct dive_site *get_dive_site_for_dive(const struct dive *dive);
+extern const char *get_dive_country(const struct dive *dive);
+extern const char *get_dive_location(const struct dive *dive);
+extern unsigned int number_of_computers(const struct dive *dive);
 extern struct divecomputer *get_dive_dc(struct dive *dive, int nr);
 extern timestamp_t dive_endtime(const struct dive *dive);
 
@@ -475,8 +475,8 @@ extern "C" {
 
 extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
-extern bool dive_site_has_gps_location(struct dive_site *ds);
-extern int dive_has_gps_location(struct dive *dive);
+extern bool dive_site_has_gps_location(const struct dive_site *ds);
+extern int dive_has_gps_location(const struct dive *dive);
 
 extern int report_error(const char *fmt, ...);
 extern void set_error_cb(void(*cb)(char *));	// Callback takes ownership of passed string

--- a/core/dive.h
+++ b/core/dive.h
@@ -100,7 +100,7 @@ struct event {
 	char name[];
 };
 
-extern int event_is_gaschange(struct event *ev);
+extern int event_is_gaschange(const struct event *ev);
 
 extern int get_pressure_units(int mb, const char **units);
 extern double get_depth_units(int mm, int *frac, const char **units);
@@ -137,7 +137,7 @@ extern void fill_pressures(struct gas_pressures *pressures, const double amb_pre
 
 extern void sanitize_gasmix(struct gasmix *mix);
 extern int gasmix_distance(struct gasmix a, struct gasmix b);
-extern int find_best_gasmix_match(struct gasmix mix, cylinder_t array[], unsigned int used);
+extern int find_best_gasmix_match(struct gasmix mix, const cylinder_t array[], unsigned int used);
 
 extern bool gasmix_is_air(struct gasmix gasmix);
 
@@ -334,7 +334,7 @@ struct dive {
 extern void invalidate_dive_cache(struct dive *dive);
 extern bool dive_cache_is_valid(const struct dive *dive);
 
-extern int get_cylinder_idx_by_use(struct dive *dive, enum cylinderuse cylinder_use_type);
+extern int get_cylinder_idx_by_use(const struct dive *dive, enum cylinderuse cylinder_use_type);
 extern void cylinder_renumber(struct dive *dive, int mapping[]);
 extern int same_gasmix_cylinder(cylinder_t *cyl, int cylid, struct dive *dive, bool check_unused);
 
@@ -352,9 +352,9 @@ struct dive_components {
 	unsigned int weights : 1;
 };
 
-extern enum divemode_t get_current_divemode(struct divecomputer *dc, int time, struct event **evp, enum divemode_t *divemode);
-extern struct event *get_next_divemodechange(struct event **evd, bool update_pointer);
-extern enum divemode_t get_divemode_at_time(struct divecomputer *dc, int dtime, struct event **ev_dmc);
+extern enum divemode_t get_current_divemode(const struct divecomputer *dc, int time, const struct event **evp, enum divemode_t *divemode);
+extern struct event *get_next_divemodechange(const struct event **evd, bool update_pointer);
+extern enum divemode_t get_divemode_at_time(const struct divecomputer *dc, int dtime, const struct event **ev_dmc);
 
 /* picture list and methods related to dive picture handling */
 struct picture {
@@ -382,8 +382,8 @@ extern bool picture_check_valid(const char *filename, int shift_time);
 extern void dive_set_geodata_from_picture(struct dive *d, struct picture *pic);
 extern void picture_free(struct picture *picture);
 
-extern bool has_gaschange_event(struct dive *dive, struct divecomputer *dc, int idx);
-extern int explicit_first_cylinder(struct dive *dive, struct divecomputer *dc);
+extern bool has_gaschange_event(const struct dive *dive, const struct divecomputer *dc, int idx);
+extern int explicit_first_cylinder(const struct dive *dive, const struct divecomputer *dc);
 extern int get_depth_at_time(const struct divecomputer *dc, unsigned int time);
 
 extern fraction_t best_o2(depth_t depth, const struct dive *dive);
@@ -581,11 +581,11 @@ extern void fill_default_cylinder(cylinder_t *cyl);
 extern void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int time, int idx);
 extern struct event *add_event(struct divecomputer *dc, unsigned int time, int type, int flags, int value, const char *name);
 extern void remove_event(struct event *event);
-extern void update_event_name(struct dive *d, struct event* event, const char *name);
+extern void update_event_name(struct dive *d, struct event *event, const char *name);
 extern void add_extra_data(struct divecomputer *dc, const char *key, const char *value);
 extern void per_cylinder_mean_depth(struct dive *dive, struct divecomputer *dc, int *mean, int *duration);
-extern int get_cylinder_index(struct dive *dive, struct event *ev);
-extern struct gasmix get_gasmix_from_event(struct dive *, struct event *ev);
+extern int get_cylinder_index(const struct dive *dive, const struct event *ev);
+extern struct gasmix get_gasmix_from_event(const struct dive *, const struct event *ev);
 extern int nr_cylinders(struct dive *dive);
 extern int nr_weightsystems(struct dive *dive);
 
@@ -716,16 +716,18 @@ extern void vpmb_start_gradient(struct deco_state *ds);
 extern void clear_vpmb_state(struct deco_state *ds);
 extern void printdecotable(struct decostop *table);
 
-extern struct event *get_next_event(struct event *event, const char *name);
+/* Since C doesn't have parameter-based overloading, two versions of get_next_event. */
+extern const struct event *get_next_event(const struct event *event, const char *name);
+extern struct event *get_next_event_mutable(struct event *event, const char *name);
 
 /* Get gasmixes at increasing timestamps.
  * In "evp", pass a pointer to a "struct event *" which is NULL-initialized on first invocation.
  * On subsequent calls, pass the same "evp" and the "gasmix" from previous calls.
  */
-extern struct gasmix get_gasmix(struct dive *dive, struct divecomputer *dc, int time, struct event **evp, struct gasmix gasmix);
+extern struct gasmix get_gasmix(const struct dive *dive, const struct divecomputer *dc, int time, const struct event **evp, struct gasmix gasmix);
 
 /* Get gasmix at a given time */
-extern struct gasmix get_gasmix_at_time(struct dive *dive, struct divecomputer *dc, duration_t time);
+extern struct gasmix get_gasmix_at_time(const struct dive *dive, const struct divecomputer *dc, duration_t time);
 
 /* these structs holds the information that
  * describes the cylinders / weight systems.
@@ -762,7 +764,7 @@ extern void set_informational_units(const char *units);
 extern void set_git_prefs(const char *prefs);
 
 extern char *get_dive_date_c_string(timestamp_t when);
-extern void update_setpoint_events(struct dive *dive, struct divecomputer *dc);
+extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 
 #ifdef __cplusplus
 }

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -405,7 +405,7 @@ static void add_dive_to_deco(struct deco_state *ds, struct dive *dive)
 	struct divecomputer *dc = &dive->dc;
 	struct gasmix gasmix = { 0 };
 	int i;
-	struct event *ev = NULL, *evd = NULL;
+	const struct event *ev = NULL, *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 
 	if (!dc)

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -134,8 +134,7 @@ int total_weight(struct dive *dive)
 
 static int active_o2(struct dive *dive, struct divecomputer *dc, duration_t time)
 {
-	struct gasmix gas;
-	get_gas_at_time(dive, dc, time, &gas);
+	struct gasmix gas = get_gasmix_at_time(dive, dc, time);
 	return get_o2(&gas);
 }
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -404,7 +404,7 @@ static int calculate_sac(struct dive *dive)
 static void add_dive_to_deco(struct deco_state *ds, struct dive *dive)
 {
 	struct divecomputer *dc = &dive->dc;
-	struct gasmix *gasmix = NULL;
+	struct gasmix gasmix = { 0 };
 	int i;
 	struct event *ev = NULL, *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
@@ -421,8 +421,8 @@ static void add_dive_to_deco(struct deco_state *ds, struct dive *dive)
 
 		for (j = t0; j < t1; j++) {
 			int depth = interpolate(psample->depth.mm, sample->depth.mm, j - t0, t1 - t0);
-			gasmix = get_gasmix(dive, dc, j, &ev, gasmix);
-			add_segment(ds, depth_to_bar(depth, dive), gasmix, 1, sample->setpoint.mbar,
+			gasmix = get_gasmix(dive, dc, j, &ev, &gasmix);
+			add_segment(ds, depth_to_bar(depth, dive), &gasmix, 1, sample->setpoint.mbar,
 				get_current_divemode(&dive->dc, j, &evd, &current_divemode), dive->sac);
 		}
 	}

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -94,8 +94,8 @@ void get_dive_gas(struct dive *dive, int *o2_p, int *he_p, int *o2max_p)
 
 	for (i = 0; i < MAX_CYLINDERS; i++) {
 		cylinder_t *cyl = dive->cylinder + i;
-		int o2 = get_o2(&cyl->gasmix);
-		int he = get_he(&cyl->gasmix);
+		int o2 = get_o2(cyl->gasmix);
+		int he = get_he(cyl->gasmix);
 
 		if (!is_cylinder_used(dive, i))
 			continue;
@@ -135,7 +135,7 @@ int total_weight(struct dive *dive)
 static int active_o2(struct dive *dive, struct divecomputer *dc, duration_t time)
 {
 	struct gasmix gas = get_gasmix_at_time(dive, dc, time);
-	return get_o2(&gas);
+	return get_o2(gas);
 }
 
 /* calculate OTU for a dive - this only takes the first divecomputer into account */
@@ -420,8 +420,8 @@ static void add_dive_to_deco(struct deco_state *ds, struct dive *dive)
 
 		for (j = t0; j < t1; j++) {
 			int depth = interpolate(psample->depth.mm, sample->depth.mm, j - t0, t1 - t0);
-			gasmix = get_gasmix(dive, dc, j, &ev, &gasmix);
-			add_segment(ds, depth_to_bar(depth, dive), &gasmix, 1, sample->setpoint.mbar,
+			gasmix = get_gasmix(dive, dc, j, &ev, gasmix);
+			add_segment(ds, depth_to_bar(depth, dive), gasmix, 1, sample->setpoint.mbar,
 				get_current_divemode(&dive->dc, j, &evd, &current_divemode), dive->sac);
 		}
 	}
@@ -576,7 +576,7 @@ int init_decompression(struct deco_state *ds, struct dive *dive)
 #endif
 				return surface_time;
 			}
-			add_segment(ds, surface_pressure, &air, surface_time, 0, dive->dc.divemode, prefs.decosac);
+			add_segment(ds, surface_pressure, air, surface_time, 0, dive->dc.divemode, prefs.decosac);
 #if DECO_CALC_DEBUG & 2
 			printf("Tissues after surface intervall of %d:%02u:\n", FRACTION(surface_time, 60));
 			dump_tissues(ds);
@@ -614,7 +614,7 @@ int init_decompression(struct deco_state *ds, struct dive *dive)
 #endif
 			return surface_time;
 		}
-		add_segment(ds, surface_pressure, &air, surface_time, 0, dive->dc.divemode, prefs.decosac);
+		add_segment(ds, surface_pressure, air, surface_time, 0, dive->dc.divemode, prefs.decosac);
 #if DECO_CALC_DEBUG & 2
 		printf("Tissues after surface intervall of %d:%02u:\n", FRACTION(surface_time, 60));
 		dump_tissues(ds);

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -81,7 +81,7 @@ bool cylinder_none(void *_data)
 	return cylinder_nodata(cyl) && cylinder_nosamples(cyl);
 }
 
-void get_gas_string(const struct gasmix *gasmix, char *text, int len)
+void get_gas_string(struct gasmix gasmix, char *text, int len)
 {
 	if (gasmix_is_air(gasmix))
 		snprintf(text, len, "%s", translate("gettextFromC", "air"));
@@ -94,7 +94,7 @@ void get_gas_string(const struct gasmix *gasmix, char *text, int len)
 }
 
 /* Returns a static char buffer - only good for immediate use by printf etc */
-const char *gasname(const struct gasmix *gasmix)
+const char *gasname(struct gasmix gasmix)
 {
 	static char gas[64];
 	get_gas_string(gasmix, gas, sizeof(gas));
@@ -216,7 +216,7 @@ void reset_cylinders(struct dive *dive, bool track_gas)
 		if (cylinder_none(cyl))
 			continue;
 		if (cyl->depth.mm == 0) /* if the gas doesn't give a mod, calculate based on prefs */
-			cyl->depth = gas_mod(&cyl->gasmix, decopo2, dive, M_OR_FT(3,10));
+			cyl->depth = gas_mod(cyl->gasmix, decopo2, dive, M_OR_FT(3,10));
 		if (track_gas)
 			cyl->start.mbar = cyl->end.mbar = cyl->type.workingpressure.mbar;
 		cyl->gas_used.mliter = 0;

--- a/core/gas-model.c
+++ b/core/gas-model.c
@@ -26,7 +26,7 @@
  * NOTE! Helium coefficients are a linear mix operation between the
  * 323K and one for 273K isotherms, to make everything be at 300K.
  */
-double gas_compressibility_factor(struct gasmix *gas, double bar)
+double gas_compressibility_factor(struct gasmix gas, double bar)
 {
 	static const double o2_coefficients[3] = {
 		-7.18092073703e-04,
@@ -69,15 +69,15 @@ double gas_compressibility_factor(struct gasmix *gas, double bar)
 /* Compute the new pressure when compressing (expanding) volome v1 at pressure p1 bar to volume v2
  * taking into account the compressebility (to first order) */
 
-double isothermal_pressure(struct gasmix *gas, double p1, int volume1, int volume2)
+double isothermal_pressure(struct gasmix gas, double p1, int volume1, int volume2)
 {
 	double p_ideal = p1 * volume1 / volume2 / gas_compressibility_factor(gas, p1);
 
 	return p_ideal * gas_compressibility_factor(gas, p_ideal);
 }
 
-inline double gas_density(struct gasmix *gas, int pressure) {
-	int density =  gas->he.permille * HE_DENSITY + gas->o2.permille * O2_DENSITY + (1000 - gas->he.permille - gas->o2.permille) * N2_DENSITY;
+inline double gas_density(struct gasmix gas, int pressure) {
+	int density =  gas.he.permille * HE_DENSITY + gas.o2.permille * O2_DENSITY + (1000 - gas.he.permille - gas.o2.permille) * N2_DENSITY;
 
 	return density * (double) pressure / gas_compressibility_factor(gas, pressure / 1000.0) / SURFACE_PRESSURE / 1000000.0;
 }

--- a/core/gaspressures.c
+++ b/core/gaspressures.c
@@ -350,7 +350,7 @@ void populate_pressure_information(struct dive *dive, struct divecomputer *dc, s
 	cylinder_t *cylinder = dive->cylinder + sensor;
 	pr_track_t *track = NULL;
 	pr_track_t *current = NULL;
-	struct event *ev, *b_ev;
+	const struct event *ev, *b_ev;
 	int missing_pr = 0, dense = 1;
 	enum divemode_t dmode = dc->divemode;
 	const double gasfactor[5] = {1.0, 0.0, prefs.pscr_ratio/1000.0, 1.0, 1.0 };

--- a/core/import-divinglog.c
+++ b/core/import-divinglog.c
@@ -137,7 +137,7 @@ extern int divinglog_profile(void *handle, int columns, char **data, char **colu
 			cur_sample->pressure[0].mbar = pressure * 100;
 			cur_sample->rbt.seconds = rbt;
 			if (oldcyl != tank) {
-				struct gasmix *mix = &cur_dive->cylinder[tank].gasmix;
+				struct gasmix mix = cur_dive->cylinder[tank].gasmix;
 				int o2 = get_o2(mix);
 				int he = get_he(mix);
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -652,7 +652,7 @@ void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int second
 	if (idx < 0 || idx >= MAX_CYLINDERS)
 		return;
 	/* The gas switch event format is insane for historical reasons */
-	struct gasmix *mix = &dive->cylinder[idx].gasmix;
+	struct gasmix mix = dive->cylinder[idx].gasmix;
 	int o2 = get_o2(mix);
 	int he = get_he(mix);
 	struct event *ev;
@@ -665,7 +665,7 @@ void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int second
 	ev = add_event(dc, seconds, he ? SAMPLE_EVENT_GASCHANGE2 : SAMPLE_EVENT_GASCHANGE, 0, value, "gaschange");
 	if (ev) {
 		ev->gas.index = idx;
-		ev->gas.mix = *mix;
+		ev->gas.mix = mix;
 	}
 }
 

--- a/core/planner.c
+++ b/core/planner.c
@@ -136,7 +136,7 @@ int tissue_at_end(struct deco_state *ds, struct dive *dive, struct deco_state **
 		return 0;
 	psample = sample = dc->sample;
 
-	struct event *evdm = NULL;
+	const struct event *evdm = NULL;
 	enum divemode_t divemode = UNDEF_COMP_TYPE;
 
 	for (i = 0; i < dc->samples; i++, sample++) {
@@ -716,7 +716,7 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 
 	current_cylinder = get_cylinderid_at_time(dive, &dive->dc, sample->time);
 	// FIXME: This needs a function to find the divemode at the end of the dive like in
-	struct event *ev = NULL;
+	const struct event *ev = NULL;
 	divemode = UNDEF_COMP_TYPE;
 	divemode = get_current_divemode(&dive->dc, bottom_time, &ev, &divemode);
 	gas = dive->cylinder[current_cylinder].gasmix;

--- a/core/planner.c
+++ b/core/planner.c
@@ -81,22 +81,6 @@ bool diveplan_empty(struct diveplan *diveplan)
 	return true;
 }
 
-/* get the gas at a certain time during the dive */
-void get_gas_at_time(struct dive *dive, struct divecomputer *dc, duration_t time, struct gasmix *gas)
-{
-	// we always start with the first gas, so that's our gas
-	// unless an event tells us otherwise
-	struct event *event = dc->events;
-	*gas = dive->cylinder[0].gasmix;
-	while (event && event->time.seconds <= time.seconds) {
-		if (!strcmp(event->name, "gaschange")) {
-			int cylinder_idx = get_cylinder_index(dive, event);
-			*gas = dive->cylinder[cylinder_idx].gasmix;
-		}
-		event = event->next;
-	}
-}
-
 /* get the cylinder index at a certain time during the dive */
 int get_cylinderid_at_time(struct dive *dive, struct divecomputer *dc, duration_t time)
 {
@@ -164,7 +148,7 @@ int tissue_at_end(struct deco_state *ds, struct dive *dive, struct deco_state **
 			setpoint = sample[0].setpoint;
 
 		t1 = sample->time;
-		get_gas_at_time(dive, dc, t0, &gas);
+		gas = get_gasmix_at_time(dive, dc, t0);
 		if (i > 0)
 			lastdepth = psample->depth;
 

--- a/core/planner.h
+++ b/core/planner.h
@@ -18,7 +18,7 @@ extern void set_display_runtime(bool display);
 extern void set_display_duration(bool display);
 extern void set_display_transitions(bool display);
 extern int get_cylinderid_at_time(struct dive *dive, struct divecomputer *dc, duration_t time);
-extern int get_gasidx(struct dive *dive, struct gasmix *mix);
+extern int get_gasidx(struct dive *dive, struct gasmix mix);
 extern bool diveplan_empty(struct diveplan *diveplan);
 extern void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error);
 

--- a/core/planner.h
+++ b/core/planner.h
@@ -17,7 +17,6 @@ extern void set_verbatim(bool verbatim);
 extern void set_display_runtime(bool display);
 extern void set_display_duration(bool display);
 extern void set_display_transitions(bool display);
-extern void get_gas_at_time(struct dive *dive, struct divecomputer *dc, duration_t time, struct gasmix *gas);
 extern int get_cylinderid_at_time(struct dive *dive, struct divecomputer *dc, duration_t time);
 extern int get_gasidx(struct dive *dive, struct gasmix *mix);
 extern bool diveplan_empty(struct diveplan *diveplan);

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -551,7 +551,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	bool o2warning_exist = false;
 	enum divemode_t current_divemode;
 	double amb;
-	struct event *evd = NULL;
+	const struct event *evd = NULL;
 	current_divemode = UNDEF_COMP_TYPE;
 
 	if (dive->dc.divemode != CCR) {

--- a/core/profile.c
+++ b/core/profile.c
@@ -333,7 +333,7 @@ int get_cylinder_index(struct dive *dive, struct event *ev)
 	fprintf(stderr, "Still looking up cylinder based on gas mix in get_cylinder_index()!\n");
 
 	mix = get_gasmix_from_event(dive, ev);
-	best = find_best_gasmix_match(&mix, dive->cylinder, 0);
+	best = find_best_gasmix_match(mix, dive->cylinder, 0);
 	return best < 0 ? 0 : best;
 }
 
@@ -760,14 +760,14 @@ static void fill_sac(struct dive *dive, struct plot_info *pi, int idx, unsigned 
 /*
  * Create a bitmap of cylinders that match our current gasmix
  */
-static unsigned int matching_gases(struct dive *dive, struct gasmix *gasmix)
+static unsigned int matching_gases(struct dive *dive, struct gasmix gasmix)
 {
 	int i;
 	unsigned int gases = 0;
 
 	for (i = 0; i < MAX_CYLINDERS; i++) {
 		cylinder_t *cyl = dive->cylinder + i;
-		if (same_gasmix(gasmix, &cyl->gasmix))
+		if (same_gasmix(gasmix, cyl->gasmix))
 			gases |= 1 << i;
 	}
 	return gases;
@@ -781,10 +781,10 @@ static void calculate_sac(struct dive *dive, struct divecomputer *dc, struct plo
 
 	for (int i = 0; i < pi->nr; i++) {
 		struct plot_data *entry = pi->entry + i;
-		struct gasmix newmix = get_gasmix(dive, dc, entry->sec, &ev, &gasmix);
-		if (!same_gasmix(&newmix, &gasmix)) {
+		struct gasmix newmix = get_gasmix(dive, dc, entry->sec, &ev, gasmix);
+		if (!same_gasmix(newmix, gasmix)) {
 			gasmix = newmix;
-			gases = matching_gases(dive, &newmix);
+			gases = matching_gases(dive, newmix);
 		}
 
 		fill_sac(dive, pi, i, gases);
@@ -907,7 +907,7 @@ static void setup_gas_sensor_pressure(struct dive *dive, struct divecomputer *dc
 
 #ifndef SUBSURFACE_MOBILE
 /* calculate DECO STOP / TTS / NDL */
-static void calculate_ndl_tts(struct deco_state *ds, struct dive *dive, struct plot_data *entry, struct gasmix *gasmix, double surface_pressure,enum divemode_t divemode)
+static void calculate_ndl_tts(struct deco_state *ds, struct dive *dive, struct plot_data *entry, struct gasmix gasmix, double surface_pressure,enum divemode_t divemode)
 {
 	/* FIXME: This should be configurable */
 	/* ascent speed up to first deco stop */
@@ -1026,7 +1026,7 @@ void calculate_deco_information(struct deco_state *ds, struct deco_state *planne
 			int time_stepsize = 20;
 
 			current_divemode = get_current_divemode(dc, entry->sec, &evd, &current_divemode);
-			gasmix = get_gasmix(dive, dc, t1, &ev, &gasmix);
+			gasmix = get_gasmix(dive, dc, t1, &ev, gasmix);
 			entry->ambpressure = depth_to_bar(entry->depth, dive);
 			entry->gfline = get_gf(ds, entry->ambpressure, dive) * (100.0 - AMB_PERCENTAGE) + AMB_PERCENTAGE;
 			if (t0 > t1) {
@@ -1040,7 +1040,7 @@ void calculate_deco_information(struct deco_state *ds, struct deco_state *planne
 			for (j = t0 + time_stepsize; j <= t1; j += time_stepsize) {
 				int depth = interpolate(entry[-1].depth, entry[0].depth, j - t0, t1 - t0);
 				add_segment(ds, depth_to_bar(depth, dive),
-					    &gasmix, time_stepsize, entry->o2pressure.mbar, current_divemode, entry->sac);
+					    gasmix, time_stepsize, entry->o2pressure.mbar, current_divemode, entry->sac);
 				entry->icd_warning = ds->icd_warning;
 				if ((t1 - j < time_stepsize) && (j < t1))
 					time_stepsize = t1 - j;
@@ -1115,7 +1115,7 @@ void calculate_deco_information(struct deco_state *ds, struct deco_state *planne
 				/* We are going to mess up deco state, so store it for later restore */
 				struct deco_state *cache_data = NULL;
 				cache_deco_state(ds, &cache_data);
-				calculate_ndl_tts(ds, dive, entry, &gasmix, surface_pressure, current_divemode);
+				calculate_ndl_tts(ds, dive, entry, gasmix, surface_pressure, current_divemode);
 				if (decoMode() == VPMB && !in_planner() && i == pi->nr - 1)
 					final_tts = entry->tts_calc;
 				/* Restore "real" deco state for next real time step */
@@ -1213,15 +1213,15 @@ static void calculate_gas_information_new(struct dive *dive, struct divecomputer
 		int fn2, fhe;
 		struct plot_data *entry = pi->entry + i;
 
-		gasmix = get_gasmix(dive, dc, entry->sec, &evg, &gasmix);
+		gasmix = get_gasmix(dive, dc, entry->sec, &evg, gasmix);
 		amb_pressure = depth_to_bar(entry->depth, dive);
 		current_divemode = get_current_divemode(dc, entry->sec, &evd, &current_divemode);
-		fill_pressures(&entry->pressures, amb_pressure, &gasmix, (current_divemode == OC) ? 0.0 : entry->o2pressure.mbar / 1000.0, current_divemode);
+		fill_pressures(&entry->pressures, amb_pressure, gasmix, (current_divemode == OC) ? 0.0 : entry->o2pressure.mbar / 1000.0, current_divemode);
 		fn2 = (int)(1000.0 * entry->pressures.n2 / amb_pressure);
 		fhe = (int)(1000.0 * entry->pressures.he / amb_pressure);
 		if (dc->divemode == PSCR) { // OC pO2 is calulated for PSCR with or without external PO2 monitoring.
-			struct gasmix gasmix2 = get_gasmix(dive, dc, entry->sec, &evg, &gasmix);
-			entry->scr_OC_pO2.mbar = (int) depth_to_mbar(entry->depth, dive) * get_o2(&gasmix2) / 1000;
+			struct gasmix gasmix2 = get_gasmix(dive, dc, entry->sec, &evg, gasmix);
+			entry->scr_OC_pO2.mbar = (int) depth_to_mbar(entry->depth, dive) * get_o2(gasmix2) / 1000;
 		}
 
 		/* Calculate MOD, EAD, END and EADD based on partial pressures calculated before
@@ -1229,7 +1229,7 @@ static void calculate_gas_information_new(struct dive *dive, struct divecomputer
 		 * END takes O₂ + N₂ (air) into account ("Narcotic" for trimix dives)
 		 * EAD just uses N₂ ("Air" for nitrox dives) */
 		pressure_t modpO2 = { .mbar = (int)(prefs.modpO2 * 1000) };
-		entry->mod = (double)gas_mod(&gasmix, modpO2, dive, 1).mm;
+		entry->mod = (double)gas_mod(gasmix, modpO2, dive, 1).mm;
 		entry->end = (entry->depth + 10000) * (1000 - fhe) / 1000.0 - 10000;
 		entry->ead = (entry->depth + 10000) * fn2 / (double)N2_IN_AIR - 10000;
 		entry->eadd = (entry->depth + 10000) *
@@ -1237,7 +1237,7 @@ static void calculate_gas_information_new(struct dive *dive, struct divecomputer
 				       entry->pressures.n2 / amb_pressure * N2_DENSITY +
 				       entry->pressures.he / amb_pressure * HE_DENSITY) /
 				      (O2_IN_AIR * O2_DENSITY + N2_IN_AIR * N2_DENSITY) * 1000 - 10000;
-		entry->density = gas_density(&gasmix, depth_to_mbar(entry->depth, dive));
+		entry->density = gas_density(gasmix, depth_to_mbar(entry->depth, dive));
 		if (entry->mod < 0)
 			entry->mod = 0;
 		if (entry->ead < 0)
@@ -1387,11 +1387,10 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 	depthvalue = get_depth_units(entry->depth, NULL, &depth_unit);
 	put_format_loc(b, translate("gettextFromC", "@: %d:%02d\nD: %.1f%s\n"), FRACTION(entry->sec, 60), depthvalue, depth_unit);
 	for (cyl = 0; cyl < MAX_CYLINDERS; cyl++) {
-		struct gasmix *mix;
 		int mbar = GET_PRESSURE(entry, cyl);
 		if (!mbar)
 			continue;
-		mix = &displayed_dive.cylinder[cyl].gasmix;
+		struct gasmix mix = displayed_dive.cylinder[cyl].gasmix;
 		pressurevalue = get_pressure_units(mbar, &pressure_unit);
 		put_format_loc(b, translate("gettextFromC", "P: %d%s (%s)\n"), pressurevalue, pressure_unit, gasname(mix));
 	}

--- a/core/profile.h
+++ b/core/profile.h
@@ -77,7 +77,7 @@ void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int 
 struct plot_data *populate_plot_entries(struct dive *dive, struct divecomputer *dc, struct plot_info *pi);
 struct plot_info *analyze_plot_info(struct plot_info *pi);
 void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool fast, struct deco_state *planner_ds);
-void calculate_deco_information(struct deco_state *ds, struct deco_state *planner_de, struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool print_mode);
+void calculate_deco_information(struct deco_state *ds, const struct deco_state *planner_de, const struct dive *dive, const struct divecomputer *dc, struct plot_info *pi, bool print_mode);
 struct plot_data *get_plot_details_new(struct plot_info *pi, int time, struct membuffer *);
 
 /*

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -400,7 +400,7 @@ void selectedDivesGasUsed(QVector<QPair<QString, int> > &gasUsedOrdered)
 		get_gas_used(d, diveGases);
 		for (j = 0; j < MAX_CYLINDERS; j++)
 			if (diveGases[j].mliter) {
-				QString gasName = gasname(&d->cylinder[j].gasmix);
+				QString gasName = gasname(d->cylinder[j].gasmix);
 				gasUsed[gasName] += diveGases[j].mliter;
 			}
 	}
@@ -1228,8 +1228,8 @@ extern "C" char *picturedir_string()
 
 QString get_gas_string(struct gasmix gas)
 {
-	uint o2 = (get_o2(&gas) + 5) / 10, he = (get_he(&gas) + 5) / 10;
-	QString result = gasmix_is_air(&gas) ? gettextFromC::tr("AIR") : he == 0 ? (o2 == 100 ? gettextFromC::tr("OXYGEN") : QString("EAN%1").arg(o2, 2, 10, QChar('0'))) : QString("%1/%2").arg(o2).arg(he);
+	uint o2 = (get_o2(gas) + 5) / 10, he = (get_he(gas) + 5) / 10;
+	QString result = gasmix_is_air(gas) ? gettextFromC::tr("AIR") : he == 0 ? (o2 == 100 ? gettextFromC::tr("OXYGEN") : QString("EAN%1").arg(o2, 2, 10, QChar('0'))) : QString("%1/%2").arg(o2).arg(he);
 	return result;
 }
 

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -126,10 +126,10 @@ static void save_extra_data(struct membuffer *b, struct extra_data *ed)
 	}
 }
 
-static void put_gasmix(struct membuffer *b, struct gasmix *mix)
+static void put_gasmix(struct membuffer *b, struct gasmix mix)
 {
-	int o2 = mix->o2.permille;
-	int he = mix->he.permille;
+	int o2 = mix.o2.permille;
+	int he = mix.he.permille;
 
 	if (o2) {
 		put_format(b, " o2=%u.%u%%", FRACTION(o2, 10));
@@ -154,7 +154,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		put_pressure(b, cylinder->type.workingpressure, " workpressure=", "bar");
 		show_utf8(b, " description=", description, "");
 		strip_mb(b);
-		put_gasmix(b, &cylinder->gasmix);
+		put_gasmix(b, cylinder->gasmix);
 		put_pressure(b, cylinder->start, " start=", "bar");
 		put_pressure(b, cylinder->end, " end=", "bar");
 		if (cylinder->cylinder_use != OC_GAS)
@@ -385,7 +385,7 @@ static void save_one_event(struct membuffer *b, struct dive *dive, struct event 
 		struct gasmix mix = get_gasmix_from_event(dive, ev);
 		if (ev->gas.index >= 0)
 			show_integer(b, ev->gas.index, "cylinder=", "");
-		put_gasmix(b, &mix);
+		put_gasmix(b, mix);
 	}
 	put_string(b, "\n");
 }

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -382,10 +382,10 @@ static void save_one_event(struct membuffer *b, struct dive *dive, struct event 
 		show_index(b, ev->value, "value=", "");
 	show_utf8(b, " name=", ev->name, "");
 	if (event_is_gaschange(ev)) {
-		struct gasmix *mix = get_gasmix_from_event(dive, ev);
+		struct gasmix mix = get_gasmix_from_event(dive, ev);
 		if (ev->gas.index >= 0)
 			show_integer(b, ev->gas.index, "cylinder=", "");
-		put_gasmix(b, mix);
+		put_gasmix(b, &mix);
 	}
 	put_string(b, "\n");
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -307,10 +307,10 @@ static void save_one_event(struct membuffer *b, struct dive *dive, struct event 
 		show_index(b, ev->value, "value='", "'");
 	show_utf8(b, ev->name, " name='", "'", 1);
 	if (event_is_gaschange(ev)) {
-		struct gasmix *mix = get_gasmix_from_event(dive, ev);
+		struct gasmix mix = get_gasmix_from_event(dive, ev);
 		if (ev->gas.index >= 0)
 			show_integer(b, ev->gas.index, "cylinder='", "'");
-		put_gasmix(b, mix);
+		put_gasmix(b, &mix);
 	}
 	put_format(b, " />\n");
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -127,10 +127,10 @@ static void save_overview(struct membuffer *b, struct dive *dive)
 	show_utf8(b, dive->suit, "  <suit>", "</suit>\n", 0);
 }
 
-static void put_gasmix(struct membuffer *b, struct gasmix *mix)
+static void put_gasmix(struct membuffer *b, struct gasmix mix)
 {
-	int o2 = mix->o2.permille;
-	int he = mix->he.permille;
+	int o2 = mix.o2.permille;
+	int he = mix.he.permille;
 
 	if (o2) {
 		put_format(b, " o2='%u.%u%%'", FRACTION(o2, 10));
@@ -155,7 +155,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 			put_milli(b, " size='", volume, " l'");
 		put_pressure(b, cylinder->type.workingpressure, " workpressure='", " bar'");
 		show_utf8(b, description, " description='", "'", 1);
-		put_gasmix(b, &cylinder->gasmix);
+		put_gasmix(b, cylinder->gasmix);
 		put_pressure(b, cylinder->start, " start='", " bar'");
 		put_pressure(b, cylinder->end, " end='", " bar'");
 		if (cylinder->cylinder_use != OC_GAS)
@@ -310,7 +310,7 @@ static void save_one_event(struct membuffer *b, struct dive *dive, struct event 
 		struct gasmix mix = get_gasmix_from_event(dive, ev);
 		if (ev->gas.index >= 0)
 			show_integer(b, ev->gas.index, "cylinder='", "'");
-		put_gasmix(b, &mix);
+		put_gasmix(b, mix);
 	}
 	put_format(b, " />\n");
 }

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -236,10 +236,10 @@ void process_selected_dives(void)
 
 #define SOME_GAS 5000 // 5bar drop in cylinder pressure makes cylinder used
 
-bool has_gaschange_event(struct dive *dive, struct divecomputer *dc, int idx)
+bool has_gaschange_event(const struct dive *dive, const struct divecomputer *dc, int idx)
 {
 	bool first_gas_explicit = false;
-	struct event *event = get_next_event(dc->events, "gaschange");
+	const struct event *event = get_next_event(dc->events, "gaschange");
 	while (event) {
 		if (dc->sample && (event->time.seconds == 0 ||
 				   (dc->samples && dc->sample[0].time.seconds == event->time.seconds)))

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -309,14 +309,14 @@ static void get_gas_parts(struct gasmix mix, volume_t vol, int o2_in_topup, volu
 {
 	volume_t air = {};
 
-	if (gasmix_is_air(&mix)) {
+	if (gasmix_is_air(mix)) {
 		o2->mliter = 0;
 		he->mliter = 0;
 		return;
 	}
 
-	air.mliter = lrint(((double)vol.mliter * (1000 - get_he(&mix) - get_o2(&mix))) / (1000 - o2_in_topup));
-	he->mliter = lrint(((double)vol.mliter * get_he(&mix)) / 1000.0);
+	air.mliter = lrint(((double)vol.mliter * (1000 - get_he(mix) - get_o2(mix))) / (1000 - o2_in_topup));
+	he->mliter = lrint(((double)vol.mliter * get_he(mix)) / 1000.0);
 	o2->mliter += vol.mliter - he->mliter - air.mliter;
 }
 

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -207,7 +207,7 @@ QString DiveObjectHelper::gas() const
 		gas = m_dive->cylinder[i].type.description;
 		if (!gas.isEmpty())
 			gas += QChar(' ');
-		gas += gasname(&m_dive->cylinder[i].gasmix);
+		gas += gasname(m_dive->cylinder[i].gasmix);
 		// if has a description and if such gas is not already present
 		if (!gas.isEmpty() && gases.indexOf(gas) == -1) {
 			if (!gases.isEmpty())

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -351,10 +351,10 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 
 			if (is_cylinder_used(dive, i) || (prefs.display_unused_tanks && dive->cylinder[i].type.description)){
 				put_format(&buf, "\\def\\cyl%cdescription{%s}\n", 'a' + i, dive->cylinder[i].type.description);
-				put_format(&buf, "\\def\\cyl%cgasname{%s}\n", 'a' + i, gasname(&dive->cylinder[i].gasmix));
-				put_format(&buf, "\\def\\cyl%cmixO2{%.1f\\%%}\n", 'a' + i, get_o2(&dive->cylinder[i].gasmix)/10.0);
-				put_format(&buf, "\\def\\cyl%cmixHe{%.1f\\%%}\n", 'a' + i, get_he(&dive->cylinder[i].gasmix)/10.0);
-				put_format(&buf, "\\def\\cyl%cmixN2{%.1f\\%%}\n", 'a' + i, (100.0 - (get_o2(&dive->cylinder[i].gasmix)/10.0) - (get_he(&dive->cylinder[i].gasmix)/10.0)));
+				put_format(&buf, "\\def\\cyl%cgasname{%s}\n", 'a' + i, gasname(dive->cylinder[i].gasmix));
+				put_format(&buf, "\\def\\cyl%cmixO2{%.1f\\%%}\n", 'a' + i, get_o2(dive->cylinder[i].gasmix)/10.0);
+				put_format(&buf, "\\def\\cyl%cmixHe{%.1f\\%%}\n", 'a' + i, get_he(dive->cylinder[i].gasmix)/10.0);
+				put_format(&buf, "\\def\\cyl%cmixN2{%.1f\\%%}\n", 'a' + i, (100.0 - (get_o2(dive->cylinder[i].gasmix)/10.0) - (get_he(dive->cylinder[i].gasmix)/10.0)));
 				delta_p.mbar += dive->cylinder[i].start.mbar - dive->cylinder[i].end.mbar;
 				put_format(&buf, "\\def\\cyl%cstartpress{%.1f\\pressureunit}\n", 'a' + i, get_pressure_units(dive->cylinder[i].start.mbar, &unit)/1.0);
 				put_format(&buf, "\\def\\cyl%cendpress{%.1f\\pressureunit}\n", 'a' + i, get_pressure_units(dive->cylinder[i].end.mbar, &unit)/1.0);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -62,7 +62,7 @@ void TabDiveInformation::updateData()
 		gaslist.append(separator); volumes.append(separator); SACs.append(separator);
 		separator = "\n";
 
-		gaslist.append(gasname(&displayed_dive.cylinder[i].gasmix));
+		gaslist.append(gasname(displayed_dive.cylinder[i].gasmix));
 		if (!gases[i].mliter)
 			continue;
 		volumes.append(get_volume_string(gases[i], true));

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -51,7 +51,7 @@ struct event *DiveEventItem::getEvent()
 	return internalEvent;
 }
 
-void DiveEventItem::setEvent(struct event *ev, struct gasmix *lastgasmix)
+void DiveEventItem::setEvent(struct event *ev, struct gasmix lastgasmix)
 {
 	if (!ev)
 		return;
@@ -63,7 +63,7 @@ void DiveEventItem::setEvent(struct event *ev, struct gasmix *lastgasmix)
 	recalculatePos(true);
 }
 
-void DiveEventItem::setupPixmap(struct gasmix *lastgasmix)
+void DiveEventItem::setupPixmap(struct gasmix lastgasmix)
 {
 	const IconMetrics& metrics = defaultIconMetrics();
 #ifndef SUBSURFACE_MOBILE
@@ -94,13 +94,13 @@ void DiveEventItem::setupPixmap(struct gasmix *lastgasmix)
 	} else if (event_is_gaschange(internalEvent)) {
 		struct gasmix mix = get_gasmix_from_event(&displayed_dive, internalEvent);
 		struct icd_data icd_data;
-		bool icd = isobaric_counterdiffusion(lastgasmix, &mix, &icd_data);
+		bool icd = isobaric_counterdiffusion(lastgasmix, mix, &icd_data);
 		if (mix.he.permille) {
 			if (icd)
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-trimix-ICD-icon"));
 			else
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-trimix-icon"));
-		} else if (gasmix_is_air(&mix)) {
+		} else if (gasmix_is_air(mix)) {
 			if (icd)
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-air-ICD-icon"));
 			else
@@ -165,7 +165,7 @@ void DiveEventItem::setupPixmap(struct gasmix *lastgasmix)
 #undef EVENT_PIXMAP_BIGGER
 }
 
-void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
+void DiveEventItem::setupToolTipString(struct gasmix lastgasmix)
 {
 	// we display the event on screen - so translate
 	QString name = gettextFromC::tr(internalEvent->name);
@@ -177,12 +177,12 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 		struct gasmix mix = get_gasmix_from_event(&displayed_dive, internalEvent);
 		struct membuffer mb = {};
 		name += ": ";
-		name += gasname(&mix);
+		name += gasname(mix);
 
 		/* Do we have an explicit cylinder index?  Show it. */
 		if (internalEvent->gas.index >= 0)
 			name += tr(" (cyl. %1)").arg(internalEvent->gas.index + 1);
-		bool icd = isobaric_counterdiffusion(lastgasmix, &mix, &icd_data);
+		bool icd = isobaric_counterdiffusion(lastgasmix, mix, &icd_data);
 		if (icd_data.dHe < 0) {
 			put_format(&mb, "\n%s %s:%+.3g%% %s:%+.3g%%%s%+.3g%%",
 				qPrintable(tr("ICD")),
@@ -192,7 +192,7 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 			name += QString::fromUtf8(mb.buffer, mb.len);
 			free_buffer(&mb);
 		}
-		*lastgasmix = mix;
+		lastgasmix = mix;
 	} else if (same_string(internalEvent->name, "modechange")) {
 		name += QString(": %1").arg(gettextFromC::tr(divemode_text_ui[internalEvent->value]));
 	} else if (value) {

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -92,20 +92,20 @@ void DiveEventItem::setupPixmap(struct gasmix *lastgasmix)
 	} else if (internalEvent->type == SAMPLE_EVENT_BOOKMARK) {
 		setPixmap(EVENT_PIXMAP(":dive-bookmark-icon"));
 	} else if (event_is_gaschange(internalEvent)) {
-		struct gasmix *mix = get_gasmix_from_event(&displayed_dive, internalEvent);
+		struct gasmix mix = get_gasmix_from_event(&displayed_dive, internalEvent);
 		struct icd_data icd_data;
-		bool icd = isobaric_counterdiffusion(lastgasmix, mix, &icd_data);
-		if (mix->he.permille) {
+		bool icd = isobaric_counterdiffusion(lastgasmix, &mix, &icd_data);
+		if (mix.he.permille) {
 			if (icd)
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-trimix-ICD-icon"));
 			else
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-trimix-icon"));
-		} else if (gasmix_is_air(mix)) {
+		} else if (gasmix_is_air(&mix)) {
 			if (icd)
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-air-ICD-icon"));
 			else
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-air-icon"));
-		} else if (mix->o2.permille == 1000) {
+		} else if (mix.o2.permille == 1000) {
 			if (icd)
 				setPixmap(EVENT_PIXMAP_BIGGER(":gaschange-oxygen-ICD-icon"));
 			else
@@ -174,15 +174,15 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 
 	if (event_is_gaschange(internalEvent)) {
 		struct icd_data icd_data;
-		struct gasmix *mix = get_gasmix_from_event(&displayed_dive, internalEvent);
+		struct gasmix mix = get_gasmix_from_event(&displayed_dive, internalEvent);
 		struct membuffer mb = {};
 		name += ": ";
-		name += gasname(mix);
+		name += gasname(&mix);
 
 		/* Do we have an explicit cylinder index?  Show it. */
 		if (internalEvent->gas.index >= 0)
 			name += tr(" (cyl. %1)").arg(internalEvent->gas.index + 1);
-		bool icd = isobaric_counterdiffusion(lastgasmix, mix, &icd_data);
+		bool icd = isobaric_counterdiffusion(lastgasmix, &mix, &icd_data);
 		if (icd_data.dHe < 0) {
 			put_format(&mb, "\n%s %s:%+.3g%% %s:%+.3g%%%s%+.3g%%",
 				qPrintable(tr("ICD")),
@@ -192,7 +192,7 @@ void DiveEventItem::setupToolTipString(struct gasmix *lastgasmix)
 			name += QString::fromUtf8(mb.buffer, mb.len);
 			free_buffer(&mb);
 		}
-		*lastgasmix = *mix;
+		*lastgasmix = mix;
 	} else if (same_string(internalEvent->name, "modechange")) {
 		name += QString(": %1").arg(gettextFromC::tr(divemode_text_ui[internalEvent->value]));
 	} else if (value) {

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -13,7 +13,7 @@ class DiveEventItem : public DivePixmapItem {
 public:
 	DiveEventItem(QGraphicsItem *parent = 0);
 	~DiveEventItem();
-	void setEvent(struct event *ev, struct gasmix *lastgasmix);
+	void setEvent(struct event *ev, struct gasmix lastgasmix);
 	struct event *getEvent();
 	void eventVisibilityChanged(const QString &eventName, bool visible);
 	void setVerticalAxis(DiveCartesianAxis *axis);
@@ -25,8 +25,8 @@ slots:
 	void recalculatePos(bool instant = false);
 
 private:
-	void setupToolTipString(struct gasmix *lastgasmix);
-	void setupPixmap(struct gasmix *lastgasmix);
+	void setupToolTipString(struct gasmix lastgasmix);
+	void setupPixmap(struct gasmix lastgasmix);
 	DiveCartesianAxis *vAxis;
 	DiveCartesianAxis *hAxis;
 	DivePlotDataModel *dataModel;

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -413,8 +413,8 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 			struct gasmix gasmix = { 0 };
 			struct event *ev = NULL;
 			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
-			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, &gasmix);
-			int inert = 1000 - get_o2(&gasmix);
+			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);
+			int inert = 1000 - get_o2(gasmix);
 			mypen.setBrush(QBrush(ColorScale(value, inert)));
 			painter->setPen(mypen);
 			painter->drawLine(poly[i - 1], poly[i]);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -411,7 +411,7 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 		if (i < poly.count()) {
 			double value = dataModel->index(i, vDataColumn).data().toDouble();
 			struct gasmix gasmix = { 0 };
-			struct event *ev = NULL;
+			const struct event *ev = NULL;
 			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
 			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);
 			int inert = 1000 - get_o2(gasmix);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -410,11 +410,11 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 	for (int i = 1, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
 		if (i < poly.count()) {
 			double value = dataModel->index(i, vDataColumn).data().toDouble();
-			struct gasmix *gasmix = NULL;
+			struct gasmix gasmix = { 0 };
 			struct event *ev = NULL;
 			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
-			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);
-			int inert = 1000 - get_o2(gasmix);
+			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, &gasmix);
+			int inert = 1000 - get_o2(&gasmix);
 			mypen.setBrush(QBrush(ColorScale(value, inert)));
 			painter->setPen(mypen);
 			painter->drawLine(poly[i - 1], poly[i]);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -781,7 +781,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 		item->setHorizontalAxis(timeAxis);
 		item->setVerticalAxis(profileYAxis);
 		item->setModel(dataModel);
-		item->setEvent(event, &lastgasmix);
+		item->setEvent(event, lastgasmix);
 		item->setZValue(2);
 		scene()->addItem(item);
 		eventItems.push_back(item);
@@ -1710,7 +1710,7 @@ void ProfileWidget2::changeGas()
 		tank = rx.cap(1).toInt() - 1; // we display the tank 1 based
 	} else {
 		qDebug() << "failed to parse tank number";
-		tank = get_gasidx(&displayed_dive, &gasmix);
+		tank = get_gasidx(&displayed_dive, gasmix);
 	}
 	// add this both to the displayed dive and the current dive
 	add_gas_switch_event(current_dive, current_dc, seconds, tank);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -758,8 +758,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 	qDeleteAll(eventItems);
 	eventItems.clear();
 	struct event *event = currentdc->events;
-	struct event *ev;
-	struct gasmix lastgasmix = get_gasmix(&displayed_dive, current_dc, 1, &ev, NULL);
+	struct gasmix lastgasmix = get_gasmix_at_time(&displayed_dive, current_dc, duration_t{1});
 
 	while (event) {
 #ifndef SUBSURFACE_MOBILE

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -759,7 +759,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 	eventItems.clear();
 	struct event *event = currentdc->events;
 	struct event *ev;
-	struct gasmix lastgasmix = *get_gasmix(&displayed_dive, current_dc, 1, &ev, NULL);
+	struct gasmix lastgasmix = get_gasmix(&displayed_dive, current_dc, 1, &ev, NULL);
 
 	while (event) {
 #ifndef SUBSURFACE_MOBILE

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1452,7 +1452,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 	action->setData(event->globalPos());
 	QAction *splitAction = m.addAction(tr("Split dive into two"), this, SLOT(splitDive()));
 	splitAction->setData(event->globalPos());
-	struct event *ev = NULL;
+	const struct event *ev = NULL;
 	enum divemode_t divemode = UNDEF_COMP_TYPE;
 	QPointF scenePos = mapToScene(mapFromGlobal(event->globalPos()));
 	QString gas = action->text();
@@ -1695,7 +1695,7 @@ void ProfileWidget2::changeGas()
 
 	// if there is a gas change at this time stamp, remove it before adding the new one
 	struct event *gasChangeEvent = current_dc->events;
-	while ((gasChangeEvent = get_next_event(gasChangeEvent, "gaschange")) != NULL) {
+	while ((gasChangeEvent = get_next_event_mutable(gasChangeEvent, "gaschange")) != NULL) {
 		if (gasChangeEvent->time.seconds == seconds) {
 			remove_event(gasChangeEvent);
 			gasChangeEvent = current_dc->events;

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -104,7 +104,7 @@ void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
 
 	// start with the first gasmix and at the start of the dive
 	int cyl = explicit_first_cylinder(&displayed_dive, dc);
-	struct gasmix *gasmix = &displayed_dive.cylinder[cyl].gasmix;
+	struct gasmix gasmix = displayed_dive.cylinder[cyl].gasmix;
 	int startTime = 0;
 
 	// work through all the gas changes and add the rectangle for each gas while it was used
@@ -112,14 +112,14 @@ void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
 	while (ev && (int)ev->time.seconds < last_entry->sec) {
 		width = hAxis->posAtValue(ev->time.seconds) - hAxis->posAtValue(startTime);
 		left = hAxis->posAtValue(startTime);
-		createBar(left, width, gasmix);
+		createBar(left, width, &gasmix);
 		startTime = ev->time.seconds;
 		gasmix = get_gasmix_from_event(&displayed_dive, ev);
 		ev = get_next_event(ev->next, "gaschange");
 	}
 	width = hAxis->posAtValue(last_entry->sec) - hAxis->posAtValue(startTime);
 	left = hAxis->posAtValue(startTime);
-	createBar(left, width, gasmix);
+	createBar(left, width, &gasmix);
 }
 
 void TankItem::setHorizontalAxis(DiveCartesianAxis *horizontal)

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -108,7 +108,7 @@ void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
 	int startTime = 0;
 
 	// work through all the gas changes and add the rectangle for each gas while it was used
-	struct event *ev = get_next_event(dc->events, "gaschange");
+	const struct event *ev = get_next_event(dc->events, "gaschange");
 	while (ev && (int)ev->time.seconds < last_entry->sec) {
 		width = hAxis->posAtValue(ev->time.seconds) - hAxis->posAtValue(startTime);
 		left = hAxis->posAtValue(startTime);

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -57,15 +57,15 @@ void TankItem::setData(DivePlotDataModel *model, struct plot_info *plotInfo, str
 	modelDataChanged();
 }
 
-void TankItem::createBar(qreal x, qreal w, struct gasmix *gas)
+void TankItem::createBar(qreal x, qreal w, struct gasmix gas)
 {
 	// pick the right gradient, size, position and text
 	QGraphicsRectItem *rect = new QGraphicsRectItem(x, 0, w, height, this);
 	if (gasmix_is_air(gas))
 		rect->setBrush(air);
-	else if (gas->he.permille)
+	else if (gas.he.permille)
 		rect->setBrush(trimix);
-	else if (gas->o2.permille == 1000)
+	else if (gas.o2.permille == 1000)
 		rect->setBrush(oxygen);
 	else
 		rect->setBrush(nitrox);
@@ -112,14 +112,14 @@ void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
 	while (ev && (int)ev->time.seconds < last_entry->sec) {
 		width = hAxis->posAtValue(ev->time.seconds) - hAxis->posAtValue(startTime);
 		left = hAxis->posAtValue(startTime);
-		createBar(left, width, &gasmix);
+		createBar(left, width, gasmix);
 		startTime = ev->time.seconds;
 		gasmix = get_gasmix_from_event(&displayed_dive, ev);
 		ev = get_next_event(ev->next, "gaschange");
 	}
 	width = hAxis->posAtValue(last_entry->sec) - hAxis->posAtValue(startTime);
 	left = hAxis->posAtValue(startTime);
-	createBar(left, width, &gasmix);
+	createBar(left, width, gasmix);
 }
 
 void TankItem::setHorizontalAxis(DiveCartesianAxis *horizontal)

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -25,7 +25,7 @@ public slots:
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 
 private:
-	void createBar(qreal x, qreal w, struct gasmix *gas);
+	void createBar(qreal x, qreal w, struct gasmix gas);
 	DivePlotDataModel *dataModel;
 	DiveCartesianAxis *hAxis;
 	struct dive diveCylinderStore;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -81,7 +81,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	o2pressure_t last_sp;
 	bool oldRec = recalc;
 	struct divecomputer *dc = &(d->dc);
-	struct event *evd = NULL;
+	const struct event *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 	recalc = false;
 	CylindersModel::instance()->updateDive();

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -506,16 +506,16 @@ static void merge_cylinder_type(cylinder_type_t *src, cylinder_type_t *dst)
 	}
 }
 
-static void merge_cylinder_mix(struct gasmix *src, struct gasmix *dst)
+static void merge_cylinder_mix(struct gasmix src, struct gasmix *dst)
 {
 	if (!dst->o2.permille)
-		*dst = *src;
+		*dst = src;
 }
 
 static void merge_cylinder_info(cylinder_t *src, cylinder_t *dst)
 {
 	merge_cylinder_type(&src->type, &dst->type);
-	merge_cylinder_mix(&src->gasmix, &dst->gasmix);
+	merge_cylinder_mix(src->gasmix, &dst->gasmix);
 	MERGE_MAX(dst, dst, src, start.mbar);
 	MERGE_MIN(dst, dst, src, end.mbar);
 	if (!dst->cylinder_use)

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -58,8 +58,8 @@ void setupPlan(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(79, 260) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(&ean36, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean36, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(79, 260), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(79, 260), 0, 0, 1, OC);
 }
@@ -86,8 +86,8 @@ void setupPlanVpmb45m30mTx(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(45, 150) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(45, 150), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(45, 150), 0, 0, 1, OC);
 }
@@ -114,8 +114,8 @@ void setupPlanVpmb60m10mTx(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(&tx50_15, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(tx50_15, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 10 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -159,7 +159,7 @@ void setupPlanVpmb60m30minEan50(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -183,7 +183,7 @@ void setupPlanVpmb60m30minTx(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -231,8 +231,8 @@ void setupPlanVpmb100m60min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 60 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 }
@@ -258,8 +258,8 @@ void setupPlanVpmb100m10min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 10 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 }
@@ -307,9 +307,9 @@ void setupPlanVpmb100mTo70m30min(struct diveplan *dp)
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(18, 60);
-	plan_add_segment(dp, 0, gas_mod(&tx21_35, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(&oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 3, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(tx21_35, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 3, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 20 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 3 * 60, M_OR_FT(70, 230), 0, 0, 1, OC);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a split-off of a too-large commit in #1528. The ultimate goal is to make `merge_dive()` not modify the source dives, which is realized by taking `const` pointers. This is a part of the necessary `const`-ification. For `gasmix` I chose to pass by value instead of `const`-pointer. The old passing around pointers to mutable data seemed scary and `gasmix` is only two `int`s, which nicely fit into a 64-bit register.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make a number of functions `const`-clean.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
