### PR TITLE
Two more potential leak fixes in parser

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -970,6 +970,8 @@ static void divinglog_place(char *place, uint32_t *uuid)
 		*uuid = create_dive_site(buffer, cur_dive->when);
 
 	// TODO: capture the country / city info in the taxonomy instead
+	free(city);
+	free(country);
 	city = NULL;
 	country = NULL;
 }
@@ -1197,7 +1199,7 @@ static void gps_picture_location(char *buffer, struct picture *pic)
 /* We're in the top-level dive xml. Try to convert whatever value to a dive value */
 static void try_to_fill_dive(struct dive *dive, const char *name, char *buf)
 {
-	char *hash;
+	char *hash = NULL;
 	start_match("dive", name, buf);
 
 	switch (import_source) {

--- a/core/parse.c
+++ b/core/parse.c
@@ -394,10 +394,16 @@ void userid_stop(void)
 	in_userid = false;
 }
 
+/*
+ * Copy whitespace-trimmed string. Warning: the passed in string will be freed,
+ * therefore make sure to only pass in to NULL-initialized pointers or pointers
+ * to owned strings
+ */
 void utf8_string(char *buffer, void *_res)
 {
 	char **res = _res;
 	int size;
+	free(*res);
 	size = trimspace(buffer);
 	if(size)
 		*res = strdup(buffer);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Two minor leak fixes in the parser. One of them is obvious (city and country), the other (utf8_string) is a bit hairy. It frees strings before overwriting them, which means that the caller must pass in NULL initialized structs or pointers to owned strings.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Free city and country after use
2) Free strings before overwriting them in utf8_string

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
