### PR TITLE
Planner: fix display of "overlapping dives" message

### DIFF
--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -120,7 +120,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	}
 
 	if (diveplan->surface_interval < 0) {
-		put_format(&buf, "<div><b>%s (%s) %s<br>",
+		put_format(&buf, "<div><b>%s (%s) %s<br></div>",
 			translate("gettextFromC", "Subsurface"),
 			subsurface_canonical_version(),
 			translate("gettextFromC", "dive plan</b> (overlapping dives detected)"));

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -433,7 +433,7 @@ void MainTab::updateDiveInfo(bool clear)
 	ui.notes->setText(QString());
 	if (!clear) {
 		QString tmp(displayed_dive.notes);
-		if (tmp.indexOf("<table") != -1) {
+		if (tmp.indexOf("<div") != -1) {
 			tmp.replace(QString("\n"), QString("<br>"));
 			ui.notes->setHtml(tmp);
 		} else {
@@ -1427,7 +1427,7 @@ void MainTab::on_notes_textChanged()
 		if (same_string(displayed_dive.notes, qPrintable(ui.notes->toPlainText())))
 			return;
 		free(displayed_dive.notes);
-		if (ui.notes->toHtml().indexOf("<table") != -1)
+		if (ui.notes->toHtml().indexOf("<div") != -1)
 			displayed_dive.notes = copy_qstring(ui.notes->toHtml());
 		else
 			displayed_dive.notes = copy_qstring(ui.notes->toPlainText());
@@ -1512,7 +1512,7 @@ void MainTab::showAndTriggerEditSelective(struct dive_components what)
 	SHOW_SELECTIVE(suit);
 	if (what.notes) {
 		QString tmp(displayed_dive.notes);
-		if (tmp.contains("<table")) {
+		if (tmp.contains("<div")) {
 			tmp.replace(QString("\n"), QString("<br>"));
 			ui.notes->setHtml(tmp);
 		} else {


### PR DESCRIPTION
1) Add a missing `<div>`

2) More importantly: recognize html content via `<div>`-tags instead of
   `<table>`-tags.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a display bug. To test:
CTRL-L. Save.
Open dive in planner. Save as new.
CTRL-L. Save.
--> Message will be shown as HTML gibberish.

I'm not sure if that fix is correct!
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add missing `<div>`-tag
2) Recognize HTML by `<div>` instead of `<table>`-tag.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Probably too trivial.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @sfuchs79 @dirkhh 