### PR TITLE
Mobile: prevent crash and more cosmetics

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -71,6 +71,10 @@ void DownloadThread::run()
 	internalData->descriptor = descriptorLookup[m_data->vendor() + m_data->product()];
 	internalData->download_table = &downloadTable;
 	internalData->btname = strdup(m_data->devBluetoothName().toUtf8());
+	if (!internalData->descriptor) {
+		qDebug() << "No download possible when DC type is unknown";
+		return;
+	}
 #if defined(Q_OS_ANDROID)
 	// on Android we either use BT, a USB device, or we download via FTDI cable
 	if (!internalData->bluetooth_mode && (same_string(internalData->devname, "FTDI") || same_string(internalData->devname, "")))

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -273,6 +273,8 @@ Kirigami.Page {
 			SsrfButton {
 				id: download
 				text: qsTr("Download")
+				enabled: comboVendor.currentIndex != -1 && comboProduct.currentIndex != -1 &&
+					 comboConnection.currentIndex != -1
 				onClicked: {
 					text = qsTr("Retry")
 					// strip any BT Name from the address

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -303,6 +303,7 @@ Kirigami.Page {
 			SsrfButton {
 				id:rescanbutton
 				text: qsTr("Rescan")
+				enabled: manager.btEnabled
 				onClicked: {
 					manager.btRescan()
 				}


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
2 simple commits. It was possible to crash the mobile app by selecting download from dc, and have the product/vendor not filled in. Found this by accident. Not having a DC paired and BT switched off on the device, shows the DL screen without product/vendor. Hit download results in SIGSEGV. The reason is simple, and made more safe here too. 

And while we are at it. Disable the rescan button when BT is off. It makes no sense.
