### PR TITLE
make qPref constructor private (WITHOUT problems in QML)

### DIFF
--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -49,10 +49,9 @@ void CloudStorageAuthenticate::uploadFinished()
 
 	QString cloudAuthReply(reply->readAll());
 	qDebug() << "Completed connection with cloud storage backend, response" << cloudAuthReply;
-	qPrefCloudStorage csSettings(parent());
 
 	if (cloudAuthReply == QLatin1String("[VERIFIED]") || cloudAuthReply == QLatin1String("[OK]")) {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
 		/* TODO: Move this to a correct place
 		NotificationWidget *nw = MainWindow::instance()->getNotificationWidget();
 		if (nw->getNotificationText() == myLastError)
@@ -61,15 +60,15 @@ void CloudStorageAuthenticate::uploadFinished()
 		myLastError.clear();
 	} else if (cloudAuthReply == QLatin1String("[VERIFY]") ||
 		   cloudAuthReply == QLatin1String("Invalid PIN")) {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_NEED_TO_VERIFY);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {
-		csSettings.set_cloud_storage_password(cloudNewPassword);
+		qPrefCloudStorage::set_cloud_storage_password(cloudNewPassword);
 		cloudNewPassword.clear();
 		emit passwordChangeSuccessful();
 		return;
 	} else {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_INCORRECT_USER_PASSWD);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_INCORRECT_USER_PASSWD);
 		myLastError = cloudAuthReply;
 		report_error("%s", qPrintable(cloudAuthReply));
 	}

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -19,10 +19,6 @@
 #include <QtQml>
 #include <QQmlContext>
 
-qPref::qPref(QObject *parent) : QObject(parent)
-{
-}
-
 qPref *qPref::instance()
 {
 	static qPref *self = new qPref;

--- a/core/settings/qPref.h
+++ b/core/settings/qPref.h
@@ -13,7 +13,6 @@ class qPref : public QObject {
 	Q_PROPERTY(QString mobile_version READ mobile_version);
 
 public:
-	qPref(QObject *parent = NULL);
 	static qPref *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -28,6 +27,8 @@ public:
 	static const QString mobile_version() { return QString(MOBILE_VERSION_STRING); }
 
 private:
+	qPref() {}
+
 	static void loadSync(bool doSync);
 };
 #endif

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("CloudStorage");
 
-qPrefCloudStorage::qPrefCloudStorage(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefCloudStorage *qPrefCloudStorage::instance()
 {
 	static qPrefCloudStorage *self = new qPrefCloudStorage;

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -18,7 +18,6 @@ class qPrefCloudStorage : public QObject {
 	Q_PROPERTY(bool save_password_local READ save_password_local WRITE set_save_password_local NOTIFY save_password_localChanged);
 
 public:
-	qPrefCloudStorage(QObject *parent = NULL);
 	static qPrefCloudStorage *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -67,6 +66,8 @@ signals:
 	void save_password_localChanged(bool value);
 
 private:
+	qPrefCloudStorage() {}
+
 	// functions to load/sync variable with disk
 	static void disk_cloud_base_url(bool doSync);
 	static void disk_cloud_storage_email(bool doSync);

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -41,10 +41,6 @@ static const QByteArray st_windowState_default = 0;
 int qPrefDisplay::st_lastState;
 static int st_lastState_default = false; 
 
-qPrefDisplay::qPrefDisplay(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDisplay *qPrefDisplay::instance()
 {
 	static qPrefDisplay *self = new qPrefDisplay;

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -26,7 +26,6 @@ class qPrefDisplay : public QObject {
 	Q_PROPERTY(int lastState READ lastState WRITE set_lastState NOTIFY lastStateChanged);
 
 public:
-	qPrefDisplay(QObject *parent = NULL);
 	static qPrefDisplay *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -89,6 +88,8 @@ signals:
 	void lastStateChanged(int value);
 
 private:
+	qPrefDisplay() {}
+
 	// functions to load/sync variable with disk
 	static void disk_animation_speed(bool doSync);
 	static void disk_divelist_font(bool doSync);

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("DiveComputer");
 
-qPrefDiveComputer::qPrefDiveComputer(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDiveComputer *qPrefDiveComputer::instance()
 {
 	static qPrefDiveComputer *self = new qPrefDiveComputer;

--- a/core/settings/qPrefDiveComputer.h
+++ b/core/settings/qPrefDiveComputer.h
@@ -14,7 +14,6 @@ class qPrefDiveComputer : public QObject {
 	Q_PROPERTY(QString vendor READ vendor WRITE set_vendor NOTIFY vendorChanged);
 
 public:
-	qPrefDiveComputer(QObject *parent = NULL);
 	static qPrefDiveComputer *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -44,6 +43,8 @@ signals:
 	void vendorChanged(const QString &vendor);
 
 private:
+	qPrefDiveComputer() {}
+
 	// functions to load/sync variable with disk
 	static void disk_device(bool doSync);
 	static void disk_device_name(bool doSync);

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -5,10 +5,6 @@
 
 static const QString group = QStringLiteral("Planner");
 
-qPrefDivePlanner::qPrefDivePlanner(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDivePlanner *qPrefDivePlanner::instance()
 {
 	static qPrefDivePlanner *self = new qPrefDivePlanner;

--- a/core/settings/qPrefDivePlanner.h
+++ b/core/settings/qPrefDivePlanner.h
@@ -34,7 +34,6 @@ class qPrefDivePlanner : public QObject {
 	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged);
 
 public:
-	qPrefDivePlanner(QObject *parent = NULL);
 	static qPrefDivePlanner *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -124,6 +123,8 @@ signals:
 	void verbatim_planChanged(bool value);
 
 private:
+	qPrefDivePlanner() {}
+
 	static void disk_ascratelast6m(bool doSync);
 	static void disk_ascratestops(bool doSync);
 	static void disk_ascrate50(bool doSync);

--- a/core/settings/qPrefFacebook.cpp
+++ b/core/settings/qPrefFacebook.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("WebApps/Facebook");
 
-qPrefFacebook::qPrefFacebook(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefFacebook*qPrefFacebook::instance()
 {
 	static qPrefFacebook *self = new qPrefFacebook;

--- a/core/settings/qPrefFacebook.h
+++ b/core/settings/qPrefFacebook.h
@@ -13,7 +13,6 @@ class qPrefFacebook : public QObject {
 	Q_PROPERTY(QString user_id READ user_id WRITE set_user_id NOTIFY user_idChanged);
 
 public:
-	qPrefFacebook(QObject *parent = NULL);
 	static qPrefFacebook *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -37,6 +36,8 @@ signals:
 	void user_idChanged(const QString& value);
 
 private:
+	qPrefFacebook() {}
+
 	static void disk_access_token(bool doSync);
 	static void disk_album_id(bool doSync);
 	static void disk_user_id(bool doSync);

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -11,10 +11,6 @@ static const QString st_diveshareExport_uid_default = "";
 bool qPrefGeneral::st_diveshareExport_private;
 static const bool st_diveshareExport_private_default = false;
 
-qPrefGeneral::qPrefGeneral(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefGeneral *qPrefGeneral::instance()
 {
 	static qPrefGeneral *self = new qPrefGeneral;

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -22,7 +22,6 @@ class qPrefGeneral : public QObject {
 	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged);
 
 public:
-	qPrefGeneral(QObject *parent = NULL);
 	static qPrefGeneral *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -76,6 +75,8 @@ signals:
 	void diveshareExport_privateChanged(bool value);
 
 private:
+	qPrefGeneral() {}
+
 	static void disk_auto_recalculate_thumbnails(bool doSync);
 	static void disk_default_cylinder(bool doSync);
 	static void disk_default_filename(bool doSync);

--- a/core/settings/qPrefGeocoding.cpp
+++ b/core/settings/qPrefGeocoding.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("geocoding");
 
-qPrefGeocoding::qPrefGeocoding(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefGeocoding *qPrefGeocoding::instance()
 {
 	static qPrefGeocoding *self = new qPrefGeocoding;

--- a/core/settings/qPrefGeocoding.h
+++ b/core/settings/qPrefGeocoding.h
@@ -13,7 +13,6 @@ class qPrefGeocoding : public QObject {
 	Q_PROPERTY(taxonomy_category third_taxonomy_category READ third_taxonomy_category WRITE set_third_taxonomy_category NOTIFY third_taxonomy_categoryChanged);
 
 public:
-	qPrefGeocoding(QObject *parent = NULL);
 	static qPrefGeocoding *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -22,9 +21,9 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
-	taxonomy_category first_taxonomy_category() { return prefs.geocoding.category[0]; }
-	taxonomy_category second_taxonomy_category() { return prefs.geocoding.category[1]; }
-	taxonomy_category third_taxonomy_category() { return prefs.geocoding.category[2]; }
+	static taxonomy_category first_taxonomy_category() { return prefs.geocoding.category[0]; }
+	static taxonomy_category second_taxonomy_category() { return prefs.geocoding.category[1]; }
+	static taxonomy_category third_taxonomy_category() { return prefs.geocoding.category[2]; }
 
 public slots:
 	static void set_first_taxonomy_category(taxonomy_category value);
@@ -37,6 +36,8 @@ signals:
 	void third_taxonomy_categoryChanged(taxonomy_category value);
 
 private:
+	qPrefGeocoding() {}
+
 	static void disk_first_taxonomy_category(bool doSync);
 	static void disk_second_taxonomy_category(bool doSync);
 	static void disk_third_taxonomy_category(bool doSync);

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("Language");
 
-qPrefLanguage::qPrefLanguage(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefLanguage *qPrefLanguage::instance()
 {
 	static qPrefLanguage *self = new qPrefLanguage;

--- a/core/settings/qPrefLanguage.h
+++ b/core/settings/qPrefLanguage.h
@@ -17,7 +17,6 @@ class qPrefLanguage : public QObject {
 	Q_PROPERTY(bool use_system_language READ use_system_language WRITE set_use_system_language NOTIFY use_system_languageChanged);
 
 public:
-	qPrefLanguage(QObject *parent = NULL);
 	static qPrefLanguage *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -56,6 +55,8 @@ signals:
 	void use_system_languageChanged(bool value);
 
 private:
+	qPrefLanguage() {}
+
 	static void disk_date_format(bool doSync);
 	static void disk_date_format_override(bool doSync);
 	static void disk_date_format_short(bool doSync);

--- a/core/settings/qPrefLocationService.cpp
+++ b/core/settings/qPrefLocationService.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("LocationService");
 
-qPrefLocationService::qPrefLocationService(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefLocationService *qPrefLocationService::instance()
 {
 	static qPrefLocationService *self = new qPrefLocationService;

--- a/core/settings/qPrefLocationService.h
+++ b/core/settings/qPrefLocationService.h
@@ -12,7 +12,6 @@ class qPrefLocationService : public QObject {
 	Q_PROPERTY(int time_threshold READ time_threshold WRITE set_time_threshold NOTIFY time_thresholdChanged);
 
 public:
-	qPrefLocationService(QObject *parent = NULL);
 	static qPrefLocationService *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -34,6 +33,8 @@ signals:
 
 
 private:
+	qPrefLocationService() {}
+
 	static void disk_distance_threshold(bool doSync);
 	static void disk_time_threshold(bool doSync);
 };

--- a/core/settings/qPrefPartialPressureGas.cpp
+++ b/core/settings/qPrefPartialPressureGas.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("TecDetails");
 
-qPrefPartialPressureGas::qPrefPartialPressureGas(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefPartialPressureGas *qPrefPartialPressureGas::instance()
 {
 	static qPrefPartialPressureGas *self = new qPrefPartialPressureGas;

--- a/core/settings/qPrefPartialPressureGas.h
+++ b/core/settings/qPrefPartialPressureGas.h
@@ -16,7 +16,6 @@ class qPrefPartialPressureGas : public QObject {
 	Q_PROPERTY(double po2_threshold_min READ po2_threshold_min WRITE set_po2_threshold_min NOTIFY po2_threshold_minChanged);
 
 public:
-	qPrefPartialPressureGas(QObject *parent = NULL);
 	static qPrefPartialPressureGas *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -52,6 +51,8 @@ signals:
 	void po2_threshold_minChanged(double value);
 
 private:
+	qPrefPartialPressureGas() {}
+
 	static void disk_phe(bool doSync);
 	static void disk_phe_threshold(bool doSync);
 	static void disk_pn2(bool doSync);

--- a/core/settings/qPrefProxy.cpp
+++ b/core/settings/qPrefProxy.cpp
@@ -6,10 +6,6 @@
 
 static const QString group = QStringLiteral("Network");
 
-qPrefProxy::qPrefProxy(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefProxy *qPrefProxy::instance()
 {
 	static qPrefProxy *self = new qPrefProxy;

--- a/core/settings/qPrefProxy.h
+++ b/core/settings/qPrefProxy.h
@@ -16,7 +16,6 @@ class qPrefProxy : public QObject {
 	Q_PROPERTY(QString proxy_user READ proxy_user WRITE set_proxy_user NOTIFY proxy_userChanged);
 
 public:
-	qPrefProxy(QObject *parent = NULL);
 	static qPrefProxy *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -49,6 +48,8 @@ signals:
 	void proxy_userChanged(const QString &value);
 
 private:
+	qPrefProxy() {}
+
 	static void disk_proxy_auth(bool doSync);
 	static void disk_proxy_host(bool doSync);
 	static void disk_proxy_pass(bool doSync);

--- a/core/settings/qPrefTechnicalDetails.cpp
+++ b/core/settings/qPrefTechnicalDetails.cpp
@@ -6,10 +6,6 @@
 
 static const QString group = QStringLiteral("TecDetails");
 
-qPrefTechnicalDetails::qPrefTechnicalDetails(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefTechnicalDetails *qPrefTechnicalDetails::instance()
 {
 	static qPrefTechnicalDetails *self = new qPrefTechnicalDetails;

--- a/core/settings/qPrefTechnicalDetails.h
+++ b/core/settings/qPrefTechnicalDetails.h
@@ -37,7 +37,6 @@ class qPrefTechnicalDetails : public QObject {
 	Q_PROPERTY(bool zoomed_plot READ zoomed_plot WRITE set_zoomed_plot NOTIFY zoomed_plotChanged);
 
 public:
-	qPrefTechnicalDetails(QObject *parent = NULL);
 	static qPrefTechnicalDetails *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -133,6 +132,8 @@ signals:
 	void zoomed_plotChanged(bool value);
 
 private:
+	qPrefTechnicalDetails() {}
+
 	static void disk_calcalltissues(bool doSync);
 	static void disk_calcceiling(bool doSync);
 	static void disk_calcceiling3m(bool doSync);

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -5,10 +5,6 @@
 
 static const QString group = QStringLiteral("Units");
 
-qPrefUnits::qPrefUnits(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefUnits *qPrefUnits::instance()
 {
 	static qPrefUnits *self = new qPrefUnits;

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -20,7 +20,6 @@ class qPrefUnits : public QObject {
 	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged);
 
 public:
-	qPrefUnits(QObject *parent = NULL);
 	static qPrefUnits *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -65,6 +64,8 @@ signals:
 	void weightChanged(int value);
 
 private:
+	qPrefUnits() {}
+
 	static void disk_coordinates_traditional(bool doSync);
 	static void disk_duration_units(bool doSync);
 	static void disk_length(bool doSync);

--- a/core/settings/qPrefUpdateManager.cpp
+++ b/core/settings/qPrefUpdateManager.cpp
@@ -8,10 +8,6 @@ static const QString group = QStringLiteral("UpdateManager");
 QString qPrefUpdateManager::st_uuidString;
 static const QString st_uuidString_default = "";
 
-qPrefUpdateManager::qPrefUpdateManager(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefUpdateManager *qPrefUpdateManager::instance()
 {
 	static qPrefUpdateManager *self = new qPrefUpdateManager;

--- a/core/settings/qPrefUpdateManager.h
+++ b/core/settings/qPrefUpdateManager.h
@@ -15,7 +15,6 @@ class qPrefUpdateManager : public QObject {
 	Q_PROPERTY(const QString uuidString READ uuidString WRITE set_uuidString NOTIFY uuidStringChanged);
 
 public:
-	qPrefUpdateManager(QObject *parent = NULL);
 	static qPrefUpdateManager *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -45,6 +44,8 @@ signals:
 	void uuidStringChanged(const QString& value);
 
 private:
+	qPrefUpdateManager() {}
+
 	static void disk_dont_check_for_updates(bool doSync);
 	static void disk_last_version_used(bool doSync);
 	static void disk_next_check(bool doSync);

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -155,13 +155,11 @@ void TestQPrefCloudStorage::test_multiple()
 {
 	// test multiple instances have the same information
 
-	auto tst_direct = new qPrefCloudStorage;
-
 	prefs.cloud_timeout = 25;
 	auto tst = qPrefCloudStorage::instance();
 
-	QCOMPARE(tst->cloud_timeout(), tst_direct->cloud_timeout());
-	QCOMPARE(tst_direct->cloud_timeout(), 25);
+	QCOMPARE(tst->cloud_timeout(), qPrefCloudStorage::cloud_timeout());
+	QCOMPARE(qPrefCloudStorage::cloud_timeout(), 25);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefDisplay.cpp
+++ b/tests/testqPrefDisplay.cpp
@@ -154,15 +154,13 @@ void TestQPrefDisplay::test_struct_disk()
 void TestQPrefDisplay::test_multiple()
 {
 	// test multiple instances have the same information
-	auto display_direct = qPrefDisplay::instance();
 	prefs.divelist_font = copy_qstring("comic");
-
 	auto display = qPrefDisplay::instance();
 	prefs.font_size = 15.0;
 
-	QCOMPARE(display->divelist_font(), display_direct->divelist_font());
+	QCOMPARE(display->divelist_font(), qPrefDisplay::divelist_font());
 	QCOMPARE(display->divelist_font(), QString("comic"));
-	QCOMPARE(display->font_size(), display_direct->font_size());
+	QCOMPARE(display->font_size(), qPrefDisplay::font_size());
 	QCOMPARE(display->font_size(), 15.0);
 }
 

--- a/tests/testqPrefDiveComputer.cpp
+++ b/tests/testqPrefDiveComputer.cpp
@@ -111,15 +111,14 @@ void TestQPrefDiveComputer::test_struct_disk()
 void TestQPrefDiveComputer::test_multiple()
 {
 	// test multiple instances have the same information
-	auto tst_direct = new qPrefDiveComputer;
 	prefs.dive_computer.download_mode = 57;
 
 	auto tst = qPrefDiveComputer::instance();
 	prefs.dive_computer.device = copy_qstring("mine");
 
-	QCOMPARE(tst->device(), tst_direct->device());
+	QCOMPARE(tst->device(), qPrefDiveComputer::device());
 	QCOMPARE(tst->device(), QString("mine"));
-	QCOMPARE(tst->download_mode(), tst_direct->download_mode());
+	QCOMPARE(tst->download_mode(), qPrefDiveComputer::download_mode());
 	QCOMPARE(tst->download_mode(), 57);
 }
 

--- a/tests/testqPrefDivePlanner.cpp
+++ b/tests/testqPrefDivePlanner.cpp
@@ -312,17 +312,14 @@ void TestQPrefDivePlanner::test_multiple()
 {
 	// test multiple instances have the same information
 
-	prefs.sacfactor = 22;
 	prefs.safetystop = true;
-	auto tst_direct = new qPrefDivePlanner;
-
 	prefs.sacfactor = 32;
 	auto tst = qPrefDivePlanner::instance();
 
-	QCOMPARE(tst->sacfactor(), tst_direct->sacfactor());
-	QCOMPARE(tst->safetystop(), tst_direct->safetystop());
-	QCOMPARE(tst_direct->sacfactor(), 32);
-	QCOMPARE(tst_direct->safetystop(), true);
+	QCOMPARE(tst->sacfactor(), qPrefDivePlanner::sacfactor());
+	QCOMPARE(tst->safetystop(), qPrefDivePlanner::safetystop());
+	QCOMPARE(qPrefDivePlanner::sacfactor(), 32);
+	QCOMPARE(qPrefDivePlanner::safetystop(), true);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefFacebook.cpp
+++ b/tests/testqPrefFacebook.cpp
@@ -48,16 +48,14 @@ void TestQPrefFacebook::test_set_struct()
 void TestQPrefFacebook::test_multiple()
 {
 	// test multiple instances have the same information
-
-	auto tst_direct = new qPrefFacebook;
 	prefs.facebook.access_token = copy_qstring("test 1");
 
 	auto tst = qPrefFacebook::instance();
 	prefs.facebook.album_id = copy_qstring("test 2");
 
-	QCOMPARE(tst->access_token(), tst_direct->access_token());
+	QCOMPARE(tst->access_token(), qPrefFacebook::access_token());
 	QCOMPARE(tst->access_token(), QString("test 1"));
-	QCOMPARE(tst->album_id(), tst_direct->album_id());
+	QCOMPARE(tst->album_id(), qPrefFacebook::album_id());
 	QCOMPARE(tst->album_id(), QString("test 2"));
 }
 

--- a/tests/testqPrefGeneral.cpp
+++ b/tests/testqPrefGeneral.cpp
@@ -181,15 +181,13 @@ void TestQPrefGeneral::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.o2consumption = 17;
-	auto tst_direct = new qPrefGeneral;
-
 	prefs.pscr_ratio = 18;
 	auto tst = qPrefGeneral::instance();
 
-	QCOMPARE(tst->o2consumption(), tst_direct->o2consumption());
-	QCOMPARE(tst->pscr_ratio(), tst_direct->pscr_ratio());
-	QCOMPARE(tst_direct->o2consumption(), 17);
-	QCOMPARE(tst_direct->pscr_ratio(), 18);
+	QCOMPARE(tst->o2consumption(), qPrefGeneral::o2consumption());
+	QCOMPARE(tst->pscr_ratio(), qPrefGeneral::pscr_ratio());
+	QCOMPARE(qPrefGeneral::o2consumption(), 17);
+	QCOMPARE(qPrefGeneral::pscr_ratio(), 18);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefGeocoding.cpp
+++ b/tests/testqPrefGeocoding.cpp
@@ -93,13 +93,11 @@ void TestQPrefGeocoding::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.geocoding.category[0] = TC_NONE;
-	auto tst_direct = new qPrefGeocoding;
-
 	prefs.geocoding.category[1] = TC_OCEAN;
 	auto tst = qPrefGeocoding::instance();
 
-	QCOMPARE(tst->first_taxonomy_category(), tst_direct->first_taxonomy_category());
-	QCOMPARE(tst->second_taxonomy_category(), tst_direct->second_taxonomy_category());
+	QCOMPARE(tst->first_taxonomy_category(), qPrefGeocoding::first_taxonomy_category());
+	QCOMPARE(tst->second_taxonomy_category(), qPrefGeocoding::second_taxonomy_category());
 	QCOMPARE(tst->first_taxonomy_category(), TC_NONE);
 	QCOMPARE(tst->second_taxonomy_category(), TC_OCEAN);
 }

--- a/tests/testqPrefLanguage.cpp
+++ b/tests/testqPrefLanguage.cpp
@@ -141,15 +141,14 @@ void TestQPrefLanguage::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.locale.use_system_language = false;
-	auto tst_direct = new qPrefLanguage;
 
 	prefs.time_format_override = true;
 	auto tst = qPrefLanguage::instance();
 
-	QCOMPARE(tst->use_system_language(), tst_direct->use_system_language());
-	QCOMPARE(tst->time_format_override(), tst_direct->time_format_override());
-	QCOMPARE(tst_direct->use_system_language(), false);
-	QCOMPARE(tst_direct->time_format_override(), true);
+	QCOMPARE(tst->use_system_language(), qPrefLanguage::use_system_language());
+	QCOMPARE(tst->time_format_override(), qPrefLanguage::time_format_override());
+	QCOMPARE(qPrefLanguage::use_system_language(), false);
+	QCOMPARE(qPrefLanguage::time_format_override(), true);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefLocationService.cpp
+++ b/tests/testqPrefLocationService.cpp
@@ -81,15 +81,13 @@ void TestQPrefLocationService::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.distance_threshold = 52;
-	auto tst_direct = new qPrefLocationService;
-
 	prefs.time_threshold = 62;
 	auto tst = qPrefLocationService::instance();
 
-	QCOMPARE(tst->distance_threshold(), tst_direct->distance_threshold());
-	QCOMPARE(tst->time_threshold(), tst_direct->time_threshold());
-	QCOMPARE(tst_direct->distance_threshold(), 52);
-	QCOMPARE(tst_direct->time_threshold(), 62);
+	QCOMPARE(tst->distance_threshold(), qPrefLocationService::distance_threshold());
+	QCOMPARE(tst->time_threshold(), qPrefLocationService::time_threshold());
+	QCOMPARE(qPrefLocationService::distance_threshold(), 52);
+	QCOMPARE(qPrefLocationService::time_threshold(), 62);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefPartialPressureGas.cpp
+++ b/tests/testqPrefPartialPressureGas.cpp
@@ -131,15 +131,13 @@ void TestQPrefPartialPressureGas::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.pp_graphs.phe_threshold = 2.2;
-	auto tst_direct = new qPrefPartialPressureGas;
-
 	prefs.pp_graphs.pn2_threshold = 2.3;
 	auto tst = qPrefPartialPressureGas::instance();
 
-	QCOMPARE(tst->phe_threshold(), tst_direct->phe_threshold());
-	QCOMPARE(tst->pn2_threshold(), tst_direct->pn2_threshold());
-	QCOMPARE(tst_direct->phe_threshold(), 2.2);
-	QCOMPARE(tst_direct->pn2_threshold(), 2.3);
+	QCOMPARE(tst->phe_threshold(), qPrefPartialPressureGas::phe_threshold());
+	QCOMPARE(tst->pn2_threshold(), qPrefPartialPressureGas::pn2_threshold());
+	QCOMPARE(qPrefPartialPressureGas::phe_threshold(), 2.2);
+	QCOMPARE(qPrefPartialPressureGas::pn2_threshold(), 2.3);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefProxy.cpp
+++ b/tests/testqPrefProxy.cpp
@@ -122,14 +122,12 @@ void TestQPrefProxy::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.proxy_port= 37;
-	auto tst_direct = new qPrefProxy;
-
 	prefs.proxy_type = 25;
 	auto tst = qPrefProxy::instance();
 
-	QCOMPARE(tst->proxy_port(), tst_direct->proxy_port());
+	QCOMPARE(tst->proxy_port(), qPrefProxy::proxy_port());
 	QCOMPARE(tst->proxy_port(), 37);
-	QCOMPARE(tst->proxy_type(), tst_direct->proxy_type());
+	QCOMPARE(tst->proxy_type(), qPrefProxy::proxy_type());
 	QCOMPARE(tst->proxy_type(), 25);
 }
 

--- a/tests/testqPrefTechnicalDetails.cpp
+++ b/tests/testqPrefTechnicalDetails.cpp
@@ -329,15 +329,13 @@ void TestQPrefTechnicalDetails::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.gfhigh = 27;
-	auto tst_direct = new qPrefTechnicalDetails;
-
 	prefs.gflow = 25;
 	auto tst = qPrefTechnicalDetails::instance();
 
-	QCOMPARE(tst->gfhigh(), tst_direct->gfhigh());
-	QCOMPARE(tst->gflow(), tst_direct->gflow());
-	QCOMPARE(tst_direct->gfhigh(), 27);
-	QCOMPARE(tst_direct->gflow(), 25);
+	QCOMPARE(tst->gfhigh(), qPrefTechnicalDetails::gfhigh());
+	QCOMPARE(tst->gflow(), qPrefTechnicalDetails::gflow());
+	QCOMPARE(qPrefTechnicalDetails::gfhigh(), 27);
+	QCOMPARE(qPrefTechnicalDetails::gflow(), 25);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -152,14 +152,13 @@ void TestQPrefUnits::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.units.length = units::METERS;
-	auto tst_direct = new qPrefUnits;
 
 	prefs.units.pressure = units::BAR;
 	auto tst = qPrefUnits::instance();
 
-	QCOMPARE(tst->length(), tst_direct->length());
+	QCOMPARE(tst->length(), qPrefUnits::length());
 	QCOMPARE(tst->length(), units::METERS);
-	QCOMPARE(tst->pressure(), tst_direct->pressure());
+	QCOMPARE(tst->pressure(), qPrefUnits::pressure());
 	QCOMPARE(tst->pressure(), units::BAR);
 }
 

--- a/tests/testqPrefUpdateManager.cpp
+++ b/tests/testqPrefUpdateManager.cpp
@@ -114,15 +114,14 @@ void TestQPrefUpdateManager::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.update_manager.dont_check_for_updates = false;
-	auto tst_direct = new qPrefUpdateManager;
 
 	prefs.update_manager.dont_check_exists = false;
 	auto tst = qPrefUpdateManager::instance();
 
-	QCOMPARE(tst->dont_check_for_updates(), tst_direct->dont_check_for_updates());
+	QCOMPARE(tst->dont_check_for_updates(), qPrefUpdateManager::dont_check_for_updates());
 	QCOMPARE(tst->dont_check_for_updates(), false);
-	QCOMPARE(tst->dont_check_exists(), tst_direct->dont_check_exists());
-	QCOMPARE(tst_direct->dont_check_exists(), false);
+	QCOMPARE(tst->dont_check_exists(), qPrefUpdateManager::dont_check_exists());
+	QCOMPARE(qPrefUpdateManager::dont_check_exists(), false);
 }
 
 void TestQPrefUpdateManager::test_next_check()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
@bstoeger pursues securing only instance() is used and not new, that is absolutely a good goal.

This PR makes all qPref constructors private, WITHOUT using singleton, since they were only used in a few other files (not qml).

qmlprefs/qmlmanager are on purpose not included, since they are currently work in progress in another branch of mine. Once the cleanup work is completed, they too will have setContextProperty to ensure correct signal handling and NOT singleton (which is perfect for some cases, but not if we want signalling, and keeping the QQmlEngine dynamic).

REMARK: QML does not instantiate any qPref objects, but uses the C++ object we provide, that is all done to secure that the C++ object is connected to the whole QML sphere. Singleton et al, provides a class interface, which is used when QML need to inherit the C++ class (like in profile widget)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh every single commit have been tested with "make test" and furthermore in case of cloudstorage checked against my pending credentials changes.