### PR TITLE
Dive list: fix crash on dive import

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2130,7 +2130,8 @@ static void merge_weightsystem_info(weightsystem_t *res, const weightsystem_t *a
 {
 	if (!a->weight.grams)
 		a = b;
-	*res = *a;
+	res->weight = a->weight;
+	res->description = copy_string(a->description);
 }
 
 /* get_cylinder_idx_by_use(): Find the index of the first cylinder with a particular CCR use type.

--- a/core/dive.c
+++ b/core/dive.c
@@ -3475,7 +3475,7 @@ struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset,
 	MERGE_MAX(res, a, b, number);
 	MERGE_NONZERO(res, a, b, cns);
 	MERGE_NONZERO(res, a, b, visibility);
-	MERGE_NONZERO(res, a, b, picture_list);
+	STRUCTURED_LIST_COPY(struct picture, a->picture_list ? a->picture_list : b->picture_list, res->picture_list, copy_pl);
 	taglist_merge(&res->tag_list, a->tag_list, b->tag_list);
 	merge_cylinders(res, a, b, cylinders_map_a, cylinders_map_b);
 	merge_equipment(res, a, b);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1600,6 +1600,9 @@ void process_imported_dives(struct dive_table *import_table, bool prefer_importe
 	if (!sequence_changed)
 		try_to_renumber(preexisting);
 
+	/* We might have deleted the old selected dive.
+	 * Choose the newest dive as selected (if any) */
+	current_dive = dive_table.nr > 0 ? dive_table.dives[dive_table.nr - 1] : NULL;
 	mark_divelist_changed(true);
 }
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1507,6 +1507,7 @@ static bool try_to_merge_into(struct dive *dive_to_add, int idx, bool prefer_imp
 		add_dive_to_trip(merged, trip);
 	}
 	free_dive(old_dive);
+	remove_dive_from_trip(dive_to_add, false);
 	free_dive(dive_to_add);
 
 	return true;


### PR DESCRIPTION
In commit 8c2383b4952fa22d41745d29484462ed6a67112b dive merging was
changed to not modify the original dive. On import, dives were then
merged and the original deleted. The merge_weightsystem_info() was
not adapted accordingly (deep copy of string instead of pointer),
leading to a use-after-free crash.

Resolve this by doing a deep copy.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix use-after-free (see commit message).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Do a deep copy of the weight-system-description
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug introduced in current release cycle.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: This trivially fixes at least one crash condition, I will audit for more after work.