### PR TITLE
core: shift dive time in correct direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Core: shift dive time in correct direction [#1893]
 - Include average max depth in statistics
 - Fix bug in cloud save after removing dives from a trip
 - Dive: Perform more accurate OTU calculations, and include

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -600,7 +600,7 @@ ShiftTime::ShiftTime(const QVector<dive *> &changedDives, int amount)
 void ShiftTime::redoit()
 {
 	for (dive *d: diveList)
-		d->when -= timeChanged;
+		d->when += timeChanged;
 
 	// Changing times may have unsorted the dive table
 	sort_table(&dive_table);


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Unsure where this bug got introduced, but when asking for the dive
time to be shifted 1 hour later, the divelist and the dive details
showed 1 our earlier.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Related issues:
Fixes: #1893

### Release note:
As its user reported. Yes.

### Mentions:
@bstoeger: do you understand where this is coming from? The history is not easy to see in the big undo/divelist rewrite. 
