### PR TITLE
qPref: use helper function to ensure key/name grouping

### DIFF
--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -46,16 +46,16 @@ void qPrefCloudStorage::set_cloud_base_url(const QString &value)
 void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 {
 	if (doSync) {
-		qPrefPrivate::propSetValue(group + "/cloud_base_url", prefs.cloud_base_url, default_prefs.cloud_base_url);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cloud_base_url"), prefs.cloud_base_url, default_prefs.cloud_base_url);
 	} else {
-		prefs.cloud_base_url = copy_qstring(qPrefPrivate::propValue(group + "/cloud_base_url", default_prefs.cloud_base_url).toString());
+		prefs.cloud_base_url = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, "cloud_base_url"), default_prefs.cloud_base_url).toString());
 		qPrefPrivate::copy_txt(&prefs.cloud_git_url, QString(prefs.cloud_base_url) + "/git");
 	}
 }
 
-HANDLE_PREFERENCE_TXT(CloudStorage, "/email", cloud_storage_email);
+HANDLE_PREFERENCE_TXT(CloudStorage, "email", cloud_storage_email);
 
-HANDLE_PREFERENCE_TXT(CloudStorage, "/email_encoded", cloud_storage_email_encoded);
+HANDLE_PREFERENCE_TXT(CloudStorage, "email_encoded", cloud_storage_email_encoded);
 
 void qPrefCloudStorage::set_cloud_storage_newpassword(const QString &value)
 {
@@ -80,37 +80,37 @@ void qPrefCloudStorage::disk_cloud_storage_password(bool doSync)
 {
 	if (doSync) {
 		if (prefs.save_password_local)
-			qPrefPrivate::propSetValue(group + "/password", prefs.cloud_storage_password, default_prefs.cloud_storage_password);
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, "password"), prefs.cloud_storage_password, default_prefs.cloud_storage_password);
 	} else {
-		prefs.cloud_storage_password = copy_qstring(qPrefPrivate::propValue(group + "/password", default_prefs.cloud_storage_password).toString());
+		prefs.cloud_storage_password = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, "password"), default_prefs.cloud_storage_password).toString());
 	}
 }
 
-HANDLE_PREFERENCE_TXT(CloudStorage, "/pin", cloud_storage_pin);
+HANDLE_PREFERENCE_TXT(CloudStorage, "pin", cloud_storage_pin);
 
-HANDLE_PREFERENCE_INT(CloudStorage, "/timeout", cloud_timeout);
+HANDLE_PREFERENCE_INT(CloudStorage, "timeout", cloud_timeout);
 
-HANDLE_PREFERENCE_INT(CloudStorage, "/cloud_verification_status", cloud_verification_status);
+HANDLE_PREFERENCE_INT(CloudStorage, "cloud_verification_status", cloud_verification_status);
 
-HANDLE_PREFERENCE_BOOL(CloudStorage, "/git_local_only", git_local_only);
+HANDLE_PREFERENCE_BOOL(CloudStorage, "git_local_only", git_local_only);
 
-HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_password_local", save_password_local);
+HANDLE_PREFERENCE_BOOL(CloudStorage, "save_password_local", save_password_local);
 
-HANDLE_PREFERENCE_BOOL(CloudStorage, "/save_userid_local", save_userid_local);
+HANDLE_PREFERENCE_BOOL(CloudStorage, "save_userid_local", save_userid_local);
 
 SET_PREFERENCE_TXT(CloudStorage, userid);
 void qPrefCloudStorage::disk_userid(bool doSync)
 {
 	if (doSync) {
 		// always save in new position (part of cloud storage group)
-		qPrefPrivate::propSetValue(group + "/subsurface_webservice_uid", prefs.userid, default_prefs.userid);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "subsurface_webservice_uid"), prefs.userid, default_prefs.userid);
 	} else {
 		//WARNING: UserId was  stored outside of any group.
 		// try to read from new location, if it fails read from old location
-		prefs.userid = copy_qstring(qPrefPrivate::propValue(group + "/subsurface_webservice_uid", "NoUserIdHere").toString());
+		prefs.userid = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, "subsurface_webservice_uid"), "NoUserIdHere").toString());
 		if (QString(prefs.userid) == "NoUserIdHere") {
 			const QString group = QStringLiteral("");
-			prefs.userid = copy_qstring(qPrefPrivate::propValue(group + "/subsurface_webservice_uid", default_prefs.userid).toString());
+			prefs.userid = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group,"subsurface_webservice_uid"), default_prefs.userid).toString());
 		}
 	}
 }

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -90,7 +90,7 @@ void qPrefDisplay::set_divelist_font(const QString &value)
 void qPrefDisplay::disk_divelist_font(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/divelist_font", prefs.divelist_font, default_prefs.divelist_font);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "divelist_font"), prefs.divelist_font, default_prefs.divelist_font);
 	else
 		setCorrectFont();
 }
