### PR TITLE
Qt ble prep

### DIFF
--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -23,9 +23,8 @@ public:
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
 
-	//TODO: need better mode of selecting the desired service than below
-	inline QLowEnergyService *preferredService()
-				{ return services.isEmpty() ? nullptr : services[0]; }
+	inline QLowEnergyService *preferredService() { return preferred; }
+	dc_status_t select_preferred_service(void);
 
 public slots:
 	void addService(const QBluetoothUuid &newService);
@@ -39,6 +38,7 @@ private:
 	QVector<QLowEnergyService *> services;
 
 	QLowEnergyController *controller = nullptr;
+	QLowEnergyService *preferred = nullptr;
 	QList<QByteArray> receivedPackets;
 	bool isCharacteristicWritten;
 	dc_user_device_t *device;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This cleans up the qt-ble GATT service discovery and makes it more generic. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) it uses the WAITFOR() macro to do the "wait for event to complete", which makes for much simpler code, and can improve latency tii. 

2) it moves the special service test logic from the service discovery phase to a later "now that we've discovered all services, let's figure out which one is the preferred one".

That second change in particular makes it much easier to look at what characteristics and descriptors the different services offer, and should make it much clearer how we pick one GATT service to be the preferred communication service.

It also outputs the service information in a much more legible format along with all their characteristics and descriptor information. 

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
