### PR TITLE
Mobile filter

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -126,6 +126,8 @@ struct preferences {
 	int         o2consumption; // ml per min
 	int         pscr_ratio; // dump ratio times 1000
 	bool        use_default_file;
+	bool        filterFullTextNotes; // mobile only - include notes information in full text searh
+	bool        filterCaseSensitive; // mobile only - make fltering case sensitive
 
 	// ********** Geocoding **********
 	geocoding_prefs_t geocoding;

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -36,6 +36,9 @@ void qPrefGeneral::loadSync(bool doSync)
 	disk_o2consumption(doSync);
 	disk_pscr_ratio(doSync);
 	disk_use_default_file(doSync);
+	disk_filterFullTextNotes(doSync);
+	disk_filterCaseSensitive(doSync);
+
 	if (!doSync) {
 		load_diveshareExport_uid();
 		load_diveshareExport_private();
@@ -95,3 +98,7 @@ HANDLE_PREFERENCE_BOOL(General, "use_default_file", use_default_file);
 HANDLE_PROP_QSTRING(General, "diveshareExport/uid", diveshareExport_uid);
 
 HANDLE_PROP_BOOL(General, "diveshareExport/private", diveshareExport_private);
+
+HANDLE_PREFERENCE_BOOL(General, "filterFullTextNotes", filterFullTextNotes);
+
+HANDLE_PREFERENCE_BOOL(General, "filterCaseSensitive", filterCaseSensitive);

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -20,6 +20,8 @@ class qPrefGeneral : public QObject {
 	Q_PROPERTY(bool use_default_file READ use_default_file WRITE set_use_default_file NOTIFY use_default_fileChanged);
 	Q_PROPERTY(QString diveshareExport_uid READ diveshareExport_uid WRITE set_diveshareExport_uid NOTIFY diveshareExport_uidChanged);
 	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged);
+	Q_PROPERTY(bool filterFullTextNotes READ filterFullTextNotes WRITE set_filterFullTextNotes NOTIFY filterFullTextNotesChanged)
+	Q_PROPERTY(bool filterCaseSensitive READ filterCaseSensitive WRITE set_filterCaseSensitive NOTIFY filterCaseSensitiveChanged)
 
 public:
 	qPrefGeneral(QObject *parent = NULL);
@@ -44,6 +46,8 @@ public:
 	static bool use_default_file() { return prefs.use_default_file; }
 	static QString diveshareExport_uid() { return st_diveshareExport_uid; }
 	static bool diveshareExport_private() { return st_diveshareExport_private; }
+	static bool filterFullTextNotes() { return prefs.filterFullTextNotes; }
+	static bool filterCaseSensitive() { return prefs.filterCaseSensitive; }
 
 public slots:
 	static void set_auto_recalculate_thumbnails(bool value);
@@ -59,6 +63,8 @@ public slots:
 	static void set_use_default_file(bool value);
 	static void set_diveshareExport_uid(const QString& value);
 	static void set_diveshareExport_private(bool value);
+	static void set_filterFullTextNotes(bool value);
+	static void set_filterCaseSensitive(bool value);
 
 signals:
 	void auto_recalculate_thumbnailsChanged(bool value);
@@ -74,6 +80,8 @@ signals:
 	void use_default_fileChanged(bool value);
 	void diveshareExport_uidChanged(const QString& value);
 	void diveshareExport_privateChanged(bool value);
+	void filterFullTextNotesChanged(bool value);
+	void filterCaseSensitiveChanged(bool value);
 
 private:
 	static void disk_auto_recalculate_thumbnails(bool doSync);
@@ -87,6 +95,8 @@ private:
 	static void disk_o2consumption(bool doSync);
 	static void disk_pscr_ratio(bool doSync);
 	static void disk_use_default_file(bool doSync);
+	static void disk_filterFullTextNotes(bool doSync);
+	static void disk_filterCaseSensitive(bool doSync);
 
 	// class variables are load only
 	static void load_diveshareExport_uid();

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -438,5 +438,5 @@ QStringList DiveObjectHelper::firstGas() const
 // for a full text search / filter function
 QString DiveObjectHelper::fullText() const
 {
-	return trip() + location() + buddy() + divemaster() + suit() + tags();
+	return trip() + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags() + ":-:" + notes();
 }

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -434,3 +434,9 @@ QStringList DiveObjectHelper::firstGas() const
 	}
 	return gas;
 }
+
+// for a full text search / filter function
+QString DiveObjectHelper::fullText() const
+{
+	return trip() + location() + buddy() + divemaster() + suit() + tags();
+}

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -438,5 +438,10 @@ QStringList DiveObjectHelper::firstGas() const
 // for a full text search / filter function
 QString DiveObjectHelper::fullText() const
 {
-	return trip() + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags() + ":-:" + notes();
+	return fullTextNoNotes() + ":-:" + notes();
+}
+
+QString DiveObjectHelper::fullTextNoNotes() const
+{
+	return trip() + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
 }

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -49,6 +49,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
+	Q_PROPERTY(QString fullText READ fullText CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
 	~DiveObjectHelper();
@@ -93,6 +94,7 @@ public:
 	QStringList startPressure() const;
 	QStringList endPressure() const;
 	QStringList firstGas() const;
+	QString fullText() const;
 
 private:
 	struct dive *m_dive;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -50,6 +50,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
 	Q_PROPERTY(QString fullText READ fullText CONSTANT)
+	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive = NULL);
 	~DiveObjectHelper();
