### PR TITLE
Fix Cressi interface ftdi opening bug

### DIFF
--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -156,7 +156,7 @@ static int serial_ftdi_open_device (struct ftdi_context *ftdi_ctx)
 		0xF680, // Suunto
 		0x87D0, // Cressi (Leonardo)
 	};
-	int num_accepted_pids = 6;
+	int num_accepted_pids = sizeof(accepted_pids) / sizeof(accepted_pids[0]);
 	int i, pid, ret;
 	for (i = 0; i < num_accepted_pids; i++) {
 		pid = accepted_pids[i];


### PR DESCRIPTION
The Cressi specific PID was not used
when  serial_ftdi_open_device tried
to open the device.

Reported-by: Daniel Krupp
Signed-off-by: Daniel Krupp <daniel.krupp@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
On subsurface-mobile DC download 
did not start from a Cressi Newton computer
using official Cressi USB cable.

The issue was that Cressi specific PID was not used
when  serial_ftdi_open_device tried
to open the device.

### Changes made:
num_accepted_pids set properly to the array size.

### Related issues:
https://groups.google.com/forum/#!topic/subsurface-divelog/47N7gaCV_ik

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
Fix Cressi Leonardo/Newton USB interface works now on subsurface-mobile

### Documentation change:
None.

### Mentions:

