### PR TITLE
serial_ftdi: use Sleep() on Win32

### DIFF
--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -26,11 +26,16 @@
 #include <string.h>     // strerror
 #include <errno.h>      // errno
 #include <sys/time.h>   // gettimeofday
-#include <time.h>       // nanosleep
 #include <stdio.h>
 
 #include <libusb.h>
 #include <ftdi.h>
+
+#ifdef _WIN32
+#include <windows.h>    // Sleep
+#else
+#include <time.h>       // nanosleep
+#endif
 
 #ifndef __ANDROID__
 #define INFO(context, fmt, ...)	fprintf(stderr, "INFO: " fmt "\n", ##__VA_ARGS__)
@@ -107,6 +112,9 @@ static dc_status_t serial_ftdi_sleep (void *io, unsigned int timeout)
 
 	INFO (device->context, "Sleep: value=%u", timeout);
 
+#ifdef _WIN32
+	Sleep((DWORD)timeout);
+#else
 	struct timespec ts;
 	ts.tv_sec  = (timeout / 1000);
 	ts.tv_nsec = (timeout % 1000) * 1000000;
@@ -117,6 +125,7 @@ static dc_status_t serial_ftdi_sleep (void *io, unsigned int timeout)
 			return DC_STATUS_IO;
 		}
 	}
+#endif
 
 	return DC_STATUS_SUCCESS;
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Windows doesn't have nanosleep() unless libwinpthread is used.

Since the nanosleep() usage in serial_ftdi_sleep():
- does not break in case of EINTR
- has input in milliseconds

the WINAPI Sleep() should be a good alternative.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) call Sleep() on Win32.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
NONE

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
i must admit, i didn't try building with SERIAL_FTDI, so let's see if CI is happy.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
NONE

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
