### PR TITLE
Remember dive computers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Desktop & Mobile: remember up to four dive computers that have been used to
+  download dives and provide easy shortcut buttons to switch between them
 Mobile: add units selection to Settings page
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/Documentation/mobile-manual.html.git
+++ b/Documentation/mobile-manual.html.git
@@ -700,6 +700,9 @@ settings). Android devices also support all Bluetooth dive computers that
 are supported in Subsurface. And both Android and iOS devices allow direct
 download of dive data from a hand full of Bluetooth LE enabled dive
 computers.</p></div>
+<div class="paragraph"><p>Use the <em>Vendor name</em> and <em>Dive Computer</em> drop-downs to pick the correct
+dive computer. When downloading from multiple different dive computers, shortcut
+buttons to easily switch between them will appear below the drop-downs.</p></div>
 <div class="paragraph"><p>The process for download is slightly different between the two OSs.
 In our testing we got the best results on iOS when the dive computer was
 in Bluetooth mode before <em>Subsurface-mobile</em> is started. On most dive
@@ -952,7 +955,7 @@ device and the font characteristics used by <em>Subsurface-mobile</em>.</p></div
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-09-15 15:42:56 PDT
+ 2018-09-21 19:29:32 PDT
 </div>
 </div>
 </body>

--- a/Documentation/mobile-manual.txt
+++ b/Documentation/mobile-manual.txt
@@ -244,6 +244,10 @@ are supported in Subsurface. And both Android and iOS devices allow direct
 download of dive data from a hand full of Bluetooth LE enabled dive
 computers.
 
+Use the _Vendor name_ and _Dive Computer_ drop-downs to pick the correct
+dive computer. When downloading from multiple different dive computers, shortcut
+buttons to easily switch between them will appear below the drop-downs.
+
 The process for download is slightly different between the two OSs.
 In our testing we got the best results on iOS when the dive computer was
 in Bluetooth mode before _Subsurface-mobile_ is started. On most dive

--- a/Documentation/user-manual.html.git
+++ b/Documentation/user-manual.html.git
@@ -897,6 +897,18 @@ The <strong>Device or Mount Point</strong> drop-down list contains the USB or Bl
    specific dive
    computer and, in some cases, how to do the correct settings to the operating
    system of the computer on which <em>Subsurface</em> is running.
+   Some dive computers disable this drop-down as they use other means to find and
+   connect to the device. For some dive computers the data entered here is actually
+   the mount point of the USB storage device as which the dive computer identifies
+   itself.
+</p>
+</li>
+<li>
+<p>
+Below the three drop downs are up to four shortcut buttons that allow you to
+   easily switch between multiple dive computers that you are frequently downloading
+   from. These buttons only appear once you have downloaded from different dive
+   computers.
 </p>
 </li>
 <li>
@@ -7434,7 +7446,7 @@ cannot be salvaged after being overwritten by new dives.</p></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-09-18 15:11:32 PDT
+ 2018-09-21 19:29:32 PDT
 </div>
 </div>
 </body>

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -372,6 +372,15 @@ of the dive computer (at least for those not charging while connected via USB).
    specific dive
    computer and, in some cases, how to do the correct settings to the operating
    system of the computer on which _Subsurface_ is running.
+   Some dive computers disable this drop-down as they use other means to find and
+   connect to the device. For some dive computers the data entered here is actually
+   the mount point of the USB storage device as which the dive computer identifies
+   itself.
+
+ - Below the three drop downs are up to four shortcut buttons that allow you to
+   easily switch between multiple dive computers that you are frequently downloading
+   from. These buttons only appear once you have downloaded from different dive
+   computers.
 
  - If all the dives on the dive computer need to be downloaded, check the
    checkbox _Force download of all dives_. Normally, _Subsurface_ only downloads

--- a/core/connectionlistmodel.cpp
+++ b/core/connectionlistmodel.cpp
@@ -53,5 +53,6 @@ void ConnectionListModel::removeAllAddresses()
 
 int ConnectionListModel::indexOf(QString address)
 {
-	return m_addresses.indexOf(address);
+	const QRegExp re(address, Qt::CaseInsensitive);
+	return m_addresses.indexOf(re);
 }

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -24,6 +24,42 @@ static QString str_error(const char *fmt, ...)
 	return str;
 }
 
