### PR TITLE
Implement custom sort function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- Import: Fix import of CSV files containing quotes
+- Desktop: Show coordinates if no tags from reverse geo lookup
+- Desktop: Sort on date in case of equal fields
+- Desktop: Indicate sort direction in list header
+- Desktop: Use defined sort-order when switching sort column
 - Fix a bug in planner for dives with manual gas changes.
 - Mobile: add full text filtering of the dive list
 - Desktop: don't add dive-buddy or dive-master when tabbing through fields

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -33,12 +33,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 	setItemDelegate(new DiveListDelegate(this));
 	setUniformRowHeights(true);
 	setItemDelegateForColumn(DiveTripModel::RATING, new StarWidgetsDelegate(this));
-	MultiFilterSortModel *model = MultiFilterSortModel::instance();
-	model->setSortRole(DiveTripModel::SORT_ROLE);
-	model->setFilterKeyColumn(-1); // filter all columns
-	model->setFilterCaseSensitivity(Qt::CaseInsensitive);
-	model->setSourceModel(DiveTripModel::instance());
-	setModel(model);
+	setModel(MultiFilterSortModel::instance());
 
 	setSortingEnabled(false);
 	setContextMenuPolicy(Qt::DefaultContextMenu);
@@ -503,8 +498,7 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 	header()->setSectionsClickable(true);
 	connect(header(), SIGNAL(sectionPressed(int)), this, SLOT(headerClicked(int)), Qt::UniqueConnection);
 
-	DiveTripModel *tripModel = DiveTripModel::instance();
-	tripModel->setLayout(layout);	// Note: setLayout() resets the whole model
+	MultiFilterSortModel::instance()->setLayout(layout);
 
 	if (!forceSort)
 		return;

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -479,8 +479,9 @@ void DiveListView::headerClicked(int i)
 		unselectDives();
 		if (currentLayout == DiveTripModel::TREE)
 			backupExpandedRows();
-		reload(newLayout, false);
+		currentLayout = newLayout;
 		currentOrder = Qt::DescendingOrder;
+		MultiFilterSortModel::instance()->setLayout(newLayout);
 		sortByColumn(i, currentOrder);
 		if (newLayout == DiveTripModel::TREE)
 			restoreExpandedRows();
@@ -490,7 +491,7 @@ void DiveListView::headerClicked(int i)
 	sortColumn = i;
 }
 
-void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
+void DiveListView::reload(DiveTripModel::Layout layout)
 {
 	if (layout == DiveTripModel::CURRENT)
 		layout = currentLayout;
@@ -498,9 +499,6 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 		currentLayout = layout;
 
 	MultiFilterSortModel::instance()->setLayout(layout);
-
-	if (!forceSort)
-		return;
 
 	sortByColumn(sortColumn, currentOrder);
 	if (amount_selected && current_dive != NULL)

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -47,6 +47,8 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 
 	header()->setStretchLastSection(true);
 	header()->setSortIndicatorShown(true);
+	header()->setSectionsClickable(true);
+	connect(header(), &QHeaderView::sectionPressed, this, &DiveListView::headerClicked);
 
 	installEventFilter(this);
 
@@ -494,9 +496,6 @@ void DiveListView::reload(DiveTripModel::Layout layout, bool forceSort)
 		layout = currentLayout;
 	else
 		currentLayout = layout;
-
-	header()->setSectionsClickable(true);
-	connect(header(), SIGNAL(sectionPressed(int)), this, SLOT(headerClicked(int)), Qt::UniqueConnection);
 
 	MultiFilterSortModel::instance()->setLayout(layout);
 

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -25,7 +25,7 @@ public:
 	void mouseDoubleClickEvent(QMouseEvent * event);
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 	void currentChanged(const QModelIndex &current, const QModelIndex &previous);
-	void reload(DiveTripModel::Layout layout, bool forceSort = true);
+	void reload(DiveTripModel::Layout layout);
 	bool eventFilter(QObject *, QEvent *);
 	void unselectDives();
 	void clearTripSelection();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -926,7 +926,7 @@ void MainTab::acceptChanges()
 	int scrolledBy = MainWindow::instance()->diveList->verticalScrollBar()->sliderPosition();
 	resetPallete();
 	if (editMode == MANUALLY_ADDED_DIVE) {
-		MainWindow::instance()->diveList->reload(DiveTripModel::CURRENT, true);
+		MainWindow::instance()->diveList->reload(DiveTripModel::CURRENT);
 		int newDiveNr = get_divenr(get_dive_by_uniq_id(addedId));
 		MainWindow::instance()->diveList->unselectDives();
 		MainWindow::instance()->diveList->selectDive(newDiveNr, true);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -320,9 +320,6 @@ DiveTripModel::DiveTripModel(QObject *parent) :
 	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModel::divesSelected);
 	connect(&diveListNotifier, &DiveListNotifier::divesDeselected, this, &DiveTripModel::divesDeselected);
 	connect(&diveListNotifier, &DiveListNotifier::currentDiveChanged, this, &DiveTripModel::currentDiveChanged);
-
-	// Update trip headers if filter finished
-	connect(MultiFilterSortModel::instance(), &MultiFilterSortModel::filterFinished, this, &DiveTripModel::filterFinished);
 }
 
 int DiveTripModel::columnCount(const QModelIndex&) const

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -55,6 +55,7 @@ public:
 	int rowCount(const QModelIndex &parent) const;
 	QModelIndex index(int row, int column, const QModelIndex &parent) const;
 	QModelIndex parent(const QModelIndex &index) const;
