### PR TITLE
Git parser: don't produce user-visible error on git parsing

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -799,6 +799,14 @@ static void parse_dc_event(char *line, struct membuffer *str, void *_dc)
 	}
 }
 
+/* Not needed anymore - trip date calculated implicitly from first dive */
+static void parse_trip_date(char *line, struct membuffer *str, void *trip)
+{ UNUSED(line); UNUSED(str); UNUSED(trip); }
+
+/* Not needed anymore - trip date calculated implicitly from first dive */
+static void parse_trip_time(char *line, struct membuffer *str, void *trip)
+{ UNUSED(line); UNUSED(str); UNUSED(trip); }
+
 static void parse_trip_location(char *line, struct membuffer *str, void *_trip)
 { UNUSED(line); dive_trip_t *trip = _trip; trip->location = get_utf8(str); }
 
@@ -1001,7 +1009,7 @@ static void site_parser(char *line, struct membuffer *str, void *_ds)
 struct keyword_action trip_action[] = {
 #undef D
 #define D(x) { #x, parse_trip_ ## x }
-	D(location), D(notes),
+	D(date), D(location), D(notes), D(time),
 };
 
 static void trip_parser(char *line, struct membuffer *str, void *_trip)


### PR DESCRIPTION
In 64e6e435f82801f4f440ef5b1caf58a91a7c9929 the when field of struct
trip was removed. Accordingly it was not read from git repositories.
This produced a large amount of user-visible error messages.

Reinstate the trip-date and time parsing functions, but ignore
the value.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes error messages barfed at the user that are due to ignoring trip-date and time.

See discussion in #1858. To me, the behavior of the parser (complaining about unknown attributes) is very surprising. But from the discussion so far I understand that it's supposed to be that way..

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add trip date and time parsing functions but ignore the value.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder @dirkhh