@@ -95,6 +96,7 @@ public:
 	QStringList endPressure() const;
 	QStringList firstGas() const;
 	QString fullText() const;
+	QString fullTextNoNotes() const;
 
 private:
 	struct dive *m_dive;

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -100,6 +100,8 @@ struct preferences default_prefs = {
 	.auto_recalculate_thumbnails = true,
 	.extract_video_thumbnails = true,
 	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
+	.filterCaseSensitive = false,
+	.filterFullTextNotes = true,
 };
 
 int run_survey;

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -20,6 +20,8 @@ Kirigami.ScrollablePage {
 	property int horizontalPadding: Kirigami.Units.gridUnit / 2 - Kirigami.Units.smallSpacing  + 1
 	property string activeTrip
 	property bool showBusy: false
+	property QtObject diveListModel: diveModel
+	property string numShownText
 
 	supportsRefreshing: true
 	onRefreshingChanged: {
@@ -409,7 +411,6 @@ Kirigami.ScrollablePage {
 				anchors.right: parent.right
 				anchors.leftMargin: Kirigami.Units.gridUnit / 2
 				anchors.rightMargin: Kirigami.Units.gridUnit / 2
-				onVisibleChanged: numShown.text = diveModel.shown()
 				Controls.TextField  {
 					id: sitefilter
 					z: 10
@@ -424,7 +425,6 @@ Kirigami.ScrollablePage {
 						diveModel.setFilter(text)
 						console.log("back from setFilter")
 						showBusy = false
-						numShown.text = diveModel.shown()
 					}
 					onEnabledChanged: {
 						// reset the filter when it gets toggled
@@ -438,10 +438,7 @@ Kirigami.ScrollablePage {
 					id: numShown
 					z: 10
 					verticalAlignment: Text.AlignVCenter
-					// when this is first rendered, the model is still empty, so
-					// instead of having a misleading 0 here, just don't show a count
-					// it gets set whenever visibility or the search text changes
-					text: ""
+					text: numShownText
 				}
 			}
 		}
@@ -452,7 +449,7 @@ Kirigami.ScrollablePage {
 		anchors.fill: parent
 		opacity: 1.0 - startPage.opacity
 		visible: opacity > 0
-		model: diveModel
+		model: page.diveListModel
 		currentIndex: -1
 		delegate: diveDelegate
 		header: filterHeader

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -362,7 +362,7 @@ Kirigami.ScrollablePage {
 		anchors.fill: parent
 		horizontalAlignment: Text.AlignHCenter
 		verticalAlignment: Text.AlignVCenter
-		text: qsTr("No dives in dive list")
+		text: diveListModel ? qsTr("No dives in dive list") : qsTr("Please wait, filtering dive list")
 		visible: diveListView.visible && diveListView.count === 0
 	}
 	Component {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -415,6 +415,10 @@ Kirigami.ScrollablePage {
 					diveModel.setFilter(text)
 					numShown.text = diveModel.shown()
 				}
+				onVisibleChanged: {
+					// reset the filter when it gets toggled
+					text = ""
+				}
 			}
 			Controls.Label {
 				id: numShown

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -19,7 +19,6 @@ Kirigami.ScrollablePage {
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor
 	property int horizontalPadding: Kirigami.Units.gridUnit / 2 - Kirigami.Units.smallSpacing  + 1
 	property string activeTrip
-	property bool showBusy: false
 	property QtObject diveListModel: diveModel
 	property string numShownText
 
@@ -327,13 +326,6 @@ Kirigami.ScrollablePage {
 		}
 	}
 
-	Controls.BusyIndicator {
-		running: showBusy
-		z: 10
-		anchors.fill: parent
-		anchors.margins: Kirigami.Units.gridUnit
-	}
-
 	StartPage {
 		id: startPage
 		anchors.fill: parent
@@ -419,12 +411,9 @@ Kirigami.ScrollablePage {
 					text: ""
 					placeholderText: "Full text search"
 					onAccepted: {
-						showBusy = true
-						console.log("show busy")
 						rootItem.filterPattern = text
 						diveModel.setFilter(text)
 						console.log("back from setFilter")
-						showBusy = false
 					}
 					onEnabledChanged: {
 						// reset the filter when it gets toggled

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -363,14 +363,58 @@ Kirigami.ScrollablePage {
 		text: qsTr("No dives in dive list")
 		visible: diveListView.visible && diveListView.count === 0
 	}
-
 	Component {
 		id: filterHeader
 		RowLayout {
+			id: filterBar
+			states: [
+				State {
+					name: "isVisible"
+					when: rootItem.filterToggle
+					PropertyChanges { target: filterBar; visible: true; height: sitefilter.implicitHeight }
+				},
+				State {
+					name: "isHidden"
+					when: !rootItem.filterToggle
+					PropertyChanges { target: filterBar; visible: false; height: 0 }
+				}
+
+			]
+			transitions: [
+				Transition {
+					from: "isHidden"
+					to: "isVisible"
+					SequentialAnimation {
+						NumberAnimation {
+							property: "visible"
+							duration: 1
+						}
+						NumberAnimation {
+							property: "height"
+							duration: 200
+							easing.type: Easing.InOutQuad
+						}
+					}
+				},
+				Transition {
+					from: "isVisible"
+					to: "isHidden"
+					SequentialAnimation {
+						NumberAnimation {
+							property: "height"
+							duration: 200
+							easing.type: Easing.InOutQuad
+						}
+						NumberAnimation {
+							property: "visible"
+							duration: 1
+						}
+					}
+				}
+			]
+
 			anchors.left: parent.left
 			anchors.right: parent.right
-			visible: rootItem.filterToggle
-			height: rootItem.filterToggle ? sitefilter.implicitHeight * 1.1 : 0
 			Rectangle {
 				width: Kirigami.Units.gridUnit / 4
 			}
@@ -397,7 +441,6 @@ Kirigami.ScrollablePage {
 			Rectangle {
 				width: Kirigami.Units.regularSpacing
 			}
-
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -410,7 +410,7 @@ Kirigami.ScrollablePage {
 				verticalAlignment: TextInput.AlignVCenter
 				text: ""
 				placeholderText: "Full text search"
-				onTextChanged: {
+				onAccepted: {
 					rootItem.filterPattern = text
 					diveModel.setFilter(text)
 					numShown.text = diveModel.shown()

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -418,6 +418,9 @@ Kirigami.ScrollablePage {
 				onVisibleChanged: {
 					// reset the filter when it gets toggled
 					text = ""
+					if (visible) {
+						forceActiveFocus()
+					}
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -375,36 +375,24 @@ Kirigami.ScrollablePage {
 		id: filterHeader
 		RowLayout {
 			id: filterBar
+			enabled: rootItem.filterToggle
 			z: 5 //make sure it sits on top
 			states: [
 				State {
 					name: "isVisible"
 					when: rootItem.filterToggle
-					PropertyChanges { target: filterBar; visible: true; height: sitefilter.implicitHeight }
+					PropertyChanges { target: filterBar; height: sitefilter.implicitHeight }
 				},
 				State {
 					name: "isHidden"
 					when: !rootItem.filterToggle
-					PropertyChanges { target: filterBar; visible: false; height: 0 }
+					PropertyChanges { target: filterBar; height: 0 }
 				}
 
 			]
 			transitions: [
 				Transition {
-					from: "isHidden"
-					to: "isVisible"
-					SequentialAnimation {
-						NumberAnimation { property: "visible"; duration: 1 }
-						NumberAnimation { property: "height"; duration: 200; easing.type: Easing.InOutQuad }
-					}
-				},
-				Transition {
-					from: "isVisible"
-					to: "isHidden"
-					SequentialAnimation {
-						NumberAnimation { property: "height"; duration: 200; easing.type: Easing.InOutQuad }
-						NumberAnimation { property: "visible"; duration: 1 }
-					}
+					NumberAnimation { property: "height"; duration: 400; easing.type: Easing.InOutQuad }
 				}
 			]
 
@@ -428,7 +416,7 @@ Kirigami.ScrollablePage {
 					showBusy = false
 					numShown.text = diveModel.shown()
 				}
-				onVisibleChanged: {
+				onEnabledChanged: {
 					// reset the filter when it gets toggled
 					text = ""
 					if (visible) {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -26,10 +26,8 @@ Kirigami.ScrollablePage {
 	onRefreshingChanged: {
 		if (refreshing) {
 			if (prefs.credentialStatus === CloudStatus.CS_VERIFIED) {
-				console.log("User pulled down dive list - syncing with cloud storage")
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
-				console.log("done syncing, turn off spinner")
 				refreshing = false
 			} else {
 				console.log("sync with cloud storage requested, but credentialStatus is " + prefs.credentialStatus)
@@ -412,7 +410,6 @@ Kirigami.ScrollablePage {
 					placeholderText: "Full text search"
 					onAccepted: {
 						manager.setFilter(text)
-						console.log("back from setFilter")
 					}
 					onEnabledChanged: {
 						// reset the filter when it gets toggled
@@ -452,7 +449,6 @@ Kirigami.ScrollablePage {
 		section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
 		onModelChanged: {
 			numShownText = diveModel.shown()
-			console.log("update number shown to " + numShownText)
 		}
 		Connections {
 			target: detailsWindow

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -367,6 +367,7 @@ Kirigami.ScrollablePage {
 		id: filterHeader
 		RowLayout {
 			id: filterBar
+			z: 5 //make sure it sits on top
 			states: [
 				State {
 					name: "isVisible"

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -411,8 +411,7 @@ Kirigami.ScrollablePage {
 					text: ""
 					placeholderText: "Full text search"
 					onAccepted: {
-						rootItem.filterPattern = text
-						diveModel.setFilter(text)
+						manager.setFilter(text)
 						console.log("back from setFilter")
 					}
 					onEnabledChanged: {
@@ -451,6 +450,10 @@ Kirigami.ScrollablePage {
 		section.criteria: ViewSection.FullString
 		section.delegate: tripHeading
 		section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+		onModelChanged: {
+			numShownText = diveModel.shown()
+			console.log("update number shown to " + numShownText)
+		}
 		Connections {
 			target: detailsWindow
 			onCurrentIndexChanged: diveListView.currentIndex = detailsWindow.currentIndex

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -366,15 +366,38 @@ Kirigami.ScrollablePage {
 
 	Component {
 		id: filterHeader
-		Controls.TextField  {
-			id: sitefilter
-			visible: (opacity > 0) && rootItem.filterToggle
-			text: ""
-			placeholderText: "Dive site name"
-			onTextChanged: {
-				rootItem.filterPattern = text
-				diveModel.setFilter(text)
+		RowLayout {
+			anchors.left: parent.left
+			anchors.right: parent.right
+			visible: rootItem.filterToggle
+			height: rootItem.filterToggle ? sitefilter.implicitHeight * 1.1 : 0
+			Rectangle {
+				width: Kirigami.Units.gridUnit / 4
 			}
+			onVisibleChanged: numShown.text = diveModel.shown()
+			Controls.TextField  {
+				id: sitefilter
+				verticalAlignment: TextInput.AlignVCenter
+				text: ""
+				placeholderText: "Full text search"
+				onTextChanged: {
+					rootItem.filterPattern = text
+					diveModel.setFilter(text)
+					numShown.text = diveModel.shown()
+				}
+			}
+			Controls.Label {
+				id: numShown
+				verticalAlignment: Text.AlignVCenter
+				// when this is first rendered, the model is still empty, so
+				// instead of having a misleading 0 here, just don't show a count
+				// it gets set whenever visibility or the search text changes
+				text: ""
+			}
+			Rectangle {
+				width: Kirigami.Units.regularSpacing
+			}
+
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -373,9 +373,18 @@ Kirigami.ScrollablePage {
 	}
 	Component {
 		id: filterHeader
+		Rectangle {
+			id: filterRectangle
+			default property alias data: filterBar.data
+			implicitHeight: filterBar.implicitHeight
+			implicitWidth: filterBar.implicitWidth
+			height: filterBar.height
+			anchors.left: parent.left
+			anchors.right: parent.right
+			color: subsurfaceTheme.backgroundColor
+			enabled: rootItem.filterToggle
 		RowLayout {
 			id: filterBar
-			enabled: rootItem.filterToggle
 			z: 5 //make sure it sits on top
 			states: [
 				State {
@@ -403,6 +412,7 @@ Kirigami.ScrollablePage {
 			onVisibleChanged: numShown.text = diveModel.shown()
 			Controls.TextField  {
 				id: sitefilter
+				z: 10
 				verticalAlignment: TextInput.AlignVCenter
 				Layout.fillWidth: true
 				text: ""
@@ -426,12 +436,14 @@ Kirigami.ScrollablePage {
 			}
 			Controls.Label {
 				id: numShown
+				z: 10
 				verticalAlignment: Text.AlignVCenter
 				// when this is first rendered, the model is still empty, so
 				// instead of having a misleading 0 here, just don't show a count
 				// it gets set whenever visibility or the search text changes
 				text: ""
 			}
+		}
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -387,6 +387,7 @@ Kirigami.ScrollablePage {
 		currentIndex: -1
 		delegate: diveDelegate
 		header: filterHeader
+		headerPositioning: ListView.OverlayHeader
 		boundsBehavior: Flickable.DragOverBounds
 		maximumFlickVelocity: parent.height * 5
 		bottomMargin: Kirigami.Units.iconSizes.medium + Kirigami.Units.gridUnit

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -385,37 +385,23 @@ Kirigami.ScrollablePage {
 					from: "isHidden"
 					to: "isVisible"
 					SequentialAnimation {
-						NumberAnimation {
-							property: "visible"
-							duration: 1
-						}
-						NumberAnimation {
-							property: "height"
-							duration: 200
-							easing.type: Easing.InOutQuad
-						}
+						NumberAnimation { property: "visible"; duration: 1 }
+						NumberAnimation { property: "height"; duration: 200; easing.type: Easing.InOutQuad }
 					}
 				},
 				Transition {
 					from: "isVisible"
 					to: "isHidden"
 					SequentialAnimation {
-						NumberAnimation {
-							property: "height"
-							duration: 200
-							easing.type: Easing.InOutQuad
-						}
-						NumberAnimation {
-							property: "visible"
-							duration: 1
-						}
+						NumberAnimation { property: "height"; duration: 200; easing.type: Easing.InOutQuad }
+						NumberAnimation { property: "visible"; duration: 1 }
 					}
 				}
 			]
 
 			anchors.left: parent.left
 			anchors.right: parent.right
-			Rectangle {
+			Rectangle { // margins didn't work, but adding a rectangle did
 				width: Kirigami.Units.gridUnit / 4
 			}
 			onVisibleChanged: numShown.text = diveModel.shown()

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -336,6 +336,7 @@ Kirigami.ScrollablePage {
 					prefs.credentialStatus === CloudStatus.CS_NOCLOUD) {
 				page.actions.main = page.downloadFromDCAction
 				page.actions.right = page.addDiveAction
+				page.actions.left = page.filterToggleAction
 				page.title = qsTr("Dive list")
 				if (diveListView.count === 0)
 					showPassiveNotification(qsTr("Please tap the '+' button to add a dive (or download dives from a supported dive computer)"), 3000)
@@ -363,6 +364,20 @@ Kirigami.ScrollablePage {
 		visible: diveListView.visible && diveListView.count === 0
 	}
 
+	Component {
+		id: filterHeader
+		Controls.TextField  {
+			id: sitefilter
+			visible: (opacity > 0) && rootItem.filterToggle
+			text: ""
+			placeholderText: "Dive site name"
+			onTextChanged: {
+				rootItem.filterPattern = text
+				diveModel.setFilter(text)
+			}
+		}
+	}
+
 	ListView {
 		id: diveListView
 		anchors.fill: parent
@@ -371,6 +386,7 @@ Kirigami.ScrollablePage {
 		model: diveModel
 		currentIndex: -1
 		delegate: diveDelegate
+		header: filterHeader
 		boundsBehavior: Flickable.DragOverBounds
 		maximumFlickVelocity: parent.height * 5
 		bottomMargin: Kirigami.Units.iconSizes.medium + Kirigami.Units.gridUnit
@@ -417,6 +433,22 @@ Kirigami.ScrollablePage {
 		text: qsTr("Add dive")
 		onTriggered: {
 			startAddDive()
+		}
+	}
+
+	property QtObject filterToggleAction: Kirigami.Action {
+		icon {
+			name: ":icons/ic_filter_list"
+		}
+		text: qsTr("Filter dives")
+		onTriggered: {
+			rootItem.filterToggle = !rootItem.filterToggle
+			if (rootItem.filterToggle) {
+				diveModel.setFilter(rootItem.filterPattern)
+			} else {
+				diveModel.resetFilter()
+				rootItem.filterPattern = ""
+			}
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -383,67 +383,67 @@ Kirigami.ScrollablePage {
 			anchors.right: parent.right
 			color: subsurfaceTheme.backgroundColor
 			enabled: rootItem.filterToggle
-		RowLayout {
-			id: filterBar
-			z: 5 //make sure it sits on top
-			states: [
-				State {
-					name: "isVisible"
-					when: rootItem.filterToggle
-					PropertyChanges { target: filterBar; height: sitefilter.implicitHeight }
-				},
-				State {
-					name: "isHidden"
-					when: !rootItem.filterToggle
-					PropertyChanges { target: filterBar; height: 0 }
-				}
+			RowLayout {
+				id: filterBar
+				z: 5 //make sure it sits on top
+				states: [
+					State {
+						name: "isVisible"
+						when: rootItem.filterToggle
+						PropertyChanges { target: filterBar; height: sitefilter.implicitHeight }
+					},
+					State {
+						name: "isHidden"
+						when: !rootItem.filterToggle
+						PropertyChanges { target: filterBar; height: 0 }
+					}
 
-			]
-			transitions: [
-				Transition {
-					NumberAnimation { property: "height"; duration: 400; easing.type: Easing.InOutQuad }
-				}
-			]
+				]
+				transitions: [
+					Transition {
+						NumberAnimation { property: "height"; duration: 400; easing.type: Easing.InOutQuad }
+					}
+				]
 
-			anchors.left: parent.left
-			anchors.right: parent.right
-			anchors.leftMargin: Kirigami.Units.gridUnit / 2
-			anchors.rightMargin: Kirigami.Units.gridUnit / 2
-			onVisibleChanged: numShown.text = diveModel.shown()
-			Controls.TextField  {
-				id: sitefilter
-				z: 10
-				verticalAlignment: TextInput.AlignVCenter
-				Layout.fillWidth: true
-				text: ""
-				placeholderText: "Full text search"
-				onAccepted: {
-					showBusy = true
-					console.log("show busy")
-					rootItem.filterPattern = text
-					diveModel.setFilter(text)
-					console.log("back from setFilter")
-					showBusy = false
-					numShown.text = diveModel.shown()
-				}
-				onEnabledChanged: {
-					// reset the filter when it gets toggled
-					text = ""
-					if (visible) {
-						forceActiveFocus()
+				anchors.left: parent.left
+				anchors.right: parent.right
+				anchors.leftMargin: Kirigami.Units.gridUnit / 2
+				anchors.rightMargin: Kirigami.Units.gridUnit / 2
+				onVisibleChanged: numShown.text = diveModel.shown()
+				Controls.TextField  {
+					id: sitefilter
+					z: 10
+					verticalAlignment: TextInput.AlignVCenter
+					Layout.fillWidth: true
+					text: ""
+					placeholderText: "Full text search"
+					onAccepted: {
+						showBusy = true
+						console.log("show busy")
+						rootItem.filterPattern = text
+						diveModel.setFilter(text)
+						console.log("back from setFilter")
+						showBusy = false
+						numShown.text = diveModel.shown()
+					}
+					onEnabledChanged: {
+						// reset the filter when it gets toggled
+						text = ""
+						if (visible) {
+							forceActiveFocus()
+						}
 					}
 				}
+				Controls.Label {
+					id: numShown
+					z: 10
+					verticalAlignment: Text.AlignVCenter
+					// when this is first rendered, the model is still empty, so
+					// instead of having a misleading 0 here, just don't show a count
+					// it gets set whenever visibility or the search text changes
+					text: ""
+				}
 			}
-			Controls.Label {
-				id: numShown
-				z: 10
-				verticalAlignment: Text.AlignVCenter
-				// when this is first rendered, the model is still empty, so
-				// instead of having a misleading 0 here, just don't show a count
-				// it gets set whenever visibility or the search text changes
-				text: ""
-			}
-		}
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -510,12 +510,7 @@ Kirigami.ScrollablePage {
 		text: qsTr("Filter dives")
 		onTriggered: {
 			rootItem.filterToggle = !rootItem.filterToggle
-			if (rootItem.filterToggle) {
-				diveModel.setFilter(rootItem.filterPattern)
-			} else {
-				diveModel.resetFilter()
-				rootItem.filterPattern = ""
-			}
+			diveModel.resetFilter()
 		}
 	}
 

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 import QtQuick 2.6
-import QtQuick.Controls 2.2 as Controls
+import QtQuick.Controls 2.4 as Controls
 import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
@@ -19,6 +19,7 @@ Kirigami.ScrollablePage {
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor
 	property int horizontalPadding: Kirigami.Units.gridUnit / 2 - Kirigami.Units.smallSpacing  + 1
 	property string activeTrip
+	property bool showBusy: false
 
 	supportsRefreshing: true
 	onRefreshingChanged: {
@@ -324,6 +325,13 @@ Kirigami.ScrollablePage {
 		}
 	}
 
+	Controls.BusyIndicator {
+		running: showBusy
+		z: 10
+		anchors.fill: parent
+		anchors.margins: Kirigami.Units.gridUnit
+	}
+
 	StartPage {
 		id: startPage
 		anchors.fill: parent
@@ -412,8 +420,12 @@ Kirigami.ScrollablePage {
 				text: ""
 				placeholderText: "Full text search"
 				onAccepted: {
+					showBusy = true
+					console.log("show busy")
 					rootItem.filterPattern = text
 					diveModel.setFilter(text)
+					console.log("back from setFilter")
+					showBusy = false
 					numShown.text = diveModel.shown()
 				}
 				onVisibleChanged: {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -401,13 +401,13 @@ Kirigami.ScrollablePage {
 
 			anchors.left: parent.left
 			anchors.right: parent.right
-			Rectangle { // margins didn't work, but adding a rectangle did
-				width: Kirigami.Units.gridUnit / 4
-			}
+			anchors.leftMargin: Kirigami.Units.gridUnit / 2
+			anchors.rightMargin: Kirigami.Units.gridUnit / 2
 			onVisibleChanged: numShown.text = diveModel.shown()
 			Controls.TextField  {
 				id: sitefilter
 				verticalAlignment: TextInput.AlignVCenter
+				Layout.fillWidth: true
 				text: ""
 				placeholderText: "Full text search"
 				onAccepted: {
@@ -427,9 +427,6 @@ Kirigami.ScrollablePage {
 				// instead of having a misleading 0 here, just don't show a count
 				// it gets set whenever visibility or the search text changes
 				text: ""
-			}
-			Rectangle {
-				width: Kirigami.Units.regularSpacing
 			}
 		}
 	}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -478,6 +478,57 @@ Kirigami.ScrollablePage {
 			opacity: 0.5
 			Layout.fillWidth: true
 		}
+		GridLayout {
+			id: filterPrefs
+			columns: 2
+
+			Controls.Label {
+				text: qsTr("Filter preferences")
+				font.pointSize: subsurfaceTheme.headingPointSize
+				font.weight: Font.Light
+				color: subsurfaceTheme.textColor
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+				Layout.columnSpan: 2
+			}
+			Controls.Label {
+				text: qsTr("Include notes in full text filtering")
+				font.pointSize: subsurfaceTheme.regularPointSize
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+
+			SsrfSwitch {
+				id: fullTextNotes
+				checked: PrefGeneral.filterFullTextNotes
+				Layout.preferredWidth: gridWidth * 0.25
+				onClicked: {
+					PrefGeneral.set_filterFullTextNotes(checked)
+				}
+			}
+
+			Controls.Label {
+				text: qsTr("Match filter case sensitive")
+				font.pointSize: subsurfaceTheme.regularPointSize
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+
+			SsrfSwitch {
+				id: filterCaseSensitive
+				checked: PrefGeneral.filterCaseSensitive
+				Layout.preferredWidth: gridWidth * 0.25
+				onClicked: {
+					PrefGeneral.set_filterCaseSensitive(checked)
+				}
+			}
+
+		}
+
+		Rectangle {
+			color: subsurfaceTheme.darkerPrimaryColor
+			height: 1
+			opacity: 0.5
+			Layout.fillWidth: true
+		}
 
 		GridLayout {
 			id: developer

--- a/mobile-widgets/qml/icons/ic_filter_list_24px.svg
+++ b/mobile-widgets/qml/icons/ic_filter_list_24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/></svg>

--- a/mobile-widgets/qml/icons/ic_sort_24px.svg
+++ b/mobile-widgets/qml/icons/ic_sort_24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/></svg>

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -55,8 +55,20 @@ Kirigami.ApplicationWindow {
 	}
 	visible: false
 
-	// TODO: Verify where the opacity went to.
-	// opacity: 0
+	BusyIndicator {
+		id: busy
+		running: false
+		anchors.fill: parent
+		anchors.margins: Kirigami.Units.gridUnit
+	}
+
+	function showBusy() {
+		busy.running = true
+	}
+
+	function hideBusy() {
+		busy.running = false
+	}
 
 	function returnTopPage() {
 		for (var i=pageStack.depth; i>1; i--) {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -64,10 +64,12 @@ Kirigami.ApplicationWindow {
 
 	function showBusy() {
 		busy.running = true
+		diveList.diveListModel = null
 	}
 
 	function hideBusy() {
 		busy.running = false
+		diveList.diveListModel = diveModel
 	}
 
 	function returnTopPage() {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -32,6 +32,9 @@ Kirigami.ApplicationWindow {
 	property alias pluggedInDeviceName: manager.pluggedInDeviceName
 	property alias showPin: prefs.showPin
 	property alias defaultCylinderIndex: settingsWindow.defaultCylinderIndex
+	property bool filterToggle: false
+	property string filterPattern: ""
+
 	onNotificationTextChanged: {
 		if (notificationText != "") {
 			// there's a risk that we have a >5 second gap in update events;

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -58,6 +58,8 @@
 		<file>icons/ic_star_border.svg</file>
 		<file>icons/ic_sync.svg</file>
 		<file>icons/Pink_gps.svg</file>
+		<file alias="icons/ic_filter_list.svg">icons/ic_filter_list_24px.svg</file>
+		<file alias="icons/ic_sort.svg">icons/ic_sort_24px.svg</file>
 
 		<!-- ********** kirigami icons ********** -->
 		<file alias="icons/application-menu.svg">kirigami/icons/application-menu.svg</file>

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -15,6 +15,8 @@
 #include <QDateTime>
 #include <QClipboard>
 #include <QFile>
+#include <QtConcurrent>
+#include <QFuture>
 
 #include <QBluetoothLocalDevice>
 
@@ -1845,6 +1847,17 @@ void QMLManager::showDownloadPage(QString deviceString)
 	// inform the QML UI that it should show the download page
 	m_pluggedInDeviceName = strdup(qPrintable(name));
 	emit pluggedInDeviceNameChanged();
+}
+
+void QMLManager::setFilter(const QString filterText)
+{
+	// show that we are doing something, then do something in another thread in order not to block the UI
+	QMetaObject::invokeMethod(qmlWindow, "showBusy");
+	QFuture<void> future = QtConcurrent::run(QThreadPool::globalInstance(),
+						 [=]{
+		dlSortModel->setFilter(filterText);
+		QMetaObject::invokeMethod(qmlWindow, "hideBusy");
+	});
 }
 
 #if defined(Q_OS_ANDROID)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -136,6 +136,7 @@ public:
 	QStringList cylinderInit() const;
 	Q_INVOKABLE void setStatusbarColor(QColor color);
 	void btHostModeChange(QBluetoothLocalDevice::HostMode state);
+	QObject *qmlWindow;
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	void writeToAppLogFile(QString logText);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -88,6 +88,7 @@ public:
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
 	Q_INVOKABLE int getConnectionIndex(const QString &deviceSubstr);
 	Q_INVOKABLE void setGitLocalOnly(const bool &value);
+	Q_INVOKABLE void setFilter(const QString filterText);
 
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -10,8 +10,9 @@ DiveListSortModel::DiveListSortModel(QObject *parent) : QSortFilterProxyModel(pa
 
 void DiveListSortModel::setFilter(QString f)
 {
-	setFilterRole(DiveListModel::DiveSiteRole);
-	setFilterRegExp(f);
+	setFilterRole(DiveListModel::FullTextRole);
+	setFilterRegExp(QString(".*%1.*").arg(f));
+	setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
 
 void DiveListSortModel::resetFilter()
@@ -162,7 +163,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
-	case DiveSiteRole: return curr_dive->location();
+	case FullTextRole: return curr_dive->fullText();
 	}
 	return QVariant();
 
@@ -173,7 +174,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
-	roles[DiveSiteRole] = "site";
+	roles[FullTextRole] = "fulltext";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -8,6 +8,17 @@ DiveListSortModel::DiveListSortModel(QObject *parent) : QSortFilterProxyModel(pa
 
 }
 
+void DiveListSortModel::setFilter(QString f)
+{
+	setFilterRole(DiveListModel::DiveSiteRole);
+	setFilterRegExp(f);
+}
+
+void DiveListSortModel::resetFilter()
+{
+	setFilterRegExp("");
+}
+
 int DiveListSortModel::getDiveId(int idx)
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
@@ -151,6 +162,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
+	case DiveSiteRole: return curr_dive->location();
 	}
 	return QVariant();
 
@@ -161,6 +173,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
+	roles[DiveSiteRole] = "site";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -20,6 +20,11 @@ void DiveListSortModel::resetFilter()
 	setFilterRegExp("");
 }
 
+int DiveListSortModel::shown()
+{
+	return rowCount();
+}
+
 int DiveListSortModel::getDiveId(int idx)
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -169,6 +169,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
 	case FullTextRole: return curr_dive->fullText();
+	case FullTextNoNotesRole: return curr_dive->fullTextNoNotes();
 	}
 	return QVariant();
 
@@ -180,6 +181,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
 	roles[FullTextRole] = "fulltext";
+	roles[FullTextNoNotesRole] = "fulltextnonotes";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -2,6 +2,7 @@
 #include "qt-models/divelistmodel.h"
 #include "core/qthelper.h"
 #include <QDateTime>
+#include "core/settings/qPrefGeneral.h"
 
 DiveListSortModel::DiveListSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
@@ -10,9 +11,14 @@ DiveListSortModel::DiveListSortModel(QObject *parent) : QSortFilterProxyModel(pa
 
 void DiveListSortModel::setFilter(QString f)
 {
-	setFilterRole(DiveListModel::FullTextRole);
+	if (qPrefGeneral::filterFullTextNotes())
+		setFilterRole(DiveListModel::FullTextRole);
+	else
+		setFilterRole(DiveListModel::FullTextNoNotesRole);
+
 	setFilterRegExp(QString(".*%1.*").arg(f));
-	setFilterCaseSensitivity(Qt::CaseInsensitive);
+	if (!qPrefGeneral::filterCaseSensitive())
+		setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
 
 void DiveListSortModel::resetFilter()

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -30,7 +30,8 @@ public:
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
-		FullTextRole
+		FullTextRole,
+		FullTextNoNotesRole
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -17,6 +17,8 @@ public:
 public slots:
 	int getDiveId(int idx);
 	int getIdxForId(int id);
+	void setFilter(QString f);
+	void resetFilter();
 };
 
 class DiveListModel : public QAbstractListModel
@@ -26,7 +28,8 @@ public:
 
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
-		DiveDateRole
+		DiveDateRole,
+		DiveSiteRole
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -12,6 +12,7 @@ class DiveListSortModel : public QSortFilterProxyModel
 	Q_OBJECT
 public:
 	DiveListSortModel(QObject *parent = 0);
+	void setSourceModel(QAbstractItemModel *sourceModel);
 	Q_INVOKABLE void addAllDives();
 	Q_INVOKABLE void clear();
 public slots:
@@ -20,6 +21,12 @@ public slots:
 	void setFilter(QString f);
 	void resetFilter();
 	int shown();
+protected:
+	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
+private:
+	std::vector<bool> filteredRows;
+	QString filterString;
+	void updateFilterState();
 };
 
 class DiveListModel : public QAbstractListModel

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -19,6 +19,7 @@ public slots:
 	int getIdxForId(int id);
 	void setFilter(QString f);
 	void resetFilter();
+	int shown();
 };
 
 class DiveListModel : public QAbstractListModel

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -29,7 +29,7 @@ public:
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
-		DiveSiteRole
+		FullTextRole
 	};
 
 	static DiveListModel *instance();

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -119,7 +119,6 @@ void run_ui()
 	}
 	QQuickWindow *qml_window = qobject_cast<QQuickWindow *>(qqWindowObject);
 	qml_window->setIcon(QIcon(":subsurface-mobile-icon"));
-	qqWindowObject->setProperty("messageText", QVariant("Subsurface-mobile startup"));
 	qDebug() << "qqwindow devicePixelRatio" << qml_window->devicePixelRatio() << qml_window->screen()->devicePixelRatio();
 	QScreen *screen = qml_window->screen();
 	QObject::connect(qml_window, &QQuickWindow::screenChanged, QMLManager::instance(), &QMLManager::screenChanged);

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -130,6 +130,7 @@ void run_ui()
 
 	manager->setDevicePixelRatio(qml_window->devicePixelRatio(), qml_window->screen());
 	manager->dlSortModel = sortModel;
+	manager->qmlWindow = qqWindowObject;
 	manager->screenChanged(screen);
 	qDebug() << "qqwindow screen has ldpi/pdpi" << screen->logicalDotsPerInch() << screen->physicalDotsPerInch();
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is mainly code originally done by @janmulder  and then massaged into place by me.
It adds filtering to the mobile UI.
So far only tested on mobile-on-desktop. I'll look at it on device between dives later, but I wanted to get it out for the Europeans to play with.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add a UI action to toggle the filter (this is all Jan's work)
2) add a backend to apply the filtering (mostly Jan's)
3) changed that backend to do full text search instead of just dive sites
4) added a count of filtered dives to the header (and made it an overlay)

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
The count on top should be correct, but the count that is part of the trip headers is wrong - it shows the count of all dives (filtered or not) in the trip. That's a bit confusing and needs to be fixed.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
TODO

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
TODO

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder @jbygdell and anyone else who plays with the mobile UI
Which soon will be @mturkia :-)