### PR TITLE
Unglobalize downloadTable

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -278,10 +278,10 @@ struct divecomputer {
 #define W_IDX_PRIMARY 0
 #define W_IDX_SECONDARY 1
 
-struct dive_table {
+typedef struct dive_table {
 	int nr, allocated;
 	struct dive **dives;
-};
+} dive_table_t;
 
 typedef struct dive_trip
 {
@@ -425,7 +425,7 @@ extern const struct units SI_units, IMPERIAL_units;
 extern const struct units *get_units(void);
 extern int run_survey, verbose, quit, force_root;
 
-extern struct dive_table dive_table, downloadTable;
+extern struct dive_table dive_table;
 extern struct dive displayed_dive;
 extern unsigned int dc_number;
 extern struct dive *current_dive;
@@ -759,10 +759,14 @@ extern void average_max_depth(struct diveplan *dive, int *avg_depth, int *max_de
 #ifdef __cplusplus
 }
 
-/* Make pointers to dive and dive_trip "Qt metatypes" so that they can
- * be passed through QVariants. */
+/* Make pointers to dive, dive_trip and dive_table "Qt metatypes" so that they can
+ * be passed through QVariants and through QML.
+ * Note: we have to use the typedef "dive_table_t" instead of "struct dive_table",
+ * because MOC removes the "struct", but dive_table is already the name of a global
+ * variable, leading to compilation errors. */
 Q_DECLARE_METATYPE(struct dive *);
 Q_DECLARE_METATYPE(struct dive_trip *);
+Q_DECLARE_METATYPE(dive_table_t *);
 
 #endif
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -77,9 +77,6 @@ dive_trip_t *dive_trip_list;
 
 unsigned int amount_selected;
 
-// We need to stop using globals, really.
-struct dive_table downloadTable;
-
 #if DEBUG_SELECTION_TRACKING
 void dump_selection(void)
 {

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -59,9 +59,9 @@ static void updateRememberedDCs()
 }
 
 
-DownloadThread::DownloadThread()
+DownloadThread::DownloadThread() : downloadTable({ 0 }),
+	m_data(DCDeviceData::instance())
 {
-	m_data = DCDeviceData::instance();
 }
 
 void DownloadThread::run()
@@ -80,7 +80,7 @@ void DownloadThread::run()
 		internalData->devname = "ftdi";
 #endif
 	qDebug() << "Starting download from " << (internalData->bluetooth_mode ? "BT" : internalData->devname);
-	downloadTable.nr = 0;
+	clear_table(&downloadTable);
 
 	Q_ASSERT(internalData->download_table != nullptr);
 	const char *errorText;
@@ -300,6 +300,11 @@ int DCDeviceData::getMatchingAddress(const QString &vendor, const QString &produ
 DCDeviceData *DownloadThread::data()
 {
 	return m_data;
+}
+
+struct dive_table *DownloadThread::table()
+{
+	return &downloadTable;
 }
 
 QString DCDeviceData::vendor() const

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -24,7 +24,6 @@ static QString str_error(const char *fmt, ...)
 	return str;
 }
 
-
 static void updateRememberedDCs()
 {
 	QString current = qPrefDiveComputer::vendor() + " - " + qPrefDiveComputer::product() + " - " + qPrefDiveComputer::device();
@@ -254,7 +253,6 @@ void show_computer_list()
 		qDebug() << msg;
 	}
 }
-DCDeviceData *DCDeviceData::m_instance = NULL;
 
 DCDeviceData::DCDeviceData()
 {
@@ -276,18 +274,12 @@ DCDeviceData::DCDeviceData()
 #else
 	data.libdc_log = false;
 #endif
-	if (m_instance) {
-		qDebug() << "already have an instance of DCDevieData";
-		return;
-	}
-	m_instance = this;
 }
 
 DCDeviceData *DCDeviceData::instance()
 {
-	if (!m_instance)
-		m_instance = new DCDeviceData;
-	return m_instance;
+	static DCDeviceData self;
+	return &self;
 }
 
 QStringList DCDeviceData::getProductListFromVendor(const QString &vendor)

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -6,6 +6,7 @@
 #include <QHash>
 #include <QLoggingCategory>
 
+#include "dive.h"
 #include "libdivecomputer.h"
 #include "connectionlistmodel.h"
 #if BT_SUPPORT
@@ -59,15 +60,18 @@ private:
 
 class DownloadThread : public QThread {
 	Q_OBJECT
+	Q_PROPERTY(dive_table_t *table READ table CONSTANT)
 
 public:
 	DownloadThread();
 	void run() override;
 
 	DCDeviceData *data();
+	struct dive_table *table();
 	QString error;
 
 private:
+	struct dive_table downloadTable;
 	DCDeviceData *m_data;
 };
 

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -51,7 +51,6 @@ public:
 	void setSaveDump(bool dumpMode);
 	void setSaveLog(bool saveLog);
 private:
-	static DCDeviceData *m_instance;
 	device_data_t data;
 
 	// Bluetooth name is managed outside of libdivecomputer

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1387,7 +1387,7 @@ const char *do_libdivecomputer_import(device_data_t *data)
 			/* TODO: Show the logfile to the user on error. */
 			dc_device_close(data->device);
 			data->device = NULL;
-			if (!downloadTable.nr)
+			if (!data->download_table->nr)
 				dev_info(data, translate("gettextFromC", "No new dives downloaded from dive computer"));
 		}
 		dc_iostream_close(data->iostream);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -492,10 +492,7 @@ void DownloadFromDCWidget::onDownloadThreadFinished()
 	}
 	ui.downloadCancelRetryButton->setText(tr("Retry download"));
 	ui.downloadCancelRetryButton->setEnabled(true);
