### PR TITLE
Cleanup: user properly typed pointers

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -740,9 +740,8 @@ struct ws_info_t {
 extern struct ws_info_t ws_info[MAX_WS_INFO];
 
 extern bool cylinder_nodata(const cylinder_t *cyl);
-extern bool cylinder_none(void *_data);
-extern bool weightsystem_none(void *_data);
-extern bool no_weightsystems(weightsystem_t *ws);
+extern bool cylinder_none(const cylinder_t *cyl);
+extern bool weightsystem_none(const weightsystem_t *ws);
 extern void remove_cylinder(struct dive *dive, int idx);
 extern void remove_weightsystem(struct dive *dive, int idx);
 extern void reset_cylinders(struct dive *dive, bool track_gas);

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -69,15 +69,14 @@ bool cylinder_nodata(const cylinder_t *cyl)
 	       !cyl->deco_gas_used.mliter;
 }
 
-static bool cylinder_nosamples(cylinder_t *cyl)
+static bool cylinder_nosamples(const cylinder_t *cyl)
 {
 	return !cyl->sample_start.mbar &&
 	       !cyl->sample_end.mbar;
 }
 
-bool cylinder_none(void *_data)
+bool cylinder_none(const cylinder_t *cyl)
 {
-	cylinder_t *cyl = _data;
 	return cylinder_nodata(cyl) && cylinder_nosamples(cyl);
 }
 
@@ -101,18 +100,9 @@ const char *gasname(const struct gasmix *gasmix)
 	return gas;
 }
 
-bool weightsystem_none(void *_data)
+bool weightsystem_none(const weightsystem_t *ws)
 {
-	weightsystem_t *ws = _data;
 	return !ws->weight.grams && !ws->description;
-}
-
-bool no_weightsystems(weightsystem_t *ws)
-{
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++)
-		if (!weightsystem_none(ws + i))
-			return false;
-	return true;
 }
 
 /*

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1040,7 +1040,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	}
 	// not sure what we'd do if there was more than one weight system
 	// defined - for now just ignore that case
-	if (weightsystem_none((void *)&d->weightsystem[1])) {
+	if (weightsystem_none(&d->weightsystem[1])) {
 		if (myDive->sumWeight() != weight) {
 			diveChanged = true;
 			d->weightsystem[0].weight.grams = parseWeightToGrams(weight);


### PR DESCRIPTION
A trivial cleanup: replace void by properly typed pointers in
cylinder_none() and weightsystem_none(). Moreover, remove the
unused function no_weightsystems().

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial code cleanup. Nothing to add to the commit message.
