### PR TITLE
[RFC] Import: remove unnecessary processing of dives in DAN import

### DIFF
--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -129,14 +129,6 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 		char *iter_end = NULL;
 		unsigned int pnr_local = pnr;
 
-		/*
-		 * Process the dives, but let the last round be parsed
-		 * from C++ code
-		 */
-
-		if (end_ptr)
-			process_imported_dives(false);
-
 		mem_csv.buffer = malloc(mem.size + 1);
 		mem_csv.size = mem.size;
 


### PR DESCRIPTION
On DAN-file import after each dive except the first, the dive-list
was processed. This seem bogus and inefficient. An artefact from
old code? In any case, remove.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes what seems to be bogus code. Tested with the example file in the `dives` folder.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove bogus `process_imported_dives()` call.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
