### PR TITLE
QML, cleanup: remove stackView

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -155,7 +155,7 @@ Kirigami.Page {
 			var deletedId = currentItem.modelData.dive.id
 			var deletedIndex = diveDetailsListView.currentIndex
 			manager.deleteDive(deletedId)
-			stackView.pop()
+			pageStack.pop()
 			showPassiveNotification("Dive deleted", 3000, "Undo",
 						function() {
 							diveDetailsListView.currentIndex = manager.undoDelete(deletedId) ? deletedIndex : diveDetailsListView.currentIndex
@@ -206,7 +206,7 @@ Kirigami.Page {
 			event.accepted = true;
 		} else if (state === "add") {
 			endEditMode()
-			stackView.pop()
+			pageStack.pop()
 			event.accepted = true;
 		}
 		// if we were in view mode, don't accept the event and pop the page

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.2 as Controls
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
-import org.kde.kirigami 2.4 as Kirigami
+import org.kde.kirigami 2.5 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 
 Kirigami.ScrollablePage {
@@ -113,7 +113,7 @@ Kirigami.ScrollablePage {
 				if (detailsWindow.state === "view") {
 					diveListView.currentIndex = index
 					detailsWindow.showDiveIndex(index);
-					stackView.push(detailsWindow);
+					pageStack.push(detailsWindow);
 				}
 			}
 
@@ -387,7 +387,7 @@ Kirigami.ScrollablePage {
 
 	function showDownloadPage(vendor, product, connection) {
 		downloadFromDc.dcImportModel.clearTable()
-		stackView.push(downloadFromDc)
+		pageStack.push(downloadFromDc)
 		if (vendor !== undefined && product !== undefined && connection !== undefined) {
 			/* set up the correct values on the download page */
 			if (vendor !== -1)

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -292,7 +292,7 @@ Kirigami.Page {
 				onClicked: {
 					manager.cancelDownloadDC()
 					if (!progressBar.visible) {
-						stackView.pop();
+						pageStack.pop();
 						download.text = qsTr("Download")
 						divesDownloaded = false
 						manager.progressMessage = ""
@@ -356,7 +356,7 @@ Kirigami.Page {
 					manager.saveChangesLocal()
 					diveModel.clear()
 					diveModel.addAllDives()
-					stackView.pop();
+					pageStack.pop();
 					download.text = qsTr("Download")
 					divesDownloaded = false
 				}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -56,8 +56,8 @@ Kirigami.ApplicationWindow {
 	// opacity: 0
 
 	function returnTopPage() {
-		for (var i=stackView.depth; i>1; i--) {
-			stackView.pop()
+		for (var i=pageStack.depth; i>1; i--) {
+			pageStack.pop()
 		}
 		detailsWindow.endEditMode()
 	}
@@ -69,7 +69,7 @@ Kirigami.ApplicationWindow {
 	function showMap() {
 		globalDrawer.close()
 		returnTopPage()
-		stackView.push(mapPage)
+		pageStack.push(mapPage)
 	}
 
 	function startAddDive() {
@@ -105,7 +105,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.startpressure = []
 		detailsWindow.endpressure = []
 		detailsWindow.gpsCheckbox = false
-		stackView.push(detailsWindow)
+		pageStack.push(detailsWindow)
 	}
 
 	globalDrawer: Kirigami.GlobalDrawer {
@@ -236,7 +236,7 @@ Kirigami.ApplicationWindow {
 					onTriggered: {
 						globalDrawer.close()
 						downloadFromDc.dcImportModel.clearTable()
-						stackView.push(downloadFromDc)
+						pageStack.push(downloadFromDc)
 					}
 				}
 				Kirigami.Action {
@@ -303,7 +303,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 						globalDrawer.close()
 						returnTopPage()
 						manager.populateGpsData();
-						stackView.push(gpsWindow)
+						pageStack.push(gpsWindow)
 					}
 				}
 
@@ -336,7 +336,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				text: qsTr("About")
 				onTriggered: {
 					globalDrawer.close()
-					stackView.push(aboutWindow)
+					pageStack.push(aboutWindow)
 					detailsWindow.endEditMode()
 				}
 			},
@@ -349,7 +349,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					globalDrawer.close()
 					settingsWindow.defaultCylinderModel = manager.cylinderInit
 					PrefGeneral.default_cylinder === "" ? defaultCylinderIndex = "-1" : defaultCylinderIndex = settingsWindow.defaultCylinderModel.indexOf(PrefGeneral.default_cylinder)
-					stackView.push(settingsWindow)
+					pageStack.push(settingsWindow)
 					detailsWindow.endEditMode()
 				}
 			},
@@ -363,7 +363,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					text: qsTr("App log")
 					onTriggered: {
 						globalDrawer.close()
-						stackView.push(logWindow)
+						pageStack.push(logWindow)
 					}
 				}
 
@@ -371,7 +371,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					text: qsTr("Theme information")
 					onTriggered: {
 						globalDrawer.close()
-						stackView.push(themetest)
+						pageStack.push(themetest)
 					}
 				}
 			},
@@ -527,7 +527,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				darkTheme()
 		}
 	}
-	property Item stackView: pageStack
 	pageStack.initialPage: DiveList {
 		id: diveList
 		opacity: 0
@@ -546,7 +545,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		if (pageStack.currentItem === null) {
 			console.log("there's no current page")
 		} else {
-			stackView.interactive = pageStack.currentItem.objectName !== mapPage.objectName
+			pageStack.interactive = pageStack.currentItem.objectName !== mapPage.objectName
 
 			// is there a better way to reload the map markers instead of doing that
 			// every time the map page is shown - e.g. link to the dive list model somehow?


### PR DESCRIPTION
There is no reason (any more?) to have a property defined that basically renames the global pageStack into a local pageView. Just cleanup.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

