### PR TITLE
Desktop: enable tab-changes-focus for TagWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: don't add dive-buddy or dive-master when tabbing through fields
 - Filter: don't recalculate all filters on dive list-modifying operations
 - Desktop: don't recalculate full dive list on dive list-modifying operations
 - Undo: implement undo/redo for all dive list-modifying operations

--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -26,6 +26,7 @@ TagWidget::TagWidget(QWidget *parent) : GroupedLineEdit(parent), m_completer(NUL
 		addColor(QColor(Qt::green).darker(120));
 		addColor(QColor(Qt::blue).darker(120));
 	} // light text. get a dark background.
+	setTabChangesFocus(true);
 	setFocusPolicy(Qt::StrongFocus);
 }
 


### PR DESCRIPTION
When tabbing through the dive-info screen, a dive-master and a
dive-buddy would be added. The reason is that pressing tab would
be interpreted as a text-input. Disable this behavior by calling
setTabChangesFocus(true) in the TagWidget constructor.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
There was a weird behavior on tabbing through the dive-info fields: an empty dive-buddy and a dive-master would be added, because TAB would be registered as text-input. This can be prevented by setting the tabChangesFocus flag.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder: see our previous discussion on the topic.