+
+static void updateRememberedDCs()
+{
+	QString current = qPrefDiveComputer::vendor() + " - " + qPrefDiveComputer::product();
+	QStringList dcs = {
+		qPrefDiveComputer::vendor1() + " - " + qPrefDiveComputer::product1(),
+		qPrefDiveComputer::vendor2() + " - " + qPrefDiveComputer::product2(),
+		qPrefDiveComputer::vendor3() + " - " + qPrefDiveComputer::product3(),
+		qPrefDiveComputer::vendor4() + " - " + qPrefDiveComputer::product4()
+	};
+	if (dcs.contains(current))
+		// already in the list
+		return;
+	// add the current one as the first remembered one and drop the 4th one
+	// don't get confused by 0-based and 1-based indices!
+	if (dcs[2] != " - ") {
+		qPrefDiveComputer::set_vendor4(qPrefDiveComputer::vendor3());
+		qPrefDiveComputer::set_product4(qPrefDiveComputer::product3());
+		qPrefDiveComputer::set_device4(qPrefDiveComputer::device3());
+	}
+	if (dcs[1] != " - ") {
+		qPrefDiveComputer::set_vendor3(qPrefDiveComputer::vendor2());
+		qPrefDiveComputer::set_product3(qPrefDiveComputer::product2());
+		qPrefDiveComputer::set_device3(qPrefDiveComputer::device2());
+	}
+	if (dcs[0] != " - ") {
+		qPrefDiveComputer::set_vendor2(qPrefDiveComputer::vendor1());
+		qPrefDiveComputer::set_product2(qPrefDiveComputer::product1());
+		qPrefDiveComputer::set_device2(qPrefDiveComputer::device1());
+	}
+	qPrefDiveComputer::set_vendor1(qPrefDiveComputer::vendor());
+	qPrefDiveComputer::set_product1(qPrefDiveComputer::product());
+	qPrefDiveComputer::set_device1(qPrefDiveComputer::device());
+}
+
+
 DownloadThread::DownloadThread()
 {
 	m_data = DCDeviceData::instance();
@@ -61,6 +97,8 @@ void DownloadThread::run()
 	qPrefDiveComputer::set_product(internalData->product);
 	qPrefDiveComputer::set_device(internalData->devname);
 	qPrefDiveComputer::set_device_name(m_data->devBluetoothName());
+
+	updateRememberedDCs();
 }
 
 static void fill_supported_mobile_list()

--- a/core/pref.h
+++ b/core/pref.h
@@ -99,6 +99,10 @@ struct preferences {
 
 	// ********** DiveComputer **********
 	dive_computer_prefs_t dive_computer;
+	dive_computer_prefs_t dive_computer1;
+	dive_computer_prefs_t dive_computer2;
+	dive_computer_prefs_t dive_computer3;
+	dive_computer_prefs_t dive_computer4;
 
 	// ********** Display **********
 	bool        display_invalid_dives;

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -17,19 +17,48 @@ qPrefDiveComputer *qPrefDiveComputer::instance()
 
 void qPrefDiveComputer::loadSync(bool doSync)
 {
+	// last computer used
 	disk_device(doSync);
 	disk_device_name(doSync);
 	disk_download_mode(doSync);
 	disk_product(doSync);
 	disk_vendor(doSync);
+
+	// the four shortcuts
+#define DISK_DC(num) \
+	disk_device##num(doSync); \
+	disk_device_name##num(doSync); \
+	disk_product##num(doSync); \
+	disk_vendor##num(doSync);
+
+	DISK_DC(1)
+	DISK_DC(2)
+	DISK_DC(3)
+	DISK_DC(4)
+
 }
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device", device, dive_computer.);
+// these are the 'active' settings
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device", device, dive_computer.)
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device_name", device_name, dive_computer.)
+HANDLE_PREFERENCE_INT_EXT(DiveComputer, "dive_computer_download_mode", download_mode, dive_computer.)
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_product", product, dive_computer.)
+HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_vendor", vendor, dive_computer.)
 
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_device_name", device_name, dive_computer.);
-
-HANDLE_PREFERENCE_INT_EXT(DiveComputer, "dive_computer_download_mode", download_mode, dive_computer.);
-
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_product", product, dive_computer.);
-
-HANDLE_PREFERENCE_TXT_EXT(DiveComputer, "dive_computer_vendor", vendor, dive_computer.);
+// these are the previous four to make it easy to go back and forth between multiple dive computers
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device1", device, dive_computer, 1)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device2", device, dive_computer, 2)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device3", device, dive_computer, 3)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device4", device, dive_computer, 4)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device_name1", device_name, dive_computer, 1)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device_name2", device_name, dive_computer, 2)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device_name3", device_name, dive_computer, 3)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_device_name4", device_name, dive_computer, 4)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_product1", product, dive_computer, 1)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_product2", product, dive_computer, 2)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_product3", product, dive_computer, 3)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_product4", product, dive_computer, 4)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_vendor1", vendor, dive_computer, 1)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_vendor2", vendor, dive_computer, 2)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_vendor3", vendor, dive_computer, 3)
+HANDLE_PREFERENCE_TXT_EXT_ALT(DiveComputer, "dive_computer_vendor4", vendor, dive_computer, 4)

--- a/core/settings/qPrefDiveComputer.h
+++ b/core/settings/qPrefDiveComputer.h
@@ -5,13 +5,36 @@
 
 #include <QObject>
 
+#define IMPLEMENT5GETTERS(name) \
+	static QString name() { return prefs.dive_computer.name; } \
+	static QString name##1() { return prefs.dive_computer##1 .name; } \
+	static QString name##2() { return prefs.dive_computer##2 .name; } \
+	static QString name##3() { return prefs.dive_computer##3 .name; } \
+	static QString name##4() { return prefs.dive_computer##4 .name; }
+
 class qPrefDiveComputer : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(QString device READ device WRITE set_device NOTIFY deviceChanged);
