### PR TITLE
Android build: use our own gradle build spec

### DIFF
--- a/android-mobile/build.gradle
+++ b/android-mobile/build.gradle
@@ -1,0 +1,64 @@
+/*******************************************************
+ * SPDX-License-Identifier: GPL-2.0 
+ * Subsurface-Mobile own Gradle build spec. Derived from
+ * the one supplied by Qt.
+ *******************************************************/
+buildscript {
+    repositories {
+        jcenter()
+        maven { url "https://dl.bintray.com/android/android-tools/" }
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.3.3'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        maven { url "https://dl.bintray.com/android/android-tools/" }
+    }
+}
+
+apply plugin: 'com.android.application'
+
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+}
+
+android {
+    /*******************************************************
+     * The following variables:
+     * - androidBuildToolsVersion,
+     * - androidCompileSdkVersion
+     * - qt5AndroidDir - holds the path to qt android files
+     *                   needed to build any Qt application
+     *                   on Android.
+     *
+     * are defined in gradle.properties file. This file is
+     * updated by QtCreator and androiddeployqt tools.
+     * Changing them manually might break the compilation!
+     *******************************************************/
+
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+
+    buildToolsVersion androidBuildToolsVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = [qt5AndroidDir + '/src', 'src', 'java']
+            aidl.srcDirs = [qt5AndroidDir + '/src', 'src', 'aidl']
+            res.srcDirs = [qt5AndroidDir + '/res', 'res']
+            resources.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
+       }
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+}


### PR DESCRIPTION
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

At this point in time there seems something wrong with jcenter that
is used to download all Android build artifacts from. It simply does
not find the needed stuff on there and our build fails. Its unclear
if this is a temporary issue at jcenter, or its just an intended change.

This fix is a bit of a hack. It provides our own gradle build spec
instead of the one that is provided from Qt (which is pulled in using
androiddeployqt). Added is a working download link to maven, and a
newer com.android.tools.build:gradle is used compared to Qt.

All this makes Travis happy again.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See above

### Additional information:
Not fully sure this is a long term solution, and just a fix for a temporary problem at jcenter

### Mentions: 
bit of a hack. So let @dirkhh decide about merging. 