### PR TITLE
Core: split process_dives() in post-import and post-load versions

### DIFF
--- a/core/divelist.h
+++ b/core/divelist.h
@@ -18,7 +18,8 @@ extern void remove_autogen_trips(void);
 extern int init_decompression(struct deco_state *ds, struct dive *dive);
 
 /* divelist core logic functions */
-extern void process_dives(bool imported, bool prefer_imported);
+extern void process_loaded_dives();
+extern void process_imported_dives(bool prefer_imported);
 extern char *get_dive_gas_string(struct dive *dive);
 
 struct dive **grow_dive_table(struct dive_table *table);

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -135,7 +135,7 @@ static int parse_dan_format(const char *filename, char **params, int pnr)
 		 */
 
 		if (end_ptr)
-			process_dives(true, false);
+			process_imported_dives(false);
 
 		mem_csv.buffer = malloc(mem.size + 1);
 		mem_csv.size = mem.size;

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -947,7 +947,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 		}
 	}
 
-	process_dives(true, false);
+	process_imported_dives(false);
 	MainWindow::instance()->refreshDisplay();
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -454,8 +454,8 @@ void DownloadFromDCWidget::on_ok_clicked()
 	dive = get_dive(dive_table.nr - 1);
 	if (dive != NULL) {
 		uniqId = get_dive(dive_table.nr - 1)->id;
-		process_dives(true, preferDownloaded());
-		// after process_dives does any merging or resorting needed, we need
+		process_imported_dives(preferDownloaded());
+		// after process_imported_dives does any merging or resorting needed, we need
 		// to recreate the model for the dive list so we can select the newest dive
 		MainWindow::instance()->recreateDiveList();
 		idx = get_idx_by_uniq_id(uniqId);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -616,7 +616,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 	QByteArray fileNamePtr = QFile::encodeName(filename);
 	if (!parse_file(fileNamePtr.data(), &dive_table))
 		setCurrentFile(fileNamePtr.data());
-	process_dives(false, false);
+	process_loaded_dives();
 	hideProgressBar();
 	refreshDisplay();
 }
@@ -1737,7 +1737,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
 		parse_file(fileNamePtr.data(), &dive_table);
 	}
-	process_dives(true, false);
+	process_imported_dives(false);
 	refreshDisplay();
 }
 
@@ -1767,7 +1767,7 @@ void MainWindow::importTxtFiles(const QStringList fileNames)
 		DiveLogImportDialog *diveLogImport = new DiveLogImportDialog(csvFiles, this);
 		diveLogImport->show();
 	}
-	process_dives(true, false);
+	process_imported_dives(false);
 	refreshDisplay();
 }
 
@@ -1789,7 +1789,7 @@ void MainWindow::loadFiles(const QStringList fileNames)
 	}
 	hideProgressBar();
 	updateRecentFiles();
-	process_dives(false, false);
+	process_loaded_dives();
 
 	refreshDisplay();
 
@@ -1827,7 +1827,7 @@ void MainWindow::on_actionImportDiveLog_triggered()
 	if (csvFiles.size()) {
 		DiveLogImportDialog *diveLogImport = new DiveLogImportDialog(csvFiles, this);
 		diveLogImport->show();
-		process_dives(true, false);
+		process_imported_dives(false);
 		refreshDisplay();
 	}
 

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -768,7 +768,7 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 		}
 		/* parse file and import dives */
 		parse_file(QFile::encodeName(zipFile.fileName()), &dive_table);
-		process_dives(true, false);
+		process_imported_dives(false);
 		MainWindow::instance()->refreshDisplay();
 
 		/* store last entered user/pass in config */

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -288,7 +288,7 @@ void QMLManager::openLocalThenRemote(QString url)
 		qPrefTechnicalDetails::set_show_ccr_setpoint(git_prefs.show_ccr_setpoint);
 		qPrefTechnicalDetails::set_show_ccr_sensors(git_prefs.show_ccr_sensors);
 		qPrefPartialPressureGas::set_po2(git_prefs.pp_graphs.po2);
-		process_dives(false, false);
+		process_loaded_dives();
 		DiveListModel::instance()->clear();
 		DiveListModel::instance()->addAllDives();
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
@@ -326,7 +326,7 @@ void QMLManager::mergeLocalRepo()
 {
 	char *filename = NOCLOUD_LOCALSTORAGE;
 	parse_file(filename, &dive_table);
-	process_dives(true, false);
+	process_imported_dives(false);
 }
 
 void QMLManager::copyAppLogToClipboard()
@@ -735,7 +735,7 @@ void QMLManager::consumeFinishedLoad(timestamp_t currentDiveTimestamp)
 	prefs.show_ccr_sensors = git_prefs.show_ccr_sensors;
 	prefs.pp_graphs.po2 = git_prefs.pp_graphs.po2;
 	DiveListModel::instance()->clear();
