### PR TITLE
SmartTrak import tool. Back to arrays.

### DIFF
--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -205,46 +205,6 @@ static  MdbTableDef *smtk_open_table(MdbHandle *mdb, char *tablename, MdbColumn 
 }
 
 /*
- * Utility function which returns the value from a given column in a given table,
- * whose row equals the given idx string.
- * Idx should be a numeric value, but all values obtained from mdbtools are strings,
- * so let's compare strings instead of numbers to avoid unnecessary transforms.
- */
-static char *smtk_value_by_idx(MdbHandle *mdb, char *tablename, int colnum, char *idx)
-{
-	MdbCatalogEntry *entry;
-	MdbTableDef *table;
-	MdbColumn *idxcol, *valuecol;
-	char *bounder[MDB_MAX_COLS], *str = NULL;
-	int i = 0;
-
-	entry = mdb_get_catalogentry_by_name(mdb, tablename);
-	table = mdb_read_table(entry);
-	if (!table) {
-		report_error("[Error][smartrak_import]\t%s table doesn't exist\n", tablename);
-		return str;
-	}
-	mdb_read_columns(table);
-	idxcol = g_ptr_array_index(table->columns, 0);
-	valuecol = g_ptr_array_index(table->columns, colnum);
-	for (i = 0; i < table->num_cols; i++) {
-		bounder[i] = (char *) g_malloc(MDB_BIND_SIZE);
-		mdb_bind_column(table, i+1, bounder[i], NULL);
-	}
-	mdb_rewind_table(table);
-	for (i = 0; i < table->num_rows; i++) {
-		mdb_fetch_row(table);
-		if (!strcmp(idxcol->bind_ptr, idx)) {
-			str = copy_string(valuecol->bind_ptr);
-			break;
-		}
-	}
-	smtk_free(bounder, table->num_cols);
-	mdb_free_tabledef(table);
-	return str;
-}
-
-/*
  * Utility function which joins three strings, being the second a separator string,
  * usually a "\n". The third is a format string with an argument list.
  * If the original string is NULL, then just returns the third.
@@ -568,7 +528,6 @@ static void smtk_head_insert(struct types_list **head, int index, char *txt)
 	item->text = txt;
 	*head = item;
 	item = NULL;
-	free(item);
 }
 
 /* Clean types_list lists */

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -583,6 +583,31 @@ static void smtk_list_free(struct types_list *head)
 	}
 }
 
+/* Return the number of rows in a given table */
+static int get_rows_num(MdbHandle *mdb,  char *table_name)
+{
+	MdbTableDef *table;
+	MdbColumn *col[MDB_MAX_COLS];
+	char *bound_values[MDB_MAX_COLS];
+	int n = 0, i = 0;
+
+	table = smtk_open_table(mdb, table_name, col, bound_values);
+	if (!table)
+		return n;
+
+	/* We can get an sparse array (less rows in the table than
+	 * index). Ensure we allocate as many strings as greater
+	 * index, at least */
+	while (mdb_fetch_row(table)) {
+		i = atoi(col[0]->bind_ptr);
+		if (i > n)
+			n = i;
+	}
+	smtk_free(bound_values, table->num_cols);
+	mdb_free_tabledef(table);
+	return n;
+}
+
 /*
  * Build a list from a given table_name (Type, Gear, etc)
  * Managed tables formats: Just consider Idx and Text


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] Code rework

### Pull request long description:
<!-- Describe your pull request in detail. -->
In PR #1599 comments, @bstoeger , @janiversen  and @dirkhh pointed out the benefits of dinamically growing arrays in front of linked lists. While I fully agree in speed concerns, past bad experiences in reallocating arrays make me very cautious with them (too much probably).
Fortunately there is no need to use them, as we can know in advance how many elements will conform the array.
As a bonus, smartrak tables are all indexed, so we can use the index to access directly the array elements without search. The drawback is the "holes" we can find in the tables which have to be allocated too, to port the table index to the array.

In summary, I keep lists to the relations tables (which have to be traversed in full anyway, and are quite short), and take the rest of tables back to arrays.  The speed for a >400 dives file and some list quite long, improves about a 12% (although full import in CLI mode takes only 2 seconds in my "notsopowerful" laptop).

By the way, I've added some other tables to subsurface's dive notes, which were out till now  (weather, surface and underwater).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