@@ -110,29 +110,29 @@ void qPrefDisplay::set_font_size(double value)
 void qPrefDisplay::disk_font_size(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/font_size", prefs.font_size, default_prefs.font_size);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "font_size"), prefs.font_size, default_prefs.font_size);
 	else
 		setCorrectFont();
 }
 
 //JAN static const QString group = QStringLiteral("Animations");
-HANDLE_PREFERENCE_INT(Display, "/animation_speed", animation_speed);
+HANDLE_PREFERENCE_INT(Display, "animation_speed", animation_speed);
 
-HANDLE_PREFERENCE_BOOL(Display, "/displayinvalid", display_invalid_dives);
+HANDLE_PREFERENCE_BOOL(Display, "displayinvalid", display_invalid_dives);
 
-HANDLE_PREFERENCE_BOOL(Display, "/show_developer", show_developer);
+HANDLE_PREFERENCE_BOOL(Display, "show_developer", show_developer);
 
 void qPrefDisplay::setCorrectFont()
 {
 	// get the font from the settings or our defaults
 	// respect the system default font size if none is explicitly set
-	QFont defaultFont = qPrefPrivate::propValue(group + "/divelist_font", prefs.divelist_font).value<QFont>();
+	QFont defaultFont = qPrefPrivate::propValue(keyFromGroupAndName(group, "divelist_font"), prefs.divelist_font).value<QFont>();
 	if (IS_FP_SAME(system_divelist_default_font_size, -1.0)) {
 		prefs.font_size = qApp->font().pointSizeF();
 		system_divelist_default_font_size = prefs.font_size; // this way we don't save it on exit
 	}
 
-	prefs.font_size = qPrefPrivate::propValue(group + "/font_size", prefs.font_size).toFloat();
+	prefs.font_size = qPrefPrivate::propValue(keyFromGroupAndName(group, "font_size"), prefs.font_size).toFloat();
 	// painful effort to ignore previous default fonts on Windows - ridiculous
 	QString fontName = defaultFont.toString();
 	if (fontName.contains(","))
@@ -146,7 +146,7 @@ void qPrefDisplay::setCorrectFont()
 	defaultFont.setPointSizeF(prefs.font_size);
 	qApp->setFont(defaultFont);
 
-	prefs.display_invalid_dives = qPrefPrivate::propValue(group + "/displayinvalid", default_prefs.display_invalid_dives).toBool();
+	prefs.display_invalid_dives = qPrefPrivate::propValue(keyFromGroupAndName(group, "displayinvalid"), default_prefs.display_invalid_dives).toBool();
 }
 
 HANDLE_PROP_QSTRING(Display, "FileDialog/LastDir", lastDir);

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -23,12 +23,12 @@ void qPrefDiveComputer::loadSync(bool doSync)
 	disk_vendor(doSync);
 }
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_device", device, dive_computer.);
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device", device, dive_computer.);
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_device_name", device_name, dive_computer.);
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device_name", device_name, dive_computer.);
 
-HANDLE_PREFERENCE_INT_EXT(DiveComputer, "/dive_computer_download_mode", download_mode, dive_computer.);
+HANDLE_PREFERENCE_INT_EXT(DiveComputer, "dive_computer_download_mode", download_mode, dive_computer.);
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_product", product, dive_computer.);
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_product", product, dive_computer.);
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "/dive_computer_vendor", vendor, dive_computer.);
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_vendor", vendor, dive_computer.);

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -45,51 +45,51 @@ void qPrefDivePlanner::loadSync(bool doSync)
 	disk_verbatim_plan(doSync);
 }
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/ascratelast6m", ascratelast6m);
+HANDLE_PREFERENCE_INT(DivePlanner, "ascratelast6m", ascratelast6m);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/ascratestops", ascratestops);
+HANDLE_PREFERENCE_INT(DivePlanner, "ascratestops", ascratestops);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/ascrate50", ascrate50);
+HANDLE_PREFERENCE_INT(DivePlanner, "ascrate50", ascrate50);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/ascrate75", ascrate75);
+HANDLE_PREFERENCE_INT(DivePlanner, "ascrate75", ascrate75);
 
