### PR TITLE
Fix typo in INSTALL file.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,7 +35,7 @@ see https://github.com/Subsurface-divelog/libdc.git
 
 In order to get the modified sources, do
 - locate yourself in the subsurface repo on your local computer
-- run "git submoule init"
+- run "git submodule init"
 - run "git submodule update"
 
 The branches won't have a pretty history and will include ugly merges,


### PR DESCRIPTION
Changes git submoule to git submodule. In the INSTALL file.
Just a minor spelling fix.

Signed-off-by: Cole Rogers <colerogers@protonmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [X ] Documentation change
- [ ] Language translation

### Pull request long description:
Fixes a spelling mistake where git submodule was git submoule in the INSTALL file

### Changes made:
INSTALL File typo fixed.

