### PR TITLE
Dive list: update trip headers on filter-finish

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -289,7 +289,7 @@ void DiveListView::selectTrip(dive_trip_t *trip)
 	if (!trip)
 		return;
 
-	QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(model());
+	QAbstractItemModel *m = model();
 	QModelIndexList match = m->match(m->index(0, 0), DiveTripModel::TRIP_ROLE, QVariant::fromValue<void *>(trip), 2, Qt::MatchRecursive);
 	QItemSelectionModel::SelectionFlags flags;
 	if (!match.count())
@@ -374,7 +374,7 @@ void DiveListView::selectDive(int i, bool scrollto, bool toggle)
 {
 	if (i == -1)
 		return;
-	QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(model());
+	QAbstractItemModel *m = model();
 	QModelIndexList match = m->match(m->index(0, 0), DiveTripModel::DIVE_IDX, i, 2, Qt::MatchRecursive);
 	if (match.isEmpty())
 		return;
@@ -411,7 +411,7 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 		if ((d = get_dive(newSelection)) != NULL && !d->hidden_by_filter)
 			selectDive(newSelection);
 	}
-	QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(model());
+	QAbstractItemModel *m = model();
 	QModelIndexList idxList = m->match(m->index(0, 0), DiveTripModel::DIVE_IDX, get_divenr(current_dive), 2, Qt::MatchRecursive);
 	if (!idxList.isEmpty()) {
 		QModelIndex idx = idxList.first();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -29,8 +29,11 @@ public:
 	bool eventFilter(QObject *, QEvent *);
 	void unselectDives();
 	void clearTripSelection();
+	void selectDive(QModelIndex index, bool scrollto = false, bool toggle = false);
 	void selectDive(int dive_table_idx, bool scrollto = false, bool toggle = false);
 	void selectDives(const QList<int> &newDiveSelection);
+	void selectFirstDive();
+	QModelIndex indexOfFirstDive();
 	void rememberSelection();
 	void restoreSelection();
 	void contextMenuEvent(QContextMenuEvent *event);
@@ -60,6 +63,7 @@ slots:
 	void loadWebImages();
 	void diveSelectionChanged(const QVector<QModelIndex> &indexes, bool select);
 	void currentDiveChanged(QModelIndex index);
+	void filterFinished();
 private:
 	bool mouseClickSelection;
 	QList<int> expandedRows;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -75,6 +75,7 @@ private slots:
 	void divesSelected(dive_trip *trip, const QVector<dive *> &dives);
 	void divesDeselected(dive_trip *trip, const QVector<dive *> &dives);
 	void currentDiveChanged();
+	void filterFinished();
 private:
 	// The model has up to two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -641,10 +641,8 @@ void MultiFilterSortModel::filterChanged(const QModelIndex &from, const QModelIn
 
 void MultiFilterSortModel::myInvalidate()
 {
-#if !defined(SUBSURFACE_MOBILE)
 	int i;
 	struct dive *d;
-	DiveListView *dlv = MainWindow::instance()->diveList;
 
 	divesDisplayed = 0;
 
@@ -658,33 +656,11 @@ void MultiFilterSortModel::myInvalidate()
 
 	invalidateFilter();
 
-	// first make sure the trips are no longer shown as selected
-	// (but without updating the selection state of the dives... this just cleans
-	//  up an oddity in the filter handling)
-	// TODO: This should go internally to DiveList, to be triggered after a filter is due.
-	dlv->clearTripSelection();
-
-	// if we have no more selected dives, clean up the display - this later triggers us
-	// to pick one of the dives that are shown in the list as selected dive which is the
-	// natural behavior
-	if (amount_selected == 0) {
-		MainWindow::instance()->cleanUpEmpty();
-	} else {
-		// otherwise find the dives that should still be selected (the filter above unselected any
-		// dive that's no longer visible) and select them again
-		QList<int> curSelectedDives;
-		for_each_dive (i, d) {
-			if (d->selected)
-				curSelectedDives.append(get_divenr(d));
-		}
-		dlv->selectDives(curSelectedDives);
-	}
-
 	emit filterFinished();
 
-	if (curr_dive_site) {
-		dlv->expandAll();
-	}
+#if !defined(SUBSURFACE_MOBILE)
+	if (curr_dive_site)
+		MainWindow::instance()->diveList->expandAll();
 #endif
 }
 


### PR DESCRIPTION
On change of the filter, the headers of non-extended trips were not
updated. Therefore, on filter-finish-event loop over all trips
in DiveTripModel and signal data-changed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another fix for fallout from divelist changes: Trip headers were not updated if the trip was not expanded. Send data-changed events for all trips on filter-repopulation.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - introduced during this release cycle.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