-HANDLE_PREFERENCE_STRUCT(DivePlanner, depth_t, "/bestmixend", bestmixend, mm);
+HANDLE_PREFERENCE_STRUCT(DivePlanner, depth_t, "bestmixend", bestmixend, mm);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/bottompo2", bottompo2);
+HANDLE_PREFERENCE_INT(DivePlanner, "bottompo2", bottompo2);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/bottomsac", bottomsac);
+HANDLE_PREFERENCE_INT(DivePlanner, "bottomsac", bottomsac);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/decopo2", decopo2);
+HANDLE_PREFERENCE_INT(DivePlanner, "decopo2", decopo2);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/decosac", decosac);
+HANDLE_PREFERENCE_INT(DivePlanner, "decosac", decosac);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/descrate", descrate);
+HANDLE_PREFERENCE_INT(DivePlanner, "descrate", descrate);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/display_duration", display_duration);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "display_duration", display_duration);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/display_runtime", display_runtime);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "display_runtime", display_runtime);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/display_transitions", display_transitions);
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/display_variations", display_variations);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "display_transitions", display_transitions);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "display_variations", display_variations);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/doo2breaks", doo2breaks);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "doo2breaks", doo2breaks);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/drop_stone_mode", drop_stone_mode);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "drop_stone_mode", drop_stone_mode);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/last_stop", last_stop);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "last_stop", last_stop);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/min_switch_duration", min_switch_duration);
+HANDLE_PREFERENCE_INT(DivePlanner, "min_switch_duration", min_switch_duration);
 
-HANDLE_PREFERENCE_ENUM(DivePlanner, deco_mode, "/deco_mode", planner_deco_mode);
+HANDLE_PREFERENCE_ENUM(DivePlanner, deco_mode, "deco_mode", planner_deco_mode);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/problemsolvingtime", problemsolvingtime);
+HANDLE_PREFERENCE_INT(DivePlanner, "problemsolvingtime", problemsolvingtime);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/reserve_gas", reserve_gas);
+HANDLE_PREFERENCE_INT(DivePlanner, "reserve_gas", reserve_gas);
 
-HANDLE_PREFERENCE_INT(DivePlanner, "/sacfactor", sacfactor);
+HANDLE_PREFERENCE_INT(DivePlanner, "sacfactor", sacfactor);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/safetystop", safetystop);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "safetystop", safetystop);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/switch_at_req_stop", switch_at_req_stop);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "switch_at_req_stop", switch_at_req_stop);
 
-HANDLE_PREFERENCE_BOOL(DivePlanner, "/verbatim_plan", verbatim_plan);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "verbatim_plan", verbatim_plan);

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -41,11 +41,11 @@ void qPrefGeneral::loadSync(bool doSync)
 	}
 }
 
-HANDLE_PREFERENCE_BOOL(General, "/auto_recalculate_thumbnails", auto_recalculate_thumbnails);
+HANDLE_PREFERENCE_BOOL(General, "auto_recalculate_thumbnails", auto_recalculate_thumbnails);
 
-HANDLE_PREFERENCE_TXT(General, "/default_cylinder", default_cylinder);
+HANDLE_PREFERENCE_TXT(General, "default_cylinder", default_cylinder);
 
-HANDLE_PREFERENCE_TXT(General, "/default_filename", default_filename);
+HANDLE_PREFERENCE_TXT(General, "default_filename", default_filename);
 
 
 void qPrefGeneral::set_default_file_behavior(enum def_file_behavior value)
@@ -67,9 +67,9 @@ void qPrefGeneral::set_default_file_behavior(enum def_file_behavior value)
 void qPrefGeneral::disk_default_file_behavior(bool doSync)
 {
 	if (doSync) {
-		qPrefPrivate::propSetValue(group + "/default_file_behavior", prefs.default_file_behavior, default_prefs.default_file_behavior);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "default_file_behavior"), prefs.default_file_behavior, default_prefs.default_file_behavior);
 	} else {
-		prefs.default_file_behavior = (enum def_file_behavior)qPrefPrivate::propValue(group + "/default_file_behavior", default_prefs.default_file_behavior).toInt();
+		prefs.default_file_behavior = (enum def_file_behavior)qPrefPrivate::propValue(keyFromGroupAndName(group, "default_file_behavior"), default_prefs.default_file_behavior).toInt();
 		if (prefs.default_file_behavior == UNDEFINED_DEFAULT_FILE)
 			// undefined, so check if there's a filename set and
 			// use that, otherwise go with no default file
@@ -77,19 +77,19 @@ void qPrefGeneral::disk_default_file_behavior(bool doSync)
 	}
 }
 
