### PR TITLE
Mobile: scale UI, part 2

### DIFF
--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -99,7 +99,7 @@ void qPrefDisplay::disk_divelist_font(bool doSync)
 
 void qPrefDisplay::set_font_size(double value)
 {
-	if (value != prefs.font_size) {
+	if (!IS_FP_SAME(value, prefs.font_size)) {
 		prefs.font_size = value;
 		disk_font_size(true);
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -304,6 +304,7 @@ Kirigami.ScrollablePage {
 					wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 					visible: text !== ""
 					font.weight: Font.Bold
+					font.pointSize: subsurfaceTheme.regularPointSize
 					anchors {
 						top: parent.top
 						left: dateBox.right

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -262,6 +262,7 @@ Kirigami.ScrollablePage {
 					enabled: PrefDisplay.mobile_scale !== 0.85
 					onClicked: {
 						PrefDisplay.mobile_scale = 0.85
+						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
 					}
 				}
 				SsrfButton {
@@ -269,6 +270,7 @@ Kirigami.ScrollablePage {
 					enabled: PrefDisplay.mobile_scale !== 1.0
 					onClicked: {
 						PrefDisplay.mobile_scale = 1.0
+						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
 					}
 				}
 				SsrfButton {
@@ -276,6 +278,7 @@ Kirigami.ScrollablePage {
 					enabled: PrefDisplay.mobile_scale !== 1.15
 					onClicked: {
 						PrefDisplay.mobile_scale = 1.15
+						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
 					}
 				}
 			}

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -62,6 +62,13 @@ Kirigami.Page {
 		}
 
 		Controls.Label {
+			text: "basePointSize:"
+		}
+		Controls.Label {
+			text: subsurfaceTheme.basePointSize
+		}
+
+		Controls.Label {
 			text: "FontMetrics pointSize:"
 		}
 		Controls.Label {

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.2 as Controls
 import QtQuick.Window 2.2
 import org.kde.kirigami 2.2 as Kirigami
+import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.Page {
 
@@ -24,9 +25,6 @@ Kirigami.Page {
 			text: "Screen"
 			Layout.columnSpan: 2
 			level: 3
-		}
-		FontMetrics {
-			id: fm
 		}
 
 		Controls.Label {
@@ -67,35 +65,35 @@ Kirigami.Page {
 			text: "FontMetrics pointSize:"
 		}
 		Controls.Label {
-			text: fm.font.pointSize
+			text: fontMetrics.font.pointSize
 		}
 
 		Controls.Label {
 			text: "FontMetrics pixelSize:"
 		}
 		Controls.Label {
-			text: Number(fm.height).toFixed(2)
+			text: Number(fontMetrics.height).toFixed(2)
 		}
 
 		Controls.Label {
 			text: "FontMetrics devicePixelRatio:"
 		}
 		Controls.Label {
-			text: Number(fm.height / fm.font.pointSize).toFixed(2)
+			text: Number(fontMetrics.height / fontMetrics.font.pointSize).toFixed(2)
 		}
 
 		Controls.Label {
 			text: "Text item pixelSize:"
 		}
 		Text {
-			text: font.pixelSize
+			text: fontMetrics.font.pixelSize
 		}
 
 		Controls.Label {
 			text: "Text item pointSize:"
 		}
 		Text {
-			text: font.pointSize
+			text: fontMetrics.font.pointSize
 		}
 
 		Controls.Label {
@@ -109,7 +107,7 @@ Kirigami.Page {
 			text: "Height of default font:"
 		}
 		Text {
-			text: Number(font.pixelSize / Screen.pixelDensity).toFixed(2) + "mm"
+			text: Number(fontMetrics.font.pixelSize / Screen.pixelDensity).toFixed(2) + "mm"
 		}
 
 		Controls.Label {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -46,7 +46,9 @@ Kirigami.ApplicationWindow {
 	FontMetrics {
 		id: fontMetrics
 		Component.onCompleted: {
-			console.log("Using the following font: " + fontMetrics.font.family + " at " + fontMetrics.font.pointSize + "pt")
+			console.log("Using the following font: " + fontMetrics.font.family
+				    + " at " + subsurfaceTheme.basePointSize + "pt" +
+				    " with mobile_scale: " + PrefDisplay.mobile_scale)
 		}
 	}
 	visible: false
@@ -444,9 +446,16 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 	QtObject {
 		id: subsurfaceTheme
-		property int regularPointSize: fontMetrics.font.pointSize
-		property int titlePointSize: Math.round(regularPointSize * 1.5)
-		property int smallPointSize: Math.round(regularPointSize * 0.8)
+
+		// basePointSize is determinded at start of the app and shall
+		// never be changed. This is very tricky. In order to break the
+		// binding between basePointSize and fontMetrics.font.pointSize we
+		// multipy it by 1.0 in the onComplete hander of this object.
+		property double basePointSize: fontMetrics.font.pointSize;
+
+		property double regularPointSize: fontMetrics.font.pointSize
+		property double titlePointSize: regularPointSize * 1.5
+		property double smallPointSize: regularPointSize * 0.8
 
 		// colors currently in use
 		property string currentTheme
@@ -500,6 +509,13 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 		property int columnWidth: Math.round(rootItem.width/(Kirigami.Units.gridUnit*28)) > 0 ? Math.round(rootItem.width / Math.round(rootItem.width/(Kirigami.Units.gridUnit*28))) : rootItem.width
 		Component.onCompleted: {
+			// break binding explicitly. Now we have a basePointSize that we can
+			// use to easily scale against
+			basePointSize = basePointSize * 1.0;
+
+			// set the initial UI scaling as in the the preferences
+			fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+
 			// this needs to pick the theme from persistent preference settings
 			var theme = PrefDisplay.theme
 			if (theme == "Blue")


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
**WARNING**: this is PR on top of #1709, that I first rebased on master, so Dirks commits are in this PR as well.

Make the font scaling work also on Android, and added a POC for the divelist (which is very simple as it already scaled very nicely). It now dynamically changes correctly (the part that was missing in #1709), and also on Android device.

### Changes made:

By manipulation the used font pointSize property, we can dynamically scale fonts and derived UI objects. At the same time, we have some logic to determine the default font, its size, etc, for example depending on screen properties. The scaling of the UI (and its font) does not need to interfere with those defaults.

However, when we want to reset the pointSize, we alter the default, so a backup of the default is needed. Ok, not al full backup, as the only thing we like to manipulate is the pointSize, to which we want to be able to return.

All this leads to these changes. A basePointSize property is added, that is initialized from the default. Due to the binding logic of the QML engine, it is not a classic initialization, but a binding between the 2 properties. We need to break that binding explicitly, so that the original PointSize is always preserved.

See commits for further details.

### Related issues:
#1709 


### Release note:
as #1709 

### Documentation change:
as #1709

### Mentions:
@dirkhh 
