### PR TITLE
Show coordinates if no tags from reverse geolookup

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -419,6 +419,12 @@ void MainTab::updateDiveInfo(bool clear)
 		if (ds) {
 			ui.location->setCurrentDiveSiteUuid(ds->uuid);
 			ui.locationTags->setText(constructLocationTags(&ds->taxonomy, true));
+
+			if (ui.locationTags->text().isEmpty() && has_location(&ds->location)) {
+				const char *coords = printGPSCoords(&ds->location);
+				ui.locationTags->setText(coords);
+				free((void *)coords);
+			}
 		} else {
 			ui.location->clear();
 			ui.locationTags->clear();


### PR DESCRIPTION


Signed-off-by: Miika Turkia <miika.turkia@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This will display the dive site coordinates after the Location label if
there are no associated tags from reverse geolookup. Thus it'll be
clearer for users that we do have GPS location stored for the dive, and
might be able to see more easily if the recorded coordinates are
correct.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
