### PR TITLE
Cleanup: constify get_units()

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -286,7 +286,7 @@ int get_pressure_units(int mb, const char **units)
 {
 	int pressure;
 	const char *unit;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	switch (units_p->pressure) {
 	case PASCAL:
@@ -312,7 +312,7 @@ double get_temp_units(unsigned int mk, const char **units)
 {
 	double deg;
 	const char *unit;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	if (units_p->temperature == FAHRENHEIT) {
 		deg = mkelvin_to_F(mk);
@@ -331,7 +331,7 @@ double get_volume_units(unsigned int ml, int *frac, const char **units)
 	int decimals;
 	double vol;
 	const char *unit;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	switch (units_p->volume) {
 	case LITER:
@@ -377,7 +377,7 @@ double get_depth_units(int mm, int *frac, const char **units)
 	int decimals;
 	double d;
 	const char *unit;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	switch (units_p->length) {
 	case METERS:
@@ -435,7 +435,7 @@ double get_weight_units(unsigned int grams, int *frac, const char **units)
 	int decimals;
 	double value;
 	const char *unit;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	if (units_p->weight == LBS) {
 		value = grams_to_lbs(grams);

--- a/core/dive.h
+++ b/core/dive.h
@@ -423,7 +423,7 @@ extern struct dive_trip *clone_empty_trip(struct dive_trip *trip);
 extern const struct units SI_units, IMPERIAL_units;
 extern struct units xml_parsing_units;
 
-extern struct units *get_units(void);
+extern const struct units *get_units(void);
 extern int run_survey, verbose, quit, force_root;
 
 struct dive_table {

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -273,7 +273,7 @@ void put_HTML_depth(struct membuffer *b, struct dive *dive, const char *pre, con
 {
 	const char *unit;
 	double value;
-	struct units *units_p = get_units();
+	const struct units *units_p = get_units();
 
 	if (!dive->maxdepth.mm) {
 		put_format(b, "%s--%s", pre, post);

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -106,7 +106,7 @@ struct preferences default_prefs = {
 
 int run_survey;
 
-struct units *get_units()
+const struct units *get_units()
 {
 	return &prefs.units;
 }

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -232,7 +232,7 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 	FILE *f;
 	QDir texdir = QFileInfo(filename).dir();
 	struct dive *dive;
-	struct units *units = get_units();
+	const struct units *units = get_units();
 	const char *unit;
 	int i;
 	bool need_pagebreak = false;

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -999,7 +999,7 @@ void PartialPressureGasItem::paint(QPainter *painter, const QStyleOptionGraphics
 	painter->restore();
 }
 
-void PartialPressureGasItem::setThresholdSettingsKey(double *prefPointerMin, double *prefPointerMax)
+void PartialPressureGasItem::setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax)
 {
 	thresholdPtrMin = prefPointerMin;
 	thresholdPtrMax = prefPointerMax;

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -213,14 +213,14 @@ public:
 	PartialPressureGasItem();
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	void setThresholdSettingsKey(double *prefPointerMin, double *prefPointerMax);
+	void setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax);
 	void setVisibilitySettingsKey(const QString &setVisibilitySettingsKey);
 	void setColors(const QColor &normalColor, const QColor &alertColor);
 
 private:
 	QVector<QPolygonF> alertPolygons;
-	double *thresholdPtrMin;
-	double *thresholdPtrMax;
+	const double *thresholdPtrMin;
+	const double *thresholdPtrMax;
 	QString visibilityKey;
 	QColor normalColor;
 	QColor alertColor;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -378,7 +378,7 @@ void ProfileWidget2::replot(struct dive *d)
 }
 
 void ProfileWidget2::createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
-				 double *thresholdSettingsMin, double *thresholdSettingsMax)
+				 const double *thresholdSettingsMin, const double *thresholdSettingsMax)
 {
 	setupItem(item, gasYAxis, verticalColumn, DivePlotDataModel::TIME, 0);
 	item->setThresholdSettingsKey(thresholdSettingsMin, thresholdSettingsMax);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -171,7 +171,7 @@ private: /*methods*/
 	struct plot_data *getEntryFromPos(QPointF pos);
 	void addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)());
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
-			 double *thresholdSettingsMin, double *thresholdSettingsMax);
+			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
 private:
 	DivePlotDataModel *dataModel;


### PR DESCRIPTION
get_units() returns a pointer to the units struct in the preferences.
Callers should not modify the preferences via this struct, therefore
make the return value point to const.

This is a small step in constifying the global preferences structure.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A tiny const-ification cleanup. Commit message says it all.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make `get_units()` return pointer-to-const.
2) Fix fallout

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
