### PR TITLE
Dive site: remove displayed_dive_site object

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -18,7 +18,6 @@
  * it's used in the UI, but it seems to make the most sense to have it
  * here */
 struct dive displayed_dive;
-struct dive_site displayed_dive_site;
 
 struct tag_entry *g_tag_list = NULL;
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -439,7 +439,6 @@ struct dive_table {
 
 extern struct dive_table dive_table, downloadTable;
 extern struct dive displayed_dive;
-extern struct dive_site displayed_dive_site;
 extern unsigned int dc_number;
 extern struct dive *current_dive;
 #define current_dc (get_dive_dc(current_dive, dc_number))

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1677,7 +1677,6 @@ void clear_dive_file_data()
 		delete_dive_site(get_dive_site(0)->uuid);
 
 	clear_dive(&displayed_dive);
-	clear_dive_site(&displayed_dive_site);
 
 	reset_min_datafile_version();
 	saved_git_id = "";

--- a/core/divesite-helper.cpp
+++ b/core/divesite-helper.cpp
@@ -3,11 +3,11 @@
 #include "pref.h"
 #include "gettextfromc.h"
 
-QString constructLocationTags(struct dive_site *ds, bool for_maintab)
+QString constructLocationTags(struct taxonomy_data *taxonomy, bool for_maintab)
 {
 	QString locationTag;
 
-	if (!ds || !ds->taxonomy.nr)
+	if (!taxonomy->nr)
 		return locationTag;
 
 	/* Check if the user set any of the 3 geocoding categories */
@@ -33,9 +33,9 @@ QString constructLocationTags(struct dive_site *ds, bool for_maintab)
 	for (int i = 0; i < 3; i++) {
 		if (prefs.geocoding.category[i] == TC_NONE)
 			continue;
-		for (int j = 0; j < ds->taxonomy.nr; j++) {
-			if (ds->taxonomy.category[j].category == prefs.geocoding.category[i]) {
-				QString tag = ds->taxonomy.category[j].value;
+		for (int j = 0; j < taxonomy->nr; j++) {
+			if (taxonomy->category[j].category == prefs.geocoding.category[i]) {
+				QString tag = taxonomy->category[j].value;
 				if (!tag.isEmpty()) {
 					locationTag += connector + tag;
 					connector = " / ";

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -249,26 +249,6 @@ bool dive_site_is_empty(struct dive_site *ds)
 	       ds->longitude.udeg == 0);
 }
 
-void copy_dive_site_taxonomy(struct dive_site *orig, struct dive_site *copy)
-{
-	if (orig->taxonomy.category == NULL) {
-		free_taxonomy(&copy->taxonomy);
-	} else {
-		if (copy->taxonomy.category == NULL)
-			copy->taxonomy.category = alloc_taxonomy();
-		for (int i = 0; i < TC_NR_CATEGORIES; i++) {
-			if (i < copy->taxonomy.nr) {
-				free((void *)copy->taxonomy.category[i].value);
-				copy->taxonomy.category[i].value = NULL;
-			}
-			if (i < orig->taxonomy.nr) {
-				copy->taxonomy.category[i] = orig->taxonomy.category[i];
-				copy->taxonomy.category[i].value = copy_string(orig->taxonomy.category[i].value);
-			}
-		}
-		copy->taxonomy.nr = orig->taxonomy.nr;
-	}
-}
 void copy_dive_site(struct dive_site *orig, struct dive_site *copy)
 {
 	free(copy->name);
@@ -281,7 +261,7 @@ void copy_dive_site(struct dive_site *orig, struct dive_site *copy)
 	copy->notes = copy_string(orig->notes);
 	copy->description = copy_string(orig->description);
 	copy->uuid = orig->uuid;
-	copy_dive_site_taxonomy(orig, copy);
+	copy_taxonomy(&orig->taxonomy, &copy->taxonomy);
 }
 
 static void merge_string(char **a, char **b)

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -75,7 +75,7 @@ void merge_dive_sites(uint32_t ref, uint32_t *uuids, int count);
 
 #ifdef __cplusplus
 }
-QString constructLocationTags(struct dive_site *ds, bool for_maintab);
+QString constructLocationTags(struct taxonomy_data *taxonomy, bool for_maintab);
 
 #endif
 

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "taxonomy.h"
 #include "gettext.h"
+#include "subsurface-string.h"
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -38,6 +39,27 @@ void free_taxonomy(struct taxonomy_data *t)
 		free(t->category);
 		t->category = NULL;
 		t->nr = 0;
+	}
+}
+
+void copy_taxonomy(struct taxonomy_data *orig, struct taxonomy_data *copy)
+{
+	if (orig->category == NULL) {
+		free_taxonomy(copy);
+	} else {
+		if (copy->category == NULL)
+			copy->category = alloc_taxonomy();
+		for (int i = 0; i < TC_NR_CATEGORIES; i++) {
+			if (i < copy->nr) {
+				free((void *)copy->category[i].value);
+				copy->category[i].value = NULL;
+			}
+			if (i < orig->nr) {
+				copy->category[i] = orig->category[i];
+				copy->category[i].value = copy_string(orig->category[i].value);
+			}
+		}
+		copy->nr = orig->nr;
 	}
 }
 

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -41,6 +41,7 @@ struct taxonomy_data {
 
 struct taxonomy *alloc_taxonomy();
 void free_taxonomy(struct taxonomy_data *t);
+void copy_taxonomy(struct taxonomy_data *orig, struct taxonomy_data *copy);
 int taxonomy_index_for_category(struct taxonomy_data *t, enum taxonomy_category cat);
 const char *taxonomy_get_country(struct taxonomy_data *t);
 void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin);

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -19,6 +19,7 @@
 
 LocationInformationWidget::LocationInformationWidget(QWidget *parent) : QGroupBox(parent), modified(false)
 {
+	memset(&displayed_dive_site, 0, sizeof(displayed_dive_site));
 	ui.setupUi(this);
 	ui.diveSiteMessage->setCloseButtonVisible(false);
 
@@ -373,7 +374,7 @@ QVariant DiveLocationModel::data(const QModelIndex &index, int role) const
 		case Qt::DisplayRole:
 			return new_ds_value[index.row()];
 		case Qt::ToolTipRole:
-			return displayed_dive_site.uuid ?
+			return displayed_dive.dive_site_uuid ?
 				tr("Create a new dive site, copying relevant information from the current dive.") :
 				tr("Create a new dive site with this name");
 		case Qt::DecorationRole:

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -200,7 +200,6 @@ void LocationInformationWidget::acceptChanges()
 		LocationInformationModel::instance()->removeRow(get_divesite_idx(currentDs));
 		displayed_dive.dive_site_uuid = 0;
 	}
-	copy_dive_site(currentDs, &displayed_dive_site);
 	mark_divelist_changed(true);
 	resetState();
 }
@@ -210,9 +209,10 @@ void LocationInformationWidget::rejectChanges()
 	resetState();
 }
 
-void LocationInformationWidget::showEvent(QShowEvent *ev)
+void LocationInformationWidget::initFields(dive_site *ds)
 {
-	if (displayed_dive_site.uuid) {
+	if (ds) {
+		copy_dive_site(ds, &displayed_dive_site);
 		filter_model.set(displayed_dive_site.uuid, displayed_dive_site.latitude, displayed_dive_site.longitude);
 		updateLabels();
 		enableLocationButtons(dive_site_has_gps_location(&displayed_dive_site));
@@ -221,11 +221,11 @@ void LocationInformationWidget::showEvent(QShowEvent *ev)
 		if (m)
 			m->invalidate();
 	} else {
+		clear_dive_site(&displayed_dive_site);
 		filter_model.set(0, degrees_t{ 0 }, degrees_t{ 0 });
 		clearLabels();
 	}
 	MapWidget::instance()->prepareForGetDiveCoordinates(displayed_dive_site.uuid);
-	QGroupBox::showEvent(ev);
 }
 
 void LocationInformationWidget::markChangedWidget(QWidget *w)

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -3,6 +3,7 @@
 #define LOCATIONINFORMATION_H
 
 #include "core/units.h"
+#include "core/divesite.h"
 #include "ui_locationInformation.h"
 #include "qt-models/divelocationmodel.h"
 #include <stdint.h>
@@ -50,6 +51,7 @@ private:
 	bool modified;
 	QAction *acceptAction, *rejectAction;
 	GPSLocationInformationModel filter_model;
+	dive_site displayed_dive_site;
 };
 
 class DiveLocationFilterProxyModel : public QSortFilterProxyModel {

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -52,7 +52,7 @@ private:
 	bool modified;
 	QAction *acceptAction, *rejectAction;
 	GPSLocationInformationModel filter_model;
-	dive_site displayed_dive_site;
+	dive_site *diveSite;
 	taxonomy_data taxonomy;
 };
 

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -14,9 +14,9 @@ Q_OBJECT
 public:
 	LocationInformationWidget(QWidget *parent = 0);
 	bool eventFilter(QObject*, QEvent*) override;
+	void initFields(dive_site *ds);
 
 protected:
-	void showEvent(QShowEvent *);
 	void enableLocationButtons(bool enable);
 
 public slots:

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -4,6 +4,7 @@
 
 #include "core/units.h"
 #include "core/divesite.h"
+#include "core/taxonomy.h"
 #include "ui_locationInformation.h"
 #include "qt-models/divelocationmodel.h"
 #include <stdint.h>
@@ -52,6 +53,7 @@ private:
 	QAction *acceptAction, *rejectAction;
 	GPSLocationInformationModel filter_model;
 	dive_site displayed_dive_site;
+	taxonomy_data taxonomy;
 };
 
 class DiveLocationFilterProxyModel : public QSortFilterProxyModel {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -173,7 +173,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	profLayout->addWidget(profileWidget);
 	profileContainer->setLayout(profLayout);
 
-	LocationInformationWidget * diveSiteEdit = new LocationInformationWidget();
+	diveSiteEdit = new LocationInformationWidget(this);
 	connect(diveSiteEdit, &LocationInformationWidget::endEditDiveSite,
 			this, &MainWindow::setDefaultState);
 	connect(diveSiteEdit, SIGNAL(endEditDiveSite()), this, SLOT(refreshDisplay()));
@@ -445,7 +445,9 @@ void MainWindow::setStateProperties(const QByteArray& state, const PropertyList&
 	stateProperties[state] = PropertiesForQuadrant(tl, tr, bl, br);
 }
 
-void MainWindow::on_actionDiveSiteEdit_triggered() {
+void MainWindow::on_actionDiveSiteEdit_triggered()
+{
+	diveSiteEdit->initFields(get_dive_site_for_dive(&displayed_dive));
 	setApplicationState("EditDiveSite");
 }
 
@@ -957,7 +959,6 @@ void MainWindow::setupForAddAndPlan(const char *model)
 {
 	// clean out the dive and give it an id and the correct dc model
 	clear_dive(&displayed_dive);
-	clear_dive_site(&displayed_dive_site);
 	displayed_dive.id = dive_getUniqID();
 	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
 	displayed_dive.dc.model = strdup(model); // don't translate! this is stored in the XML file

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -214,6 +214,7 @@ private:
 	void enterState(CurrentState);
 	bool filesAsArguments;
 	UpdateManager *updateManager;
+	LocationInformationWidget *diveSiteEdit;
 
 	bool plannerStateClean();
 	void setupForAddAndPlan(const char *model);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -418,7 +418,7 @@ void MainTab::updateDiveInfo(bool clear)
 		ds = get_dive_site_by_uuid(displayed_dive.dive_site_uuid);
 		if (ds) {
 			ui.location->setCurrentDiveSiteUuid(ds->uuid);
-			ui.locationTags->setText(constructLocationTags(ds, true));
+			ui.locationTags->setText(constructLocationTags(&ds->taxonomy, true));
 		} else {
 			ui.location->clear();
 			ui.locationTags->clear();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -419,11 +419,9 @@ void MainTab::updateDiveInfo(bool clear)
 		if (ds) {
 			ui.location->setCurrentDiveSiteUuid(ds->uuid);
 			ui.locationTags->setText(constructLocationTags(ds, true));
-			copy_dive_site(ds, &displayed_dive_site);
 		} else {
 			ui.location->clear();
 			ui.locationTags->clear();
-			clear_dive_site(&displayed_dive_site);
 		}
 
 		// Subsurface always uses "local time" as in "whatever was the local time at the location"
@@ -657,10 +655,8 @@ MainTab::EditMode MainTab::getEditMode() const
 void MainTab::refreshDisplayedDiveSite()
 {
 	struct dive_site *ds = get_dive_site_for_dive(&displayed_dive);
-	if (ds) {
-		copy_dive_site(ds, &displayed_dive_site);
+	if (ds)
 		ui.location->setCurrentDiveSiteUuid(ds->uuid);
-	}
 }
 
 // when this is called we already have updated the current_dive and know that it exists
@@ -906,9 +902,6 @@ void MainTab::acceptChanges()
 		// so let's make sure here that our data is consistent now that we have handled the
 		// dive sites
 		displayed_dive.dive_site_uuid = current_dive->dive_site_uuid;
-		struct dive_site *ds = get_dive_site_by_uuid(displayed_dive.dive_site_uuid);
-		if (ds)
-			copy_dive_site(ds, &displayed_dive_site);
 
 		// each dive that was selected might have had the temperatures in its active divecomputer changed
 		// so re-populate the temperatures - easiest way to do this is by calling fixup_dive

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -656,9 +656,10 @@ MainTab::EditMode MainTab::getEditMode() const
 
 void MainTab::refreshDisplayedDiveSite()
 {
-	if (displayed_dive_site.uuid) {
-		copy_dive_site(get_dive_site_by_uuid(displayed_dive_site.uuid), &displayed_dive_site);
-		ui.location->setCurrentDiveSiteUuid(displayed_dive_site.uuid);
+	struct dive_site *ds = get_dive_site_for_dive(&displayed_dive);
+	if (ds) {
+		copy_dive_site(ds, &displayed_dive_site);
+		ui.location->setCurrentDiveSiteUuid(ds->uuid);
 	}
 }
 

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -415,20 +415,11 @@ void MainTab::updateDiveInfo(bool clear)
 
 	if (!clear) {
 		struct dive_site *ds = NULL;
-		// if we are showing a dive and editing it, let's refer to the displayed_dive_site as that
-		// already may contain changes, otherwise start with the dive site referred to by the displayed
-		// dive
-		if (rememberEM == DIVE) {
-			ds = &displayed_dive_site;
-		} else {
-			ds = get_dive_site_by_uuid(displayed_dive.dive_site_uuid);
-			if (ds)
-				copy_dive_site(ds, &displayed_dive_site);
-		}
-
+		ds = get_dive_site_by_uuid(displayed_dive.dive_site_uuid);
 		if (ds) {
 			ui.location->setCurrentDiveSiteUuid(ds->uuid);
 			ui.locationTags->setText(constructLocationTags(ds, true));
+			copy_dive_site(ds, &displayed_dive_site);
 		} else {
 			ui.location->clear();
 			ui.locationTags->clear();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -693,8 +693,6 @@ uint32_t MainTab::updateDiveSite(uint32_t pickedUuid, dive *d)
 
 	newDs = get_dive_site_by_uuid(pickedUuid);
 
-	// Copy everything from the displayed_dive_site, so we have the latitude, longitude, notes, etc.
-	// The user *might* be using wrongly the 'choose dive site' just to edit the name of it, sigh.
 	if (origDs) {
 		if(createdNewDive) {
 			copy_dive_site(origDs, newDs);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is the final part of a sub-series that removes the `displayed_dive_site` object. This makes it distinctly easier to replace dive-site uuids by pointers. Indeed, the `displayed_dive_site` object is replaced by a pointer.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove external updates to `displayed_dive_site`
2) Make `displayed_dive_site` local to `LocationInformationWidget`
3) Don't write taxonomy and GPS data into `displayed_dive_site`
4) Replace `displayed_dive_site` by pointer to edited site.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This introduces a pointer to the LocationInformationWidget in Mainwindow according to the simplified scheme in #1777 instead of doing the weird fetch from application state descriptor array.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
