### PR TITLE
More dive-list churn

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -556,6 +556,7 @@ extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);
 extern int legacy_format_o2pressures(const struct dive *dive, const struct divecomputer *dc);
 
 extern bool dive_less_than(const struct dive *a, const struct dive *b);
+extern bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b);
 extern void sort_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);

--- a/core/dive.h
+++ b/core/dive.h
@@ -418,8 +418,6 @@ extern void add_dive_to_trip(struct dive *, dive_trip_t *);
 
 struct dive *unregister_dive(int idx);
 extern void delete_single_dive(int idx);
-extern int dive_get_insertion_index(struct dive *dive);
-extern void add_single_dive(int idx, struct dive *dive);
 
 extern void insert_trip(dive_trip_t *trip);
 extern void unregister_trip(dive_trip_t *trip);

--- a/core/dive.h
+++ b/core/dive.h
@@ -338,6 +338,12 @@ struct dive {
 	unsigned char git_id[20];
 };
 
+/* For the top-level list: an entry is either a dive or a trip */
+struct dive_or_trip {
+	struct dive *dive;
+	struct dive_trip *trip;
+};
+
 extern void invalidate_dive_cache(struct dive *dive);
 extern bool dive_cache_is_valid(const struct dive *dive);
 
@@ -557,6 +563,7 @@ extern int legacy_format_o2pressures(const struct dive *dive, const struct divec
 
 extern bool dive_less_than(const struct dive *a, const struct dive *b);
 extern bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b);
+extern bool dive_or_trip_less_than(struct dive_or_trip a, struct dive_or_trip b);
 extern void sort_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);

