### PR TITLE
More dive site related cleanups

### DIFF
--- a/core/divesitehelpers.cpp
+++ b/core/divesitehelpers.cpp
@@ -22,8 +22,11 @@
 
 void reverseGeoLookup()
 {
+	// By making the QNetworkAccessManager static and local to this function,
+	// only one manager exists for all geo-lookups and it is only initialized
+	// on first call to this function.
+	static QNetworkAccessManager rgl;
 	QNetworkRequest request;
-	QNetworkAccessManager *rgl = new QNetworkAccessManager();
 	QEventLoop loop;
 	QString geonamesURL("http://api.geonames.org/findNearbyPlaceNameJSON?lang=%1&lat=%2&lng=%3&radius=50&username=dirkhh");
 	QString geonamesOceanURL("http://api.geonames.org/oceanJSON?lang=%1&lat=%2&lng=%3&radius=50&username=dirkhh");
@@ -38,7 +41,7 @@ void reverseGeoLookup()
 	// first check the findNearbyPlaces API from geonames - that should give us country, state, city
 	request.setUrl(geonamesURL.arg(uiLanguage(NULL).section(QRegExp("[-_ ]"), 0, 0)).arg(ds->latitude.udeg / 1000000.0).arg(ds->longitude.udeg / 1000000.0));
 
-	QNetworkReply *reply = rgl->get(request);
+	QNetworkReply *reply = rgl.get(request);
 	timer.setSingleShot(true);
 	QObject::connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
 	timer.start(5000);   // 5 secs. timeout
@@ -114,7 +117,7 @@ void reverseGeoLookup()
 	}
 	// next check the oceans API to figure out the body of water
 	request.setUrl(geonamesOceanURL.arg(uiLanguage(NULL).section(QRegExp("[-_ ]"), 0, 0)).arg(ds->latitude.udeg / 1000000.0).arg(ds->longitude.udeg / 1000000.0));
-	reply = rgl->get(request);
+	reply = rgl.get(request);
 	QObject::connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
 	timer.start(5000);   // 5 secs. timeout
 	loop.exec();
@@ -161,6 +164,4 @@ void reverseGeoLookup()
 
 clear_reply:
 	reply->deleteLater();
-
-	rgl->deleteLater();
 }

--- a/core/divesitehelpers.h
+++ b/core/divesitehelpers.h
@@ -2,6 +2,11 @@
 #ifndef DIVESITEHELPERS_H
 #define DIVESITEHELPERS_H
 
-void reverseGeoLookup();
+#include "taxonomy.h"
+#include "units.h"
+
+// Perform a reverse geo-lookup and put data in the provided taxonomy field.
+// Original data with the exception of OCEAN will be overwritten.
+void reverseGeoLookup(degrees_t latitude, degrees_t longitude, taxonomy_data *taxonomy);
 
 #endif // DIVESITEHELPERS_H

--- a/core/divesitehelpers.h
+++ b/core/divesitehelpers.h
@@ -2,18 +2,6 @@
 #ifndef DIVESITEHELPERS_H
 #define DIVESITEHELPERS_H
 
-#include "units.h"
-#include <QThread>
-
-class ReverseGeoLookupThread : public QThread {
-Q_OBJECT
-public:
-	static ReverseGeoLookupThread *instance();
-	void lookup(struct dive_site *ds);
-	void run() override;
-
-private:
-	ReverseGeoLookupThread(QObject *parent = 0);
-};
+void reverseGeoLookup();
 
 #endif // DIVESITEHELPERS_H

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -330,8 +330,7 @@ void LocationInformationWidget::resetPallete()
 
 void LocationInformationWidget::reverseGeocode()
 {
-	ReverseGeoLookupThread *geoLookup = ReverseGeoLookupThread::instance();
-	geoLookup->run();
+	reverseGeoLookup();
 	updateLabels();
 }
 

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -330,7 +330,7 @@ void LocationInformationWidget::resetPallete()
 
 void LocationInformationWidget::reverseGeocode()
 {
-	reverseGeoLookup();
+	reverseGeoLookup(displayed_dive_site.latitude, displayed_dive_site.longitude, &displayed_dive_site.taxonomy);
 	updateLabels();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -268,9 +268,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	undoRedoActions.append(redoAction);
 	ui.menu_Edit->addActions(undoRedoActions);
 
-	ReverseGeoLookupThread *geoLookup = ReverseGeoLookupThread::instance();
-	connect(geoLookup, SIGNAL(started()),information(), SLOT(disableGeoLookupEdition()));
-	connect(geoLookup, SIGNAL(finished()), information(), SLOT(enableGeoLookupEdition()));
 #ifndef NO_PRINTING
 	// copy the bundled print templates to the user path
 	QStringList templateBackupList;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -194,21 +194,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 		ui.cylinders->view()->horizontalHeader()->addAction(action);
 	}
 
-	ui.waitingSpinner->setRoundness(70.0);
-	ui.waitingSpinner->setMinimumTrailOpacity(15.0);
-	ui.waitingSpinner->setTrailFadePercentage(70.0);
-	ui.waitingSpinner->setNumberOfLines(8);
-	ui.waitingSpinner->setLineLength(5);
-	ui.waitingSpinner->setLineWidth(3);
-	ui.waitingSpinner->setInnerRadius(5);
-	ui.waitingSpinner->setRevolutionsPerSecond(1);
-
-	connect(ReverseGeoLookupThread::instance(), SIGNAL(finished()),
-			LocationInformationModel::instance(), SLOT(update()));
-
-	connect(ReverseGeoLookupThread::instance(), &QThread::finished,
-			this, &MainTab::setCurrentLocationIndex);
-
 	connect(ui.diveNotesMessage, &KMessageWidget::showAnimationFinished,
 					ui.location, &DiveLocationLineEdit::fixPopupPosition);
 
@@ -242,16 +227,6 @@ void MainTab::setCurrentLocationIndex()
 		else
 			ui.location->clear();
 	}
-}
-
-void MainTab::enableGeoLookupEdition()
-{
-	ui.waitingSpinner->stop();
-}
-
-void MainTab::disableGeoLookupEdition()
-{
-	ui.waitingSpinner->start();
 }
 
 void MainTab::toggleTriggeredColumn()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -98,8 +98,6 @@ slots:
 	void updateTextLabels(bool showUnits = true);
 	void escDetected(void);
 	void showLocation();
-	void enableGeoLookupEdition();
-	void disableGeoLookupEdition();
 	void setCurrentLocationIndex();
 	EditMode getEditMode() const;
 private:

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -230,9 +230,6 @@
                  </property>
                 </widget>
                </item>
-               <item>
-                <widget class="QtWaitingSpinner" name="waitingSpinner" native="true"/>
-               </item>
               </layout>
              </item>
              <item>
@@ -598,12 +595,6 @@
    <class>TagWidget</class>
    <extends>QPlainTextEdit</extends>
    <header>desktop-widgets/tagwidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QtWaitingSpinner</class>
-   <extends>QWidget</extends>
-   <header>desktop-widgets/qtwaitingspinner.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>DiveLocationLineEdit</class>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The first commit is a rather simple don't go via `displayed_dive_site` but via `current_dive`.
The second commit is, I fear, "bull in a china shop". But the `ReverseGeoLookupThread` plain and simply was not functional. The function call was synchronous and the signals never fired. Remove the whole construct.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replaced `displayed_dive_site` by `current_dive`
2) Replace `ReverseGeoLookupThread` by a function call, as it was just that since a long time.
3) Remove the WaitingSpinner from maintab, as it was never activated.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1772
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
