### PR TITLE
Cleanup: don't access downloadTable in libdivecomputer.c

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -91,6 +91,8 @@ void DownloadThread::run()
 		error = str_error(errorText, internalData->devname, internalData->vendor, internalData->product);
 		qDebug() << "Finishing download thread:" << error;
 	} else {
+		if (!downloadTable.nr)
+			error = tr("No new dives downloaded from dive computer");
 		qDebug() << "Finishing download thread:" << downloadTable.nr << "dives downloaded";
 	}
 	qPrefDiveComputer::set_vendor(internalData->vendor);

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1422,8 +1422,6 @@ const char *do_libdivecomputer_import(device_data_t *data)
 		data->device = NULL;
 		dc_iostream_close(data->iostream);
 		data->iostream = NULL;
-		if (!downloadTable.nr)
-			dev_info(data, translate("gettextFromC", "No new dives downloaded from dive computer"));
 	}
 
 	dc_context_free(data->context);


### PR DESCRIPTION
If no dives were downloaded in do_libdivecomputer_import(), an
error message would be produced. To check for downloaded dives,
the function would access the global downloadTable instead of
the actual table the dives are imported to (at the moment the
same - but the interface allows for a different table).

Move the error-creation to the caller to avoid this situation.
An alternative option would be to check the actual table the
dives were supposed to be downloaded to. But from a program-logic
point of view "no dives" does not seem like an error condition.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another trivial cleanup, which removes an access to the global downloadTable. A different solution is schematized in the commit message [test the actual table]. Tested it briefly and I still get the "no dives downloaded" message.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move creation of "no dives downloaded" error from libdivecomputer.c to the caller.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
