### PR TITLE
[Cleanup] silence warnings

### DIFF
--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -606,10 +606,13 @@ static bool uemis_get_answer(const char *path, char *request, int n_param_in,
 #ifdef UEMIS_DEBUG
 			fprintf(debugfile, "open %s failed with errno %d\n", ans_path, errno);
 #endif
+			free(ans_path);
 			return false;
 		}
-		if (read(ans_file, tmp, 100) < 0)
+		if (read(ans_file, tmp, 100) < 0) {
+			free(ans_path);
 			return false;
+		}
 		close(ans_file);
 #if UEMIS_DEBUG & 8
 		tmp[100] = '\0';
@@ -670,6 +673,7 @@ static bool uemis_get_answer(const char *path, char *request, int n_param_in,
 #ifdef UEMIS_DEBUG
 				fprintf(debugfile, "open %s failed with errno %d\n", ans_path, errno);
 #endif
+				free(ans_path);
 				return false;
 			}
 			free(ans_path);
@@ -707,6 +711,7 @@ static bool uemis_get_answer(const char *path, char *request, int n_param_in,
 #ifdef UEMIS_DEBUG
 				fprintf(debugfile, "open %s failed with errno %d\n", ans_path, errno);
 #endif
+				free(ans_path);
 				return false;
 			}
 

--- a/desktop-widgets/templateedit.cpp
+++ b/desktop-widgets/templateedit.cpp
@@ -147,7 +147,7 @@ void TemplateEdit::saveSettings()
 		msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel);
 		msgBox.setDefaultButton(QMessageBox::Cancel);
 		if (msgBox.exec() == QMessageBox::Save) {
-			memcpy(templateOptions, &newTemplateOptions, sizeof(struct template_options));
+			*templateOptions = newTemplateOptions;
 			if (templateChanged) {
 				TemplateLayout::writeTemplate(printOptions->p_template, ui->plainTextEdit->toPlainText());
 				if (printOptions->type == print_options::DIVELIST)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes noisy warning I get since upgrading to Kubuntu 18.10 and accordingly to gcc 8.2.
The first one is a bit dubious - an alternative would be to increase the filename buffers, but I understand that this is supposed to generate MS-DOS 8.3 filenames!?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Silence warnings.
