### PR TITLE
Core: don't remove dive from trip in add_dive_to_trip()

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -19,7 +19,6 @@
  * void insert_trip(dive_trip_t *dive_trip_p)
  * void unregister_trip(dive_trip_t *trip)
  * void free_trip(dive_trip_t *trip)
- * void remove_dive_from_trip(struct dive *dive)
  * void remove_dive_from_trip(struct dive *dive, bool was_autogen)
  * void add_dive_to_trip(struct dive *dive, dive_trip_t *trip)
  * dive_trip_t *create_and_hookup_trip_from_dive(struct dive *dive)
@@ -912,11 +911,14 @@ void remove_dive_from_trip(struct dive *dive, short was_autogen)
 		delete_trip(trip);
 }
 
+/* Add dive to a trip. Caller is responsible for removing dive
+ * from trip beforehand. */
 void add_dive_to_trip(struct dive *dive, dive_trip_t *trip)
 {
 	if (dive->divetrip == trip)
 		return;
-	remove_dive_from_trip(dive, false);
+	if (dive->divetrip)
+		fprintf(stderr, "Warning: adding dive to trip that has trip set\n");
 	add_dive_to_table(&trip->dives, -1, dive);
 	dive->divetrip = trip;
 }
@@ -1522,10 +1524,8 @@ static bool try_to_merge_into(struct dive *dive_to_add, int idx, bool prefer_imp
 	merged->id = old_dive->id;
 	merged->selected = old_dive->selected;
 	dive_table.dives[idx] = merged;
-	if (trip) {
+	if (trip)
 		remove_dive_from_trip(old_dive, false);
-		add_dive_to_trip(merged, trip);
-	}
 	free_dive(old_dive);
 	remove_dive_from_trip(dive_to_add, false);
 	free_dive(dive_to_add);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1077,16 +1077,15 @@ void delete_dive_from_table(struct dive_table *table, int idx)
 	unregister_dive_from_table(table, idx);
 }
 
-/* this removes a dive from the dive table and trip-list but doesn't
- * free the resources associated with the dive. It returns a pointer
- * to the unregistered dive. The returned dive has the selection-
- * and hidden-flags cleared. */
+/* This removes a dive from the global dive table but doesn't free the
+ * resources associated with the dive. The caller must removed the dive
+ * from the trip-list. Returns a pointer to the unregistered dive.
+ * The unregistered dive has the selection- and hidden-flags cleared. */
 struct dive *unregister_dive(int idx)
 {
 	struct dive *dive = get_dive(idx);
 	if (!dive)
 		return NULL; /* this should never happen */
-	remove_dive_from_trip(dive, false);
 	unregister_dive_from_table(&dive_table, idx);
 	if (dive->selected)
 		amount_selected--;
@@ -1094,8 +1093,8 @@ struct dive *unregister_dive(int idx)
 	return dive;
 }
 
-/* this implements the mechanics of removing the dive from the table,
- * but doesn't deal with updating dive trips, etc */
+/* this implements the mechanics of removing the dive from the global
+ * dive table and the trip, but doesn't deal with updating dive trips, etc */
 void delete_single_dive(int idx)
 {
 	struct dive *dive = get_dive(idx);
@@ -1103,8 +1102,8 @@ void delete_single_dive(int idx)
 		return; /* this should never happen */
 	if (dive->selected)
 		deselect_dive(dive);
-	dive = unregister_dive(idx);
-	free_dive(dive);
+	remove_dive_from_trip(dive, false);
+	delete_dive_from_table(&dive_table, idx);
 }
 
 struct dive **grow_dive_table(struct dive_table *table)


### PR DESCRIPTION
All callers of add_dive_to_trip() work on freshly generated dives,
with one exception, that was redundant anyway. Therefore it is not
necessary to remove the dive from a potential previous trip. Move the
responsibility of removing the dive from a trip to the caller,
respectively remove the redundant call. Add a warning message in the
case that trip is set.

Background: On import (either download or file-import) we might not
want to add trips to the global trip-list. For example to enable undo
of import but more generally to detangle that data flow. Thus,
add_dive_to_trip() should not mingle with the global trip-list,
which it has to do if a trip is deleted because the old dive was
removed.

Analysis of the add_dive_to_trip() callers:

1) core/dive.c

pick_trip():
    called on freshly generated merged dive.

finish_split():
    called on two freshly generated split dives.

2) core/divelist.c

create_and_hookup_trip_from_dive():
    called on freshly downloaded dive in dive_cb().
    called on freshly downloaded dive in record_uemis_dive().

autogroup_dives():
    called on dive from get_dives_to_autogroup(), which only
    finds dives that are outside of trips.

combine_trips():
    unused - removed in sibling commit.

try_to_merge_into():
    this call was actually erroneous - dive was already added
    to trip in try_to_merge(). Remove call.

3) core/libdivecomputer.c

dive_cb():
    called on freshly downloaded dive.

4) core/uemis_downloader.c

record_uemis_dive():
    called on freshly downloaded dive.

5) core/load_git.c

create_new_dive():
    called on freshly allocated dive.

6) core/parse.c

dive_end():
    called on freshly parsed dive.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This moves the responsibility of removing a dive from a trip from `add_dive_to_trip()` to the caller. Actually, this function was only called on non-trip dives anyway, so no change needed. Add a warning printf in case the function is called on a dive inside a trip.

While this may look like idle code-reshuffling, it does actually simplify the work-in-progress on dive-import. The problem with automatically removing the dive from the trip is that if the trip becomes empty it is deleted from the global trip-list. But we might not want to add all trips to the global trip-list. For example to make download/import undo-able.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't remove dive from trip in add_dive_to_trip().

