### PR TITLE
Filter: don't count dives on mouse-hover

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -69,6 +69,16 @@ void FilterModelBase::updateList(const QStringList &newList)
 		items.back().checked = true;
 		anyChecked = true;
 	}
+
+	// Finally, calculate and cache the counts. Ignore the last item, since
+	// this is the "Show Empty Tags" entry.
+	for (int i = 0; i < (int)newList.size() - 1; i++)
+		items[i].count = countDives(qPrintable(newList[i]));
+
+	// Calculate count of "Empty Tags".
+	if (!items.empty())
+		items.back().count = countDives("");
+
 	setStringList(newList);
 }
 
@@ -99,9 +109,8 @@ QVariant FilterModelBase::data(const QModelIndex &index, int role) const
 	if (role == Qt::CheckStateRole) {
 		return items[index.row()].checked ? Qt::Checked : Qt::Unchecked;
 	} else if (role == Qt::DisplayRole) {
-		QString value = stringList()[index.row()];
-		int count = countDives((index.row() == rowCount() - 1) ? "" : qPrintable(value));
-		return value + QString(" (%1)").arg(count);
+		int row = index.row();
+		return QStringLiteral("%1 (%2)").arg(stringList()[row], QString::number(items[row].count));
 	}
 	return QVariant();
 }

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -124,7 +124,7 @@ void FilterModelBase::selectAll()
 
 void FilterModelBase::invertSelection()
 {
-	for (Item &item : items)
+	for (Item &item: items)
 		item.checked = !item.checked;
 	anyChecked = std::any_of(items.begin(), items.end(), [](Item &item) { return !!item.checked; });
 	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
@@ -258,7 +258,7 @@ bool BuddyFilterModel::doFilter(const dive *d) const
 	// Checked means 'Show', Unchecked means 'Hide'.
 	QString persons = QString(d->buddy) + "," + QString(d->divemaster);
 	QStringList personsList = persons.split(',', QString::SkipEmptyParts);
-	for (QString &s : personsList)
+	for (QString &s: personsList)
 		s = s.trimmed();
 	// only show empty buddie dives if the user checked that.
 	if (personsList.isEmpty())

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -14,6 +14,7 @@ class FilterModelBase : public QStringListModel {
 protected:
 	struct Item {
 		bool checked;
+		int count;
 	};
 	std::vector<Item> items;
 public:

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -11,12 +11,16 @@ struct dive;
 
 class FilterModelBase : public QStringListModel {
 	Q_OBJECT
+protected:
+	struct Item {
+		bool checked;
+	};
+	std::vector<Item> items;
 public:
 	virtual bool doFilter(const dive *d) const = 0;
 	void clearFilter();
 	void selectAll();
 	void invertSelection();
-	std::vector<char> checkState;
 	bool anyChecked;
 	bool negate;
 public


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While working on integrating #1528 with the filters, I noticed that we have some very crazy behavior:

In `FilterModelBase::data()`, when accessing the name of a filter-item, the dives are counted. This is fired - among other things - for every mouse-hover event(!). It's amazing that people with huge dive logs didn't notice (especially since some people are reportedly working with 32-bit machines).

This commit fixes this problem by calculating the counts once on repopulating the filters. Moreover, this is a first step towards proper qt-model semantics for the filter-boxes [insert / move / remove].

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn the checked-flag into a struct.
2) Add a count item to the struct.
3) Count dives on repopulate and then use the cached value.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed (not really user-visible).

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed (not really user-visible).

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