-	Q_PROPERTY(QString device_name READ device_name WRITE set_device_name NOTIFY device_nameChanged);
-	Q_PROPERTY(int download_mode READ download_mode WRITE set_download_mode NOTIFY download_modeChanged);
-	Q_PROPERTY(QString product READ product WRITE set_product NOTIFY productChanged);
-	Q_PROPERTY(QString vendor READ vendor WRITE set_vendor NOTIFY vendorChanged);
+	Q_PROPERTY(QString device READ device WRITE set_device NOTIFY deviceChanged)
+	Q_PROPERTY(QString device1 READ device1 WRITE set_device1 NOTIFY device1Changed)
+	Q_PROPERTY(QString device2 READ device2 WRITE set_device2 NOTIFY device2Changed)
+	Q_PROPERTY(QString device3 READ device3 WRITE set_device3 NOTIFY device3Changed)
+	Q_PROPERTY(QString device4 READ device4 WRITE set_device4 NOTIFY device4Changed)
+	Q_PROPERTY(QString device_name READ device_name WRITE set_device_name NOTIFY device_nameChanged)
+	Q_PROPERTY(QString device_name1 READ device_name1 WRITE set_device_name1 NOTIFY device_name1Changed)
+	Q_PROPERTY(QString device_name2 READ device_name2 WRITE set_device_name2 NOTIFY device_name2Changed)
+	Q_PROPERTY(QString device_name3 READ device_name3 WRITE set_device_name3 NOTIFY device_name3Changed)
+	Q_PROPERTY(QString device_name4 READ device_name4 WRITE set_device_name4 NOTIFY device_name4Changed)
+	Q_PROPERTY(QString product READ product WRITE set_product NOTIFY productChanged)
+	Q_PROPERTY(QString product1 READ product1 WRITE set_product1 NOTIFY product1Changed)
+	Q_PROPERTY(QString product2 READ product2 WRITE set_product2 NOTIFY product2Changed)
+	Q_PROPERTY(QString product3 READ product3 WRITE set_product3 NOTIFY product3Changed)
+	Q_PROPERTY(QString product4 READ product4 WRITE set_product4 NOTIFY product4Changed)
+	Q_PROPERTY(QString vendor READ vendor WRITE set_vendor NOTIFY vendorChanged)
+	Q_PROPERTY(QString vendor1 READ vendor1 WRITE set_vendor1 NOTIFY vendor1Changed)
+	Q_PROPERTY(QString vendor2 READ vendor2 WRITE set_vendor2 NOTIFY vendor2Changed)
+	Q_PROPERTY(QString vendor3 READ vendor3 WRITE set_vendor3 NOTIFY vendor3Changed)
+	Q_PROPERTY(QString vendor4 READ vendor4 WRITE set_vendor4 NOTIFY vendor4Changed)
+	Q_PROPERTY(int download_mode READ download_mode WRITE set_download_mode NOTIFY download_modeChanged)
 
 public:
 	qPrefDiveComputer(QObject *parent = NULL);
@@ -23,33 +46,95 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
-	static QString device() { return prefs.dive_computer.device; }
-	static QString device_name() { return prefs.dive_computer.device_name; }
+	IMPLEMENT5GETTERS(device)
+	IMPLEMENT5GETTERS(device_name)
+	IMPLEMENT5GETTERS(product)
+	IMPLEMENT5GETTERS(vendor)
 	static int download_mode() { return prefs.dive_computer.download_mode; }
-	static QString product() { return prefs.dive_computer.product; }
-	static QString vendor() { return prefs.dive_computer.vendor; }
 
 public slots:
 	static void set_device(const QString &device);
+	static void set_device1(const QString &device);
+	static void set_device2(const QString &device);
+	static void set_device3(const QString &device);
+	static void set_device4(const QString &device);
+
 	static void set_device_name(const QString &device_name);
-	static void set_download_mode(int mode);
+	static void set_device_name1(const QString &device_name);
+	static void set_device_name2(const QString &device_name);
+	static void set_device_name3(const QString &device_name);
+	static void set_device_name4(const QString &device_name);
+
 	static void set_product(const QString &product);
+	static void set_product1(const QString &product);
+	static void set_product2(const QString &product);
+	static void set_product3(const QString &product);
+	static void set_product4(const QString &product);
+
 	static void set_vendor(const QString &vendor);
+	static void set_vendor1(const QString &vendor);
+	static void set_vendor2(const QString &vendor);
+	static void set_vendor3(const QString &vendor);
+	static void set_vendor4(const QString &vendor);
+
+	static void set_download_mode(int mode);
 
 signals:
 	void deviceChanged(const QString &device);
+	void device1Changed(const QString &device);
+	void device2Changed(const QString &device);
+	void device3Changed(const QString &device);
+	void device4Changed(const QString &device);
+
 	void device_nameChanged(const QString &device_name);
-	void download_modeChanged(int mode);
+	void device_name1Changed(const QString &device_name);
+	void device_name2Changed(const QString &device_name);
+	void device_name3Changed(const QString &device_name);
+	void device_name4Changed(const QString &device_name);
+
 	void productChanged(const QString &product);
+	void product1Changed(const QString &product);
+	void product2Changed(const QString &product);
+	void product3Changed(const QString &product);
+	void product4Changed(const QString &product);
+
 	void vendorChanged(const QString &vendor);
+	void vendor1Changed(const QString &vendor);
+	void vendor2Changed(const QString &vendor);
+	void vendor3Changed(const QString &vendor);
+	void vendor4Changed(const QString &vendor);
+
+	void download_modeChanged(int mode);
 
 private:
 	// functions to load/sync variable with disk
+
 	static void disk_device(bool doSync);
+	static void disk_device1(bool doSync);
+	static void disk_device2(bool doSync);
+	static void disk_device3(bool doSync);
+	static void disk_device4(bool doSync);
+
 	static void disk_device_name(bool doSync);
-	static void disk_download_mode(bool doSync);
+	static void disk_device_name1(bool doSync);
+	static void disk_device_name2(bool doSync);
+	static void disk_device_name3(bool doSync);
+	static void disk_device_name4(bool doSync);
+
 	static void disk_product(bool doSync);