+	void filterFinished();
 signals:
 	// The propagation of selection changes is complex.
 	// The control flow of dive-selection goes:
@@ -74,7 +75,6 @@ private slots:
 	void divesSelected(dive_trip *trip, const QVector<dive *> &dives);
 	void divesDeselected(dive_trip *trip, const QVector<dive *> &dives);
 	void currentDiveChanged();
-	void filterFinished();
 private:
 	// The model has up to two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -34,7 +34,6 @@ public:
 		STAR_ROLE = Qt::UserRole + 1,
 		DIVE_ROLE,
 		TRIP_ROLE,
-		SORT_ROLE,
 		DIVE_IDX,
 		SELECTED_ROLE
 	};
@@ -56,6 +55,10 @@ public:
 	QModelIndex index(int row, int column, const QModelIndex &parent) const;
 	QModelIndex parent(const QModelIndex &index) const;
 	void filterFinished();
+
+	// Used for sorting. This is a bit of a layering violation, as sorting should be performed
+	// by the higher-up QSortFilterProxyModel, but it makes things so much easier!
+	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const;
 signals:
 	// The propagation of selection changes is complex.
 	// The control flow of dive-selection goes:

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -560,12 +560,12 @@ void LocationFilterModel::addName(const QString &newName)
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent),
 	divesDisplayed(0),
-	curr_dive_site(NULL)
+	curr_dive_site(NULL),
+	model(DiveTripModel::instance())
 {
-	setSortRole(DiveTripModel::SORT_ROLE);
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
-	setSourceModel(DiveTripModel::instance());
+	setSourceModel(model);
 }
 
 void MultiFilterSortModel::setLayout(DiveTripModel::Layout layout)
@@ -706,4 +706,10 @@ void MultiFilterSortModel::stopFilterDiveSite()
 {
 	curr_dive_site = NULL;
 	myInvalidate();
+}
+
+bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
+{
+	// Hand sorting down to the source model.
+	return model->lessThan(i1, i2);
 }

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -562,6 +562,16 @@ MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyMo
 	divesDisplayed(0),
 	curr_dive_site(NULL)
 {
+	setSortRole(DiveTripModel::SORT_ROLE);
+	setFilterKeyColumn(-1); // filter all columns
+	setFilterCaseSensitivity(Qt::CaseInsensitive);
+	setSourceModel(DiveTripModel::instance());
+}
+
+void MultiFilterSortModel::setLayout(DiveTripModel::Layout layout)
+{
+	DiveTripModel *tripModel = DiveTripModel::instance();
+	tripModel->setLayout(layout);	// Note: setLayout() resets the whole model
 }
 
 void MultiFilterSortModel::divesAdded(const QVector<dive *> &dives)
@@ -656,6 +666,8 @@ void MultiFilterSortModel::myInvalidate()
 
 	invalidateFilter();
 
+	// Tell the dive trip model to update the displayed-counts
+	DiveTripModel::instance()->filterFinished();
 	emit filterFinished();
 
 #if !defined(SUBSURFACE_MOBILE)

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -11,6 +11,7 @@
 
 struct dive;
 struct dive_trip;
+class DiveTripModel;
 
 class FilterModelBase : public QAbstractListModel {
 	Q_OBJECT
@@ -127,6 +128,7 @@ public:
 	void divesDeleted(const QVector<dive *> &dives);
 	bool showDive(const struct dive *d) const;
 	int divesDisplayed;
+	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
 public
 slots:
 	void myInvalidate();
@@ -142,6 +144,7 @@ private:
 	MultiFilterSortModel(QObject *parent = 0);
 	QList<FilterModelBase *> models;
 	struct dive_site *curr_dive_site;
+	DiveTripModel *model;
 };
 
 #endif

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -2,6 +2,8 @@
 #ifndef FILTERMODELS_H
 #define FILTERMODELS_H
 
+#include "divetripmodel.h" // For DiveTripModel::Layout. TODO: remove in due course
+
 #include <QStringListModel>
 #include <QSortFilterProxyModel>
 #include <stdint.h>
@@ -132,6 +134,7 @@ slots:
 	void startFilterDiveSite(struct dive_site *ds);
 	void stopFilterDiveSite();
 	void filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles);
+	void setLayout(DiveTripModel::Layout layout);
 
 signals:
 	void filterFinished();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Implement a custom sort function for more flexibility (and potential for optimization). I repeat the commit message of the major commit here:
```
The dive list was sorted using the default-sorter of
QSortFilterProxy model. This is mighty inflexible as it
considers only one column. This has the funky effect that
for rows with identical elements, the sort order depends
on the previous sorting.

Implement a lessThan() function in the MultiFilterSortModel,
which simply hands the sorting down to the actual model.
This might be considered a layering violation, but it makes
things so much easier.

Sadly, it seems like the column-to-be-sorted is transported
in the provided indices. Therefore, the comparison is chosen
using a switch for *every* comparison. It would seem much
more logical to set a function pointer once and use that.
Further investigations are necessary.

The new code uses the "strcasecmp" function instead of Qt's
string function. This might have effect on the collation
of non-ASCII UTF-8 strings. Let's see.
```
From a user's perspective, this provides stable sorting.
But note that the actual reason for this change is an attempt in splitting the `DiveTripModel` in two, viz. a Tree and a List mode.
 
RFC Material: This now uses `strcasecmp`. I am not sure if that is as "good" as Qt's string comparison / collation.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Change control flow to match data flow: core --> DiveTripModel --> MultiFilterSortModel --> DiveListView.
2) Detangle code in DiveListView.
3) Implement custom comparison function.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Probaby should do.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
