### PR TITLE
win32: fix utf-16 to utf-8 conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Core, Windows: fix a bug related to non-ASCII characters in user names
 - Core, Mobile: all controller states other than powered off are valid [#1903]
 - Core: shift dive time in correct direction [#1893]
 - Include average max depth in statistics

--- a/core/windows.c
+++ b/core/windows.c
@@ -50,16 +50,20 @@ static char *utf16_to_utf8_fl(const wchar_t *utf16, char *file, int line)
 	assert(file != NULL);
 	assert(line);
 	/* estimate buffer size */
-	const int sz = wcslen(utf16) + 1;
+	const int sz = WideCharToMultiByte(CP_UTF8, 0, utf16, -1, NULL, 0, NULL, NULL);
+	if (!sz) {
+		fprintf(stderr, "%s:%d: cannot estimate buffer size\n", file, line);
+		return NULL;
+	}
 	char *utf8 = (char *)malloc(sz);
 	if (!utf8) {
-		fprintf(stderr, "%s:%d: %s %d.", file, line, "cannot allocate buffer of size", sz);
+		fprintf(stderr, "%s:%d: cannot allocate buffer of size: %d\n", file, line, sz);
 		return NULL;
 	}
 	if (WideCharToMultiByte(CP_UTF8, 0, utf16, -1, utf8, sz, NULL, NULL)) {
 		return utf8;
 	}
-	fprintf(stderr, "%s:%d: %s", file, line, "cannot convert string.");
+	fprintf(stderr, "%s:%d: cannot convert string\n", file, line);
 	free((void *)utf8);
 	return NULL;
 }
@@ -78,12 +82,12 @@ static wchar_t *utf8_to_utf16_fl(const char *utf8, char *file, int line)
 	const int sz = strlen(utf8) + 1;
 	wchar_t *utf16 = (wchar_t *)malloc(sizeof(wchar_t) * sz);
 	if (!utf16) {
-		fprintf(stderr, "%s:%d: %s %d.", file, line, "cannot allocate buffer of size", sz);
+		fprintf(stderr, "%s:%d: cannot allocate buffer of size: %d\n", file, line, sz);
 		return NULL;
 	}
 	if (MultiByteToWideChar(CP_UTF8, 0, utf8, -1, utf16, sz))
 		return utf16;
-	fprintf(stderr, "%s:%d: %s", file, line, "cannot convert string.");
+	fprintf(stderr, "%s:%d: cannot convert string\n", file, line);
 	free((void *)utf16);
 	return NULL;
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

wcslen() returns the number of characters in a wchar_t string.
In the case of WideCharToMultiByte() an estimate for the size of
the utf8 buffer is needed. Using wcslen() is incorrect for such a buffer,
because for any non-ASCII character the estimate will be off by 1 byte.

Call the following instead to obtain the proper UTF8 buffer size
for the conversation:
  WideCharToMultiByte(CP_UTF8, 0, utf16, -1, NULL, 0, NULL, NULL);

Also fix some missing "\n" in fprintf() calls.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) fix WideCharToMultiByte issue
2) fix fprintf() missing `\n`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
NONE

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
NONE

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
added

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
NONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
