### PR TITLE
Fix typo of submoule init to submodule init

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,7 +35,7 @@ see https://github.com/Subsurface-divelog/libdc.git
 
 In order to get the modified sources, do
 - locate yourself in the subsurface repo on your local computer
-- run "git submoule init"
+- run "git submodule init"
 - run "git submodule update"
 
 The branches won't have a pretty history and will include ugly merges,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:

Documentation change

### Pull request long description:
Fix typo

### Changes made:
typo fixed 



### Documentation change:
just fixes submoule, to submodule in the INSTALL file
