### PR TITLE
Desktop: improve navigation options on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: disable UI elements that make no sense during editing [#1445]
 - Mobil: setting for developer menu entry is remembered across sessions
 - Mobile: remove UI components of the Webservice GPS interaction
 - Desktop: remove UI components of the Webservice GPS import. This functionality will

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1054,9 +1054,6 @@ void MainWindow::on_actionAddDive_triggered()
 	// now show the mostly empty main tab
 	information()->updateDiveInfo();
 
-	// show main tab
-	information()->setCurrentIndex(0);
-
 	information()->addDiveStarted();
 
 	graphics()->setAddState();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -270,6 +270,11 @@ void MainTab::toggleTriggeredColumn()
 
 void MainTab::addDiveStarted()
 {
+	ui.tabWidget->setCurrentIndex(0);
+	ui.tabWidget->setTabEnabled(2, false);
+	ui.tabWidget->setTabEnabled(3, false);
+	ui.tabWidget->setTabEnabled(4, false);
+	ui.tabWidget->setTabEnabled(5, false);
 	enableEdition(ADD);
 }
 
@@ -339,6 +344,9 @@ void MainTab::enableEdition(EditMode newEditMode)
 	MainWindow::instance()->dive_list()->setEnabled(false);
 	MainWindow::instance()->setEnabledToolbar(false);
 	MainWindow::instance()->enterEditState();
+	ui.tabWidget->setTabEnabled(2, false);
+	ui.tabWidget->setTabEnabled(3, false);
+	ui.tabWidget->setTabEnabled(5, false);
 
 	if (isTripEdit) {
 		// we are editing trip location and notes
@@ -534,6 +542,8 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.tabWidget->setTabText(0, tr("Notes"));
 			ui.tabWidget->setTabEnabled(1, true);
 			ui.tabWidget->setTabEnabled(2, true);
+			ui.tabWidget->setTabEnabled(3, true);
+			ui.tabWidget->setTabEnabled(4, true);
 			ui.tabWidget->setTabEnabled(5, true);
 			// Recover the tab selected for last dive
 			if (!lastSelectedDive)


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
As described in the referenced issue, we where able to navigate to nonlogical static pages (like information, statistics. extra data) when adding a dive. These are output style pages that make no sense on edit or add. Further, disable access to some pages when entering edit mode.

Notice that the small change in file mainwindow.cpp is simply because this did not work at all, and became superfluous any way.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Fixes: #1445

### Release note:
Not sure... needed for this trivial thing?