+	static void disk_product1(bool doSync);
+	static void disk_product2(bool doSync);
+	static void disk_product3(bool doSync);
+	static void disk_product4(bool doSync);
+
 	static void disk_vendor(bool doSync);
+	static void disk_vendor1(bool doSync);
+	static void disk_vendor2(bool doSync);
+	static void disk_vendor3(bool doSync);
+	static void disk_vendor4(bool doSync);
+
+	static void disk_download_mode(bool doSync);
+
 };
 
 #endif

--- a/core/settings/qPrefPrivate.h
+++ b/core/settings/qPrefPrivate.h
@@ -145,6 +145,20 @@ extern QString keyFromGroupAndName(QString group, QString name);
 			current_state = QString(prefs.usestruct field); \
 		} \
 	}
+#define DISK_LOADSYNC_TXT_EXT_ALT(usegroup, name, field, usestruct, alt) \
+	void qPref##usegroup::disk_##field##alt(bool doSync) \
+	{ \
+		static QString current_state; \
+		if (doSync) { \
+			if (current_state != QString(prefs.usestruct ## alt .field)) { \
+				current_state = QString(prefs.usestruct ## alt .field); \
+				qPrefPrivate::propSetValue(keyFromGroupAndName(group, name), prefs.usestruct ##alt .field, default_prefs.usestruct ##alt .field); \
+			} \
+		} else { \
+			prefs.usestruct ##alt .field = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, name), default_prefs.usestruct ##alt .field).toString()); \
+			current_state = QString(prefs.usestruct ##alt .field); \
+		} \
+	}
 #define DISK_LOADSYNC_TXT(usegroup, name, field) \
 	DISK_LOADSYNC_TXT_EXT(usegroup, name, field, )
 
@@ -218,6 +232,17 @@ extern QString keyFromGroupAndName(QString group, QString name);
 			emit instance()->field##Changed(value); \
 		} \
 	}
+
+#define SET_PREFERENCE_TXT_EXT_ALT(usegroup, field, usestruct, alt) \
+	void qPref##usegroup::set_##field##alt(const QString &value) \
+	{ \
+		if (value != prefs.usestruct ##alt .field) { \
+			qPrefPrivate::copy_txt(&prefs.usestruct ##alt .field, value); \
+			disk_##field##alt(true); \
+			emit instance()->field##alt##Changed(value); \
+		} \
+	}
+
 #define SET_PREFERENCE_TXT(usegroup, field) \
 	SET_PREFERENCE_TXT_EXT(usegroup, field, )
 
@@ -263,6 +288,10 @@ extern QString keyFromGroupAndName(QString group, QString name);
 	DISK_LOADSYNC_TXT_EXT(usegroup, name, field, usestruct);
 #define HANDLE_PREFERENCE_TXT(usegroup, name, field) \
 	HANDLE_PREFERENCE_TXT_EXT(usegroup, name, field, )
+
+#define HANDLE_PREFERENCE_TXT_EXT_ALT(usegroup, name, field, usestruct, alt) \
+	SET_PREFERENCE_TXT_EXT_ALT(usegroup, field, usestruct, alt); \
+	DISK_LOADSYNC_TXT_EXT_ALT(usegroup, name, field, usestruct, alt);
 
 #define HANDLE_PROP_QPOINTF(useclass, name, field) \
 	void qPref##useclass::set_##field(const QPointF& value) \

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -79,18 +79,7 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	}
 
 	// now lets set the four shortcuts for previously used dive computers
-#define SETUPDC(num) \
-	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
-		ui.DC##num->setVisible(true); \
-		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
-		connect(ui.DC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DC##num##Clicked); \
-	} else { \
-		ui.DC##num->setVisible(false); \
-	}
-	SETUPDC(1)
-	SETUPDC(2)
-	SETUPDC(3)
-	SETUPDC(4)
+	showRememberedDCs();
 
 	updateState(INITIAL);
 	ui.ok->setEnabled(false);
@@ -113,6 +102,23 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 #endif
 	if (!deviceText.isEmpty())
 		ui.device->setEditText(deviceText);
+}
+
+#define SETUPDC(num) \
+	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
+		ui.DC##num->setVisible(true); \
+		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
+		connect(ui.DC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DC##num##Clicked, Qt::UniqueConnection); \
+	} else { \
+		ui.DC##num->setVisible(false); \
+	}
+
+void DownloadFromDCWidget::showRememberedDCs()
+{
+	SETUPDC(1)
+	SETUPDC(2)
+	SETUPDC(3)
+	SETUPDC(4)
 }
 
 // DC button slots
@@ -354,8 +360,6 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	qPrefDiveComputer::set_product(data->product());
 	qPrefDiveComputer::set_device(data->devName());
 
-	updateRememberedDCs();
-
 #if defined(BT_SUPPORT)
 	qPrefDiveComputer::set_download_mode(ui.bluetoothMode->isChecked() ? DC_TRANSPORT_BLUETOOTH : DC_TRANSPORT_SERIAL);
 #endif
@@ -376,48 +380,6 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	    !data->saveDump()) {
 		ostcFirmwareCheck = new OstcFirmwareCheck(product);
 	}
