### PR TITLE
RFC: Move and split match() function

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -468,6 +468,24 @@ static void event_divemode(char *buffer, int *value)
 	}
 }
 
+typedef void (*matchfn_t)(char *buffer, void *);
+static int match(const char *pattern, int plen,
+		 const char *name,
+		 matchfn_t fn, char *buf, void *data)
+{
+	switch (name[plen]) {
+	case '\0':
+	case '.':
+		break;
+	default:
+		return 0;
+	}
+	if (memcmp(pattern, name, plen))
+		return 0;
+	fn(buf, data);
+	return 1;
+}
+
 #define MATCH(pattern, fn, dest) ({ 			\
 	/* Silly type compatibility test */ 		\
 	if (0) (fn)("test", dest);			\

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -468,19 +468,21 @@ static void event_divemode(char *buffer, int *value)
 	}
 }
 
+/* Compare a pattern with a name, whereby the name may end in '\0' or '.'. */
+static int match_name(const char *pattern, const char *name)
+{
+	while (*pattern == *name && *pattern) {
+		pattern++;
+		name++;
+	}
+	return *pattern == '\0' && (*name == '\0' || *name == '.');
+}
+
 typedef void (*matchfn_t)(char *buffer, void *);
-static int match(const char *pattern, int plen,
-		 const char *name,
+static int match(const char *pattern, const char *name,
 		 matchfn_t fn, char *buf, void *data)
 {
-	switch (name[plen]) {
-	case '\0':
-	case '.':
-		break;
-	default:
-		return 0;
-	}
-	if (memcmp(pattern, name, plen))
+	if (!match_name(pattern, name))
 		return 0;
 	fn(buf, data);
 	return 1;
@@ -489,7 +491,7 @@ static int match(const char *pattern, int plen,
 #define MATCH(pattern, fn, dest) ({ 			\
 	/* Silly type compatibility test */ 		\
 	if (0) (fn)("test", dest);			\
-	match(pattern, strlen(pattern), name, (matchfn_t) (fn), buf, dest); })
+	match(pattern, name, (matchfn_t) (fn), buf, dest); })
 
 static void get_index(char *buffer, int *i)
 {

--- a/core/parse.c
+++ b/core/parse.c
@@ -114,23 +114,6 @@ void nonmatch(const char *type, const char *name, char *buffer)
 		       type, name, buffer);
 }
 
-int match(const char *pattern, int plen,
-		 const char *name,
-		 matchfn_t fn, char *buf, void *data)
-{
-	switch (name[plen]) {
-	case '\0':
-	case '.':
-		break;
-	default:
-		return 0;
-	}
-	if (memcmp(pattern, name, plen))
-		return 0;
-	fn(buf, data);
-	return 1;
-}
-
 void event_start(void)
 {
 	memset(&cur_event, 0, sizeof(cur_event));

--- a/core/parse.h
+++ b/core/parse.h
@@ -61,8 +61,6 @@ int trimspace(char *buffer);
 void clear_table(struct dive_table *table);
 void start_match(const char *type, const char *name, char *buffer);
 void nonmatch(const char *type, const char *name, char *buffer);
-typedef void (*matchfn_t)(char *buffer, void *);
-int match(const char *pattern, int plen, const char *name, matchfn_t fn, char *buf, void *data);
 void event_start(void);
 void event_end(void);
 struct divecomputer *get_dc(void);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a tiny first step to make the parser reentrant. Some match-functions have side-effects and therefore need to be passed parser-context. But they are the exception. Therefore split out the name comparison for these cases, whereas the old `match()` function can still be used for the common case.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move `match()` to `parse-xml.c`. It seems awfully XML specific
2) Split `match()` in two parts. One only for comparison, the other for comparison and calling the callback for matches.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
