### PR TITLE
Cleanup: make surface sample in merge_one_sample() non-static

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1828,19 +1828,21 @@ static void merge_one_sample(struct sample *sample, int time, struct divecompute
 {
 	int last = dc->samples - 1;
 	if (last >= 0) {
-		static struct sample surface = { .bearing.degrees = -1, .ndl.seconds = -1 };
 		struct sample *prev = dc->sample + last;
 		int last_time = prev->time.seconds;
 		int last_depth = prev->depth.mm;
-		/* Init a few values from prev sample to avoid useless info in XML */
-		surface.bearing.degrees = prev->bearing.degrees;
-		surface.ndl.seconds = prev->ndl.seconds;
 
 		/*
 		 * Only do surface events if the samples are more than
 		 * a minute apart, and shallower than 5m
 		 */
 		if (time > last_time + 60 && last_depth < 5000) {
+			struct sample surface = { 0 };
+
+			/* Init a few values from prev sample to avoid useless info in XML */
+			surface.bearing.degrees = prev->bearing.degrees;
+			surface.ndl.seconds = prev->ndl.seconds;
+
 			add_sample(&surface, last_time + 20, dc);
 			add_sample(&surface, time - 20, dc);
 		}


### PR DESCRIPTION
The merge_one_sample() function adds a sample to the destination
dive if dives are merged. For long periods between samples at surface
depths, it adds a surface interval.

To decrease the number of global objects, make the sample structure
non-static. Of course, initialization of an on-stack structure is
slower. Therefore move it into the corresponding if. Thus, the
structure will be initialized only once per surface-interval.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a tiny, mostly irrelevant code-cleanup, which removes a static variable. This is a spin-of coming from hunting strange hangs on dive-merging in the undo-branch.

Note that you would think that the compiler would be smart enough to move the initialization of `surface` into the if. In my tests it was not.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make `surface` sample non-static
2) Initialize `surface` sample only if needed.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
