### PR TITLE
Parse: pass dive_table argument to parse_file()

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -499,9 +499,9 @@ extern int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, i
 extern int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table);
 extern int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table);
 extern int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table);
-extern int parse_dlf_buffer(unsigned char *buffer, size_t size);
+extern int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table);
 
-extern int parse_file(const char *filename);
+extern int parse_file(const char *filename, struct dive_table *table);
 extern int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 extern int parse_seabear_log(const char *filename);
 extern int parse_txt_file(const char *filename, const char *csv);

--- a/core/file.h
+++ b/core/file.h
@@ -16,7 +16,7 @@ extern void ostctools_import(const char *file, struct dive_table *table);
 extern "C" {
 #endif
 extern int readfile(const char *filename, struct memblock *mem);
-extern int try_to_open_zip(const char *filename);
+extern int try_to_open_zip(const char *filename, struct dive_table *table);
 #ifdef __cplusplus
 }
 #endif

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1654,7 +1654,7 @@ static timestamp_t parse_dlf_timestamp(unsigned char *buffer)
 	return offset + 946684800;
 }
 
-int parse_dlf_buffer(unsigned char *buffer, size_t size)
+int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table)
 {
 	unsigned char *ptr = buffer;
 	unsigned char event;
@@ -1663,7 +1663,7 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size)
 	int i;
 	char serial[6];
 
-	target_table = &dive_table;
+	target_table = table;
 
 	// Check for the correct file magic
 	if (ptr[0] != 'D' || ptr[1] != 'i' || ptr[2] != 'v' || ptr[3] != 'E')

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -620,7 +620,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 
 	showProgressBar();
 	QByteArray fileNamePtr = QFile::encodeName(filename);
-	if (!parse_file(fileNamePtr.data()))
+	if (!parse_file(fileNamePtr.data(), &dive_table))
 		setCurrentFile(fileNamePtr.data());
 	process_dives(false, false);
 	hideProgressBar();
@@ -1776,7 +1776,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		parse_file(fileNamePtr.data());
+		parse_file(fileNamePtr.data(), &dive_table);
 	}
 	process_dives(true, false);
 	refreshDisplay();
@@ -1823,7 +1823,7 @@ void MainWindow::loadFiles(const QStringList fileNames)
 	showProgressBar();
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		if (!parse_file(fileNamePtr.data())) {
+		if (!parse_file(fileNamePtr.data(), &dive_table)) {
 			setCurrentFile(fileNamePtr.data());
 			addRecentFile(fileNamePtr, false);
 		}

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -986,7 +986,7 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 			break;
 		}
 		/* parse file and import dives */
-		parse_file(QFile::encodeName(zipFile.fileName()));
+		parse_file(QFile::encodeName(zipFile.fileName()), &dive_table);
 		process_dives(true, false);
 		MainWindow::instance()->refreshDisplay();
 

--- a/export-html.cpp
+++ b/export-html.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 		qDebug() << "need --source and --output";
 		exit(1);
 	}
-	int ret = parse_file(qPrintable(source));
+	int ret = parse_file(qPrintable(source, &dive_table));
 	if (ret) {
 		fprintf(stderr, "parse_file returned %d\n", ret);
 		exit(1);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -255,7 +255,7 @@ void QMLManager::openLocalThenRemote(QString url)
 	QByteArray fileNamePrt = QFile::encodeName(url);
 	bool glo = qPrefCloudStorage::git_local_only();
 	prefs.git_local_only = true;
-	int error = parse_file(fileNamePrt.data());
+	int error = parse_file(fileNamePrt.data(), &dive_table);
 	qPrefCloudStorage::set_git_local_only(glo);
 	if (error) {
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
@@ -324,7 +324,7 @@ void QMLManager::updateAllGlobalLists()
 void QMLManager::mergeLocalRepo()
 {
 	char *filename = NOCLOUD_LOCALSTORAGE;
-	parse_file(filename);
+	parse_file(filename, &dive_table);
 	process_dives(true, false);
 }
 
@@ -389,7 +389,7 @@ void QMLManager::finishSetup()
 		QMLPrefs::instance()->setCredentialStatus(qPref::CS_NOCLOUD);
 		saveCloudCredentials();
 		appendTextToLog(tr("working in no-cloud mode"));
-		int error = parse_file(existing_filename);
+		int error = parse_file(existing_filename, &dive_table);
 		if (error) {
 			// we got an error loading the local file
 			setNotificationText(tr("Error parsing local storage, giving up"));
@@ -678,7 +678,7 @@ void QMLManager::loadDivesWithValidCredentials()
 		error = git_load_dives(git, branch);
 	} else {
 		appendTextToLog(QString("didn't receive valid git repo, try again"));
-		error = parse_file(fileNamePrt.data());
+		error = parse_file(fileNamePrt.data(), &dive_table);
 	}
 	if (!error) {
 		report_error("filename is now %s", fileNamePrt.data());

--- a/tests/testdivesiteduplication.cpp
+++ b/tests/testdivesiteduplication.cpp
@@ -5,7 +5,7 @@
 
 void TestDiveSiteDuplication::testReadV2()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf", &dive_table), 0);
 	QCOMPARE(dive_site_table.nr, 2);
 }
 

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -88,7 +88,7 @@ void TestGitStorage::testGitStorageLocal()
 	// test writing and reading back from local git storage
 	git_repository *repo;
 	git_libgit2_init();
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table), 0);
 	QFETCH(QString, testDirName);
 	QFETCH(QString, prefixRead);
 	QFETCH(QString, prefixWrite);
