### PR TITLE
Mobile: simpify startup logic

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -334,12 +334,8 @@ Kirigami.ScrollablePage {
 		visible: opacity > 0
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 		function setupActions() {
-			if (visible) {
-				page.actions.main = null
-				page.actions.right = null
-				page.title = qsTr("Cloud credentials")
-			} else if (prefs.credentialStatus === CloudStatus.CS_VERIFIED ||
-						prefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
+			if (prefs.credentialStatus === CloudStatus.CS_VERIFIED ||
+					prefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
 				page.title = qsTr("Dive list")
@@ -348,7 +344,7 @@ Kirigami.ScrollablePage {
 			} else {
 				page.actions.main = null
 				page.actions.right = null
-				page.title = qsTr("Dive list")
+				page.title = qsTr("Cloud credentials")
 			}
 		}
 		onVisibleChanged: {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix (visual only)
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When starting the mobile app, I noticed a short display of an empty page with title "Cloud credentials" just before showing the divelist. Simply a not nice visual effect.

This commit simplifies some logic and resolves this. 

### Additional information:
As the code in this part is fragile, this is tested for normal and clean startup of the app, switching credentials, from no cloud to valid account (which even nicely imports the no cloud dives: this surprised me as I have never seen this working).