### PR TITLE
Dive sites: don't delete unused dive sites on save

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -346,6 +346,23 @@ struct dive_site *find_or_create_dive_site_with_name(const char *name, timestamp
 	return create_dive_site(name, divetime);
 }
 
+void purge_empty_dive_sites()
+{
+	int i, j;
+	struct dive *d;
+	struct dive_site *ds;
+
+	for (i = 0; i < dive_site_table.nr; i++) {
+		ds = get_dive_site(i);
+		if (!dive_site_is_empty(ds))
+			continue;
+		for_each_dive(j, d) {
+			if (d->dive_site == ds)
+				d->dive_site = NULL;
+		}
+	}
+}
+
 static int compare_sites(const void *_a, const void *_b)
 {
 	const struct dive_site *a = (const struct dive_site *)*(void **)_a;

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -73,6 +73,7 @@ void clear_dive_site(struct dive_site *ds);
 unsigned int get_distance(const location_t *loc1, const location_t *loc2);
 struct dive_site *find_or_create_dive_site_with_name(const char *name, timestamp_t divetime);
 void merge_dive_sites(struct dive_site *ref, struct dive_site *dive_sites[], int count);
+void purge_empty_dive_sites();
 
 #ifdef __cplusplus
 }

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -879,18 +879,12 @@ static void save_divesites(git_repository *repo, struct dir *tree)
 	subdir = new_directory(repo, tree, &dirname);
 	free_buffer(&dirname);
 
+	purge_empty_dive_sites();
 	for (int i = 0; i < dive_site_table.nr; i++) {
 		struct membuffer b = { 0 };
 		struct dive_site *ds = get_dive_site(i);
-		if (dive_site_is_empty(ds) || !is_dive_site_used(ds, false)) {
-			int j;
-			struct dive *d;
-			for_each_dive(j, d) {
-				if (d->dive_site == ds)
-					d->dive_site = NULL;
-			}
-			delete_dive_site(ds);
-			i--; // since we just deleted that one
+		if (!is_dive_site_used(ds, false)) {
+			/* Only write used dive sites */
 			continue;
 		} else if (ds->name &&
 			   (strncmp(ds->name, "Auto-created dive", 17) == 0 ||

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -592,18 +592,14 @@ void save_dives_buffer(struct membuffer *b, const bool select_only, bool anonymi
 
 	/* save the dive sites - to make the output consistent let's sort the table, first */
 	dive_site_table_sort();
+	purge_empty_dive_sites();
 	put_format(b, "<divesites>\n");
 	for (i = 0; i < dive_site_table.nr; i++) {
 		int j;
 		struct dive *d;
 		struct dive_site *ds = get_dive_site(i);
-		if (dive_site_is_empty(ds) || !is_dive_site_used(ds, false)) {
-			for_each_dive(j, d) {
-				if (d->dive_site == ds)
-					d->dive_site = NULL;
-			}
-			delete_dive_site(ds);
-			i--; // since we just deleted that one
+		if (!is_dive_site_used(ds, false)) {
+			/* Only write used dive sites */
 			continue;
 		} else if (ds->name &&
 			   (strncmp(ds->name, "Auto-created dive", 17) == 0 ||


### PR DESCRIPTION
Unused dive sites were deleted on save. This clashed with the undo
system in the following scenario:

1) Delete single-use dive site.
2) Save (dive site deleted)
3) Undo (reference to freed dive site)

Therefore, as a quick-fix, keep the referenced dive site around.
Note that this also means that empty dive sites must not be
deleted, as it might refer to a dive in the undo system. Instead
only clear references to empty dive sites in the global dive
table. Factor this functionality out, as it was common to the
XML and git savers.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes an easily reproduced crash:
1) Delete dive with single-use dive site
2) Save
3) Undo

The reason is that on save "unused" dive sites were deleted, but might still be references from the deleted dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't delete unused dive sites on save.
2) Factor out common purge empty dive site code in the XML and git savers.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1907 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Perhaps?
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