-HANDLE_PREFERENCE_INT(General, "/defaultsetpoint", defaultsetpoint);
+HANDLE_PREFERENCE_INT(General, "defaultsetpoint", defaultsetpoint);
 
-HANDLE_PREFERENCE_BOOL(General, "/extract_video_thumbnails", extract_video_thumbnails);
+HANDLE_PREFERENCE_BOOL(General, "extract_video_thumbnails", extract_video_thumbnails);
 
-HANDLE_PREFERENCE_INT(General, "/extract_video_thumbnails_position", extract_video_thumbnails_position);
+HANDLE_PREFERENCE_INT(General, "extract_video_thumbnails_position", extract_video_thumbnails_position);
 
-HANDLE_PREFERENCE_TXT(General, "/ffmpeg_executable", ffmpeg_executable);
+HANDLE_PREFERENCE_TXT(General, "ffmpeg_executable", ffmpeg_executable);
 
-HANDLE_PREFERENCE_INT(General, "/o2consumption", o2consumption);
+HANDLE_PREFERENCE_INT(General, "o2consumption", o2consumption);
 
-HANDLE_PREFERENCE_INT(General, "/pscr_ratio", pscr_ratio);
+HANDLE_PREFERENCE_INT(General, "pscr_ratio", pscr_ratio);
 
-HANDLE_PREFERENCE_BOOL(General, "/use_default_file", use_default_file);
+HANDLE_PREFERENCE_BOOL(General, "use_default_file", use_default_file);
 
 HANDLE_PROP_QSTRING(General, "diveshareExport/uid", diveshareExport_uid);
 

--- a/core/settings/qPrefGeocoding.cpp
+++ b/core/settings/qPrefGeocoding.cpp
@@ -32,9 +32,9 @@ void qPrefGeocoding::set_first_taxonomy_category(taxonomy_category value)
 void qPrefGeocoding::disk_first_taxonomy_category(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/cat0", prefs.geocoding.category[0], default_prefs.geocoding.category[0]);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cat0"), prefs.geocoding.category[0], default_prefs.geocoding.category[0]);
 	else
-		prefs.geocoding.category[0] = (enum taxonomy_category)qPrefPrivate::propValue(group + "/cat0", default_prefs.geocoding.category[0]).toInt();
+		prefs.geocoding.category[0] = (enum taxonomy_category)qPrefPrivate::propValue(keyFromGroupAndName(group, "cat0"), default_prefs.geocoding.category[0]).toInt();
 }
 
 
@@ -49,9 +49,9 @@ void qPrefGeocoding::set_second_taxonomy_category(taxonomy_category value)
 void qPrefGeocoding::disk_second_taxonomy_category(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/cat1", prefs.geocoding.category[1], default_prefs.geocoding.category[1]);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cat1"), prefs.geocoding.category[1], default_prefs.geocoding.category[1]);
 	else
-		prefs.geocoding.category[1] = (enum taxonomy_category)qPrefPrivate::propValue(group + "/cat1", default_prefs.geocoding.category[1]).toInt();
+		prefs.geocoding.category[1] = (enum taxonomy_category)qPrefPrivate::propValue(keyFromGroupAndName(group, "cat1"), default_prefs.geocoding.category[1]).toInt();
 }
 
 
@@ -66,7 +66,7 @@ void qPrefGeocoding::set_third_taxonomy_category(taxonomy_category value)
 void qPrefGeocoding::disk_third_taxonomy_category(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/cat2", prefs.geocoding.category[2], default_prefs.geocoding.category[2]);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cat2"), prefs.geocoding.category[2], default_prefs.geocoding.category[2]);
 	else
