### PR TITLE
more qmlpref cleanup, and correct default_cylinder setting

### DIFF
--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
 			}
 			Controls.Label {
-				text: prefs.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : prefs.cloudUserName
+				text: prefs.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
 				Layout.alignment: Qt.AlignRight
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 2
@@ -328,7 +328,7 @@ Kirigami.ScrollablePage {
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 				onActivated: {
-					PrefGeneral.set_default_cylinder(defaultCylinderBox.currentText)
+					PrefGeneral.default_cylinder = defaultCylinderBox.currentText
 				}
 			}
 		}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2,7 +2,7 @@
 #include "qmlmanager.h"
 #include "qmlprefs.h"
 #include <QUrl>
-#include <QSettings>
+#include <QDebug>
 #include <QDebug>
 #include <QNetworkAccessManager>
 #include <QAuthenticator>
@@ -427,7 +427,6 @@ QMLManager *QMLManager::instance()
 
 void QMLManager::saveCloudCredentials()
 {
-	QSettings s;
 	bool cloudCredentialsChanged = false;
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
@@ -446,11 +445,9 @@ void QMLManager::saveCloudCredentials()
 			return;
 		}
 	}
-	s.beginGroup("CloudStorage");
-	s.setValue("email", QMLPrefs::instance()->cloudUserName());
-	s.setValue("password", QMLPrefs::instance()->cloudPassword());
-	s.setValue("cloud_verification_status", QMLPrefs::instance()->credentialStatus());
-	s.sync();
+	qPrefCloudStorage::set_cloud_storage_email(QMLPrefs::instance()->cloudUserName());
+	qPrefCloudStorage::set_cloud_storage_password(QMLPrefs::instance()->cloudPassword());
+	qPrefCloudStorage::set_cloud_verification_status(QMLPrefs::instance()->credentialStatus());
 	if (!same_string(prefs.cloud_storage_email,
 		qPrintable(QMLPrefs::instance()->cloudUserName()))) {
 		free((void *)prefs.cloud_storage_email);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) do not call set_xyz(value) in qml, use xyz = value
2) remove Qsetting of qPref variables in saveCloudCredentials
Ps. I am aware 2) is against the never guideline of not remove QSettings in the code, but
it uses QSetting to set variables, where the exact same code is in qPref (and was in SettingsObjectWrapper), that simply does not make sense to me, but explains why I wanted to remove QSettings.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh both commits have been tested manually (the second with a compare of the plist file generated by QSettings).