### PR TITLE
[TRIVIAL] Cleanup: remove redundant 'extern "C"' in dive.h

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -462,10 +462,6 @@ extern void delete_current_divecomputer(void);
 #define for_each_gps_location(_i, _x) \
 	for ((_i) = 0; ((_x) = get_gps_location(_i, &gps_location_table)) != NULL; (_i)++)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
 extern bool dive_site_has_gps_location(const struct dive_site *ds);
@@ -601,10 +597,6 @@ extern void clear_events(void);
 extern void set_dc_nickname(struct dive *dive);
 extern void set_autogroup(bool value);
 extern int total_weight(const struct dive *);
-
-#ifdef __cplusplus
-}
-#endif
 
 #define DIVE_ERROR_PARSE 1
 #define DIVE_ERROR_PLAN 2


### PR DESCRIPTION
In dive.h there was a redundant 'extern "C"' block defined inside
another 'extern "C"' block. Remove.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial cleanup - see commit description.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove redundant `extern "C" { ... }` in `dive.h`.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
