### PR TITLE
Fix #1725 and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: preserve manual/auto sync with cloud [#1725]
 - Performance: calculate full statistics only when needed
 - HTML export: write statistics of exported dives only
 - Desktop: fix calculation of surface interval in the case of overlappimg dives

--- a/core/pref.h
+++ b/core/pref.h
@@ -87,6 +87,7 @@ struct preferences {
 	int animation_speed;
 
 	// ********** CloudStorage **********
+	bool       cloud_auto_sync;
 	const char *cloud_base_url;
 	const char *cloud_git_url;
 	const char *cloud_storage_email;

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -16,6 +16,7 @@ qPrefCloudStorage *qPrefCloudStorage::instance()
 
 void qPrefCloudStorage::loadSync(bool doSync)
 {
+	disk_cloud_auto_sync(doSync);
 	disk_cloud_base_url(doSync);
 	disk_cloud_storage_email(doSync);
 	disk_cloud_storage_email_encoded(doSync);
@@ -25,6 +26,8 @@ void qPrefCloudStorage::loadSync(bool doSync)
 	disk_cloud_verification_status(doSync);
 	disk_save_password_local(doSync);
 }
+
+HANDLE_PREFERENCE_BOOL(CloudStorage, "cloud_auto_sync", cloud_auto_sync);
 
 void qPrefCloudStorage::set_cloud_base_url(const QString &value)
 {

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -7,6 +7,7 @@
 
 class qPrefCloudStorage : public QObject {
 	Q_OBJECT
+	Q_PROPERTY(bool cloud_auto_sync READ cloud_auto_sync WRITE set_cloud_auto_sync NOTIFY cloud_auto_syncChanged);
 	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_urlChanged);
 	Q_PROPERTY(QString cloud_git_url READ cloud_git_url);
 	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_emailChanged);
@@ -36,6 +37,7 @@ public:
 	};
 	Q_ENUM(cloud_status);
 
+	static bool cloud_auto_sync() { return prefs.cloud_auto_sync; }
 	static QString cloud_base_url() { return prefs.cloud_base_url; }
 	static QString cloud_git_url() { return prefs.cloud_git_url; }
 	static QString cloud_storage_email() { return prefs.cloud_storage_email; }
@@ -47,6 +49,7 @@ public:
 	static bool save_password_local() { return prefs.save_password_local; }
 
 public slots:
+	static void set_cloud_auto_sync(bool value);
 	static void set_cloud_base_url(const QString &value);
 	static void set_cloud_storage_email(const QString &value);
 	static void set_cloud_storage_email_encoded(const QString &value);
@@ -57,6 +60,7 @@ public slots:
 	static void set_save_password_local(bool value);
 
 signals:
+	void cloud_auto_syncChanged(bool value);
 	void cloud_base_urlChanged(const QString &value);
 	void cloud_storage_emailChanged(const QString &value);
 	void cloud_storage_email_encodedChanged(const QString &value);
@@ -68,6 +72,7 @@ signals:
 
 private:
 	// functions to load/sync variable with disk
