### PR TITLE
Cleanup: split out free_dive() function from delete_single_dive() [Leak fix?]

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -528,11 +528,7 @@ static void copy_tl(struct tag_entry *st, struct tag_entry *dt)
 		*_dptr = 0;                              \
 	}
 
-/* copy_dive makes duplicates of many components of a dive;
- * in order not to leak memory, we need to free those .
- * copy_dive doesn't play with the divetrip and forward/backward pointers
- * so we can ignore those */
-void clear_dive(struct dive *d)
+static void free_dive_structures(struct dive *d)
 {
 	if (!d)
 		return;
@@ -550,6 +546,23 @@ void clear_dive(struct dive *d)
 		free((void *)d->cylinder[i].type.description);
 	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++)
 		free((void *)d->weightsystem[i].description);
+}
+
+void free_dive(struct dive *d)
+{
+	free_dive_structures(d);
+	free(d);
+}
+
+/* copy_dive makes duplicates of many components of a dive;
+ * in order not to leak memory, we need to free those .
+ * copy_dive doesn't play with the divetrip and forward/backward pointers
+ * so we can ignore those */
+void clear_dive(struct dive *d)
+{
+	if (!d)
+		return;
+	free_dive_structures(d);
 	memset(d, 0, sizeof(struct dive));
 }
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -544,6 +544,7 @@ extern timestamp_t utc_mktime(struct tm *tm);
 extern void utc_mkdate(timestamp_t, struct tm *tm);
 
 extern struct dive *alloc_dive(void);
+extern void free_dive(struct dive *);
 extern void record_dive_to_table(struct dive *dive, struct dive_table *table);
 extern void record_dive(struct dive *dive);
 extern void clear_dive(struct dive *dive);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -931,14 +931,7 @@ void delete_single_dive(int idx)
 	for (i = idx; i < dive_table.nr - 1; i++)
 		dive_table.dives[i] = dive_table.dives[i + 1];
 	dive_table.dives[--dive_table.nr] = NULL;
-	/* free all allocations */
-	free(dive->dc.sample);
-	free((void *)dive->notes);
-	free((void *)dive->divemaster);
-	free((void *)dive->buddy);
-	free((void *)dive->suit);
-	taglist_free(dive->tag_list);
-	free(dive);
+	free_dive(dive);
 }
 
 struct dive **grow_dive_table(struct dive_table *table)


### PR DESCRIPTION
Currently, we can only delete dives that are indexed in the main
dive table. In the future, we will have to delete dives outside
of this table (e.g. for undo). Therefore, split out the free_dive()
function from delete_single_dive(), which takes an index into
the main dive table.

In the process, adopt the dive freeing-code from clear_dive(),
which frees more data than the code in delete_single_dive().
This potentially fixes a memory-leak.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While looking at my undo-branch it occurred to me that the split-out `free_dive()` function frees less than the `clean_dive()` function. I'm not 100% sure, because the code is convoluted - but doesn't that mean that the dive-deletion in `UndoDeleteDive::redo()` (desktop-widgets/undocommands.c) leaks memory?

The mobile version has a `clear_dive()` call, but I couldn't convince my self that all code-paths don't leak memory.

This commit tries to unify the free-dive-memory functions and adds a `free_dive()` function in preparation of the undo-work.

In case it isn't obvious, this is a bit experimental and therefore post-release material. Therefore I assign the `priority-low` tag.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move dive-memory freeing into a local functions.
2) Split out `free_dive()` from `delete_single_dive()`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
