### PR TITLE
Cleanup: remove getDiveId() functions

### DIFF
--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -61,12 +61,6 @@ int DiveListSortModel::shown()
 	return rowCount();
 }
 
-int DiveListSortModel::getDiveId(int idx)
-{
-	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	return mySourceModel->getDiveId(mapToSource(index(idx,0)).row());
-}
-
 int DiveListSortModel::getIdxForId(int id)
 {
 	for (int i = 0; i < rowCount(); i++) {
@@ -229,13 +223,6 @@ void DiveListModel::resetInternalData()
 int DiveListModel::rowCount(const QModelIndex &) const
 {
 	return m_dives.count();
-}
-
-int DiveListModel::getDiveId(int idx) const
-{
-	if (idx < 0 || idx >= m_dives.count())
-		return -1;
-	return m_dives[idx]->id();
 }
 
 int DiveListModel::getDiveIdx(int id) const

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -19,7 +19,6 @@ public:
 	Q_INVOKABLE QString tripTitle(const QVariant &trip);
 	Q_INVOKABLE QString tripShortDate(const QVariant &trip);
 public slots:
-	int getDiveId(int idx);
 	int getIdxForId(int id);
 	void setFilter(QString f);
 	void resetFilter();
@@ -53,7 +52,6 @@ public:
 	void updateDive(int i, dive *d);
 	void clear();
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
-	int getDiveId(int idx) const;
 	int getDiveIdx(int id) const;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 	QHash<int, QByteArray> roleNames() const;


### PR DESCRIPTION
These functions in DiveListSortModel and DiveListModel had no
users. Remove them.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removes two seemingly unused functions. Not Much more to say.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unused functions.