+	static void disk_cloud_auto_sync(bool doSync);
 	static void disk_cloud_base_url(bool doSync);
 	static void disk_cloud_storage_email(bool doSync);
 	static void disk_cloud_storage_email_encoded(bool doSync);

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -143,7 +143,7 @@ Item {
 				id: toNoCloudMode
 				text: qsTr("No cloud mode")
 				onClicked: {
-					manager.syncToCloud = false
+					manager.setGitLocalOnly(true)
 					PrefCloudStorage.cloud_auto_sync = false
 					prefs.credentialStatus = CloudStatus.CS_NOCLOUD
 					manager.saveCloudCredentials()

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -144,6 +144,7 @@ Item {
 				text: qsTr("No cloud mode")
 				onClicked: {
 					manager.syncToCloud = false
+					PrefCloudStorage.cloud_auto_sync = false
 					prefs.credentialStatus = CloudStatus.CS_NOCLOUD
 					manager.saveCloudCredentials()
 					manager.openNoCloudRepo()

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -276,7 +276,7 @@ Kirigami.ApplicationWindow {
 					name: syncToCloud ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
 				text: syncToCloud ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
-					enabled: prefs.credentialStatus !== CloudStatus.CS_NOCLOUD
+					visible: prefs.credentialStatus !== CloudStatus.CS_NOCLOUD
 					onTriggered: {
 						syncToCloud = !syncToCloud
 						if (!syncToCloud) {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -273,13 +273,14 @@ Kirigami.ApplicationWindow {
 				}
 				Kirigami.Action {
 				icon {
-					name: syncToCloud ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
+					name: PrefCloudStorage.cloud_auto_sync ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
-				text: syncToCloud ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
+				text: PrefCloudStorage.cloud_auto_sync ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
 					visible: prefs.credentialStatus !== CloudStatus.CS_NOCLOUD
 					onTriggered: {
-						syncToCloud = !syncToCloud
-						if (!syncToCloud) {
+						PrefCloudStorage.cloud_auto_sync = !PrefCloudStorage.cloud_auto_sync
+						syncToCloud = PrefCloudStorage.cloud_auto_sync
+						if (!PrefCloudStorage.cloud_auto_sync) {
 							showPassiveNotification(qsTr("Turning off automatic sync to cloud causes all data to only be \
 stored locally. This can be very useful in situations with limited or no network access. Please choose 'Manual sync with cloud' \
 if you have network connectivity and want to sync your data to cloud storage."), 10000)

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -28,7 +28,6 @@ Kirigami.ApplicationWindow {
 	}
 	property alias oldStatus: prefs.oldStatus
 	property alias notificationText: manager.notificationText
-	property alias syncToCloud: manager.syncToCloud
 	property alias locationServiceEnabled: manager.locationServiceEnabled
 	property alias pluggedInDeviceName: manager.pluggedInDeviceName
 	property alias showPin: prefs.showPin
@@ -279,7 +278,7 @@ Kirigami.ApplicationWindow {
 					visible: prefs.credentialStatus !== CloudStatus.CS_NOCLOUD
 					onTriggered: {
 						PrefCloudStorage.cloud_auto_sync = !PrefCloudStorage.cloud_auto_sync
-						syncToCloud = PrefCloudStorage.cloud_auto_sync
+						manager.setGitLocalOnly(PrefCloudStorage.cloud_auto_sync)
 						if (!PrefCloudStorage.cloud_auto_sync) {
 							showPassiveNotification(qsTr("Turning off automatic sync to cloud causes all data to only be \
 stored locally. This can be very useful in situations with limited or no network access. Please choose 'Manual sync with cloud' \

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -375,7 +375,7 @@ void QMLManager::finishSetup()
 	// Initialize cloud credentials.
 	QMLPrefs::instance()->setCloudUserName(qPrefCloudStorage::cloud_storage_email());
 	QMLPrefs::instance()->setCloudPassword(qPrefCloudStorage::cloud_storage_password());
-	setSyncToCloud(!git_local_only);
+	git_local_only = !prefs.cloud_auto_sync;
 	QMLPrefs::instance()->setCredentialStatus((qPrefCloudStorage::cloud_status) prefs.cloud_verification_status);
 	// if the cloud credentials are valid, we should get the GPS Webservice ID as well
 	QString url;
@@ -679,9 +679,9 @@ successful_exit:
 		noCloudToCloud = false;
 		mark_divelist_changed(true);
 		saveChangesLocal();
-		if (m_syncToCloud == false) {
+		if (git_local_only == false) {
 			appendTextToLog(QStringLiteral("taking things back offline now that storage is synced"));
-			git_local_only = m_syncToCloud;
+			git_local_only = true;
 		}
 	}
 	// if we got here just for an initial connection to the cloud, reset to offline
@@ -705,9 +705,9 @@ void QMLManager::revertToNoCloudIfNeeded()
 		// and cloud data) failed - so let's delete the cloud credentials and go
 		// back to CS_NOCLOUD mode in order to prevent us from losing the locally stored
 		// dives
-		if (m_syncToCloud == false) {
+		if (git_local_only == true) {
 			appendTextToLog(QStringLiteral("taking things back offline since sync with cloud failed"));
-			git_local_only = m_syncToCloud;
+			git_local_only = false;
 		}
 		free((void *)prefs.cloud_storage_email);
 		prefs.cloud_storage_email = NULL;
@@ -1492,13 +1492,6 @@ void QMLManager::setNotificationText(QString text)
 	emit notificationTextChanged();
 }
 
-void QMLManager::setSyncToCloud(bool status)
-{
-	m_syncToCloud = status;
-	git_local_only = !status;
-	emit syncToCloudChanged();
-}
-
 void QMLManager::setUpdateSelectedDive(int idx)
 {
 	m_updateSelectedDive = idx;
@@ -1762,6 +1755,11 @@ int QMLManager::getDetectedProductIndex(const QString &currentVendorText)
 int QMLManager::getConnectionIndex(const QString &deviceSubstr)
 {
 	return connectionListModel.indexOf(deviceSubstr);
+}
+
+void QMLManager::setGitLocalOnly(const bool &value)
+{
+	git_local_only = value;
 }
 
 void QMLManager::showDownloadPage(QString deviceString)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -677,6 +677,7 @@ successful_exit:
 		DiveListModel::instance()->addAllDives();
 		appendTextToLog(QStringLiteral("%1 dives loaded after importing nocloud local storage").arg(dive_table.nr));
 		noCloudToCloud = false;
+		mark_divelist_changed(true);
 		saveChangesLocal();
 		if (m_syncToCloud == false) {
 			appendTextToLog(QStringLiteral("taking things back offline now that storage is synced"));

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -28,7 +28,6 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QString startPageText MEMBER m_startPageText WRITE setStartPageText NOTIFY startPageTextChanged)
 	Q_PROPERTY(bool verboseEnabled MEMBER m_verboseEnabled WRITE setVerboseEnabled NOTIFY verboseEnabledChanged)
 	Q_PROPERTY(QString notificationText MEMBER m_notificationText WRITE setNotificationText NOTIFY notificationTextChanged)
-	Q_PROPERTY(bool syncToCloud MEMBER m_syncToCloud WRITE setSyncToCloud NOTIFY syncToCloudChanged)
 	Q_PROPERTY(int updateSelectedDive MEMBER m_updateSelectedDive WRITE setUpdateSelectedDive NOTIFY updateSelectedDiveChanged)
 	Q_PROPERTY(int selectedDiveTimestamp MEMBER m_selectedDiveTimestamp WRITE setSelectedDiveTimestamp NOTIFY selectedDiveTimestampChanged)
 	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
@@ -88,6 +87,7 @@ public:
 	Q_INVOKABLE int getDetectedVendorIndex();
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
 	Q_INVOKABLE int getConnectionIndex(const QString &deviceSubstr);
+	Q_INVOKABLE void setGitLocalOnly(const bool &value);
 
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);
@@ -114,9 +114,6 @@ public:
 
 	QString notificationText() const;
 	void setNotificationText(QString text);
-
-	bool syncToCloud() const;
-	void setSyncToCloud(bool status);
 
 	int updateSelectedDive() const;
 	void setUpdateSelectedDive(int idx);
@@ -210,7 +207,6 @@ private:
 	struct dive *deletedDive;
 	struct dive_trip *deletedTrip;
 	QString m_notificationText;
-	bool m_syncToCloud;
 	int m_updateSelectedDive;
 	int m_selectedDiveTimestamp;
 	qreal m_lastDevicePixelRatio;
@@ -241,7 +237,6 @@ signals:
 	void loadFromCloudChanged();
 	void startPageTextChanged();
 	void notificationTextChanged();
-	void syncToCloudChanged();
 	void updateSelectedDiveChanged();
 	void selectedDiveTimestampChanged();
 	void sendScreenChanged(QScreen *screen);

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -21,6 +21,7 @@ void TestQPrefCloudStorage::test_struct_get()
 
 	auto tst = qPrefCloudStorage::instance();
 
+	prefs.cloud_auto_sync = true;
 	prefs.cloud_base_url = copy_qstring("new url");
 	prefs.cloud_git_url = copy_qstring("new again url");
 	prefs.cloud_storage_email = copy_qstring("myEmail");
@@ -31,6 +32,7 @@ void TestQPrefCloudStorage::test_struct_get()
 	prefs.cloud_verification_status = qPrefCloudStorage::CS_NOCLOUD;
 	prefs.save_password_local = true;
 
+	QCOMPARE(tst->cloud_auto_sync(), prefs.cloud_auto_sync);
 	QCOMPARE(tst->cloud_base_url(), QString(prefs.cloud_base_url));
 	QCOMPARE(tst->cloud_git_url(), QString(prefs.cloud_git_url));
 	QCOMPARE(tst->cloud_storage_email(), QString(prefs.cloud_storage_email));
@@ -48,6 +50,7 @@ void TestQPrefCloudStorage::test_set_struct()
 
 	auto tst = qPrefCloudStorage::instance();
 
+	tst->set_cloud_auto_sync(false);
 	tst->set_cloud_base_url("t2 base");
 	tst->set_cloud_storage_email("t2 email");
 	tst->set_cloud_storage_email_encoded("t2 email2");
@@ -57,6 +60,7 @@ void TestQPrefCloudStorage::test_set_struct()
 	tst->set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
 	tst->set_save_password_local(false);
 
+	QCOMPARE(prefs.cloud_auto_sync, false);
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t2 base"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t2 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t2 email2"));
@@ -80,11 +84,13 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	tst->set_cloud_storage_email("t3 email");
 	tst->set_cloud_storage_email_encoded("t3 email2");
 	tst->set_save_password_local(true);
+	tst->set_cloud_auto_sync(true);
 	tst->set_cloud_storage_password("t3 pass2");
 	tst->set_cloud_storage_pin("t3 pin");
 	tst->set_cloud_timeout(321);
 	tst->set_cloud_verification_status(qPrefCloudStorage::CS_NOCLOUD);
 
+	prefs.cloud_auto_sync = false;
 	prefs.cloud_base_url = copy_qstring("error1");
 	prefs.cloud_git_url = copy_qstring("error1");
 	prefs.cloud_storage_email = copy_qstring("error1");
@@ -96,6 +102,7 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	prefs.save_password_local = false;
 
 	tst->load();
+	QCOMPARE(prefs.cloud_auto_sync, true);
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t3 base"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t3 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t3 email2"));
@@ -119,6 +126,7 @@ void TestQPrefCloudStorage::test_struct_disk()
 	prefs.cloud_storage_email = copy_qstring("t4 email");
 	prefs.cloud_storage_email_encoded = copy_qstring("t4 email2");
 	prefs.save_password_local = true;
+	prefs.cloud_auto_sync = true;
 	prefs.cloud_storage_password = copy_qstring("t4 pass2");
 	prefs.cloud_storage_pin = copy_qstring("t4 pin");
 	prefs.cloud_timeout = 123;
@@ -126,6 +134,7 @@ void TestQPrefCloudStorage::test_struct_disk()
 
 	tst->sync();
 
+	prefs.cloud_auto_sync = false;
 	prefs.cloud_base_url = copy_qstring("error1");
 	prefs.cloud_git_url = copy_qstring("error1");
 	prefs.cloud_storage_email = copy_qstring("error1");
@@ -138,6 +147,7 @@ void TestQPrefCloudStorage::test_struct_disk()
 
 	tst->load();
 
+	QCOMPARE(prefs.cloud_auto_sync, true);
 	QCOMPARE(QString(prefs.cloud_base_url), QString("t4 base"));
 	QCOMPARE(QString(prefs.cloud_storage_email), QString("t4 email"));
 	QCOMPARE(QString(prefs.cloud_storage_email_encoded), QString("t4 email2"));
@@ -189,6 +199,11 @@ void TestQPrefCloudStorage::test_oldPreferences()
 	cloud->set_cloud_storage_password("ABCABC");
 	TEST(cloud->cloud_storage_password(), QStringLiteral("ABCABC"));
 
+	cloud->set_cloud_auto_sync(true);
+	TEST(cloud->cloud_auto_sync(), true);
+	cloud->set_cloud_auto_sync(false);
+	TEST(cloud->cloud_auto_sync(), false);
+
 	cloud->set_save_password_local(true);
 	TEST(cloud->save_password_local(), true);
 	cloud->set_save_password_local(false);
@@ -210,6 +225,7 @@ void TestQPrefCloudStorage::test_signals()
 	QSignalSpy spy6(qPrefCloudStorage::instance(), SIGNAL(cloud_timeoutChanged(int)));
 	QSignalSpy spy7(qPrefCloudStorage::instance(), SIGNAL(cloud_verification_statusChanged(int)));
 	QSignalSpy spy9(qPrefCloudStorage::instance(), SIGNAL(save_password_localChanged(bool)));
+	QSignalSpy spy10(qPrefCloudStorage::instance(), SIGNAL(cloud_auto_syncChanged(bool)));
 
 	qPrefCloudStorage::set_cloud_base_url("signal url");
 	qPrefCloudStorage::set_cloud_storage_email("signal myEmail");
@@ -219,6 +235,7 @@ void TestQPrefCloudStorage::test_signals()
 	qPrefCloudStorage::set_cloud_timeout(11);
 	qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
 	qPrefCloudStorage::set_save_password_local(true);
+	qPrefCloudStorage::set_cloud_auto_sync(true);
 
 	QCOMPARE(spy1.count(), 1);
 	QCOMPARE(spy2.count(), 1);
@@ -228,6 +245,7 @@ void TestQPrefCloudStorage::test_signals()
 	QCOMPARE(spy6.count(), 1);
 	QCOMPARE(spy7.count(), 1);
 	QCOMPARE(spy9.count(), 1);
+	QCOMPARE(spy10.count(), 1);
 
 	QVERIFY(spy1.takeFirst().at(0).toString() == "signal url");
 	QVERIFY(spy2.takeFirst().at(0).toString() == "signal myEmail");
@@ -237,6 +255,7 @@ void TestQPrefCloudStorage::test_signals()
 	QVERIFY(spy6.takeFirst().at(0).toInt() == 11);
 	QVERIFY(spy7.takeFirst().at(0).toInt() == qPrefCloudStorage::CS_VERIFIED);
 	QVERIFY(spy9.takeFirst().at(0).toBool() == true);
+	QVERIFY(spy10.takeFirst().at(0).toBool() == true);
 }
 
 QTEST_MAIN(TestQPrefCloudStorage)


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This batch of commits consists of 3 related ones, and 2 separate ones. The 3 related ones fix #1725, by adding a new preference to store the setting (as it got lost in the git_local_only cleanup). and adapting the logic for that. Finally, the now superfluous syncToClould construct is removed. The separate ones are a plain bugfix and something more optical. See commits for more detail.

### Changes made:
see above and the commits

### Related issues:
#1725

### Additional information:
Commit 9a9caf1 includes a question. The manual sync to cloud menu item takes you to the Cloud Credentials page in case pressed in no cloud mode. While valid, this seems strange. As there is specific code to implement this, I consider it by design. However, talking about syncing to any cloud in a no-cloud setup seems a contradiction in terms to me.

### Release note:
will be added. User reported bug fixed.
