### PR TITLE
Enable smtk-import windows build in containers

### DIFF
--- a/packaging/windows/smtk2ssrf-mxe-build.sh
+++ b/packaging/windows/smtk2ssrf-mxe-build.sh
@@ -162,6 +162,9 @@ fi
 		     --enable-shared=no \
 		     --disable-man \
 		     --disable-gmdb2
+# hack to make mdbtools build outsource
+ln -vs "$BUILDDIR"/mdbtools/include/mdbver.h "$BASEDIR"/mdbtools/include/mdbver.h
+
 make $JOBS >/dev/null && make install || \
 	echo -e "$RED---> Building mdbtools failed ...$LIGHT_GRAY Trying to build with precompiled mxe binaries$DEFAULT"
 

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -16,6 +16,7 @@ CURRENT_LIBFTDI="1.3"
 CURRENT_KIRIGAMI="8691651c1f0d09430416ba5fe2130647554b06a9"
 CURRENT_BREEZE_ICONS=""
 CURRENT_GRANTLEE="v5.0.0"
+CURRENT_MDBTOOLS="master"
 
 # Checkout library from git
 # Ensure specified version is checked out,
@@ -186,6 +187,9 @@ for package in "${PACKAGES[@]}" ; do
 			;;
 		grantlee)
 			git_checkout_library grantlee $CURRENT_GRANTLEE https://github.com/steveire/grantlee.git
+			;;
+		mdbtools)
+			git_checkout_library mdbtools $CURRENT_MDBTOOLS https://github.com/brianb/mdbtools.git
 			;;
 		*)
 			echo "unknown package \"$package\""

--- a/scripts/windows-container/after_success.sh
+++ b/scripts/windows-container/after_success.sh
@@ -25,5 +25,4 @@ wget -c https://raw.githubusercontent.com/dirkhh/uploadtool/master/upload.sh
 bash ./upload.sh ${TRAVIS_BUILD_DIR}/../win32/subsurface/subsurface*.exe*
 
 # upload smtk2ssrf
-cd ${TRAVIS_BUILD_DIR}/../win32/smtk-import
-bash ../subsurface/upload.sh smtk2ssrf*.exe*
+bash ./upload.sh ${TRAVIS_BUILD_DIR}/../win32/smtk-import/smtk2ssrf*.exe*

--- a/scripts/windows-container/after_success.sh
+++ b/scripts/windows-container/after_success.sh
@@ -24,7 +24,6 @@ cd ${TRAVIS_BUILD_DIR}
 wget -c https://raw.githubusercontent.com/dirkhh/uploadtool/master/upload.sh
 bash ./upload.sh ${TRAVIS_BUILD_DIR}/../win32/subsurface/subsurface*.exe*
 
-
 # upload smtk2ssrf
-#cd ${TRAVIS_BUILD_DIR}/../win32/smtk-import
-#bash ../subsurface/upload.sh smtk2ssrf*.exe*
+cd ${TRAVIS_BUILD_DIR}/../win32/smtk-import
+bash ../subsurface/upload.sh smtk2ssrf*.exe*

--- a/scripts/windows-container/before_install.sh
+++ b/scripts/windows-container/before_install.sh
@@ -37,7 +37,8 @@ mkdir -p win32
 docker run -v $PWD/win32:/win/win32 -v $PWD/subsurface:/win/subsurface --name=builder -w /win -d dirkhh/mxe-build-container:0.6 /bin/sleep 60m
 
 # for some reason this package was installed but still isn't there?
-docker exec -t builder apt-get install -y ca-certificates
+# hmmmm. The container doesn't seem to have libtool installed
+docker exec -t builder apt-get install -y ca-certificates libtool
 
 # now set up our other dependencies
 # these are either not available in MXE, or a version that's too old
@@ -46,17 +47,14 @@ docker exec -t builder bash subsurface/scripts/get-dep-lib.sh single . hidapi
 docker exec -t builder bash subsurface/scripts/get-dep-lib.sh single . googlemaps
 docker exec -t builder bash subsurface/scripts/get-dep-lib.sh single . grantlee
 
+# smtk2ssrf build
+docker exec -t builder bash subsurface/scripts/get-dep-lib.sh single . mdbtools
 
-# the rest we'll need when we enable smtk2ssrf
-
-#echo "Get mdbtools"
-#cd ${TRAVIS_BUILD_DIR}/..
-#git clone https://github.com/brianb/mdbtools.git
-
-# get prebuilt mxe libraries for mdbtools and glib.
+# get prebuilt static mxe libraries for glib.
 # do not overwrite upstream prebuilt mxe binaries if there is any coincidence.
-#wget https://www.dropbox.com/s/842skyusb96ii1u/mxe-static-minimal-994ad473.tar.xz
-#[[ ! -f mxe-static-minimal-994ad473.tar.xz ]] && exit 1
-#cd mxe
-#tar -xJf ../mxe-static-minimal-994ad473.tar.xz --skip-old-files
-#ls -al usr/
+echo -n "Downloading prebuilt static mxe ... "
+docker exec -t builder wget -q https://www.dropbox.com/s/2ahfkyi6rhbihtn/mxe-static-minimal-a08b3225.tar.xz
+echo -n "Untarring ... "
+docker exec -t builder tar -C /win/mxe -xJf mxe-static-minimal-a08b3225.tar.xz --skip-old-files
+echo "Done."
+docker exec -t builder ln -vs /win/mxe /usr/src/mxe

--- a/scripts/windows-container/in-container-build.sh
+++ b/scripts/windows-container/in-container-build.sh
@@ -14,5 +14,4 @@ mkdir -p win32
 cd win32
 bash -ex ../subsurface/packaging/windows/mxe-based-build.sh installer
 
-# re-enable this when smtk2ssrf is figured out
-#bash -ex ${TRAVIS_BUILD_DIR}/packaging/windows/smtk2ssrf-mxe-build.sh -i
+bash -ex ../subsurface/packaging/windows/smtk2ssrf-mxe-build.sh -a -i

--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -33,6 +33,7 @@ pkg_config_library(GLIB2 glib-2.0 REQUIRED)
 pkg_config_library(LIBGIT2 libgit2 REQUIRED)
 pkg_config_library(LIBMDB libmdb REQUIRED)
 pkg_config_library(LIBDC libdivecomputer REQUIRED)
+pkg_config_library(LIBFTDI libftdi1 QUIET)
 
 find_package(Qt5 REQUIRED COMPONENTS Core
 				     Concurrent


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Quite simple modifications to enable building smtk2ssrf windows package in containerized environment.
At this moment seems impossible to make a shared build of mdbtools (see [mxe's build matrix](https://mxe.cc/build-matrix.html)) so I've built a lighter prebuilt binaries tarball including just Glib-2.0 and its dependencies.
This way we relay on building mdbtools from source.
BTW, libftdi is included, as we are not building a lightweight subsurface in windows.  Curiously in regular windows build libftdi is excluded on purpose.

Changes have been tested in travis (except after_success.sh) and seem to work well. Sadly I haven't figured out yet how to fix the issues I'm having with grantlee and googlemaps in my system when running the container scripts.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