-}
-
-void DownloadFromDCWidget::updateRememberedDCs()
-{
-	QString current = qPrefDiveComputer::vendor() + " - " + qPrefDiveComputer::product();
-	QStringList dcs = {
-		qPrefDiveComputer::vendor1() + " - " + qPrefDiveComputer::product1(),
-		qPrefDiveComputer::vendor2() + " - " + qPrefDiveComputer::product2(),
-		qPrefDiveComputer::vendor3() + " - " + qPrefDiveComputer::product3(),
-		qPrefDiveComputer::vendor4() + " - " + qPrefDiveComputer::product4()
-	};
-	if (dcs.contains(current))
-		// already in the list
-		return;
-	// add the current one as the first remembered one and drop the 4th one
-	// don't get confused by 0-based and 1-based indices!
-	if (dcs[2] != " - ") {
-		qPrefDiveComputer::set_vendor4(qPrefDiveComputer::vendor3());
-		qPrefDiveComputer::set_product4(qPrefDiveComputer::product3());
-		qPrefDiveComputer::set_device4(qPrefDiveComputer::device3());
-		ui.DC4->setText(dcs[2]);
-		ui.DC4->setVisible(true);
-	}
-	if (dcs[1] != " - ") {
-		qPrefDiveComputer::set_vendor3(qPrefDiveComputer::vendor2());
-		qPrefDiveComputer::set_product3(qPrefDiveComputer::product2());
-		qPrefDiveComputer::set_device3(qPrefDiveComputer::device2());
-		ui.DC3->setText(dcs[1]);
-		ui.DC3->setVisible(true);
-	}
-	if (dcs[0] != " - ") {
-		qPrefDiveComputer::set_vendor2(qPrefDiveComputer::vendor1());
-		qPrefDiveComputer::set_product2(qPrefDiveComputer::product1());
-		qPrefDiveComputer::set_device2(qPrefDiveComputer::device1());
-		ui.DC2->setText(dcs[0]);
-		ui.DC2->setVisible(true);
-	}
-	qPrefDiveComputer::set_vendor1(qPrefDiveComputer::vendor());
-	qPrefDiveComputer::set_product1(qPrefDiveComputer::product());
-	qPrefDiveComputer::set_device1(qPrefDiveComputer::device());
-	ui.DC1->setText(current);
-	ui.DC1->setVisible(true);
 }
 
 bool DownloadFromDCWidget::preferDownloaded()
@@ -483,6 +445,9 @@ void DownloadFromDCWidget::reject()
 
 void DownloadFromDCWidget::onDownloadThreadFinished()
 {
+	// let's update the remembered DCs
+	showRememberedDCs();
+
 	if (currentState == DOWNLOADING) {
 		if (thread.error.isEmpty())
 			updateState(DONE);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -78,6 +78,19 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 			ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product()));
 	}
 
+	// now lets set the four shortcuts for previously used dive computers
+#define SETUPDC(num) \
+	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
+		ui.DC##num->setVisible(true); \
+		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
+	} else { \
+		ui.DC##num->setVisible(false); \
+	}
+	SETUPDC(1)
+	SETUPDC(2)
+	SETUPDC(3)
+	SETUPDC(4)
+
 	updateState(INITIAL);
 	ui.ok->setEnabled(false);
 	ui.downloadCancelRetryButton->setEnabled(true);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -83,6 +83,7 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
 		ui.DC##num->setVisible(true); \
 		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
+		connect(ui.DC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DC##num##Clicked); \
 	} else { \
 		ui.DC##num->setVisible(false); \
 	}
@@ -113,6 +114,28 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	if (!deviceText.isEmpty())
 		ui.device->setEditText(deviceText);
 }
