### PR TITLE
Mobile, Remember DCs: the final part

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -291,16 +291,6 @@ QStringList DCDeviceData::getProductListFromVendor(const QString &vendor)
 
 int DCDeviceData::getMatchingAddress(const QString &vendor, const QString &product)
 {
-	if (qPrefDiveComputer::vendor() == vendor &&
-	    qPrefDiveComputer::product() == product) {
-		// we are trying to show the last dive computer selected
-		for (int i = 0; i < connectionListModel.rowCount(); i++) {
-			QString address = connectionListModel.address(i);
-			if (address.contains(qPrefDiveComputer::device()))
-				return i;
-		}
-	}
-
 	for (int i = 0; i < connectionListModel.rowCount(); i++) {
 		QString address = connectionListModel.address(i);
 		if (address.contains(product))
@@ -453,14 +443,6 @@ device_data_t *DCDeviceData::internalData()
 
 int DCDeviceData::getDetectedVendorIndex()
 {
-	if (!qPrefDiveComputer::vendor().isEmpty()) {
-		// use the last one
-		for (int i = 0; i < vendorList.length(); i++) {
-			if (vendorList[i] == qPrefDiveComputer::vendor())
-				return i;
-		}
-	}
-
 #if defined(BT_SUPPORT)
 	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 
@@ -473,16 +455,6 @@ int DCDeviceData::getDetectedVendorIndex()
 
 int DCDeviceData::getDetectedProductIndex(const QString &currentVendorText)
 {
-	if (!qPrefDiveComputer::vendor().isEmpty()) {
-		if (qPrefDiveComputer::vendor() == currentVendorText) {
-			// we are trying to show the last dive computer selected
-			for (int i = 0; i < productList[currentVendorText].length(); i++) {
-				if (productList[currentVendorText][i] == qPrefDiveComputer::product())
-					return i;
-			}
-		}
-	}
-
 #if defined(BT_SUPPORT)
 	QList<BTDiscovery::btVendorProduct> btDCs = BTDiscovery::instance()->getBtDcs();
 

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -179,6 +179,20 @@ Kirigami.Page {
 					else
 						manager.DC_bluetoothMode = false
 					manager.DC_devName = currentText
+					dc1.enabled = dc2.enabled = dc3.enabled = dc4.enabled = true
+					for (var i = 1; i < 5; i++) {
+						if (comboProduct.currentIndex === -1 && currentText === "FTDI"){
+							if ( eval("PrefDiveComputer.vendor" + i) === comboVendor.currentText && eval("PrefDiveComputer.device" + i).toUpperCase() === currentText){
+								rememberedDCsGrid.setDC(eval("PrefDiveComputer.vendor" + i), eval("PrefDiveComputer.product" + i), ("PrefDiveComputer.device" + i))
+							}
+						}else if (comboProduct.currentIndex !== -1 && currentText === "FTDI") {
+							if ( eval("PrefDiveComputer.vendor" + i) === comboVendor.currentText && eval("PrefDiveComputer.product" + i) === comboProduct.currentText && eval("PrefDiveComputer.device" + i).toUpperCase() === currentText){
+								eval("dc"+ i + ".enabled = false")
+							}
+						}else if ( eval("PrefDiveComputer.vendor" + i) === comboVendor.currentText && eval("PrefDiveComputer.product" + i) === comboProduct.currentText && eval("PrefDiveComputer.product" + i) +" " + eval("PrefDiveComputer.device" + i).toUpperCase() === currentText){
+							eval("dc"+ i + ".enabled = false")
+						}
+					}
 				}
 			}
 		}
@@ -380,9 +394,12 @@ Kirigami.Page {
 
 		onVisibleChanged: {
 			comboVendor.currentIndex = comboProduct.currentIndex = comboConnection.currentIndex = -1
-			if (visible && PrefDiveComputer.vendor !== "" ) {
-				rememberedDCsGrid.setDC(PrefDiveComputer.vendor1, PrefDiveComputer.product1, PrefDiveComputer.device1)
-				dc1.enabled = false
+			dc1.enabled = dc2.enabled = dc3.enabled = dc4.enabled = true
+			if (visible) {
+				comboVendor.currentIndex = manager.getDetectedVendorIndex()
+				comboProduct.currentIndex = manager.getDetectedProductIndex(comboVendor.currentText)
+				comboConnection.currentIndex = manager.getMatchingAddress(comboVendor.currentText, comboProduct.currentText)
+				
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Since we now keep track of up to 4 dive computers the logic when entering download mode needs to change. Instead of displaying the last used DC we need to match the connected DC against the ones we have stored. If we have a match against a DC that have been used before the corresponding button is marked as selected.
Some USB cables only supply Vendor name and not the device, in that case we still try to match against the previously used DCs. If we find a possible match we select that device.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1707 #1710 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
