### PR TITLE
Cleanup: remove declaration of unused signal

### DIFF
--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -40,7 +40,6 @@ private slots:
 	void updateLabels();
 	void updateLocationOnMap();
 signals:
-	void startEditDiveSite(uint32_t uuid);
 	void endEditDiveSite();
 	void startFilterDiveSite(uint32_t uuid);
 	void stopFilterDiveSite();


### PR DESCRIPTION
The last use of the LocationInformation::startEditDiveSite()
signal was removed in ff26ffe0d078a891cbc52afa7ffb59943644ad82.
Remove its declaration.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another trivial dead code removal. Nothing to say, sorry.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove declaration of unused signal.
