### PR TITLE
Planner: Add checkbox to force OC bailout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Planner: Add UI element for bailout planning for rebreather dives
 - Allow to filter for logged/planned dives
 - Core, Windows: fix a bug related to non-ASCII characters in user names
 - Shearwater import: add suppport for importing Shearwater Cloud logs

--- a/core/planner.c
+++ b/core/planner.c
@@ -742,6 +742,10 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 	printf("depth %5.2lfm \n", depth / 1000.0);
 	printf("current_cylinder %i\n", current_cylinder);
 #endif
+	if ((divemode == CCR || divemode == PSCR) && prefs.dobailout) {
+		divemode = OC;
+		po2 = 0;
+	}
 
 	best_first_ascend_cylinder = current_cylinder;
 	/* Find the gases available for deco */

--- a/core/pref.h
+++ b/core/pref.h
@@ -168,6 +168,7 @@ struct preferences {
 	bool            display_transitions;
 	bool            display_variations;
 	bool            doo2breaks;
+	bool            dobailout;
 	bool            drop_stone_mode;
 	bool            last_stop;   // At 6m?
 	int             min_switch_duration; // seconds

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -34,6 +34,7 @@ void qPrefDivePlanner::loadSync(bool doSync)
 	disk_display_transitions(doSync);
 	disk_display_variations(doSync);
 	disk_doo2breaks(doSync);
+	disk_dobailout(doSync);
 	disk_drop_stone_mode(doSync);
 	disk_last_stop(doSync);
 	disk_min_switch_duration(doSync);
@@ -74,6 +75,7 @@ HANDLE_PREFERENCE_BOOL(DivePlanner, "display_transitions", display_transitions);
 HANDLE_PREFERENCE_BOOL(DivePlanner, "display_variations", display_variations);
 
 HANDLE_PREFERENCE_BOOL(DivePlanner, "doo2breaks", doo2breaks);
+HANDLE_PREFERENCE_BOOL(DivePlanner, "dobailbout", dobailout);
 
 HANDLE_PREFERENCE_BOOL(DivePlanner, "drop_stone_mode", drop_stone_mode);
 

--- a/core/settings/qPrefDivePlanner.h
+++ b/core/settings/qPrefDivePlanner.h
@@ -22,6 +22,7 @@ class qPrefDivePlanner : public QObject {
 	Q_PROPERTY(bool display_transitions READ display_transitions WRITE set_display_transitions NOTIFY      display_transitionsChanged);
 	Q_PROPERTY(bool display_variations READ display_variations WRITE set_display_variations NOTIFY display_variationsChanged);
 	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
+	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
 	Q_PROPERTY(bool drop_stone_mode READ drop_stone_mode WRITE set_drop_stone_mode NOTIFY drop_stone_modeChanged);
 	Q_PROPERTY(bool last_stop READ last_stop WRITE set_last_stop NOTIFY last_stopChanged);
 	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
@@ -58,6 +59,7 @@ public:
 	static bool display_transitions() { return prefs.display_transitions; }
 	static bool display_variations() { return prefs.display_variations; }
 	static bool doo2breaks() { return prefs.doo2breaks; }
+	static bool dobailout() { return prefs.dobailout; }
 	static bool drop_stone_mode() { return prefs.drop_stone_mode; }
 	static bool last_stop() { return prefs.last_stop; }
 	static int min_switch_duration() { return prefs.min_switch_duration; }
@@ -85,6 +87,7 @@ public slots:
 	static void set_display_transitions(bool value);
 	static void set_display_variations(bool value);
 	static void set_doo2breaks(bool value);
+	static void set_dobailout(bool value);
 	static void set_drop_stone_mode(bool value);
 	static void set_last_stop(bool value);
 	static void set_min_switch_duration(int value);
@@ -112,6 +115,7 @@ signals:
 	void display_transitionsChanged(bool value);
 	void display_variationsChanged(bool value);
 	void doo2breaksChanged(bool value);
+	void dobailoutChanged(bool value);
 	void drop_stone_modeChanged(bool value);
 	void last_stopChanged(bool value);
 	void min_switch_durationChanged(int value);
@@ -140,6 +144,7 @@ private:
 	static void disk_display_transitions(bool doSync);
 	static void disk_display_variations(bool doSync);
 	static void disk_doo2breaks(bool doSync);
+	static void disk_dobailout(bool doSync);
 	static void disk_drop_stone_mode(bool doSync);
 	static void disk_last_stop(bool doSync);
 	static void disk_min_switch_duration(bool doSync);

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -59,6 +59,7 @@ struct preferences default_prefs = {
 	.decopo2 = 1600,
 	.bestmixend.mm = 30000,
 	.doo2breaks = false,
+	.dobailout = false,
 	.drop_stone_mode = false,
 	.switch_at_req_stop = false,
 	.min_switch_duration = 60,

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -123,6 +123,7 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);
 	waterTypeUpdateTexts();
+
 	QTableView *view = ui.cylinderTableWidget->view();
 	view->setColumnHidden(CylindersModel::START, true);
 	view->setColumnHidden(CylindersModel::END, true);
@@ -307,6 +308,10 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.backgasBreaks->blockSignals(true);
 		ui.backgasBreaks->setChecked(false);
 		ui.backgasBreaks->blockSignals(false);
+		ui.bailout->setDisabled(true);
+		ui.bailout->blockSignals(true);
+		ui.bailout->setChecked(false);
+		ui.bailout->blockSignals(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(true);
 		ui.safetystop->setDisabled(false);
@@ -344,6 +349,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 			ui.backgasBreaks->setChecked(false);
 			ui.backgasBreaks->blockSignals(false);
 		}
+		ui.bailout->setDisabled(!(displayed_dive.dc.divemode == CCR || displayed_dive.dc.divemode == PSCR));
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -377,6 +383,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 			ui.backgasBreaks->setChecked(false);
 			ui.backgasBreaks->blockSignals(false);
 		}
+		ui.bailout->setDisabled(!(displayed_dive.dc.divemode == CCR || displayed_dive.dc.divemode == PSCR));
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -438,6 +445,8 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.bottompo2->setValue(prefs.bottompo2 / 1000.0);
 	ui.decopo2->setValue(prefs.decopo2 / 1000.0);
 	ui.backgasBreaks->setChecked(prefs.doo2breaks);
+	setBailout(false);
+	setBailoutVisibility(false);
 	ui.drop_stone_mode->setChecked(prefs.drop_stone_mode);
 	ui.switch_at_req_stop->setChecked(prefs.switch_at_req_stop);
 	ui.min_switch_duration->setValue(prefs.min_switch_duration / 60);
@@ -481,9 +490,11 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.gflow, SIGNAL(valueChanged(int)), plannerModel, SLOT(setGFLow(int)));
 	connect(ui.vpmb_conservatism, SIGNAL(valueChanged(int)), plannerModel, SLOT(setVpmbConservatism(int)));
 	connect(ui.backgasBreaks, SIGNAL(toggled(bool)), this, SLOT(setBackgasBreaks(bool)));
