### PR TITLE
Build: remove --skip-googlemaps build option

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,17 +59,13 @@ while [[ $# -gt 0 ]] ; do
 			# we are building an AppImage as by product
 			CREATE_APPDIR="1"
 			;;
-		-skip-googlemaps)
-			# hack for Travix Mac build
-			SKIP_GOOGLEMAPS="1"
-			;;
 		-release)
 			# don't build Debug binaries
 			DEBUGRELEASE="Release"
 			;;
 		*)
 			echo "Unknown command line argument $arg"
-			echo "Usage: build.sh [-no-bt] [-build-deps] [-build-with-webkit] [-mobile] [-desktop] [-both] [-create-appdir] [-skip-googlemaps] [-release]"
+			echo "Usage: build.sh [-no-bt] [-build-deps] [-build-with-webkit] [-mobile] [-desktop] [-both] [-create-appdir] [-release]"
 			exit 1
 			;;
 	esac
@@ -421,27 +417,25 @@ else
 	PRINTING="-DNO_PRINTING=ON"
 fi
 
-if [ "$SKIP_GOOGLEMAPS" != "1" ] ; then
-	# build the googlemaps map plugin
+# build the googlemaps map plugin
 
-	cd $SRC
-	./subsurface/scripts/get-dep-lib.sh single . googlemaps
-	pushd googlemaps
-	mkdir -p build
-	mkdir -p J10build
-	cd build
-	$QMAKE "INCLUDEPATH=$INSTALL_ROOT/include" ../googlemaps.pro
-	# on Travis the compiler doesn't support c++1z, yet qmake adds that flag;
-	# since things compile fine with c++11, let's just hack that away
-	# similarly, don't use -Wdata-time
-	if [ "$TRAVIS" = "true" ] ; then
-		mv Makefile Makefile.bak
-		cat Makefile.bak | sed -e 's/std=c++1z/std=c++11/g ; s/-Wdate-time//' > Makefile
-	fi
-	make -j4
-	make install
-	popd
+cd $SRC
+./subsurface/scripts/get-dep-lib.sh single . googlemaps
+pushd googlemaps
+mkdir -p build
+mkdir -p J10build
+cd build
+$QMAKE "INCLUDEPATH=$INSTALL_ROOT/include" ../googlemaps.pro
+# on Travis the compiler doesn't support c++1z, yet qmake adds that flag;
+# since things compile fine with c++11, let's just hack that away
+# similarly, don't use -Wdata-time
+if [ "$TRAVIS" = "true" ] ; then
+	mv Makefile Makefile.bak
+	cat Makefile.bak | sed -e 's/std=c++1z/std=c++11/g ; s/-Wdate-time//' > Makefile
 fi
+make -j4
+make install
+popd
 
 # finally, build Subsurface
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The scripts/build.sh script has an option --skip-googlemaps. Introduced
in 2017 at a moment the Travis Mac build failed on this. Interestingly,
when Mac building of the maps plugin was possible again (commit 79e3f69f488df)
the --skip-googlemaps stayed. Obviously, this hack was never intended
to be used for anything else then getting it passed Travis on
some point in time for a specific Mac build.

So, remove this option.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit

### Additional information:
Simple cleanup. And when this option should remain, all fallout needs to be handled properly. As in, no run time link error of a mapwidget that cannot find the plugin.