### PR TITLE
Mobile: show temperature graph when no gas graph

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -734,7 +734,16 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 		ccrsensor2GasItem->setVisible(prefs.show_ccr_sensors && (currentdc->no_o2sensors > 1));
 		ccrsensor3GasItem->setVisible(prefs.show_ccr_sensors && (currentdc->no_o2sensors > 1));
 		ocpo2GasItem->setVisible((currentdc->divemode == PSCR) && prefs.show_scr_ocpo2);
-		temperatureItem->setVisible(false);
+		//when no gas graph, we can show temperature
+		if (!po2GasItem->isVisible() &&
+		    !o2SetpointGasItem->isVisible() &&
+		    !ccrsensor1GasItem->isVisible() &&
+		    !ccrsensor2GasItem->isVisible() &&
+		    !ccrsensor3GasItem->isVisible() &&
+		    !ocpo2GasItem->isVisible())
+			temperatureItem->setVisible(true);
+		else
+			temperatureItem->setVisible(false);
 	} else {
 		tankItem->setVisible(prefs.tankbar);
 		gasYAxis->setPos(itemPos.partialPressure.pos.off);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In commit bd0c99dfb71 (display pO2 and Setpoint for CCR dives) the choice was made: when CCR than never a temperature graph. While this seems reasonable, there is small group of mCCR divers that do not log their po2 digitally, so the only po2 they can display is the setpoint that is reported by the used DC. As this is a bit of a dull flat line, most of these divers do not display this. And this leaves room on the small mobile display for the temperature data.

So effectively: show temperature or po2 graphs.

Suggested-by: Peter Zaal <pzaal@xs4all.nl>
Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
commit bd0c99dfb71

### Release note:
Well ... this is a change for a tiny group mCCR divers ... I dot not feel this is needed.