### PR TITLE
Invalidate git cache when removing dive from trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix bug in cloud save after removing dives from a trip
 - Dive: Perform more accurate OTU calculations, and include
   OTU calculations for rebreather dives [#1851 & #1865].
 - Mobile: add initial copy-paste support

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -92,6 +92,7 @@ dive *DiveListBase::addDive(DiveToAdd &d)
 	res->hidden_by_filter = !show;
 
 	add_single_dive(d.idx, res);		// Return ownership to backend
+	invalidate_dive_cache(res);		// Ensure that dive is written in git_save()
 
 	// If the dive to be removed is selected, we will inform the frontend
 	// later via a signal that the dive changed.
@@ -191,7 +192,7 @@ std::vector<dive *> DiveListBase::addDives(std::vector<DiveToAdd> &divesToAdd)
 
 // This helper function renumbers dives according to an array of id/number pairs.
 // The old numbers are stored in the array, thus calling this function twice has no effect.
-// TODO: switch from uniq-id to indexes once all divelist-actions are controlled by undo-able commands
+// TODO: switch from uniq-id to indices once all divelist-actions are controlled by undo-able commands
 static void renumberDives(QVector<QPair<dive *, int>> &divesToRenumber)
 {
 	for (auto &pair: divesToRenumber) {
@@ -199,6 +200,7 @@ static void renumberDives(QVector<QPair<dive *, int>> &divesToRenumber)
 		if (!d)
 			continue;
 		std::swap(d->number, pair.second);
+		invalidate_dive_cache(d);
 	}
 
 	// Emit changed signals per trip.
@@ -239,6 +241,7 @@ static OwningTripPtr moveDiveToTrip(DiveToTrip &diveToTrip)
 	// Store old trip and get new trip we should associate this dive with
 	std::swap(trip, diveToTrip.trip);
 	add_dive_to_trip(diveToTrip.dive, trip);
+	invalidate_dive_cache(diveToTrip.dive);		// Ensure that dive is written in git_save()
 	return res;
 }
 


### PR DESCRIPTION
... otherwise this change is not saved when saving to git.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug reported in the google group 
https://groups.google.com/d/msgid/subsurface-divelog/aa812413-8fcc-4817-ab3b-964144e2046e%40googlegroups.com?utm_medium=email&utm_source=footer

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
