### PR TITLE
[RFC] Import: import Poseidon MkIV logs via DiveLogImportDialog

### DIFF
--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -15,7 +15,24 @@ static QString subsurface_index = "subsurface/csvindex";
 
 #define SILENCE_WARNING 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ""
 
-const DiveLogImportDialog::CSVAppConfig DiveLogImportDialog::CSVApps[CSVAPPS] = {
+struct CSVAppConfig {
+	QString name;
+	int time;
+	int depth;
+	int temperature;
+	int po2;
+	int sensor1;
+	int sensor2;
+	int sensor3;
+	int cns;
+	int ndl;
+	int tts;
+	int stopdepth;
+	int pressure;
+	int setpoint;
+	QString separator;
+};
+static const CSVAppConfig CSVApps[] = {
 	// time, depth, temperature, po2, sensor1, sensor2, sensor3, cns, ndl, tts, stopdepth, pressure, setpoint
 	// indices are 0 based, -1 means the column doesn't exist
 	{ "Manual import", SILENCE_WARNING },
@@ -28,7 +45,6 @@ const DiveLogImportDialog::CSVAppConfig DiveLogImportDialog::CSVApps[CSVAPPS] = 
 	{ "SubsurfaceCSV", -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, "Tab" },
 	{ "AV1", 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, " " },
 	{ "Poseidon MkVI", 0, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, "," },
-	{ NULL, SILENCE_WARNING }
 };
 
 enum Known {
@@ -347,8 +363,8 @@ DiveLogImportDialog::DiveLogImportDialog(QStringList fn, QWidget *parent) : QDia
 	specialCSV << AV1;
 	specialCSV << POSEIDON;
 
-	for (int i = 0; !CSVApps[i].name.isNull(); ++i)
-		ui->knownImports->addItem(CSVApps[i].name);
+	for (const CSVAppConfig &conf: CSVApps)
+		ui->knownImports->addItem(conf.name);
 
 	ui->CSVSeparator->addItems( QStringList() << tr("Tab") << "," << ";" << "|");
 

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -1010,22 +1010,6 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 	MainWindow::instance()->refreshDisplay();
 }
 
-// Since this is a non-modal dialog, the caller can't delete it at the call-site.
-// Therefore, hook into the accept() and reject() functions and schedule the object
-// for deletion with deleteLater(). Horrible, but absolutely the "Qt-way".
-// TODO: Think about making the dialog modal.
-void DiveLogImportDialog::accept()
-{
-	QDialog::accept();
-	deleteLater();
-}
-
-void DiveLogImportDialog::reject()
-{
-	QDialog::reject();
-	deleteLater();
-}
-
 TagDragDelegate::TagDragDelegate(QObject *parent) : QStyledItemDelegate(parent)
 {
 }

--- a/desktop-widgets/divelogimportdialog.h
+++ b/desktop-widgets/divelogimportdialog.h
@@ -103,26 +103,6 @@ private:
 	QString hw;
 	bool txtLog;
 
-	struct CSVAppConfig {
-		QString name;
-		int time;
-		int depth;
-		int temperature;
-		int po2;
-		int sensor1;
-		int sensor2;
-		int sensor3;
-		int cns;
-		int ndl;
-		int tts;
-		int stopdepth;
-		int pressure;
-		int setpoint;
-		QString separator;
-	};
-
-#define CSVAPPS 11
-	static const CSVAppConfig CSVApps[CSVAPPS];
 };
 
 class TagDragDelegate : public QStyledItemDelegate {

--- a/desktop-widgets/divelogimportdialog.h
+++ b/desktop-widgets/divelogimportdialog.h
@@ -121,7 +121,7 @@ private:
 		QString separator;
 	};
 
-#define CSVAPPS 10
+#define CSVAPPS 11
 	static const CSVAppConfig CSVApps[CSVAPPS];
 };
 

--- a/desktop-widgets/divelogimportdialog.h
+++ b/desktop-widgets/divelogimportdialog.h
@@ -89,8 +89,6 @@ slots:
 	void loadFileContents(int value, enum whatChanged triggeredBy);
 	int setup_csv_params(QStringList r, char **params, int pnr);
 	int parseTxtHeader(QString fileName, char **params, int pnr);
-	void accept() override;
-	void reject() override;
 
 private:
 	bool selector;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1811,8 +1811,8 @@ void MainWindow::on_actionImportDiveLog_triggered()
 	}
 
 	if (csvFiles.size()) {
-		DiveLogImportDialog *diveLogImport = new DiveLogImportDialog(csvFiles, this);
-		diveLogImport->show();
+		DiveLogImportDialog diveLogImport(csvFiles, this);
+		diveLogImport.exec();
 	}
 }
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -73,7 +73,6 @@ public:
 
 	void loadFiles(const QStringList files);
 	void importFiles(const QStringList importFiles);
-	void importTxtFiles(const QStringList fileNames);
 	void cleanUpEmpty();
 	void setToolButtonsEnabled(bool enabled);
 	ProfileWidget2 *graphics() const;


### PR DESCRIPTION
Poseidon MkIV logs (.txt) were special cased in MainWindow.cpp,
which led to a user-interface inconsistency. In some cases
[user chooses ".txt" (non-Poseidon) and ".csv"], *two*
import-dialogs were shown.

Move handling of Poseidon MkIV logs into DiveLogImportDialog.
There are already other "special" cases handled in this dialog.

At the moment, this shows the first 10 depth-values, which is
kind of useless, as this will all be at surface level. We
might think about something more useful.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This moves the handling of Poseidon logs into `DiveLogImportDialog` in an attempt to make the user-interface more consistent and also the code more consistent. This will ease the detangling of the import code (think undo, don't unnecessarily import dive-sites, remove divesite-uuids).

Currently, the display is quite useless (first 10 depth values); I'm all ears for other ideas.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move handling of Poseidon into `DiveLogImportDialog`
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do if code is accepted.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Will check if code is accepted.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 