### PR TITLE
 divelistview: always show at least one column 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: fix a bug where it is possible for the user to hide all divelist columns [#1600]
 - Mobile: add default cylinder functionality for new dives [#1535]
 - Desktop/Export: fix bug related to quoted text when exporting to HTML [#1576]
 - Desktop/Map-Widget: add support for filtering of map locations [#1581]

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -501,13 +501,30 @@ void DiveListView::toggleColumnVisibilityByIndex()
 	QAction *action = qobject_cast<QAction *>(sender());
 	if (!action)
 		return;
+	const int idx = action->property("index").toInt();
+
+	// Count the number of visible columns.
+	int totalVisible = 0, lastVisibleIdx = -1;
+	for (int i = 0; i < model()->columnCount(); i++) {
+		if (isColumnHidden(i))
+			continue;
+		totalVisible++;
+		lastVisibleIdx = i;
+	}
+	// If there is only one visible column and we are performing an action on it,
+	// don't hide the column and revert the action back to checked == true.
+	// This keeps one column visible at all times.
+	if (totalVisible == 1 && idx == lastVisibleIdx) {
+		action->setChecked(true);
+		return;
+	}
 
 	QSettings s;
 	s.beginGroup("DiveListColumnState");
 	s.setValue(action->property("settingName").toString(), action->isChecked());
 	s.endGroup();
 	s.sync();
-	setColumnHidden(action->property("index").toInt(), !action->isChecked());
+	setColumnHidden(idx, !action->isChecked());
 	setColumnWidth(lastVisibleColumn(), 10);
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Currently it is possible to hide all columns by unchecking them
in the context menu that appears by right clicking the header
of the divelist. But once all are hidden the header disappears.
This can cause a situation where the user cannot show any
columns and the only fix for that is to edit the application
configuration.

To avoid this situation prevent the last column from being hidden.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) in `DiveListView::toggleColumnVisibilityByIndex()` check if an action is performed on the last visible column
2) if the action is to hide the column revert the action and return.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1600 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
NONE

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
```
- Desktop: fix a bug where it is possible for the user to hide all divelist columns [#1600]
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
