### PR TITLE
[Core] Rework dive-importing interface

### DIFF
--- a/core/cochran.c
+++ b/core/cochran.c
@@ -785,7 +785,6 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		dc->duration.seconds = duration;
 	}
 
-	dive->downloaded = true;
 	record_dive_to_table(dive, table);
 	mark_divelist_changed(true);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -431,7 +431,7 @@ extern const struct units *get_units(void);
 extern int run_survey, verbose, quit, force_root;
 
 struct dive_table {
-	int nr, allocated, preexisting;
+	int nr, allocated;
 	struct dive **dives;
 };
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -309,7 +309,6 @@ struct dive {
 	struct dive *next, **pprev;
 	bool selected;
 	bool hidden_by_filter;
-	bool downloaded;
 	timestamp_t when;
 	uint32_t dive_site_uuid;
 	char *notes;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1339,10 +1339,13 @@ static bool try_to_merge_into(struct dive *dive_to_add, int idx, bool prefer_imp
  * Add imported dive to global dive table. Overlapping dives will
  * be merged if possible. If prefer_imported is true, data of the
  * new dives are prioritized in such a case.
+ * If downloaded is true, only the divecomputer of the first dive
+ * will be considered, as it is assumed that all dives come from
+ * the same computer.
  * Note: the dives in import_table are consumed! On return import_table
  * has size 0.
  */
-void process_imported_dives(struct dive_table *import_table, bool prefer_imported)
+void process_imported_dives(struct dive_table *import_table, bool prefer_imported, bool downloaded)
 {
 	int i, j;
 	struct dive *old_dive, *merged;
@@ -1356,7 +1359,7 @@ void process_imported_dives(struct dive_table *import_table, bool prefer_importe
 	/* check if we need a nickname for the divecomputer for newly downloaded dives;
 	 * since we know they all came from the same divecomputer we just check for the
 	 * first one */
-	if (import_table->dives[0]->downloaded)
+	if (downloaded)
 		set_dc_nickname(import_table->dives[0]);
 	else
 		/* they aren't downloaded, so record / check all new ones */

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1367,9 +1367,6 @@ void process_imported_dives(struct dive_table *import_table, bool prefer_importe
 	sort_table(import_table);
 	merge_imported_dives(import_table);
 
-	for (i = 0; i < import_table->nr; i++)
-		import_table->dives[i]->downloaded = true;
-
 	/* Merge newly imported dives into the dive table.
 	 * Since both lists (old and new) are sorted, we can step
 	 * through them concurrently and locate the insertions points.
@@ -1415,10 +1412,6 @@ void process_imported_dives(struct dive_table *import_table, bool prefer_importe
 	/* If there are still dives to add, add them at the end of the dive table. */
 	for ( ; i <  import_table->nr; i++)
 		add_single_dive(dive_table.nr, import_table->dives[i]);
-
-	/* make sure no dives are still marked as downloaded */
-	for (i = 0; i < dive_table.nr; i++)
-		dive_table.dives[i]->downloaded = false;
 
 	/* we took care of all dives, clean up the import table */
 	import_table->nr = 0;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -16,7 +16,7 @@
  * void update_cylinder_related_info(struct dive *dive)
  * void dump_trip_list(void)
  * void insert_trip(dive_trip_t **dive_trip_p)
- * void remove_dive_from_trip(struct dive *dive)
+ * void remove_dive_from_trip(struct dive *dive, bool was_autogen)
  * void add_dive_to_trip(struct dive *dive, dive_trip_t *trip)
  * dive_trip_t *create_and_hookup_trip_from_dive(struct dive *dive)
  * void autogroup_dives(void)
@@ -30,6 +30,7 @@
  * void remove_autogen_trips()
  * void sort_table(struct dive_table *table)
  * bool is_trip_before_after(const struct dive *dive, bool before)
+ * void delete_dive_from_table(struct dive_table *table, int idx)
  */
 #include <unistd.h>
 #include <stdio.h>
@@ -917,21 +918,29 @@ void autogroup_dives(void)
 #endif
 }
 
+/* Remove a dive from a dive table. This assumes that the
+ * dive was already removed from any trip and deselected.
+ * It simply shrinks the table and frees the trip */
+void delete_dive_from_table(struct dive_table *table, int idx)
+{
+	int i;
+	free_dive(table->dives[idx]);
+	for (i = idx; i < table->nr - 1; i++)
+		table->dives[i] = table->dives[i + 1];
+	table->dives[--table->nr] = NULL;
+}
+
 /* this implements the mechanics of removing the dive from the table,
  * but doesn't deal with updating dive trips, etc */
 void delete_single_dive(int idx)
 {
-	int i;
 	struct dive *dive = get_dive(idx);
 	if (!dive)
 		return; /* this should never happen */
 	remove_dive_from_trip(dive, false);
 	if (dive->selected)
 		deselect_dive(idx);
-	for (i = idx; i < dive_table.nr - 1; i++)
-		dive_table.dives[i] = dive_table.dives[i + 1];
-	dive_table.dives[--dive_table.nr] = NULL;
-	free_dive(dive);
+	delete_dive_from_table(&dive_table, idx);
 }
 
 struct dive **grow_dive_table(struct dive_table *table)
@@ -1219,16 +1228,16 @@ void remove_autogen_trips()
  * what the numbers should be - in which case you need to do
  * a manual re-numbering.
  */
-static void try_to_renumber(struct dive *last, int preexisting)
+static void try_to_renumber(int preexisting)
 {
 	int i, nr;
+	struct dive *last = get_dive(preexisting - 1);
 
 	/*
-	 * If the new dives aren't all strictly at the end,
-	 * we're going to expect the user to do a manual
-	 * renumbering.
+	 * If there was a last dive, but it didn't have
+	 * a number, give up.
 	 */
-	if (preexisting && get_dive(preexisting - 1) != last)
+	if (last && !last->number)
 		return;
 
 	/*
@@ -1266,40 +1275,18 @@ void process_loaded_dives()
 	sort_table(&dive_table);
 }
 
-void process_imported_dives(bool prefer_imported)
+/*
+ * Merge subsequent dives in a table, if mergeable. This assumes
+ * that the dives are neither selected, not part of a trip, as
+ * is the case of freshly imported dives.
+ */
+static void merge_imported_dives(struct dive_table *table)
 {
 	int i;
-	int preexisting = dive_table.preexisting;
-	struct dive *last;
-
-	/* If no dives were imported, don't bother doing anything */
-	if (preexisting >= dive_table.nr)
-		return;
-
-	/* check if we need a nickname for the divecomputer for newly downloaded dives;
-	 * since we know they all came from the same divecomputer we just check for the
-	 * first one */
-	if (dive_table.dives[preexisting]->downloaded)
-		set_dc_nickname(dive_table.dives[preexisting]);
-	else
-		/* they aren't downloaded, so record / check all new ones */
-		for (i = preexisting; i < dive_table.nr; i++)
-			set_dc_nickname(dive_table.dives[i]);
-
-	for (i = preexisting; i < dive_table.nr; i++)
-		dive_table.dives[i]->downloaded = true;
-
-	/* This does the right thing for -1: NULL */
-	last = get_dive(preexisting - 1);
-
-	sort_table(&dive_table);
-
-	for (i = 1; i < dive_table.nr; i++) {
-		struct dive **pp = &dive_table.dives[i - 1];
-		struct dive *prev = pp[0];
-		struct dive *dive = pp[1];
+	for (i = 1; i < table->nr; i++) {
+		struct dive *prev = table->dives[i - 1];
+		struct dive *dive = table->dives[i];
 		struct dive *merged;
-		int id;
 
 		/* only try to merge overlapping dives - or if one of the dives has
 		 * zero duration (that might be a gps marker from the webservice) */
@@ -1307,33 +1294,138 @@ void process_imported_dives(bool prefer_imported)
 		    dive_endtime(prev) < dive->when)
 			continue;
 
-		merged = try_to_merge(prev, dive, prefer_imported);
+		merged = try_to_merge(prev, dive, false);
 		if (!merged)
 			continue;
 
-		// remember the earlier dive's id
-		id = prev->id;
-
-		/* careful - we might free the dive that last points to. Oops... */
-		if (last == prev || last == dive)
-			last = merged;
+		/* Overwrite the first of the two dives and remove the second */
+		free_dive(prev);
+		table->dives[i - 1] = merged;
+		delete_dive_from_table(table, i);
 
 		/* Redo the new 'i'th dive */
 		i--;
-		add_single_dive(i, merged);
-		delete_single_dive(i + 1);
-		delete_single_dive(i + 1);
-		// keep the id or the first dive for the merged dive
-		merged->id = id;
+	}
+}
+
+/*
+ * Try to merge a new dive into the dive at position idx. Return
+ * true on success. On success, the dive to add and the old dive
+ * will be deleted. On failure, they are untouched.
+ * If "prefer_imported" is true, use data of the new dive.
+ */
+static bool try_to_merge_into(struct dive *dive_to_add, int idx, bool prefer_imported)
+{
+	struct dive *old_dive = dive_table.dives[idx];
+	struct dive_trip *trip = old_dive->divetrip;
+	struct dive *merged = try_to_merge(old_dive, dive_to_add, prefer_imported);
+	if (!merged)
+		return false;
+
+	merged->id = old_dive->id;
+	merged->selected = old_dive->selected;
+	dive_table.dives[idx] = merged;
+	if (trip) {
+		remove_dive_from_trip(old_dive, false);
+		add_dive_to_trip(merged, trip);
+	}
+	free_dive(old_dive);
+	free_dive(dive_to_add);
+
+	return true;
+}
+
+/*
+ * Add imported dive to global dive table. Overlapping dives will
+ * be merged if possible. If prefer_imported is true, data of the
+ * new dives are prioritized in such a case.
+ * Note: the dives in import_table are consumed! On return import_table
+ * has size 0.
+ */
+void process_imported_dives(struct dive_table *import_table, bool prefer_imported)
+{
+	int i, j;
+	struct dive *old_dive, *merged;
+	int preexisting;
+	bool sequence_changed = false;
+
+	/* If no dives were imported, don't bother doing anything */
+	if (!import_table->nr)
+		return;
+
+	/* check if we need a nickname for the divecomputer for newly downloaded dives;
+	 * since we know they all came from the same divecomputer we just check for the
+	 * first one */
+	if (import_table->dives[0]->downloaded)
+		set_dc_nickname(import_table->dives[0]);
+	else
+		/* they aren't downloaded, so record / check all new ones */
+		for (i = 0; i < import_table->nr; i++)
+			set_dc_nickname(import_table->dives[i]);
+
+	/* Sort the table of dives to be imported and combine mergable dives */
+	sort_table(import_table);
+	merge_imported_dives(import_table);
+
+	for (i = 0; i < import_table->nr; i++)
+		import_table->dives[i]->downloaded = true;
+
+	/* Merge newly imported dives into the dive table.
+	 * Since both lists (old and new) are sorted, we can step
+	 * through them concurrently and locate the insertions points.
+	 * Once found, check if the new dive can be merged in the
+	 * previous or next dive.
+	 * Note that this doesn't consider pathological cases such as:
+	 *  - New dive "connects" two old dives (turn three into one).
+	 *  - New dive can not be merged into adjacent but some further dive.
+	 */
+	j = 0; /* Index in old dives */
+	preexisting = dive_table.nr; /* Remember old size for renumbering */
+	for (i = 0; i < import_table->nr; i++) {
+		struct dive *dive_to_add = import_table->dives[i];
+
+		/* Find insertion point. */
+		while (j < dive_table.nr && dive_table.dives[j]->when < dive_to_add->when)
+			j++;
+
+		/* Try to merge into previous dive. */
+		if (j > 0 && dive_endtime(dive_table.dives[j - 1]) > dive_to_add->when) {
+			if (try_to_merge_into(dive_to_add, j - 1, prefer_imported))
+				continue;
+		}
+
+		/* That didn't merge into the previous dive. If we're
+		 * at the end of the dive table, quit the loop and add
+		 * all new dives at the end. */
+		if (j >= dive_table.nr)
+			break;
+
+		/* Try to merge into next dive. */
+		if (dive_endtime(dive_to_add) > dive_table.dives[j]->when) {
+			if (try_to_merge_into(dive_to_add, j, prefer_imported))
+				continue;
+		}
+
+		/* We couldnt merge dives, add at the given position. */
+		add_single_dive(j, dive_to_add);
+		j++;
+		sequence_changed = true;
 	}
 
+	/* If there are still dives to add, add them at the end of the dive table. */
+	for ( ; i <  import_table->nr; i++)
+		add_single_dive(dive_table.nr, import_table->dives[i]);
+
 	/* make sure no dives are still marked as downloaded */
-	for (i = 1; i < dive_table.nr; i++)
+	for (i = 0; i < dive_table.nr; i++)
 		dive_table.dives[i]->downloaded = false;
 
-	/* If there are dives in the table, are they numbered */
-	if (!last || last->number)
-		try_to_renumber(last, preexisting);
+	/* we took care of all dives, clean up the import table */
+	import_table->nr = 0;
+
+	/* If the sequence wasn't changed, renumber */
+	if (!sequence_changed)
+		try_to_renumber(preexisting);
 
 	mark_divelist_changed(true);
 }

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -19,7 +19,7 @@ extern int init_decompression(struct deco_state *ds, struct dive *dive);
 
 /* divelist core logic functions */
 extern void process_loaded_dives();
-extern void process_imported_dives(struct dive_table *import_table, bool prefer_imported);
+extern void process_imported_dives(struct dive_table *import_table, bool prefer_imported, bool downloaded);
 extern char *get_dive_gas_string(struct dive *dive);
 
 struct dive **grow_dive_table(struct dive_table *table);

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -19,7 +19,7 @@ extern int init_decompression(struct deco_state *ds, struct dive *dive);
 
 /* divelist core logic functions */
 extern void process_loaded_dives();
-extern void process_imported_dives(bool prefer_imported);
+extern void process_imported_dives(struct dive_table *import_table, bool prefer_imported);
 extern char *get_dive_gas_string(struct dive *dive);
 
 struct dive **grow_dive_table(struct dive_table *table);
@@ -42,6 +42,7 @@ extern struct dive *first_selected_dive();
 extern struct dive *last_selected_dive();
 extern bool is_trip_before_after(const struct dive *dive, bool before);
 extern void set_dive_nr_for_current_dive();
+extern void delete_dive_from_table(struct dive_table *table, int idx);
 
 int get_min_datafile_version();
 void reset_min_datafile_version();

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -77,7 +77,6 @@ void DownloadThread::run()
 #endif
 	qDebug() << "Starting download from " << (internalData->bluetooth_mode ? "BT" : internalData->devname);
 	downloadTable.nr = 0;
-	dive_table.preexisting = dive_table.nr;
 
 	Q_ASSERT(internalData->download_table != nullptr);
 	const char *errorText;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -503,7 +503,7 @@ static int find_dive(struct divecomputer *match)
 {
 	int i;
 
-	for (i = dive_table.preexisting - 1; i >= 0; i--) {
+	for (i = dive_table.nr - 1; i >= 0; i--) {
 		struct dive *old = dive_table.dives[i];
 
 		if (match_one_dive(match, old))

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -861,7 +861,6 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 			add_dive_to_trip(dive, devdata->trip);
 	}
 
-	dive->downloaded = true;
 	record_dive_to_table(dive, devdata->download_table);
 	mark_divelist_changed(true);
 	return true;

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -427,7 +427,6 @@ static void parse_dives (int log_version, const unsigned char *buf, unsigned int
 		}
 
 		// End dive
-		dive->downloaded = true;
 		record_dive_to_table(dive, table);
 		dive = NULL;
 		mark_divelist_changed(true);

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -197,7 +197,6 @@ static void uemis_get_weight(char *buffer, weightsystem_t *weight, int diveid)
 static struct dive *uemis_start_dive(uint32_t deviceid)
 {
 	struct dive *dive = alloc_dive();
-	dive->downloaded = true;
 	dive->dc.model = strdup("Uemis Zurich");
 	dive->dc.deviceid = deviceid;
 	return dive;
@@ -1148,12 +1147,12 @@ static int get_memory(struct dive_table *td, int checkpoint)
 	return UEMIS_MEM_OK;
 }
 
-/* mark a dive as deleted by setting download to false
- * this will be picked up by some cleaning statement later */
+/* we misuse the hidden_by_filter flag to mark a dive as deleted.
+ * this will be picked up by some cleaning statement later. */
 static void do_delete_dives(struct dive_table *td, int idx)
 {
 	for (int x = idx; x < td->nr; x++)
-		td->dives[x]->downloaded = false;
+		td->dives[x]->hidden_by_filter = true;
 }
 
 static bool load_uemis_divespot(const char *mountpath, int divespot_id)
@@ -1266,7 +1265,7 @@ static bool get_matching_dive(int idx, char *newmax, int *uemis_mem_status, devi
 #endif
 						deleted_files++;
 						/* mark this log entry as deleted and cleanup later, otherwise we mess up our array */
-						dive->downloaded = false;
+						dive->hidden_by_filter = true;
 #if UEMIS_DEBUG & 2
 						fprintf(debugfile, "Deleted dive from %s, with id %d from table -- newmax is %s\n", d_time, dive->dc.diveid, newmax);
 #endif
@@ -1472,7 +1471,7 @@ const char *do_uemis_import(device_data_t *data)
 	 * to see if we have to clean some dead bodies from our download table */
 	next_table_index = 0;
 	while (next_table_index < data->download_table->nr) {
-		if (!data->download_table->dives[next_table_index]->downloaded)
+		if (data->download_table->dives[next_table_index]->hidden_by_filter)
 			uemis_delete_dive(data, data->download_table->dives[next_table_index]->dc.diveid);
 		else
 			next_table_index++;

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -896,14 +896,15 @@ int DiveLogImportDialog::parseTxtHeader(QString fileName, char **params, int pnr
 
 void DiveLogImportDialog::on_buttonBox_accepted()
 {
+	struct dive_table table = { 0 };
 	QStringList r = resultModel->result();
 	if (ui->knownImports->currentText() != "Manual import") {
 		for (int i = 0; i < fileNames.size(); ++i) {
 			if (ui->knownImports->currentText() == "Seabear CSV") {
-				parse_seabear_log(qPrintable(fileNames[i]), &dive_table);
+				parse_seabear_log(qPrintable(fileNames[i]), &table);
 			} else if (ui->knownImports->currentText() == "Poseidon MkVI") {
 				QPair<QString, QString> pair = poseidonFileNames(fileNames[i]);
-				parse_txt_file(qPrintable(pair.second), qPrintable(pair.first), &dive_table);
+				parse_txt_file(qPrintable(pair.second), qPrintable(pair.first), &table);
 			} else {
 				char *params[49];
 				int pnr = 0;
@@ -920,7 +921,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				pnr = setup_csv_params(r, params, pnr);
 				parse_csv_file(qPrintable(fileNames[i]), params, pnr - 1,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
-						&dive_table);
+						&table);
 			}
 		}
 	} else {
@@ -984,7 +985,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				params[pnr++] = intdup(r.indexOf(tr("Rating")));
 				params[pnr++] = NULL;
 
-				parse_manual_file(qPrintable(fileNames[i]), params, pnr - 1, &dive_table);
+				parse_manual_file(qPrintable(fileNames[i]), params, pnr - 1, &table);
 			} else {
 				char *params[51];
 				int pnr = 0;
@@ -1001,12 +1002,12 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				pnr = setup_csv_params(r, params, pnr);
 				parse_csv_file(qPrintable(fileNames[i]), params, pnr - 1,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
-						&dive_table);
+						&table);
 			}
 		}
 	}
 
-	process_imported_dives(false);
+	process_imported_dives(&table, false);
 	MainWindow::instance()->refreshDisplay();
 }
 

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -1007,7 +1007,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 		}
 	}
 
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	MainWindow::instance()->refreshDisplay();
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -487,34 +487,30 @@ void DownloadFromDCWidget::on_cancel_clicked()
 
 void DownloadFromDCWidget::on_ok_clicked()
 {
-	struct dive *dive;
-
 	if (currentState != DONE && currentState != ERROR)
 		return;
 
-	// record all the dives in the 'real' dive_table
-	for (int i = 0; i < downloadTable.nr; i++) {
+	// delete non-selected dives
+	int total = downloadTable.nr;
+	int j = 0;
+	for (int i = 0; i < total; i++) {
 		if (diveImportedModel->data(diveImportedModel->index(i, 0), Qt::CheckStateRole) == Qt::Checked)
-			record_dive(downloadTable.dives[i]);
+			j++;
 		else
-			clear_dive(downloadTable.dives[i]);
-		downloadTable.dives[i] = NULL;
+			delete_dive_from_table(&downloadTable, j);
 	}
-	downloadTable.nr = 0;
 
-	int uniqId, idx;
-	// remember the last downloaded dive (on most dive computers this will be the chronologically
-	// first new dive) and select it again after processing all the dives
 	MainWindow::instance()->dive_list()->unselectDives();
 
-	dive = get_dive(dive_table.nr - 1);
-	if (dive != NULL) {
-		uniqId = get_dive(dive_table.nr - 1)->id;
-		process_imported_dives(preferDownloaded());
+	if (downloadTable.nr > 0) {
+		// remember the last downloaded dive (on most dive computers this will be the chronologically
+		// first new dive) and select it again after processing all the dives
+		int uniqId = downloadTable.dives[downloadTable.nr - 1]->id;
+		process_imported_dives(&downloadTable, preferDownloaded());
 		// after process_imported_dives does any merging or resorting needed, we need
 		// to recreate the model for the dive list so we can select the newest dive
 		MainWindow::instance()->recreateDiveList();
-		idx = get_idx_by_uniq_id(uniqId);
+		int idx = get_idx_by_uniq_id(uniqId);
 		// this shouldn't be necessary - but there are reports that somehow existing dives stay selected
 		// (but not visible as selected)
 		MainWindow::instance()->dive_list()->unselectDives();

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -506,7 +506,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 		// remember the last downloaded dive (on most dive computers this will be the chronologically
 		// first new dive) and select it again after processing all the dives
 		int uniqId = downloadTable.dives[downloadTable.nr - 1]->id;
-		process_imported_dives(&downloadTable, preferDownloaded());
+		process_imported_dives(&downloadTable, preferDownloaded(), true);
 		// after process_imported_dives does any merging or resorting needed, we need
 		// to recreate the model for the dive list so we can select the newest dive
 		MainWindow::instance()->recreateDiveList();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1733,12 +1733,13 @@ void MainWindow::importFiles(const QStringList fileNames)
 		return;
 
 	QByteArray fileNamePtr;
+	struct dive_table table = { 0 };
 
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		parse_file(fileNamePtr.data(), &dive_table);
+		parse_file(fileNamePtr.data(), &table);
 	}
-	process_imported_dives(false);
+	process_imported_dives(&table, false);
 	refreshDisplay();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1739,7 +1739,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
 		parse_file(fileNamePtr.data(), &table);
 	}
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	refreshDisplay();
 }
 

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -769,7 +769,7 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 		/* parse file and import dives */
 		struct dive_table table = { 0 };
 		parse_file(QFile::encodeName(zipFile.fileName()), &table);
-		process_imported_dives(&table, false);
+		process_imported_dives(&table, false, false);
 		MainWindow::instance()->refreshDisplay();
 
 		/* store last entered user/pass in config */

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -767,8 +767,9 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 			break;
 		}
 		/* parse file and import dives */
-		parse_file(QFile::encodeName(zipFile.fileName()), &dive_table);
-		process_imported_dives(false);
+		struct dive_table table = { 0 };
+		parse_file(QFile::encodeName(zipFile.fileName()), &table);
+		process_imported_dives(&table, false);
 		MainWindow::instance()->refreshDisplay();
 
 		/* store last entered user/pass in config */

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -671,7 +671,6 @@ successful_exit:
 	// for the remote data - which then later gets merged with the remote data if necessary
 	if (noCloudToCloud) {
 		git_storage_update_progress(qPrintable(tr("Loading dives from local storage ('no cloud' mode)")));
-		dive_table.preexisting = dive_table.nr;
 		mergeLocalRepo();
 		DiveListModel::instance()->clear();
 		DiveListModel::instance()->addAllDives();

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -325,8 +325,9 @@ void QMLManager::updateAllGlobalLists()
 void QMLManager::mergeLocalRepo()
 {
 	char *filename = NOCLOUD_LOCALSTORAGE;
-	parse_file(filename, &dive_table);
-	process_imported_dives(false);
+	struct dive_table table = { 0 };
+	parse_file(filename, &table);
+	process_imported_dives(&table, false, false);
 }
 
 void QMLManager::copyAppLogToClipboard()

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -173,7 +173,7 @@ void DiveImportedModel::recordDives()
 			delete_dive_from_table(&downloadTable, j);
 	}
 
-	process_imported_dives(diveTable, true);
+	process_imported_dives(diveTable, true, true);
 	if (autogroup)
 		autogroup_dives();
 }

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -163,21 +163,17 @@ void DiveImportedModel::recordDives()
 		// nothing to do, just exit
 		return;
 
-	// walk the table of imported dives and record the ones that the user picked
-	// clearing out the table as we go
-	for (int i = 0; i < rowCount(); i++) {
-		struct dive *d = diveTable->dives[i];
-		if (d && checkStates[i]) {
-			record_dive(d);
-		} else {
-			// we should free the dives that weren't recorded
-			clear_dive(d);
-			free(d);
-		}
-		diveTable->dives[i] = NULL;
+	// delete non-selected dives
+	int total = diveTable->nr;
+	int j = 0;
+	for (int i = 0; i < total; i++) {
+		if (checkStates[i])
+			j++;
+		else
+			delete_dive_from_table(&downloadTable, j);
 	}
-	diveTable->nr = 0;
-	process_imported_dives(true);
+
+	process_imported_dives(diveTable, true);
 	if (autogroup)
 		autogroup_dives();
 }

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -611,7 +611,6 @@ void DiveTripModel::setupModelData()
 	clear();
 	if (autogroup)
 		autogroup_dives();
-	dive_table.preexisting = dive_table.nr;
 	QMap<dive_trip_t *, TripItem *> trips;
 	while (--i >= 0) {
 		struct dive *dive = get_dive(i);

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -21,10 +21,11 @@ void TestMerge::testMergeEmpty()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
-	process_imported_dives(false);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
-	process_imported_dives(false);
+	struct dive_table table = { 0 };
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table), 0);
+	process_imported_dives(&table, false);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table), 0);
+	process_imported_dives(&table, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
@@ -44,10 +45,11 @@ void TestMerge::testMergeBackwards()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &dive_table), 0);
-	process_imported_dives(false);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
-	process_imported_dives(false);
+	struct dive_table table = { 0 };
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table), 0);
+	process_imported_dives(&table, false);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table), 0);
+	process_imported_dives(&table, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -23,9 +23,9 @@ void TestMerge::testMergeEmpty()
 	 */
 	struct dive_table table = { 0 };
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
@@ -47,9 +47,9 @@ void TestMerge::testMergeBackwards()
 	 */
 	struct dive_table table = { 0 };
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -14,8 +14,9 @@ void TestRenumber::setup()
 
 void TestRenumber::testMerge()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &dive_table), 0);
