### PR TITLE
Desktop: Enable next/prev DCs only for applicable dives

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -457,6 +457,13 @@ void MainWindow::enableDisableCloudActions()
 	ui.actionCloudstoragesave->setEnabled(prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED);
 }
 
+void MainWindow::enableDisableOtherDCsActions()
+{
+	bool nr = number_of_computers(current_dive) > 1;
+	ui.actionNextDC->setEnabled(nr);
+	ui.actionPreviousDC->setEnabled(nr);
+}
+
 void MainWindow::setDefaultState() {
 	setApplicationState("Default");
 	if (mainTab->getEditMode() != MainTab::NONE) {
@@ -530,6 +537,7 @@ void MainWindow::selectionChanged()
 		graphics->plotDive(nullptr, false, true);
 		mainTab->updateDiveInfo();
 		configureToolbar();
+		enableDisableOtherDCsActions();
 		MapWidget::instance()->reload();
 	}
 }

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -77,6 +77,7 @@ public:
 	bool inPlanner();
 	NotificationWidget *getNotificationWidget();
 	void enableDisableCloudActions();
+	void enableDisableOtherDCsActions();
 	void setCheckedActionFilterTags(bool checked);
 	void enterEditState();
 	void exitEditState();


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Does not solve any problem, but might help users that are confused about the next/prev DC menu items, to select a different profile for the currently selected dive. So, enable these menu items only for dives where more than one DC is used.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl

### Additional information:
Yes, trivial.
