### PR TITLE
Cleanup: make DiveTripModel a global object

### DIFF
--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -78,7 +78,7 @@ private:
 	QMultiHash<dive_trip_t *, int> selectedDives;
 	void merge_trip(const QModelIndex &a, const int offset);
 	void setColumnWidths();
-	void calculateInitialColumnWidth(const DiveTripModel &tripModel, int col);
+	void calculateInitialColumnWidth(int col);
 	void backupExpandedRows();
 	void restoreExpandedRows();
 	int lastVisibleColumn();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -437,6 +437,12 @@ int DiveItem::weight() const
 	return tw.grams;
 }
 
+DiveTripModel *DiveTripModel::instance()
+{
+	static DiveTripModel self;
+	return &self;
+}
+
 DiveTripModel::DiveTripModel(QObject *parent) :
 	TreeModel(parent),
 	currentLayout(TREE)
@@ -586,9 +592,11 @@ void DiveTripModel::setupModelData()
 
 	beginResetModel();
 
+	clear();
 	if (autogroup)
 		autogroup_dives();
 	dive_table.preexisting = dive_table.nr;
+	QMap<dive_trip_t *, TripItem *> trips;
 	while (--i >= 0) {
 		struct dive *dive = get_dive(i);
 		update_cylinder_related_info(dive);
@@ -598,7 +606,7 @@ void DiveTripModel::setupModelData()
 		diveItem->diveId = dive->id;
 
 		if (!trip || currentLayout == LIST) {
-			diveItem->parent = rootItem;
+			diveItem->parent = rootItem.get();
 			rootItem->children.push_back(diveItem);
 			continue;
 		}
@@ -608,7 +616,7 @@ void DiveTripModel::setupModelData()
 		if (!trips.keys().contains(trip)) {
 			TripItem *tripItem = new TripItem();
 			tripItem->trip = trip;
-			tripItem->parent = rootItem;
+			tripItem->parent = rootItem.get();
 			tripItem->children.push_back(diveItem);
 			trips[trip] = tripItem;
 			rootItem->children.push_back(tripItem);

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -93,6 +93,7 @@ public:
 		CURRENT
 	};
 
+	static DiveTripModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
@@ -102,7 +103,6 @@ public:
 
 private:
 	void setupModelData();
-	QMap<dive_trip_t *, TripItem *> trips;
 	Layout currentLayout;
 };
 

--- a/qt-models/treemodel.cpp
+++ b/qt-models/treemodel.cpp
@@ -32,12 +32,12 @@ QVariant TreeItem::data(int, int) const
 TreeModel::TreeModel(QObject *parent) : QAbstractItemModel(parent)
 {
 	columns = 0; // I'm not sure about this one - I can't see where it gets initialized
-	rootItem = new TreeItem();
+	rootItem.reset(new TreeItem);
 }
 
-TreeModel::~TreeModel()
+void TreeModel::clear()
 {
-	delete rootItem;
+	rootItem.reset(new TreeItem);
 }
 
 QVariant TreeModel::data(const QModelIndex &index, int role) const
@@ -64,7 +64,7 @@ QModelIndex TreeModel::index(int row, int column, const QModelIndex &parent) con
 	if (!hasIndex(row, column, parent))
 		return QModelIndex();
 
-	TreeItem *parentItem = (!parent.isValid()) ? rootItem : static_cast<TreeItem *>(parent.internalPointer());
+	TreeItem *parentItem = (!parent.isValid()) ? rootItem.get() : static_cast<TreeItem *>(parent.internalPointer());
 
 	TreeItem *childItem = parentItem->children[row];
 
@@ -79,7 +79,7 @@ QModelIndex TreeModel::parent(const QModelIndex &index) const
 	TreeItem *childItem = static_cast<TreeItem *>(index.internalPointer());
 	TreeItem *parentItem = childItem->parent;
 
-	if (parentItem == rootItem || !parentItem)
+	if (parentItem == rootItem.get() || !parentItem)
 		return QModelIndex();
 
 	return createIndex(parentItem->row(), 0, parentItem);
@@ -90,7 +90,7 @@ int TreeModel::rowCount(const QModelIndex &parent) const
 	TreeItem *parentItem;
 
 	if (!parent.isValid())
-		parentItem = rootItem;
+		parentItem = rootItem.get();
 	else
 		parentItem = static_cast<TreeItem *>(parent.internalPointer());
 

--- a/qt-models/treemodel.h
+++ b/qt-models/treemodel.h
@@ -4,6 +4,7 @@
 
 #include <QAbstractItemModel>
 #include <QCoreApplication>
+#include <memory>
 
 struct TreeItem {
 	Q_DECLARE_TR_FUNCTIONS(TreeItemDT)
@@ -25,16 +26,16 @@ class TreeModel : public QAbstractItemModel {
 	Q_OBJECT
 public:
 	TreeModel(QObject *parent = 0);
-	~TreeModel();
 	QVariant data(const QModelIndex &index, int role) const;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	int columnCount(const QModelIndex &parent = QModelIndex()) const;
 	QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
 	QModelIndex parent(const QModelIndex &child) const;
+	void clear();
 
 protected:
 	int columns;
-	TreeItem *rootItem;
+	std::unique_ptr<TreeItem> rootItem;
 };
 
 #endif

--- a/qt-models/yearlystatisticsmodel.cpp
+++ b/qt-models/yearlystatisticsmodel.cpp
@@ -187,7 +187,7 @@ void YearlyStatisticsModel::update_yearly_stats()
 			month++;
 		}
 		rootItem->children.append(item);
-		item->parent = rootItem;
+		item->parent = rootItem.get();
 	}
 
 
@@ -199,7 +199,7 @@ void YearlyStatisticsModel::update_yearly_stats()
 			iChild->parent = item;
 		}
 		rootItem->children.append(item);
-		item->parent = rootItem;
+		item->parent = rootItem.get();
 	}
 
 	/* Show the statistic sorted by dive type */
@@ -213,6 +213,6 @@ void YearlyStatisticsModel::update_yearly_stats()
 			iChild->parent = item;
 		}
 		rootItem->children.append(item);
-		item->parent = rootItem;
+		item->parent = rootItem.get();
 	}
 }


### PR DESCRIPTION
DiveTripModel (the model describing the dive-list) was destroyed
and recreated on every reset of the list. This seems excessive.
Instead - in analogy to most other models - make it a single
global object.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a cherry-pick from #1528, which makes the `DiveTripModel` a global object instead of regenerating it all the time. Since this is still based on `TreeModel`, I had to add a `clear()` function to tree model.

The reason for cherry-picking this is that setting the source model seems to make problems under not-yet-understood circumstances (see #1607)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Add `clear()` function to `TreeModel`
2) Move `trips` from `DiveTripModel` class to function.
3) Make `DiveTripModel` a single global object.

<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528, #1607
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @janmulder