### PR TITLE
Dive list: remove trip from model only once

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -305,9 +305,12 @@ static void moveDivesBetweenTrips(DivesToTrip &dives)
 		for (size_t k = i; k < j; ++k)
 			divesInTrip[k - i] = divesMoved[k].d;
 
-		// Check if the from-trip was deleted: If yes, it was recorded in the tripsToAdd structure
+		// Check if the from-trip was deleted: If yes, it was recorded in the tripsToAdd structure.
+		// Only set the flag if this is that last time this trip is featured.
 		bool deleteFrom = from &&
-				  std::find_if(dives.tripsToAdd.begin(), dives.tripsToAdd.end(),
+				  std::find_if(divesMoved.begin() + j, divesMoved.end(), // Is this the last occurence of "from"?
+					       [from](const DiveMoved &entry) { return entry.from == from; }) == divesMoved.end() &&
+				  std::find_if(dives.tripsToAdd.begin(), dives.tripsToAdd.end(), // Is "from" in tripsToAdd?
 					       [from](const OwningTripPtr &trip) { return trip.get() == from; }) != dives.tripsToAdd.end();
 		// Check if the to-trip has to be created. For this purpose, we saved an array of trips to be created.
 		bool createTo = false;


### PR DESCRIPTION
In moveDivesBetweenTrips() a the model is informed of dives
that are moved between trips. A flag tells the model to delete
empty trips. If dives were removed in batches [use case: split
a big trip into multiple smaller trips] the flag would be sent
for every batch. This was handled gracefully by the model code,
but it gave a warning message.

Set the flag only for the last batch, when the trip is *really*
empty.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a fix of a non-critical bug: When moving dives between trips it could happen that the model was told to delete trips twice. This was handled gracefully, but it produced a warning message and is very dubious practice.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make sure to send delete-trip flag only for last batch
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - hopefully not user visible.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
