### PR TITLE
[BUGFIX] Map: zoom on dive sites when flipping through dive site list

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -360,7 +360,6 @@ bool DiveLocationFilterProxyModel::lessThan(const QModelIndex &source_left, cons
 	return source_left.data().toString() < source_right.data().toString();
 }
 
-
 DiveLocationModel::DiveLocationModel(QObject*)
 {
 	resetModel();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -229,7 +229,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(DivePlannerPointsModel::instance(), SIGNAL(variationsComputed(QString)), this, SLOT(updateVariations(QString)));
 	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget(), SLOT(printDecoPlan()));
 	connect(this, SIGNAL(startDiveSiteEdit()), this, SLOT(on_actionDiveSiteEdit_triggered()));
-	connect(information(), SIGNAL(diveSiteChanged(struct dive_site *)), mapWidget, SLOT(centerOnDiveSite(struct dive_site *)));
+	connect(information(), &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -50,6 +50,13 @@ void MapWidget::doneLoading(QQuickWidget::Status status)
 		this, SLOT(coordinatesChangedLocal()));
 }
 
+void MapWidget::centerOnSelectedDiveSite()
+{
+	CHECK_IS_READY_RETURN_VOID();
+	if (!skipReload)
+		m_mapHelper->centerOnSelectedDiveSite();
+}
+
 void MapWidget::centerOnDiveSite(struct dive_site *ds)
 {
 	CHECK_IS_READY_RETURN_VOID();
@@ -60,9 +67,9 @@ void MapWidget::centerOnDiveSite(struct dive_site *ds)
 void MapWidget::centerOnIndex(const QModelIndex& idx)
 {
 	CHECK_IS_READY_RETURN_VOID();
-	struct dive_site *ds = get_dive_site_by_uuid(idx.model()->index(idx.row(), 0).data().toInt());
+	struct dive_site *ds = get_dive_site_by_uuid(idx.model()->index(idx.row(), 0).data().toUInt());
 	if (!ds || !dive_site_has_gps_location(ds))
-		centerOnDiveSite(&displayed_dive_site);
+		centerOnSelectedDiveSite();
 	else
 		centerOnDiveSite(ds);
 }

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -27,6 +27,7 @@ signals:
 	void coordinatesChanged();
 
 public slots:
+	void centerOnSelectedDiveSite();
 	void centerOnDiveSite(struct dive_site *);
 	void centerOnIndex(const QModelIndex& idx);
 	void endGetDiveCoordinates();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -643,7 +643,7 @@ void MainTab::updateDiveInfo(bool clear)
 
 	if (verbose)
 		qDebug() << "Set the current dive site:" << displayed_dive.dive_site_uuid;
-	emit diveSiteChanged(get_dive_site_by_uuid(displayed_dive.dive_site_uuid));
+	emit diveSiteChanged();
 }
 
 void MainTab::addCylinder_clicked()
@@ -1384,7 +1384,7 @@ void MainTab::on_location_diveSiteSelected()
 	if (ui.location->text().isEmpty()) {
 		displayed_dive.dive_site_uuid = 0;
 		markChangedWidget(ui.location);
-		emit diveSiteChanged(0);
+		emit diveSiteChanged();
 		return;
 	} else {
 		if (ui.location->currDiveSiteUuid() != displayed_dive.dive_site_uuid) {

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -59,7 +59,7 @@ public:
 signals:
 	void addDiveFinished();
 	void dateTimeChanged();
-	void diveSiteChanged(struct dive_site * ds);
+	void diveSiteChanged();
 public
 slots:
 	void addCylinder_clicked();

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -27,6 +27,7 @@ public:
 	explicit MapWidgetHelper(QObject *parent = NULL);
 
 	void centerOnDiveSite(struct dive_site *);
+	void centerOnSelectedDiveSite();
 	Q_INVOKABLE QGeoCoordinate getCoordinatesForUUID(QVariant dive_site_uuid);
 	Q_INVOKABLE void centerOnDiveSiteUUID(QVariant dive_site_uuid);
 	Q_INVOKABLE void reloadMapLocations();


### PR DESCRIPTION
The dive site list was connected to centerOnDiveSite(). Apparently,
the currently selected dive site should have been shown in the map.
Yet, this never worked, because the actual dive site of the selected
dive had precedence in centerOnDiveSite().

It seems that centerOnDiveSite() had actually to purposes:
1) center on the passed in dive site
2) center on the dive sites of the selected dives

Therefore, split this function in two separate functions for
each of these use-cases. This allows us to remove some pre-processor
magic (mobile vs. desktop) and to remove a parameter from the
MainTab::diveSiteChanged() signal.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code cleanup / bugfix: skipping through the divelist did not switch zoom on the divesites as the code apparently intended. Fix this by splitting `centerOnDiveSite` in two functions. Note: I didn't test mobile. Do some minor refactoring while at it. Notably, remove one vector and a signal-argument.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Split `centerOnDiveSite` in two versions
2) Refactor the new `centerOnSelectedDiveSite` slightly
3) On change of current dive site call the new `centerOnSelectedDiveSite`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123: seems like you touched the code last. Please have a look, especially concerning the mobile-version.