### PR TITLE
[Please Test] Dive information: fix surface interval calculation

### DIFF
--- a/core/divelist.h
+++ b/core/divelist.h
@@ -42,6 +42,7 @@ extern struct dive *first_selected_dive();
 extern struct dive *last_selected_dive();
 extern bool is_trip_before_after(const struct dive *dive, bool before);
 extern void set_dive_nr_for_current_dive();
+extern timestamp_t get_surface_interval(timestamp_t when);
 
 int get_min_datafile_version();
 void reset_min_datafile_version();

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -3,7 +3,7 @@
  *
  * core logic for the Info & Stats page -
  * char *get_minutes(int seconds);
- * void process_all_dives(struct dive *dive, struct dive **prev_dive);
+ * void process_all_dives();
  */
 #include "gettext.h"
 #include <string.h>
@@ -91,7 +91,7 @@ char *get_minutes(int seconds)
 	return buf;
 }
 
-void process_all_dives(struct dive *dive, struct dive **prev_dive)
+void process_all_dives()
 {
 	int idx;
 	struct dive *dp;
@@ -105,7 +105,6 @@ void process_all_dives(struct dive *dive, struct dive **prev_dive)
 	dive_trip_t *trip_ptr = 0;
 	unsigned int size, tsize;
 
-	*prev_dive = NULL;
 	memset(&stats, 0, sizeof(stats));
 	if (dive_table.nr > 0) {
 		stats.shortest_time.seconds = dive_table.dives[0]->duration.seconds;
@@ -152,11 +151,6 @@ void process_all_dives(struct dive *dive, struct dive **prev_dive)
 	/* this relies on the fact that the dives in the dive_table
 	 * are in chronological order */
 	for_each_dive (idx, dp) {
-		if (dive && dp->when == dive->when) {
-			/* that's the one we are showing */
-			if (idx > 0)
-				*prev_dive = dive_table.dives[idx - 1];
-		}
 		process_dive(dp, &stats);
 
 		/* yearly statistics */

--- a/core/statistics.h
+++ b/core/statistics.h
@@ -48,7 +48,7 @@ extern stats_t *stats_by_trip;
 extern stats_t *stats_by_type;
 
 extern char *get_minutes(int seconds);
-extern void process_all_dives(struct dive *dive, struct dive **prev_dive);
+extern void process_all_dives();
 extern void get_gas_used(struct dive *dive, volume_t gases[MAX_CYLINDERS]);
 extern void process_selected_dives(void);
 void selected_dives_gas_parts(volume_t *o2_tot, volume_t *he_tot);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -77,12 +77,9 @@ void TabDiveInformation::updateData()
 	ui->diveTimeText->setText(get_dive_duration_string(displayed_dive.duration.seconds, tr("h"), tr("min"), tr("sec"),
 			" ", displayed_dive.dc.divemode == FREEDIVE));
 
-	struct dive *prevd;
-	process_all_dives(&displayed_dive, &prevd);
-
-	if (prevd)
-		ui->surfaceIntervalText->setText(get_dive_surfint_string(displayed_dive.when - (dive_endtime(prevd)), tr("d"), tr("h"), tr("min")));
-
+	timestamp_t surface_interval = get_surface_interval(displayed_dive.when);
+	if (surface_interval >= 0)
+		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else
 		ui->surfaceIntervalText->clear();
 

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -429,10 +429,8 @@ void MainTab::updateDiveInfo(bool clear)
 	// If exactly one trip has been selected, we show the location / notes
 	// for the trip in the Info tab, otherwise we show the info of the
 	// selected_dive
-	struct dive *prevd;
-
 	process_selected_dives();
-	process_all_dives(&displayed_dive, &prevd);
+	process_all_dives();
 
 	for (auto widget : extraWidgets) {
 		widget->updateData();

--- a/export-html.cpp
+++ b/export-html.cpp
@@ -54,11 +54,7 @@ int main(int argc, char **argv)
 	prefs.units = git_prefs.units;
 
 	// populate the statistics
-	struct dive *d = get_dive(0);
-	struct dive *pd;
-	if (d) {
-		process_all_dives(d, &pd);
-	}
+	process_all_dives();
 
 	// now set up the export settings to create the HTML export
 	struct htmlExportSetting hes;


### PR DESCRIPTION
The old surface interval calculation had fundamental issues:

1) process_all_dives(), which calculates the statistics over *all*
   dives was used to get the pointer to the previous dive.
2) If two dives in the table had the same time, one of those would
   have been considered the "previous" dive.
3) If the dive, for which the surface interval is calculated is
   not yet in the table, no previous dive would be determined.

Fix all this by creating a get_surface_interval() function and
removing the "get previous dive" functionality of process_all_dives().
Remove the process_all_dives() call from TabDiveInformation::updateData().

Reported-by: Jan Mulder <jlmulder@xs4all.nl>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The surface interval calculation was broken in a spectacular way [*all* statistics were calculated just to get the pointer to the previous dive - and even that didn't work properly]. Try to fix this. See commit message. This could need some testing.

N.B.: The `process_all_dives()` call in `MainTab::updateDiveInfo` also seems dubious, as in the general case yearly stats will *not* be displayed. Why should this be calculated on switching dives?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create `get_surface_interval()` function.
2) Remove "get previous dive" functionality from `process_all_dives()`
3) Remove `process_all_dives()` call from `TabDiveInformation::updateData()`
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder