### PR TITLE
Two more tiny parser-related cleanups.

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1202,7 +1202,6 @@ static void match_standard_cylinder(cylinder_type_t *type)
 	type->description = p;
 }
 
-
 /*
  * There are two ways to give cylinder size information:
  *  - total amount of gas in cuft (depends on working pressure and physical size)
@@ -1215,8 +1214,6 @@ static void match_standard_cylinder(cylinder_type_t *type)
  */
 static void sanitize_cylinder_type(cylinder_type_t *type)
 {
-	double volume_of_air, volume;
-
 	/* If we have no working pressure, it had *better* be just a physical size! */
 	if (!type->workingpressure.mbar)
 		return;
@@ -1224,15 +1221,6 @@ static void sanitize_cylinder_type(cylinder_type_t *type)
 	/* No size either? Nothing to go on */
 	if (!type->size.mliter)
 		return;
-
-	if (xml_parsing_units.volume == CUFT) {
-		double bar = type->workingpressure.mbar / 1000.0;
-		/* confusing - we don't really start from ml but millicuft !*/
-		volume_of_air = cuft_to_l(type->size.mliter);
-		/* milliliters at 1 atm: not corrected for compressibility! */
-		volume = volume_of_air / bar_to_atm(bar);
-		type->size.mliter = lrint(volume);
-	}
 
 	/* Ok, we have both size and pressure: try to match a description */
 	match_standard_cylinder(type);

--- a/core/dive.h
+++ b/core/dive.h
@@ -427,7 +427,6 @@ extern void unregister_trip(dive_trip_t *trip);
 extern void free_trip(dive_trip_t *trip);
 
 extern const struct units SI_units, IMPERIAL_units;
-extern struct units xml_parsing_units;
 
 extern const struct units *get_units(void);
 extern int run_survey, verbose, quit, force_root;

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -35,7 +35,7 @@ int last_xml_version = -1;
 
 static xmlDoc *test_xslt_transforms(xmlDoc *doc, const char **params);
 
-struct units xml_parsing_units;
+static struct units xml_parsing_units;
 const struct units SI_units = SI_UNITS;
 const struct units IMPERIAL_units = IMPERIAL_UNITS;
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Two more tiny parser-related cleanups (dead-code removal + unglobalization of a variable). Looks obvious to me, but perhaps I'm missing something. Notably the `sanitize_cylinder_type()` function now looks a bit naked and I wonder if it should be folded into `match_standard_cylinder()`. But I'm not familiar enough with the whole `fixup_dive()` code to do that.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove dead code from `sanitize_cylinder_type()`
2) Un-globalize the now non-global `xml_parsing_units`
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
No.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