-		prefs.geocoding.category[2] = (enum taxonomy_category)qPrefPrivate::propValue(group + "/cat2", default_prefs.geocoding.category[2]).toInt();
+		prefs.geocoding.category[2] = (enum taxonomy_category)qPrefPrivate::propValue(keyFromGroupAndName(group, "cat2"), default_prefs.geocoding.category[2]).toInt();
 }

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -26,18 +26,18 @@ void qPrefLanguage::loadSync(bool doSync)
 	disk_use_system_language(doSync);
 }
 
-HANDLE_PREFERENCE_TXT(Language, "/date_format", date_format);
+HANDLE_PREFERENCE_TXT(Language, "date_format", date_format);
 
-HANDLE_PREFERENCE_BOOL(Language,"/date_format_override", date_format_override);
+HANDLE_PREFERENCE_BOOL(Language,"date_format_override", date_format_override);
 
-HANDLE_PREFERENCE_TXT(Language, "/date_format_short", date_format_short);
+HANDLE_PREFERENCE_TXT(Language, "date_format_short", date_format_short);
 
-HANDLE_PREFERENCE_TXT_EXT(Language, "/UiLanguage", language, locale.);
+HANDLE_PREFERENCE_TXT_EXT(Language, "UiLanguage", language, locale.);
 
-HANDLE_PREFERENCE_TXT_EXT(Language, "/UiLangLocale", lang_locale, locale.);
+HANDLE_PREFERENCE_TXT_EXT(Language, "UiLangLocale", lang_locale, locale.);
 
-HANDLE_PREFERENCE_TXT(Language, "/time_format", time_format);
+HANDLE_PREFERENCE_TXT(Language, "time_format", time_format);
 
-HANDLE_PREFERENCE_BOOL(Language, "/time_format_override", time_format_override);
+HANDLE_PREFERENCE_BOOL(Language, "time_format_override", time_format_override);
 
-HANDLE_PREFERENCE_BOOL_EXT(Language, "/UseSystemLanguage", use_system_language, locale.);
+HANDLE_PREFERENCE_BOOL_EXT(Language, "UseSystemLanguage", use_system_language, locale.);

--- a/core/settings/qPrefLocationService.cpp
+++ b/core/settings/qPrefLocationService.cpp
@@ -19,6 +19,6 @@ void qPrefLocationService::loadSync(bool doSync)
 	disk_time_threshold(doSync);
 }
 
-HANDLE_PREFERENCE_INT(LocationService, "/distance_threshold", distance_threshold);
+HANDLE_PREFERENCE_INT(LocationService, "distance_threshold", distance_threshold);
 
-HANDLE_PREFERENCE_INT(LocationService, "/time_threshold", time_threshold);
+HANDLE_PREFERENCE_INT(LocationService, "time_threshold", time_threshold);

--- a/core/settings/qPrefPartialPressureGas.cpp
+++ b/core/settings/qPrefPartialPressureGas.cpp
@@ -25,16 +25,16 @@ void qPrefPartialPressureGas::loadSync(bool doSync)
 }
 
 
-HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "/phegraph", phe, pp_graphs.);
+HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "phegraph", phe, pp_graphs.);
 
-HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "/phethreshold", phe_threshold, pp_graphs.);
+HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "phethreshold", phe_threshold, pp_graphs.);
 
-HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "/pn2graph", pn2, pp_graphs.);
+HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "pn2graph", pn2, pp_graphs.);
 
-HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "/pn2threshold", pn2_threshold, pp_graphs.);
+HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "pn2threshold", pn2_threshold, pp_graphs.);
 
-HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "/po2graph", po2, pp_graphs.);
+HANDLE_PREFERENCE_BOOL_EXT(PartialPressureGas, "po2graph", po2, pp_graphs.);
 
-HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "/po2thresholdmax", po2_threshold_max, pp_graphs.);
+HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "po2thresholdmax", po2_threshold_max, pp_graphs.);
 
-HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "/po2thresholdmin", po2_threshold_min, pp_graphs.);
+HANDLE_PREFERENCE_DOUBLE_EXT(PartialPressureGas, "po2thresholdmin", po2_threshold_min, pp_graphs.);

--- a/core/settings/qPrefPrivate.cpp
+++ b/core/settings/qPrefPrivate.cpp
@@ -9,6 +9,12 @@ void qPrefPrivate::copy_txt(const char **name, const QString &string)
 	*name = copy_qstring(string);
 }
 
