### PR TITLE
Filter: unify data structure of FilterBaseModel

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -211,7 +211,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 	connect(ui.diveNotesMessage, &KMessageWidget::showAnimationFinished,
 					ui.location, &DiveLocationLineEdit::fixPopupPosition);
-	connect(this, SIGNAL(diveSiteAdded(const QString &)), LocationFilterModel::instance(), SLOT(addName(const QString &)));
 
 	// enable URL clickability in notes:
 	new TextHyperlinkEventFilter(ui.notes);//destroyed when ui.notes is destroyed
@@ -739,7 +738,7 @@ uint32_t MainTab::updateDiveSite(uint32_t pickedUuid, int divenr)
 		QString name = ui.location->text().isEmpty() ? tr("New dive site") : ui.location->text();
 		pickedUuid = create_dive_site(qPrintable(name), displayed_dive.when);
 		createdNewDive = true;
-		emit diveSiteAdded(name);
+		LocationFilterModel::instance()->addName(name);
 	}
 
 	newDs = get_dive_site_by_uuid(pickedUuid);

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -60,7 +60,6 @@ signals:
 	void addDiveFinished();
 	void dateTimeChanged();
 	void diveSiteChanged(struct dive_site * ds);
-	void diveSiteAdded(const QString &);
 public
 slots:
 	void addCylinder_clicked();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -102,8 +102,13 @@ void FilterModelBase::changeName(const QString &oldName, const QString &newName)
 
 // Update the the items array.
 // The last item is supposed to be the "Show Empty Tags" entry.
-void FilterModelBase::updateList(const QStringList &newList)
+// All other items will be sorted alphabetically. Attention: the passed-in list is modified!
+void FilterModelBase::updateList(QStringList &newList)
 {
+	// Sort list, but leave out last element by using std::prev()
+	if (!newList.empty())
+		std::sort(newList.begin(), std::prev(newList.end()));
+
 	beginResetModel();
 
 	// Keep copy of the old items array to reimport the checked state later.
@@ -264,7 +269,6 @@ void SuitsFilterModel::repopulate()
 			list.append(suit);
 		}
 	}
-	qSort(list);
 	list << tr("No suit set");
 	updateList(list);
 }
@@ -289,7 +293,6 @@ void TagFilterModel::repopulate()
 			list.append(QString(current_tag_entry->tag->name));
 		current_tag_entry = current_tag_entry->next;
 	}
-	qSort(list);
 	list << tr("Empty tags");
 	updateList(list);
 }
@@ -368,7 +371,6 @@ void BuddyFilterModel::repopulate()
 			}
 		}
 	}
-	qSort(list);
 	list << tr("No buddies");
 	updateList(list);
 }
@@ -415,7 +417,6 @@ void LocationFilterModel::repopulate()
 			list.append(location);
 		}
 	}
-	qSort(list);
 	list << tr("No location set");
 	updateList(list);
 }

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -36,7 +36,7 @@ slots:
 	void changeName(const QString &oldName, const QString &newName);
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
-	void updateList(const QStringList &new_list);
+	void updateList(QStringList &new_list);
 	virtual int countDives(const char *) const = 0;
 private:
 	Qt::ItemFlags flags(const QModelIndex &index) const;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -9,14 +9,20 @@
 
 struct dive;
 
-class FilterModelBase : public QStringListModel {
+class FilterModelBase : public QAbstractListModel {
 	Q_OBJECT
+private:
+	int findInsertionIndex(const QString &name);
 protected:
 	struct Item {
+		QString name;
 		bool checked;
 		int count;
 	};
 	std::vector<Item> items;
+	int indexOf(const QString &name) const;
+	void addItem(const QString &name, bool checked, int count);
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 public:
 	virtual bool doFilter(const dive *d) const = 0;
 	void clearFilter();
@@ -27,6 +33,7 @@ public:
 public
 slots:
 	void setNegate(bool negate);
+	void changeName(const QString &oldName, const QString &newName);
 protected:
 	explicit FilterModelBase(QObject *parent = 0);
 	void updateList(const QStringList &new_list);
@@ -73,7 +80,6 @@ public:
 public
 slots:
 	void repopulate();
-	void changeName(const QString &oldName, const QString &newName);
 	void addName(const QString &newName);
 
 private:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
`FilterBaseModel` is a strange hybrid. It derives from `QStringListModel` to keep track of the items, but has additional data (`checked`, `count`) in a separate list. Make it a "real" Model by also moving the name into the structure. Start implementing model semantics beyond full reset, viz. adding an item and renaming an item.

Ultimately, this should lead to dynamically updated filters on do and undo.

This PR should probably wait until #1607 and #1608 are understood.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove a signal that ultimately should be put at a different place.
2) Move the name into the item struct in `FilterModelBase`.
3) Derive `FilterModelBase` from `QAbstractListItem`.
4) Implement `addItem` and rename functionality.
5) Sort the list in `updateList()`, not the individual callers.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

None.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

None.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

No.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
