### PR TITLE
Cleanup: remove DiveObjectHelper::trip() function

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -324,11 +324,6 @@ QList<CylinderObjectHelper*> DiveObjectHelper::cylinderObjects() const
 	return m_cyls;
 }
 
-QString DiveObjectHelper::trip() const
-{
-	return m_dive->divetrip ? m_dive->divetrip->location : EMPTY_DIVE_STRING;
-}
-
 // combine the pointer address with the trip title so that
 // we detect multiple, destinct trips with the same title
 // the trip title is designed to be
@@ -448,5 +443,6 @@ QString DiveObjectHelper::fullText() const
 
 QString DiveObjectHelper::fullTextNoNotes() const
 {
-	return trip() + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
+	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : EMPTY_DIVE_STRING;
+	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
 }

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -39,7 +39,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
 	Q_PROPERTY(QList<CylinderObjectHelper*> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(QString trip READ trip CONSTANT)
 	Q_PROPERTY(QString tripMeta READ tripMeta CONSTANT)
 	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
@@ -86,7 +85,6 @@ public:
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
 	QList<CylinderObjectHelper*> cylinderObjects() const;
-	QString trip() const;
 	QString tripMeta() const;
 	int tripNrDives() const;
 	int maxcns() const;


### PR DESCRIPTION
The DiveObjectHelper::trip() function was
1) Misnamed: it returned the *location* of the trip
2) Not used outside of DiveObjectHelper

Remove it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove an (apparently - you never can tell with QML!) unused and misnamed function. Reason: let's add a `trip()` function that *actually* returns the trip of the dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove function

