### PR TITLE
[TEST] Mobile: use editText instead of currentText in Suit and DiveMaster boxes

### DIFF
--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -110,8 +110,7 @@ Item {
 		// apply the changes to the dive_table
 		manager.commitChanges(dive_id, detailsEdit.dateText, locationBox.editText, detailsEdit.gpsText, detailsEdit.durationText,
 				      detailsEdit.depthText, detailsEdit.airtempText, detailsEdit.watertempText,
-				      suitBox.currentText != "" ? suitBox.currentText : suitBox.editText, buddyBox.editText,
-				      divemasterBox.currentText != "" ? divemasterBox.currentText : divemasterBox.editText,
+				      suitBox.editText, buddyBox.editText, divemasterBox.editText,
 				      detailsEdit.weightText, detailsEdit.notesText, startpressure,
 				      endpressure, usedGas, usedCyl ,
 				      detailsEdit.rating,


### PR DESCRIPTION
A user reported problems with editing the Suit and DiveMaster fields.
Apparently, editing does not change the currentText. Without doing
a deeper analysis, simply use editText (a more proper fix might be
changing the currentIndex on editing).

(Parially?) fixes #1694

Reported-by: Mark Powell <mcpowell123@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Attempt at fixing (or at least duct taping) #1694 

@dirkhh: Could you ask the user if this fixes their problems?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Directly use `editText` instead of conditional for Suit and DiveMaster boxes.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

#1694 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Perhaps?

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
