### PR TITLE
[TRIVIAL] Mobile: don't call clear_dive() on deleteDive

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1294,11 +1294,9 @@ void QMLManager::deleteDive(int id)
 		appendTextToLog("trying to delete non-existing dive");
 		return;
 	}
-	// clean up (or create) the storage for the deleted dive and trip (if applicable)
+	// create the storage for the deleted dive and trip (if applicable)
 	if (!deletedDive)
 		deletedDive = alloc_dive();
-	else
-		clear_dive(deletedDive);
 	copy_dive(d, deletedDive);
 	if (!deletedTrip) {
 		deletedTrip = (struct dive_trip *)calloc(1, sizeof(struct dive_trip));


### PR DESCRIPTION
clear_dive() will be called anyway in the subsequent call to
copy_dive().

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup, see commit message.

Post-release material, therefore tagged `priority-low`

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove redundant clear_dive() call.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
