### PR TITLE
[RFC] Preferences: make prefs structure const

### DIFF
--- a/appdata/subsurface.appdata.xml
+++ b/appdata/subsurface.appdata.xml
@@ -36,7 +36,7 @@
   <url type="help">https://subsurface-divelog.org/documentation/</url>
   <url type="translate">https://www.transifex.com/subsurface/subsurface/</url>
   <releases>
-    <release version="" date="" />
+    <release version="v4.8.1-402-g5623a9ed45de" date="2018-09-08" />
   </releases>
   <developer_name>The Subsurface development team</developer_name>
   <update_contact>subsurface@subsurface-divelog.org</update_contact>

--- a/core/dive.c
+++ b/core/dive.c
@@ -3795,17 +3795,17 @@ void set_informational_units(const char *units)
 
 }
 
-void set_git_prefs(const char *prefs)
+void set_git_prefs(const char *field)
 {
-	if (strstr(prefs, "TANKBAR"))
+	if (strstr(field, "TANKBAR"))
 		git_prefs.tankbar = 1;
-	if (strstr(prefs, "DCCEILING"))
+	if (strstr(field, "DCCEILING"))
 		git_prefs.dcceiling = 1;
-	if (strstr(prefs, "SHOW_SETPOINT"))
+	if (strstr(field, "SHOW_SETPOINT"))
 		git_prefs.show_ccr_setpoint = 1;
-	if (strstr(prefs, "SHOW_SENSORS"))
+	if (strstr(field, "SHOW_SENSORS"))
 		git_prefs.show_ccr_sensors = 1;
-	if (strstr(prefs, "PO2_GRAPH"))
+	if (strstr(field, "PO2_GRAPH"))
 		git_prefs.pp_graphs.po2 = 1;
 }
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -764,7 +764,7 @@ extern void dump_cylinders(struct dive *dive, bool verbose);
 #endif
 
 extern void set_informational_units(const char *units);
-extern void set_git_prefs(const char *prefs);
+extern void set_git_prefs(const char *field);
 
 extern char *get_dive_date_c_string(timestamp_t when);
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -915,7 +915,7 @@ static struct git_repository *is_remote_git_repository(char *remote, const char 
 			/* grab the part between "protocol://" and "@" as encoded email address
 			 * (that's our username) and move the rest of the URL forward, remembering
 			 * to copy the closing NUL as well */
-			prefs.cloud_storage_email_encoded = strndup(p, at - p);
+			get_prefs_mutable()->cloud_storage_email_encoded = strndup(p, at - p);
 			memmove(p, at + 1, strlen(at + 1) + 1);
 		}
 	}

--- a/core/pref.h
+++ b/core/pref.h
@@ -211,7 +211,29 @@ struct preferences {
 	update_manager_prefs_t update_manager;
 };
 
-extern struct preferences prefs, default_prefs, git_prefs;
+extern struct preferences default_prefs, git_prefs;
+
+/* In general, we want to avoid uncontrolled writing to the
+ * prefs structure. Therefore, prefs is a macro that
+ * casts the underlying structure to const.
+ * Places that nevertheless write to prefs are supposed
+ * to use the "get_prefs_mutable()" function. This allows
+ * us to easily find these places.
+ *
+ * Preferences code, which legitimately writes to prefs,
+ * can define PREFERENCES_SOURCE before including this file.
+ * prefs will then be defined as mutable structures.
+ */
+extern struct preferences prefs_internal; /* Don't use directly! */
+#ifdef PREFERENCES_SOURCE
+#	define prefs prefs_internal
+#else
+#	define prefs (*(const struct preferences*)&prefs_internal)
+static inline struct preferences *get_prefs_mutable()
+{
+	return &prefs_internal;
+}
+#endif // PREFERENCES_SOURCE
 
 extern const char *system_divelist_default_font;
 extern double system_divelist_default_font_size;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -470,7 +470,7 @@ QString uiLanguage(QLocale *callerLoc)
 	else
 		uiLang = languages[0];
 
