### PR TITLE
Trivial: un-static function-local buffer

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1451,7 +1451,7 @@ static const char *nodename(xmlNode *node, char *buf, int len)
 static bool visit_one_node(xmlNode *node)
 {
 	xmlChar *content;
-	static char buffer[MAXNAME];
+	char buffer[MAXNAME];
 	const char *name;
 
 	content = node->content;


### PR DESCRIPTION
In visit_on_node() in core/parse-xml.c the name is extracted into
a static buffer. There seems to be no need for this being static,
as the name is only passed to the entry() function which (hopefully)
does not store a reference to the name anywhere.

If it does, this would need a *big* *fat* comment.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial cleanup: remove another static variable. See commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace static by local variable.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
-
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
-
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
