### PR TITLE
Trivial: Minor header cleanup

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -506,10 +506,6 @@ extern int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *
 extern int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table);
 
 extern int parse_file(const char *filename, struct dive_table *table);
-extern int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
-extern int parse_seabear_log(const char *filename);
-extern int parse_txt_file(const char *filename, const char *csv);
-extern int parse_manual_file(const char *filename, char **params, int pnr);
 extern int save_dives(const char *filename);
 extern int save_dives_logic(const char *filename, bool select_only, bool anonymize);
 extern int save_dive(FILE *f, struct dive *dive, bool anonymize);

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -47,7 +47,7 @@ static timestamp_t parse_date(const char *date)
 	return utc_mktime(&tm);
 }
 
-void add_sample_data(struct sample *sample, enum csv_format type, double val)
+static void add_sample_data(struct sample *sample, enum csv_format type, double val)
 {
 	switch (type) {
 	case CSV_DEPTH:

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -17,7 +17,6 @@ enum csv_format {
 
 #define MAXCOLDIGITS 10
 
-void add_sample_data(struct sample *sample, enum csv_format type, double val);
 int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 int try_to_open_csv(struct memblock *mem, enum csv_format type);
 int parse_txt_file(const char *filename, const char *csv);

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -17,11 +17,19 @@ enum csv_format {
 
 #define MAXCOLDIGITS 10
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate);
 int try_to_open_csv(struct memblock *mem, enum csv_format type);
 int parse_txt_file(const char *filename, const char *csv);
 
 int parse_seabear_log(const char *filename);
 int parse_manual_file(const char *filename, char **params, int pnr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // IMPORTCSV_H

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -23,6 +23,7 @@
 #include "core/gettextfromc.h"
 #include "core/git-access.h"
 #include "core/isocialnetworkintegration.h"
+#include "core/import-csv.h"
 #include "core/planner.h"
 #include "core/pluginmanager.h"
 #include "core/qthelper.h"

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -3,6 +3,7 @@
 #include "core/dive.h"
 #include "core/divelist.h"
 #include "core/file.h"
+#include "core/import-csv.h"
 #include "core/parse.h"
 #include "core/qthelper.h"
 #include "core/subsurface-string.h"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Minor header cleanup in `import-csv.h`. Make one local function static. And remove redundant prototypes. These were a bit scary, because in `dive.h` they were declared `extern "C"`, whereas in `import-csv.h` they were not. I have my doubts that this is well defined.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make function static.
2) Remove redundant prototypes from `dive.h`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