-	// regardless, if we got dives, we should show them to the user
-	if (downloadTable.nr) {
-		diveImportedModel->setImportedDivesIndexes(0, downloadTable.nr - 1);
-	}
+	diveImportedModel->repopulate();
 }
 
 void DownloadFromDCWidget::on_cancel_clicked()

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -28,7 +28,7 @@ Kirigami.Page {
 		id: downloadThread
 
 		onFinished : {
-			importModel.repopulate()
+			importModel.repopulate(table)
 			progressBar.visible = false
 			if (dcImportModel.rowCount() > 0) {
 				console.log(dcImportModel.rowCount() + " dive downloaded")

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -144,7 +144,6 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_updateSelectedDive(-1),
 	m_selectedDiveTimestamp(0),
 	alreadySaving(false),
-	m_device_data(new DCDeviceData),
 	m_pluggedInDeviceName("")
 {
 	LOG_STP("qmlmgr starting");
@@ -1673,117 +1672,117 @@ void QMLManager::setStatusbarColor(QColor)
 
 QString QMLManager::DC_vendor() const
 {
-	return m_device_data->vendor();
+	return DCDeviceData::instance()->vendor();
 }
 
 QString QMLManager::DC_product() const
 {
-	return m_device_data->product();
+	return DCDeviceData::instance()->product();
 }
 
 QString QMLManager::DC_devName() const
 {
-	return m_device_data->devName();
+	return DCDeviceData::instance()->devName();
 }
 
 QString QMLManager::DC_devBluetoothName() const
 {
-	return m_device_data->devBluetoothName();
+	return DCDeviceData::instance()->devBluetoothName();
 }
 
 QString QMLManager::DC_descriptor() const
 {
-	return m_device_data->descriptor();
+	return DCDeviceData::instance()->descriptor();
 }
 
 bool QMLManager::DC_forceDownload() const
 {
-	return m_device_data->forceDownload();
+	return DCDeviceData::instance()->forceDownload();
 }
 
 bool QMLManager::DC_bluetoothMode() const
 {
-	return m_device_data->bluetoothMode();
+	return DCDeviceData::instance()->bluetoothMode();
 }
 
 bool QMLManager::DC_createNewTrip() const
 {
-	return m_device_data->createNewTrip();
+	return DCDeviceData::instance()->createNewTrip();
 }
 
 bool QMLManager::DC_saveDump() const
 {
-	return m_device_data->saveDump();
+	return DCDeviceData::instance()->saveDump();
 }
 
 int QMLManager::DC_deviceId() const
 {
-	return m_device_data->deviceId();
+	return DCDeviceData::instance()->deviceId();
 }
 
 void QMLManager::DC_setDeviceId(int deviceId)
 {
-	m_device_data->setDeviceId(deviceId);
+	DCDeviceData::instance()->setDeviceId(deviceId);
 }
 
 void QMLManager::DC_setVendor(const QString& vendor)
 {
-	m_device_data->setVendor(vendor);
+	DCDeviceData::instance()->setVendor(vendor);
 }
 
 void QMLManager::DC_setProduct(const QString& product)
 {
-	m_device_data->setProduct(product);
+	DCDeviceData::instance()->setProduct(product);
 }
 
 void QMLManager::DC_setDevName(const QString& devName)
 {
-	m_device_data->setDevName(devName);
+	DCDeviceData::instance()->setDevName(devName);
 }
 
 void QMLManager::DC_setDevBluetoothName(const QString& devBluetoothName)
 {
-	m_device_data->setDevBluetoothName(devBluetoothName);
+	DCDeviceData::instance()->setDevBluetoothName(devBluetoothName);
 }
 
 void QMLManager::DC_setBluetoothMode(bool mode)
 {
-	m_device_data->setBluetoothMode(mode);
+	DCDeviceData::instance()->setBluetoothMode(mode);
 }
 
 void QMLManager::DC_setForceDownload(bool force)
 {
-	m_device_data->setForceDownload(force);
+	DCDeviceData::instance()->setForceDownload(force);
 }
 
 void QMLManager::DC_setCreateNewTrip(bool create)
 {
-	m_device_data->setCreateNewTrip(create);
+	DCDeviceData::instance()->setCreateNewTrip(create);
 }
 
 void QMLManager::DC_setSaveDump(bool dumpMode)
 {
-	m_device_data->setSaveDump(dumpMode);
+	DCDeviceData::instance()->setSaveDump(dumpMode);
 }
 
 QStringList QMLManager::getProductListFromVendor(const QString &vendor)
 {
-	return m_device_data->getProductListFromVendor(vendor);
+	return DCDeviceData::instance()->getProductListFromVendor(vendor);
 }
 
 int QMLManager::getMatchingAddress(const QString &vendor, const QString &product)
 {
-	return m_device_data->getMatchingAddress(vendor, product);
+	return DCDeviceData::instance()->getMatchingAddress(vendor, product);
 }
 
 int QMLManager::getDetectedVendorIndex()
 {
-	return m_device_data->getDetectedVendorIndex();
+	return DCDeviceData::instance()->getDetectedVendorIndex();
 }
 
 int QMLManager::getDetectedProductIndex(const QString &currentVendorText)
 {
-	return m_device_data->getDetectedProductIndex(currentVendorText);
+	return DCDeviceData::instance()->getDetectedProductIndex(currentVendorText);
 }
 
 int QMLManager::getConnectionIndex(const QString &deviceSubstr)

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -6,8 +6,6 @@ DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
 	lastIndex(-1),
 	diveTable(nullptr)
 {
-	// Defaults to downloadTable, can be changed later.
-	diveTable = &downloadTable;
 }
 
 int DiveImportedModel::columnCount(const QModelIndex&) const
@@ -43,11 +41,6 @@ QVariant DiveImportedModel::headerData(int section, Qt::Orientation orientation,
 		}
 	}
 	return QVariant();
-}
-
-void DiveImportedModel::setDiveTable(struct dive_table* table)
-{
-	diveTable = table;
 }
 
 QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
@@ -134,10 +127,11 @@ void DiveImportedModel::clearTable()
 	endRemoveRows();
 }
 
-void DiveImportedModel::repopulate()
+void DiveImportedModel::repopulate(dive_table_t *table)
 {
 	beginResetModel();
 
+	diveTable = table;
 	firstIndex = 0;
 	lastIndex = diveTable->nr - 1;
 	checkStates.resize(diveTable->nr);
@@ -159,7 +153,7 @@ void DiveImportedModel::recordDives()
 		if (checkStates[i])
 			j++;
 		else
-			delete_dive_from_table(&downloadTable, j);
+			delete_dive_from_table(diveTable, j);
 	}
 
 	process_imported_dives(diveTable, true, true);

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -4,7 +4,6 @@
 DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
 	firstIndex(0),
 	lastIndex(-1),
-	checkStates(nullptr),
 	diveTable(nullptr)
 {
 	// Defaults to downloadTable, can be changed later.
@@ -97,7 +96,7 @@ void DiveImportedModel::changeSelected(QModelIndex clickedIndex)
 
 void DiveImportedModel::selectAll()
 {
-	memset(checkStates, true, lastIndex - firstIndex + 1);
+	std::fill(checkStates.begin(), checkStates.end(), true);
 	dataChanged(index(0, 0), index(lastIndex - firstIndex, 0), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
@@ -109,7 +108,7 @@ void DiveImportedModel::selectRow(int row)
 
 void DiveImportedModel::selectNone()
 {
-	memset(checkStates, false, lastIndex - firstIndex + 1);
+	std::fill(checkStates.begin(), checkStates.end(), false);
 	dataChanged(index(0, 0), index(lastIndex - firstIndex,0 ), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
@@ -141,9 +140,8 @@ void DiveImportedModel::repopulate()
 
 	firstIndex = 0;
 	lastIndex = diveTable->nr - 1;
-	delete[] checkStates;
-	checkStates = new bool[diveTable->nr];
-	memset(checkStates, true, diveTable->nr);
+	checkStates.resize(diveTable->nr);
+	std::fill(checkStates.begin(), checkStates.end(), true);
 
 	endResetModel();
 }

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -135,26 +135,17 @@ void DiveImportedModel::clearTable()
 	endRemoveRows();
 }
 
-void DiveImportedModel::setImportedDivesIndexes(int first, int last)
-{
-	if (lastIndex >= firstIndex) {
-		beginRemoveRows(QModelIndex(), 0, lastIndex - firstIndex);
-		endRemoveRows();
-	}
-	if (last >= first)
-		beginInsertRows(QModelIndex(), 0, last - first);
-	lastIndex = last;
-	firstIndex = first;
-	delete[] checkStates;
-	checkStates = new bool[last - first + 1];
-	memset(checkStates, true, last - first + 1);
-	if (last >= first)
-		endInsertRows();
-}
-
 void DiveImportedModel::repopulate()
 {
-	setImportedDivesIndexes(0, diveTable->nr-1);
+	beginResetModel();
+
+	firstIndex = 0;
+	lastIndex = diveTable->nr - 1;
+	delete[] checkStates;
+	checkStates = new bool[diveTable->nr];
+	memset(checkStates, true, diveTable->nr);
+
+	endResetModel();
 }
 
 void DiveImportedModel::recordDives()

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -3,6 +3,7 @@
 
 #include <QAbstractTableModel>
 #include <vector>
+#include "core/dive.h"
 
 class DiveImportedModel : public QAbstractTableModel
 {
@@ -11,7 +12,6 @@ public:
 	enum roleTypes { DateTime = Qt::UserRole + 1, Duration, Depth, Selected};
 
 	DiveImportedModel(QObject *parent = 0);
-	void setDiveTable(struct dive_table *table);
 	int columnCount(const QModelIndex& index = QModelIndex()) const;
 	int rowCount(const QModelIndex& index = QModelIndex()) const;
 	QVariant data(const QModelIndex& index, int role) const;
@@ -20,7 +20,7 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
-	Q_INVOKABLE void repopulate();
+	Q_INVOKABLE void repopulate(dive_table_t *table);
 	Q_INVOKABLE void recordDives();
 public
 slots:

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -2,6 +2,7 @@
 #define DIVEIMPORTEDMODEL_H
 
 #include <QAbstractTableModel>
+#include <vector>
 
 class DiveImportedModel : public QAbstractTableModel
 {
@@ -31,7 +32,7 @@ slots:
 private:
 	int firstIndex;
 	int lastIndex;
-	bool *checkStates;
+	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table *diveTable;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a long-standing pet peeve of mine. While working on import I finally got a reason to un-globalize the `downloadTable` and make it a sub-object of `DownloadThread`. The problem was QML's object-system. I'm not particularly happy about the result, but it seems like a step forward.

This is only compile & run tested, as I don't have a device with dives ATM. The only device I have is BLE anyway, which doesn't seem to be supported by my mobile-on-desktop build.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Cleanup the singleton mess of DCDeviceData. It seems that incorporation of DCDeviceData into QMLManager made this strange pattern useless. In my short tests, the constructor was called at most once.
2) Unifiy DiveImportedModel::setImportedDivesIndexes and DiveImportedModel::repopulate.
3) Change DiveImportedModel::checkStates to a vector. The old code was in-principle wrong, because it assumed that sizeof(bool)=1 [which is the case for all supported architectures though].
4) unglobalize downloadTable

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder: would you care to give this a quick download test?