--- a/core/dive.h
+++ b/core/dive.h
@@ -293,7 +293,6 @@ struct dive_table {
 
 typedef struct dive_trip
 {
-	timestamp_t when;
 	char *location;
 	char *notes;
 	struct dive_table dives;
@@ -432,6 +431,7 @@ extern void delete_single_dive(int idx);
 extern void insert_trip(dive_trip_t *trip);
 extern void unregister_trip(dive_trip_t *trip);
 extern void free_trip(dive_trip_t *trip);
+extern timestamp_t trip_date(const struct dive_trip *trip);
 
 extern const struct units SI_units, IMPERIAL_units;
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -286,13 +286,18 @@ typedef enum {
 	NUM_TRIPFLAGS
 } tripflag_t;
 
+struct dive_table {
+	int nr, allocated;
+	struct dive **dives;
+};
+
 typedef struct dive_trip
 {
 	timestamp_t when;
 	char *location;
 	char *notes;
-	struct dive *dives;
-	int nrdives, showndives;
+	struct dive_table dives;
+	int showndives;
 	/* Used by the io-routines to mark trips that have already been written. */
 	bool saved;
 	bool autogen;
@@ -306,7 +311,6 @@ struct dive {
 	int number;
 	tripflag_t tripflag;
 	dive_trip_t *divetrip;
-	struct dive *next, **pprev;
 	bool selected;
 	bool hidden_by_filter;
 	timestamp_t when;
@@ -427,11 +431,6 @@ extern const struct units SI_units, IMPERIAL_units;
 
 extern const struct units *get_units(void);
 extern int run_survey, verbose, quit, force_root;
-
-struct dive_table {
-	int nr, allocated;
-	struct dive **dives;
-};
 
 extern struct dive_table dive_table, downloadTable;
 extern struct dive displayed_dive;

--- a/core/dive.h
+++ b/core/dive.h
@@ -421,8 +421,7 @@ extern void delete_single_dive(int idx);
 extern int dive_get_insertion_index(struct dive *dive);
 extern void add_single_dive(int idx, struct dive *dive);
 
-extern void insert_trip(dive_trip_t **trip);
-extern void insert_trip_dont_merge(dive_trip_t *trip);
+extern void insert_trip(dive_trip_t *trip);
 extern void unregister_trip(dive_trip_t *trip);
 extern void free_trip(dive_trip_t *trip);
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -40,6 +40,7 @@
  * void remove_autogen_trips()
  * bool dive_less_than(const struct dive *a, const struct dive *b)
  * bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b)
+ * bool dive_or_trip_less_than(struct dive_or_trip a, struct dive_or_trip b)
  * void sort_table(struct dive_table *table)
  * bool is_trip_before_after(const struct dive *dive, bool before)
  * void delete_dive_from_table(struct dive_table *table, int idx)
@@ -1559,7 +1560,7 @@ void process_imported_dives(struct dive_table *import_table, bool prefer_importe
 		struct dive *dive_to_add = import_table->dives[i];
 
 		/* Find insertion point. */
-		while (j < dive_table.nr && dive_table.dives[j]->when < dive_to_add->when)
+		while (j < dive_table.nr && dive_less_than(dive_table.dives[j], dive_to_add))
 			j++;
 
 		/* Try to merge into previous dive. */
@@ -1742,13 +1743,11 @@ bool dive_less_than(const struct dive *a, const struct dive *b)
 	return comp_dives(a, b) < 0;
 }
 
-/* Trips are compared according to the first dive in the trip.
- * Even though it shouldn't happen, take care about "empty" trips.
- * Since a dive can only belong to one trip, no two trips should
- * compare as equal
- */
+/* Trips are compared according to the first dive in the trip. */
 static int comp_trips(const struct dive_trip *a, const struct dive_trip *b)
 {
+	/* This should never happen, nevertheless don't crash on trips
+	 * with no (or worse a negative number of) dives. */
 	if (a->dives.nr <= 0)
 		return b->dives.nr <= 0 ? 0 : -1;
 	if (b->dives.nr <= 0)
@@ -1759,6 +1758,33 @@ static int comp_trips(const struct dive_trip *a, const struct dive_trip *b)
 bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b)
 {
 	return comp_trips(a, b) < 0;
+}
+
+/* When comparing a dive to a trip, use the first dive of the trip. */
+static int comp_dive_to_trip(struct dive *a, struct dive_trip *b)
+{
+	/* This should never happen, nevertheless don't crash on trips
+	 * with no (or worse a negative number of) dives. */
+	if (b->dives.nr <= 0)
+		return -1;
+	return comp_dives(a, b->dives.dives[0]);
+}
+
+static int comp_dive_or_trip(struct dive_or_trip a, struct dive_or_trip b)
+{
+	if (a.dive && b.dive)
+		return comp_dives(a.dive, b.dive);
+	if (a.trip && b.trip)
+		return comp_trips(a.trip, b.trip);
+	if (a.dive)
+		return comp_dive_to_trip(a.dive, b.trip);
+	else
+		return -comp_dive_to_trip(b.dive, a.trip);
+}
+
+bool dive_or_trip_less_than(struct dive_or_trip a, struct dive_or_trip b)
+{
+	return comp_dive_or_trip(a, b) < 0;
 }
 
 static int sortfn(const void *_a, const void *_b)

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -22,7 +22,10 @@ extern void process_loaded_dives();
 extern void process_imported_dives(struct dive_table *import_table, bool prefer_imported, bool downloaded);
 extern char *get_dive_gas_string(const struct dive *dive);
 
-struct dive **grow_dive_table(struct dive_table *table);
+extern struct dive **grow_dive_table(struct dive_table *table);
+extern int dive_get_insertion_index(struct dive_table *table, struct dive *dive);
+extern void add_dive_to_table(struct dive_table *table, int idx, struct dive *dive);
+extern void add_single_dive(int idx, struct dive *dive);
 extern void get_dive_gas(const struct dive *dive, int *o2_p, int *he_p, int *o2low_p);
 extern int get_divenr(const struct dive *dive);
 extern int get_divesite_idx(const struct dive_site *ds);

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -46,7 +46,6 @@ extern void deselect_dives_in_trip(struct dive_trip *trip);
 extern void filter_dive(struct dive *d, bool shown);
 extern void combine_trips(struct dive_trip *trip_a, struct dive_trip *trip_b);
 extern dive_trip_t *combine_trips_create(struct dive_trip *trip_a, struct dive_trip *trip_b);
-extern void find_new_trip_start_time(dive_trip_t *trip);
 extern struct dive *first_selected_dive();
 extern struct dive *last_selected_dive();
 extern bool is_trip_before_after(const struct dive *dive, bool before);

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -799,12 +799,6 @@ static void parse_dc_event(char *line, struct membuffer *str, void *_dc)
 	}
 }
 
-static void parse_trip_date(char *line, struct membuffer *str, void *_trip)
-{ UNUSED(str); dive_trip_t *trip = _trip; update_date(&trip->when, line); }
-
-static void parse_trip_time(char *line, struct membuffer *str, void *_trip)
-{ UNUSED(str); dive_trip_t *trip = _trip; update_time(&trip->when, line); }
-
 static void parse_trip_location(char *line, struct membuffer *str, void *_trip)
 { UNUSED(line); dive_trip_t *trip = _trip; trip->location = get_utf8(str); }
 
@@ -1007,7 +1001,7 @@ static void site_parser(char *line, struct membuffer *str, void *_ds)
 struct keyword_action trip_action[] = {
 #undef D
 #define D(x) { #x, parse_trip_ ## x }
-	D(date), D(location), D(notes), D(time),
+	D(location), D(notes),
 };
 
 static void trip_parser(char *line, struct membuffer *str, void *_trip)
@@ -1202,20 +1196,6 @@ static struct dive *create_new_dive(timestamp_t when)
 	return dive;
 }
 
