### PR TITLE
Filter: connect widget and filter

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -88,18 +88,23 @@ void FilterWidget2::updateFilter()
 	data.invertFilter = ui->invertFilter->isChecked();
 
 	filterData = data;
-	emit filterDataChanged(data);
+	filterDataChanged(data);
 }
 
 void FilterWidget2::showEvent(QShowEvent *event)
 {
 	QWidget::showEvent(event);
-	emit filterDataChanged(filterData);
+	filterDataChanged(filterData);
 }
 
 void FilterWidget2::hideEvent(QHideEvent *event)
 {
 	QWidget::hideEvent(event);
 	FilterData data;
-	emit filterDataChanged(data);
+	filterDataChanged(data);
+}
+
+void FilterWidget2::filterDataChanged(const FilterData &data)
+{
+	MultiFilterSortModel::instance()->filterDataChanged(data);
 }

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -68,27 +68,24 @@ FilterWidget2::FilterWidget2(QWidget* parent)
 
 void FilterWidget2::updateFilter()
 {
-	FilterData data;
+	filterData.validFilter = true;
+	filterData.minVisibility = ui->minVisibility->currentStars();
+	filterData.maxVisibility = ui->maxVisibility->currentStars();
+	filterData.minRating = ui->minRating->currentStars();
+	filterData.maxRating = ui->maxRating->currentStars();
+	filterData.minWaterTemp = ui->minWaterTemp->value();
+	filterData.maxWaterTemp = ui->maxWaterTemp->value();
+	filterData.minAirTemp = ui->minAirTemp->value();
+	filterData.maxWaterTemp = ui->maxWaterTemp->value();
+	filterData.from = ui->from->dateTime();
+	filterData.to = ui->to->dateTime();
+	filterData.tags = ui->tags->text().split(",", QString::SkipEmptyParts);
+	filterData.people = ui->people->text().split(",", QString::SkipEmptyParts);
+	filterData.location = ui->location->text().split(",", QString::SkipEmptyParts);
+	filterData.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
+	filterData.invertFilter = ui->invertFilter->isChecked();
 
-	data.validFilter = true;
-	data.minVisibility = ui->minVisibility->currentStars();
-	data.maxVisibility = ui->maxVisibility->currentStars();
-	data.minRating = ui->minRating->currentStars();
-	data.maxRating = ui->maxRating->currentStars();
-	data.minWaterTemp = ui->minWaterTemp->value();
-	data.maxWaterTemp = ui->maxWaterTemp->value();
-	data.minAirTemp = ui->minAirTemp->value();
-	data.maxWaterTemp = ui->maxWaterTemp->value();
-	data.from = ui->from->dateTime();
-	data.to = ui->to->dateTime();
-	data.tags = ui->tags->text().split(",", QString::SkipEmptyParts);
-	data.people = ui->people->text().split(",", QString::SkipEmptyParts);
-	data.location = ui->location->text().split(",", QString::SkipEmptyParts);
-	data.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
-	data.invertFilter = ui->invertFilter->isChecked();
-
-	filterData = data;
-	filterDataChanged(data);
+	filterDataChanged(filterData);
 }
 
 void FilterWidget2::showEvent(QShowEvent *event)

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -24,11 +24,9 @@ protected:
 	void hideEvent(QHideEvent *event) override;
 	void showEvent(QShowEvent *event) override;
 
-signals:
-	void filterDataChanged(const FilterData& data);
-
 private:
 	std::unique_ptr<Ui::FilterWidget2> ui;
+	void filterDataChanged(const FilterData &data);
 	FilterData filterData;
 };
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -222,7 +222,7 @@ bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2
 	return model->lessThan(i1, i2);
 }
 
-void MultiFilterSortModel::filterDataChanged(const FilterData& data)
+void MultiFilterSortModel::filterDataChanged(const FilterData &data)
 {
 	filterData = data;
 	myInvalidate();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -50,7 +50,7 @@ slots:
 	void stopFilterDiveSite();
 	void filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles);
 	void setLayout(DiveTripModel::Layout layout);
-	void filterDataChanged(const FilterData& data);
+	void filterDataChanged(const FilterData &data);
 
 signals:
 	void filterFinished();


### PR DESCRIPTION
In the latest version of the new filter-widget the connection
between widget and filter was lost. Connect both - but use a
simple function call instead of a signal, since it is not
immediately obivous were the connection should be made.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the new filter-widget by connecting it to the filter. This is a temporary fix until @tcanabrava finds time to do it like it was intended. It is supposed to let people play with the new widget. I replaced the signal by a simple function as I was too lazy to think about where the `connect` call should be placed [I always find it weird when an object connects is own signal - unless it is supposed to be a call across thread boundaries.]
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Call filter from filter-widget.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder: This should make it possible to test.