### PR TITLE
 map-widget: add support for filtering of map locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop/Map-Widget: add support for filtering of map locations [#1581]
 - Android: switch to Download page when dive computer is plugged in and try to
   populate vendor / device / connection based on the information we get
 - Mobile: enable multiple cylinder editing for dives that uses more than one cylinder 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

If the dive list is filtered the map should hide dive locations
that do not match the dive list filter.

To achieve that, loop over dives instead of dive sites in
MapWidgetHelper::reloadMapLocations() and discard
dives that are hidden by the filter. Then check if a dive
has a dive site attached to it and re-use the old functionality.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

see above.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes https://github.com/Subsurface-divelog/subsurface/issues/1581

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

none

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

```
Desktop/Map-Widget: add support for filtering of map locations [#1581]
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

doesn't really need it. the change makes is that the users should get the expected map + filtering behavior.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@willemferguson @dirkhh @bstoeger 