### PR TITLE
Dive trips: don't crash on repeated trip-removal

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -684,9 +684,12 @@ void DiveListView::removeFromTrip()
 	struct dive *d;
 	QMap<struct dive*, dive_trip*> divesToRemove;
 	for_each_dive (i, d) {
-		if (d->selected)
+		if (d->selected && d->divetrip)
 			divesToRemove.insert(d, d->divetrip);
 	}
+	if (divesToRemove.isEmpty())
+		return;
+
 	UndoRemoveDivesFromTrip *undoCommand = new UndoRemoveDivesFromTrip(divesToRemove);
 	MainWindow::instance()->undoStack->push(undoCommand);
 


### PR DESCRIPTION
In the UI it is possible to remove a dive from a trip twice,
which leads to a crash, because trip is NULL (obviously).

Instead of doing a proper fix (don't show the "remove from
trip" entry in the first place), ignore dives without a
trip, since a rewrite of the undo-code is planned for the
medium future anyway.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The commit message says it all: avoid null pointer access on double-trip-removal.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Check if dive belongs to trip before removing it.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