-static dive_trip_t *create_new_trip(int yyyy, int mm, int dd)
-{
-	dive_trip_t *trip = alloc_trip();
-	struct tm tm = { 0 };
-
-	/* We'll fill in the real data from the trip descriptor file */
-	tm.tm_year = yyyy;
-	tm.tm_mon = mm-1;
-	tm.tm_mday = dd;
-	trip->when = utc_mktime(&tm);
-
-	return trip;
-}
-
 static bool validate_date(int yyyy, int mm, int dd)
 {
 	return yyyy > 1930 && yyyy < 3000 &&
@@ -1243,7 +1223,7 @@ static int dive_trip_directory(const char *root, const char *name)
 	if (!validate_date(yyyy, mm, dd))
 		return GIT_WALK_SKIP;
 	finish_active_trip();
-	active_trip = create_new_trip(yyyy, mm, dd);
+	active_trip = alloc_trip();
 	return GIT_WALK_OK;
 }
 

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1176,7 +1176,7 @@ static void finish_active_trip(void)
 
 	if (trip) {
 		active_trip = NULL;
-		insert_trip(&trip);
+		insert_trip(trip);
 	}
 }
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1352,10 +1352,6 @@ static void try_to_fill_trip(dive_trip_t **dive_trip_p, const char *name, char *
 
 	dive_trip_t *dive_trip = *dive_trip_p;
 
-	if (MATCH_STATE("date", divedate, &dive_trip->when))
-		return;
-	if (MATCH_STATE("time", divetime, &dive_trip->when))
-		return;
 	if (MATCH("location", utf8_string, &dive_trip->location))
 		return;
 	if (MATCH("notes", utf8_string, &dive_trip->notes))

--- a/core/parse.c
+++ b/core/parse.c
@@ -279,7 +279,7 @@ void trip_end(struct parser_state *state)
 {
 	if (!state->cur_trip)
 		return;
-	insert_trip(&state->cur_trip);
+	insert_trip(state->cur_trip);
 	state->cur_trip = NULL;
 }
 

--- a/core/parse.c
+++ b/core/parse.c
@@ -243,10 +243,6 @@ void dive_start(struct parser_state *state)
 	state->cur_dive = alloc_dive();
 	reset_dc_info(&state->cur_dive->dc, state);
 	memset(&state->cur_tm, 0, sizeof(state->cur_tm));
-	if (state->cur_trip) {
-		add_dive_to_trip(state->cur_dive, state->cur_trip);
-		state->cur_dive->tripflag = IN_TRIP;
-	}
 	state->o2pressure_sensor = 1;
 }
 
@@ -258,6 +254,10 @@ void dive_end(struct parser_state *state)
 		free_dive(state->cur_dive);
 	else
 		record_dive_to_table(state->cur_dive, state->target_table);
+	if (state->cur_trip) {
+		add_dive_to_trip(state->cur_dive, state->cur_trip);
+		state->cur_dive->tripflag = IN_TRIP;
+	}
 	state->cur_dive = NULL;
 	state->cur_dc = NULL;
 	state->cur_location.lat.udeg = 0;

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -956,7 +956,7 @@ static int create_git_tree(git_repository *repo, struct dir *root, bool select_o
 		}
 
 		/* Create the date-based hierarchy */
