### PR TITLE
Mobile: Remove webservice, remove UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: remove UI components of the Webservice GPS interaction
 - Desktop: remove UI components of the Webservice GPS import. This functionality will
 be fully replaced by "apply on device".
 - DLF import: record battery status at end of dive

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -299,28 +299,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 				Kirigami.Action {
 					icon {
-						name: ":/icons/ic_cloud_upload.svg"
-					}
-					text: qsTr("Upload GPS data")
-					onTriggered: {
-						globalDrawer.close();
-						manager.sendGpsData();
-					}
-				}
-
-				Kirigami.Action {
-					icon {
-						name: ":/icons/ic_cloud_download.svg"
-					}
-					text: qsTr("Download GPS data")
-					onTriggered: {
-						globalDrawer.close();
-						manager.downloadGpsData();
-					}
-				}
-
-				Kirigami.Action {
-					icon {
 						name:":/icons/ic_gps_fixed.svg"
 					}
 					text: qsTr("Show GPS fixes")


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

This is the first commit related to the removal of the GPS webservice. It is nothing more then removing 2 buttons from the menu to upload and download from the server, so technically a trivial change.

### Additional information:
As with the desktop application: Be very careful here as this forces our users to use Subsurface-mobile, and a online cloud account as that is the way to transfer GPS data from a mobile device to the desktop.

### Release note:
CHANGELOG.md. added

### Documentation change:
Yes, needed.
