### PR TITLE
Dive list: fix off-by-two bug in DiveTripModel

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -696,12 +696,13 @@ void DiveTripModel::topLevelChanged(int idx)
 
 	// If that didn't change, try to move forward
 	if (newIdx == idx) {
-		while (newIdx <= (int)items.size() && !dive_or_trip_less_than(items[idx].d_or_t, items[newIdx + 1].d_or_t))
+		++newIdx;
+		while (newIdx < (int)items.size() && !dive_or_trip_less_than(items[idx].d_or_t, items[newIdx].d_or_t))
 			++newIdx;
 	}
 
 	// If index changed, move items
-	if (newIdx != idx) {
+	if (newIdx != idx && newIdx != idx + 1) {
 		beginMoveRows(QModelIndex(), idx, idx, QModelIndex(), newIdx);
 		moveInVector(items, idx, idx + 1, newIdx);
 		endMoveRows();


### PR DESCRIPTION
Commit 911edfca712a046944de6d033cc4b8dd50cedfc3 changed the dive list
on desktop to update positions of trips when adding/removing dives.
A very unlikely case, but necessary for consistency.

For a trip to be moveable down, its index has to be one-less than
the maximum index, which is "items - 1". The code was doubly wrong:
it forget the "- 1" and checked for less-or-equal instead less-than.
Thus this was effectively an off-by-two error. Fix it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a recently introduced, easily pulled off crash condition: delete dives from or add dives to either the last or the second to last dive.

Sometimes I wonder where my brain is. 😛 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix silly off-by-two error.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.