### PR TITLE
Show new firmware notice for OSTC Plus

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -236,7 +236,7 @@ OstcFirmwareCheck::OstcFirmwareCheck(QString product) : parent(0)
 {
 	QUrl url;
 	memset(&devData, 1, sizeof(devData));
-	if (product == "OSTC 3" || product == "OSTC 3+" || product == "OSTC cR") {
+	if (product == "OSTC 3" || product == "OSTC 3+" || product == "OSTC cR" || product == "OSTC Plus") {
 		url = QUrl("http://www.heinrichsweikamp.net/autofirmware/ostc3_changelog.txt");
 		latestFirmwareHexFile = QString("http://www.heinrichsweikamp.net/autofirmware/ostc3_firmware.hex");
 	} else if (product == "OSTC Sport") {

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -331,7 +331,7 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	//
 	// We shouldn't do this for memory dumps.
 	if ((product == "OSTC 3" || product == "OSTC 3+" || product == "OSTC cR" ||
-	     product == "OSTC Sport" || product == "OSTC 4") &&
+	     product == "OSTC Sport" || product == "OSTC 4" || product == "OSTC Plus") &&
 	    !data->saveDump()) {
 		ostcFirmwareCheck = new OstcFirmwareCheck(product);
 	}


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Also show a new firmware notice for a HW OSTC Plus. This appeared to be broken (as can be verified on the current master from today, as HW just released version 2.98 of the firmware).

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
Notice that there is some confusion in both Subsurface and Libdivecomputer with respect to types of OSTCs. Physically, there exist 2 type of OSTC3's. The first edition with only DC_TRANSPORT_SERIAL (and an USB connector), and a second version that lacks the connector but supports both BT and BLE. Confusingly, the second version is marked OSTC3 on the device, but the user needs to select OSTC Plus (which is basically a 3rd version of the OSTC3, combined with a successor of the OSTC Sport) to download dives using BT/BLE.
