### PR TITLE
deco: _really_ make sure the deco state is fully initialized

### DIFF
--- a/core/deco.c
+++ b/core/deco.c
@@ -540,6 +540,8 @@ void clear_vpmb_state(struct deco_state *ds) {
 void clear_deco(struct deco_state *ds, double surface_pressure)
 {
 	int ci;
+
+	memset(ds, 0, sizeof(*ds));
 	clear_vpmb_state(ds);
 	for (ci = 0; ci < 16; ci++) {
 		ds->tissue_n2_sat[ci] = (surface_pressure - ((in_planner() && (decoMode() == VPMB)) ? WV_PRESSURE_SCHREINER : WV_PRESSURE)) * N2_IN_AIR / 1000;


### PR DESCRIPTION
I incorrectly thought that 'ci_pointing_to_guiding_tissue' was the only
missing initialization, because that is the only one valgrind pointed at.

... that is, until I started looking at a few more dives, which showed
that there were other parts tht weren't initialized either, like

        double tolerated_by_tissue[16];
        double tissue_inertgas_saturation[16];
        double crushing_onset_tension[16];            // total inert gas tension in the t* moment

so just make sure to clear the whole data structure, to avoid any random
behavior due to uninitialized deco state.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
