### PR TITLE
QML UI: trivial resize of datebox

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -256,8 +256,8 @@ Kirigami.ScrollablePage {
 				Rectangle {
 					id: dateBox
 					visible: section != ""
-					height: section == "" ? 0 : 2 * Kirigami.Units.gridUnit
-					width: section == "" ? 0 : 2.5 * Kirigami.Units.gridUnit
+					height: section == "" ? 0 : parent.height - Kirigami.Units.smallSpacing
+					width: section == "" ? 0 : 2.5 * Kirigami.Units.gridUnit * PrefDisplay.mobile_scale
 					color: subsurfaceTheme.primaryColor
 					radius: Kirigami.Units.smallSpacing * 2
 					antialiasing: true


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Something that I simply overlooked earlier with respect to scaling the divelist. The trip datebox did scale a bit, but it was not nicely related to the hight of the trip header. So there was a tiny overflow on the small scale on a small device. Fixed here.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>