### PR TITLE
Autogroup only when selected

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1023,7 +1023,8 @@ dive_trip_t *get_dives_to_autogroup(int start, int *from, int *to, bool *allocat
 }
 
 /*
- * Walk the dives from the oldest dive, and see if we can autogroup them
+ * Walk the dives from the oldest dive, and see if we can autogroup them.
+ * But only do this when the user selected autogrouping.
  */
 void autogroup_dives(void)
 {
@@ -1031,6 +1032,9 @@ void autogroup_dives(void)
 	dive_trip_t *trip;
 	int i, j;
 	bool alloc;
+
+	if (!autogroup)
+		return;
 
 	for(i = 0; (trip = get_dives_to_autogroup(i, &from, &to, &alloc)) != NULL; i = to) {
 		/* If this was newly allocated, add trip to list */

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -612,8 +612,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 	if (!parse_file(fileNamePtr.data(), &dive_table))
 		setCurrentFile(fileNamePtr.data());
 	process_loaded_dives();
-	if (autogroup)
-		autogroup_dives();
+	autogroup_dives();
 	Command::clear();
 	hideProgressBar();
 	refreshDisplay();
@@ -1713,8 +1712,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 		parse_file(fileNamePtr.data(), &table);
 	}
 	process_imported_dives(&table, false, false);
-	if (autogroup)
-		autogroup_dives();
+	autogroup_dives();
 	Command::clear();
 	refreshDisplay();
 }
@@ -1738,8 +1736,7 @@ void MainWindow::loadFiles(const QStringList fileNames)
 	hideProgressBar();
 	updateRecentFiles();
 	process_loaded_dives();
-	if (autogroup)
-		autogroup_dives();
+	autogroup_dives();
 	Command::clear();
 
 	refreshDisplay();

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -174,8 +174,7 @@ void DiveImportedModel::recordDives()
 	}
 
 	process_imported_dives(diveTable, true, true);
-	if (autogroup)
-		autogroup_dives();
+	autogroup_dives();
 }
 
 QHash<int, QByteArray> DiveImportedModel::roleNames() const {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Comits f427226b3b and 43c3885249f of the undo series introduced 2 calls of autogroup_dives() without checking the autogroup global boolean. This is a bug. An import from DC (for example) then triggers an autogrouping, the divelist is autogrouped, and the UI button is off.

This commit solves this. I've chosen for a guard in the autogroup_dives() that now is a no-op when called when the user did not select autogrouping. In addition, simplified the other calls to this function, as we do
not need to check before calling any more.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
bug introduced in  f427226b3b and 43c3885249f 

### Documentation change:
No

### Mentions:
@bstoeger