### PR TITLE
Remember DC: add connection

### DIFF
--- a/core/macos.c
+++ b/core/macos.c
@@ -104,6 +104,9 @@ int enumerate_devices(device_callback_t callback, void *userdata, unsigned int t
 	struct dirent *ep = NULL;
 	size_t i;
 	if (transport & DC_TRANSPORT_SERIAL) {
+		// on Mac we always support FTDI now
+		callback("FTDI", userdata);
+
 		const char *dirname = "/dev";
 		const char *patterns[] = {
 			"tty.*",

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -121,6 +121,17 @@ void DownloadFromDCWidget::showRememberedDCs()
 	SETUPDC(4)
 }
 
+int DownloadFromDCWidget::deviceIndex(QString deviceText)
+{
+	int rv = ui.device->findText(deviceText);
+	if (rv == -1) {
+		// we need to insert the device text into the model
+		ui.device->addItem(deviceText);
+		rv = ui.device->findText(deviceText);
+	}
+	return rv;
+}
+
 // DC button slots
 #define DCBUTTON(num) \
 void DownloadFromDCWidget::DC##num##Clicked() \
@@ -128,7 +139,7 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
-	ui.device->setCurrentIndex(ui.device->findText(qPrefDiveComputer::device##num())); \
+	ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
 	if (QSysInfo::kernelType() == "darwin") { \
 		/* it makes no sense that this would be needed on macOS but not Linux */ \
 		QCoreApplication::processEvents(); \

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -54,6 +54,7 @@ slots:
 	void DC2Clicked();
 	void DC3Clicked();
 	void DC4Clicked();
+	int deviceIndex(QString deviceText);
 
 #if defined(BT_SUPPORT)
 	void enableBluetoothMode(int state);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Hopefully this is the first step towards correctly working shortcut buttons.
If the connection isn't found, it's added.
This still isn't enough for BT/BLE on a Mac as there we seem to have to scan before being able to use such device names (and I don't have a Linux box with working BT adapter - so wasn't able to test it there)
Oh, and I just see that my FTDI change snuck in there, too. 
Unrelated, but I think technically correct.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Simply add the remembered connection to the model of the drop down

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1715 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder 