### PR TITLE
Profile: fix SAC calculation for air dives

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2205,8 +2205,15 @@ void cylinder_renumber(struct dive *dive, int mapping[])
 		dc_cylinder_renumber(dive, dc, mapping);
 }
 
+static bool gasmix_is_invalid(struct gasmix mix)
+{
+	return mix.o2.permille < 0;
+}
+
 int same_gasmix(struct gasmix a, struct gasmix b)
 {
+	if (gasmix_is_invalid(a) || gasmix_is_invalid(b))
+		return 0;
 	if (gasmix_is_air(a) && gasmix_is_air(b))
 		return 1;
 	return a.o2.permille == b.o2.permille && a.he.permille == b.he.permille;
@@ -4314,6 +4321,6 @@ struct gasmix get_gasmix(const struct dive *dive, const struct divecomputer *dc,
 struct gasmix get_gasmix_at_time(const struct dive *d, const struct divecomputer *dc, duration_t time)
 {
 	const struct event *ev = NULL;
-	struct gasmix gasmix = { 0 };
+	struct gasmix gasmix = gasmix_air;
 	return get_gasmix(d, dc, time.seconds, &ev, gasmix);
 }

--- a/core/dive.h
+++ b/core/dive.h
@@ -34,10 +34,14 @@ extern const char *cylinderuse_text[];
 extern const char *divemode_text_ui[];
 extern const char *divemode_text[];
 
+// o2 == 0 && he == 0 -> air
+// o2 < 0 -> invalid
 struct gasmix {
 	fraction_t o2;
 	fraction_t he;
 };
+static const struct gasmix gasmix_invalid = { { -1 }, { -1 } };
+static const struct gasmix gasmix_air = { { 0 }, { 0 } };
 
 typedef struct
 {

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -405,7 +405,7 @@ static int calculate_sac(const struct dive *dive)
 static void add_dive_to_deco(struct deco_state *ds, struct dive *dive)
 {
 	struct divecomputer *dc = &dive->dc;
-	struct gasmix gasmix = { 0 };
+	struct gasmix gasmix = gasmix_air;
 	int i;
 	const struct event *ev = NULL, *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -76,7 +76,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	struct membuffer icdbuf = { 0 };
 	const char *deco, *segmentsymbol;
 	int lastdepth = 0, lasttime = 0, lastsetpoint = -1, newdepth = 0, lastprintdepth = 0, lastprintsetpoint = -1;
-	struct gasmix lastprintgasmix = {{ -1 }, { -1 }};
+	struct gasmix lastprintgasmix = gasmix_invalid;
 	struct divedatapoint *dp = diveplan->dp;
 	bool plan_verbatim = prefs.verbatim_plan;
 	bool plan_display_runtime = prefs.display_runtime;

--- a/core/profile.c
+++ b/core/profile.c
@@ -780,7 +780,7 @@ static unsigned int matching_gases(struct dive *dive, struct gasmix gasmix)
 
 static void calculate_sac(struct dive *dive, struct divecomputer *dc, struct plot_info *pi)
 {
-	struct gasmix gasmix = { 0 };
+	struct gasmix gasmix = gasmix_invalid;
 	const struct event *ev = NULL;
 	unsigned int gases = 0;
 
@@ -1021,7 +1021,7 @@ void calculate_deco_information(struct deco_state *ds, const struct deco_state *
 		int last_ndl_tts_calc_time = 0, first_ceiling = 0, current_ceiling, last_ceiling = 0, final_tts = 0 , time_clear_ceiling = 0;
 		if (decoMode() == VPMB)
 			ds->first_ceiling_pressure.mbar = depth_to_mbar(first_ceiling, dive);
-		struct gasmix gasmix = { 0 };
+		struct gasmix gasmix = gasmix_invalid;
 		const struct event *ev = NULL, *evd = NULL;
 		enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 
@@ -1210,7 +1210,7 @@ static void calculate_gas_information_new(struct dive *dive, struct divecomputer
 {
 	int i;
 	double amb_pressure;
-	struct gasmix gasmix = { 0 };
+	struct gasmix gasmix = gasmix_invalid;
 	const struct event *evg = NULL, *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -410,7 +410,7 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 	for (int i = 1, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
 		if (i < poly.count()) {
 			double value = dataModel->index(i, vDataColumn).data().toDouble();
-			struct gasmix gasmix = { 0 };
+			struct gasmix gasmix = gasmix_air;
 			const struct event *ev = NULL;
 			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
 			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);


### PR DESCRIPTION
Commit f5b11da changed gasmix
arguments and return values to be passed by value instead of
using pointers.

Notably, get_gasmix() is fed a default-value and returns a
new value. In the old code, NULL was passed in in a first
loop iteration and non-NULL was always returned in the first
iteration. Thus, an equality comparison of passed-in an
returned gasmix would always fail in the first loop iteration.

The new code passed in air as default. Now if air was also
returned, then the matching gases were not calculated in
calculate_sac(). To revert to the old behavior, pass in
an invalid gasmix.

Moreover, give names to the invalid and air gasmixes.

Reported-by: tormento <turment@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug reported on the ML.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Pass an invalid gas mix to `get_gasmix` on first iteration in `calculate_sac`.
2) Define `gasmix_air` and `gasmix_invalid` constants.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Reported on ML.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None needed - fixes bug not in previous release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 