### PR TITLE
clean mobile-widgets and use qPref directly in cpp as well as qml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobil: setting for developer menu entry is remembered across sessions
 - Mobile: remove UI components of the Webservice GPS interaction
 - Desktop: remove UI components of the Webservice GPS import. This functionality will
 be fully replaced by "apply on device".

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -3,6 +3,7 @@
 #include "qt-models/gpslistmodel.h"
 #include "core/pref.h"
 #include "core/qthelper.h"
+#include "core/settings/qPrefLocationService.h"
 #include <time.h>
 #include <unistd.h>
 #include <QDebug>
@@ -36,6 +37,9 @@ GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 	userAgent = getUserAgent();
 	(void)getGpsSource();
 	loadFromStorage();
+
+	// register changes in time threshold
+	connect(qPrefLocationService::instance(), SIGNAL(qPrefLocationService::time_thresholdChanged()), this, SLOT(setGpsTimeThreshold(int seconds)));
 }
 
 GpsLocation *GpsLocation::instance()

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -139,8 +139,7 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Blue"
 				onClicked: {
 					blueTheme()
-					prefs.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					PrefDisplay.theme = subsurfaceTheme.currentTheme
 				}
 			}
 
@@ -192,8 +191,7 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Pink"
 				onClicked: {
 					pinkTheme()
-					prefs.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					PrefDisplay.theme = subsurfaceTheme.currentTheme
 				}
 			}
 
@@ -244,8 +242,7 @@ Kirigami.ScrollablePage {
 				enabled: subsurfaceTheme.currentTheme !== "Dark"
 				onClicked: {
 					darkTheme()
-					prefs.theme = subsurfaceTheme.currentTheme
-					manager.savePreferences()
+					PrefDisplay.theme = subsurfaceTheme.currentTheme
 				}
 			}
 		}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -363,10 +363,12 @@ Kirigami.ScrollablePage {
 			}
 			SsrfSwitch {
 				id: developerButton
-				checked: prefs.developer
+				checked: PrefDisplay.show_developer
 				Layout.preferredWidth: gridWidth * 0.25
 				onClicked: {
-					prefs.developer = checked
+					console.log("JAN changing developer menu(" + PrefDisplay.show_developer + ")")
+					PrefDisplay.show_developer = checked
+					console.log("JAN changed developer menu(" + PrefDisplay.show_developer + ")")
 				}
 			}
 		}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -278,11 +278,10 @@ Kirigami.ScrollablePage {
 
 			Controls.TextField {
 				id: distanceThreshold
-				text: prefs.distanceThreshold
+				text: PrefLocationService.distance_threshold
 				Layout.preferredWidth: gridWidth * 0.25
 				onEditingFinished: {
-					prefs.distanceThreshold = distanceThreshold.text
-					manager.savePreferences()
+					PrefLocationService.distance_threshold = distanceThreshold.text
 				}
 			}
 
@@ -366,9 +365,7 @@ Kirigami.ScrollablePage {
 				checked: PrefDisplay.show_developer
 				Layout.preferredWidth: gridWidth * 0.25
 				onClicked: {
-					console.log("JAN changing developer menu(" + PrefDisplay.show_developer + ")")
 					PrefDisplay.show_developer = checked
-					console.log("JAN changed developer menu(" + PrefDisplay.show_developer + ")")
 				}
 			}
 		}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -293,11 +293,10 @@ Kirigami.ScrollablePage {
 
 			Controls.TextField {
 				id: timeThreshold
-				text: prefs.timeThreshold
+				text: PrefLocationService.time_threshold / 60
 				Layout.preferredWidth: gridWidth * 0.25
 				onEditingFinished: {
-					prefs.timeThreshold = timeThreshold.text
-					manager.savePreferences()
+					PrefLocationService.time_threshold = timeThreshold.text * 60
 				}
 			}
 

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -506,7 +506,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		property int columnWidth: Math.round(rootItem.width/(Kirigami.Units.gridUnit*28)) > 0 ? Math.round(rootItem.width / Math.round(rootItem.width/(Kirigami.Units.gridUnit*28))) : rootItem.width
 		Component.onCompleted: {
 			// this needs to pick the theme from persistent preference settings
-			var theme = prefs.theme
+			var theme = PrefDisplay.theme
 			if (theme == "Blue")
 				blueTheme()
 			else if (theme == "Pink")

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -361,7 +361,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					name: ":/icons/ic_adb.svg"
 				}
 				text: qsTr("Developer")
-				visible: prefs.developer
+				visible: PrefDisplay.show_developer
 				Kirigami.Action {
 					text: qsTr("App log")
 					onTriggered: {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -406,7 +406,6 @@ void QMLManager::finishSetup()
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}
-	QMLPrefs::instance()->setDistanceThreshold(qPrefLocationService::distance_threshold());
 	QMLPrefs::instance()->setTimeThreshold(qPrefLocationService::time_threshold() / 60);
 }
 
@@ -427,7 +426,6 @@ QMLManager *QMLManager::instance()
 void QMLManager::savePreferences()
 {
     qPrefLocationService::set_time_threshold(QMLPrefs::instance()->timeThreshold() * 60);
-    qPrefLocationService::set_distance_threshold(QMLPrefs::instance()->distanceThreshold());
 }
 
 #define CLOUDURL QString(prefs.cloud_base_url)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -406,7 +406,6 @@ void QMLManager::finishSetup()
 		appendTextToLog(tr("no cloud credentials"));
 		setStartPageText(RED_FONT + tr("Please enter valid cloud credentials.") + END_FONT);
 	}