+
+// DC button slots
+#define DCBUTTON(num) \
+void DownloadFromDCWidget::DC##num##Clicked() \
+{ \
+	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
+	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
+	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
+	ui.device->setCurrentIndex(ui.device->findText(qPrefDiveComputer::device##num())); \
+	if (QSysInfo::kernelType() == "darwin") { \
+		/* it makes no sense that this would be needed on macOS but not Linux */ \
+		QCoreApplication::processEvents(); \
+		ui.vendor->update(); \
+		ui.product->update(); \
+		ui.device->update(); \
+	} \
+}
+
+DCBUTTON(1)
+DCBUTTON(2)
+DCBUTTON(3)
+DCBUTTON(4)
 
 void DownloadFromDCWidget::updateProgressBar()
 {

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -331,6 +331,8 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	qPrefDiveComputer::set_product(data->product());
 	qPrefDiveComputer::set_device(data->devName());
 
+	updateRememberedDCs();
+
 #if defined(BT_SUPPORT)
 	qPrefDiveComputer::set_download_mode(ui.bluetoothMode->isChecked() ? DC_TRANSPORT_BLUETOOTH : DC_TRANSPORT_SERIAL);
 #endif
@@ -351,6 +353,48 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	    !data->saveDump()) {
 		ostcFirmwareCheck = new OstcFirmwareCheck(product);
 	}
+}
+
+void DownloadFromDCWidget::updateRememberedDCs()
+{
+	QString current = qPrefDiveComputer::vendor() + " - " + qPrefDiveComputer::product();
+	QStringList dcs = {
+		qPrefDiveComputer::vendor1() + " - " + qPrefDiveComputer::product1(),
+		qPrefDiveComputer::vendor2() + " - " + qPrefDiveComputer::product2(),
+		qPrefDiveComputer::vendor3() + " - " + qPrefDiveComputer::product3(),
+		qPrefDiveComputer::vendor4() + " - " + qPrefDiveComputer::product4()
+	};
+	if (dcs.contains(current))
+		// already in the list
+		return;
+	// add the current one as the first remembered one and drop the 4th one
+	// don't get confused by 0-based and 1-based indices!
+	if (dcs[2] != " - ") {
+		qPrefDiveComputer::set_vendor4(qPrefDiveComputer::vendor3());
+		qPrefDiveComputer::set_product4(qPrefDiveComputer::product3());
+		qPrefDiveComputer::set_device4(qPrefDiveComputer::device3());
+		ui.DC4->setText(dcs[2]);
+		ui.DC4->setVisible(true);
+	}
+	if (dcs[1] != " - ") {
+		qPrefDiveComputer::set_vendor3(qPrefDiveComputer::vendor2());
+		qPrefDiveComputer::set_product3(qPrefDiveComputer::product2());
+		qPrefDiveComputer::set_device3(qPrefDiveComputer::device2());
+		ui.DC3->setText(dcs[1]);
+		ui.DC3->setVisible(true);
+	}
+	if (dcs[0] != " - ") {
+		qPrefDiveComputer::set_vendor2(qPrefDiveComputer::vendor1());
+		qPrefDiveComputer::set_product2(qPrefDiveComputer::product1());
+		qPrefDiveComputer::set_device2(qPrefDiveComputer::device1());
+		ui.DC2->setText(dcs[0]);
+		ui.DC2->setVisible(true);
+	}
+	qPrefDiveComputer::set_vendor1(qPrefDiveComputer::vendor());
+	qPrefDiveComputer::set_product1(qPrefDiveComputer::product());
+	qPrefDiveComputer::set_device1(qPrefDiveComputer::device());
+	ui.DC1->setText(current);
+	ui.DC1->setVisible(true);
 }
 
 bool DownloadFromDCWidget::preferDownloaded()

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -64,7 +64,7 @@ private:
 	void markChildrenAsDisabled();
 	void markChildrenAsEnabled();
 	void updateDeviceEnabled();
-	void updateRememberedDCs();
+	void showRememberedDCs();
 
 	QStringListModel vendorModel;
 	QStringListModel productModel;

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -59,6 +59,7 @@ private:
 	void markChildrenAsDisabled();
 	void markChildrenAsEnabled();
 	void updateDeviceEnabled();
+	void updateRememberedDCs();
 
 	QStringListModel vendorModel;
 	QStringListModel productModel;

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -50,6 +50,11 @@ slots:
 	void checkDumpFile(int state);
 	void pickDumpFile();
 	void pickLogFile();
+	void DC1Clicked();
+	void DC2Clicked();
+	void DC3Clicked();
+	void DC4Clicked();
+
 #if defined(BT_SUPPORT)
 	void enableBluetoothMode(int state);
 	void selectRemoteBluetoothDevice();

--- a/desktop-widgets/downloadfromdivecomputer.ui
+++ b/desktop-widgets/downloadfromdivecomputer.ui
@@ -46,10 +46,34 @@
          <property name="verticalSpacing">
           <number>5</number>
          </property>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_3">
+         <item row="7" column="0">
+          <widget class="QCheckBox" name="forceDownload">
            <property name="text">
-            <string>Device or mount point</string>
+            <string>Force download of all dives</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Dive computer</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QComboBox" name="vendor"/>
+         </item>
+         <item row="8" column="0">
+          <widget class="QCheckBox" name="preferDownloaded">
+           <property name="text">
+            <string>Always prefer downloaded dives</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QCheckBox" name="logToFile">
+           <property name="text">
+            <string>Save libdivecomputer logfile</string>
            </property>
           </widget>
          </item>
@@ -60,6 +84,23 @@
            </property>
           </widget>
          </item>
+         <item row="12" column="0">
+          <widget class="QCheckBox" name="bluetoothMode">
+           <property name="text">
+            <string>Choose Bluetooth download mode</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="1">
+          <widget class="QToolButton" name="chooseBluetoothDevice">
+           <property name="toolTip">
+            <string>Select a remote Bluetooth device.</string>
+           </property>
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
          <item row="5" column="1">
           <widget class="QToolButton" name="search">
            <property name="text">
@@ -67,67 +108,22 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QCheckBox" name="forceDownload">
-           <property name="text">
-            <string>Force download of all dives</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QCheckBox" name="preferDownloaded">
-           <property name="text">
-            <string>Always prefer downloaded dives</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QCheckBox" name="createNewTrip">
-           <property name="text">
-            <string>Download into new trip</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QCheckBox" name="logToFile">
-           <property name="text">
-            <string>Save libdivecomputer logfile</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="1">
-          <widget class="QToolButton" name="chooseLogFile">
-           <property name="text">
-            <string>...</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="0">
-          <widget class="QCheckBox" name="dumpToFile">
-           <property name="text">
-            <string>Save libdivecomputer dumpfile</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="1">
+         <item row="11" column="1">
           <widget class="QToolButton" name="chooseDumpFile">
            <property name="text">
             <string>...</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="0">
-          <widget class="QCheckBox" name="bluetoothMode">
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_3">
            <property name="text">
-            <string>Choose Bluetooth download mode</string>
+            <string>Device or mount point</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="1">
-          <widget class="QToolButton" name="chooseBluetoothDevice">
-           <property name="toolTip">
-            <string>Select a remote Bluetooth device.</string>
-           </property>
+         <item row="10" column="1">
+          <widget class="QToolButton" name="chooseLogFile">
            <property name="text">
             <string>...</string>
            </property>
@@ -140,18 +136,42 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QComboBox" name="vendor"/>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QLabel" name="label_2">
+         <item row="9" column="0">
+          <widget class="QCheckBox" name="createNewTrip">
            <property name="text">
-            <string>Dive computer</string>
+            <string>Download into new trip</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0">
+          <widget class="QCheckBox" name="dumpToFile">
+           <property name="text">
+            <string>Save libdivecomputer dumpfile</string>
            </property>
           </widget>
          </item>
          <item row="3" column="0" colspan="2">
           <widget class="QComboBox" name="product"/>
+         </item>
+         <item row="6" column="0">
+          <layout class="QGridLayout" name="DCGrid">
+<item row="0" column="0">
+          <widget class="QPushButton" name="DC1">
+          </widget>
+</item>
+<item row="0" column="1">
+          <widget class="QPushButton" name="DC2">
+          </widget>
+</item>
+<item row="1" column="0">
+          <widget class="QPushButton" name="DC3">
+          </widget>
+</item>
+<item row="1" column="1">
+          <widget class="QPushButton" name="DC4">
+          </widget>
+</item>
+</layout>
          </item>
         </layout>
        </item>

--- a/desktop-widgets/downloadfromdivecomputer.ui
+++ b/desktop-widgets/downloadfromdivecomputer.ui
@@ -155,23 +155,35 @@
          </item>
          <item row="6" column="0">
           <layout class="QGridLayout" name="DCGrid">
-<item row="0" column="0">
-          <widget class="QPushButton" name="DC1">
-          </widget>
-</item>
-<item row="0" column="1">
-          <widget class="QPushButton" name="DC2">
-          </widget>
-</item>
-<item row="1" column="0">
-          <widget class="QPushButton" name="DC3">
-          </widget>
-</item>
-<item row="1" column="1">
-          <widget class="QPushButton" name="DC4">
-          </widget>
-</item>
-</layout>
+           <item row="0" column="0">
+            <widget class="QPushButton" name="DC1">
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="DC2">
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QPushButton" name="DC3">
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QPushButton" name="DC4">
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -5,6 +5,7 @@
 #include "core/settings/qPrefGeneral.h"
 #include "core/settings/qPrefDisplay.h"
 #include "core/settings/qPrefCloudStorage.h"
+#include "core/settings/qPrefDiveComputer.h"
 
 #include <QFileDialog>
 
@@ -58,6 +59,19 @@ void PreferencesDefaults::on_extractVideoThumbnails_toggled(bool toggled)
 	ui->videoThumbnailPosition->setEnabled(toggled);
 	ui->ffmpegExecutable->setEnabled(toggled);
 	ui->ffmpegFile->setEnabled(toggled);
+}
+
+void PreferencesDefaults::on_resetRememberedDCs_clicked()
+{
+	qPrefDiveComputer::set_vendor1(QString());
+	qPrefDiveComputer::set_vendor2(QString());
+	qPrefDiveComputer::set_vendor3(QString());
+	qPrefDiveComputer::set_vendor4(QString());
+}
+
+void PreferencesDefaults::on_resetSettings_clicked()
+{
+	// apparently this button was never hooked up?
 }
 
 void PreferencesDefaults::refreshSettings()

