### PR TITLE
Selection: always make newly selected dive the current dive

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1249,11 +1249,13 @@ struct dive *merge_two_dives(struct dive *a, struct dive *b)
 
 void select_dive(struct dive *dive)
 {
-	if (dive && !dive->selected) {
+	if (!dive)
+		return;
+	if (!dive->selected) {
 		dive->selected = 1;
 		amount_selected++;
-		current_dive = dive;
 	}
+	current_dive = dive;
 }
 
 void deselect_dive(struct dive *dive)


### PR DESCRIPTION
In select_dive(), the selected dive would only be made the
current dive, if it wasn't previously selected. If multiple
dives were selected and the user clicked on one of them which
is not the current dive, then the current dive would be
deselected and thus not be the current dive anymore. The
only remaining dive would not be made the current dive,
because it was already selected. End result: null dive shown.

Therefore, always make the selected dive the current dive,
even if it is already selected.

Fixes #1792

Reported-by: Jan Mulder <jlmulder@xs4all.nl>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the selection issue #1792 reported by @janmulder. See commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Always make selected dive current dive, even if already selected.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1792
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - introduced in current release cycle.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No - bug fix.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder: please check.