### PR TITLE
Mobile: default cylinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: add default cylinder functionality for new dives [#1535]
 - Desktop/Export: fix bug related to quoted text when exporting to HTML [#1576]
 - Desktop/Map-Widget: add support for filtering of map locations [#1581]
 - Android: switch to Download page when dive computer is plugged in and try to

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -10,6 +10,9 @@ import org.subsurfacedivelog.mobile 1.0
 Kirigami.ScrollablePage {
 	objectName: "Settings"
 	id: settingsPage
+	property alias defaultCylinderModel: defaultCylinderBox.model
+	property alias defaultCylinderIndex: defaultCylinderBox.currentIndex
+
 	title: qsTr("Settings")
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
@@ -300,6 +303,41 @@ Kirigami.ScrollablePage {
 			}
 
 		}
+		Rectangle {
+			color: subsurfaceTheme.darkerPrimaryColor
+			height: 1
+			opacity: 0.5
+			Layout.fillWidth: true
+		}
+		GridLayout {
+			id: defaultCylinder
+			columns: 2
+			width: parent.width - Kirigami.Units.gridUnit
+
+			Kirigami.Heading {
+				text: qsTr("Default Cylinder")
+				color: subsurfaceTheme.textColor
+				level: 4
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+				Layout.columnSpan: 2
+			}
+			Controls.Label {
+				Layout.alignment: Qt.AlignRight
+				text: qsTr("Cylinder:")
+				font.pointSize: subsurfaceTheme.smallPointSize
+			}
+			Controls.ComboBox {
+				id: defaultCylinderBox
+				flat: true
+				inputMethodHints: Qt.ImhNoPredictiveText
+				Layout.fillWidth: true
+				onActivated: {
+					general.set_default_cylinder(defaultCylinderBox.currentText)
+				}
+			}
+		}
+
 		Rectangle {
 			color: subsurfaceTheme.darkerPrimaryColor
 			height: 1

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -27,6 +27,7 @@ Kirigami.ApplicationWindow {
 	property alias locationServiceEnabled: manager.locationServiceEnabled
 	property alias pluggedInDeviceName: manager.pluggedInDeviceName
 	property alias showPin: prefs.showPin
+	property alias defaultCylinderIndex: settingsWindow.defaultCylinderIndex
 	onNotificationTextChanged: {
 		if (notificationText != "") {
 			// there's a risk that we have a >5 second gap in update events;
@@ -101,7 +102,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.cylinderModel2 = manager.cylinderInit
 		detailsWindow.cylinderModel3 = manager.cylinderInit
 		detailsWindow.cylinderModel4 = manager.cylinderInit
-		detailsWindow.cylinderIndex0 = -1
+		detailsWindow.cylinderIndex0 = general.default_cylinder == "" ? -1 : detailsWindow.cylinderModel0.indexOf(general.default_cylinder)
 		detailsWindow.usedCyl = ["",]
 		detailsWindow.weight = ""
 		detailsWindow.usedGas = []
@@ -371,6 +372,8 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				text: qsTr("Settings")
 				onTriggered: {
 					globalDrawer.close()
+					settingsWindow.defaultCylinderModel = manager.cylinderInit
+					general.default_cylinder === "" ? defaultCylinderIndex = "-1" : defaultCylinderIndex = settingsWindow.defaultCylinderModel.indexOf(general.default_cylinder)
 					stackView.push(settingsWindow)
 					detailsWindow.endEditMode()
 				}
@@ -617,6 +620,10 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	ThemeTest {
 		id: themetest
 		visible: false
+	}
+
+	SsrfGeneralPrefs {
+		id: general
 	}
 
 	onPluggedInDeviceNameChanged: {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This PR adds the default cylinder functionality to subsurface mobile.

### Changes made:
1) Add an option to the settings page for the user to select a default cylinder.
2) Make the choice persistent by saving to disk via qPrefGeneral
3) If a default cylinder is defined select that when adding a new dive.

### Related issues:
Fixes #1535

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
Add default cylinder functionality to Subsurface mobile.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
