### PR TITLE
Cleanup: don't derive UserSurveyServices from WebServices

### DIFF
--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -793,17 +793,16 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 	}
 }
 
-UserSurveyServices::UserSurveyServices(QWidget *parent, Qt::WindowFlags f) : WebServices(parent, f)
+UserSurveyServices::UserSurveyServices(QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f)
 {
-
 }
 
-QNetworkReply* UserSurveyServices::sendSurvey(QString values)
+QNetworkReply *UserSurveyServices::sendSurvey(QString values)
 {
 	QNetworkRequest request;
 	request.setUrl(QString("http://subsurface-divelog.org/survey?%1").arg(values));
 	request.setRawHeader("Accept", "text/xml");
-	request.setRawHeader("User-Agent", userAgent.toUtf8());
-	reply = manager()->get(request);
+	request.setRawHeader("User-Agent", getUserAgent().toUtf8());
+	QNetworkReply *reply = manager()->get(request);
 	return reply;
 }

--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -77,17 +77,11 @@ private:
 	bool uploadMode;
 };
 
-class UserSurveyServices : public WebServices {
+class UserSurveyServices : public QDialog {
 	Q_OBJECT
 public:
 	QNetworkReply* sendSurvey(QString values);
 	explicit UserSurveyServices(QWidget *parent = 0, Qt::WindowFlags f = 0);
-private
-slots:
-	// need to declare them as no ops or Qt4 is unhappy
-	void startDownload() { }
-	void startUpload() { }
-	void buttonClicked(QAbstractButton *button) { Q_UNUSED(button) }
 };
 
 #endif // SUBSURFACEWEBSERVICES_H

--- a/desktop-widgets/subsurfacewebservices.h
+++ b/desktop-widgets/subsurfacewebservices.h
@@ -26,7 +26,7 @@ slots:
 	virtual void startDownload() = 0;
 	virtual void startUpload() = 0;
 	virtual void buttonClicked(QAbstractButton *button) = 0;
-	virtual void downloadTimedOut();
+	void downloadTimedOut();
 
 protected
 slots:


### PR DESCRIPTION
UserSurveyServices derives from WebServices and therefore has
to define three pure virtual functions [startDownload(),
startUpload(), buttonClicked()] as no-ops. Interestingly,
a comment in the header says
	"need to declare them as no ops or Qt4 is unhappy"
which is of course not true as these functions are not
declared by Qt.

There seems to be no point in deriving from WebServices,
therefore don't do it. These function definitions can then
be removed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another very minor code cleanup, see commit-message.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't derive UserSurveyServices from WebServices
2) Unvirtualize downloadTimedOut
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
