### PR TITLE
Mobile copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Desktop: Indicate sort direction in list header
 - Desktop: Use defined sort-order when switching sort column
 - Fix a bug in planner for dives with manual gas changes.
+- Mobile: add initial copy-paste support
 - Mobile: add full text filtering of the dive list
 - Desktop: don't add dive-buddy or dive-master when tabbing through fields
 - Filter: don't recalculate all filters on dive list-modifying operations

--- a/Documentation/mobile-manual.txt
+++ b/Documentation/mobile-manual.txt
@@ -233,6 +233,27 @@ instruction to delete the dive.
 
 image::mobile-images/RedDustbin.jpg["FIGURE: delete dive from list",align="center"]
 
+== Copying dive details
+
+To copy selected dive details over to another dive, long-press a dive in the
+divelist. This will show a three icons on the right side of the selected dive
+as shown on the image below. The left image will copy details from the selected
+dive and middle button will paste what has been copied before. Naturally you
+should long-press a different dive after copying the details to perform the
+paste operation.
+
+image::mobile-images/CopyPaste.jpg["FIGURE: copy dive details in list",align="center"]
+
+Currently the details to be copied are hard-coded and include the following
+information:
+
+- divemaster
+- buddy
+- suit
+- tags
+- cylinders
+- weights
+
 [[S_Download]]
 == Download dives from a dive computer
 

--- a/cmake/Modules/RunOnBuildDir.cmake
+++ b/cmake/Modules/RunOnBuildDir.cmake
@@ -18,7 +18,8 @@ if(NOT NO_DOCS)
 		COMMAND
 		mkdir -p ${CMAKE_BINARY_DIR}/Documentation/ &&
 		rm -rf ${CMAKE_BINARY_DIR}/Documentation/images &&
