### PR TITLE
Proof of concept / do not apply: Make QMLPrefs a proper singleton

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -15,9 +15,9 @@ Item {
 	property string password: password.text;
 
 	function saveCredentials() {
-		prefs.cloudUserName = login.text
-		prefs.cloudPassword = password.text
-		prefs.cloudPin = pin.text
+		QMLPrefs.cloudUserName = login.text
+		QMLPrefs.cloudPassword = password.text
+		QMLPrefs.cloudPin = pin.text
 		manager.saveCloudCredentials()
 	}
 
@@ -53,15 +53,15 @@ Item {
 
 		Controls.Label {
 			text: qsTr("Email")
-			visible: !rootItem.showPin
+			visible: !QMLPrefs.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
 
 		Controls.TextField {
 			id: login
-			text: prefs.cloudUserName
-			visible: !rootItem.showPin
+			text: QMLPrefs.cloudUserName
+			visible: !QMLPrefs.showPin
 			Layout.fillWidth: true
 			inputMethodHints: Qt.ImhEmailCharactersOnly |
 					  Qt.ImhNoAutoUppercase
@@ -69,15 +69,15 @@ Item {
 
 		Controls.Label {
 			text: qsTr("Password")
-			visible: !rootItem.showPin
+			visible: !QMLPrefs.showPin
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.secondaryTextColor
 		}
 
 		Controls.TextField {
 			id: password
-			text: prefs.cloudPassword
-			visible: !rootItem.showPin
+			text: QMLPrefs.cloudPassword
+			visible: !QMLPrefs.showPin
 			echoMode: TextInput.PasswordEchoOnEdit
 			inputMethodHints: Qt.ImhSensitiveData |
 					  Qt.ImhHiddenText |
@@ -87,20 +87,20 @@ Item {
 
 		Controls.Label {
 			text: qsTr("PIN")
-			visible: rootItem.showPin
+			visible: QMLPrefs.showPin
 		}
 		Controls.TextField {
 			id: pin
 			text: ""
 			Layout.fillWidth: true
-			visible: rootItem.showPin
+			visible: QMLPrefs.showPin
 		}
 
 		RowLayout {
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.smallSpacing
 			spacing: Kirigami.Units.smallSpacing
-			visible: rootItem.showPin
+			visible: QMLPrefs.showPin
 			SsrfButton {
 				id: registerpin
 				text: qsTr("Register") 
@@ -126,7 +126,7 @@ Item {
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.smallSpacing
 			spacing: Kirigami.Units.smallSpacing
-			visible: !rootItem.showPin
+			visible: !QMLPrefs.showPin
 
 			SsrfButton {
 				id: signin_register_normal

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -13,7 +13,6 @@ Kirigami.ScrollablePage {
 	title: qsTr("Dive list")
 	verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
 	width: subsurfaceTheme.columnWidth
-	property int credentialStatus: prefs.credentialStatus
 	property int numDives: diveListView.count
 	property color textColor: subsurfaceTheme.textColor
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor
@@ -23,14 +22,14 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (prefs.credentialStatus === CloudStatus.CS_VERIFIED) {
+			if (QMLPrefs.credentialStatus === CloudStatus.CS_VERIFIED) {
 				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
 				console.log("done syncing, turn off spinner")
 				refreshing = false
 			} else {
-				console.log("sync with cloud storage requested, but credentialStatus is " + prefs.credentialStatus)
+				console.log("sync with cloud storage requested, but credentialStatus is " + QMLPrefs.credentialStatus)
 				console.log("no syncing, turn off spinner")
 				refreshing = false
 			}
@@ -339,8 +338,8 @@ Kirigami.ScrollablePage {
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		opacity: credentialStatus === CloudStatus.CS_NOCLOUD ||
-									(credentialStatus === CloudStatus.CS_VERIFIED) ? 0 : 1
+		opacity: QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD ||
+									(QMLPrefs.credentialStatus === CloudStatus.CS_VERIFIED) ? 0 : 1
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
@@ -348,8 +347,8 @@ Kirigami.ScrollablePage {
 				page.actions.main = null
 				page.actions.right = null
 				page.title = qsTr("Cloud credentials")
-			} else if (prefs.credentialStatus === CloudStatus.CS_VERIFIED ||
-						prefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
+			} else if (QMLPrefs.credentialStatus === CloudStatus.CS_VERIFIED ||
+						QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")
@@ -440,8 +439,8 @@ Kirigami.ScrollablePage {
 
 	onBackRequested: {
 		if (startPage.visible && diveListView.count > 0 &&
-			prefs.credentialStatus !== CloudStatus.CS_INCORRECT_USER_PASSWD) {
-			prefs.credentialStatus = oldStatus
+			QMLPrefs.credentialStatus !== CloudStatus.CS_INCORRECT_USER_PASSWD) {
+			QMLPrefs.credentialStatus = oldStatus
 			event.accepted = true;
 		}
 		if (!startPage.visible) {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: prefs.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : prefs.cloudUserName
+				text: QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : QMLPrefs.cloudUserName
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
@@ -55,7 +55,7 @@ Kirigami.ScrollablePage {
 				Layout.alignment: Qt.AlignRight
 				text: qsTr("Change")
 				onClicked: {
-					prefs.cancelCredentialsPinSetup()
+					QMLPrefs.cancelCredentialsPinSetup()
 					rootItem.returnTopPage()
 				}
 			}
@@ -66,7 +66,7 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: describe[prefs.credentialStatus]
+				text: describe[QMLPrefs.credentialStatus]
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -30,7 +30,7 @@ Kirigami.ScrollablePage {
 		}
 		Controls.Label {
 			id: explanationTextBasic
-			visible: !showPin
+			visible: !QMLPrefs.showPin
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3
@@ -43,7 +43,7 @@ Kirigami.ScrollablePage {
 		}
 		Controls.Label {
 			id: explanationTextPin
-			visible: showPin
+			visible: QMLPrefs.showPin
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3
@@ -52,7 +52,7 @@ Kirigami.ScrollablePage {
 				"If you do not receive an email from us within 15 minutes, please check " +
 				"the correct spelling of your email address and your spam box first.<br/><br/>" +
 				"In case of any problems regarding cloud account setup, please contact us " +
-				"at our user forum \(https://subsurface-divelog.org/user-forum/\).<br/><br/>").arg(prefs.cloudUserName)
+				"at our user forum \(https://subsurface-divelog.org/user-forum/\).<br/><br/>").arg(QMLPrefs.cloudUserName)
 			wrapMode: Text.WordWrap
 		}
 		Item { width: Kirigami.Units.gridUnit; height: 3 * Kirigami.Units.gridUnit}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -21,12 +21,10 @@ Kirigami.ApplicationWindow {
 		maximumHeight: Kirigami.Units.gridUnit * 2
 		background: Rectangle { color: subsurfaceTheme.primaryColor }
 	}
-	property alias oldStatus: prefs.oldStatus
 	property alias notificationText: manager.notificationText
 	property alias syncToCloud: manager.syncToCloud
 	property alias locationServiceEnabled: manager.locationServiceEnabled
 	property alias pluggedInDeviceName: manager.pluggedInDeviceName
-	property alias showPin: prefs.showPin
 	property alias defaultCylinderIndex: settingsWindow.defaultCylinderIndex
 	onNotificationTextChanged: {
 		if (notificationText != "") {
@@ -173,7 +171,7 @@ Kirigami.ApplicationWindow {
 						visible: text.length > 0
 						level: 3
 						color: "white"
-						text: prefs.cloudUserName
+						text: QMLPrefs.cloudUserName
 						wrapMode: Text.NoWrap
 						elide: Text.ElideRight
 						font.weight: Font.Normal
@@ -191,12 +189,12 @@ Kirigami.ApplicationWindow {
 				}
 				text: qsTr("Dive list")
 				onTriggered: {
-					manager.appendTextToLog("requested dive list with credential status " + prefs.credentialStatus)
-					if (prefs.credentialStatus == CloudStatus.CS_UNKNOWN) {
+					manager.appendTextToLog("requested dive list with credential status " + QMLPrefs.credentialStatus)
+					if (QMLPrefs.credentialStatus == CloudStatus.CS_UNKNOWN) {
 						// the user has asked to change credentials - if the credentials before that
 						// were valid, go back to dive list
-						if (oldStatus == CloudStatus.CS_VERIFIED) {
-							prefs.credentialStatus = oldStatus
+						if (QMLPrefs.oldStatus == CloudStatus.CS_VERIFIED) {
+							QMLPrefs.credentialStatus = QMLPrefs.oldStatus
 						}
 					}
 					returnTopPage()
@@ -222,8 +220,8 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/ic_add.svg"
 					}
 					text: qsTr("Add dive manually")
-					enabled: prefs.credentialStatus === CloudStatus.CS_VERIFIED ||
-							prefs.credentialStatus === CloudStatus.CS_NOCLOUD
+					enabled: QMLPrefs.credentialStatus === CloudStatus.CS_VERIFIED ||
+							QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD
 					onTriggered: {
 						globalDrawer.close()
 						returnTopPage()  // otherwise odd things happen with the page stack
@@ -257,14 +255,14 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/cloud_sync.svg"
 					}
 					text: qsTr("Manual sync with cloud")
-					enabled: prefs.credentialStatus === CloudStatus.CS_VERIFIED ||
-							prefs.credentialStatus === CloudStatus.CS_NOCLOUD
+					enabled: QMLPrefs.credentialStatus === CloudStatus.CS_VERIFIED ||
+							QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD
 					onTriggered: {
-						if (prefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
+						if (QMLPrefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
 							returnTopPage()
-							oldStatus = prefs.credentialStatus
+							QMLPrefs.oldStatus = QMLPrefs.credentialStatus
 							manager.startPageText = "Enter valid cloud storage credentials"
-							prefs.credentialStatus = CloudStatus.CS_UNKNOWN
+							QMLPrefs.credentialStatus = CloudStatus.CS_UNKNOWN
 							globalDrawer.close()
 						} else {
 							globalDrawer.close()
@@ -279,7 +277,7 @@ Kirigami.ApplicationWindow {
 					name: syncToCloud ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
 				text: syncToCloud ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
-					enabled: prefs.credentialStatus !== CloudStatus.CS_NOCLOUD
+					enabled: QMLPrefs.credentialStatus !== CloudStatus.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
 						if (!syncToCloud) {
@@ -548,10 +546,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				detailsWindow.endEditMode()
 			}
 		}
-	}
-
-	QMLPrefs {
-		id: prefs
 	}
 
 	QMLManager {

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -7,27 +7,17 @@
 
 
 /*** Global and constructors ***/
-QMLPrefs *QMLPrefs::m_instance = NULL;
-
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_showPin(false)
 {
-	// This strange construct is needed because QMLEngine calls new and that
-	// cannot be overwritten
-	if (!m_instance)
-		m_instance = this;
-}
-
-QMLPrefs::~QMLPrefs()
-{
-	m_instance = NULL;
 }
 
 QMLPrefs *QMLPrefs::instance()
 {
-	return m_instance;
+	static QMLPrefs *self = new QMLPrefs;
+	return self;
 }
 
 

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -33,11 +33,12 @@ class QMLPrefs : public QObject {
 				MEMBER m_oldStatus
 				WRITE setOldStatus
 				NOTIFY oldStatusChanged)
-public:
+private:
 	QMLPrefs();
-	~QMLPrefs();
 
+public:
 	static QMLPrefs *instance();
+	static constexpr const char *typeName = "QMLPrefs";
 
 	const QString cloudPassword() const;
 	void setCloudPassword(const QString &cloudPassword);

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -157,6 +157,19 @@ static void register_meta_types()
 	if (rc < 0) \
 		qWarning() << "ERROR: Cannot register " << useQML << ", QML will not work!!";
 
+template <typename T>
+QObject *instance_as_qobject(QQmlEngine *, QJSEngine *)
+{
+	return T::instance();
+}
+
+template <typename T>
+void register_qml_singleton()
+{
+	if (qmlRegisterSingletonType<T>("org.subsurfacedivelog.mobile", 1, 0, T::typeName, &instance_as_qobject<T>) < 0)
+		qWarning() << QStringLiteral("ERROR: Cannot register %1, QML will not work!").arg(T::typeName);
+}
+
 void register_qml_types(QQmlEngine *engine)
 {
 	// register qPref*
@@ -167,7 +180,7 @@ void register_qml_types(QQmlEngine *engine)
 
 #ifdef SUBSURFACE_MOBILE
 	REGISTER_TYPE(QMLManager, "QMLManager");
-	REGISTER_TYPE(QMLPrefs, "QMLPrefs");
+	register_qml_singleton<QMLPrefs>();
 	REGISTER_TYPE(QMLProfile, "QMLProfile");
 	REGISTER_TYPE(DownloadThread, "DCDownloadThread");
 	REGISTER_TYPE(DiveImportedModel, "DCImportModel");


### PR DESCRIPTION
We had that absolutely crazy construct, where in some QML-accessed
singletons the instance variable was set in the constructor. The
background was that apparently if registered as a normal type, QML
would insist on constructing an object via "new T".

Nevertheless, as a quick look in the documentation shows, QML *does*
support singletons with the qmlRegisterSingletonType() function.
This is a first proof of concept to make the QMLPrefs class a real
singleton.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is merely a proof of concept / request for discussion. QML *does* know singletons. Therefore it seems to me that we should use that for the few QML types that we have (c.f. `subsurface-helper.cpp`). This commit was mostly done blindfolded and I'm sure there is some major breakage. But it runs *and* shows my dives.

Does this fix a user-visible problem? No. Does it remove a major embaressment? Hell yes.

Yes, this used a template. This can of course be converted to a macro.

More Info: this makes the constructor private, which means that QML can in no way construct its own copies.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

Make `QMLPrefs` a singleton.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Just a proof of concept.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Just a proof of concept.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
