### PR TITLE
Fixed get_gas_at_time for equal times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix a bug in planner for dives with manual gas changes.
 - Mobile: add full text filtering of the dive list
 - Desktop: don't add dive-buddy or dive-master when tabbing through fields
 - Filter: don't recalculate all filters on dive list-modifying operations

--- a/core/dive.c
+++ b/core/dive.c
@@ -4447,7 +4447,7 @@ struct gasmix get_gasmix(const struct dive *dive, const struct divecomputer *dc,
 		res = gasmix;
 	}
 
-	while (ev && ev->time.seconds < time) {
+	while (ev && ev->time.seconds <= time) {
 		res = get_gasmix_from_event(dive, ev);
 		ev = get_next_event(ev->next, "gaschange");
 	}

--- a/core/dive.c
+++ b/core/dive.c
@@ -4433,6 +4433,7 @@ int dive_has_gps_location(const struct dive *dive)
 	return dive_site_has_gps_location(dive->dive_site);
 }
 
+/* When evaluated at the time of a gasswitch, this returns the new gas */
 struct gasmix get_gasmix(const struct dive *dive, const struct divecomputer *dc, int time, const struct event **evp, struct gasmix gasmix)
 {
 	const struct event *ev = *evp;
@@ -4456,6 +4457,7 @@ struct gasmix get_gasmix(const struct dive *dive, const struct divecomputer *dc,
 }
 
 /* get the gas at a certain time during the dive */
+/* If there is a gasswitch at that time, it returns the new gasmix */
 struct gasmix get_gasmix_at_time(const struct dive *d, const struct divecomputer *dc, duration_t time)
 {
 	const struct event *ev = NULL;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -173,7 +173,7 @@ static int calculate_otu(const struct dive *dive)
 		if (sample->setpoint.mbar) {
 			po2 = sample->setpoint.mbar;
 		} else {
-			int o2 = active_o2(dive, dc, sample->time);
+			int o2 = active_o2(dive, dc, psample->time);
 			po2 = lrint(o2 * depth_to_atm(sample->depth.mm, dive));
 		}
 		if (po2 >= 500)

--- a/dives/test51.xml
+++ b/dives/test51.xml
@@ -1,0 +1,76 @@
+<divelog program='subsurface' version='3'>
+<settings>
+  <autogroup state='1' />
+</settings>
+<divesites>
+</divesites>
+<dives>
+<trip date='2018-10-29' time='16:39:32'>
+<dive number='500' date='2018-10-29' time='16:39:32' duration='123:30 min'>
+  <notes>This dive demostrates a planner bug. Edit this dive in planner. If the dive turns red for a ceiling violation, there is a bug in detecting the correct gasmix at times.</notes>
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='55.0%' start='206.843 bar' end='87.703 bar' depth='21.0 m' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='30.0%' he='22.0%' start='206.843 bar' end='206.843 bar' use='not used' depth='42.0 m' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='31.0%' he='30.0%' start='206.843 bar' end='123.505 bar' depth='42.0 m' />
+  <cylinder size='24.0 l' workpressure='232.0 bar' description='D12 232 bar' o2='11.0%' he='60.0%' start='232.0 bar' end='95.597 bar' depth='135.0 m' />
+  <cylinder size='5.547 l' workpressure='206.843 bar' description='AL40' o2='100.0%' start='206.843 bar' end='93.141 bar' depth='6.0 m' />
+  <divecomputer model='planned dive' last-manual-time='25:00 min'>
+  <depth max='110.0 m' mean='24.543 m' />
+  <surface pressure='0.896 bar' />
+  <water salinity='1025 g/l' />
+  <event time='10:01 min' type='25' value='1966111' name='gaschange' cylinder='2' o2='31.0%' he='30.0%' />
+  <event time='14:01 min' type='25' value='3932171' name='gaschange' cylinder='3' o2='11.0%' he='60.0%' />
+  <event time='36:21 min' type='25' value='1966111' name='gaschange' cylinder='2' o2='31.0%' he='30.0%' />
+  <event time='49:21 min' type='11' value='55' name='gaschange' cylinder='0' o2='55.0%' />
+  <event time='80:21 min' type='11' value='100' name='gaschange' cylinder='4' o2='100.0%' />
+  <sample time='0:00 min' depth='0.0 m' pressure='206.843 bar' />
+  <sample time='0:47 min' depth='20.0 m' pressure='204.311 bar' />
+  <sample time='10:00 min' depth='20.0 m' pressure='158.839 bar' />
+  <sample time='10:01 min' depth='20.0 m' />
+  <sample time='14:00 min' depth='40.0 m' pressure='179.425 bar' />
+  <sample time='14:01 min' depth='40.0 m' />
+  <sample time='20:00 min' depth='110.0 m' pressure='189.19 bar' />
+  <sample time='25:00 min' depth='110.0 m' pressure='139.526 bar' />
+  <sample time='31:36 min' depth='51.0 m' pressure='109.055 bar' />
+  <sample time='32:00 min' depth='51.0 m' pressure='107.832 bar' />
+  <sample time='32:20 min' depth='48.0 m' pressure='106.839 bar' />
+  <sample time='34:00 min' depth='48.0 m' pressure='102.0 bar' />
+  <sample time='34:20 min' depth='45.0 m' pressure='101.059 bar' />
+  <sample time='36:00 min' depth='45.0 m' pressure='96.485 bar' />
+  <sample time='36:20 min' depth='42.0 m' pressure='95.597 bar' />
+  <sample time='36:21 min' depth='42.0 m' />
+  <sample time='37:20 min' depth='42.0 m' pressure='173.901 bar' />
+  <sample time='37:40 min' depth='39.0 m' pressure='172.088 bar' />
+  <sample time='38:00 min' depth='39.0 m' pressure='170.331 bar' />
+  <sample time='38:20 min' depth='36.0 m' pressure='168.63 bar' />
+  <sample time='40:00 min' depth='36.0 m' pressure='160.406 bar' />
+  <sample time='40:20 min' depth='33.0 m' pressure='158.821 bar' />
+  <sample time='41:00 min' depth='33.0 m' pressure='155.763 bar' />
+  <sample time='41:20 min' depth='30.0 m' pressure='154.29 bar' />
+  <sample time='43:00 min' depth='30.0 m' pressure='147.203 bar' />
+  <sample time='43:20 min' depth='27.0 m' pressure='145.844 bar' />
+  <sample time='46:00 min' depth='27.0 m' pressure='135.41 bar' />
+  <sample time='46:20 min' depth='24.0 m' pressure='134.164 bar' />
+  <sample time='49:00 min' depth='24.0 m' pressure='124.638 bar' />
+  <sample time='49:20 min' depth='21.0 m' pressure='123.505 bar' />
+  <sample time='49:21 min' depth='21.0 m' />
+  <sample time='52:00 min' depth='21.0 m' pressure='150.439 bar' />
+  <sample time='52:20 min' depth='18.0 m' pressure='149.438 bar' />
+  <sample time='56:00 min' depth='18.0 m' pressure='139.009 bar' />
+  <sample time='56:20 min' depth='15.0 m' pressure='138.116 bar' />
+  <sample time='61:00 min' depth='15.0 m' pressure='126.354 bar' />
+  <sample time='61:20 min' depth='12.0 m' pressure='125.568 bar' />
+  <sample time='68:00 min' depth='12.0 m' pressure='110.901 bar' />
+  <sample time='68:20 min' depth='9.0 m' pressure='110.221 bar' />
+  <sample time='80:00 min' depth='9.0 m' pressure='88.277 bar' />
+  <sample time='80:20 min' depth='6.0 m' pressure='87.703 bar' />
+  <sample time='80:21 min' depth='6.0 m' />
+  <sample time='94:00 min' depth='6.0 m' pressure='164.949 bar' />
+  <sample time='94:00 min' depth='6.0 m' />
+  <sample time='94:30 min' depth='3.0 m' pressure='163.579 bar' />
+  <sample time='123:00 min' depth='3.0 m' pressure='94.21 bar' />
+  <sample time='123:30 min' depth='0.0 m' pressure='93.141 bar' />
+  </divecomputer>
+</dive>
+</trip>
+</dives>
+</divelog>

--- a/tests/testplan.h
+++ b/tests/testplan.h
@@ -18,6 +18,7 @@ private slots:
 	void testVpmbMetricMultiLevelAir();
 	void testVpmbMetric100m10min();
 	void testVpmbMetricRepeat();
+	void testMultipleGases();
 };
 
 #endif // TESTPLAN_H


### PR DESCRIPTION
This fixes a subtle bug introduced in 5c4569247a31c which
unified two functions finding the gasmix at a given time
during the dive. There was a slight difference, though:
Does a gaschange exactly at that time count or not? For
the planner to work, the answer has to be in the affirmative.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug reported by @willemferguson by mail in planned dives that do gas changes 
in the manually entered parts.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
To test, open dives/test51.xml and edit it in the planner. If it turns red for a ceiling violation, the bug is present.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->@willemferguson this should fix your bug.