### PR TITLE
Dive site: fix oversight in 920eb7576f

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -381,7 +381,7 @@ QVariant DiveLocationModel::data(const QModelIndex &index, int role) const
 
 	if (index.row() <= 1) { // two special cases.
 		if (index.column() == LocationInformationModel::DIVESITE)
-			return QVariant::fromValue<void *>(RECENTLY_ADDED_DIVESITE);
+			return QVariant::fromValue<dive_site *>(RECENTLY_ADDED_DIVESITE);
 		switch (role) {
 		case Qt::DisplayRole:
 			return new_ds_value[index.row()];


### PR DESCRIPTION
In commit 920eb7576ff3c5fab19c12b7b291042817422ac5 "dive_site *"
was included in Qt's "metatype" system to be able to pass it
through QVariants. One instance was forgotten and a "void *"
was passed in. On readout NULL was returned, which made it
impossible to add new dive-sites under certain circumstances.

Convert this one instance to a proper "dive_site *" QVariant.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A quick-fix for a recently introduced bug. All that is to say is noted in the commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn `void *`-`QVariant` into `dive_site *`-`QVariant`.