+QString keyFromGroupAndName(QString group, QString name)
+{
+	QString slash = (group.endsWith('/') || name.startsWith('/')) ? "" : "/";
+	return group + slash + name;
+}
+
 void qPrefPrivate::propSetValue(const QString &key, const QVariant &value, const QVariant &defaultValue)
 {
 	// REMARK: making s static (which would be logical) does NOT work

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -22,15 +22,17 @@ private:
 	qPrefPrivate() {}
 };
 
+// helper function to ensure there's a '/' between group and name
+QString keyFromGroupAndName(QString group, QString name);
 
 //******* Macros to generate disk function
 #define DISK_LOADSYNC_BOOL_EXT(usegroup, name, field, usestruct) \
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = qPrefPrivate::propValue(group + name, default_prefs.usestruct field).toBool(); \
+			prefs.usestruct field = qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field).toBool(); \
 	}
 #define DISK_LOADSYNC_BOOL(usegroup, name, field) \
 	DISK_LOADSYNC_BOOL_EXT(usegroup, name, field, )
@@ -39,9 +41,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = qPrefPrivate::propValue(group + name, default_prefs.usestruct field).toDouble(); \
+			prefs.usestruct field = qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field).toDouble(); \
 	}
 #define DISK_LOADSYNC_DOUBLE(usegroup, name, field) \
 	DISK_LOADSYNC_DOUBLE_EXT(usegroup, name, field, )
@@ -50,9 +52,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = (enum type)qPrefPrivate::propValue(group + name, default_prefs.usestruct field).toInt(); \
+			prefs.usestruct field = (enum type)qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field).toInt(); \
 	}
 #define DISK_LOADSYNC_ENUM(usegroup, name, type, field) \
 	DISK_LOADSYNC_ENUM_EXT(usegroup, name, type, field, )
@@ -61,9 +63,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = qPrefPrivate::propValue(group + name, default_prefs.usestruct field).toInt(); \
+			prefs.usestruct field = qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field).toInt(); \
 	}
 #define DISK_LOADSYNC_INT(usegroup, name, field) \
 	DISK_LOADSYNC_INT_EXT(usegroup, name, field, )
@@ -72,9 +74,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = qPrefPrivate::propValue(group + name, defval).toInt(); \
+			prefs.usestruct field = qPrefPrivate::propValue(keyFromGroupAndName(group, name), defval).toInt(); \
 	}
 #define DISK_LOADSYNC_INT_DEF(usegroup, name, field, defval) \
 	DISK_LOADSYNC_INT_DEF_EXT(usegroup, name, field, defval, )
@@ -83,9 +85,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field . var, default_prefs.usestruct field . var); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field . var, default_prefs.usestruct field . var); \
 		else \
-			prefs.usestruct field . var = qPrefPrivate::propValue(group + name, default_prefs.usestruct field . var).toInt(); \
+			prefs.usestruct field . var = qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field . var).toInt(); \
 	}
 #define DISK_LOADSYNC_STRUCT(usegroup, name, field, var) \
 	DISK_LOADSYNC_STRUCT_EXT(usegroup, name, field, var, )
@@ -94,9 +96,9 @@ private:
 	void qPref##usegroup::disk_##field(bool doSync) \
 	{ \
 		if (doSync) \
-			qPrefPrivate::propSetValue(group + name, prefs.usestruct field, default_prefs.usestruct field); \
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct field, default_prefs.usestruct field); \
 		else \
-			prefs.usestruct field = copy_qstring(qPrefPrivate::propValue(group + name, default_prefs.usestruct field).toString()); \
+			prefs.usestruct field = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct field).toString()); \
 	}
 #define DISK_LOADSYNC_TXT(usegroup, name, field) \
 	DISK_LOADSYNC_TXT_EXT(usegroup, name, field, )

--- a/core/settings/qPrefProxy.cpp
+++ b/core/settings/qPrefProxy.cpp
@@ -25,14 +25,14 @@ void qPrefProxy::loadSync(bool doSync)
 	disk_proxy_user(doSync);
 }
 
-HANDLE_PREFERENCE_BOOL(Proxy, "/proxy_auth", proxy_auth);
+HANDLE_PREFERENCE_BOOL(Proxy, "proxy_auth", proxy_auth);
 
-HANDLE_PREFERENCE_TXT(Proxy, "/proxy_host", proxy_host);
+HANDLE_PREFERENCE_TXT(Proxy, "proxy_host", proxy_host);
 
