### PR TITLE
Cleanup: remove EMPTY_DIVE_STRING

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -8,14 +8,13 @@
 #include "core/subsurface-string.h"
 #include "qt-models/tankinfomodel.h"
 
-static QString EMPTY_DIVE_STRING = QStringLiteral("");
 enum returnPressureSelector {START_PRESSURE, END_PRESSURE};
 
 static QString getFormattedWeight(struct dive *dive, unsigned int idx)
 {
 	weightsystem_t *weight = &dive->weightsystem[idx];
 	if (!weight->description)
-		return QString(EMPTY_DIVE_STRING);
+		return QString();
 	QString fmt = QString(weight->description);
 	fmt += ", " + get_weight_string(weight->weight, true);
 	return fmt;
@@ -26,7 +25,7 @@ static QString getFormattedCylinder(struct dive *dive, unsigned int idx)
 	cylinder_t *cyl = &dive->cylinder[idx];
 	const char *desc = cyl->type.description;
 	if (!desc && idx > 0)
-		return QString(EMPTY_DIVE_STRING);
+		return QString();
 	QString fmt = desc ? QString(desc) : gettextFromC::tr("unknown");
 	fmt += ", " + get_volume_string(cyl->type.size, true);
 	fmt += ", " + get_pressure_string(cyl->type.workingpressure, true);
@@ -107,7 +106,7 @@ QString DiveObjectHelper::time() const
 
 QString DiveObjectHelper::location() const
 {
-	return get_dive_location(m_dive) ? QString::fromUtf8(get_dive_location(m_dive)) : EMPTY_DIVE_STRING;
+	return get_dive_location(m_dive) ? QString::fromUtf8(get_dive_location(m_dive)) : QString();
 }
 
 QString DiveObjectHelper::gps() const
@@ -149,35 +148,27 @@ QString DiveObjectHelper::depth() const
 
 QString DiveObjectHelper::divemaster() const
 {
-	return m_dive->divemaster ? m_dive->divemaster : EMPTY_DIVE_STRING;
+	return m_dive->divemaster ? m_dive->divemaster : QString();
 }
 
 QString DiveObjectHelper::buddy() const
 {
-	return m_dive->buddy ? m_dive->buddy : EMPTY_DIVE_STRING;
+	return m_dive->buddy ? m_dive->buddy : QString();
 }
 
 QString DiveObjectHelper::airTemp() const
 {
-	QString temp = get_temperature_string(m_dive->airtemp, true);
-	if (temp.isEmpty()) {
-		temp = EMPTY_DIVE_STRING;
-	}
-	return temp;
+	return get_temperature_string(m_dive->airtemp, true);
 }
 
 QString DiveObjectHelper::waterTemp() const
 {
-	QString temp = get_temperature_string(m_dive->watertemp, true);
-	if (temp.isEmpty()) {
-		temp = EMPTY_DIVE_STRING;
-	}
-	return temp;
+	return get_temperature_string(m_dive->watertemp, true);
 }
 
 QString DiveObjectHelper::notes() const
 {
-	QString tmp = m_dive->notes ? QString::fromUtf8(m_dive->notes) : EMPTY_DIVE_STRING;
+	QString tmp = m_dive->notes ? QString::fromUtf8(m_dive->notes) : QString();
 	if (same_string(m_dive->dc.model, "planned dive")) {
 		QTextDocument notes;
 	#define _NOTES_BR "&#92n"
@@ -238,7 +229,7 @@ QString DiveObjectHelper::weightList() const
 	QString weights;
 	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
 		QString w = getFormattedWeight(m_dive, i);
-		if (w == EMPTY_DIVE_STRING)
+		if (w.isEmpty())
 			continue;
 		weights += w + "; ";
 	}
@@ -250,7 +241,7 @@ QStringList DiveObjectHelper::weights() const
 	QStringList weights;
 	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
 		QString w = getFormattedWeight(m_dive, i);
-		if (w == EMPTY_DIVE_STRING)
+		if (w.isEmpty())
 			continue;
 		weights << w;
 	}
@@ -265,13 +256,13 @@ bool DiveObjectHelper::singleWeight() const
 QString DiveObjectHelper::weight(int idx) const
 {
 	if ( (idx < 0) || idx > MAX_WEIGHTSYSTEMS )
-		return QString(EMPTY_DIVE_STRING);
+		return QString();
 	return getFormattedWeight(m_dive, idx);
 }
 
 QString DiveObjectHelper::suit() const
 {
-	return m_dive->suit ? m_dive->suit : EMPTY_DIVE_STRING;
+	return m_dive->suit ? m_dive->suit : QString();
 }
 
 QStringList DiveObjectHelper::cylinderList() const
@@ -282,7 +273,7 @@ QStringList DiveObjectHelper::cylinderList() const
 	for_each_dive (i, d) {
 		for (int j = 0; j < MAX_CYLINDERS; j++) {
 			QString cyl = d->cylinder[j].type.description;
-			if (cyl == EMPTY_DIVE_STRING)
+			if (cyl.isEmpty())
 				continue;
 			cylinders << cyl;
 		}
@@ -290,7 +281,7 @@ QStringList DiveObjectHelper::cylinderList() const
 
 	for (unsigned long ti = 0; ti < MAX_TANK_INFO && tank_info[ti].name != NULL; ti++) {
 		QString cyl = tank_info[ti].name;
-		if (cyl == EMPTY_DIVE_STRING)
+		if (cyl.isEmpty())
 			continue;
 		cylinders << cyl;
 	}
@@ -305,7 +296,7 @@ QStringList DiveObjectHelper::cylinders() const
 	QStringList cylinders;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		QString cyl = getFormattedCylinder(m_dive, i);
-		if (cyl == EMPTY_DIVE_STRING)
+		if (cyl.isEmpty())
 			continue;
 		cylinders << cyl;
 	}
@@ -315,7 +306,7 @@ QStringList DiveObjectHelper::cylinders() const
 QString DiveObjectHelper::cylinder(int idx) const
 {
 	if ( (idx < 0) || idx > MAX_CYLINDERS)
-		return QString(EMPTY_DIVE_STRING);
+		return QString();
 	return getFormattedCylinder(m_dive, idx);
 }
 
@@ -412,6 +403,6 @@ QString DiveObjectHelper::fullText() const
 
 QString DiveObjectHelper::fullTextNoNotes() const
 {
-	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : EMPTY_DIVE_STRING;
+	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : QString();
 	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
 }


### PR DESCRIPTION
EMPTY_DIVE_STRING used to be a string-literal representing missing
information ("--"). In 6985c123d412d3223618247e2fcc733cd99bb842 it
was replaced by the actual empty string. Using a literal to represent
the empty string seems a bit pointless, therefore remove it completely.

Notably:
	QString(EMPTY_DIVE_STRING) -> QString()
	if (temp.isEmpty()) temp = EMPTY_DIVE_STRING; -> noop
	if (s == EMPTY_DIVE_STRING) -> if (s.isEmpty())

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another mostly trivial and self-explanatory cleanup. See commit description.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove `EMPTY_DIVE_STRING`

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
