### PR TITLE
Improve XML sample time parsing, and allow qt-ble to handle partial packets

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -322,16 +322,21 @@ static void temperature(char *buffer, temperature_t *temperature)
 static void sampletime(char *buffer, duration_t *time)
 {
 	int i;
-	int min, sec;
+	int hr, min, sec;
 
-	i = sscanf(buffer, "%d:%d", &min, &sec);
+	i = sscanf(buffer, "%d:%d:%d", &hr, &min, &sec);
 	switch (i) {
 	case 1:
-		sec = min;
-		min = 0;
+		min = hr;
+		hr = 0;
 	/* fallthrough */
 	case 2:
-		time->seconds = sec + min * 60;
+		sec = min;
+		min = hr;
+		hr = 0;
+	/* fallthrough */
+	case 3:
+		time->seconds = (hr * 60 + min) * 60 + sec;
 		break;
 	default:
 		printf("Strange sample time reading %s\n", buffer);

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -191,8 +191,15 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 
 	QByteArray packet = receivedPackets.takeFirst();
 
-	if ((size_t)packet.size() > size)
-		return DC_STATUS_NOMEMORY;
+	// Did we get more than asked for?
+	//
+	// Put back the left-over at the beginning of the
+	// received packet list, and truncate the packet
+	// we got to just the part asked for.
+	if ((size_t)packet.size() > size) {
+		receivedPackets.prepend(packet.mid(size));
+		packet.truncate(size);
+	}
 
 	memcpy((char *)data, packet.data(), packet.size());
 	if (actual)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a pull request with two fixes (or missing features, depending on how you read it) for behavior reported in the last couple of days.

The XML sample time parsing helps xslt importers from sources that describe sample times in a hh:mm:ss format, like the VMS Redbare CCR. We already supported two formats: plain seconds and 'mm:ss' format. This just extends the existing code to also support 'hh:mm:ss'.

The other fix/feature is allowing libdivecomputer backends to read partial packets, like the Mares downloader wants. Note that the Mares downloader *also* wants the reverse case, where multiple packets are joined into one big buffer, but that is handled internally by libdivecomputer with a recent update.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
