### PR TITLE
Edit: prevent not needed change marking

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -1280,47 +1280,47 @@ void MainTab::saveTaggedStrings(const QVector<dive *> &selectedDives)
 	struct dive *cd = current_dive;
 
 	if (diffTaggedStrings(cd->buddy, displayed_dive.buddy, addedList, removedList))
-	MODIFY_DIVES(selectedDives,
-		QStringList oldList = QString(mydive->buddy).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
-		QString newString;
-		QString comma;
-		Q_FOREACH (const QString tag, oldList) {
-			if (!removedList.contains(tag, Qt::CaseInsensitive)) {
-				newString += comma + tag;
-				comma = ", ";
+		MODIFY_DIVES(selectedDives,
+			QStringList oldList = QString(mydive->buddy).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
+			QString newString;
+			QString comma;
+			Q_FOREACH (const QString tag, oldList) {
+				if (!removedList.contains(tag, Qt::CaseInsensitive)) {
+					newString += comma + tag;
+					comma = ", ";
+				}
 			}
-		}
-		Q_FOREACH (const QString tag, addedList) {
-			if (!oldList.contains(tag, Qt::CaseInsensitive)) {
-				newString += comma + tag;
-				comma = ", ";
+			Q_FOREACH (const QString tag, addedList) {
+				if (!oldList.contains(tag, Qt::CaseInsensitive)) {
+					newString += comma + tag;
+					comma = ", ";
+				}
 			}
-		}
-		free(mydive->buddy);
-		mydive->buddy = copy_qstring(newString);
-	);
+			free(mydive->buddy);
+			mydive->buddy = copy_qstring(newString);
+		);
 	addedList.clear();
 	removedList.clear();
 	if (diffTaggedStrings(cd->divemaster, displayed_dive.divemaster, addedList, removedList))
-	MODIFY_DIVES(selectedDives,
-		QStringList oldList = QString(mydive->divemaster).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
-		QString newString;
-		QString comma;
-		Q_FOREACH (const QString tag, oldList) {
-			if (!removedList.contains(tag, Qt::CaseInsensitive)) {
-				newString += comma + tag;
-				comma = ", ";
+		MODIFY_DIVES(selectedDives,
+			QStringList oldList = QString(mydive->divemaster).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
+			QString newString;
+			QString comma;
+			Q_FOREACH (const QString tag, oldList) {
+				if (!removedList.contains(tag, Qt::CaseInsensitive)) {
+					newString += comma + tag;
+					comma = ", ";
+				}
 			}
-		}
-		Q_FOREACH (const QString tag, addedList) {
-			if (!oldList.contains(tag, Qt::CaseInsensitive)) {
-				newString += comma + tag;
-				comma = ", ";
+			Q_FOREACH (const QString tag, addedList) {
+				if (!oldList.contains(tag, Qt::CaseInsensitive)) {
+					newString += comma + tag;
+					comma = ", ";
+				}
 			}
-		}
-		free(mydive->divemaster);
-		mydive->divemaster = copy_qstring(newString);
-	);
+			free(mydive->divemaster);
+			mydive->divemaster = copy_qstring(newString);
+		);
 }
 
 int MainTab::diffTaggedStrings(QString currentString, QString displayedString, QStringList &addedList, QStringList &removedList)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -1279,7 +1279,7 @@ void MainTab::saveTaggedStrings(const QVector<dive *> &selectedDives)
 	QStringList addedList, removedList;
 	struct dive *cd = current_dive;
 
-	diffTaggedStrings(cd->buddy, displayed_dive.buddy, addedList, removedList);
+	if (diffTaggedStrings(cd->buddy, displayed_dive.buddy, addedList, removedList))
 	MODIFY_DIVES(selectedDives,
 		QStringList oldList = QString(mydive->buddy).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
 		QString newString;
@@ -1301,7 +1301,7 @@ void MainTab::saveTaggedStrings(const QVector<dive *> &selectedDives)
 	);
 	addedList.clear();
 	removedList.clear();
-	diffTaggedStrings(cd->divemaster, displayed_dive.divemaster, addedList, removedList);
+	if (diffTaggedStrings(cd->divemaster, displayed_dive.divemaster, addedList, removedList))
 	MODIFY_DIVES(selectedDives,
 		QStringList oldList = QString(mydive->divemaster).split(QRegExp("\\s*,\\s*"), QString::SkipEmptyParts);
 		QString newString;
@@ -1323,7 +1323,7 @@ void MainTab::saveTaggedStrings(const QVector<dive *> &selectedDives)
 	);
 }
 
-void MainTab::diffTaggedStrings(QString currentString, QString displayedString, QStringList &addedList, QStringList &removedList)
+int MainTab::diffTaggedStrings(QString currentString, QString displayedString, QStringList &addedList, QStringList &removedList)
 {
 	QStringList displayedList, currentList;
 	currentList = currentString.split(',', QString::SkipEmptyParts);
@@ -1336,6 +1336,7 @@ void MainTab::diffTaggedStrings(QString currentString, QString displayedString, 
 		if (!currentList.contains(tag, Qt::CaseInsensitive))
 			addedList << tag.trimmed();
 	}
+	return removedList.length() + addedList.length();
 }
 
 void MainTab::on_tagWidget_textChanged()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -119,7 +119,7 @@ private:
 	void copyTagsToDisplayedDive();
 	void saveTags(const QVector<dive *> &selectedDives);
 	void saveTaggedStrings(const QVector<dive *> &selectedDives);
-	void diffTaggedStrings(QString currentString, QString displayedString, QStringList &addedList, QStringList &removedList);
+	int diffTaggedStrings(QString currentString, QString displayedString, QStringList &addedList, QStringList &removedList);
 	void markChangedWidget(QWidget *w);
 	dive_trip_t *currentTrip;
 	dive_trip_t displayedTrip;


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
While trying to understand more of the big change from PR 1528, I found that the divelist was marked changed while it was not changed at all. Reason is simple. The MODIFY_DIVES code assumes
its called only for truly changed data. But in case of saving tagged strings, it was not.

This fixes this. And I do not believe this has any visual effects.

### Additional information:
The whitespace change is separated. When preferred this may be squashed.