### PR TITLE
Cleanup: Turn widget accessor-functions into simple pointers

### DIFF
--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -275,7 +275,7 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 		if (selected_only && !dive->selected)
 			continue;
 
-		ProfileWidget2 *profile = MainWindow::instance()->graphics();
+		ProfileWidget2 *profile = MainWindow::instance()->graphics;
 		profile->plotDive(dive, true);
 		profile->setToolTipVisibile(false);
 		QPixmap pix = QPixmap::grabWidget(profile);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -502,7 +502,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 			delete_dive_from_table(&downloadTable, j);
 	}
 
-	MainWindow::instance()->dive_list->unselectDives();
+	MainWindow::instance()->diveList->unselectDives();
 
 	if (downloadTable.nr > 0) {
 		// remember the last downloaded dive (on most dive computers this will be the chronologically
@@ -517,8 +517,8 @@ void DownloadFromDCWidget::on_ok_clicked()
 		int idx = get_idx_by_uniq_id(uniqId);
 		// this shouldn't be necessary - but there are reports that somehow existing dives stay selected
 		// (but not visible as selected)
-		MainWindow::instance()->dive_list->unselectDives();
-		MainWindow::instance()->dive_list->selectDive(idx, true);
+		MainWindow::instance()->diveList->unselectDives();
+		MainWindow::instance()->diveList->selectDive(idx, true);
 	}
 
 	if (ostcFirmwareCheck && currentState == DONE) {

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -502,7 +502,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 			delete_dive_from_table(&downloadTable, j);
 	}
 
-	MainWindow::instance()->dive_list()->unselectDives();
+	MainWindow::instance()->dive_list->unselectDives();
 
 	if (downloadTable.nr > 0) {
 		// remember the last downloaded dive (on most dive computers this will be the chronologically
@@ -517,8 +517,8 @@ void DownloadFromDCWidget::on_ok_clicked()
 		int idx = get_idx_by_uniq_id(uniqId);
 		// this shouldn't be necessary - but there are reports that somehow existing dives stay selected
 		// (but not visible as selected)
-		MainWindow::instance()->dive_list()->unselectDives();
-		MainWindow::instance()->dive_list()->selectDive(idx, true);
+		MainWindow::instance()->dive_list->unselectDives();
+		MainWindow::instance()->dive_list->selectDive(idx, true);
 	}
 
 	if (ostcFirmwareCheck && currentState == DONE) {

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -244,7 +244,7 @@ void LocationInformationWidget::resetState()
 {
 	modified = false;
 	resetPallete();
-	MainWindow::instance()->dive_list->setEnabled(true);
+	MainWindow::instance()->diveList->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
 	ui.diveSiteMessage->setText(tr("Dive site management"));
 	MapWidget::instance()->endGetDiveCoordinates();
@@ -256,7 +256,7 @@ void LocationInformationWidget::resetState()
 
 void LocationInformationWidget::enableEdition()
 {
-	MainWindow::instance()->dive_list->setEnabled(false);
+	MainWindow::instance()->diveList->setEnabled(false);
 	MainWindow::instance()->setEnabledToolbar(false);
 	ui.diveSiteMessage->setText(tr("You are editing a dive site"));
 }

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -244,7 +244,7 @@ void LocationInformationWidget::resetState()
 {
 	modified = false;
 	resetPallete();
-	MainWindow::instance()->dive_list()->setEnabled(true);
+	MainWindow::instance()->dive_list->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
 	ui.diveSiteMessage->setText(tr("Dive site management"));
 	MapWidget::instance()->endGetDiveCoordinates();
@@ -256,7 +256,7 @@ void LocationInformationWidget::resetState()
 
 void LocationInformationWidget::enableEdition()
 {
-	MainWindow::instance()->dive_list()->setEnabled(false);
+	MainWindow::instance()->dive_list->setEnabled(false);
 	MainWindow::instance()->setEnabledToolbar(false);
 	ui.diveSiteMessage->setText(tr("You are editing a dive site"));
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -137,14 +137,14 @@ MainWindow::MainWindow() : QMainWindow(),
 	// widgets will change on the mainwindow.
 
 	// for the "default" mode
-	MainTab *mainTab = new MainTab();
-	DiveListView *diveListView = new DiveListView();
-	ProfileWidget2 *profileWidget = new ProfileWidget2();
+	information = new MainTab(this);
+	dive_list = new DiveListView(this);
+	graphics = new ProfileWidget2(this);
 	MapWidget *mapWidget = MapWidget::instance();
 
-	PlannerSettingsWidget *plannerSettings = new PlannerSettingsWidget();
-	DivePlannerWidget *plannerWidget = new DivePlannerWidget();
-	PlannerDetails *plannerDetails = new PlannerDetails();
+	divePlannerSettingsWidget = new PlannerSettingsWidget(this);
+	divePlannerWidget = new DivePlannerWidget(this);
+	plannerDetails = new PlannerDetails(this);
 
 	// what is a sane order for those icons? we should have the ones the user is
 	// most likely to want towards the top so they are always visible
@@ -170,7 +170,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	profLayout->setMargin(0);
 	profLayout->setContentsMargins(0,0,0,0);
 	profLayout->addWidget(toolBar);
-	profLayout->addWidget(profileWidget);
+	profLayout->addWidget(graphics);
 	profileContainer->setLayout(profLayout);
 
 	LocationInformationWidget * diveSiteEdit = new LocationInformationWidget();
@@ -178,7 +178,7 @@ MainWindow::MainWindow() : QMainWindow(),
 			this, &MainWindow::setDefaultState);
 	connect(diveSiteEdit, SIGNAL(endEditDiveSite()), this, SLOT(refreshDisplay()));
 	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
-			mainTab, &MainTab::refreshDisplayedDiveSite);
+			information, &MainTab::refreshDisplayedDiveSite);
 
 	std::pair<QByteArray, QVariant> enabled = std::make_pair("enabled", QVariant(true));
 	std::pair<QByteArray, QVariant> disabled = std::make_pair("enabled", QVariant(false));
@@ -187,12 +187,12 @@ MainWindow::MainWindow() : QMainWindow(),
 	enabledList.push_back(enabled);
 	disabledList.push_back(disabled);
 
-	registerApplicationState("Default", mainTab, profileContainer, diveListView, mapWidget );
-	registerApplicationState("AddDive", mainTab, profileContainer, diveListView, mapWidget );
-	registerApplicationState("EditDive", mainTab, profileContainer, diveListView, mapWidget );
-	registerApplicationState("PlanDive", plannerWidget, profileContainer, plannerSettings, plannerDetails );
-	registerApplicationState("EditPlannedDive", plannerWidget, profileContainer, diveListView, mapWidget );
-	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, diveListView, mapWidget);
+	registerApplicationState("Default", information, profileContainer, dive_list, mapWidget );
+	registerApplicationState("AddDive", information, profileContainer, dive_list, mapWidget );
+	registerApplicationState("EditDive", information, profileContainer, dive_list, mapWidget );
+	registerApplicationState("PlanDive", divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
+	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, dive_list, mapWidget );
+	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, dive_list, mapWidget);
 
 	setStateProperties("Default", enabledList, enabledList, enabledList,enabledList);
 	setStateProperties("AddDive", enabledList, enabledList, enabledList,enabledList);
