### PR TITLE
Cleanup: remove dead code in qthelper.cpp

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -23,9 +23,6 @@
 #include <QDebug>
 #include <QStandardPaths>
 #include <QJsonDocument>
-#include <QNetworkReply>
-#include <QNetworkRequest>
-#include <QNetworkAccessManager>
 #include <QNetworkProxy>
 #include <QDateTime>
 #include <QImageReader>
@@ -985,31 +982,6 @@ QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 	}
 	return ret;
 
-}
-
-extern "C" void reverseGeoLookup(degrees_t latitude, degrees_t longitude, uint32_t uuid)
-{
-	QNetworkRequest request;
-	QNetworkAccessManager *rgl = new QNetworkAccessManager();
-	request.setUrl(QString("http://open.mapquestapi.com/nominatim/v1/reverse.php?format=json&accept-language=%1&lat=%2&lon=%3")
-		       .arg(uiLanguage(NULL)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0));
-	request.setRawHeader("Accept", "text/json");
-	request.setRawHeader("User-Agent", getUserAgent().toUtf8());
-	QNetworkReply *reply = rgl->get(request);
-	QEventLoop loop;
-	QObject::connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
-	loop.exec();
-	QJsonParseError errorObject;
-	QJsonDocument jsonDoc = QJsonDocument::fromJson(reply->readAll(), &errorObject);
-	if (errorObject.error != QJsonParseError::NoError) {
-		qDebug() << errorObject.errorString();
-	} else {
-		QJsonObject obj = jsonDoc.object();
-		QJsonObject address = obj.value("address").toObject();
-		qDebug() << "found country:" << address.value("country").toString();
-		struct dive_site *ds = get_dive_site_by_uuid(uuid);
-		ds->notes = add_to_string(ds->notes, "countrytag: %s", qPrintable(address.value("country").toString()));
-	}
 }
 
 static QMutex hashOfMutex;


### PR DESCRIPTION
The reverseGeoLookup() function defined in qthelper.cpp has long
ago moved to its own compilation unit. It is not even defined in
the headers anymore. Remove it and the now unnecessary <QNetwork*>
includes.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Dead code removal. Nothing more to say, really.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove dead code from qthelper.cpp