-		utc_mkdate(trip ? trip->when : dive->when, &tm);
+		utc_mkdate(trip ? trip_date(trip) : dive->when, &tm);
 		tree = mktree(repo, root, "%04d", tm.tm_year);
 		tree = mktree(repo, tree, "%02d", tm.tm_mon + 1);
 

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -408,7 +408,8 @@ void write_trip(struct membuffer *b, dive_trip_t *trip, int *dive_no, bool selec
 	char *separator = "";
 	bool found_sel_dive = 0;
 
-	for (dive = trip->dives; dive != NULL; dive = dive->next) {
+	for (int i = 0; i < trip->dives.nr; i++) {
+		dive = trip->dives.dives[i];
 		if (!dive->selected && selected_only)
 			continue;
 

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -520,7 +520,7 @@ static void save_trip(struct membuffer *b, dive_trip_t *trip, bool anonymize)
 	struct dive *dive;
 
 	put_format(b, "<trip");
-	show_date(b, trip->when);
+	show_date(b, trip_date(trip));
 	show_utf8(b, trip->location, " location=\'", "\'", 1);
 	put_format(b, ">\n");
 	show_utf8(b, trip->notes, "<notes>", "</notes>\n", 0);

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -350,7 +350,7 @@ QString DiveObjectHelper::tripMeta() const
 		if (title.isEmpty()) {
 			// so use the date range
 			QString firstYear = firstTime.toString("yyyy");
-			QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*dt->dives->when, Qt::UTC);
+			QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*dt->dives.dives[0]->when, Qt::UTC);
 			QString lastMonth = lastTime.toString("MMM");
 			QString lastYear = lastTime.toString("yyyy");
 			if (lastMonth == firstMonth && lastYear == firstYear)
@@ -368,7 +368,7 @@ QString DiveObjectHelper::tripMeta() const
 int DiveObjectHelper::tripNrDives() const
 {
 	struct dive_trip *dt = m_dive->divetrip;
-	return dt ? dt->nrdives : 0;
+	return dt ? dt->dives.nr : 0;
 }
 
 int DiveObjectHelper::maxcns() const

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -343,7 +343,7 @@ QString DiveObjectHelper::tripMeta() const
 	if (dt) {
 		QString numDives = tr("(%n dive(s))", "", dt->showndives);
 		QString title(dt->location);
-		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*dt->when, Qt::UTC);
+		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
 		QString firstMonth = firstTime.toString("MMM");
 		QString tripDate = QStringLiteral("%1@%2").arg(firstMonth,firstTime.toString("yy"));
 

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -82,7 +82,7 @@ DiveToAdd DiveListBase::removeDive(struct dive *d)
 dive *DiveListBase::addDive(DiveToAdd &d)
 {
 	if (d.tripToAdd)
-		insert_trip_dont_merge(d.tripToAdd.release()); // Return ownership to backend
+		insert_trip(d.tripToAdd.release()); // Return ownership to backend
 	if (d.trip)
 		add_dive_to_trip(d.dive.get(), d.trip);
 	dive *res = d.dive.release();		// Give up ownership of dive
@@ -259,7 +259,7 @@ static void moveDivesBetweenTrips(DivesToTrip &dives)
 	for (OwningTripPtr &trip: dives.tripsToAdd) {
 		dive_trip *t = trip.release();	// Give up ownership
 		createdTrips.push_back(t);
-		insert_trip_dont_merge(t);	// Return ownership to backend
+		insert_trip(t);	// Return ownership to backend
 	}
 	dives.tripsToAdd.clear();
 

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -605,15 +605,17 @@ void ShiftTime::redoit()
 	// Changing times may have unsorted the dive table
 	sort_table(&dive_table);
 
-	// We send one dives-deleted signal per trip (see comments in DiveListNotifier.h).
-	// Therefore, collect all dives in a array and sort by trip.
+	// We send one time changed signal per trip (see comments in DiveListNotifier.h).
+	// Therefore, collect all dives in an array and sort by trip.
 	std::vector<std::pair<dive_trip *, dive *>> dives;
 	dives.reserve(diveList.size());
 	for (dive *d: diveList)
 		dives.push_back({ d->divetrip, d });
 
-	// Send signals.
+	// Send signals and sort tables.
 	processByTrip(dives, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
+		if (trip)
+			sort_table(&trip->dives); // Keep the trip-table in order
 		emit diveListNotifier.divesTimeChanged(trip, timeChanged, divesInTrip);
 	});
 

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -511,7 +511,7 @@ AddDive::AddDive(dive *d, bool autogroup, bool newNumber)
 			allocTrip.reset(trip);
 	}
 
-	int idx = dive_get_insertion_index(divePtr.get());
+	int idx = dive_get_insertion_index(&dive_table, divePtr.get());
 	if (newNumber)
 		divePtr->number = get_dive_nr_at_idx(idx);
 

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -66,7 +66,7 @@ DiveToAdd DiveListBase::removeDive(struct dive *d)
 	// remove dive from trip - if this is the last dive in the trip
 	// remove the whole trip.
 	res.trip = unregister_dive_from_trip(d, false);
-	if (res.trip && res.trip->nrdives == 0) {
+	if (res.trip && res.trip->dives.nr == 0) {
 		unregister_trip(res.trip);		// Remove trip from backend
 		res.tripToAdd.reset(res.trip);		// Take ownership of trip
 	}
@@ -231,7 +231,7 @@ static OwningTripPtr moveDiveToTrip(DiveToTrip &diveToTrip)
 
 	// Remove dive from trip - if this is the last dive in the trip, remove the whole trip.
 	dive_trip *trip = unregister_dive_from_trip(diveToTrip.dive, false);
-	if (trip && trip->nrdives == 0) {
+	if (trip && trip->dives.nr == 0) {
 		unregister_trip(trip);		// Remove trip from backend
 		res.reset(trip);
 	}
@@ -737,10 +737,10 @@ MergeTrips::MergeTrips(dive_trip *trip1, dive_trip *trip2)
 		return;
 	dive_trip *newTrip = combine_trips_create(trip1, trip2);
 	divesToMove.tripsToAdd.emplace_back(newTrip);
-	for (dive *d = trip1->dives; d; d = d->next)
-		divesToMove.divesToMove.push_back( { d, newTrip } );
-	for (dive *d = trip2->dives; d; d = d->next)
-		divesToMove.divesToMove.push_back( { d, newTrip } );
+	for (int i = 0; i < trip1->dives.nr; ++i)
+		divesToMove.divesToMove.push_back( { trip1->dives.dives[i], newTrip } );
+	for (int i = 0; i < trip2->dives.nr; ++i)
+		divesToMove.divesToMove.push_back( { trip2->dives.dives[i], newTrip } );
 }
 
 SplitDives::SplitDives(dive *d, duration_t time)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -909,10 +909,6 @@ void MainTab::acceptChanges()
 				Command::shiftTime(selectedDives, (int)offset);
 		}
 	}
