### PR TITLE
Update divelist when changing units

### DIFF
--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -364,6 +364,7 @@ Kirigami.ScrollablePage {
 				onClicked: {
 					PrefUnits.set_unit_system("imperial")
 					manager.changesNeedSaving()
+					manager.refreshDiveList()
 				}
 			}
 			Controls.Label {
@@ -378,6 +379,7 @@ Kirigami.ScrollablePage {
 				onClicked: {
 					PrefUnits.set_unit_system("metric")
 					manager.changesNeedSaving()
+					manager.refreshDiveList()
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We need to explicitly refresh the divelist when switching between
metric and imperial unit systems. Or the changes will not be visible until
we restart the app or scroll outside of what's in the current cache.
This will update both the divelist view and the dive profiles to show the new units.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Related to #1698 and properly Fixes #1591
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
