### PR TITLE
win32: fix writing of logs for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Windows: write log files to the user path instead of the path where Subsurface
+  is installed.
 - Desktop: fix issue with dive list row height in case of larger fonts [#1600]
 - Desktop: fix a bug where it is possible for the user to hide all divelist columns [#1600]
 - Mobile: add default cylinder functionality for new dives [#1535]

--- a/core/windows.c
+++ b/core/windows.c
@@ -424,8 +424,14 @@ void subsurface_console_init(void)
 		console_desc.err = freopen("CON", "w", stderr);
 	} else {
 		verbose = 1; /* set the verbose level to '1' */
-		console_desc.out = freopen("subsurface_out.log", "w", stdout);
-		console_desc.err = freopen("subsurface_err.log", "w", stderr);
+		wchar_t *wpath_out = system_default_path_append(L"subsurface_out.log");
+		wchar_t *wpath_err = system_default_path_append(L"subsurface_err.log");
+		if (wpath_out && wpath_err) {
+			console_desc.out = _wfreopen(wpath_out, L"w", stdout);
+			console_desc.err = _wfreopen(wpath_err, L"w", stderr);
+		}
+		free((void *)wpath_out);
+		free((void *)wpath_err);
 	}
 
 	puts(""); /* add an empty line */


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

if the user is running the application on Windows, not from a terminal, but from the desktop, the app will write log files. but if the user does not have privileges to write to the Subsurface install path the log files will not be written.

these patches adjust `windows.c` so that the files are written in the user path.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add `utf16_to_utf8()`
1) make `system_default_path_append()` use `wchar_t` only.
1) write logs to user path

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
NONE

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

https://groups.google.com/d/msgid/subsurface-divelog/7f1b59ec-8b39-4091-be08-d499a03fd83d%40googlegroups.com?utm_medium=email&utm_source=footer

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

```
Windows: write log files to the user path instead of the path where Subsurface
  is installed.
```

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh 