+	connect(ui.bailout, SIGNAL(toggled(bool)), this, SLOT(setBailout(bool)));
 	connect(ui.switch_at_req_stop, SIGNAL(toggled(bool)), plannerModel, SLOT(setSwitchAtReqStop(bool)));
 	connect(ui.min_switch_duration, SIGNAL(valueChanged(int)), plannerModel, SLOT(setMinSwitchDuration(int)));
 	connect(ui.rebreathermode, SIGNAL(currentIndexChanged(int)), plannerModel, SLOT(setRebreatherMode(int)));
+	connect(ui.rebreathermode, SIGNAL(currentIndexChanged(int)), this, SLOT(setBailoutVisibility(int)));
 
 	connect(ui.bottompo2, SIGNAL(valueChanged(double)), CylindersModel::instance(), SLOT(updateBestMixes()));
 	connect(ui.bestmixEND, SIGNAL(valueChanged(int)), CylindersModel::instance(), SLOT(updateBestMixes()));
@@ -654,6 +665,17 @@ void PlannerSettingsWidget::setBackgasBreaks(bool dobreaks)
 {
 	qPrefDivePlanner::instance()->set_doo2breaks(dobreaks);
 	plannerModel->emitDataChanged();
+}
+
+void PlannerSettingsWidget::setBailout(bool dobailout)
+{
+	qPrefDivePlanner::instance()->set_dobailout(dobailout);
+	plannerModel->emitDataChanged();
+}
+
+void PlannerSettingsWidget::setBailoutVisibility(int mode)
+{
+		ui.bailout->setDisabled(!(mode == CCR || mode == PSCR));
 }
 
 PlannerDetails::PlannerDetails(QWidget *parent) : QWidget(parent)

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -85,9 +85,11 @@ slots:
 	void setDecoPo2(double po2);
 	void setBestmixEND(int depth);
 	void setBackgasBreaks(bool dobreaks);
