### PR TITLE
Dive list: correctly translate trip date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Tag: high level what changed (please replace this line with your first CHANGELOG entry)
+- Desktop: translate trip date
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -972,16 +972,12 @@ QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 	utc_mkdate(when, &tm);
 	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000*when,Qt::UTC);
 	localTime.setTimeSpec(Qt::UTC);
-	QString ret ;
 
 	QString suffix = " " + gettextFromC::tr("(%n dive(s))", "", nr);
-	if (getday) {
-		ret = localTime.date().toString(prefs.date_format) + suffix;
-	} else {
-		ret = localTime.date().toString("MMM yyyy") + suffix;
-	}
-	return ret;
-
+	if (getday)
+		return loc.toString(localTime, prefs.date_format) + suffix;
+	else
+		return loc.toString(localTime, "MMM yyyy") + suffix;
 }
 
 static QMutex hashOfMutex;


### PR DESCRIPTION
Adapt get_trip_date_string() to use the same logic as get_dive_date_string():
Use the static "loc" object to translate date. Before, the trip
date was shown in C locale.

Reported-by: Philippe Massart <philippe@philmassart.net>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes bug posted to the mailing list: trip dates were not translated.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Translate trip dates.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See mailing list.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
