### PR TITLE
Dive media: add media to closest dive

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -4004,20 +4004,51 @@ static bool new_picture_for_dive(struct dive *d, const char *filename)
 	return true;
 }
 
+/* Return distance of timestamp to time of dive. Result is always positive, 0 means during dive. */
+static timestamp_t time_from_dive(const struct dive *d, timestamp_t timestamp)
+{
+	timestamp_t end_time = dive_endtime(d);
+	if (timestamp < d->when)
+		return d->when - timestamp;
+	else if (timestamp > end_time)
+		return timestamp - end_time;
+	else
+		return 0;
+}
+
 // only add pictures that have timestamps between 30 minutes before the dive and
 // 30 minutes after the dive ends
 #define D30MIN (30 * 60)
-bool dive_check_picture_time(const struct dive *d, int shift_time, timestamp_t timestamp)
+static bool dive_check_picture_time(const struct dive *d, timestamp_t timestamp)
 {
-	offset_t offset;
-	if (timestamp) {
-		offset.seconds = timestamp - d->when + shift_time;
-		if (offset.seconds > -D30MIN && offset.seconds < dive_totaltime(d) + D30MIN) {
-			// this picture belongs to this dive
-			return true;
+	return time_from_dive(d, timestamp) < D30MIN;
+}
+
+/* Return dive closest selected dive to given timestamp or NULL if no dives are selected. */
+static struct dive *nearest_selected_dive(timestamp_t timestamp)
+{
+	struct dive *d, *res = NULL;
+	int i;
+	timestamp_t offset, min = 0;
+
+	for_each_dive(i, d) {
+		if (!d->selected)
+			continue;
+		offset = time_from_dive(d, timestamp);
+		if (!res || offset < min) {
+			res = d;
+			min = offset;
 		}
+
+		/* We suppose that dives are sorted chronologically. Thus
+		 * if the offset starts to increase, we can end. This ignores
+		 * pathological cases such as overlapping dives. In such a
+		 * case the user will have to add pictures manually.
+		 */
+		if (offset == 0 || offset > min)
+			break;
 	}
-	return false;
+	return res;
 }
 
 bool picture_check_valid_time(timestamp_t timestamp, int shift_time)
@@ -4026,18 +4057,26 @@ bool picture_check_valid_time(timestamp_t timestamp, int shift_time)
 	struct dive *dive;
 
 	for_each_dive (i, dive)
-		if (dive->selected && dive_check_picture_time(dive, shift_time, timestamp))
+		if (dive->selected && dive_check_picture_time(dive, timestamp + shift_time))
 			return true;
 	return false;
 }
 
-void dive_create_picture(struct dive *dive, const char *filename, int shift_time, bool match_all)
+void create_picture(const char *filename, int shift_time, bool match_all)
 {
 	struct metadata metadata;
+	struct dive *dive;
+	timestamp_t timestamp;
+
 	get_metadata(filename, &metadata);
+	timestamp = metadata.timestamp + shift_time;
+	dive = nearest_selected_dive(timestamp);
+
+	if (!dive)
+		return;
 	if (!new_picture_for_dive(dive, filename))
 		return;
-	if (!match_all && !dive_check_picture_time(dive, shift_time, metadata.timestamp))
+	if (!match_all && !dive_check_picture_time(dive, timestamp))
 		return;
 
 	struct picture *picture = alloc_picture();

--- a/core/dive.h
+++ b/core/dive.h
@@ -376,8 +376,7 @@ struct picture {
 
 extern struct picture *alloc_picture();
 extern void free_picture(struct picture *picture);
-extern bool dive_check_picture_time(const struct dive *d, int shift_time, timestamp_t timestamp);
-extern void dive_create_picture(struct dive *d, const char *filename, int shift_time, bool match_all);
+extern void create_picture(const char *filename, int shift_time, bool match_all);
 extern void dive_add_picture(struct dive *d, struct picture *newpic);
 extern bool dive_remove_picture(struct dive *d, const char *filename);
 extern unsigned int dive_get_picture_count(struct dive *d);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -969,15 +969,8 @@ void DiveListView::matchImagesToDives(QStringList fileNames)
 		return;
 	updateLastImageTimeOffset(shiftDialog.amount());
 
-	Q_FOREACH (const QString &fileName, fileNames) {
-		int j = 0;
-		struct dive *dive;
-		for_each_dive (j, dive) {
-			if (!dive->selected)
-				continue;
-			dive_create_picture(dive, qPrintable(fileName), shiftDialog.amount(), shiftDialog.matchAll());
-		}
-	}
+	for (const QString &fileName: fileNames)
+		create_picture(qPrintable(fileName), shiftDialog.amount(), shiftDialog.matchAll());
 
 	mark_divelist_changed(true);
 	copy_dive(current_dive, &displayed_dive);

--- a/tests/testpicture.cpp
+++ b/tests/testpicture.cpp
@@ -25,13 +25,15 @@ void TestPicture::addPicture()
 
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml", &dive_table), 0);
 	dive = get_dive(0);
+	// Pictures will be added to selected dives
+	dive->selected = true;
 	QVERIFY(dive != NULL);
 	pic1 = dive->picture_list;
 	// So far no picture in dive
 	QVERIFY(pic1 == NULL);
 
-	dive_create_picture(dive, SUBSURFACE_TEST_DATA "/dives/images/wreck.jpg", 0, false);
-	dive_create_picture(dive, SUBSURFACE_TEST_DATA "/dives/images/data_after_EOI.jpg", 0, false);
+	create_picture(SUBSURFACE_TEST_DATA "/dives/images/wreck.jpg", 0, false);
+	create_picture(SUBSURFACE_TEST_DATA "/dives/images/data_after_EOI.jpg", 0, false);
 	pic1 = dive->picture_list;
 	pic2 = pic1->next;
 	// Now there are two picture2


### PR DESCRIPTION
Currently, when selecting "Load media files even if time does not
match the dive time", the media are added to *all* selected dives.
Instead add it to the closest dive.

This seems like the less surprising behavior. Of course now if the
user really wants to add a media file to multiple dives, they will
have to do it manually.

To avoid a messy interface, this is solved by moving the iterate-
over-selected-dives loop to the core. Thus, a helper-function can
be made local to its translation unit.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is my idea for #1844: Add media not to *all* selected dives, but to the nearest. This seems to be the more common use case. But now users wanting to add the same file to multiple dives have more work.

Only lightly tested. This is mostly a RFC.

Since functionality moved to the core, one might think about enhancing the add-picture tests: Have multiple dives and multiple pictures and make sure that they are attributed correctly.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Upload image only to closest selected dive.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1844
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Yes - but let's discuss this first.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Perhaps - but let's discuss this first.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79