### PR TITLE
Usb storage branch

### DIFF
--- a/core/android.cpp
+++ b/core/android.cpp
@@ -81,7 +81,7 @@ const char *system_default_filename(void)
 	return path;
 }
 
-int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
+int enumerate_devices(device_callback_t callback, void *userdata, unsigned int transport)
 {
 	/* FIXME: we need to enumerate in some other way on android */
 	/* qtserialport maybee? */

--- a/core/display.h
+++ b/core/display.h
@@ -2,6 +2,8 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
+#include "libdivecomputer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,11 +46,7 @@ extern int is_default_dive_computer(const char *, const char *);
 
 typedef void (*device_callback_t)(const char *name, void *userdata);
 
-#define DC_TYPE_SERIAL 1
-#define DC_TYPE_UEMIS 2
-#define DC_TYPE_OTHER 3
-
-int enumerate_devices(device_callback_t callback, void *userdata, int dc_type);
+int enumerate_devices(device_callback_t callback, void *userdata, unsigned int transport);
 
 extern const char *default_dive_computer_vendor;
 extern const char *default_dive_computer_product;

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -158,6 +158,7 @@ void fill_computer_list()
 	mydescriptor->product = "Zurich";
 	mydescriptor->type = DC_FAMILY_NULL;
 	mydescriptor->model = 0;
+	mydescriptor->transports = DC_TRANSPORT_USBSTORAGE;
 
 	if (!vendorList.contains("Uemis"))
 		vendorList.append("Uemis");
@@ -171,14 +172,15 @@ void fill_computer_list()
 	qSort(vendorList);
 }
 