-	QMLPrefs::instance()->setTimeThreshold(qPrefLocationService::time_threshold() / 60);
 }
 
 QMLManager::~QMLManager()
@@ -421,11 +420,6 @@ QMLManager::~QMLManager()
 QMLManager *QMLManager::instance()
 {
 	return m_instance;
-}
-
-void QMLManager::savePreferences()
-{
-    qPrefLocationService::set_time_threshold(QMLPrefs::instance()->timeThreshold() * 60);
 }
 
 #define CLOUDURL QString(prefs.cloud_base_url)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -146,7 +146,6 @@ public:
 public slots:
 	void appInitialized();
 	void applicationStateChanged(Qt::ApplicationState state);
-	void savePreferences();
 	void saveCloudCredentials();
 	void tryRetrieveDataFromBackend();
 	void handleError(QNetworkReply::NetworkError nError);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -12,8 +12,7 @@ QMLPrefs *QMLPrefs::m_instance = NULL;
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
-	m_showPin(false),
-	m_timeThreshold(60)
+	m_showPin(false)
 {
 	// This strange construct is needed because QMLEngine calls new and that
 	// cannot be overwritten
@@ -107,18 +106,6 @@ void QMLPrefs::setShowPin(bool enable)
 {
 	m_showPin = enable;
 	emit showPinChanged();
-}
-
-int QMLPrefs::timeThreshold() const
-{
-	return m_timeThreshold;
-}
-
-void QMLPrefs::setTimeThreshold(int time)
-{
-	m_timeThreshold = time;
-	GpsLocation::instance()->setGpsTimeThreshold(m_timeThreshold * 60);
-	emit timeThresholdChanged();
 }
 
 const QString QMLPrefs::theme() const

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -108,19 +108,6 @@ void QMLPrefs::setShowPin(bool enable)
 	emit showPinChanged();
 }
 
-const QString QMLPrefs::theme() const
-{
-	return qPrefDisplay::theme();
-}
-
-void QMLPrefs::setTheme(QString theme)
-{
-	qPrefDisplay::set_theme(theme);
-	emit themeChanged();
-}
-
-
-
 /*** public slot functions ***/
 void QMLPrefs::cancelCredentialsPinSetup()
 {   

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -11,7 +11,6 @@ QMLPrefs *QMLPrefs::m_instance = NULL;
 
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
-	m_developer(false),
 	m_distanceThreshold(1000),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_showPin(false),
@@ -85,12 +84,6 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 		m_credentialStatus = value;
 		emit credentialStatusChanged();
 	}
-}
-
-void QMLPrefs::setDeveloper(bool value)
-{
-	m_developer = value;
-	emit developerChanged();
 }
 
 int QMLPrefs::distanceThreshold() const

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -11,7 +11,6 @@ QMLPrefs *QMLPrefs::m_instance = NULL;
 
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
-	m_distanceThreshold(1000),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_showPin(false),
 	m_timeThreshold(60)
@@ -84,17 +83,6 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 		m_credentialStatus = value;
 		emit credentialStatusChanged();
 	}
-}
-
-int QMLPrefs::distanceThreshold() const
-{
-	return m_distanceThreshold;
-}
-
-void QMLPrefs::setDistanceThreshold(int distance)
-{
-	m_distanceThreshold = distance;
-	emit distanceThresholdChanged();
 }
 
 qPrefCloudStorage::cloud_status QMLPrefs::oldStatus() const

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -33,10 +33,6 @@ class QMLPrefs : public QObject {
 				MEMBER m_oldStatus
 				WRITE setOldStatus
 				NOTIFY oldStatusChanged)
-	Q_PROPERTY(QString theme
-				READ theme
-				WRITE setTheme
-				NOTIFY themeChanged)
 public:
 	QMLPrefs();
 	~QMLPrefs();
@@ -61,9 +57,6 @@ public:
 	bool showPin() const;
 	void setShowPin(bool enable);
 