-	if (editMode != TRIP && current_dive->divetrip) {
-		current_dive->divetrip->when = current_dive->when;
-		find_new_trip_start_time(current_dive->divetrip);
-	}
 	if (editMode == MANUALLY_ADDED_DIVE) {
 		// we just added or edited the dive, let fixup_dive() make
 		// sure we get the max. depth right

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1270,7 +1270,7 @@ bool QMLManager::undoDelete(int id)
 		return false;
 	}
 	if (deletedTrip)
-		insert_trip(&deletedTrip);
+		insert_trip(deletedTrip);
 	if (deletedDive->divetrip) {
 		struct dive_trip *trip = deletedDive->divetrip;
 		tripflag_t tripflag = deletedDive->tripflag; // this gets overwritten in add_dive_to_trip()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1275,8 +1275,6 @@ bool QMLManager::undoDelete(int id)
 		struct dive_trip *trip = deletedDive->divetrip;
 		tripflag_t tripflag = deletedDive->tripflag; // this gets overwritten in add_dive_to_trip()
 		deletedDive->divetrip = NULL;
-		deletedDive->next = NULL;
-		deletedDive->pprev = NULL;
 		add_dive_to_trip(deletedDive, trip);
 		deletedDive->tripflag = tripflag;
 	}
@@ -1309,11 +1307,11 @@ void QMLManager::deleteDive(int id)
 		memset(deletedTrip, 0, sizeof(struct dive_trip));
 	}
 	// if this is the last dive in that trip, remember the trip as well
