### PR TITLE
Cleanup: make "struct dive *" and "struct dive_trip *" Qt metatypes

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -758,16 +758,22 @@ extern void set_git_prefs(const char *prefs);
 extern char *get_dive_date_c_string(timestamp_t when);
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 
-#ifdef __cplusplus
-}
-#endif
-
 extern weight_t string_to_weight(const char *str);
 extern depth_t string_to_depth(const char *str);
 extern pressure_t string_to_pressure(const char *str);
 extern volume_t string_to_volume(const char *str, pressure_t workp);
 extern fraction_t string_to_fraction(const char *str);
 extern void average_max_depth(struct diveplan *dive, int *avg_depth, int *max_depth);
+
+#ifdef __cplusplus
+}
+
+/* Make pointers to dive and dive_trip "Qt metatypes" so that they can
+ * be passed through QVariants. */
+Q_DECLARE_METATYPE(struct dive *);
+Q_DECLARE_METATYPE(struct dive_trip *);
+
+#endif
 
 #include "pref.h"
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -51,7 +51,7 @@ QVariant DiveTripModel::tripData(const dive_trip *trip, int column, int role)
 	bool oneDayTrip=true;
 
 	if (role == TRIP_ROLE)
-		return QVariant::fromValue<void *>((void *)trip); // Not nice: casting away a const
+		return QVariant::fromValue(const_cast<dive_trip *>(trip)); // Not nice: casting away a const
 
 	if (role == Qt::DisplayRole) {
 		switch (column) {
@@ -248,7 +248,7 @@ QVariant DiveTripModel::diveData(const struct dive *d, int column, int role)
 	case STAR_ROLE:
 		return d->rating;
 	case DIVE_ROLE:
-		return QVariant::fromValue<void *>((void *)d);  // Not nice: casting away a const
+		return QVariant::fromValue(const_cast<dive *>(d));  // Not nice: casting away a const
 	case DIVE_IDX:
 		return get_divenr(d);
 	case SELECTED_ROLE:

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -619,16 +619,14 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
 	QModelIndex index0 = sourceModel()->index(source_row, 0, source_parent);
-	QVariant diveVariant = sourceModel()->data(index0, DiveTripModel::DIVE_ROLE);
-	struct dive *d = (struct dive *)diveVariant.value<void *>();
+	struct dive *d = sourceModel()->data(index0, DiveTripModel::DIVE_ROLE).value<struct dive *>();
 
 	// For dives, simply check the hidden_by_filter flag
 	if (d)
 		return !d->hidden_by_filter;
 
 	// Since this is not a dive, it must be a trip
-	QVariant tripVariant = sourceModel()->data(index0, DiveTripModel::TRIP_ROLE);
-	dive_trip *trip = (dive_trip *)tripVariant.value<void *>();
+	dive_trip *trip = sourceModel()->data(index0, DiveTripModel::TRIP_ROLE).value<dive_trip *>();
 
 	if (!trip)
 		return false; // Oops. Neither dive nor trip, something is seriously wrong.


### PR DESCRIPTION
Just as we did for pointer to struct dive_site, make pointers to
struct dive and struct dive_trip "Qt metatypes". This means that
they can be passed through QVariants without taking a detour via
void *.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Make `struct dive *` and `struct dive_trip *` Qt metatypes, so that they can be passed through `QVariants` and later through `QML`. I hope that especially the latter will make it possible to remove some of the idiosyncrasies of the mobile dive list. For example, the way I read the code, the trip header is formatted for *every* dive and then the trip headers are compared. It would appear much more logical to simply compare the `dive_trip *` pointers.

Note: this is a bit hairy, because `QVariant`s often cases don't give compile time errors, but simply return null pointers! E.g. if in a `QVariant` returning functions you do
```
   return trip;
```
On readout this will give NULL.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make `struct dive *` and `struct dive_trip *` Qt metatypes
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