-HANDLE_PREFERENCE_TXT(Proxy, "/proxy_pass", proxy_pass);
+HANDLE_PREFERENCE_TXT(Proxy, "proxy_pass", proxy_pass);
 
-HANDLE_PREFERENCE_INT(Proxy, "/proxy_port", proxy_port);
+HANDLE_PREFERENCE_INT(Proxy, "proxy_port", proxy_port);
 
-HANDLE_PREFERENCE_INT_DEF(Proxy, "/proxy_type", proxy_type, QNetworkProxy::DefaultProxy);
+HANDLE_PREFERENCE_INT_DEF(Proxy, "proxy_type", proxy_type, QNetworkProxy::DefaultProxy);
 
-HANDLE_PREFERENCE_TXT(Proxy, "/proxy_user", proxy_user);
+HANDLE_PREFERENCE_TXT(Proxy, "proxy_user", proxy_user);

--- a/core/settings/qPrefTechnicalDetails.cpp
+++ b/core/settings/qPrefTechnicalDetails.cpp
@@ -48,56 +48,56 @@ void qPrefTechnicalDetails::loadSync(bool doSync)
 	disk_zoomed_plot(doSync);
 }
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/calcalltissues", calcalltissues);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "calcalltissues", calcalltissues);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/calcceiling", calcceiling);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "calcceiling", calcceiling);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/calcceiling3m", calcceiling3m);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "calcceiling3m", calcceiling3m);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/calcndltts", calcndltts);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "calcndltts", calcndltts);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/dcceiling", dcceiling);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "dcceiling", dcceiling);
 
-HANDLE_PREFERENCE_ENUM(TechnicalDetails, deco_mode, "/display_deco_mode", display_deco_mode);
+HANDLE_PREFERENCE_ENUM(TechnicalDetails, deco_mode, "display_deco_mode", display_deco_mode);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/display_unused_tanks", display_unused_tanks);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "display_unused_tanks", display_unused_tanks);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/ead", ead);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "ead", ead);
 
-HANDLE_PREFERENCE_INT(TechnicalDetails, "/gfhigh", gfhigh);
+HANDLE_PREFERENCE_INT(TechnicalDetails, "gfhigh", gfhigh);
 
-HANDLE_PREFERENCE_INT(TechnicalDetails, "/gflow", gflow);
+HANDLE_PREFERENCE_INT(TechnicalDetails, "gflow", gflow);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/gf_low_at_maxdepth", gf_low_at_maxdepth);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "gf_low_at_maxdepth", gf_low_at_maxdepth);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/hrgraph", hrgraph);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "hrgraph", hrgraph);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/mod", mod);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "mod", mod);
 
-HANDLE_PREFERENCE_DOUBLE(TechnicalDetails, "/modpO2", modpO2);
+HANDLE_PREFERENCE_DOUBLE(TechnicalDetails, "modpO2", modpO2);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/percentagegraph", percentagegraph);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "percentagegraph", percentagegraph);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/redceiling", redceiling);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "redceiling", redceiling);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/RulerBar", rulergraph);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "RulerBar", rulergraph);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_average_depth", show_average_depth);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_average_depth", show_average_depth);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_ccr_sensors", show_ccr_sensors);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_ccr_sensors", show_ccr_sensors);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_ccr_setpoint", show_ccr_setpoint);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_ccr_setpoint", show_ccr_setpoint);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_icd", show_icd);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_icd", show_icd);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_pictures_in_profile", show_pictures_in_profile);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_pictures_in_profile", show_pictures_in_profile);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_sac", show_sac);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_sac", show_sac);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/show_scr_ocpo2", show_scr_ocpo2);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "show_scr_ocpo2", show_scr_ocpo2);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/tankbar", tankbar);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "tankbar", tankbar);
 
-HANDLE_PREFERENCE_INT(TechnicalDetails, "/vpmb_conservatism", vpmb_conservatism);
+HANDLE_PREFERENCE_INT(TechnicalDetails, "vpmb_conservatism", vpmb_conservatism);
 
-HANDLE_PREFERENCE_BOOL(TechnicalDetails, "/zoomed_plot", zoomed_plot);
+HANDLE_PREFERENCE_BOOL(TechnicalDetails, "zoomed_plot", zoomed_plot);

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -29,17 +29,17 @@ void qPrefUnits::loadSync(bool doSync)
 	disk_weight(doSync);
 }
 