@@ -211,11 +211,11 @@ MainWindow::MainWindow() : QMainWindow(),
 	}
 	connect(&diveListNotifier, &DiveListNotifier::selectionChanged, this, &MainWindow::selectionChanged);
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveListView, SLOT(update()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveListView, SLOT(reloadHeaderActions()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), information(), SLOT(updateDiveInfo()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget(), SLOT(settingsChanged()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget(), SLOT(settingsChanged()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), dive_list, SLOT(update()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), dive_list, SLOT(reloadHeaderActions()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), information, SLOT(updateDiveInfo()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget, SLOT(settingsChanged()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget, SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
 	for (int i = 0; i < NUM_RECENT_FILES; i++) {
 		actionsRecent[i] = new QAction(this);
@@ -224,14 +224,14 @@ MainWindow::MainWindow() : QMainWindow(),
 		connect(actionsRecent[i], SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
 	}
 	ui.menuFile->insertSeparator(ui.actionQuit);
-	connect(information(), SIGNAL(addDiveFinished()), graphics(), SLOT(setProfileState()));
-	connect(information(), SIGNAL(dateTimeChanged()), graphics(), SLOT(dateTimeChanged()));
+	connect(information, SIGNAL(addDiveFinished()), graphics, SLOT(setProfileState()));
+	connect(information, SIGNAL(dateTimeChanged()), graphics, SLOT(dateTimeChanged()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCreated()), this, SLOT(planCreated()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCanceled()), this, SLOT(planCanceled()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(variationsComputed(QString)), this, SLOT(updateVariations(QString)));
-	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget(), SLOT(printDecoPlan()));
+	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget, SLOT(printDecoPlan()));
 	connect(this, SIGNAL(startDiveSiteEdit()), this, SLOT(on_actionDiveSiteEdit_triggered()));
-	connect(information(), &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
+	connect(information, &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);
@@ -242,17 +242,17 @@ MainWindow::MainWindow() : QMainWindow(),
 	enableDisableCloudActions();
 
 	ui.mainErrorMessage->hide();
-	graphics()->setEmptyState();
+	graphics->setEmptyState();
 	initialUiSetup();
 	readSettings();
-	diveListView->reload(DiveTripModel::TREE);
-	diveListView->reloadHeaderActions();
-	diveListView->setFocus();
+	dive_list->reload(DiveTripModel::TREE);
+	dive_list->reloadHeaderActions();
+	dive_list->setFocus();
 	MapWidget::instance()->reload();
-	diveListView->expand(dive_list()->model()->index(0, 0));
-	diveListView->scrollTo(dive_list()->model()->index(0, 0), QAbstractItemView::PositionAtCenter);
-	divePlannerWidget()->settingsChanged();
-	divePlannerSettingsWidget()->settingsChanged();
+	dive_list->expand(dive_list->model()->index(0, 0));
+	dive_list->scrollTo(dive_list->model()->index(0, 0), QAbstractItemView::PositionAtCenter);
+	divePlannerWidget->settingsChanged();
+	divePlannerSettingsWidget->settingsChanged();
 #ifdef NO_USERMANUAL
 	ui.menuHelp->removeAction(ui.actionUserManual);
 #endif
@@ -317,34 +317,34 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(ui.profPn2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_pn2);
 	connect(ui.profPO2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_po2);
 
-	connect(tec, &qPrefTechnicalDetails::calcalltissuesChanged        , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcceilingChanged           , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::dcceilingChanged             , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::eadChanged                   , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcceiling3mChanged         , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::modChanged                   , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcndlttsChanged            , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::hrgraphChanged               , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::rulergraphChanged            , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::show_sacChanged               , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::zoomed_plotChanged            , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::show_pictures_in_profileChanged , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::tankbarChanged               , graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::percentagegraphChanged       , graphics(), &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcalltissuesChanged        , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcceilingChanged           , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::dcceilingChanged             , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::eadChanged                   , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcceiling3mChanged         , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::modChanged                   , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcndlttsChanged            , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::hrgraphChanged               , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::rulergraphChanged            , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::show_sacChanged              , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::zoomed_plotChanged           , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::show_pictures_in_profileChanged , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::tankbarChanged               , graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::percentagegraphChanged       , graphics, &ProfileWidget2::actionRequestedReplot);
 
-	connect(pp_gas, &qPrefPartialPressureGas::pheChanged, graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(pp_gas, &qPrefPartialPressureGas::pn2Changed, graphics(), &ProfileWidget2::actionRequestedReplot);
-	connect(pp_gas, &qPrefPartialPressureGas::po2Changed, graphics(), &ProfileWidget2::actionRequestedReplot);
+	connect(pp_gas, &qPrefPartialPressureGas::pheChanged, graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(pp_gas, &qPrefPartialPressureGas::pn2Changed, graphics, &ProfileWidget2::actionRequestedReplot);
+	connect(pp_gas, &qPrefPartialPressureGas::po2Changed, graphics, &ProfileWidget2::actionRequestedReplot);
 
 	// now let's set up some connections
-	connect(graphics(), &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
-	connect(graphics(), &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);
-	connect(graphics(), &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
-	connect(graphics(), &ProfileWidget2::refreshDisplay, this, &MainWindow::refreshDisplay);
-	connect(graphics(), &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
-	connect(graphics(), &ProfileWidget2::updateDiveInfo, information(), &MainTab::updateDiveInfo);
+	connect(graphics, &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
+	connect(graphics, &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);
+	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
+	connect(graphics, &ProfileWidget2::refreshDisplay, this, &MainWindow::refreshDisplay);
+	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
+	connect(graphics, &ProfileWidget2::updateDiveInfo, information, &MainTab::updateDiveInfo);
 
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), graphics(), SLOT(settingsChanged()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), graphics, SLOT(settingsChanged()));
 
 	ui.profCalcAllTissues->setChecked(qPrefTechnicalDetails::calcalltissues());
 	ui.profCalcCeiling->setChecked(qPrefTechnicalDetails::calcceiling());
@@ -385,7 +385,7 @@ void MainWindow::setupSocialNetworkMenu()
 	connections = new QMenu(tr("Connect to"));
 	FacebookPlugin *facebookPlugin = new FacebookPlugin();
 	QAction *toggle_connection = new QAction(this);
-	QObject *obj = qobject_cast<QObject*>(facebookPlugin);
+	QObject *obj = facebookPlugin;
 	toggle_connection->setText(facebookPlugin->socialNetworkName());
 	toggle_connection->setIcon(QIcon(facebookPlugin->socialNetworkIcon()));
 	toggle_connection->setData(QVariant::fromValue(obj));
@@ -455,16 +455,9 @@ void MainWindow::enableDisableCloudActions()
 	ui.actionCloudstoragesave->setEnabled(prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED);
 }
 
-PlannerDetails *MainWindow::plannerDetails() const {
-	return qobject_cast<PlannerDetails*>(applicationState["PlanDive"].bottomRight);
-}
-PlannerSettingsWidget *MainWindow::divePlannerSettingsWidget() {
-	return qobject_cast<PlannerSettingsWidget*>(applicationState["PlanDive"].bottomLeft);
-}
-
 void MainWindow::setDefaultState() {
 	setApplicationState("Default");
-	if (information()->getEditMode() != MainTab::NONE) {
+	if (information->getEditMode() != MainTab::NONE) {
 		ui.bottomLeft->currentWidget()->setEnabled(false);
 	}
 }
@@ -477,22 +470,22 @@ MainWindow *MainWindow::instance()
 // This gets called after one or more dives were added, edited or downloaded for a dive computer
 void MainWindow::refreshDisplay(bool doRecreateDiveList)
 {
-	information()->reload();
+	information->reload();
 	TankInfoModel::instance()->update();
 	MapWidget::instance()->reload();
 	if (doRecreateDiveList)
 		recreateDiveList();
 
 	setApplicationState("Default");
-	dive_list()->setEnabled(true);
-	dive_list()->setFocus();
+	dive_list->setEnabled(true);
+	dive_list->setFocus();
 	WSInfoModel::instance()->updateInfo();
 	ui.actionAutoGroup->setChecked(autogroup);
 }
 
 void MainWindow::recreateDiveList()
 {
-	dive_list()->reload(DiveTripModel::CURRENT);
+	dive_list->reload(DiveTripModel::CURRENT);
 	TagFilterModel::instance()->repopulate();
 	BuddyFilterModel::instance()->repopulate();
 	LocationFilterModel::instance()->repopulate();
@@ -528,12 +521,12 @@ void MainWindow::configureToolbar() {
 void MainWindow::selectionChanged()
 {
 	if (!current_dive) {
-		information()->clearTabs();
-		information()->updateDiveInfo(true);
-		graphics()->setEmptyState();
+		information->clearTabs();
+		information->updateDiveInfo(true);
+		graphics->setEmptyState();
 	} else {
-		graphics()->plotDive(nullptr, false, true);
-		information()->updateDiveInfo();
+		graphics->plotDive(nullptr, false, true);
+		information->updateDiveInfo();
 		configureToolbar();
 		MapWidget::instance()->reload();
 	}
@@ -644,8 +637,8 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 
 	if (verbose)
 		qDebug() << "Saving cloud storage to:" << filename;
-	if (information()->isEditing())
-		information()->acceptChanges();
+	if (information->isEditing())
+		information->acceptChanges();
 
 	showProgressBar();
 	int error = save_dives(qPrintable(filename));
@@ -666,7 +659,7 @@ void MainWindow::on_actionCloudOnline_triggered()
 	// Refuse to go online if there is an edit in progress
 	if (!isOffline &&
 	    (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-	    information()->isEditing())) {
+	    information->isEditing())) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please save or cancel the current dive edit before going online"));
 		// We didn't switch to online, therefore uncheck the checkbox
 		ui.actionCloudOnline->setChecked(false);
@@ -697,17 +690,12 @@ void MainWindow::on_actionCloudOnline_triggered()
 	updateCloudOnlineStatus();
 }
 
-ProfileWidget2 *MainWindow::graphics() const
-{
-	return qobject_cast<ProfileWidget2*>(applicationState["Default"].topRight->layout()->itemAt(1)->widget());
-}
-
 void MainWindow::cleanUpEmpty()
 {
-	information()->clearTabs();
-	information()->updateDiveInfo(true);
-	graphics()->setEmptyState();
-	dive_list()->reload(DiveTripModel::TREE);
+	information->clearTabs();
+	information->updateDiveInfo(true);
+	graphics->setEmptyState();
+	dive_list->reload(DiveTripModel::TREE);
 	MapWidget::instance()->reload();
 	if (!existing_filename)
 		setTitle();
@@ -717,7 +705,7 @@ void MainWindow::cleanUpEmpty()
 bool MainWindow::okToClose(QString message)
 {
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information()->isEditing() ) {
+		information->isEditing() ) {
 		QMessageBox::warning(this, tr("Warning"), message);
 		return false;
 	}
@@ -729,7 +717,7 @@ bool MainWindow::okToClose(QString message)
 
 void MainWindow::closeCurrentFile()
 {
-	graphics()->setEmptyState();
+	graphics->setEmptyState();
 	/* free the dives and trips */
 	clear_git_id();
 	clear_dive_file_data();
@@ -802,7 +790,7 @@ void MainWindow::enableShortcuts()
 void MainWindow::showProfile()
 {
 	enableShortcuts();
-	graphics()->setProfileState();
+	graphics->setProfileState();
 	setApplicationState("Default");
 }
 
@@ -819,9 +807,9 @@ void MainWindow::on_actionPreferences_triggered()
 
 void MainWindow::on_actionQuit_triggered()
 {
-	if (information()->isEditing()) {
-		information()->rejectChanges();
-		if (information()->isEditing())
+	if (information->isEditing()) {
+		information->rejectChanges();
+		if (information->isEditing())
 			// didn't discard the edits
 			return;
 	}
@@ -862,7 +850,7 @@ bool MainWindow::plannerStateClean()
 		return false;
 
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information()->isEditing()) {
+		information->isEditing()) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please save or cancel the current dive edit before trying to add a dive."));
 		return false;
 	}
@@ -873,7 +861,7 @@ void MainWindow::refreshProfile()
 {
 	showProfile();
 	configureToolbar();
-	graphics()->replot(current_dive);
+	graphics->replot(current_dive);
 	DivePictureModel::instance()->updateDivePictures();
 }
 
@@ -890,13 +878,13 @@ void MainWindow::planCreated()
 	// make sure our UI is in a consistent state
 	showProfile();
 	setApplicationState("Default");
-	dive_list()->setEnabled(true);
-	dive_list()->setFocus();
+	dive_list->setEnabled(true);
+	dive_list->setFocus();
 }
 
 void MainWindow::setPlanNotes()
 {
-	plannerDetails()->divePlanOutput()->setHtml(displayed_dive.notes);
+	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
 }
 
 void MainWindow::updateVariations(QString variations)
@@ -904,13 +892,13 @@ void MainWindow::updateVariations(QString variations)
 	QString notes = QString(displayed_dive.notes);
 	free(displayed_dive.notes);
 	displayed_dive.notes = copy_qstring(notes.replace("VARIATIONS", variations));
-	plannerDetails()->divePlanOutput()->setHtml(displayed_dive.notes);
+	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
 }
 
 void MainWindow::printPlan()
 {
 #ifndef NO_PRINTING
-	QString diveplan = plannerDetails()->divePlanOutput()->toHtml();
+	QString diveplan = plannerDetails->divePlanOutput()->toHtml();
 	QString withDisclaimer = QString("<img height=50 src=\":subsurface-icon\"> ") + diveplan + QString(disclaimer);
 
 	QPrinter printer;
@@ -933,7 +921,7 @@ void MainWindow::printPlan()
 	painter.setRenderHint(QPainter::Antialiasing);
 	painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
-	ProfileWidget2 *profile = graphics();
+	ProfileWidget2 *profile = graphics;
 	QSize origSize = profile->size();
 	profile->resize(renderSize.toSize());
 	profile->setPrintMode(true);
@@ -947,9 +935,9 @@ void MainWindow::printPlan()
 	QString profileImage = QString("<img src=\"data:image/png;base64,") + byteArray.toBase64() + "\"/><br><br>";
 	withDisclaimer = profileImage + withDisclaimer;
 
-	plannerDetails()->divePlanOutput()->setHtml(withDisclaimer);
-	plannerDetails()->divePlanOutput()->print(&printer);
-	plannerDetails()->divePlanOutput()->setHtml(displayed_dive.notes);
+	plannerDetails->divePlanOutput()->setHtml(withDisclaimer);
+	plannerDetails->divePlanOutput()->print(&printer);
+	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
 #endif
 }
 
@@ -981,15 +969,15 @@ void MainWindow::on_actionReplanDive_triggered()
 	DivePlannerPointsModel::instance()->clear();
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
-	graphics()->setPlanState();
-	graphics()->clearHandlers();
+	graphics->setPlanState();
+	graphics->clearHandlers();
 	setApplicationState("PlanDive");
-	divePlannerWidget()->setReplanButton(true);
-	divePlannerWidget()->setupStartTime(QDateTime::fromMSecsSinceEpoch(1000 * current_dive->when, Qt::UTC));
+	divePlannerWidget->setReplanButton(true);
+	divePlannerWidget->setupStartTime(QDateTime::fromMSecsSinceEpoch(1000 * current_dive->when, Qt::UTC));
 	if (current_dive->surface_pressure.mbar)
-		divePlannerWidget()->setSurfacePressure(current_dive->surface_pressure.mbar);
+		divePlannerWidget->setSurfacePressure(current_dive->surface_pressure.mbar);
 	if (current_dive->salinity)
-		divePlannerWidget()->setSalinity(current_dive->salinity);
+		divePlannerWidget->setSalinity(current_dive->salinity);
 	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
 	reset_cylinders(&displayed_dive, true);
 	CylindersModel::instance()->updateDive();
@@ -1004,7 +992,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	setApplicationState("PlanDive");
 
-	graphics()->setPlanState();
+	graphics->setPlanState();
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
 	setupForAddAndPlan("planned dive"); // don't translate, stored in XML file
@@ -1012,16 +1000,12 @@ void MainWindow::on_actionDivePlanner_triggered()
 	DivePlannerPointsModel::instance()->createSimpleDive();
 	// plan the dive in the same mode as the currently selected one
 	if (current_dive) {
-		divePlannerSettingsWidget()->setDiveMode(current_dive->dc.divemode);
+		divePlannerSettingsWidget->setDiveMode(current_dive->dc.divemode);
 		if (current_dive->salinity)
-			divePlannerWidget()->setSalinity(current_dive->salinity);
+			divePlannerWidget->setSalinity(current_dive->salinity);
 	}
 	DivePictureModel::instance()->updateDivePictures();
-	divePlannerWidget()->setReplanButton(false);
-}
-
-DivePlannerWidget* MainWindow::divePlannerWidget() {
-	return qobject_cast<DivePlannerWidget*>(applicationState["PlanDive"].topLeft);
+	divePlannerWidget->setReplanButton(false);
 }
 
 void MainWindow::on_actionAddDive_triggered()
@@ -1029,9 +1013,9 @@ void MainWindow::on_actionAddDive_triggered()
 	if (!plannerStateClean())
 		return;
 
-	if (dive_list()->selectedTrips().count() >= 1) {
-		dive_list()->rememberSelection();
-		dive_list()->clearSelection();
+	if (dive_list->selectedTrips().count() >= 1) {
+		dive_list->rememberSelection();
+		dive_list->clearSelection();
 	}
 
 	setApplicationState("AddDive");
@@ -1041,19 +1025,19 @@ void MainWindow::on_actionAddDive_triggered()
 	setupForAddAndPlan("manually added dive"); // don't translate, stored in the XML file
 
 	// now show the mostly empty main tab
-	information()->updateDiveInfo();
+	information->updateDiveInfo();
 
-	information()->addDiveStarted();
+	information->addDiveStarted();
 
-	graphics()->setAddState();
+	graphics->setAddState();
 	DivePlannerPointsModel::instance()->createSimpleDive();
 	configureToolbar();
-	graphics()->plotDive(nullptr, false, true);
+	graphics->plotDive(nullptr, false, true);
 	fixup_dc_duration(&displayed_dive.dc);
 	displayed_dive.duration = displayed_dive.dc.duration;
 
 	// now that we have the correct depth and duration, update the dive info
-	information()->updateDepthDuration();
+	information->updateDepthDuration();
 }
 
 void MainWindow::on_actionRenumber_triggered()
@@ -1254,8 +1238,8 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics()->plotDive(nullptr, false, true);
-	information()->updateDiveInfo();
+	graphics->plotDive(nullptr, false, true);
+	information->updateDiveInfo();
 }
 
 void MainWindow::on_actionNextDC_triggered()
@@ -1263,8 +1247,8 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics()->plotDive(nullptr, false, true);
-	information()->updateDiveInfo();
+	graphics->plotDive(nullptr, false, true);
+	information->updateDiveInfo();
 }
 
 void MainWindow::on_actionFullScreen_triggered(bool checked)
@@ -1495,7 +1479,7 @@ void MainWindow::writeSettings()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information()->isEditing()) {
+		information->isEditing()) {
 		on_actionQuit_triggered();
 		event->ignore();
 		return;
@@ -1508,16 +1492,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
 	event->accept();
 	writeSettings();
 	QApplication::closeAllWindows();
-}
-
-DiveListView *MainWindow::dive_list()
-{
-	return qobject_cast<DiveListView*>(applicationState["Default"].bottomLeft);
-}
-
-MainTab *MainWindow::information()
-{
-	return qobject_cast<MainTab*>(applicationState["Default"].topLeft);
 }
 
 void MainWindow::loadRecentFiles()
@@ -1638,8 +1612,8 @@ int MainWindow::file_save_as(void)
 	if (filename.isNull() || filename.isEmpty())
 		return report_error("No filename to save into");
 
-	if (information()->isEditing())
-		information()->acceptChanges();
+	if (information->isEditing())
+		information->acceptChanges();
 
 	if (save_dives(qPrintable(filename)))
 		return -1;
@@ -1662,8 +1636,8 @@ int MainWindow::file_save(void)
 	if (is_cloud && !saveToCloudOK())
 		return -1;
 
-	if (information()->isEditing())
-		information()->acceptChanges();
+	if (information->isEditing())
+		information->acceptChanges();
 
 	current_default = prefs.default_filename;
 	if (strcmp(existing_filename, current_default) == 0) {
@@ -1826,7 +1800,7 @@ void MainWindow::editCurrentDive()
 	if (!current_dive)
 		return;
 
-	if (information()->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
+	if (information->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please, first finish the current edition before trying to do another."));
 		return;
 	}
@@ -1837,18 +1811,18 @@ void MainWindow::editCurrentDive()
 	disableShortcuts();
 	if (defaultDC == "manually added dive") {
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
-		graphics()->setAddState();
+		graphics->setAddState();
 		setApplicationState("EditDive");
 		DivePlannerPointsModel::instance()->loadFromDive(d);
-		information()->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
+		information->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else if (defaultDC == "planned dive") {
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 		setApplicationState("EditPlannedDive");
 		DivePlannerPointsModel::instance()->loadFromDive(d);
-		information()->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
+		information->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else {
 		setApplicationState("EditDive");
-		information()->enableEdition();
+		information->enableEdition();
 	}
 }
 
@@ -1890,7 +1864,7 @@ void MainWindow::on_paste_triggered()
 {
 	// take the data in our copyPasteDive and apply it to selected dives
 	selective_copy_dive(&copyPasteDive, &displayed_dive, what, false);
-	information()->showAndTriggerEditSelective(what);
+	information->showAndTriggerEditSelective(what);
 }
 
 void MainWindow::on_actionFilterTags_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -137,8 +137,8 @@ MainWindow::MainWindow() : QMainWindow(),
 	// widgets will change on the mainwindow.
 
 	// for the "default" mode
-	information = new MainTab(this);
-	dive_list = new DiveListView(this);
+	mainTab = new MainTab(this);
+	diveList = new DiveListView(this);
 	graphics = new ProfileWidget2(this);
 	MapWidget *mapWidget = MapWidget::instance();
 
@@ -178,7 +178,7 @@ MainWindow::MainWindow() : QMainWindow(),
 			this, &MainWindow::setDefaultState);
 	connect(diveSiteEdit, SIGNAL(endEditDiveSite()), this, SLOT(refreshDisplay()));
 	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
-			information, &MainTab::refreshDisplayedDiveSite);
+			mainTab, &MainTab::refreshDisplayedDiveSite);
 
 	std::pair<QByteArray, QVariant> enabled = std::make_pair("enabled", QVariant(true));
 	std::pair<QByteArray, QVariant> disabled = std::make_pair("enabled", QVariant(false));
@@ -187,12 +187,12 @@ MainWindow::MainWindow() : QMainWindow(),
 	enabledList.push_back(enabled);
 	disabledList.push_back(disabled);
 
-	registerApplicationState("Default", information, profileContainer, dive_list, mapWidget );
-	registerApplicationState("AddDive", information, profileContainer, dive_list, mapWidget );
-	registerApplicationState("EditDive", information, profileContainer, dive_list, mapWidget );
+	registerApplicationState("Default", mainTab, profileContainer, diveList, mapWidget );
+	registerApplicationState("AddDive", mainTab, profileContainer, diveList, mapWidget );
+	registerApplicationState("EditDive", mainTab, profileContainer, diveList, mapWidget );
 	registerApplicationState("PlanDive", divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
-	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, dive_list, mapWidget );
-	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, dive_list, mapWidget);
+	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, diveList, mapWidget );
+	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, diveList, mapWidget);
 
 	setStateProperties("Default", enabledList, enabledList, enabledList,enabledList);
 	setStateProperties("AddDive", enabledList, enabledList, enabledList,enabledList);
@@ -211,9 +211,9 @@ MainWindow::MainWindow() : QMainWindow(),
 	}
 	connect(&diveListNotifier, &DiveListNotifier::selectionChanged, this, &MainWindow::selectionChanged);
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), dive_list, SLOT(update()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), dive_list, SLOT(reloadHeaderActions()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), information, SLOT(updateDiveInfo()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(update()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(reloadHeaderActions()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), mainTab, SLOT(updateDiveInfo()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget, SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget, SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
@@ -224,14 +224,14 @@ MainWindow::MainWindow() : QMainWindow(),
 		connect(actionsRecent[i], SIGNAL(triggered(bool)), this, SLOT(recentFileTriggered(bool)));
 	}
 	ui.menuFile->insertSeparator(ui.actionQuit);
-	connect(information, SIGNAL(addDiveFinished()), graphics, SLOT(setProfileState()));
-	connect(information, SIGNAL(dateTimeChanged()), graphics, SLOT(dateTimeChanged()));
+	connect(mainTab, SIGNAL(addDiveFinished()), graphics, SLOT(setProfileState()));
+	connect(mainTab, SIGNAL(dateTimeChanged()), graphics, SLOT(dateTimeChanged()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCreated()), this, SLOT(planCreated()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCanceled()), this, SLOT(planCanceled()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(variationsComputed(QString)), this, SLOT(updateVariations(QString)));
 	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget, SLOT(printDecoPlan()));
 	connect(this, SIGNAL(startDiveSiteEdit()), this, SLOT(on_actionDiveSiteEdit_triggered()));
-	connect(information, &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
+	connect(mainTab, &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);
@@ -245,12 +245,12 @@ MainWindow::MainWindow() : QMainWindow(),
 	graphics->setEmptyState();
 	initialUiSetup();
 	readSettings();
-	dive_list->reload(DiveTripModel::TREE);
-	dive_list->reloadHeaderActions();
-	dive_list->setFocus();
+	diveList->reload(DiveTripModel::TREE);
+	diveList->reloadHeaderActions();
+	diveList->setFocus();
 	MapWidget::instance()->reload();
-	dive_list->expand(dive_list->model()->index(0, 0));
-	dive_list->scrollTo(dive_list->model()->index(0, 0), QAbstractItemView::PositionAtCenter);
+	diveList->expand(diveList->model()->index(0, 0));
+	diveList->scrollTo(diveList->model()->index(0, 0), QAbstractItemView::PositionAtCenter);
 	divePlannerWidget->settingsChanged();
 	divePlannerSettingsWidget->settingsChanged();
 #ifdef NO_USERMANUAL
@@ -342,7 +342,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
 	connect(graphics, &ProfileWidget2::refreshDisplay, this, &MainWindow::refreshDisplay);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
-	connect(graphics, &ProfileWidget2::updateDiveInfo, information, &MainTab::updateDiveInfo);
+	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab, &MainTab::updateDiveInfo);
 
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), graphics, SLOT(settingsChanged()));
 
@@ -457,7 +457,7 @@ void MainWindow::enableDisableCloudActions()
 
 void MainWindow::setDefaultState() {
 	setApplicationState("Default");
-	if (information->getEditMode() != MainTab::NONE) {
+	if (mainTab->getEditMode() != MainTab::NONE) {
 		ui.bottomLeft->currentWidget()->setEnabled(false);
 	}
 }
@@ -470,22 +470,22 @@ MainWindow *MainWindow::instance()
 // This gets called after one or more dives were added, edited or downloaded for a dive computer
 void MainWindow::refreshDisplay(bool doRecreateDiveList)
 {
-	information->reload();
+	mainTab->reload();
 	TankInfoModel::instance()->update();
 	MapWidget::instance()->reload();
 	if (doRecreateDiveList)
 		recreateDiveList();
 
 	setApplicationState("Default");
-	dive_list->setEnabled(true);
-	dive_list->setFocus();
+	diveList->setEnabled(true);
+	diveList->setFocus();
 	WSInfoModel::instance()->updateInfo();
 	ui.actionAutoGroup->setChecked(autogroup);
 }
 
 void MainWindow::recreateDiveList()
 {
-	dive_list->reload(DiveTripModel::CURRENT);
+	diveList->reload(DiveTripModel::CURRENT);
 	TagFilterModel::instance()->repopulate();
 	BuddyFilterModel::instance()->repopulate();
 	LocationFilterModel::instance()->repopulate();
@@ -521,12 +521,12 @@ void MainWindow::configureToolbar() {
 void MainWindow::selectionChanged()
 {
 	if (!current_dive) {
-		information->clearTabs();
-		information->updateDiveInfo(true);
+		mainTab->clearTabs();
+		mainTab->updateDiveInfo(true);
 		graphics->setEmptyState();
 	} else {
 		graphics->plotDive(nullptr, false, true);
-		information->updateDiveInfo();
+		mainTab->updateDiveInfo();
 		configureToolbar();
 		MapWidget::instance()->reload();
 	}
@@ -637,8 +637,8 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 
 	if (verbose)
 		qDebug() << "Saving cloud storage to:" << filename;
-	if (information->isEditing())
-		information->acceptChanges();
+	if (mainTab->isEditing())
+		mainTab->acceptChanges();
 
 	showProgressBar();
 	int error = save_dives(qPrintable(filename));
@@ -659,7 +659,7 @@ void MainWindow::on_actionCloudOnline_triggered()
 	// Refuse to go online if there is an edit in progress
 	if (!isOffline &&
 	    (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-	    information->isEditing())) {
+	    mainTab->isEditing())) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please save or cancel the current dive edit before going online"));
 		// We didn't switch to online, therefore uncheck the checkbox
 		ui.actionCloudOnline->setChecked(false);
@@ -692,10 +692,10 @@ void MainWindow::on_actionCloudOnline_triggered()
 
 void MainWindow::cleanUpEmpty()
 {
-	information->clearTabs();
-	information->updateDiveInfo(true);
+	mainTab->clearTabs();
+	mainTab->updateDiveInfo(true);
 	graphics->setEmptyState();
-	dive_list->reload(DiveTripModel::TREE);
+	diveList->reload(DiveTripModel::TREE);
 	MapWidget::instance()->reload();
 	if (!existing_filename)
 		setTitle();
@@ -705,7 +705,7 @@ void MainWindow::cleanUpEmpty()
 bool MainWindow::okToClose(QString message)
 {
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information->isEditing() ) {
+		mainTab->isEditing() ) {
 		QMessageBox::warning(this, tr("Warning"), message);
 		return false;
 	}
@@ -807,9 +807,9 @@ void MainWindow::on_actionPreferences_triggered()
 
 void MainWindow::on_actionQuit_triggered()
 {
-	if (information->isEditing()) {
-		information->rejectChanges();
-		if (information->isEditing())
+	if (mainTab->isEditing()) {
+		mainTab->rejectChanges();
+		if (mainTab->isEditing())
 			// didn't discard the edits
 			return;
 	}
@@ -850,7 +850,7 @@ bool MainWindow::plannerStateClean()
 		return false;
 
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information->isEditing()) {
+		mainTab->isEditing()) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please save or cancel the current dive edit before trying to add a dive."));
 		return false;
 	}
@@ -878,8 +878,8 @@ void MainWindow::planCreated()
 	// make sure our UI is in a consistent state
 	showProfile();
 	setApplicationState("Default");
-	dive_list->setEnabled(true);
-	dive_list->setFocus();
+	diveList->setEnabled(true);
+	diveList->setFocus();
 }
 
 void MainWindow::setPlanNotes()
@@ -1013,9 +1013,9 @@ void MainWindow::on_actionAddDive_triggered()
 	if (!plannerStateClean())
 		return;
 
-	if (dive_list->selectedTrips().count() >= 1) {
-		dive_list->rememberSelection();
-		dive_list->clearSelection();
+	if (diveList->selectedTrips().count() >= 1) {
+		diveList->rememberSelection();
+		diveList->clearSelection();
 	}
 
 	setApplicationState("AddDive");
@@ -1025,9 +1025,9 @@ void MainWindow::on_actionAddDive_triggered()
 	setupForAddAndPlan("manually added dive"); // don't translate, stored in the XML file
 
 	// now show the mostly empty main tab
-	information->updateDiveInfo();
+	mainTab->updateDiveInfo();
 
-	information->addDiveStarted();
+	mainTab->addDiveStarted();
 
 	graphics->setAddState();
 	DivePlannerPointsModel::instance()->createSimpleDive();
@@ -1037,7 +1037,7 @@ void MainWindow::on_actionAddDive_triggered()
 	displayed_dive.duration = displayed_dive.dc.duration;
 
 	// now that we have the correct depth and duration, update the dive info
-	information->updateDepthDuration();
+	mainTab->updateDepthDuration();
 }
 
 void MainWindow::on_actionRenumber_triggered()
@@ -1239,7 +1239,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
 	graphics->plotDive(nullptr, false, true);
-	information->updateDiveInfo();
+	mainTab->updateDiveInfo();
 }
 
 void MainWindow::on_actionNextDC_triggered()
@@ -1248,7 +1248,7 @@ void MainWindow::on_actionNextDC_triggered()
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
 	graphics->plotDive(nullptr, false, true);
-	information->updateDiveInfo();
+	mainTab->updateDiveInfo();
 }
 
 void MainWindow::on_actionFullScreen_triggered(bool checked)
@@ -1479,7 +1479,7 @@ void MainWindow::writeSettings()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
-		information->isEditing()) {
+		mainTab->isEditing()) {
 		on_actionQuit_triggered();
 		event->ignore();
 		return;
@@ -1612,8 +1612,8 @@ int MainWindow::file_save_as(void)
 	if (filename.isNull() || filename.isEmpty())
 		return report_error("No filename to save into");
 
-	if (information->isEditing())
-		information->acceptChanges();
+	if (mainTab->isEditing())
+		mainTab->acceptChanges();
 
 	if (save_dives(qPrintable(filename)))
 		return -1;
@@ -1636,8 +1636,8 @@ int MainWindow::file_save(void)
 	if (is_cloud && !saveToCloudOK())
 		return -1;
 
-	if (information->isEditing())
-		information->acceptChanges();
+	if (mainTab->isEditing())
+		mainTab->acceptChanges();
 
 	current_default = prefs.default_filename;
 	if (strcmp(existing_filename, current_default) == 0) {
@@ -1800,7 +1800,7 @@ void MainWindow::editCurrentDive()
 	if (!current_dive)
 		return;
 
-	if (information->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
+	if (mainTab->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
 		QMessageBox::warning(this, tr("Warning"), tr("Please, first finish the current edition before trying to do another."));
 		return;
 	}
@@ -1814,15 +1814,15 @@ void MainWindow::editCurrentDive()
 		graphics->setAddState();
 		setApplicationState("EditDive");
 		DivePlannerPointsModel::instance()->loadFromDive(d);
-		information->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
+		mainTab->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else if (defaultDC == "planned dive") {
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 		setApplicationState("EditPlannedDive");
 		DivePlannerPointsModel::instance()->loadFromDive(d);
-		information->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
+		mainTab->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else {
 		setApplicationState("EditDive");
-		information->enableEdition();
+		mainTab->enableEdition();
 	}
 }
 
@@ -1864,7 +1864,7 @@ void MainWindow::on_paste_triggered()
 {
 	// take the data in our copyPasteDive and apply it to selected dives
 	selective_copy_dive(&copyPasteDive, &displayed_dive, what, false);
-	information->showAndTriggerEditSelective(what);
+	mainTab->showAndTriggerEditSelective(what);
 }
 
 void MainWindow::on_actionFilterTags_triggered()

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -59,14 +59,10 @@ public:
 	MainWindow();
 	~MainWindow();
 	static MainWindow *instance();
-	MainTab *information();
 	void loadRecentFiles();
 	void updateRecentFiles();
 	void updateRecentFilesMenu();
 	void addRecentFile(const QString &file, bool update);
-	DiveListView *dive_list();
-	DivePlannerWidget *divePlannerWidget();
-	PlannerSettingsWidget *divePlannerSettingsWidget();
 	LocationInformationWidget *locationInformationWidget();
 	void setTitle();
 
@@ -74,8 +70,6 @@ public:
 	void importFiles(const QStringList importFiles);
 	void cleanUpEmpty();
 	void setToolButtonsEnabled(bool enabled);
-	ProfileWidget2 *graphics() const;
-	PlannerDetails *plannerDetails() const;
 	void printPlan();
 	void checkSurvey();
 	void setApplicationState(const QByteArray& state);
@@ -87,6 +81,12 @@ public:
 	void enterEditState();
 	void exitEditState();
 
+	MainTab *information;
+	PlannerDetails *plannerDetails;
+	PlannerSettingsWidget *divePlannerSettingsWidget;
+	ProfileWidget2 *graphics;
+	DivePlannerWidget *divePlannerWidget;
+	DiveListView *dive_list;
 private
 slots:
 	/* file menu action */

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -81,12 +81,12 @@ public:
 	void enterEditState();
 	void exitEditState();
 
-	MainTab *information;
+	MainTab *mainTab;
 	PlannerDetails *plannerDetails;
 	PlannerSettingsWidget *divePlannerSettingsWidget;
 	ProfileWidget2 *graphics;
 	DivePlannerWidget *divePlannerWidget;
-	DiveListView *dive_list;
+	DiveListView *diveList;
 private
 slots:
 	/* file menu action */

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -103,9 +103,9 @@ void MapWidget::selectedDivesChanged(QList<int> list)
 {
 	CHECK_IS_READY_RETURN_VOID();
 	skipReload = true;
-	MainWindow::instance()->dive_list()->unselectDives();
+	MainWindow::instance()->dive_list->unselectDives();
 	if (!list.empty())
-		MainWindow::instance()->dive_list()->selectDives(list);
+		MainWindow::instance()->dive_list->selectDives(list);
 	skipReload = false;
 }
 

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -103,9 +103,9 @@ void MapWidget::selectedDivesChanged(QList<int> list)
 {
 	CHECK_IS_READY_RETURN_VOID();
 	skipReload = true;
-	MainWindow::instance()->dive_list->unselectDives();
+	MainWindow::instance()->diveList->unselectDives();
 	if (!list.empty())
-		MainWindow::instance()->dive_list->selectDives(list);
+		MainWindow::instance()->diveList->selectDives(list);
 	skipReload = false;
 }
 

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -263,10 +263,10 @@ TankInfoDelegate::TankInfoDelegate(QObject *parent) : ComboBoxDelegate(TankInfoM
 
 void TankInfoDelegate::reenableReplot(QWidget*, QAbstractItemDelegate::EndEditHint)
 {
-	MainWindow::instance()->graphics()->setReplot(true);
+	MainWindow::instance()->graphics->setReplot(true);
 	// FIXME: We need to replot after a cylinder is selected but the replot below overwrites
 	//        the newly selected cylinder.
-	//	MainWindow::instance()->graphics()->replot();
+	//	MainWindow::instance()->graphics->replot();
 }
 
 void TankInfoDelegate::revertModelData(QWidget*, QAbstractItemDelegate::EndEditHint hint)
@@ -290,7 +290,7 @@ QWidget *TankInfoDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	currCylinderData.type = copy_string(cyl->type.description);
 	currCylinderData.pressure = cyl->type.workingpressure.mbar;
 	currCylinderData.size = cyl->type.size.mliter;
-	MainWindow::instance()->graphics()->setReplot(false);
+	MainWindow::instance()->graphics->setReplot(false);
 	return delegate;
 }
 

--- a/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
+++ b/desktop-widgets/plugins/facebook/facebookconnectwidget.cpp
@@ -197,7 +197,7 @@ void FacebookManager::userIdReceived()
 QPixmap FacebookManager::grabProfilePixmap()
 {
 	qCDebug(lcFacebook) << "Grabbing Dive Profile pixmap";
-	ProfileWidget2 *profile = MainWindow::instance()->graphics();
+	ProfileWidget2 *profile = MainWindow::instance()->graphics;
 
 	QSize size = fbInfo.profileSize == FacebookInfo::SMALL  ? QSize(800,600) :
 		     fbInfo.profileSize == FacebookInfo::MEDIUM ? QSize(1024,760) :

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -134,7 +134,7 @@ void Printer::flowRender()
 void Printer::render(int Pages = 0)
 {
 	// keep original preferences
-	QPointer<ProfileWidget2> profile = MainWindow::instance()->graphics();
+	QPointer<ProfileWidget2> profile = MainWindow::instance()->graphics;
 	int profileFrameStyle = profile->frameStyle();
 	int animationOriginal = qPrefDisplay::animation_speed();
 	double fontScale = profile->getFontPrintScale();

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -159,7 +159,7 @@ void RenumberDialog::renumberOnlySelected(bool selected)
 void RenumberDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
-		MainWindow::instance()->dive_list()->rememberSelection();
+		MainWindow::instance()->dive_list->rememberSelection();
 		// we remember a list from dive uuid to a new number
 		QVector<QPair<dive *, int>> renumberedDives;
 		int i;
@@ -205,7 +205,7 @@ void SetpointDialog::buttonClicked(QAbstractButton *button)
 		invalidate_dive_cache(current_dive);
 	}
 	mark_divelist_changed(true);
-	MainWindow::instance()->graphics()->replot();
+	MainWindow::instance()->graphics->replot();
 }
 
 SetpointDialog::SetpointDialog(QWidget *parent) : QDialog(parent),

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -159,7 +159,7 @@ void RenumberDialog::renumberOnlySelected(bool selected)
 void RenumberDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
-		MainWindow::instance()->dive_list->rememberSelection();
+		MainWindow::instance()->diveList->rememberSelection();
 		// we remember a list from dive uuid to a new number
 		QVector<QPair<dive *, int>> renumberedDives;
 		int i;

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -109,12 +109,12 @@ void TabDivePhotos::recalculateSelectedThumbnails()
 //TODO: This looks overly wrong. We shouldn't call MainWindow to retrieve the DiveList to add Images.
 void TabDivePhotos::addPhotosFromFile()
 {
-	MainWindow::instance()->dive_list->loadImages();
+	MainWindow::instance()->diveList->loadImages();
 }
 
 void TabDivePhotos::addPhotosFromURL()
 {
-	MainWindow::instance()->dive_list->loadWebImages();
+	MainWindow::instance()->diveList->loadWebImages();
 }
 
 void TabDivePhotos::removeAllPhotos()

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -109,12 +109,12 @@ void TabDivePhotos::recalculateSelectedThumbnails()
 //TODO: This looks overly wrong. We shouldn't call MainWindow to retrieve the DiveList to add Images.
 void TabDivePhotos::addPhotosFromFile()
 {
-	MainWindow::instance()->dive_list()->loadImages();
+	MainWindow::instance()->dive_list->loadImages();
 }
 
 void TabDivePhotos::addPhotosFromURL()
 {
-	MainWindow::instance()->dive_list()->loadWebImages();
+	MainWindow::instance()->dive_list->loadWebImages();
 }
 
 void TabDivePhotos::removeAllPhotos()

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -293,7 +293,7 @@ void MainTab::updateTextLabels(bool showUnits)
 void MainTab::enableEdition(EditMode newEditMode)
 {
 	const bool isTripEdit = MainWindow::instance() &&
-		MainWindow::instance()->dive_list()->selectedTrips().count() == 1;
+		MainWindow::instance()->dive_list->selectedTrips().count() == 1;
 
 	if (((newEditMode == DIVE || newEditMode == NONE) && current_dive == NULL) || editMode != NONE)
 		return;
@@ -317,7 +317,7 @@ void MainTab::enableEdition(EditMode newEditMode)
 	}
 
 	ui.editDiveSiteButton->setEnabled(false);
-	MainWindow::instance()->dive_list()->setEnabled(false);
+	MainWindow::instance()->dive_list->setEnabled(false);
 	MainWindow::instance()->setEnabledToolbar(false);
 	MainWindow::instance()->enterEditState();
 	ui.tabWidget->setTabEnabled(2, false);
@@ -384,7 +384,7 @@ void MainTab::updateDiveInfo(bool clear)
 	ui.location->refreshDiveSiteCache();
 	EditMode rememberEM = editMode;
 	// don't execute this while adding / planning a dive
-	if (editMode == ADD || editMode == MANUALLY_ADDED_DIVE || MainWindow::instance()->graphics()->isPlanner())
+	if (editMode == ADD || editMode == MANUALLY_ADDED_DIVE || MainWindow::instance()->graphics->isPlanner())
 		return;
 	if (!isEnabled() && !clear )
 		setEnabled(true);
@@ -441,7 +441,7 @@ void MainTab::updateDiveInfo(bool clear)
 		localTime.setTimeSpec(Qt::UTC);
 		ui.dateEdit->setDate(localTime.date());
 		ui.timeEdit->setTime(localTime.time());
-		if (MainWindow::instance() && MainWindow::instance()->dive_list()->selectedTrips().count() == 1) {
+		if (MainWindow::instance() && MainWindow::instance()->dive_list->selectedTrips().count() == 1) {
 			// Remember the tab selected for last dive
 			if (lastSelectedDive)
 				lastTabSelectedDive = ui.tabWidget->currentIndex();
@@ -453,7 +453,7 @@ void MainTab::updateDiveInfo(bool clear)
 			if (lastSelectedDive)
 				ui.tabWidget->setCurrentIndex(lastTabSelectedDiveTrip);
 			lastSelectedDive = false;
-			currentTrip = *MainWindow::instance()->dive_list()->selectedTrips().begin();
+			currentTrip = *MainWindow::instance()->dive_list->selectedTrips().begin();
 			// only use trip relevant fields
 			ui.divemaster->setVisible(false);
 			ui.DivemasterLabel->setVisible(false);
@@ -777,11 +777,11 @@ void MainTab::acceptChanges()
 		ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 		emit addDiveFinished();
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
-		MainWindow::instance()->dive_list()->setFocus();
+		MainWindow::instance()->dive_list->setFocus();
 		resetPallete();
 		displayed_dive.divetrip = nullptr; // Should not be necessary, just in case!
 		return;
-	} else if (MainWindow::instance() && MainWindow::instance()->dive_list()->selectedTrips().count() == 1) {
+	} else if (MainWindow::instance() && MainWindow::instance()->dive_list->selectedTrips().count() == 1) {
 		/* now figure out if things have changed */
 		if (displayedTrip.notes && !same_string(displayedTrip.notes, currentTrip->notes)) {
 			currentTrip->notes = copy_string(displayedTrip.notes);
@@ -949,27 +949,27 @@ void MainTab::acceptChanges()
 		mark_divelist_changed(true);
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
 	}
-	int scrolledBy = MainWindow::instance()->dive_list()->verticalScrollBar()->sliderPosition();
+	int scrolledBy = MainWindow::instance()->dive_list->verticalScrollBar()->sliderPosition();
 	resetPallete();
 	if (editMode == MANUALLY_ADDED_DIVE) {
-		MainWindow::instance()->dive_list()->reload(DiveTripModel::CURRENT, true);
+		MainWindow::instance()->dive_list->reload(DiveTripModel::CURRENT, true);
 		int newDiveNr = get_divenr(get_dive_by_uniq_id(addedId));
-		MainWindow::instance()->dive_list()->unselectDives();
-		MainWindow::instance()->dive_list()->selectDive(newDiveNr, true);
+		MainWindow::instance()->dive_list->unselectDives();
+		MainWindow::instance()->dive_list->selectDive(newDiveNr, true);
 		editMode = NONE;
 		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->graphics()->replot();
+		MainWindow::instance()->graphics->replot();
 	} else {
 		editMode = NONE;
 		if (do_replot)
-			MainWindow::instance()->graphics()->replot();
-		MainWindow::instance()->dive_list()->rememberSelection();
+			MainWindow::instance()->graphics->replot();
+		MainWindow::instance()->dive_list->rememberSelection();
 		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->dive_list()->restoreSelection();
+		MainWindow::instance()->dive_list->restoreSelection();
 	}
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
-	MainWindow::instance()->dive_list()->verticalScrollBar()->setSliderPosition(scrolledBy);
-	MainWindow::instance()->dive_list()->setFocus();
+	MainWindow::instance()->dive_list->verticalScrollBar()->setSliderPosition(scrolledBy);
+	MainWindow::instance()->dive_list->setFocus();
 	MainWindow::instance()->exitEditState();
 	cylindersModel->changed = false;
 	weightModel->changed = false;
@@ -1020,7 +1020,7 @@ void MainTab::rejectChanges()
 	// no harm done to call cancelPlan even if we were not in ADD or PLAN mode...
 	DivePlannerPointsModel::instance()->cancelPlan();
 	if(lastMode == ADD)
-		MainWindow::instance()->dive_list()->restoreSelection();
+		MainWindow::instance()->dive_list->restoreSelection();
 
 	// now make sure that the correct dive is displayed
 	if (current_dive)
@@ -1036,7 +1036,7 @@ void MainTab::rejectChanges()
 	// let's get the correct location back in view
 	MapWidget::instance()->centerOnDiveSite(get_dive_site_by_uuid(displayed_dive.dive_site_uuid));
 	// show the profile and dive info
-	MainWindow::instance()->graphics()->replot();
+	MainWindow::instance()->graphics->replot();
 	MainWindow::instance()->setEnabledToolbar(true);
 	MainWindow::instance()->exitEditState();
 	cylindersModel->changed = false;
@@ -1096,7 +1096,7 @@ void MainTab::on_duration_textChanged(const QString &text)
 	if (editMode == IGNORE || acceptingEdit == true)
 		return;
 	// parse this
-	MainWindow::instance()->graphics()->setReplot(false);
+	MainWindow::instance()->graphics->setReplot(false);
 	if (!isEditing())
 		enableEdition();
 	displayed_dive.dc.duration.seconds = parseDurationToSeconds(text);
@@ -1105,8 +1105,8 @@ void MainTab::on_duration_textChanged(const QString &text)
 	displayed_dive.dc.samples = 0;
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	markChangedWidget(ui.duration);
-	MainWindow::instance()->graphics()->setReplot(true);
-	MainWindow::instance()->graphics()->plotDive();
+	MainWindow::instance()->graphics->setReplot(true);
+	MainWindow::instance()->graphics->plotDive();
 
 }
 
@@ -1115,7 +1115,7 @@ void MainTab::on_depth_textChanged(const QString &text)
 	if (editMode == IGNORE || acceptingEdit == true)
 		return;
 	// don't replot until we set things up the way we want them
-	MainWindow::instance()->graphics()->setReplot(false);
+	MainWindow::instance()->graphics->setReplot(false);
 	if (!isEditing())
 		enableEdition();
 	displayed_dive.dc.maxdepth.mm = parseLengthToMm(text);
@@ -1124,8 +1124,8 @@ void MainTab::on_depth_textChanged(const QString &text)
 	displayed_dive.dc.samples = 0;
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	markChangedWidget(ui.depth);
-	MainWindow::instance()->graphics()->setReplot(true);
-	MainWindow::instance()->graphics()->plotDive();
+	MainWindow::instance()->graphics->setReplot(true);
+	MainWindow::instance()->graphics->plotDive();
 }
 
 void MainTab::on_airtemp_textChanged(const QString &text)
@@ -1144,7 +1144,7 @@ void MainTab::divetype_Changed(int index)
 	displayed_dc->divemode = (enum divemode_t) index;
 	update_setpoint_events(&displayed_dive, displayed_dc);
 	markChangedWidget(ui.DiveType);
-	MainWindow::instance()->graphics()->recalcCeiling();
+	MainWindow::instance()->graphics->recalcCeiling();
 }
 
 void MainTab::on_watertemp_textChanged(const QString &text)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -293,7 +293,7 @@ void MainTab::updateTextLabels(bool showUnits)
 void MainTab::enableEdition(EditMode newEditMode)
 {
 	const bool isTripEdit = MainWindow::instance() &&
-		MainWindow::instance()->dive_list->selectedTrips().count() == 1;
+		MainWindow::instance()->diveList->selectedTrips().count() == 1;
 
 	if (((newEditMode == DIVE || newEditMode == NONE) && current_dive == NULL) || editMode != NONE)
 		return;
@@ -317,7 +317,7 @@ void MainTab::enableEdition(EditMode newEditMode)
 	}
 
 	ui.editDiveSiteButton->setEnabled(false);
-	MainWindow::instance()->dive_list->setEnabled(false);
+	MainWindow::instance()->diveList->setEnabled(false);
 	MainWindow::instance()->setEnabledToolbar(false);
 	MainWindow::instance()->enterEditState();
 	ui.tabWidget->setTabEnabled(2, false);
@@ -441,7 +441,7 @@ void MainTab::updateDiveInfo(bool clear)
 		localTime.setTimeSpec(Qt::UTC);
 		ui.dateEdit->setDate(localTime.date());
 		ui.timeEdit->setTime(localTime.time());
-		if (MainWindow::instance() && MainWindow::instance()->dive_list->selectedTrips().count() == 1) {
+		if (MainWindow::instance() && MainWindow::instance()->diveList->selectedTrips().count() == 1) {
 			// Remember the tab selected for last dive
 			if (lastSelectedDive)
 				lastTabSelectedDive = ui.tabWidget->currentIndex();
@@ -453,7 +453,7 @@ void MainTab::updateDiveInfo(bool clear)
 			if (lastSelectedDive)
 				ui.tabWidget->setCurrentIndex(lastTabSelectedDiveTrip);
 			lastSelectedDive = false;
-			currentTrip = *MainWindow::instance()->dive_list->selectedTrips().begin();
+			currentTrip = *MainWindow::instance()->diveList->selectedTrips().begin();
 			// only use trip relevant fields
 			ui.divemaster->setVisible(false);
 			ui.DivemasterLabel->setVisible(false);
@@ -777,11 +777,11 @@ void MainTab::acceptChanges()
 		ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 		emit addDiveFinished();
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
-		MainWindow::instance()->dive_list->setFocus();
+		MainWindow::instance()->diveList->setFocus();
 		resetPallete();
 		displayed_dive.divetrip = nullptr; // Should not be necessary, just in case!
 		return;
-	} else if (MainWindow::instance() && MainWindow::instance()->dive_list->selectedTrips().count() == 1) {
+	} else if (MainWindow::instance() && MainWindow::instance()->diveList->selectedTrips().count() == 1) {
 		/* now figure out if things have changed */
 		if (displayedTrip.notes && !same_string(displayedTrip.notes, currentTrip->notes)) {
 			currentTrip->notes = copy_string(displayedTrip.notes);
@@ -949,13 +949,13 @@ void MainTab::acceptChanges()
 		mark_divelist_changed(true);
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
 	}
-	int scrolledBy = MainWindow::instance()->dive_list->verticalScrollBar()->sliderPosition();
+	int scrolledBy = MainWindow::instance()->diveList->verticalScrollBar()->sliderPosition();
 	resetPallete();
 	if (editMode == MANUALLY_ADDED_DIVE) {
-		MainWindow::instance()->dive_list->reload(DiveTripModel::CURRENT, true);
+		MainWindow::instance()->diveList->reload(DiveTripModel::CURRENT, true);
 		int newDiveNr = get_divenr(get_dive_by_uniq_id(addedId));
-		MainWindow::instance()->dive_list->unselectDives();
-		MainWindow::instance()->dive_list->selectDive(newDiveNr, true);
+		MainWindow::instance()->diveList->unselectDives();
+		MainWindow::instance()->diveList->selectDive(newDiveNr, true);
 		editMode = NONE;
 		MainWindow::instance()->refreshDisplay();
 		MainWindow::instance()->graphics->replot();
@@ -963,13 +963,13 @@ void MainTab::acceptChanges()
 		editMode = NONE;
 		if (do_replot)
 			MainWindow::instance()->graphics->replot();
-		MainWindow::instance()->dive_list->rememberSelection();
+		MainWindow::instance()->diveList->rememberSelection();
 		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->dive_list->restoreSelection();
+		MainWindow::instance()->diveList->restoreSelection();
 	}
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
-	MainWindow::instance()->dive_list->verticalScrollBar()->setSliderPosition(scrolledBy);
-	MainWindow::instance()->dive_list->setFocus();
+	MainWindow::instance()->diveList->verticalScrollBar()->setSliderPosition(scrolledBy);
+	MainWindow::instance()->diveList->setFocus();
 	MainWindow::instance()->exitEditState();
 	cylindersModel->changed = false;
 	weightModel->changed = false;
@@ -1020,7 +1020,7 @@ void MainTab::rejectChanges()
 	// no harm done to call cancelPlan even if we were not in ADD or PLAN mode...
 	DivePlannerPointsModel::instance()->cancelPlan();
 	if(lastMode == ADD)
-		MainWindow::instance()->dive_list->restoreSelection();
+		MainWindow::instance()->diveList->restoreSelection();
 
 	// now make sure that the correct dive is displayed
 	if (current_dive)

--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -91,7 +91,7 @@ void TagWidget::reparse()
 	 * Do not show the completer when not in edit mode - basically
 	 * this returns when we are accepting or discarding the changes.
 	 */
-	if (MainWindow::instance()->information()->isEditing() == false) {
+	if (MainWindow::instance()->information->isEditing() == false) {
 		return;
 	}
 
@@ -185,7 +185,7 @@ void TagWidget::keyPressEvent(QKeyEvent *e)
 	  }
 	}
 	if (e->key() == Qt::Key_Tab && lastFinishedTag) {		    // if we already end in comma, go to next/prev field
-		MainWindow::instance()->information()->nextInputField(e);   // by sending the key event to the MainTab widget
+		MainWindow::instance()->information->nextInputField(e);     // by sending the key event to the MainTab widget
 	} else if (e->key() == Qt::Key_Tab || e->key() == Qt::Key_Return) { // otherwise let's pretend this is a comma instead
 		QKeyEvent fakeEvent(e->type(), Qt::Key_Comma, e->modifiers(), QString(","));
 		keyPressEvent(&fakeEvent);

--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -91,7 +91,7 @@ void TagWidget::reparse()
 	 * Do not show the completer when not in edit mode - basically
 	 * this returns when we are accepting or discarding the changes.
 	 */
-	if (MainWindow::instance()->information->isEditing() == false) {
+	if (MainWindow::instance()->mainTab->isEditing() == false) {
 		return;
 	}
 
@@ -185,7 +185,7 @@ void TagWidget::keyPressEvent(QKeyEvent *e)
 	  }
 	}
 	if (e->key() == Qt::Key_Tab && lastFinishedTag) {		    // if we already end in comma, go to next/prev field
-		MainWindow::instance()->information->nextInputField(e);     // by sending the key event to the MainTab widget
+		MainWindow::instance()->mainTab->nextInputField(e);         // by sending the key event to the MainTab widget
 	} else if (e->key() == Qt::Key_Tab || e->key() == Qt::Key_Return) { // otherwise let's pretend this is a comma instead
 		QKeyEvent fakeEvent(e->type(), Qt::Key_Comma, e->modifiers(), QString(","));
 		keyPressEvent(&fakeEvent);

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -644,7 +644,7 @@ void MultiFilterSortModel::myInvalidate()
 #if !defined(SUBSURFACE_MOBILE)
 	int i;
 	struct dive *d;
-	DiveListView *dlv = MainWindow::instance()->dive_list();
+	DiveListView *dlv = MainWindow::instance()->dive_list;
 
 	divesDisplayed = 0;
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -644,7 +644,7 @@ void MultiFilterSortModel::myInvalidate()
 #if !defined(SUBSURFACE_MOBILE)
 	int i;
 	struct dive *d;
-	DiveListView *dlv = MainWindow::instance()->dive_list;
+	DiveListView *dlv = MainWindow::instance()->diveList;
 
 	divesDisplayed = 0;
 


### PR DESCRIPTION
The keeps track of different sub widgets needed by other parts
of the code, notably:
	MainTab
	PlannerDetails
	PlannerSettingsWidget
	ProfileWidget2
	DivePlannerWidget
	DiveListView
Access to these widgets was provided with accessor functions.
Now these functions were very weird: instead of simply returning
pointers that were stored in the class, they accessed a data
structure which describes the different application states.
But this data structure was "duck-typed", so there was an
implicit agreement at which position the pointers to the
widgets were put inside. The widgets were then down-cast by
the accessor functions. This might make sense if the individual
widgets could for some reason be replaced by other widgets
[dynamic plugins?], but even then it would be strange, as one
would expect to get a pointer to some base class.

Therefore, directly store the properly typed pointers to the
widgets and simply remove the accessor functions. Why bother?

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a small cleanup which removes "duck typing" in `MainWindow`. It touches a hairy part of the code though. The reason for this cleanup is that I want to add access to the dive-location edit widget outside of `MainWindow`'s constructor. But I couldn't be motivated to add one of those strange accessor-functions, which might have been useful at one point. But now, I think they just needlessly complicate things.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace widget-accessors by simple pointers
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
No.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
None.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
