### PR TITLE
Dive site: fix editing of dive site

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -1062,6 +1062,7 @@ void DiveListView::filterFinished()
 	// If there are no more selected dives, select the first visible dive
 	if (!selectionModel()->hasSelection())
 		selectFirstDive();
+	emit diveListNotifier.selectionChanged();
 }
 
 QString DiveListView::lastUsedImageDir()


### PR DESCRIPTION
In commit 9829e49815de1b81b5c9848b71eaa810faab2bcf the dive
selection code was moved from the filter to the dive list.
As a consequence of that change, the selectionChanged signal
was not emitted anymore and therefore the map widget was not
informed of the new dive site list. This had funky effects on
the dive-site editing. Notably, changing the location would
move the map, but not update the flag.

Explicitly emit selectionChanged in filterFinished() to fix
dive site editing.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a regression introduced in 9829e49815de1b81b5c9848b71eaa810faab2bcf which made dive-site editing behave strangely. Notably, setting the GPS coordinates would move the map, but not the flag. Unfortunately, the dive-selection data-flow is still very convoluted. :(
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Explicitly emit selectionChanged signal in DiveListView::filterChanged to repopulate the map.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes regression introduced in 9829e49815de1b81b5c9848b71eaa810faab2bcf
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - introduced in current release cycle.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
