### PR TITLE
Move arrays to linked lists while parsing SmartTrak tables

### DIFF
--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -8,7 +8,6 @@ option(COMMANDLINE "Build command line version" OFF)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_BUILD_TYPE "Release")
 
 set(SSRF_PATH ../)
 set(CMAKE_MODULE_PATH ${SSRF_PATH}cmake/Modules)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A user reported recently a crash of the importer tool to mailing list.
The crash was due to a too short memory allocation for an array while parsing Fish table.  It could be fixed by simply giving the array a higher (and supposedly) unreachable space, but it doesn't looks like a good practice.
So, I've gone to a major rework and changed most tables to linked lists which seem the simpler and best option.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Do no set CMake build type in CMakeLists, or we will be unable to build a binary with debug symbols.  Unrelated to the main bug but necessary or script selected mode would be useless.
2) Add some helper functions to manage lists (head insert, free, build ...)
3) Apply lists to table parsing  functions.
4) Disassociate table building from dive parsing. Just build the table equivalent list  once and reuse for each dive we parse.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
