### PR TITLE
Parser: don't leak extra data key/value pairs

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -270,6 +270,9 @@ static void extra_data_end(void)
 	// don't save partial structures - we must have both key and value
 	if (cur_extra_data.key && cur_extra_data.value)
 		add_extra_data(get_dc(), cur_extra_data.key, cur_extra_data.value);
+	free((void *)cur_extra_data.key);
+	free((void *)cur_extra_data.value);
+	cur_extra_data.key = cur_extra_data.value = NULL;
 }
 
 static void weight(char *buffer, weight_t *weight)


### PR DESCRIPTION
On parsing of dive computer extra data, key/value pairs are stored
in global state. They are added to the dive computer with
add_extra_data(), which makes a copy of the string. The local
copies of the strings are never freed.

free() the strings after storing them. The data still leaks in case
of unfinished parsing of extra_data tags, but this will be
taken care of in a subsequent commit.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A simple leak-fix, see commit message. Looks obvious, but as usual the devil is in the details.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Free extra-data strings after adding them to the dive-computer.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
