### PR TITLE
Cleanup: do proper resource management for struct divecomputer

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -4158,11 +4158,7 @@ void delete_current_divecomputer(void)
 		/* remove the first one, so copy the second one in place of the first and free the second one
 		 * be careful about freeing the no longer needed structures - since we copy things around we can't use free_dc()*/
 		struct divecomputer *fdc = dc->next;
-		free(dc->sample);
-		free((void *)dc->model);
-		free((void *)dc->serial);
-		free((void *)dc->fw_version);
-		free_events(dc->events);
+		free_dc_contents(dc);
 		memcpy(dc, fdc, sizeof(struct divecomputer));
 		free(fdc);
 	} else {

--- a/core/dive.c
+++ b/core/dive.c
@@ -515,6 +515,8 @@ static void copy_dc(const struct divecomputer *sdc, struct divecomputer *ddc)
 {
 	*ddc = *sdc;
 	ddc->model = copy_string(sdc->model);
+	ddc->serial = copy_string(sdc->serial);
+	ddc->fw_version = copy_string(sdc->fw_version);
 	copy_samples(sdc, ddc);
 	copy_events(sdc, ddc);
 	STRUCTURED_LIST_COPY(struct extra_data, sdc->extra_data, ddc->extra_data, copy_extra_data);
@@ -2976,6 +2978,8 @@ static void free_dc_contents(struct divecomputer *dc)
 {
 	free(dc->sample);
 	free((void *)dc->model);
+	free((void *)dc->serial);
+	free((void *)dc->fw_version);
 	free_events(dc->events);
 	STRUCTURED_LIST_FREE(struct extra_data, dc->extra_data, free_extra_data);
 }
@@ -3091,6 +3095,8 @@ static void copy_dive_computer(struct divecomputer *res, const struct divecomput
 {
 	*res = *a;
 	res->model = copy_string(a->model);
+	res->serial = copy_string(a->serial);
+	res->fw_version = copy_string(a->fw_version);
 	STRUCTURED_LIST_COPY(struct extra_data, a->extra_data, res->extra_data, copy_extra_data);
 	res->samples = res->alloc_samples = 0;
 	res->sample = NULL;
@@ -4154,6 +4160,8 @@ void delete_current_divecomputer(void)
 		struct divecomputer *fdc = dc->next;
 		free(dc->sample);
 		free((void *)dc->model);
+		free((void *)dc->serial);
+		free((void *)dc->fw_version);
 		free_events(dc->events);
 		memcpy(dc, fdc, sizeof(struct divecomputer));
 		free(fdc);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A number of elements of `struct divecomputer` were simply copied by pointer, as they were considered as "const" and never freed. Instead deep-copy and free them as appropriate. Lightly tested.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Copy / free extra_data.
2) Copy / free serial and fw_version.
3) Reuse free_dc_contents() function.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
None.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
