### PR TITLE
Desktop: prevent crash when deleting all dives in trip

### DIFF
--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -412,6 +412,8 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 {
 	QModelIndex index0 = sourceModel()->index(source_row, 0, source_parent);
 	QVariant diveVariant = sourceModel()->data(index0, DiveTripModel::DIVE_ROLE);
+	if (!diveVariant.isValid())
+		return true;
 	struct dive *d = (struct dive *)diveVariant.value<void *>();
 
 	// For dives, simply check the hidden_by_filter flag


### PR DESCRIPTION
Instead of trying to dereference a dive pointer extracted from an
invalid QVariant, we should just accept that row and let the work
continue (which will eventually remove the trip which caused us to
even call the filter).

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When playing around with something completely unrelated, I noticed a way to crash Subsurface. We were dereferencing an invalid QVariant.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
simply bail if the QVariant is invalid - in my case this happened while we were removing the last dive in a trip and then the trip

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
The stack trace when crashing looks suspiciously like the one in #1607 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure if this is big enough to deserve a mention. "Desktop: fix potential crash when deleting dive trips"

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@p-neves @bstoeger 