### PR TITLE
Mobile: fix editing dive site (Quickfix for #1887)

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -887,11 +887,9 @@ bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString
 	qDebug() << "checkLocation" << location << "gps" << gps << "dive had" << myDive->location() << "gps" << myDive->gas();
 	if (myDive->location() != location) {
 		diveChanged = true;
-		if (!ds)
-			ds = get_dive_site_by_name(qPrintable(location));
-		if (!ds && !location.isEmpty()) {
+		ds = get_dive_site_by_name(qPrintable(location));
+		if (!ds && !location.isEmpty())
 			ds = create_dive_site(qPrintable(location), d->when);
-		}
 		d->dive_site = ds;
 	}
 	// now make sure that the GPS coordinates match - if the user changed the name but not


### PR DESCRIPTION
Commit 68961a169efc37039cd3fda334efb9ad9927444f made it impossible
to edit a dive site on mobile if a dive-site was already set: If
divesite was non-null, no actions were taken. Remove the conditional.

Reported-by: Miika Turkia <miika.turkia@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a quick-fix for #1887. Do not apply yet, as I'm unsure what happens when location is empty, but coordinates are set. Then `d->dive_site` is NULL, but what happens if the GPS coordinates are set? Crash? Will have to check later.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove bogus test for `ds == NULL`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Perhaps fixes #1887.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
First have a closer look at corner cases.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 
@dirkhh 