### PR TITLE
Mobile filter2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: add full text filtering of the dive list
 - Desktop: don't add dive-buddy or dive-master when tabbing through fields
 - Filter: don't recalculate all filters on dive list-modifying operations
 - Desktop: don't recalculate full dive list on dive list-modifying operations

--- a/core/dive.h
+++ b/core/dive.h
@@ -292,7 +292,7 @@ typedef struct dive_trip
 	char *location;
 	char *notes;
 	struct dive *dives;
-	int nrdives;
+	int nrdives, showndives;
 	/* Used by the io-routines to mark trips that have already been written. */
 	bool saved;
 	unsigned expanded : 1, selected : 1, autogen : 1, fixup : 1;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -891,6 +891,7 @@ void add_dive_to_trip(struct dive *dive, dive_trip_t *trip)
 		return;
 	remove_dive_from_trip(dive, false);
 	trip->nrdives++;
+	trip->showndives++;
 	dive->divetrip = trip;
 	dive->tripflag = ASSIGNED_TRIP;
 

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -81,6 +81,11 @@ int DiveObjectHelper::id() const
 	return m_dive->id;
 }
 
+struct dive *DiveObjectHelper::getDive() const
+{
+	return m_dive;
+}
+
 QString DiveObjectHelper::date() const
 {
 	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000*m_dive->when, Qt::UTC);

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -341,7 +341,7 @@ QString DiveObjectHelper::tripMeta() const
 	QString ret = EMPTY_DIVE_STRING;
 	struct dive_trip *dt = m_dive->divetrip;
 	if (dt) {
-		QString numDives = tr("(%n dive(s))", "", dt->nrdives);
+		QString numDives = tr("(%n dive(s))", "", dt->showndives);
 		QString title(dt->location);
 		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*dt->when, Qt::UTC);
 		QString firstMonth = firstTime.toString("MMM");

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -56,6 +56,7 @@ public:
 	~DiveObjectHelper();
 	int number() const;
 	int id() const;
+	struct dive *getDive() const;
 	int rating() const;
 	int visibility() const;
 	QString date() const;

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -21,6 +21,7 @@ public slots:
 	void setFilter(QString f);
 	void resetFilter();
 	int shown();
+	void updateDivesShownInTrips();
 protected:
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 private:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not sure if I should call this a bug fix or a new feature :-)
We now update the trip count on mobile to reflect filtering.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) two changes to core code: a new member in the dive trip structure to hold the number of dives shown (vs total nr of dives) in a trip
2) and the ability to get to the underlying dive structure from the DiveObjectHelper. This one I was worried about - one could see it as a hack. But then adding an accessor to get the dive_trip member seemed equally strange. And adding accessors to get to the showndives member of the trip was just ridiculous. I'm curious to hear what people think would be the right abstraction layer here
3) update the filter model to track how many dives of each trip are shown
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See comments in #1808 where this change is requested

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
That reminds me, I need to add an entry for the whole mobile filtering thingy

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
still to be done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder @jbygdell 

(I'm on a plane, connected via WiFi, 11km or so above the ground... I don't think it's a good idea for me to try and upload Android binaries...)