-HANDLE_PREFERENCE_BOOL(Units, "/coordinates", coordinates_traditional);
+HANDLE_PREFERENCE_BOOL(Units, "coordinates", coordinates_traditional);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::DURATION, "/duration_units", duration_units, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::DURATION, "duration_units", duration_units, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::LENGTH, "/length", length, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::LENGTH, "length", length, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, "/pressure", pressure, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, "pressure", pressure, units.);
 
-HANDLE_PREFERENCE_BOOL_EXT(Units, "/show_units_table", show_units_table, units.);
+HANDLE_PREFERENCE_BOOL_EXT(Units, "show_units_table", show_units_table, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, "/temperature", temperature, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, "temperature", temperature, units.);
 
 QString qPrefUnits::unit_system()
 {
@@ -66,10 +66,10 @@ void qPrefUnits::set_unit_system(const QString& value)
 		emit instance()->unit_system_changed(value);
 	}
 }
-DISK_LOADSYNC_ENUM(Units, "/unit_system", unit_system_values, unit_system);
+DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::TIME, "/vertical_speed_time", vertical_speed_time, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::TIME, "vertical_speed_time", vertical_speed_time, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::VOLUME, "/volume", volume, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::VOLUME, "volume", volume, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, "/weight", weight, units.);
+HANDLE_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, "weight", weight, units.);

--- a/core/settings/qPrefUpdateManager.cpp
+++ b/core/settings/qPrefUpdateManager.cpp
@@ -30,7 +30,7 @@ void qPrefUpdateManager::loadSync(bool doSync)
 }
 
 
-HANDLE_PREFERENCE_BOOL_EXT(UpdateManager, "/DontCheckForUpdates", dont_check_for_updates, update_manager.);
+HANDLE_PREFERENCE_BOOL_EXT(UpdateManager, "DontCheckForUpdates", dont_check_for_updates, update_manager.);
 
 void qPrefUpdateManager::set_dont_check_exists(bool value)
 {
@@ -42,7 +42,7 @@ void qPrefUpdateManager::set_dont_check_exists(bool value)
 }
 
 
-HANDLE_PREFERENCE_TXT_EXT(UpdateManager, "/LastVersionUsed", last_version_used, update_manager.);
+HANDLE_PREFERENCE_TXT_EXT(UpdateManager, "LastVersionUsed", last_version_used, update_manager.);
 
 
 void qPrefUpdateManager::set_next_check(const QDate& value)
@@ -57,9 +57,9 @@ void qPrefUpdateManager::set_next_check(const QDate& value)
 void qPrefUpdateManager::disk_next_check(bool doSync)
 {
 	if (doSync)
-		qPrefPrivate::propSetValue(group + "/NextCheck", prefs.update_manager.next_check, default_prefs.update_manager.next_check);
+		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "NextCheck"), prefs.update_manager.next_check, default_prefs.update_manager.next_check);
 	else
-		prefs.update_manager.next_check = qPrefPrivate::propValue(group + "/NextCheck", 0).toInt();
+		prefs.update_manager.next_check = qPrefPrivate::propValue(keyFromGroupAndName(group, "NextCheck"), 0).toInt();
 }
 
 HANDLE_PROP_QSTRING(UpdateManager, "UpdateManager/UUID", uuidString);


### PR DESCRIPTION
We had a couple of instances of names being incorrectly merged with their
group, this should handle that better. It's a bit of a big hammer to use, but
it seems to work (and it makes it easy to then git grep for cases that don't
use the new helper function.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
This should change all invocations that had the `/` as part of the name to drop that (and I think I found a couple where this was still missing). And it makes it fairly easy to use git grep for situations where we aren't using the helper.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Calling this a cleanup is misleading. The existing code was fine, it just opened the door to typos that would cause group and key to be concatenated without a `/` between them. Now the pattern should make it easier to avoid that (and the helper tries to be smart in case I missed a case where the `/` was already present.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add helper function that ensures there's exactly one `/` between `group` and `name` (that's a lie, if you call it with both `group` ending with `/` and `name` starting with `/`, it doesn't remove one of them...)
2) edit the macros and the users of `qPref` to not include the `/` in the name anymore (this one is more for simplification and consistency than anything else)

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixe s an issue. -->
#1649 #1643
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder @bstoeger @janiversen - could the three of you take a look to make sure this is sane and doesn't break anything? It feels like overkill, but I think it should get the job done.