### PR TITLE
Extend the libdivecomputer interfaces

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -418,9 +418,9 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 			sample->in_deco = in_deco = false;
 		} else if (value.deco.type == DC_DECO_DECOSTOP ||
 			   value.deco.type == DC_DECO_DEEPSTOP) {
-			sample->in_deco = in_deco = true;
 			sample->stopdepth.mm = stopdepth = lrint(value.deco.depth * 1000.0);
 			sample->stoptime.seconds = stoptime = value.deco.time;
+			sample->in_deco = in_deco = stopdepth > 0;
 			ndl = 0;
 		} else if (value.deco.type == DC_DECO_SAFETYSTOP) {
 			sample->in_deco = in_deco = false;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -373,6 +373,11 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 	case DC_SAMPLE_RBT:
 		sample->rbt.seconds = (!strncasecmp(dc->model, "suunto", 6)) ? value.rbt : value.rbt * 60;
 		break;
+#ifdef DC_SAMPLE_TTS
+	case DC_SAMPLE_TTS:
+		sample->tts.seconds = value.time;
+		break;
+#endif
 	case DC_SAMPLE_HEARTBEAT:
 		sample->heartbeat = heartbeat = value.heartbeat;
 		break;


### PR DESCRIPTION
This updates our libdivecomputer interfaces two ways:

 - add support for the new DC_SAMPLE_TTS sample type

 - allow clearing deco state with DC_DECO_DECOSTOP with a zero ceiling

both of which seem entirely trivial, and are to help the Garmin Descent downloader.

The traditional way to clear the deco state is to just give a non-zero NDL time, but if you don't _have_ a NDL time from the dive computer, it's hard to just make something up.

And the time to surface data should always have been there, but libdivecomputer didn't have that sample type for some reason. 

Note that you need to have a very recent libdivecomputer version to have that DC_SAMPLE_TTS thing, and if you build against an older version the code is just disabled.