### PR TITLE
Undo: fix addition of multiple dives

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -753,9 +753,9 @@ void DiveTripModel::addDivesToTrip(int trip, const QVector<dive *> &dives)
 // before the trip in the case of equal timestamps.
 bool DiveTripModel::dive_before_entry(const dive *d, const Item &entry)
 {
-	// Dives at the same time come before trips, therefore use the "<=" operator.
+	// Dives at the same time come before trips, therefore use the ">=" operator.
 	if (entry.trip)
-		return d->when <= entry.trip->when;
+		return d->when >= entry.trip->when;
 	return !dive_less_than(d, entry.getDive());
 }
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -717,7 +717,7 @@ void addInBatches(Vector1 &v1, const Vector2 &v2, Comparator comp, Inserter inse
 			// We were at end -> insert the remaining items
 			j = v2.size();
 		} else {
-			for (j = i + 1; j < (int)v2.size() && comp(v2[i], v1[idx]); ++j)
+			for (j = i + 1; j < (int)v2.size() && comp(v2[j], v1[idx]); ++j)
 				; // Pass
 		}
 


### PR DESCRIPTION
The generic addInBatches() function is used to add batches of
contiguous sets of dives to the dive-list models. The loop
searching for the end of the batch used the wrong index and
would therefore not properly cut the batches.

Fix this.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a horrible bug in the qt-models code introduced with the undo work.
To reproduce the bug:
1) select non contiguous set of dives
2) delete dives
3) undo

The dives will be added as a contiguous set. Thus, the list will not have proper chronological order and all hell breaks loose!

The bug is a release-blocker, therefore I'm tagging `priority-high`.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use proper index for finding end of the range

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
