### PR TITLE
Fix 2 SIGSEGV related to empty dive site

### DIFF
--- a/core/save-git.c
+++ b/core/save-git.c
@@ -431,7 +431,8 @@ static void create_dive_buffer(struct dive *dive, struct membuffer *b)
 	SAVE("visibility", visibility);
 	cond_put_format(dive->tripflag == NO_TRIP, b, "notrip\n");
 	save_tags(b, dive->tag_list);
-	cond_put_format(!!dive->dive_site, b, "divesiteid %08x\n", dive->dive_site->uuid);
+	if (dive->dive_site)
+		put_format(b, "divesiteid %08x\n", dive->dive_site->uuid);
 	if (verbose && dive->dive_site)
 		fprintf(stderr, "removed reference to non-existant dive site with uuid %08x\n", dive->dive_site->uuid);
 	save_overview(b, dive);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -604,7 +604,7 @@ void MainTab::updateDiveInfo(bool clear)
 	else
 		ui.cylinders->view()->hideColumn(CylindersModel::USE);
 
-	if (verbose)
+	if (verbose && displayed_dive.dive_site)
 		qDebug() << "Set the current dive site:" << displayed_dive.dive_site->uuid;
 	emit diveSiteChanged();
 }


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Apparently, my workflow after coming back from a short dive trip exposes 2 crashes related to dive site handling. My workflow is simple. Git storage, verbose mode, download from DC: add dives to dive list: crash 1. This fixed, proceed to dive list, and save the logbook (git storage). Crash 2. Both crashes due to trying to dereferencing a null pointer.

### Changes made:
See commits.

### Related issues:
No.

### Release note:
No, in current release. 

### Mentions:
@bstoeger 
