### PR TITLE
modeldelegates: use font metrics for dive list row height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: fix issue with dive list row height in case of larger fonts [#1600]
 - Mobile: add default cylinder functionality for new dives [#1535]
 - Desktop/Export: fix bug related to quoted text when exporting to HTML [#1576]
 - Desktop/Map-Widget: add support for filtering of map locations [#1581]

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -24,7 +24,8 @@
 
 QSize DiveListDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const
 {
-	return QSize(50, 22);
+	const QFontMetrics metrics(qApp->font());
+	return QSize(50, qMax(22, metrics.height()));
 }
 
 // Gets the index of the model in the currentRow and column.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Include font metrics as part of the height in DiveListDelegate::sizeHint().

When 22px is hardcoded, this handles small fonts, but for larger
fonts it seem that the bottom of the dive list row text is cut
on Windows.

Keep 22px as the minimum size hint, but for larger fonts
use QFontMetric::height().

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) use font metrics in `DiveListDelegate::sizeHint()`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Refs #1600 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
NONE

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
```
- Desktop: fix issue with dive list row height in case of larger fonts [#1600]
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
