### PR TITLE
Mobile QML UI: Download screen scalability 

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -55,7 +55,7 @@ Kirigami.Page {
 	title: currentItem && currentItem.modelData ? currentItem.modelData.dive.location : qsTr("Dive details")
 	state: "view"
 	leftPadding: 0
-	topPadding: Kirigami.Units.gridUnit * 2 // make room for the title bar
+	topPadding: Kirigami.Units.gridUnit / 2
 	rightPadding: 0
 	bottomPadding: 0
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -9,10 +9,10 @@ import org.kde.kirigami 2.2 as Kirigami
 
 Kirigami.Page {
 	id: diveComputerDownloadWindow
-	anchors.top:parent.top
-	width: parent.width
-	height: parent.height
-	Layout.fillWidth: true;
+	leftPadding: Kirigami.Units.gridUnit / 2
+	rightPadding: Kirigami.Units.gridUnit / 2
+	topPadding: 0
+	bottomPadding: 0
 	title: qsTr("Dive Computer")
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
@@ -49,12 +49,12 @@ Kirigami.Page {
 		anchors.top: parent.top
 		height: parent.height
 		width: parent.width
-		Layout.fillWidth: true
 		GridLayout {
 			id: buttonGrid
 			Layout.alignment: Qt.AlignTop
 			Layout.topMargin: Kirigami.Units.smallSpacing * 4
 			columns: 2
+			rowSpacing: 0
 			Controls.Label {
 				text: qsTr(" Vendor name: ")
 				font.pointSize: subsurfaceTheme.regularPointSize
@@ -313,7 +313,7 @@ Kirigami.Page {
 		ListView {
 			id: dlList
 			Layout.topMargin: Kirigami.Units.smallSpacing * 4
-			Layout.bottomMargin: bottomButtons.height * 1.5
+			Layout.bottomMargin: bottomButtons.height / 2
 			Layout.fillWidth: true
 			Layout.fillHeight: true
 
@@ -334,7 +334,6 @@ Kirigami.Page {
 
 		RowLayout {
 			id: bottomButtons
-			Layout.fillWidth: true
 			Controls.Label {
 				text: ""  // Spacer on the left for hamburger menu
 				Layout.fillWidth: true
@@ -343,6 +342,7 @@ Kirigami.Page {
 				id: acceptButton
 				enabled: divesDownloaded
 				text: qsTr("Accept")
+				bottomPadding: Kirigami.Units.gridUnit / 2
 				onClicked: {
 					manager.appendTextToLog("Save downloaded dives that were selected")
 					importModel.recordDives()
@@ -362,6 +362,7 @@ Kirigami.Page {
 				id: select
 				enabled: divesDownloaded
 				text: qsTr("Select All")
+				bottomPadding: Kirigami.Units.gridUnit / 2
 				onClicked : {
 					importModel.selectAll()
 				}
@@ -370,6 +371,7 @@ Kirigami.Page {
 				id: unselect
 				enabled: divesDownloaded
 				text: qsTr("Unselect All")
+				bottomPadding: Kirigami.Units.gridUnit / 2
 				onClicked : {
 					importModel.selectNone()
 				}

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -55,14 +55,19 @@ Kirigami.Page {
 			Layout.alignment: Qt.AlignTop
 			Layout.topMargin: Kirigami.Units.smallSpacing * 4
 			columns: 2
-			Controls.Label { text: qsTr(" Vendor name: ") }
+			Controls.Label {
+				text: qsTr(" Vendor name: ")
+				font.pointSize: subsurfaceTheme.regularPointSize
+			}
 			Controls.ComboBox {
 				id: comboVendor
 				Layout.fillWidth: true
+				Layout.preferredHeight: fontMetrics.height * 2.5
 				model: vendorList
 				currentIndex: -1
 				delegate: Controls.ItemDelegate {
 					width: comboVendor.width
+					height: fontMetrics.height * 2.0
 					contentItem: Text {
 						text: modelData
 						font.pointSize: subsurfaceTheme.regularPointSize
@@ -92,14 +97,19 @@ Kirigami.Page {
 					}
 				}
 			}
-			Controls.Label { text: qsTr(" Dive Computer:") }
+			Controls.Label {
+				text: qsTr(" Dive Computer:")
+				font.pointSize: subsurfaceTheme.regularPointSize
+			}
 			Controls.ComboBox {
 				id: comboProduct
 				Layout.fillWidth: true
+				Layout.preferredHeight: fontMetrics.height * 2.5
 				model: null
 				currentIndex: -1
 				delegate: Controls.ItemDelegate {
 					width: comboProduct.width
+					height: fontMetrics.height * 2.0
 					contentItem: Text {
 						text: modelData
 						font.pointSize: subsurfaceTheme.regularPointSize
@@ -127,17 +137,21 @@ Kirigami.Page {
 					currentIndex = manager.getDetectedProductIndex(comboVendor.currentText)
 				}
 			}
-			Controls.Label { text: qsTr(" Connection:") }
+			Controls.Label {
+				text: qsTr(" Connection:")
+				font.pointSize: subsurfaceTheme.regularPointSize
+			}
 			Controls.ComboBox {
 				id: comboConnection
 				Layout.fillWidth: true
+				Layout.preferredHeight: fontMetrics.height * 2.5
 				model: connectionListModel
 				currentIndex: -1
 				delegate: Controls.ItemDelegate {
 					width: comboConnection.width
+					height: fontMetrics.height * 2.0
 					contentItem: Text {
 						text: modelData
-						// color: "#21be2b"
 						font.pointSize: subsurfaceTheme.smallPointSize
 						verticalAlignment: Text.AlignVCenter
 						elide: Text.ElideRight

--- a/mobile-widgets/qml/DownloadedDiveDelegate.qml
+++ b/mobile-widgets/qml/DownloadedDiveDelegate.qml
@@ -36,7 +36,7 @@ Kirigami.AbstractListItem {
 		SsrfCheckBox {
 			id: diveIsSelected
 			checked: innerListItem.selected;
-			width: childrenRect.width - Kirigami.Units.smallSpacing;
+			width: childrenRect.width + 4 * Kirigami.Units.smallSpacing;
 			height: childrenRect.heigh - Kirigami.Units.smallSpacing;
 			anchors.verticalCenter: parent.verticalCenter
 			onClicked: {

--- a/mobile-widgets/qml/SsrfButton.qml
+++ b/mobile-widgets/qml/SsrfButton.qml
@@ -15,6 +15,7 @@ Button {
 	contentItem: Text {
 		id: buttonText
 		text: root.text
+		font.pointSize: subsurfaceTheme.regularPointSize
 		anchors.centerIn: buttonBackground
 		color: root.pressed ? subsurfaceTheme.darkerPrimaryTextColor :subsurfaceTheme.primaryTextColor
 	}

--- a/mobile-widgets/qml/SsrfCheckBox.qml
+++ b/mobile-widgets/qml/SsrfCheckBox.qml
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
 import QtQuick.Controls 2.2
+import org.subsurfacedivelog.mobile 1.0
 import org.kde.kirigami 2.2 as Kirigami
 
 CheckBox {
 	id: root
 	indicator: Rectangle {
-		implicitWidth: 20
-		implicitHeight: 20
+		implicitWidth: 20 * PrefDisplay.mobile_scale
+		implicitHeight: 20 * PrefDisplay.mobile_scale
 		x: root.leftPadding
 		y: parent.height / 2 - height / 2
 		radius: 4
@@ -16,10 +17,10 @@ CheckBox {
 		color: subsurfaceTheme.backgroundColor
 
 		Rectangle {
-			width: 12
-			height: 12
-			x: 4
-			y: 4
+			width: 12 * PrefDisplay.mobile_scale
+			height: 12 * PrefDisplay.mobile_scale
+			x: (parent.width - width) / 2
+			y: (parent.height - height) / 2
 			radius: 3
 			color: root.down ? subsurfaceTheme.darkerPrimaryColor : subsurfaceTheme.primaryColor
 			visible: root.checked


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
A set of small commits all (but one) related to the Download from DC screen, and related Button and CheckBox variant we use. Almost all is related to scalability of the UI, and some bug fixing of layout that was rather poor. 1 change to the DiveDetails (related to whitspace) is added to this PR.

### Changes made:
See commits

### Related issues:
QML UI scalability
