### PR TITLE
Parser: fix leakage of dive-site and dive data

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -40,7 +40,6 @@ uint32_t get_dive_site_uuid_by_gps(degrees_t latitude, degrees_t longitude, stru
 	return 0;
 }
 
-
 /* to avoid a bug where we have two dive sites with different name and the same GPS coordinates
  * and first get the gps coordinates (reading a V2 file) and happen to get back "the other" name,
  * this function allows us to verify if a very specific name/GPS combination already exists */
@@ -167,16 +166,22 @@ bool is_dive_site_used(uint32_t uuid, bool select_only)
 	return found;
 }
 
+void free_dive_site(struct dive_site *ds)
+{
+	free(ds->name);
+	free(ds->notes);
+	free(ds->description);
+	free_taxonomy(&ds->taxonomy);
+	free(ds);
+}
+
 void delete_dive_site(uint32_t id)
 {
 	int nr = dive_site_table.nr;
 	for (int i = 0; i < nr; i++) {
 		struct dive_site *ds = get_dive_site(i);
 		if (ds->uuid == id) {
-			free(ds->name);
-			free(ds->notes);
-			free_taxonomy(&ds->taxonomy);
-			free(ds);
+			free_dive_site(ds);
 			if (nr - 1 > i)
 				memmove(&dive_site_table.dive_sites[i],
 					&dive_site_table.dive_sites[i+1],

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -56,6 +56,7 @@ void dive_site_table_sort();
 struct dive_site *alloc_or_get_dive_site(uint32_t uuid);
 int nr_of_dives_at_dive_site(uint32_t uuid, bool select_only);
 bool is_dive_site_used(uint32_t uuid, bool select_only);
+void free_dive_site(struct dive_site *ds);
 void delete_dive_site(uint32_t id);
 uint32_t create_dive_site(const char *name, timestamp_t divetime);
 uint32_t create_dive_site_from_current_dive(const char *name);

--- a/core/parse.c
+++ b/core/parse.c
@@ -228,8 +228,7 @@ void dive_site_end(void)
 		if (verbose > 3)
 			printf("completed dive site uuid %x8 name {%s}\n", ds->uuid, ds->name);
 	}
-	free_taxonomy(&cur_dive_site->taxonomy);
-	free(cur_dive_site);
+	free_dive_site(cur_dive_site);
 	cur_dive_site = NULL;
 }
 
@@ -254,7 +253,7 @@ void dive_end(void)
 	if (!cur_dive)
 		return;
 	if (!is_dive())
-		free(cur_dive);
+		free_dive(cur_dive);
 	else
 		record_dive_to_table(cur_dive, target_table);
 	cur_dive = NULL;


### PR DESCRIPTION
Dive site data was collected in "cur_dive_site", which was then
merged into an existing or a new dive site. But only the struct
dive_site pointed to by "cur_dive_site" and the taxonomy data
were freed, not the textual data such as name or description.
Therefore, split out the approrpriate free-ing from the
delete_dive_site() function and call that instead of a simple
free().

A similar situation occured for dives that would not be added
to the dive-table because they were deemed incomplete. Use
free_dive() here instead of a simple free() too.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A borderline bug-fix: the dive-site parsing was leaking memory of name and description. Likewise, but a much less common case, incomplete dives could perhaps leak data(?). This is all a bit hairy, but at least normal loading still seems to work.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) split out free_dive_site().
2) use free_dive_site() and free_dive() instead of plain free().
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
