### PR TITLE
Update the dive list context menu to reflect new media interface

### DIFF
--- a/appdata/subsurface.appdata.xml
+++ b/appdata/subsurface.appdata.xml
@@ -36,7 +36,7 @@
   <url type="help">https://subsurface-divelog.org/documentation/</url>
   <url type="translate">https://www.transifex.com/subsurface/subsurface/</url>
   <releases>
-    <release version="" date="" />
+    <release version="v4.8.1-428-gd16bcd897811" date="2018-09-14" />
   </releases>
   <developer_name>The Subsurface development team</developer_name>
   <update_contact>subsurface@subsurface-divelog.org</update_contact>

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -892,8 +892,8 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 		popup.addAction(tr("Renumber dive(s)"), this, SLOT(renumberDives()));
 		popup.addAction(tr("Shift dive times"), this, SLOT(shiftTimes()));
 		popup.addAction(tr("Split selected dives"), this, SLOT(splitDives()));
-		popup.addAction(tr("Load image(s) from file(s)"), this, SLOT(loadImages()));
-		popup.addAction(tr("Load image from web"), this, SLOT(loadWebImages()));
+		popup.addAction(tr("Load media from file(s)"), this, SLOT(loadImages()));
+		popup.addAction(tr("Load media from web"), this, SLOT(loadWebImages()));
 	}
 
 	// "collapse all" really closes all trips,


### PR DESCRIPTION
A minor change to the UI. The wording of the two items in the dive
list context menu "Load image(s) from file(s)" and "Load
image from web" are updated since we now deal with both images
and videos. So it becomes "Load media from file(s)".... etc.

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
