### PR TITLE
Filter planned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Allow to filter for logged/planned dives
 - Core, Windows: fix a bug related to non-ASCII characters in user names
 - Core, Mobile: all controller states other than powered off are valid [#1903]
 - Core: shift dive time in correct direction [#1893]

--- a/core/dive.c
+++ b/core/dive.c
@@ -3361,6 +3361,18 @@ bool is_dc_planner(const struct divecomputer *dc) {
 	return same_string(dc->model, "planned dive");
 }
 
+// Does this dive have a dive computer for which is_dc_planner has value planned
+bool has_planned(const struct dive *dive, bool planned) {
+	const struct divecomputer *dc = &dive->dc;
+
+	while (dc) {
+		if (is_dc_planner(&dive->dc) == planned)
+			return true;
+		dc = dc->next;
+	}
+	return false;
+}
+
 /*
  * Merging two dives can be subtle, because there's two different ways
  * of merging:

--- a/core/dive.c
+++ b/core/dive.c
@@ -3357,6 +3357,10 @@ void dump_taglist(const char *intro, struct tag_entry *tl)
 	fprintf(stderr, "\n");
 }
 
+bool is_dc_planner(const struct divecomputer *dc) {
+	return same_string(dc->model, "planned dive");
+}
+
 /*
  * Merging two dives can be subtle, because there's two different ways
  * of merging:
@@ -3401,7 +3405,7 @@ struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset,
 			offset = 0;
 	}
 
-	if (same_string(a->dc.model, "planned dive")) {
+	if (is_dc_planner(&a->dc)) {
 		const struct dive *tmp = a;
 		a = b;
 		b = tmp;

--- a/core/dive.h
+++ b/core/dive.h
@@ -651,6 +651,7 @@ extern void nuclear_regeneration(struct deco_state *ds, double time);
 extern void vpmb_start_gradient(struct deco_state *ds);
 extern void vpmb_next_gradient(struct deco_state *ds, double deco_time, double surface_pressure);
 extern double tissue_tolerance_calc(struct deco_state *ds, const struct dive *dive, double pressure);
+extern bool is_dc_planner(const struct divecomputer *dc);
 
 /* this should be converted to use our types */
 struct divedatapoint {

--- a/core/dive.h
+++ b/core/dive.h
@@ -652,6 +652,8 @@ extern void vpmb_start_gradient(struct deco_state *ds);
 extern void vpmb_next_gradient(struct deco_state *ds, double deco_time, double surface_pressure);
 extern double tissue_tolerance_calc(struct deco_state *ds, const struct dive *dive, double pressure);
 extern bool is_dc_planner(const struct divecomputer *dc);
+extern bool has_planned(const struct dive *dive, bool planned);
+
 
 /* this should be converted to use our types */
 struct divedatapoint {

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -169,7 +169,7 @@ QString DiveObjectHelper::waterTemp() const
 QString DiveObjectHelper::notes() const
 {
 	QString tmp = m_dive->notes ? QString::fromUtf8(m_dive->notes) : QString();
-	if (same_string(m_dive->dc.model, "planned dive")) {
+	if (is_dc_planner(&m_dive->dc)) {
 		QTextDocument notes;
 	#define _NOTES_BR "&#92n"
 		tmp.replace("<thead>", "<thead>" _NOTES_BR)

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -18,6 +18,8 @@ FilterWidget2::FilterWidget2(QWidget* parent)
 	ui->maxAirTemp->setValue(data.maxAirTemp);
 	ui->minWaterTemp->setValue(data.minWaterTemp);
 	ui->maxWaterTemp->setValue(data.maxWaterTemp);
+	ui->planned->setChecked(data.logged);
+	ui->planned->setChecked(data.planned);
 
 	// TODO: unhide this when we discover how to search for equipment.
 	ui->equipment->hide();
@@ -64,6 +66,11 @@ FilterWidget2::FilterWidget2(QWidget* parent)
 
 	connect(ui->location, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
+
+	connect(ui->logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
+
+	connect(ui->planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
+
 }
 
 void FilterWidget2::updateFilter()
@@ -86,10 +93,25 @@ void FilterWidget2::updateFilter()
 	data.location = ui->location->text().split(",", QString::SkipEmptyParts);
 	data.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
 	data.invertFilter = ui->invertFilter->isChecked();
+	data.logged = ui->logged->isChecked();
+	data.planned = ui->planned->isChecked();
 
 	filterData = data;
 	emit filterDataChanged(data);
 }
+
+void FilterWidget2::updateLogged(int value) {
+	if (value == Qt::Unchecked)
+		ui->planned->setChecked(true);
+	updateFilter();
+}
+
+void FilterWidget2::updatePlanned(int value) {
+	if (value == Qt::Unchecked)
+		ui->logged->setChecked(true);
+	updateFilter();
+}
+
 
 void FilterWidget2::showEvent(QShowEvent *event)
 {

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -27,6 +27,12 @@ protected:
 signals:
 	void filterDataChanged(const FilterData& data);
 
+public slots:
+	void updatePlanned(int value);
+	void updateLogged(int value);
+
+
+
 private:
 	std::unique_ptr<Ui::FilterWidget2> ui;
 	FilterData filterData;

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -7,77 +7,24 @@
     <x>0</x>
     <y>0</y>
     <width>510</width>
-    <height>320</height>
+    <height>349</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="1">
-    <widget class="QLabel" name="label_12">
+   <item row="8" column="1" colspan="4">
+    <widget class="QLineEdit" name="tags"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Min</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
-    <widget class="StarWidget" name="maxVisibility" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QDoubleSpinBox" name="minWaterTemp"/>
-   </item>
-   <item row="2" column="2">
-    <widget class="StarWidget" name="minVisibility" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Tags</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string> Rating</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="StarWidget" name="minRating" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_8">
      <property name="text">
       <string>People</string>
@@ -91,17 +38,24 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="label_3">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Min</string>
+      <string> Rating</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="4">
-    <widget class="QLineEdit" name="tags"/>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Tags</string>
+     </property>
+    </widget>
    </item>
-   <item row="11" column="1" colspan="4">
+   <item row="3" column="2">
+    <widget class="QDoubleSpinBox" name="minWaterTemp"/>
+   </item>
+   <item row="12" column="1" colspan="4">
     <widget class="QCheckBox" name="invertFilter">
      <property name="toolTip">
       <string>Display dives that will not match the search, only applies to tags, people, location and equipment</string>
@@ -118,57 +72,12 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="4">
-    <widget class="QDateTimeEdit" name="from"/>
-   </item>
-   <item row="8" column="1" colspan="4">
-    <widget class="QLineEdit" name="people"/>
-   </item>
-   <item row="1" column="4">
-    <widget class="StarWidget" name="maxRating" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="labelEquipment">
+   <item row="3" column="1">
+    <widget class="QLabel" name="label_12">
      <property name="text">
-      <string>Equipment</string>
+      <string>Min</string>
      </property>
     </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QLabel" name="label_15">
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Location</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="4">
-    <widget class="QLineEdit" name="location"/>
-   </item>
-   <item row="6" column="1" colspan="4">
-    <widget class="QDateTimeEdit" name="to"/>
-   </item>
-   <item row="10" column="1" colspan="4">
-    <widget class="QLineEdit" name="equipment"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_4">
@@ -184,17 +93,20 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Min</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Visibility</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Water Temp</string>
      </property>
     </widget>
    </item>
@@ -205,24 +117,20 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Air Temp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QLabel" name="label_18">
+   <item row="1" column="3">
+    <widget class="QLabel" name="label_15">
      <property name="text">
       <string>Max</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="4">
+    <widget class="QLineEdit" name="location"/>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="labelEquipment">
+     <property name="text">
+      <string>Equipment</string>
      </property>
     </widget>
    </item>
@@ -231,6 +139,118 @@
    </item>
    <item row="4" column="4">
     <widget class="QDoubleSpinBox" name="maxAirTemp"/>
+   </item>
+   <item row="11" column="1" colspan="4">
+    <widget class="QLineEdit" name="equipment"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Water Temp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" colspan="4">
+    <widget class="QLineEdit" name="people"/>
+   </item>
+   <item row="4" column="3">
+    <widget class="QLabel" name="label_18">
+     <property name="text">
+      <string>Max</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="4">
+    <widget class="QDateTimeEdit" name="from"/>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Location</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="4">
+    <widget class="QDateTimeEdit" name="to"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Air Temp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="StarWidget" name="maxVisibility" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="StarWidget" name="minVisibility" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="StarWidget" name="minRating" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="StarWidget" name="maxRating" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QCheckBox" name="logged">
+     <property name="text">
+      <string>Logged</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QCheckBox" name="planned">
+     <property name="text">
+      <string>Planned</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -965,7 +965,7 @@ void MainWindow::on_actionReplanDive_triggered()
 {
 	if (!plannerStateClean() || !current_dive)
 		return;
-	else if (!current_dive->dc.model || strcmp(current_dive->dc.model, "planned dive")) {
+	else if (!is_dc_planner(&current_dive->dc)) {
 		if (QMessageBox::warning(this, tr("Warning"), tr("Trying to replan a dive that's not a planned dive."),
 					 QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel)
 					return;

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -138,6 +138,12 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 	if (!hasEquipment(filterData.equipment, d))
 		return false;
 
+	// Planned/Logged
+	if (!filterData.logged && !has_planned(d, true))
+		return false;
+	if (!filterData.planned && !has_planned(d, false))
+		return false;
+
 	return true;
 }
 

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -31,6 +31,8 @@ struct FilterData {
 	QStringList people;
 	QStringList location;
 	QStringList equipment;
+	bool logged = true;
+	bool planned = true;
 	bool invertFilter;
 };
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add a filter option to search for planned or logged dives. As this is in a dive computer, a dive can have both logged data as well as planned (for example to compare the actual dive to the initial plan).

This implements part of what was suggested in #1913.

Note: I could not test this as the new filter widget is currently non-operational for me!

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
 
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1913

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
CHANGELOG updated

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->