### PR TITLE
Desktop: remove "edit dive" from log menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: remove "edit dive" from the log menu. Nowadays we edit in place.
 - Desktop: disable UI elements that make no sense during editing [#1445]
 - Mobil: setting for developer menu entry is remembered across sessions
 - Mobile: remove UI components of the Webservice GPS interaction

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1067,11 +1067,6 @@ void MainWindow::on_actionAddDive_triggered()
 	information()->updateDepthDuration();
 }
 
-void MainWindow::on_actionEditDive_triggered()
-{
-	editCurrentDive();
-}
-
 void MainWindow::on_actionRenumber_triggered()
 {
 	RenumberDialog::instance()->renumberOnlySelected(false);

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -112,7 +112,6 @@ slots:
 	void on_actionDivelogs_de_triggered();
 	void on_actionEditDeviceNames_triggered();
 	void on_actionAddDive_triggered();
-	void on_actionEditDive_triggered();
 	void on_actionRenumber_triggered();
 	void on_actionAutoGroup_triggered();
 	void on_actionYearlyStatistics_triggered();

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -82,7 +82,6 @@
      <string>&amp;Log</string>
     </property>
     <addaction name="actionAddDive"/>
-    <addaction name="actionEditDive"/>
     <addaction name="actionDivePlanner"/>
     <addaction name="actionReplanDive"/>
     <addaction name="copy"/>
@@ -250,11 +249,6 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl++</string>
-   </property>
-  </action>
-  <action name="actionEditDive">
-   <property name="text">
-    <string>&amp;Edit dive</string>
    </property>
   </action>
   <action name="copy">


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Nowadays, we edit dives just by starting to enter data for the dive. There is no need to explicitly ask to start editing the dive, using the now removed menu option. This was a left-over of a long past history.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
This is fallout from PR #1673.

### Release note:
added.

### Documentation change:
Needed.