-	prefs.locale.lang_locale = copy_qstring(uiLang);
+	get_prefs_mutable()->locale.lang_locale = copy_qstring(uiLang);
 
 	// there's a stupid Qt bug on MacOS where uiLanguages doesn't give us the country info
 	if (!uiLang.contains('-') && uiLang != loc.bcp47Name()) {
@@ -500,11 +500,11 @@ QString uiLanguage(QLocale *callerLoc)
 		dateFormat.replace("'en' 'den' d:'e'", " d");
 		if (!prefs.date_format_override || empty_string(prefs.date_format)) {
 			free((void *)prefs.date_format);
-			prefs.date_format = copy_qstring(dateFormat);
+			get_prefs_mutable()->date_format = copy_qstring(dateFormat);
 		}
 		if (!prefs.date_format_override || empty_string(prefs.date_format_short)) {
 			free((void *)prefs.date_format_short);
-			prefs.date_format_short = copy_qstring(shortDateFormat);
+			get_prefs_mutable()->date_format_short = copy_qstring(shortDateFormat);
 		}
 	}
 	if (!prefs.time_format_override || empty_string(prefs.time_format)) {
@@ -512,7 +512,7 @@ QString uiLanguage(QLocale *callerLoc)
 		timeFormat.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
 		timeFormat.replace(".ss", "").replace(":ss", "").replace("ss", "");
 		free((void *)prefs.time_format);
-		prefs.time_format = copy_qstring(timeFormat);
+		get_prefs_mutable()->time_format = copy_qstring(timeFormat);
 	}
 	return uiLang;
 }
@@ -1374,7 +1374,7 @@ int getCloudURL(QString &filename)
 		return report_error("Please configure Cloud storage email and password in the preferences");
 	if (email != prefs.cloud_storage_email_encoded) {
 		free((void *)prefs.cloud_storage_email_encoded);
-		prefs.cloud_storage_email_encoded = copy_qstring(email);
+		get_prefs_mutable()->cloud_storage_email_encoded = copy_qstring(email);
 	}
 	filename = QString(QString(prefs.cloud_git_url) + "/%1[%1]").arg(email);
 	if (verbose)

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPref.h"
 #include "qPrefPrivate.h"
 #include "qPrefCloudStorage.h"

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefCloudStorage.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("CloudStorage");
 

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "core/subsurface-string.h"
 #include "qPrefDisplay.h"
-#include "qPrefPrivate.h"
 
 #include <QApplication>
 #include <QFont>

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefDiveComputer.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("DiveComputer");
 

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "core/subsurface-string.h"
 #include "qPrefDivePlanner.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("Planner");
 

--- a/core/settings/qPrefFacebook.cpp
+++ b/core/settings/qPrefFacebook.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefFacebook.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("WebApps/Facebook");
 

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefGeneral.h"
-#include "qPrefPrivate.h"
 
 
 static const QString group = QStringLiteral("GeneralSettings");

--- a/core/settings/qPrefGeocoding.cpp
+++ b/core/settings/qPrefGeocoding.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefGeocoding.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("geocoding");
 

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefLanguage.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("Language");
 

--- a/core/settings/qPrefLocationService.cpp
+++ b/core/settings/qPrefLocationService.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefLocationService.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("LocationService");
 

--- a/core/settings/qPrefPartialPressureGas.cpp
+++ b/core/settings/qPrefPartialPressureGas.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefPartialPressureGas.h"
-#include "qPrefPrivate.h"
 
 static const QString group = QStringLiteral("TecDetails");
 

--- a/core/settings/qPrefPrivate.cpp
+++ b/core/settings/qPrefPrivate.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-#include "qPrefPrivate.h"
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 
 #include <QSettings>
 

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -2,6 +2,8 @@
 #ifndef QPREFPRIVATE_H
 #define QPREFPRIVATE_H
 
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
+
 // Header used by all qPref<class> implementations to avoid duplicating code
 #include "core/qthelper.h"
 #include "qPref.h"

--- a/core/settings/qPrefProxy.cpp
+++ b/core/settings/qPrefProxy.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefProxy.h"
-#include "qPrefPrivate.h"
 
 #include <QNetworkProxy>
 

--- a/core/settings/qPrefTechnicalDetails.cpp
+++ b/core/settings/qPrefTechnicalDetails.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefTechnicalDetails.h"
-#include "qPrefPrivate.h"
 
 
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefUnit.h"
-#include "qPrefPrivate.h"
 
 
 static const QString group = QStringLiteral("Units");

--- a/core/settings/qPrefUpdateManager.cpp
+++ b/core/settings/qPrefUpdateManager.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+#include "qPrefPrivate.h" // Include first, to make prefs mutable
 #include "qPrefUpdateManager.h"