+	void setBailout(bool dobailout);
 	void disableDecoElements(int mode);
 	void disableBackgasBreaks(bool enabled);
 	void setDiveMode(int mode);
+	void setBailoutVisibility(int mode);
 
 private:
 	Ui::plannerSettingsWidget ui;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1006,6 +1006,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 	// plan the dive in the same mode as the currently selected one
 	if (current_dive) {
 		divePlannerSettingsWidget->setDiveMode(current_dive->dc.divemode);
+		divePlannerSettingsWidget->setBailoutVisibility(current_dive->dc.divemode);
 		if (current_dive->salinity)
 			divePlannerWidget->setSalinity(current_dive->salinity);
 	}

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -255,7 +255,7 @@
           <property name="spacing">
            <number>2</number>
           </property>
-          <item row="2" column="2">
+          <item row="4" column="2">
            <widget class="QSpinBox" name="reserve_gas">
             <property name="suffix">
              <string>bar</string>
@@ -274,7 +274,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="6" column="1">
            <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -287,7 +287,7 @@
             </property>
            </spacer>
           </item>
-          <item row="18" column="1" colspan="2">
+          <item row="22" column="1" colspan="2">
            <widget class="QCheckBox" name="switch_at_req_stop">
             <property name="toolTip">
              <string>Postpone gas change if a stop is not required</string>
@@ -297,74 +297,37 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
-           <widget class="QLabel" name="label_gfhigh">
+          <item row="18" column="1" colspan="2">
+           <widget class="QCheckBox" name="lastStop">
             <property name="text">
-             <string>GFHigh</string>
-            </property>
-            <property name="indent">
-             <number>25</number>
+             <string>Last stop at 6m</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
-           <widget class="QLabel" name="label_gflow">
-            <property name="text">
-             <string>GFLow</string>
+          <item row="15" column="2">
+           <widget class="QSpinBox" name="vpmb_conservatism">
+            <property name="prefix">
+             <string>+</string>
             </property>
-            <property name="indent">
-             <number>26</number>
+            <property name="maximum">
+             <number>4</number>
             </property>
            </widget>
           </item>
-          <item row="9" column="2">
-           <widget class="QSpinBox" name="gflow">
+          <item row="12" column="2">
+           <widget class="QSpinBox" name="gfhigh">
             <property name="suffix">
              <string>%</string>
             </property>
             <property name="minimum">
-             <number>10</number>
+             <number>40</number>
             </property>
             <property name="maximum">
              <number>150</number>
             </property>
            </widget>
           </item>
-          <item row="15" column="1" colspan="2">
-           <widget class="QCheckBox" name="drop_stone_mode">
-            <property name="text">
-             <string>Drop to first depth</string>
-            </property>
-           </widget>
-          </item>
-          <item row="19" column="1">
-           <widget class="QLabel" name="label_min_switch_duration">
-            <property name="text">
-             <string>Min. switch duration O₂% below 100%</string>
-            </property>
-           </widget>
-          </item>
-          <item row="21" column="1">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="17" column="1" colspan="2">
-           <widget class="QCheckBox" name="backgasBreaks">
-            <property name="text">
-             <string>Plan backgas breaks</string>
-            </property>
-           </widget>
-          </item>
-          <item row="19" column="2">
+          <item row="23" column="2">
            <widget class="QSpinBox" name="min_switch_duration">
             <property name="suffix">
              <string>min</string>
