### PR TITLE
Add preferences for unit selection on mobile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+Add units selection to mobiel preferences.
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -53,19 +53,17 @@ void qPrefUnits::set_unit_system(const QString& value)
 	short int v = value == QStringLiteral("metric") ? METRIC :
 					value == QStringLiteral("imperial")? IMPERIAL :
 							PERSONALIZE;
-	if (v != prefs.unit_system) {
-		if (v == METRIC) {
-			prefs.unit_system = METRIC;
-			prefs.units = SI_units;
-		} else if (v == IMPERIAL) {
-			prefs.unit_system = IMPERIAL;
-			prefs.units = IMPERIAL_units;
-		} else {
-			prefs.unit_system = PERSONALIZE;
-		}
-		disk_unit_system(true);
-		emit instance()->unit_systemChanged(value);
+	if (v == METRIC) {
+		prefs.unit_system = METRIC;
+		prefs.units = SI_units;
+	} else if (v == IMPERIAL) {
+		prefs.unit_system = IMPERIAL;
+		prefs.units = IMPERIAL_units;
+	} else {
+		prefs.unit_system = PERSONALIZE;
 	}
+	disk_unit_system(true);
+	emit instance()->unit_systemChanged(value);
 }
 DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -340,6 +340,56 @@ Kirigami.ScrollablePage {
 			Layout.fillWidth: true
 		}
 		GridLayout {
+			id: unit_system
+			columns: 2
+			width: parent.width - Kirigami.Units.gridUnit
+			Kirigami.Heading {
+				text: qsTr("Units")
+				color: subsurfaceTheme.textColor
+				level: 4
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+				Layout.columnSpan: 2
+			}
+
+			Controls.Label {
+				text: qsTr("Use Imperial Units")
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+			SsrfSwitch {
+				id: imperialButton
+				checked: PrefUnits.unit_system === "imperial"
+				enabled: PrefUnits.unit_system === "metric"
+				Layout.preferredWidth: gridWidth * 0.25
+				onClicked: {
+					PrefUnits.set_unit_system("imperial")
+					manager.changesNeedSaving()
+				}
+			}
+			Controls.Label {
+				text: qsTr("Use Metric Units")
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+			SsrfSwitch {
+				id: metricButtton
+				checked: PrefUnits.unit_system === "metric"
+				enabled: PrefUnits.unit_system === "imperial"
+				Layout.preferredWidth: gridWidth * 0.25
+				onClicked: {
+					PrefUnits.set_unit_system("metric")
+					manager.changesNeedSaving()
+				}
+			}
+		}
+
+		Rectangle {
+			color: subsurfaceTheme.darkerPrimaryColor
+			height: 1
+			opacity: 0.5
+			Layout.fillWidth: true
+		}
+
+		GridLayout {
 			id: developer
 			columns: 2
 			width: parent.width - Kirigami.Units.gridUnit

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -38,6 +38,7 @@
 #include "core/settings/qPrefLocationService.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "core/settings/qPrefPartialPressureGas.h"
+#include "core/settings/qPrefUnit.h"
 
 QMLManager *QMLManager::m_instance = NULL;
 bool noCloudToCloud = false;
@@ -278,12 +279,10 @@ void QMLManager::openLocalThenRemote(QString url)
 		// if we can load from the cache, we know that we have a valid cloud account
 		if (QMLPrefs::instance()->credentialStatus() == qPrefCloudStorage::CS_UNKNOWN)
 			QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_VERIFIED);
-		prefs.unit_system = git_prefs.unit_system;
 		if (git_prefs.unit_system == IMPERIAL)
-			git_prefs.units = IMPERIAL_units;
+			qPrefUnits::set_unit_system("imperial");
 		else if (git_prefs.unit_system == METRIC)
-			git_prefs.units = SI_units;
-		prefs.units = git_prefs.units;
+			qPrefUnits::set_unit_system("metric");
 		qPrefTechnicalDetails::set_tankbar(git_prefs.tankbar);
 		qPrefTechnicalDetails::set_dcceiling(git_prefs.dcceiling);
 		qPrefTechnicalDetails::set_show_ccr_setpoint(git_prefs.show_ccr_setpoint);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -4,6 +4,7 @@
 
 #include "core/membuffer.h"
 #include "core/gpslocation.h"
+#include "core/settings/qPrefUnit.h"
 
 
 /*** Global and constructors ***/
@@ -78,6 +79,10 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE);
 			clearCredentials();
+			if (qPrefUnits::unit_system() == "imperial")
+				prefs.units = IMPERIAL_units;
+			else if (qPrefUnits::unit_system() == "metric")
+				prefs.units = SI_units;
 		}
 		m_credentialStatus = value;
 		emit credentialStatusChanged();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is the first part of a planned addition of  settings to Subsurface-mobile.
This on enables the user to change the unit system used, independently of 
what is set by system locale.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Added unit selection to settings page
2) Fix various issues related to preference choice vs. locale when
starting the app.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1591

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
