### PR TITLE
Bluetooth: all states other than HostPoweredOff qualify as valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Core, Mobile: all controller states other than powered off are valid [#1903]
 - Core: shift dive time in correct direction [#1893]
 - Include average max depth in statistics
 - Fix bug in cloud save after removing dives from a trip

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -102,10 +102,11 @@ BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
 void BTDiscovery::BTDiscoveryReDiscover()
 {
 #if !defined(Q_OS_IOS)
+	qDebug() << "BTDiscoveryReDiscover: localBtDevice.isValid()" << localBtDevice.isValid();
 	if (localBtDevice.isValid() &&
-	    localBtDevice.hostMode() == QBluetoothLocalDevice::HostConnectable) {
+	    localBtDevice.hostMode() != QBluetoothLocalDevice::HostPoweredOff) {
 		btPairedDevices.clear();
-		qDebug() <<  "localDevice " + localBtDevice.name() + " is valid, starting discovery";
+		qDebug() <<  "BTDiscoveryReDiscover: localDevice " + localBtDevice.name() + " is powered on, starting discovery";
 #else
 	// for iOS we can't use the localBtDevice as iOS is BLE only
 	// we need to find some other way to test if Bluetooth is enabled, though


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Attempted bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This is an attempt to fix issue #1896. While this seems a Qt issue in
combination with very specific Android devices, this might be a fix. Do
not check for a very specific state of the local BT controller, but just
check if it is powered on.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit.

### Related issues:
Related to #1896

### Additional information:
Requires testing by @JMZalewski.

### Release note:
Yes, when test is successful.