### PR TITLE
Profile: show correct info box for multiple DCs

### DIFF
--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -240,8 +240,6 @@ void ToolTipItem::refresh(const QPointF &pos)
 	refreshTime.start();
 
 	int time = lrint(timeAxis->valueAt(pos));
-	if (time == lastTime)
-		return;
 
 	lastTime = time;
 	clear();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -828,6 +828,8 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures)
 		clearPictures();
 	else
 		plotPictures();
+
+	toolTipItem->refresh(mapToScene(mapFromGlobal(QCursor::pos())));
 #endif
 
 	// OK, how long did this take us? Anything above the second is way too long,
@@ -1066,7 +1068,8 @@ void ProfileWidget2::scrollViewTo(const QPoint &pos)
 void ProfileWidget2::mouseMoveEvent(QMouseEvent *event)
 {
 	QPointF pos = mapToScene(event->pos());
-	toolTipItem->refresh(pos);
+	toolTipItem->refresh(mapToScene(mapFromGlobal(QCursor::pos())));
+
 	if (zoomLevel == 0) {
 		QGraphicsView::mouseMoveEvent(event);
 	} else {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Update the dive info box when toggling the chosen DC using the keyboard. The keyboard toggle does not generate a mouse move event, so this data was not repainted. For this, a sub-optimization of not repainting when not moving the mouse had to be removed. This does not impact ant performance as 99.9999% of the calls of the repaint are caused by mouse movement anyway.

### Related issues:
Fixes: #1802

### Release note:
not needed IMHO