-	process_dives(false, false);
+	process_loaded_dives();
 	DiveListModel::instance()->addAllDives();
 	if (currentDiveTimestamp)
 		setUpdateSelectedDive(dlSortModel->getIdxForId(get_dive_id_closest_to(currentDiveTimestamp)));

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -177,7 +177,7 @@ void DiveImportedModel::recordDives()
 		diveTable->dives[i] = NULL;
 	}
 	diveTable->nr = 0;
-	process_dives(true, true);
+	process_imported_dives(true);
 	if (autogroup)
 		autogroup_dives();
 }

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -137,9 +137,9 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	// read the local repo from the previous test and add dive 10
 	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml", &dive_table), 0);
-	// calling process_dive() sorts the table, but calling it with
-	// is_imported == true causes it to try to update the window title... let's not do that
-	process_dives(false, false);
+	// calling process_loaded_dives() sorts the table, but calling process_imported_dives()
+	// causes it to try to update the window title... let's not do that
+	process_loaded_dives();
 	// now save only to the local cache but not to the remote server
 	QCOMPARE(save_dives(qPrintable(localCacheRepo)), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10local.ssrf"), 0);
@@ -186,14 +186,14 @@ void TestGitStorage::testGitStorageCloudMerge()
 	QString localCacheRepoSave = localCacheDir + "save[ssrftest@hohndel.org]";
 	QCOMPARE(parse_file(qPrintable(localCacheRepoSave), &dive_table), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	QCOMPARE(save_dives(qPrintable(localCacheRepoSave)), 0);
 	clear_dive_file_data();
 
 	// now we open the cloud storage repo and add a different dive to it
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
@@ -208,9 +208,9 @@ void TestGitStorage::testGitStorageCloudMerge()
 	clear_dive_file_data();
 	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf", &dive_table), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10-11-12-merged.ssrf");
 	org.open(QFile::ReadOnly);
@@ -232,7 +232,7 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
 	QCOMPARE(save_dives("./SampleDivesMinus1.ssrf"), 0);
@@ -248,7 +248,7 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	}
 	// now we open the cloud storage repo and modify that first dive
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
 	free(dive->notes);
@@ -288,7 +288,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	QString localCacheDir(get_local_dir("https://cloud.subsurface-divelog.org/git/ssrftest@hohndel.org", "ssrftest@hohndel.org"));
 	QString localCacheRepo = localCacheDir + "[ssrftest@hohndel.org]";
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	struct dive *dive = get_dive(0);
 	QVERIFY(dive != 0);
 	dive->notes = strdup("Create multi line dive notes\nLine 2\nLine 3\nLine 4\nLine 5\nThat should be enough");
@@ -300,7 +300,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	clear_dive_file_data();
 
 	QCOMPARE(parse_file(qPrintable(localCacheRepo), &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	dive = get_dive(0);
 	dive->notes = strdup("Create multi line dive notes\nDifferent line 2 and removed 3-5\n\nThat should be enough");
 	dive = get_dive(1);
@@ -319,7 +319,7 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	}
 	// now we open the cloud storage repo and modify those first dive notes differently
 	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	dive = get_dive(0);
 	dive->notes = strdup("Completely different dive notes\nBut also multi line");
 	dive = get_dive(1);

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -22,9 +22,9 @@ void TestMerge::testMergeEmpty()
 	 * check that we correctly merge mixed cylinder dives
 	 */
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
@@ -45,9 +45,9 @@ void TestMerge::testMergeBackwards()
 	 * check that we correctly merge mixed cylinder dives
 	 */
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -8,14 +8,14 @@
 void TestRenumber::setup()
 {
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
-	process_dives(false, false);
+	process_loaded_dives();
 	dive_table.preexisting = dive_table.nr;
 }
 
 void TestRenumber::testMerge()
 {
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
 	mark_divelist_changed(false);
@@ -25,7 +25,7 @@ void TestRenumber::testMerge()
 void TestRenumber::testMergeAndAppend()
 {
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &dive_table), 0);
-	process_dives(true, false);
+	process_imported_dives(false);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);
 	struct dive *d = get_dive(1);


### PR DESCRIPTION
process_dives() is used to post-process the dive table after loading
or importing. The first parameter states whether this was after
load or import.

Especially in the light of undo, load and import are fundamentally
different things. Notably, that latter should be undo-able, whereas
the former is not. Therefore, as a first step to make import undo-able,
split the function in two versions and remove the first parameter.

It turns out the the load-version is very light. It only sets the
DC nicknames and sorts the dive-table. There seems to be no reason
to merge dives.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a small detangling in preparation for undo of dive-import (which is a bigger project). Please check - it looks trivial enough, but I might have missed something obvious.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Split `process_dives()` in two versions: one for load, one for import.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1528
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
No.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
