### PR TITLE
Dive list: invert sort-direction to reflect core

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1712,8 +1712,12 @@ void clear_table(struct dive_table *table)
  * probably want to unify the models.
  * After editing a key used in this sort-function, the order of
  * the dives must be re-astablished.
- * Currently, this does a lexicographic sort on the (start-time, id)
- * tuple. "id" is a stable, strictly increasing unique number, that
+ * Currently, this does a lexicographic sort on the
+ * (start-time, trip-time, id) tuple.
+ * trip-time is defined such that dives that do not belong to
+ * a trip are sorted *after* dives that do. Thus, in the default
+ * chronologically-descending sort order, they are shown *before*.
+ * "id" is a stable, strictly increasing unique number, that
  * is handed out when a dive is added to the system.
  * We might also consider sorting by end-time and other criteria,
  * but see the caveat above (editing means rearrangement of the dives).
@@ -1724,6 +1728,16 @@ static int comp_dives(const struct dive *a, const struct dive *b)
 		return -1;
 	if (a->when > b->when)
 		return 1;
+	if (a->divetrip != b->divetrip) {
+		if (!b->divetrip)
+			return -1;
+		if (!a->divetrip)
+			return 1;
+		if (a->divetrip->when < b->divetrip->when)
+			return -1;
+		if (a->divetrip->when > b->divetrip->when)
+			return 1;
+	}
 	if (a->id < b->id)
 		return -1;
 	if (a->id > b->id)

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -35,7 +35,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 	setItemDelegateForColumn(DiveTripModel::RATING, new StarWidgetsDelegate(this));
 	setModel(MultiFilterSortModel::instance());
 
-	setSortingEnabled(false);
+	setSortingEnabled(true);
 	setContextMenuPolicy(Qt::DefaultContextMenu);
 	setSelectionMode(ExtendedSelection);
 	header()->setContextMenuPolicy(Qt::ActionsContextMenu);


### PR DESCRIPTION
Traditionally, the DiveTripModel has its data sorted in opposite
direction to the core-data (chronologically descending vs. ascending).
This bring a number of subtle problems. For example, when filling
the model, trips are filled according to the *last* dive, whereas
later insertion points are according to the ->when value from the
core, which depends on the *first* dive.

As a start of fixing these subtleties, change the sort direction
to reflect the core-data. Ideally, this should lead to a removal
of the redundant data-representation.

Since the model is now sorted in ascending order, sorting has to
be enabled in the DiveListView constructor to reflect the
default-descending order.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
On closer look, the `DiveTripModel` code has a number of problems concerning overlapping trips and dives that happened during a trip, but are not part of a trip. This PR does not fix all of these problems, but is a first step in making them fixable. It also is a first step in removing the redundant representation of list-mode.

I have difficulties giving this a risk / gain rating. It certainly needs testing, comparisons are infamously tricky.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Reverse order in DiveTripModel to reflect core.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
