### PR TITLE
Download improvements

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1413,16 +1413,18 @@ const char *do_libdivecomputer_import(device_data_t *data)
 #else
 			err = translate("gettextFromC", "Error opening the device %s %s (%s).\nIn most cases, in order to debug this issue, a libdivecomputer logfile will be useful.\nYou can create this logfile by selecting the corresponding checkbox in the download dialog.");
 #endif
-	}
-
-	if (rc == DC_STATUS_SUCCESS) {
-		err = do_device_import(data);
-		/* TODO: Show the logfile to the user on error. */
-		dc_device_close(data->device);
-		data->device = NULL;
+		if (rc == DC_STATUS_SUCCESS) {
+			err = do_device_import(data);
+			/* TODO: Show the logfile to the user on error. */
+			dc_device_close(data->device);
+			data->device = NULL;
+			if (!downloadTable.nr)
+				dev_info(data, translate("gettextFromC", "No new dives downloaded from dive computer"));
+		}
 		dc_iostream_close(data->iostream);
 		data->iostream = NULL;
 	}
+
 
 	dc_context_free(data->context);
 	data->context = NULL;

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -131,6 +131,7 @@ BLEObject::BLEObject(QLowEnergyController *c, dc_user_device_t *d)
 	device = d;
 	debugCounter = 0;
 	isCharacteristicWritten = false;
+	timeout = BLE_TIMEOUT;
 }
 
 BLEObject::~BLEObject()
@@ -203,7 +204,7 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 
 		qDebug() << QTime::currentTime() << "packet WAIT";
 
-		WAITFOR(!receivedPackets.isEmpty(), BLE_TIMEOUT);
+		WAITFOR(!receivedPackets.isEmpty(), timeout);
 		if (receivedPackets.isEmpty())
 			return DC_STATUS_IO;
 	}
@@ -514,6 +515,17 @@ static void checkThreshold()
 		QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = false"));
 		qDebug() << "turning off further BT debug output";
 	}
+}
+
+/*
+ * NOTE! The 'set_timeout()' function only affects the timeout
+ * for qt_ble_read(), not for the various general BLE operations.
+ */
+dc_status_t qt_ble_set_timeout(void *io, int timeout)
+{
+	BLEObject *ble = (BLEObject *) io;
+	ble->set_timeout(timeout);
+	return DC_STATUS_SUCCESS;
 }
 
 dc_status_t qt_ble_read(void *io, void* data, size_t size, size_t *actual)

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -92,6 +92,7 @@ void BLEObject::characteristicWritten(const QLowEnergyCharacteristic &c, const Q
 void BLEObject::writeCompleted(const QLowEnergyDescriptor&, const QByteArray&)
 {
 	qDebug() << "BLE write completed";
+	desc_written++;
 }
 
 void BLEObject::addService(const QBluetoothUuid &newService)
@@ -489,6 +490,7 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, dc_user_
 			qDebug() << "now writing \"0x0100\" to the descriptor" << d.uuid().toString();
 
 			ble->preferredService()->writeDescriptor(d, QByteArray::fromHex("0100"));
+			WAITFOR(ble->descriptorWritten(), 1000);
 			break;
 		}
 	}

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -24,6 +24,7 @@ public:
 	dc_status_t read(void* data, size_t size, size_t *actual);
 
 	inline QLowEnergyService *preferredService() { return preferred; }
+	inline int descriptorWritten() { return desc_written; }
 	dc_status_t select_preferred_service(void);
 
 public slots:
@@ -43,6 +44,7 @@ private:
 	bool isCharacteristicWritten;
 	dc_user_device_t *device;
 	unsigned int hw_credit = 0;
+	unsigned int desc_written = 0;
 
 	QList<QUuid> hwAllCharacteristics = {
 		"{00000001-0000-1000-8000-008025000000}", // HW_OSTC_BLE_DATA_RX

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -20,6 +20,7 @@ class BLEObject : public QObject
 public:
 	BLEObject(QLowEnergyController *c, dc_user_device_t *);
 	~BLEObject();
+	inline void set_timeout(int value) { timeout = value; }
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
 
@@ -45,6 +46,7 @@ private:
 	dc_user_device_t *device;
 	unsigned int hw_credit = 0;
 	unsigned int desc_written = 0;
+	int timeout;
 
 	QList<QUuid> hwAllCharacteristics = {
 		"{00000001-0000-1000-8000-008025000000}", // HW_OSTC_BLE_DATA_RX
@@ -57,6 +59,7 @@ private:
 
 extern "C" {
 dc_status_t qt_ble_open(void **io, dc_context_t *context, const char *devaddr, dc_user_device_t *user_device);
+dc_status_t qt_ble_set_timeout(void *io, int timeout);
 dc_status_t qt_ble_read(void *io, void* data, size_t size, size_t *actual);
 dc_status_t qt_ble_write(void *io, const void* data, size_t size, size_t *actual);
 dc_status_t qt_ble_close(void *io);

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -410,7 +410,7 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 	void *io = NULL;
 
 	static const dc_custom_cbs_t callbacks = {
-		NULL, /* set_timeout */
+		qt_ble_set_timeout, /* set_timeout */
 		NULL, /* set_latency */
 		NULL, /* set_break */
 		NULL, /* set_dtr */


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Various divecomputer download improvements.

This fixes error recovery in general, and fixes various BLE issues that could cause excessive delays and failures.

Tested with my Suunto EON Core, Shearwater Perdix AI and Aqualung i770R.  Since some of the issues are a bit random, it's hard to state with any certainty, but in all cases the initial connection seems both faster and more reliable.

Your mileage may vary.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Fix a resource leak that can cause subsequent downloads to fail until suhbsurface is restarted (particularly for serial lines)

2) Speed up BLE discovery phase

3) Serialize notification enable with actual IO

4) Make BLE downloading honor the specified IO timeout

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