-	process_imported_dives(false);
+	struct dive_table table = { 0 };
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table), 0);
+	process_imported_dives(&table, false);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
 	mark_divelist_changed(false);
@@ -24,8 +25,9 @@ void TestRenumber::testMerge()
 
 void TestRenumber::testMergeAndAppend()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &dive_table), 0);
-	process_imported_dives(false);
+	struct dive_table table = { 0 };
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table), 0);
+	process_imported_dives(&table, false);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);
 	struct dive *d = get_dive(1);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -15,7 +15,7 @@ void TestRenumber::testMerge()
 {
 	struct dive_table table = { 0 };
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
 	mark_divelist_changed(false);
@@ -25,7 +25,7 @@ void TestRenumber::testMergeAndAppend()
 {
 	struct dive_table table = { 0 };
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table), 0);
-	process_imported_dives(&table, false);
+	process_imported_dives(&table, false, false);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);
 	struct dive *d = get_dive(1);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -9,7 +9,6 @@ void TestRenumber::setup()
 {
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table), 0);
 	process_loaded_dives();
-	dive_table.preexisting = dive_table.nr;
 }
 
 void TestRenumber::testMerge()
@@ -20,7 +19,6 @@ void TestRenumber::testMerge()
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
 	mark_divelist_changed(false);
-	dive_table.preexisting = dive_table.nr;
 }
 
 void TestRenumber::testMergeAndAppend()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This changes the dive-importing interface such that dives are imported into a distinct table and then passed down to `process_imported_dives()`. For dive-computer downloads this was already effectively the case (downloads were into a downloadTable), this PR just finalizes the interface. This allows removal of the `preexisting` variable of `struct dive_table` and the `downloaded` flag of `struct dive`, which had a weird hybrid meaning anyway.

There is a functional change, which is described in the commit message as:
```
    This actually introduces (at least) two functional changes:
    1) If a new dive spans two old dives, it will only be merged to the
       first dive. But this seems like a pathological case, which is of
       dubious value anyway.
    2) Dives unrelated to the import will not be merged. The old code
       would happily merge dives which were not even close to the
       newly imported dives. A surprising behavior.
```

The uemis downloaded used (misused?) dive->downloaded to mark deleted dives. This is changed to use (misuse?) dive->hidden_by_filter.

This work is in context of undo and removal of divesite uuids.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Pass dive_table to process_imported_dives.
2) Remove preexisting from struct dive_table.
3) Remove dive->downloaded.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Only user visible in pathological cases.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Only user visible in pathological cases.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
