### PR TITLE
Fix sort arrows

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -26,8 +26,8 @@
 #include "core/metrics.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 
-DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false), sortColumn(DiveTripModel::NR),
-	currentOrder(Qt::AscendingOrder), currentLayout(DiveTripModel::TREE), dontEmitDiveChangedSignal(false), selectionSaved(false),
+DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false),
+	currentLayout(DiveTripModel::TREE), dontEmitDiveChangedSignal(false), selectionSaved(false),
 	initialColumnWidths(DiveTripModel::COLUMNS, 50)	// Set up with default length 50
 {
 	setItemDelegate(new DiveListDelegate(this));
@@ -478,9 +478,6 @@ void DiveListView::sortIndicatorChanged(int i, Qt::SortOrder order)
 			restoreExpandedRows();
 		restoreSelection();
 	}
-	// remember the new sort column
-	sortColumn = i;
-	currentOrder = order;
 }
 
 void DiveListView::setSortOrder(int i, Qt::SortOrder order)
@@ -890,6 +887,7 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 			if (!d->divetrip) {
 				struct dive *top = d;
 				struct dive *bottom = d;
+				Qt::SortOrder currentOrder = header()->sortIndicatorOrder();
 				if (d->selected) {
 					if (currentOrder == Qt::AscendingOrder) {
 						top = first_selected_dive();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -68,8 +68,6 @@ slots:
 private:
 	bool mouseClickSelection;
 	QList<int> expandedRows;
-	int sortColumn;
-	Qt::SortOrder currentOrder;
 	DiveTripModel::Layout currentLayout;
 	QModelIndex contextMenuIndex;
 	bool dontEmitDiveChangedSignal;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -25,7 +25,8 @@ public:
 	void mouseDoubleClickEvent(QMouseEvent * event);
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 	void currentChanged(const QModelIndex &current, const QModelIndex &previous);
-	void reload(DiveTripModel::Layout layout);
+	void setSortOrder(int i, Qt::SortOrder order); // Call to set sort order
+	void reload(); // Call to reload model data
 	bool eventFilter(QObject *, QEvent *);
 	void unselectDives();
 	void clearTripSelection();
@@ -44,7 +45,7 @@ public
 slots:
 	void toggleColumnVisibilityByIndex();
 	void reloadHeaderActions();
-	void headerClicked(int);
+	void sortIndicatorChanged(int index, Qt::SortOrder order);
 	void removeFromTrip();
 	void deleteDive();
 	void markDiveInvalid();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -245,7 +245,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	graphics->setEmptyState();
 	initialUiSetup();
 	readSettings();
-	diveList->reload(DiveTripModel::TREE);
+	diveList->reload();
 	diveList->reloadHeaderActions();
 	diveList->setFocus();
 	MapWidget::instance()->reload();
@@ -494,7 +494,7 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 
 void MainWindow::recreateDiveList()
 {
-	diveList->reload(DiveTripModel::CURRENT);
+	diveList->reload();
 	TagFilterModel::instance()->repopulate();
 	BuddyFilterModel::instance()->repopulate();
 	LocationFilterModel::instance()->repopulate();
@@ -704,7 +704,8 @@ void MainWindow::cleanUpEmpty()
 	mainTab->clearTabs();
 	mainTab->updateDiveInfo(true);
 	graphics->setEmptyState();
-	diveList->reload(DiveTripModel::TREE);
+	diveList->reload();
+	diveList->setSortOrder(DiveTripModel::NR, Qt::AscendingOrder);
 	MapWidget::instance()->reload();
 	if (!existing_filename)
 		setTitle();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -705,7 +705,7 @@ void MainWindow::cleanUpEmpty()
 	mainTab->updateDiveInfo(true);
 	graphics->setEmptyState();
 	diveList->reload();
-	diveList->setSortOrder(DiveTripModel::NR, Qt::AscendingOrder);
+	diveList->setSortOrder(DiveTripModel::NR, Qt::DescendingOrder);
 	MapWidget::instance()->reload();
 	if (!existing_filename)
 		setTitle();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -926,7 +926,7 @@ void MainTab::acceptChanges()
 	int scrolledBy = MainWindow::instance()->diveList->verticalScrollBar()->sliderPosition();
 	resetPallete();
 	if (editMode == MANUALLY_ADDED_DIVE) {
-		MainWindow::instance()->diveList->reload(DiveTripModel::CURRENT);
+		MainWindow::instance()->diveList->reload();
 		int newDiveNr = get_divenr(get_dive_by_uniq_id(addedId));
 		MainWindow::instance()->diveList->unselectDives();
 		MainWindow::instance()->diveList->selectDive(newDiveNr, true);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -350,6 +350,9 @@ QVariant DiveTripModel::headerData(int section, Qt::Orientation orientation, int
 		return dive_table_alignment(section);
 	case Qt::FontRole:
 		return defaultModelFont();
+	case Qt::InitialSortOrderRole:
+		// By default, sort NR and DATE descending, everything else ascending.
+		return section == NR || section == DATE ? Qt::DescendingOrder : Qt::AscendingOrder;
 	case Qt::DisplayRole:
 		switch (section) {
 		case NR:
@@ -1084,7 +1087,9 @@ bool DiveTripModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
 	if (currentLayout != LIST) {
 		// In tree mode we don't support any sorting!
 		// Simply keep the original position.
-		return i1.row() < i2.row();
+		// Note that the model is filled in reverse order, therefore
+		// ascending means sorting in descending order. TODO: fix.
+		return i1.row() > i2.row();
 	}
 
 	// We assume that i1.column() == i2.column().
@@ -1100,7 +1105,9 @@ bool DiveTripModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
 	case NR:
 	case DATE:
 	default:
-		return row1 < row2;
+		// Note that the model is filled in reverse order, therefore
+		// ascending means sorting in descending order. TODO: fix.
+		return row1 > row2;
 	case RATING:
 		return lessThanHelper(d1->rating - d2->rating, row_diff);
 	case DEPTH:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the problem of the sort arrows reported by @sfuchs79 in #1832.
It was necessary to split the `reload()` function in two functions, one for reloading the model and one for setting the sort order. The fundamental change of this commit is that the `QHeaderView` is now responsible for the sort order. Now point in fighting it.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Split `reload()` function
2) Make `QHeaderView` responsible for sort criterion
3) Remove now redundant fields.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1832
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - arrows only since this release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not really - perhaps a few new pictures in due course?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79