@@ -383,14 +346,74 @@
             </property>
            </widget>
           </item>
-          <item row="16" column="1" colspan="2">
-           <widget class="QCheckBox" name="lastStop">
+          <item row="20" column="1" colspan="2">
+           <widget class="QCheckBox" name="backgasBreaks">
             <property name="text">
-             <string>Last stop at 6m</string>
+             <string>Plan backgas breaks</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="25" column="1">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="23" column="1">
+           <widget class="QLabel" name="label_min_switch_duration">
+            <property name="text">
+             <string>Min. switch duration O₂% below 100%</string>
+            </property>
+           </widget>
+          </item>
+          <item row="17" column="1" colspan="2">
+           <widget class="QCheckBox" name="drop_stone_mode">
+            <property name="text">
+             <string>Drop to first depth</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="2">
+           <widget class="QSpinBox" name="gflow">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>150</number>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="QLabel" name="label_gflow">
+            <property name="text">
+             <string>GFLow</string>
+            </property>
+            <property name="indent">
+             <number>26</number>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="QLabel" name="label_gfhigh">
+            <property name="text">
+             <string>GFHigh</string>
+            </property>
+            <property name="indent">
+             <number>25</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
            <widget class="QRadioButton" name="recreational_deco">
             <property name="toolTip">
              <string>Maximize bottom time allowed by gas and no decompression limits</string>
@@ -400,47 +423,24 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="2">
-           <widget class="QSpinBox" name="gfhigh">
-            <property name="suffix">
-             <string>%</string>
+          <item row="15" column="1">
+           <widget class="QLabel" name="label_vpmb_conservatism">
+            <property name="text">
+             <string>Conservatism level</string>
             </property>
-            <property name="minimum">
-             <number>40</number>
-            </property>
-            <property name="maximum">
-             <number>150</number>
+            <property name="indent">
+             <number>25</number>
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
+          <item row="14" column="1">
            <widget class="QRadioButton" name="vpmb_deco">
             <property name="text">
              <string>VPM-B deco</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QRadioButton" name="buehlmann_deco">
-            <property name="text">
-             <string>Bühlmann deco</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="label_reserve_gas">
-            <property name="text">
-             <string>Reserve gas</string>
-            </property>
-            <property name="indent">
-             <number>26</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" alignment="Qt::AlignHCenter">
+          <item row="5" column="1" alignment="Qt::AlignHCenter">
            <widget class="QCheckBox" name="safetystop">
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
@@ -453,7 +453,7 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
+          <item row="13" column="1">
            <spacer name="verticalSpacer_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -466,7 +466,7 @@
             </property>
            </spacer>
           </item>
-          <item row="14" column="1">
+          <item row="16" column="1">
            <spacer name="verticalSpacer_5">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -478,26 +478,6 @@
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="13" column="1">
-           <widget class="QLabel" name="label_vpmb_conservatism">
-            <property name="text">
-             <string>Conservatism level</string>
-            </property>
-            <property name="indent">
-             <number>25</number>
-            </property>
-           </widget>
-          </item>
-          <item row="13" column="2">
-           <widget class="QSpinBox" name="vpmb_conservatism">
-            <property name="prefix">
-             <string>+</string>
-            </property>
-            <property name="maximum">
-             <number>4</number>
-            </property>
-           </widget>
           </item>
           <item row="0" column="2">
            <widget class="QComboBox" name="rebreathermode">
@@ -513,6 +493,33 @@
            <widget class="QLabel" name="label_dive_type">
             <property name="text">
              <string>Dive mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QRadioButton" name="buehlmann_deco">
+            <property name="text">
+             <string>Bühlmann deco</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="label_reserve_gas">
+            <property name="text">
+             <string>Reserve gas</string>
+            </property>
+            <property name="indent">
+             <number>26</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="bailout">
+            <property name="text">
+             <string>Bailout: Deco on OC</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This adds a checkbox for rebreather modes of the planner
that force the ascent to be in OC mode. Before, one had
to add a one minute last segment with the mode change but
this is not practical when manually searching for the
maximal bottom time given gas reserves.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
CHANGELOG updated

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson maybe you  want to comment on this.