-		ln -sf ${CMAKE_SOURCE_DIR}/Documentation/images ${CMAKE_BINARY_DIR}/Documentation/images
+		ln -sf ${CMAKE_SOURCE_DIR}/Documentation/images ${CMAKE_BINARY_DIR}/Documentation/images &&
+		ln -sf ${CMAKE_SOURCE_DIR}/Documentation/mobile-images ${CMAKE_BINARY_DIR}/Documentation/mobile-images
 	)
 	add_custom_target(
 		documentation ALL

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -118,9 +118,13 @@ Kirigami.ScrollablePage {
 			}
 
 			property bool deleteButtonVisible: false
+			property bool copyButtonVisible: true	// TODO: false
+			property bool pasteButtonVisible: false
 
 			onPressAndHold: {
-				deleteButtonVisible = true
+				deleteButtonVisible = false	// TODO: true
+				copyButtonVisible = false	// TODO: true
+				pasteButtonVisible = true
 				timer.restart()
 			}
 			Item {
@@ -195,6 +199,77 @@ Kirigami.ScrollablePage {
 					}
 				}
 				Rectangle {
+					id: copyButton
+					visible: copyButtonVisible
+					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
+					width: height - 3 * Kirigami.Units.smallSpacing
+					color: subsurfaceTheme.lightDrawerColor
+					antialiasing: true
+					radius: Kirigami.Units.smallSpacing
+					anchors {
+						left: diveListEntry.right
+						right: parent.right
+						verticalCenter: diveListEntry.verticalCenter
+						verticalCenterOffset: Kirigami.Units.smallSpacing / 2
+					}
+					Kirigami.Icon {
+						anchors {
+							horizontalCenter: parent.horizontalCenter
+							verticalCenter: parent.verticalCenter
+						}
+						source: ":/icons/edit-copy"
+						width: parent.height
+						height: width
+					}
+					MouseArea {
+						anchors.fill: parent
+						enabled: parent.visible
+						onClicked: {
+							deleteButtonVisible = false
+							copyButtonVisible = false
+							pasteButtonVisible = false
+							timer.stop()
+							manager.copyDiveData(dive.id)
+						}
+					}
+				}
+				Rectangle {
+					id: pasteButton
+					visible: pasteButtonVisible
+					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
+					width: height - 3 * Kirigami.Units.smallSpacing
+					color: subsurfaceTheme.contrastAccentColor
+					antialiasing: true
+					radius: Kirigami.Units.smallSpacing
+					anchors {
+						left: diveListEntry.right
+						right: parent.right
+						verticalCenter: diveListEntry.verticalCenter
+						verticalCenterOffset: Kirigami.Units.smallSpacing / 2
+					}
+					Kirigami.Icon {
+						anchors {
+							horizontalCenter: parent.horizontalCenter
+							verticalCenter: parent.verticalCenter
+						}
+						source: ":/icons/edit-paste"
+						width: parent.height
+						height: width
+					}
+					MouseArea {
+						anchors.fill: parent
+						enabled: parent.visible
+						onClicked: {
+							deleteButtonVisible = false
+							copyButtonVisible = false
+							pasteButtonVisible = false
+							timer.stop()
+							manager.pasteDiveData(dive.id)
+						}
+					}
+				}
+				Rectangle {
+					id: deleteButton
 					visible: deleteButtonVisible
 					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
 					width: height - 3 * Kirigami.Units.smallSpacing
@@ -221,6 +296,8 @@ Kirigami.ScrollablePage {
 						enabled: parent.visible
 						onClicked: {
 							deleteButtonVisible = false
+							copyButtonVisible = false
+							pasteButtonVisible = false
 							timer.stop()
 							manager.deleteDive(dive.id)
 						}
@@ -231,6 +308,8 @@ Kirigami.ScrollablePage {
 					interval: 4000
 					onTriggered: {
 						deleteButtonVisible = false
+						copyButtonVisible = false
+						pasteButtonVisible = false
 					}
 				}
 			}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -118,12 +118,12 @@ Kirigami.ScrollablePage {
 			}
 
 			property bool deleteButtonVisible: false
-			property bool copyButtonVisible: true	// TODO: false
+			property bool copyButtonVisible: false
 			property bool pasteButtonVisible: false
 
 			onPressAndHold: {
-				deleteButtonVisible = false	// TODO: true
-				copyButtonVisible = false	// TODO: true
+				deleteButtonVisible = true
+				copyButtonVisible = true
 				pasteButtonVisible = true
 				timer.restart()
 			}
@@ -143,7 +143,7 @@ Kirigami.ScrollablePage {
 				}
 				Item {
 					id: diveListEntry
-					width: parent.width - Kirigami.Units.gridUnit * (innerListItem.deleteButtonVisible ? 3 : 1)
+					width: parent.width - Kirigami.Units.gridUnit * (innerListItem.deleteButtonVisible ? 3 * 3 : 1)
 					height: Math.ceil(childrenRect.height + Kirigami.Units.smallSpacing)
 					anchors.left: leftBarDive.right
 					Controls.Label {
@@ -202,15 +202,16 @@ Kirigami.ScrollablePage {
 					id: copyButton
 					visible: copyButtonVisible
 					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
-					width: height - 3 * Kirigami.Units.smallSpacing
+					width: height
 					color: subsurfaceTheme.lightDrawerColor
 					antialiasing: true
 					radius: Kirigami.Units.smallSpacing
 					anchors {
 						left: diveListEntry.right
-						right: parent.right
 						verticalCenter: diveListEntry.verticalCenter
 						verticalCenterOffset: Kirigami.Units.smallSpacing / 2
+						rightMargin: horizontalPadding * 2
+						leftMargin: horizontalPadding * 2
 					}
 					Kirigami.Icon {
 						anchors {
@@ -237,15 +238,16 @@ Kirigami.ScrollablePage {
 					id: pasteButton
 					visible: pasteButtonVisible
 					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
-					width: height - 3 * Kirigami.Units.smallSpacing
-					color: subsurfaceTheme.contrastAccentColor
+					width: height
+					color: subsurfaceTheme.lightDrawerColor
 					antialiasing: true
 					radius: Kirigami.Units.smallSpacing
 					anchors {
-						left: diveListEntry.right
-						right: parent.right
+						left: copyButton.right
 						verticalCenter: diveListEntry.verticalCenter
 						verticalCenterOffset: Kirigami.Units.smallSpacing / 2
+						rightMargin: horizontalPadding * 2
+						leftMargin: horizontalPadding * 2
 					}
 					Kirigami.Icon {
 						anchors {
@@ -272,15 +274,17 @@ Kirigami.ScrollablePage {
 					id: deleteButton
 					visible: deleteButtonVisible
 					height: diveListEntry.height - 2 * Kirigami.Units.smallSpacing
-					width: height - 3 * Kirigami.Units.smallSpacing
+					width: height
 					color: subsurfaceTheme.contrastAccentColor
 					antialiasing: true
 					radius: Kirigami.Units.smallSpacing
 					anchors {
-						left: diveListEntry.right
+						left: pasteButton.right
 						right: parent.right
 						verticalCenter: diveListEntry.verticalCenter
 						verticalCenterOffset: Kirigami.Units.smallSpacing / 2
+						rightMargin: horizontalPadding * 2
+						leftMargin: horizontalPadding * 2
 					}
 					Kirigami.Icon {
 						anchors {

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -75,6 +75,8 @@
 		<file alias="icons/list-add.svg">kirigami/icons/list-add.svg</file>
 		<file alias="icons/overflow-menu.svg">kirigami/icons/overflow-menu.svg</file>
 		<file alias="icons/trash-empty.svg">kirigami/icons/trash-empty.svg</file>
+		<file alias="icons/edit-copy.svg">kirigami/icons/edit-copy.svg</file>
+		<file alias="icons/edit-paste.svg">kirigami/icons/edit-paste.svg</file>
 		<file alias="icons/view-readermode.svg">kirigami/icons/view-readermode.svg</file>
 	</qresource>
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1343,6 +1343,10 @@ void QMLManager::pasteDiveData(int id)
 		appendTextToLog("trying to paste to non-existing dive");
 		return;
 	}
+	if (!m_copyPasteDive) {
+		appendTextToLog("dive to paste is not selected");
+		return;
+	}
 	selective_copy_dive(m_copyPasteDive, d, what, false);
 	changesNeedSaving();
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1319,6 +1319,34 @@ void QMLManager::deleteDive(int id)
 	changesNeedSaving();
 }
 
+void QMLManager::copyDiveData(int id)
+{
+	m_copyPasteDive = get_dive_by_uniq_id(id);
+	if (!m_copyPasteDive) {
+		appendTextToLog("trying to copy non-existing dive");
+		return;
+	}
+
+	// TODO: selection dialog for the data to be copied
+	what.divemaster = true;
+	what.buddy = true;
+	what.suit = true;
+	what.tags = true;
+	what.cylinders = true;
+	what.weights = true;
+}
+
+void QMLManager::pasteDiveData(int id)
+{
+	struct dive *d = get_dive_by_uniq_id(id);
+	if (!d) {
+		appendTextToLog("trying to paste to non-existing dive");
+		return;
+	}
+	selective_copy_dive(m_copyPasteDive, d, what, false);
+	changesNeedSaving();
+}
+
 void QMLManager::cancelDownloadDC()
 {
 	import_thread_cancelled = true;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1348,6 +1348,9 @@ void QMLManager::pasteDiveData(int id)
 		return;
 	}
 	selective_copy_dive(m_copyPasteDive, d, what, false);
+
+	invalidate_dive_cache(d);
+	mark_divelist_changed(true);
 	changesNeedSaving();
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1334,6 +1334,8 @@ void QMLManager::copyDiveData(int id)
 	what.tags = true;
 	what.cylinders = true;
 	what.weights = true;
+
+	setNotificationText("Copy");
 }
 
 void QMLManager::pasteDiveData(int id)
@@ -1352,6 +1354,7 @@ void QMLManager::pasteDiveData(int id)
 	invalidate_dive_cache(d);
 	mark_divelist_changed(true);
 	changesNeedSaving();
+	setNotificationText("Paste");
 }
 
 void QMLManager::cancelDownloadDC()

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -226,7 +226,7 @@ private:
 	bool m_btEnabled;
 	void updateAllGlobalLists();
 	QString m_pluggedInDeviceName;
-	struct dive *m_copyPasteDive;
+	struct dive *m_copyPasteDive = NULL;
 	struct dive_components what;
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -163,6 +163,8 @@ public slots:
 	void saveChangesLocal();
 	void saveChangesCloud(bool forceRemoteSync);
 	void deleteDive(int id);
+	void copyDiveData(int id);
+	void pasteDiveData(int id);
 	bool undoDelete(int id);
 	QString addDive();
 	void addDiveAborted(int id);
@@ -224,6 +226,8 @@ private:
 	bool m_btEnabled;
 	void updateAllGlobalLists();
 	QString m_pluggedInDeviceName;
+	struct dive *m_copyPasteDive;
+	struct dive_components what;
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	QString appLogFileName;

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -44,6 +44,8 @@ cp $BREEZE/icons/actions/16/view-readermode.svg $MC/icons
 cp $BREEZE/icons/actions/24/application-menu.svg $MC/icons
 cp $BREEZE/icons/actions/22/gps.svg $MC/icons
 cp $BREEZE/icons/actions/24/trash-empty.svg $MC/icons
+cp $BREEZE/icons/actions/24/edit-copy.svg $MC/icons
+cp $BREEZE/icons/actions/24/edit-paste.svg $MC/icons
 cp $BREEZE/icons/actions/24/list-add.svg $MC/icons
 cp $BREEZE/icons/actions/22/handle-left.svg $MC/icons
 cp $BREEZE/icons/actions/22/handle-right.svg $MC/icons


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Implement copy-paste for Subsurface-mobile. With a long press on divelist, you get the option to copy some dive details and then paste them to another dive. Currently the details to be copied are hardcoded, but the plan is to implement configuration possibility for this (seems to take quite a long time for me to do this, so decided to get the pull request done for the basic implementation).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
copy-paste support for mobile version

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Following info is copied, if exist:
	what.divemaster = true;
	what.buddy = true;
	what.suit = true;
	what.tags = true;
	what.cylinders = true;
	what.weights = true;

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
TODO

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
TODO
Now there are two other icons next to the dive delete icon when pressing long on divelist (mobile). And data can be copied to other dives.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