-#define NUMTRANSPORTS 6
+#define NUMTRANSPORTS 7
 static QString transportStringTable[NUMTRANSPORTS] = {
 	QStringLiteral("SERIAL"),
 	QStringLiteral("USB"),
 	QStringLiteral("USBHID"),
 	QStringLiteral("IRDA"),
 	QStringLiteral("BT"),
-	QStringLiteral("BLE")
+	QStringLiteral("BLE"),
+	QStringLiteral("USBSTORAGE"),
 };
 
 static QString getTransportString(unsigned int transport)

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -78,6 +78,7 @@ struct mydescriptor {
 	const char *product;
 	dc_family_t type;
 	unsigned int model;
+	unsigned int transports;
 };
 
 /* This fills the vendor list QStringList and related members.

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -12,6 +12,11 @@
 #include <libdivecomputer/device.h>
 #include <libdivecomputer/parser.h>
 
+// Even if we have an old libdivecomputer, Uemis uses this
+#ifndef DC_TRANSPORT_USBSTORAGE
+#define DC_TRANSPORT_USBSTORAGE (1 << 6)
+#endif
+
 #include "dive.h"
 
 #ifdef __cplusplus

--- a/core/macos.c
+++ b/core/macos.c
@@ -144,7 +144,8 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 		}
 
 		while ((ep = readdir(dp)) != NULL) {
-			if (fnmatch("UEMISSDA", ep->d_name, 0) == 0) {
+			if (fnmatch("UEMISSDA", ep->d_name, 0) == 0 ||
+			    fnmatch("GARMIN", ep->d_name, 0) == 0) {
 				char filename[1024];
 				int n = snprintf(filename, sizeof(filename), "%s/%s", dirname, ep->d_name);
 				if (n >= (int)sizeof(filename)) {

--- a/core/macos.c
+++ b/core/macos.c
@@ -97,13 +97,13 @@ const char *system_default_filename(void)
 	return path;
 }
 
-int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
+int enumerate_devices(device_callback_t callback, void *userdata, unsigned int transport)
 {
 	int index = -1, entries = 0;
 	DIR *dp = NULL;
 	struct dirent *ep = NULL;
 	size_t i;
-	if (dc_type != DC_TYPE_UEMIS) {
+	if (transport & DC_TRANSPORT_SERIAL) {
 		const char *dirname = "/dev";
 		const char *patterns[] = {
 			"tty.*",
@@ -135,7 +135,7 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 		}
 		closedir(dp);
 	}
-	if (dc_type != DC_TYPE_SERIAL) {
+	if (transport & DC_TRANSPORT_USBSTORAGE) {
 		const char *dirname = "/Volumes";
 		int num_uemis = 0;
 		dp = opendir(dirname);

--- a/core/unix.c
+++ b/core/unix.c
@@ -100,7 +100,7 @@ const char *system_default_filename(void)
 	return path;
 }
 
-int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
+int enumerate_devices(device_callback_t callback, void *userdata, unsigned int transport)
 {
 	int index = -1, entries = 0;
 	DIR *dp = NULL;
@@ -110,7 +110,7 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 	char *line = NULL;
 	char *fname;
 	size_t len;
-	if (dc_type != DC_TYPE_UEMIS) {
+	if (transport & DC_TRANSPORT_SERIAL) {
 		const char *dirname = "/dev";
 #ifdef __OpenBSD__
 		const char *patterns[] = {
@@ -153,7 +153,7 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 		closedir(dp);
 	}
 #ifdef __linux__
-	if (dc_type != DC_TYPE_SERIAL) {
+	if (transport & DC_TRANSPORT_USBSTORAGE) {
 		int num_uemis = 0;
 		file = fopen("/proc/mounts", "r");
 		if (file == NULL)

--- a/core/unix.c
+++ b/core/unix.c
@@ -161,6 +161,8 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 
 		while ((getline(&line, &len, file)) != -1) {
 			char *ptr = strstr(line, "UEMISSDA");
+			if (!ptr)
+				ptr = strstr(line, "GARMIN");
 			if (ptr) {
 				char *end = ptr, *start = ptr;
 				while (start > line && *start != ' ')

--- a/core/windows.c
+++ b/core/windows.c
@@ -173,7 +173,7 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 		int i;
 		int count_drives = 0;
 		const int bufdef = 512;
-		const char *dlabels[] = {"UEMISSDA", NULL};
+		const char *dlabels[] = {"UEMISSDA", "GARMIN", NULL};
 		char bufname[bufdef], bufval[bufdef], *p;
 		DWORD bufname_len;
 

--- a/core/windows.c
+++ b/core/windows.c
@@ -117,11 +117,11 @@ const char *system_default_filename(void)
 	return path;
 }
 
-int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
+int enumerate_devices(device_callback_t callback, void *userdata, unsigned int transport)
 {
 	int index = -1;
 	DWORD i;
-	if (dc_type != DC_TYPE_UEMIS) {
+	if (transport & DC_TRANSPORT_SERIAL) {
 		// Open the registry key.
 		HKEY hKey;
 		LONG rc = RegOpenKeyEx(HKEY_LOCAL_MACHINE, "HARDWARE\\DEVICEMAP\\SERIALCOMM", 0, KEY_QUERY_VALUE, &hKey);
@@ -169,7 +169,7 @@ int enumerate_devices(device_callback_t callback, void *userdata, int dc_type)
 
 		RegCloseKey(hKey);
 	}
-	if (dc_type != DC_TYPE_SERIAL) {
+	if (transport & DC_TRANSPORT_USBSTORAGE) {
 		int i;
 		int count_drives = 0;
 		const int bufdef = 512;

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -398,11 +398,11 @@ static void fillDeviceList(const char *name, void *data)
 	comboBox->addItem(name);
 }
 
-void ConfigureDiveComputerDialog::fill_device_list(int dc_type)
+void ConfigureDiveComputerDialog::fill_device_list(unsigned int transport)
 {
 	int deviceIndex;
 	ui.device->clear();
-	deviceIndex = enumerate_devices(fillDeviceList, ui.device, dc_type);
+	deviceIndex = enumerate_devices(fillDeviceList, ui.device, transport);
 	if (deviceIndex >= 0)
 		ui.device->setCurrentIndex(deviceIndex);
 }
@@ -1445,12 +1445,12 @@ void ConfigureDiveComputerDialog::on_DiveComputerList_currentRowChanged(int curr
 		return;
 	}
 
-	int dcType = DC_TYPE_SERIAL;
+	unsigned int transport = DC_TRANSPORT_SERIAL;
 
 
 	if (selected_vendor == QString("Uemis"))
-		dcType = DC_TYPE_UEMIS;
-	fill_device_list(dcType);
+		transport = DC_TRANSPORT_USBSTORAGE;
+	fill_device_list(transport);
 }
 
 void ConfigureDiveComputerDialog::checkLogFile(int state)

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -102,7 +102,7 @@ private:
 	device_data_t device_data;
 	void getDeviceData();
 
-	void fill_device_list(int dc_type);
+	void fill_device_list(unsigned int transport);
 
 	DeviceDetails *deviceDetails;
 	void populateDeviceDetails();

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -143,7 +143,7 @@ void DownloadFromDCWidget::updateState(states state)
 		return;
 
 	if (state == INITIAL) {
-		fill_device_list(DC_TYPE_OTHER);
+		fill_device_list(~0);
 		ui.progressBar->hide();
 		markChildrenAsEnabled();
 		timer->stop();
@@ -229,15 +229,17 @@ void DownloadFromDCWidget::updateState(states state)
 	currentState = state;
 }
 
+// FIXME! Get the transport list from libdivecomputer!
 void DownloadFromDCWidget::on_vendor_currentIndexChanged(const QString &vendor)
 {
-	int dcType = DC_TYPE_SERIAL;
+	unsigned int transport;
+	dc_descriptor_t *descriptor;
 	productModel.setStringList(productList[vendor]);
 	ui.product->setCurrentIndex(0);
 
-	if (vendor == QString("Uemis"))
-		dcType = DC_TYPE_UEMIS;
-	fill_device_list(dcType);
+	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
+	transport = dc_descriptor_get_transports(descriptor);
+	fill_device_list(transport);
 }
 
 void DownloadFromDCWidget::on_product_currentIndexChanged(const QString &)
@@ -475,7 +477,7 @@ void DownloadFromDCWidget::updateDeviceEnabled()
 	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
 
 	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
-	if (dc_descriptor_get_transports(descriptor) & DC_TRANSPORT_SERIAL) {
+	if (dc_descriptor_get_transports(descriptor) & (DC_TRANSPORT_SERIAL | DC_TRANSPORT_USBSTORAGE)) {
 		// if the dc_transport_t is DC_TRANSPORT_SERIAL, then enable the device node box.
 		ui.device->setEnabled(true);
 	} else {
@@ -567,11 +569,11 @@ static void fillDeviceList(const char *name, void *data)
 	comboBox->addItem(name);
 }
 
-void DownloadFromDCWidget::fill_device_list(int dc_type)
+void DownloadFromDCWidget::fill_device_list(unsigned int transport)
 {
 	int deviceIndex;
 	ui.device->clear();
-	deviceIndex = enumerate_devices(fillDeviceList, ui.device, dc_type);
+	deviceIndex = enumerate_devices(fillDeviceList, ui.device, transport);
 	if (deviceIndex >= 0)
 		ui.device->setCurrentIndex(deviceIndex);
 }

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -68,7 +68,7 @@ private:
 
 	int previousLast;
 
-	void fill_device_list(int dc_type);
+	void fill_device_list(unsigned int transport);
 	QTimer *timer;
 	bool dumpWarningShown;
 	OstcFirmwareCheck *ostcFirmwareCheck;


### PR DESCRIPTION
I'm finally looking at the Garmin Descent Mk1 now that the merge window is over.

And this does *not* add support for it, but this does add the scaffolding to subsurface for libdivecomputer supporting it. Eventually.

It basically does a first pass of trying to generalize some of the Uemis downloader support as a "USB Storage" support, and remove the special cases that made it Uemis only.

NOTE! Some special cases still remain, eg the whole OS specific "find the Uemis mount point" has just been hacked up into a "find the Uemis or Garmin mount point". 

But the core downloader code now just looks at "what are the supported download protocols of the dive computer" and the device node lookup looks at "do I want DC_PROTOCOL_SERIAL nodes" etc. It used to have a special "dc_type" (which was really "Uemis or not") rather than try to look at what protocols the dive computer supported.

Again - this should not change anything for existing dive computer support, it's purely preparatory for an eventual libdivecomputer entry for the Garmin Descent.