-#include "qPrefPrivate.h"
 
 
 static const QString group = QStringLiteral("UpdateManager");

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -116,9 +116,9 @@ QString DiveObjectHelper::gps_decimal() const
 	bool savep = prefs.coordinates_traditional;
 	QString val;
 
-	prefs.coordinates_traditional = false;
+	get_prefs_mutable()->coordinates_traditional = false;
 	val = gps();
-	prefs.coordinates_traditional = savep;
+	get_prefs_mutable()->coordinates_traditional = savep;
 	return val;
 }
 

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -9,7 +9,8 @@
 #include "git-access.h"
 #include "libdivecomputer/version.h"
 
-struct preferences prefs, git_prefs;
+struct preferences prefs_internal;
+struct preferences git_prefs;
 struct preferences default_prefs = {
 	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
 	.units = SI_UNITS,

--- a/core/videoframeextractor.cpp
+++ b/core/videoframeextractor.cpp
@@ -89,7 +89,7 @@ void VideoFrameExtractor::processItem(QString originalFilename, QString filename
 	if (!ffmpeg.waitForStarted()) {
 		// Since we couldn't sart ffmpeg, turn off thumbnailing
 		// TODO: call the proper preferences-functions
-		prefs.extract_video_thumbnails = false;
+		get_prefs_mutable()->extract_video_thumbnails = false;
 		report_error(qPrintable(tr("ffmpeg failed to start - video thumbnail creation suspended")));
 		qDebug() << "Failed to start ffmpeg";
 		return fail(originalFilename, duration, false);

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -66,7 +66,7 @@ void PreferencesGraph::syncSettings()
 
 	qPrefTechnicalDetails::set_modpO2(ui->maxpo2->value());
 	qPrefTechnicalDetails::set_redceiling(ui->red_ceiling->isChecked());
-	prefs.planner_deco_mode = ui->buehlmann->isChecked() ? BUEHLMANN : VPMB;
+	get_prefs_mutable()->planner_deco_mode = ui->buehlmann->isChecked() ? BUEHLMANN : VPMB;
 	qPrefTechnicalDetails::set_gflow(ui->gflow->value());
 	qPrefTechnicalDetails::set_gfhigh(ui->gfhigh->value());
 	qPrefTechnicalDetails::set_vpmb_conservatism(ui->vpmb_conservatism->value());

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -139,7 +139,7 @@ void PreferencesDialog::cancelRequested()
 
 void PreferencesDialog::defaultsRequested()
 {
-	copy_prefs(&default_prefs, &prefs);
+	copy_prefs(&default_prefs, get_prefs_mutable());
 	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
 		page->refreshSettings();
 	}

--- a/export-html.cpp
+++ b/export-html.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
 {
 	QApplication *application = new QApplication(argc, argv);
 	git_libgit2_init();
-	copy_prefs(&default_prefs, &prefs);
+	copy_prefs(&default_prefs, get_prefs_mutable());
 	init_qt_late();
 
 	QCommandLineParser parser;
@@ -50,8 +50,8 @@ int main(int argc, char **argv)
 	// this should have set up the informational preferences - let's grab
 	// the units from there
 
-	prefs.unit_system = git_prefs.unit_system;
-	prefs.units = git_prefs.units;
+	get_prefs_mutable()->unit_system = git_prefs.unit_system;
+	get_prefs_mutable()->units = git_prefs.units;
 
 	// populate the statistics
 	struct dive *d = get_dive(0);

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -256,7 +256,7 @@ void MapWidgetHelper::calculateSmallCircleRadius(QGeoCoordinate coord)
 void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool formatTraditional)
 {
 	bool savep = prefs.coordinates_traditional;
-	prefs.coordinates_traditional = formatTraditional;
+	get_prefs_mutable()->coordinates_traditional = formatTraditional;
 
 	const int lat = lrint(1000000.0 * coord.latitude());
 	const int lon = lrint(1000000.0 * coord.longitude());
@@ -264,7 +264,7 @@ void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool form
 	QApplication::clipboard()->setText(QString(coordinates), QClipboard::Clipboard);
 
 	free((void *)coordinates);
-	prefs.coordinates_traditional = savep;
+	get_prefs_mutable()->coordinates_traditional = savep;
 }
 
 void MapWidgetHelper::updateCurrentDiveSiteCoordinatesFromMap(quint32 uuid, QGeoCoordinate coord)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -278,12 +278,12 @@ void QMLManager::openLocalThenRemote(QString url)
 		// if we can load from the cache, we know that we have a valid cloud account
 		if (QMLPrefs::instance()->credentialStatus() == qPrefCloudStorage::CS_UNKNOWN)
 			QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_VERIFIED);
-		prefs.unit_system = git_prefs.unit_system;
+		get_prefs_mutable()->unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
 			git_prefs.units = IMPERIAL_units;
 		else if (git_prefs.unit_system == METRIC)
 			git_prefs.units = SI_units;
-		prefs.units = git_prefs.units;
+		get_prefs_mutable()->units = git_prefs.units;
 		qPrefTechnicalDetails::set_tankbar(git_prefs.tankbar);
 		qPrefTechnicalDetails::set_dcceiling(git_prefs.dcceiling);
 		qPrefTechnicalDetails::set_show_ccr_setpoint(git_prefs.show_ccr_setpoint);
@@ -462,7 +462,7 @@ void QMLManager::saveCloudCredentials()
 	if (!same_string(prefs.cloud_storage_email,
 		qPrintable(QMLPrefs::instance()->cloudUserName()))) {
 		free((void *)prefs.cloud_storage_email);
-		prefs.cloud_storage_email = copy_qstring(QMLPrefs::instance()->cloudUserName());
+		get_prefs_mutable()->cloud_storage_email = copy_qstring(QMLPrefs::instance()->cloudUserName());
 		cloudCredentialsChanged = true;
 	}
 
@@ -478,7 +478,7 @@ void QMLManager::saveCloudCredentials()
 	if (!same_string(prefs.cloud_storage_password,
 					qPrintable(QMLPrefs::instance()->cloudPassword()))) {
 		free((void *)prefs.cloud_storage_password);
-		prefs.cloud_storage_password = copy_qstring(QMLPrefs::instance()->cloudPassword());
+		get_prefs_mutable()->cloud_storage_password = copy_qstring(QMLPrefs::instance()->cloudPassword());
 	}
 	if (QMLPrefs::instance()->oldStatus() == qPrefCloudStorage::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {
 		// we came from NOCLOUD and are connecting to a cloud account;
@@ -718,9 +718,9 @@ void QMLManager::revertToNoCloudIfNeeded()
 			git_local_only = m_syncToCloud;
 		}
 		free((void *)prefs.cloud_storage_email);
-		prefs.cloud_storage_email = NULL;
+		get_prefs_mutable()->cloud_storage_email = NULL;
 		free((void *)prefs.cloud_storage_password);
-		prefs.cloud_storage_password = NULL;
+		get_prefs_mutable()->cloud_storage_password = NULL;
 		QMLPrefs::instance()->setCloudUserName("");
 		QMLPrefs::instance()->setCloudPassword("");
 		QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_NOCLOUD);
@@ -732,17 +732,17 @@ void QMLManager::revertToNoCloudIfNeeded()
 
 void QMLManager::consumeFinishedLoad(timestamp_t currentDiveTimestamp)
 {
-	prefs.unit_system = git_prefs.unit_system;
+	get_prefs_mutable()->unit_system = git_prefs.unit_system;
 	if (git_prefs.unit_system == IMPERIAL)
 		git_prefs.units = IMPERIAL_units;
 	else if (git_prefs.unit_system == METRIC)
 		git_prefs.units = SI_units;
-	prefs.units = git_prefs.units;
-	prefs.tankbar = git_prefs.tankbar;
-	prefs.dcceiling = git_prefs.dcceiling;
-	prefs.show_ccr_setpoint = git_prefs.show_ccr_setpoint;
-	prefs.show_ccr_sensors = git_prefs.show_ccr_sensors;
-	prefs.pp_graphs.po2 = git_prefs.pp_graphs.po2;
+	get_prefs_mutable()->units = git_prefs.units;
+	get_prefs_mutable()->tankbar = git_prefs.tankbar;
+	get_prefs_mutable()->dcceiling = git_prefs.dcceiling;
+	get_prefs_mutable()->show_ccr_setpoint = git_prefs.show_ccr_setpoint;
+	get_prefs_mutable()->show_ccr_sensors = git_prefs.show_ccr_sensors;
+	get_prefs_mutable()->pp_graphs.po2 = git_prefs.pp_graphs.po2;
 	DiveListModel::instance()->clear();
 	process_dives(false, false);
 	DiveListModel::instance()->addAllDives();

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	 */
 	qsrand(time(NULL));
 	setup_system_prefs();
-	copy_prefs(&default_prefs, &prefs);
+	copy_prefs(&default_prefs, get_prefs_mutable());
 	fill_computer_list();
 	parse_xml_init();
 	taglist_init_global();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 		default_prefs.units = SI_units;
 	else
 		default_prefs.units = IMPERIAL_units;
-	copy_prefs(&default_prefs, &prefs);
+	copy_prefs(&default_prefs, get_prefs_mutable());
 	fill_computer_list();
 
 	parse_xml_init();
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 	qPrefDisplay::set_animation_speed(0); // we render the profile to pixmap, no animations
 
 	// always show the divecomputer reported ceiling in red
-	prefs.redceiling = 1;
+	get_prefs_mutable()->redceiling = 1;
 
 	init_proxy();
 

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testgitstorage.h"
 #include "git2.h"
 

--- a/tests/testparseperformance.cpp
+++ b/tests/testparseperformance.cpp
@@ -20,7 +20,7 @@ void TestParsePerformance::initTestCase()
 	QTextCodec::setCodecForLocale(QTextCodec::codecForMib(106));
 
 	// first, setup the preferences an proxy information
-	copy_prefs(&default_prefs, &prefs);
+	copy_prefs(&default_prefs, get_prefs_mutable());
 	QCoreApplication::setOrganizationName("Subsurface");
 	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
 	QCoreApplication::setApplicationName("Subsurface");

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testplan.h"
 #include "core/dive.h"
 #include "core/planner.h"

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefCloudStorage.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefDisplay.cpp
+++ b/tests/testqPrefDisplay.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefDisplay.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefDiveComputer.cpp
+++ b/tests/testqPrefDiveComputer.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefDiveComputer.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefDivePlanner.cpp
+++ b/tests/testqPrefDivePlanner.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefDivePlanner.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefFacebook.cpp
+++ b/tests/testqPrefFacebook.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefFacebook.h"
 
 #include "core/settings/qPrefFacebook.h"

--- a/tests/testqPrefGeneral.cpp
+++ b/tests/testqPrefGeneral.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefGeneral.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefGeocoding.cpp
+++ b/tests/testqPrefGeocoding.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefGeocoding.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefLanguage.cpp
+++ b/tests/testqPrefLanguage.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefLanguage.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefLocationService.cpp
+++ b/tests/testqPrefLocationService.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefLocationService.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefPartialPressureGas.cpp
+++ b/tests/testqPrefPartialPressureGas.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefPartialPressureGas.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefProxy.cpp
+++ b/tests/testqPrefProxy.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefProxy.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefTechnicalDetails.cpp
+++ b/tests/testqPrefTechnicalDetails.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefTechnicalDetails.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefUnits.h"
 
 #include "core/pref.h"

--- a/tests/testqPrefUpdateManager.cpp
+++ b/tests/testqPrefUpdateManager.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+#define PREFERENCES_SOURCE 1 // Make prefs-structure mutable
 #include "testqPrefUpdateManager.h"
 
 #include "core/pref.h"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As discussed in #1626, we might want to identify all writers to `struct preferences pref`. Therefore, make it `const`.

Note 1: This looks very "undefined behavior"-ish to me. Low-level experts, please have a look! A (less undefined) alternative might be something like:

```
struct preferences prefs_mutable;
#define prefs ((const struct preferences)prefs_mutable)
```

Note 2: This contains the commits of #1630

What I learned from this: It turns out that things look much less scary than I had feared. Most of the things (e.g git_local_only) do not belong into prefs and need not be synced. The rest is startup / preferences code, where it is OK. And then a few things that should be converted. The only thing that needs some thought seems to be the "reset to default" feature. But I think it is no problem, since the dialog will write the changed properties anyway on "Apply" or "Save", isn't it?

If these few things are fixed, we don't need any manual syncing without completely doing away with the prefs-structure, no?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make prefs const.
2) Provide an accessor for non-const access.
3) Fix fallout.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1626
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
