### PR TITLE
Build: build libgit2 from source when less than 0.26.0

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -197,7 +197,7 @@ else
 		LIBGIT=$(pkg-config --modversion libgit2 | cut -d. -f2)
 		LIBGIT2_FROM_PKGCONFIG="-DLIBGIT2_FROM_PKGCONFIG=ON"
 	fi
-	if [[ "$LIBGIT" < "24" ]] ; then
+	if [[ "$LIBGIT" < "26" ]] ; then
 		# maybe there's a system version that's new enough?
 		LIBGIT=$(ldconfig -p | grep libgit2\\.so\\. | awk -F. '{ print $NF }')
 	fi
@@ -237,7 +237,7 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	fi
 fi
 
-if [[ "$LIBGIT" < "24" ]] ; then
+if [[ "$LIBGIT" < "26" ]] ; then
 	LIBGIT_ARGS=" -DLIBGIT2_INCLUDE_DIR=$INSTALL_ROOT/include -DLIBGIT2_LIBRARIES=$INSTALL_ROOT/lib/libgit2.$SH_LIB_EXT "
 
 	cd $SRC


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Likely bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup/maintenance
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
We currently require a minimal version of libgit2 of 0.24.0. From
issue #1926 it seems that this version is too old. So, a simple test on
Linux to see the behavior with such an old libgit2, I tried that.
Interestingly, with the current version of openssl that old libgit2
version does not even compile from source (known error in libgit2).

So, bump our minimal version of libgit2 to 0.26.0. That is also the
version we currently use on the Travis and official builds, so well
tested.

Signed-off-by: Jan Mulder <jlmulder@xs4all.nl>

### Changes made:
See commit (trivial)

### Related issues:
issue #1926 seems to show something related to an old libgit2
