### PR TITLE
Dive media: on import read metadata only once

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3869,12 +3869,11 @@ bool dive_check_picture_time(const struct dive *d, int shift_time, timestamp_t t
 	return false;
 }
 
-bool picture_check_valid(const char *filename, int shift_time)
+bool picture_check_valid_time(timestamp_t timestamp, int shift_time)
 {
 	int i;
 	struct dive *dive;
 
-	timestamp_t timestamp = picture_get_timestamp(filename);
 	for_each_dive (i, dive)
 		if (dive->selected && dive_check_picture_time(dive, shift_time, timestamp))
 			return true;

--- a/core/dive.h
+++ b/core/dive.h
@@ -382,7 +382,7 @@ extern void dive_create_picture(struct dive *d, const char *filename, int shift_
 extern void dive_add_picture(struct dive *d, struct picture *newpic);
 extern bool dive_remove_picture(struct dive *d, const char *filename);
 extern unsigned int dive_get_picture_count(struct dive *d);
-extern bool picture_check_valid(const char *filename, int shift_time);
+extern bool picture_check_valid_time(timestamp_t timestamp, int shift_time);
 extern void dive_set_geodata_from_picture(struct dive *d, struct picture *pic);
 extern void picture_free(struct picture *picture);
 

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -118,6 +118,7 @@ slots:
 
 private:
 	QStringList fileNames;
+	QVector<timestamp_t> timestamps;
 	Ui::ShiftImageTimesDialog ui;
 	time_t m_amount;
 	time_t dcImageEpoch;


### PR DESCRIPTION
On import of dive media, the timestamp is read from the
metadata to check if the image belongs to the selected dives.
The pictures are then listed in a dialog.

Currently, the metadata is read twice if images are outside
of a dive: once in picture_check_valid() and if it turns
out that the picture is not valid again in picture_get_time()
to display the proper timestamp.

Even though metadata-extraction is reasonably fast, this is
a bit of an embarrassment.

Instead, read the timestamps only once in the constructor of
the dialog and from then on only used these timestamps. Keep
the timestamps in a QVector. Rename the picture_check_valid()
function to picture_check_valid_time() and pass a timestamp
instead of a filename.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code-cleanup, which could be considered a borderline bug-fix. We read the metadata of images outside of dives twice. [Actually thrice, since once imported the metadata are read again]. In the dive-shift dialog only read the metadata once in the constructor and then access the timestamp from a `QVector`

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Rename `picture_check_valid` to `picture_check_valid_time()` and pass a timestamp instead of a filename.
2) Read metadata in the constructor of `ShiftImageTimesDialog` and remember the timestamps in a `QVector`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Too trivial. Not needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