--- a/desktop-widgets/preferences/preferences_defaults.h
+++ b/desktop-widgets/preferences/preferences_defaults.h
@@ -22,6 +22,8 @@ public slots:
 	void on_localDefaultFile_toggled(bool toggled);
 	void on_ffmpegFile_clicked();
 	void on_extractVideoThumbnails_toggled(bool toggled);
+	void on_resetSettings_clicked();
+	void on_resetRememberedDCs_clicked();
 
 private:
 	Ui::PreferencesDefaults *ui;

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -285,15 +285,16 @@
    <item>
     <widget class="QGroupBox" name="groupBox_9">
      <property name="title">
-      <string>Clear all settings</string>
+      <string>Clear settings</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_7b">
-      <property name="spacing">
-       <number>5</number>
-      </property>
-      <property name="margin">
-       <number>5</number>
-      </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="resetRememberedDCs">
+        <property name="text">
+         <string>Reset remembered dive computers</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QPushButton" name="resetSettings">
         <property name="text">

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -183,7 +183,7 @@ Kirigami.Page {
 			function setDC(vendor, product, device) {
 				comboVendor.currentIndex = comboVendor.find(vendor);
 				comboProduct.currentIndex = comboProduct.find(product);
-				comboConnection.currentIndex = comboConnection.find(device);
+				comboConnection.currentIndex = manager.getConnectionIndex(device);
 			}
 			SsrfButton {
 				id: dc1

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -169,20 +169,21 @@ Kirigami.Page {
 			}
 		}
 
-		GridLayout {
+		Controls.Label {
+			text: qsTr(" Previously used dive computers: ")
+			visible: PrefDiveComputer.vendor1 !== ""
+		}
+		Flow {
 			id: rememberedDCsGrid
 			visible: PrefDiveComputer.vendor1 !== ""
 			Layout.alignment: Qt.AlignTop
-			Layout.topMargin: Kirigami.Units.smallSpacing * 4
-			columns: 2
+			Layout.topMargin: Kirigami.Units.smallSpacing * 2
+			spacing: Kirigami.Units.smallSpacing;
+			width: subsurfaceTheme.columnWidth - Kirigami.Units.gridUnit * 4
 			function setDC(vendor, product, device) {
 				comboVendor.currentIndex = comboVendor.find(vendor);
 				comboProduct.currentIndex = comboProduct.find(product);
 				comboConnection.currentIndex = comboConnection.find(device);
-			}
-			Controls.Label {
-				Layout.columnSpan: 2
-				text: qsTr(" Previously used dive computers: ")
 			}
 			SsrfButton {
 				id: dc1

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -169,6 +169,59 @@ Kirigami.Page {
 			}
 		}
 
+		GridLayout {
+			id: rememberedDCsGrid
+			visible: PrefDiveComputer.vendor1 !== ""
+			Layout.alignment: Qt.AlignTop
+			Layout.topMargin: Kirigami.Units.smallSpacing * 4
+			columns: 2
+			function setDC(vendor, product, device) {
+				comboVendor.currentIndex = comboVendor.find(vendor);
+				comboProduct.currentIndex = comboProduct.find(product);
+				comboConnection.currentIndex = comboConnection.find(device);
+			}
+			Controls.Label {
+				Layout.columnSpan: 2
+				text: qsTr(" Previously used dive computers: ")
+			}
+			SsrfButton {
+				id: dc1
+				visible: PrefDiveComputer.vendor1 !== ""
+				text: PrefDiveComputer.vendor1 + " - " + PrefDiveComputer.product1
+				onClicked: {
+					// update comboboxes
+					rememberedDCsGrid.setDC(PrefDiveComputer.vendor1, PrefDiveComputer.product1, PrefDiveComputer.device1)
+				}
+			}
+			SsrfButton {
+				id: dc2
+				visible: PrefDiveComputer.vendor2 !== ""
+				text: PrefDiveComputer.vendor2 + " - " + PrefDiveComputer.product2
+				onClicked: {
+					// update comboboxes
+					rememberedDCsGrid.setDC(PrefDiveComputer.vendor2, PrefDiveComputer.product2, PrefDiveComputer.device2)
+				}
+			}
+			SsrfButton {
+				id: dc3
+				visible: PrefDiveComputer.vendor3 !== ""
+				text: PrefDiveComputer.vendor3 + " - " + PrefDiveComputer.product3
+				onClicked: {
+					// update comboboxes
+					rememberedDCsGrid.setDC(PrefDiveComputer.vendor3, PrefDiveComputer.product3, PrefDiveComputer.device3)
+				}
+			}
+			SsrfButton {
+				id: dc4
+				visible: PrefDiveComputer.vendor4 !== ""
+				text: PrefDiveComputer.vendor4 + " - " + PrefDiveComputer.product4
+				onClicked: {
+					// update comboboxes
+					rememberedDCsGrid.setDC(PrefDiveComputer.vendor4, PrefDiveComputer.product4, PrefDiveComputer.device4)
+				}
+			}
+		}
+
 		Controls.ProgressBar {
 			id: progressBar
 			Layout.topMargin: Kirigami.Units.smallSpacing * 4

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -339,6 +339,41 @@ Kirigami.ScrollablePage {
 			opacity: 0.5
 			Layout.fillWidth: true
 		}
+
+		GridLayout {
+			id: divecomputers
+			columns: 2
+			width: parent.width - Kirigami.Units.gridUnit
+			Kirigami.Heading {
+				text: qsTr("Dive computers")
+				color: subsurfaceTheme.textColor
+				level: 4
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing
+				Layout.columnSpan: 2
+			}
+			Controls.Label {
+				text: qsTr("Forget remembered dive computers")
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+			SsrfButton {
+				id: forgetDCButton
+				text: qsTr("Forget")
+				onClicked: {
+					PrefDiveComputer.vendor1 = ""
+					PrefDiveComputer.vendor2 = ""
+					PrefDiveComputer.vendor3 = ""
+					PrefDiveComputer.vendor4 = ""
+				}
+			}
+		}
+
+		Rectangle {
+			color: subsurfaceTheme.darkerPrimaryColor
+			height: 1
+			opacity: 0.5
+			Layout.fillWidth: true
+		}
 		GridLayout {
 			id: unit_system
 			columns: 2

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1760,6 +1760,11 @@ int QMLManager::getDetectedProductIndex(const QString &currentVendorText)
 	return m_device_data->getDetectedProductIndex(currentVendorText);
 }
 
+int QMLManager::getConnectionIndex(const QString &deviceSubstr)
+{
+	return connectionListModel.indexOf(deviceSubstr);
+}
+
 void QMLManager::showDownloadPage(QString deviceString)
 {
 	// we pass the indices for the three combo boxes for vendor, product, and connection

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -87,6 +87,7 @@ public:
 	Q_INVOKABLE int getMatchingAddress(const QString &vendor, const QString &product);
 	Q_INVOKABLE int getDetectedVendorIndex();
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
+	Q_INVOKABLE int getConnectionIndex(const QString &deviceSubstr);
 
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This remembers the last up to four dive computers that a user downloaded from and offers shortcut buttons to select them.
So in order to test this, you actually have to create that memory. So select a dive computer vendor/product/device combo, click download (doesn't matter if it works or fails). Then select a different combo and again click download (now called 'retry' if the previous download failed).
Now you should see two of these buttons.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) added settings magic to remember 4 more DCs
2) added  Desktop UI buttons to pick them and fill in the DC information
3) repeated the same for QML

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do, once this works

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Yeah, that should be documented in the manual

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @tomaz @janmulder @jbygdell 