@@ -101,7 +101,7 @@ void TestGitStorage::testGitStorageLocal()
 	QCOMPARE(save_dives(qPrintable(repoNameWrite + "[test]")), 0);
 	QCOMPARE(save_dives("./SampleDivesV3.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(repoNameRead + "[test]")), 0);
+	QCOMPARE(parse_file(qPrintable(repoNameRead + "[test]"), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viagit.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -120,10 +120,10 @@ void TestGitStorage::testGitStorageCloud()
 	// connect to the ssrftest repository on the cloud server
 	// and repeat the same test as before with the local git storage
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table), 0);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -144,8 +144,8 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	// read the local repo from the previous test and add dive 10
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml"), 0);
+	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml", &dive_table), 0);
 	// calling process_dive() sorts the table, but calling it with
 	// is_imported == true causes it to try to update the window title... let's not do that
 	process_dives(false, false);
@@ -154,7 +154,7 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QCOMPARE(save_dives("./SampleDivesV3plus10local.ssrf"), 0);
 	clear_dive_file_data();
 	// open the cloud storage and compare
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10local.ssrf");
 	org.open(QFile::ReadOnly);
@@ -172,7 +172,7 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectorySave.removeRecursively(), true);
 	QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10fromcloud.ssrf"), 0);
 	org.close();
 	org.open(QFile::ReadOnly);
@@ -193,15 +193,15 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepoSave = localCacheDir + "save[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(localCacheRepoSave)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
+	QCOMPARE(parse_file(qPrintable(localCacheRepoSave), &dive_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives(qPrintable(localCacheRepoSave)), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
@@ -212,13 +212,13 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QDir localCacheDirectorySave(localCacheDir + "save");
 	QCOMPARE(localCacheDirectory.rename(localCacheDir + "save", localCacheDir), true);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12-merged.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf"), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml"), 0);
+	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf", &dive_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table), 0);
 	process_dives(false, false);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table), 0);
 	process_dives(false, false);
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10-11-12-merged.ssrf");
@@ -240,7 +240,7 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
@@ -256,7 +256,7 @@ void TestGitStorage::testGitStorageCloudMerge2()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify that first dive
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	process_dives(false, false);
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
@@ -272,7 +272,7 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesMinus1-merged.ssrf"), 0);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	QFile org("./SampleDivesMinus1-merged.ssrf");
@@ -296,7 +296,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QString cloudTestRepo("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org[ssrftest@hohndel.org]");
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	process_dives(false, false);
 	struct dive *dive = get_dive(0);
 	QVERIFY(dive != 0);