-	const QString theme() const;
-	void setTheme(QString theme);
-
 public slots:
 	void cancelCredentialsPinSetup();
 	void clearCredentials();
@@ -84,7 +77,6 @@ signals:
 	void credentialStatusChanged();
 	void oldStatusChanged();
 	void showPinChanged();
-	void themeChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -25,10 +25,6 @@ class QMLPrefs : public QObject {
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
 				NOTIFY credentialStatusChanged)
-	Q_PROPERTY(bool developer
-				MEMBER m_developer
-				WRITE setDeveloper
-				NOTIFY developerChanged)
 	Q_PROPERTY(int distanceThreshold
 				MEMBER m_distanceThreshold
 				WRITE setDistanceThreshold
@@ -68,8 +64,6 @@ public:
 	qPrefCloudStorage::cloud_status credentialStatus() const;
 	void setCredentialStatus(const qPrefCloudStorage::cloud_status value);
 
-	void setDeveloper(bool value);
-
 	int distanceThreshold() const;
 	void setDistanceThreshold(int distance);
 
@@ -94,7 +88,6 @@ private:
 	QString m_cloudPin;
 	QString m_cloudUserName;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
-	bool m_developer;
 	int m_distanceThreshold;
 	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
@@ -107,7 +100,6 @@ signals:
 	void cloudUserNameChanged();
 	void credentialStatusChanged();
 	void distanceThresholdChanged();
-	void developerChanged();
 	void oldStatusChanged();
 	void showPinChanged();
 	void themeChanged();

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -37,11 +37,6 @@ class QMLPrefs : public QObject {
 				READ theme
 				WRITE setTheme
 				NOTIFY themeChanged)
-	Q_PROPERTY(int timeThreshold
-				MEMBER m_timeThreshold
-				WRITE setTimeThreshold
-				NOTIFY timeThresholdChanged)
-
 public:
 	QMLPrefs();
 	~QMLPrefs();
@@ -66,9 +61,6 @@ public:
 	bool showPin() const;
 	void setShowPin(bool enable);
 
-	int  timeThreshold() const;
-	void setTimeThreshold(int time);
-
 	const QString theme() const;
 	void setTheme(QString theme);
 
@@ -84,7 +76,6 @@ private:
 	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
 	bool m_showPin;
-	int m_timeThreshold;
 
 signals:
 	void cloudPasswordChanged();
@@ -94,7 +85,6 @@ signals:
 	void oldStatusChanged();
 	void showPinChanged();
 	void themeChanged();
-	void timeThresholdChanged();
 };
 
 #endif

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -25,10 +25,6 @@ class QMLPrefs : public QObject {
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
 				NOTIFY credentialStatusChanged)
-	Q_PROPERTY(int distanceThreshold
-				MEMBER m_distanceThreshold
-				WRITE setDistanceThreshold
-				NOTIFY distanceThresholdChanged)
 	Q_PROPERTY(bool showPin
 				MEMBER m_showPin
 				WRITE setShowPin
@@ -64,9 +60,6 @@ public:
 	qPrefCloudStorage::cloud_status credentialStatus() const;
 	void setCredentialStatus(const qPrefCloudStorage::cloud_status value);
 
-	int distanceThreshold() const;
-	void setDistanceThreshold(int distance);
-
 	qPrefCloudStorage::cloud_status oldStatus() const;
 	void setOldStatus(const qPrefCloudStorage::cloud_status value);
 
@@ -88,7 +81,6 @@ private:
 	QString m_cloudPin;
 	QString m_cloudUserName;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
-	int m_distanceThreshold;
 	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
 	bool m_showPin;
@@ -99,7 +91,6 @@ signals:
 	void cloudPinChanged();
 	void cloudUserNameChanged();
 	void credentialStatusChanged();
-	void distanceThresholdChanged();
 	void oldStatusChanged();
 	void showPinChanged();
 	void themeChanged();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
With qPref being stable and available in C++ as well as QML, it is time to
reduce qmlPrefs.cpp and qmlManager.cpp, who to a large extent serve as
a gateway between C++ and QML, but in a manner that are costly and do not allow signalling

qmlPrefs and qmlManager are available in QML as the C++ Class, meaning the objects will be
instanciated in QML (this is rather costly and memory consuming). qPref* are available directly
as C++ Object in QML and thus without any significant overhead.

The changes (especially around cloud credentials) are rather delicate, and needs a lot of manual testing, for that reason, each variable will be in a separate commit.

Remark: this PR is not concerned with how the qPref variables are used in the rest of the code, this is part of another discussion outside my scope.

This was the low hanging fruits in qmlmanager and qmlprefs, which all was gateway functions to gateway functions and thus not needed. All of the remaining parts needs more code changes.

Remark: there should be no connection to the desktop 4.8.2 release.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) clean cloud_storage_password

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->