-	if (d->divetrip && d->divetrip->nrdives == 1) {
+	if (d->divetrip && d->divetrip->dives.nr == 1) {
 		*deletedTrip = *d->divetrip;
 		deletedTrip->location = copy_string(d->divetrip->location);
 		deletedTrip->notes = copy_string(d->divetrip->notes);
-		deletedTrip->nrdives = 0;
+		deletedTrip->dives.nr = 0;
 		deletedDive->divetrip = deletedTrip;
 	}
 	DiveListModel::instance()->removeDiveById(id);

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -100,7 +100,7 @@ void DiveListSortModel::updateDivesShownInTrips()
 	struct dive_trip *dt = dive_trip_list;
 	int rc = rowCount();
 	while (dt) {
-		dt->showndives = rc ? 0 : dt->nrdives;
+		dt->showndives = rc ? 0 : dt->dives.nr;
 		dt = dt->next;
 	}
 	for (int i = 0; i < rowCount(); i++) {

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -57,20 +57,19 @@ QVariant DiveTripModel::tripData(const dive_trip *trip, int column, int role)
 		switch (column) {
 		case DiveTripModel::NR:
 			QString shownText;
-			struct dive *d = trip->dives;
 			int countShown = 0;
-			while (d) {
+			for (int i = 0; i < trip->dives.nr; ++i) {
+				struct dive *d = trip->dives.dives[i];
 				if (!d->hidden_by_filter)
 					countShown++;
 				oneDayTrip &= is_same_day (trip->when,  d->when);
-				d = d->next;
 			}
-			if (countShown < trip->nrdives)
+			if (countShown < trip->dives.nr)
 				shownText = tr("(%1 shown)").arg(countShown);
 			if (!empty_string(trip->location))
-				return QString(trip->location) + ", " + get_trip_date_string(trip->when, trip->nrdives, oneDayTrip) + " "+ shownText;
+				return QString(trip->location) + ", " + get_trip_date_string(trip->when, trip->dives.nr, oneDayTrip) + " "+ shownText;
 			else
-				return get_trip_date_string(trip->when, trip->nrdives, oneDayTrip) + shownText;
+				return get_trip_date_string(trip->when, trip->dives.nr, oneDayTrip) + shownText;
 		}
 	}
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -726,18 +726,18 @@ void addInBatches(Vector1 &v1, const Vector2 &v2, Comparator comp, Inserter inse
 
 void DiveTripModel::addDivesToTrip(int trip, const QVector<dive *> &dives)
 {
-		// Construct the parent index, ie. the index of the trip.
-		QModelIndex parent = createIndex(trip, 0, noParent);
+	// Construct the parent index, ie. the index of the trip.
+	QModelIndex parent = createIndex(trip, 0, noParent);
 
-		// Either this is outside of a trip or we're in list mode.
-		// Thus, add dives at the top-level in batches
-		addInBatches(items[trip].dives, dives,
-			     [](dive *d, dive *d2) { return dive_less_than(d, d2); }, // comp
-			     [&](std::vector<dive *> &items, const QVector<dive *> &dives, int idx, int from, int to) { // inserter
-				beginInsertRows(parent, idx, idx + to - from - 1);
-				items.insert(items.begin() + idx, dives.begin() + from, dives.begin() + to);
-				endInsertRows();
-			     });
+	// Either this is outside of a trip or we're in list mode.
+	// Thus, add dives at the top-level in batches
+	addInBatches(items[trip].dives, dives,
+		     [](dive *d, dive *d2) { return dive_less_than(d, d2); }, // comp
+		     [&](std::vector<dive *> &items, const QVector<dive *> &dives, int idx, int from, int to) { // inserter
+			beginInsertRows(parent, idx, idx + to - from - 1);
+			items.insert(items.begin() + idx, dives.begin() + from, dives.begin() + to);
+			endInsertRows();
+		     });
 }
 
 // This function is used to compare a dive to an arbitrary entry (dive or trip).

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -104,7 +104,7 @@ private:
 	int findTripIdx(const dive_trip *trip) const;
 	int findDiveIdx(const dive *d) const;			// Find _top_level_ dive
 	int findDiveInTrip(int tripIdx, const dive *d) const;	// Find dive inside trip. Second parameter is index of trip
-	int findInsertionIndex(timestamp_t when) const;		// Where to insert item with timestamp "when"
+	int findInsertionIndex(const dive_trip *trip) const;	// Where to insert trip
 
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -115,6 +115,7 @@ private:
 
 	// Addition and deletion of dives
 	void addDivesToTrip(int idx, const QVector<dive *> &dives);
+	void topLevelChanged(int idx);
 
 	dive *diveOrNull(const QModelIndex &index) const;	// Returns a dive if this index represents a dive, null otherwise
 	dive_or_trip tripOrDive(const QModelIndex &index) const;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -81,24 +81,15 @@ private slots:
 private:
 	// The model has up to two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"
-	// struct. Two cases two consider:
-	// 1) If "trip" is non-null, then this is a dive-trip and the dives are collected
-	// in the dives vector.  Note that in principle we could also get the dives in a
-	// trip from the backend, but there they are collected in a linked-list, which is
-	// quite inconvenient to access.
-	// 2) If "trip" is null, this is a dive and dives is supposed to contain exactly
-	// one element, which is the corresponding dive.
-	//
-	// Top-level items are ordered by timestamp. For dives, the core function
-	// dive_less_than is used, which guarantees a stable ordering even in the
-	// case of equal timestamps. For dives and trips, place dives before trips
-	// in the case of an equal timestamp. For trips with equal timestamps, the
-	// order is currently undefined. This is currently not a problem, because
-	// the core doesn't have a list of sorted trips. But nevertheless something
-	// to keep in mind.
+	// struct, which is based on the dive_or_trip structure.
+	// If it is a trip, additionally, the dives are collected in a vector.
+	// The items are ordered chronologically according to the dive_or_trip_less_than()
+	// function, which guarantees a stable ordering even in the case of equal timestamps.
+	// For dives and trips, it place dives chronologically after trips, so that in
+	// the default-descending view they are shown before trips.
 	struct Item {
-		dive_trip		*trip;
-		std::vector<dive *>	 dives;			// std::vector<> instead of QVector for insert() with three iterators
+		dive_or_trip		d_or_t;
+		std::vector<dive *>	dives;			// std::vector<> instead of QVector for insert() with three iterators
 		Item(dive_trip *t, const QVector<dive *> &dives);
 		Item(dive_trip *t, dive *d);			// Initialize a trip with one dive
 		Item(dive *d);					// Initialize a top-level dive
@@ -126,7 +117,7 @@ private:
 	void addDivesToTrip(int idx, const QVector<dive *> &dives);
 
 	dive *diveOrNull(const QModelIndex &index) const;	// Returns a dive if this index represents a dive, null otherwise
-	QPair<dive_trip *, dive *> tripOrDive(const QModelIndex &index) const;
+	dive_or_trip tripOrDive(const QModelIndex &index) const;
 								// Returns either a pointer to a trip or a dive, or twice null of index is invalid
 								// null, something is really wrong
 	void setupModelData();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -634,8 +634,8 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 		return false; // Oops. Neither dive nor trip, something is seriously wrong.
 
 	// Show the trip if any dive is visible
-	for (d = trip->dives; d; d = d->next) {
-		if (!d->hidden_by_filter)
+	for (int i = 0; i < trip->dives.nr; ++i) {
+		if (!trip->dives.dives[i]->hidden_by_filter)
 			return true;
 	}
 	return false;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is more churn that comes out of the divelist / undo work. The dive-list is not yet fully under control, but I'm trying to get there.

Firstly, there's a detangling of ownership concerning trips: The core would merge trips with the same date. But that is problematic with upcoming changes to the import code: the importer is responsible for deciding when it wants to merge trips. Also it seems ill defined, as the date of a trip is a fluctuating value. Adding / removing / editing trips changes trip date. Sadly, the git-storage uses the trip date as an id. I'll try to see what happens with two trips on the same date [A situation that can already be constructed in the old code].

Secondly, this tries to move the comparison functions into a single place (the core) to get this mess under control. Not completely there yet, but hopefully a step in the right direction.

Thirdly, this converges core and model data structures: Dives in trips are now also kept in table form in the core. The long-term goal here is to remove the double representation of the data. Ideally, the models simply present the core-data. But that's still a long way to go.

That's all a bit hairy therefore shortly after release is probably the best time to get this a bit of exposure. I'm sure that there are a number of problems lurking, but hopefully nothing fundamental.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Nothing fundamentally user visible (unless the user has strange use-cases like overlapping trips, etc). So probably not.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
The usual suspects. :)