### PR TITLE
Dive site: select dive site when entering edit mode

### DIFF
--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -302,6 +302,7 @@ void MapWidgetHelper::enterEditMode(quint32 uuid)
 	} else {
 		coord = exists->coordinate();
 	}
+	centerOnDiveSiteUUID(uuid);
 	emit coordinatesChanged(degrees_t { (int)lrint(coord.latitude() * 1000000.0) },
 				degrees_t { (int)lrint(coord.longitude() * 1000000.0) });
 	emit editModeChanged();


### PR DESCRIPTION
Commit 0aef04352a3210a6024f860758af466ea774dd5e made it impossible
to move new dive sites on the map. When entering dive-site-edit mode,
the filter would be instructed to show only dives of the corresponding
dive site [which didn't yet exist] and therefore all dive sites
on the map were deselected.

Fix this by explicitly centering on the dive site to be edited in
MapWidgetHelper::enterEditMode().

Fixes #1809

Reported-by: Jan Mulder <jlmulder@xs4all.nl>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug which made it impossible to move the dive site on the map. See commit message.

This one-liner seems obviously correct, but I wonder if the whole thing needs a bit of a refactoring. Notably, I'm not sure if it is a good idea that all other dive sites are hidden. Since usually I don't have precise GPS coordinates, I'd like to get the dive sites right at least in a relative manner (DS 1 was slightly to the east of DS2, etc.).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Center on dive site when going into edit mode.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1809.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed - bug introduced during release cycle(?).
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder reported the problem.