### PR TITLE
[RFC] ** TESTING DO NOT MERGE ** Core: don't overwrite next in copy_dc_renumber()

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -489,14 +489,24 @@ static void copy_dc(const struct divecomputer *sdc, struct divecomputer *ddc)
 
 static void dc_cylinder_renumber(struct dive *dive, struct divecomputer *dc, const int mapping[]);
 
-/* copy dive computer and renumber the cylinders */
+/* copy dive computer list and renumber the cylinders
+ * space for the first divecomputer is provided by the
+ * caller, the remainder is allocated */
 static void copy_dc_renumber(struct dive *d, const struct divecomputer *sdc, struct divecomputer *ddc, const int cylinders_map[])
 {
-	*ddc = *sdc;
-	ddc->model = copy_string(sdc->model);
-	copy_samples(sdc, ddc);
-	copy_events(sdc, ddc);
-	dc_cylinder_renumber(d, ddc, cylinders_map);
+	for (;;) {
+		*ddc = *sdc;
+		ddc->model = copy_string(sdc->model);
+		copy_samples(sdc, ddc);
+		copy_events(sdc, ddc);
+		dc_cylinder_renumber(d, ddc, cylinders_map);
+		if (!sdc->next)
+			break;
+		sdc = sdc->next;
+		ddc->next = calloc(1, sizeof(struct divecomputer));
+		ddc = ddc->next;
+	}
+	ddc->next = NULL;
 }
 
 /* copy an element in a list of pictures */


### PR DESCRIPTION
copy_dc_renumber() is an internal function to copy dive computers
and renumber the cylinders. Since the structure was copied this
would also copy the next pointer and thus effectively copy the
whole remaining list.

This meant that on dive-merge two dives shared the same computer
and if one of them is freed, use-after-free crashes would happen.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] Testing

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a test commit, in which I try to fix a crash reported by @janmulder. In the C-core I'm in full panic mode (what am I doing!?), so please have a close look. @janmulder: This fixes the crash you described, but I fear this is not @dirkhh's crash condition.

Is is correct to restore the ->next pointer?