### PR TITLE
Dive list: invert default sort order for sort by date / number

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -27,7 +27,7 @@
 #include "core/subsurface-qt/DiveListNotifier.h"
 
 DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false), sortColumn(DiveTripModel::NR),
-	currentOrder(Qt::DescendingOrder), dontEmitDiveChangedSignal(false), selectionSaved(false),
+	currentOrder(Qt::AscendingOrder), dontEmitDiveChangedSignal(false), selectionSaved(false),
 	initialColumnWidths(DiveTripModel::COLUMNS, 50)	// Set up with default length 50
 {
 	setItemDelegate(new DiveListDelegate(this));
@@ -465,11 +465,9 @@ void DiveListView::headerClicked(int i)
 	/* No layout change? Just re-sort, and scroll to first selection, making sure all selections are expanded */
 	if (currentLayout == newLayout) {
 		// If this is the same column as before, change sort order. Otherwise, choose a default
-		// sort order (descending for NR and DATE, ascending elsewise).
+		// sort order (ascending).
 		if (sortColumn == i)
 			currentOrder = (currentOrder == Qt::DescendingOrder) ? Qt::AscendingOrder : Qt::DescendingOrder;
-		else if (i == DiveTripModel::NR || i == DiveTripModel::DATE)
-			currentOrder = Qt::DescendingOrder;
 		else
 			currentOrder = Qt::AscendingOrder;
 		sortByColumn(i, currentOrder);
@@ -480,7 +478,7 @@ void DiveListView::headerClicked(int i)
 		if (currentLayout == DiveTripModel::TREE)
 			backupExpandedRows();
 		currentLayout = newLayout;
-		currentOrder = Qt::DescendingOrder;
+		currentOrder = Qt::AscendingOrder;
 		MultiFilterSortModel::instance()->setLayout(newLayout);
 		sortByColumn(i, currentOrder);
 		if (newLayout == DiveTripModel::TREE)


### PR DESCRIPTION
Commit 6dc1d239f81f16133d5954bd2b21ffa0c2dcc755 introduced a
well-defined sort order in the case of equal contents. It changed
the code for sorting by date to simply use the order of the
source model.

BUT: The source-model was already sorted in descending order
on date. Thus setting the default order on descening by date,
the data was then presented as *ascending* by date.

Change this back to descending by always using default-ascending
in the filter model.

Ultimately, the source model should simply reflect the ordering
of the core-data (ascending on date), but such a change is
too invasive shortly before release.

Reported-by: Jan Mulder <jlmulder@xs4all.nl>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes Bug introduced in 6dc1d239f81f16133d5954bd2b21ffa0c2dcc755. See commit message.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Change default sort order when sorting by date or number.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes bug introduced in #1834 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No (recently introduced).
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder: please test / comment.