@@ -308,7 +308,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
-	QCOMPARE(parse_file(qPrintable(localCacheRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Create multi line dive notes\nDifferent line 2 and removed 3-5\n\nThat should be enough");
@@ -327,7 +327,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 		QCOMPARE(localCacheDirectory.rename(localCacheDir, localCacheDir + "save"), true);
 	}
 	// now we open the cloud storage repo and modify those first dive notes differently
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	process_dives(false, false);
 	dive = get_dive(0);
 	dive->notes = strdup("Completely different dive notes\nBut also multi line");
@@ -345,7 +345,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 	QCOMPARE(localCacheDirectorySave.rename(localCacheDir + "save", localCacheDir), true);
 
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo)), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(save_dives("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -21,9 +21,9 @@ void TestMerge::testMergeEmpty()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
 	process_dives(true, false);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
 	process_dives(true, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
@@ -44,9 +44,9 @@ void TestMerge::testMergeBackwards()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
 	process_dives(true, false);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
 	process_dives(true, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -127,13 +127,13 @@ int TestParse::parseDivingLog()
 int TestParse::parseV2NoQuestion()
 {
 	// parsing of a V2 file should work
-	return parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table);
 }
 
 int TestParse::parseV3()
 {
 	// parsing of a V3 files should succeed
-	return parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml");
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml", &dive_table);
 }
 
 void TestParse::testParse()
@@ -279,7 +279,7 @@ void TestParse::testParseDLD()
 	QString filename = SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.DLD";
 
 	QVERIFY(readfile(filename.toLatin1().data(), &mem) > 0);
-	QVERIFY(try_to_open_zip(filename.toLatin1().data()) > 0);
+	QVERIFY(try_to_open_zip(filename.toLatin1().data(), &dive_table) > 0);
 
 	fprintf(stderr, "number of dives from DLD: %d \n", dive_table.nr);
 
@@ -299,8 +299,8 @@ void TestParse::testParseMerge()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml"), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml", &dive_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml", &dive_table), 0);
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
 	FILE_COMPARE("./testmerge.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
@@ -371,7 +371,7 @@ int TestParse::parseCSVmanual(int units, std::string file)
 
 void TestParse::exportCSVDiveDetails()
 {
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table);
 
 	export_dives_xslt("testcsvexportmanual.csv", 0, 0, "xml2manualcsv.xslt");
 	export_dives_xslt("testcsvexportmanualimperial.csv", 0, 1, "xml2manualcsv.xslt");
@@ -420,7 +420,7 @@ int TestParse::parseCSVprofile(int units, std::string file)
 
 void TestParse::exportCSVDiveProfile()
 {
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table);
 
 	export_dives_xslt("testcsvexportprofile.csv", 0, 0, "xml2csv.xslt");
 	export_dives_xslt("testcsvexportprofileimperial.csv", 0, 1, "xml2csv.xslt");
@@ -438,13 +438,13 @@ void TestParse::exportCSVDiveProfile()
 
 void TestParse::exportUDDF()
 {
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml");
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table);
 
 	export_dives_xslt("testuddfexport.uddf", 0, 1, "uddf-export.xslt");
 
 	clear_dive_file_data();
 
-	parse_file("testuddfexport.uddf");
+	parse_file("testuddfexport.uddf", &dive_table);
 	export_dives_xslt("testuddfexport2.uddf", 0, 1, "uddf-export.xslt");
 
 	FILE_COMPARE("testuddfexport.uddf",

--- a/tests/testpicture.cpp
+++ b/tests/testpicture.cpp
@@ -23,7 +23,7 @@ void TestPicture::addPicture()
 	struct picture *pic1, *pic2;
 	verbose = 1;
 
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml", &dive_table), 0);
 	dive = get_dive(0);
 	QVERIFY(dive != NULL);
 	pic1 = dive->picture_list;

--- a/tests/testprofile.cpp
+++ b/tests/testprofile.cpp
@@ -4,7 +4,7 @@
 
 void TestProfile::testRedCeiling()
 {
-	parse_file("../dives/deep.xml");
+	parse_file("../dives/deep.xml", &dive_table);
 }
 
 QTEST_GUILESS_MAIN(TestProfile)

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -7,14 +7,14 @@
 
 void TestRenumber::setup()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
 	process_dives(false, false);
 	dive_table.preexisting = dive_table.nr;
 }
 
 void TestRenumber::testMerge()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &dive_table), 0);
 	process_dives(true, false);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
@@ -24,7 +24,7 @@ void TestRenumber::testMerge()
 
 void TestRenumber::testMergeAndAppend()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml"), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &dive_table), 0);
 	process_dives(true, false);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);


### PR DESCRIPTION
To enable undo of divelog-importing it is crucial that parse_file()
can parse into arbitrary dive tables.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This a tiny step in preparation for undo of dive-import. See commit-message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Pass `dive_table` to be filled out to `parse_file`
2) Adapt callers accordingly

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
