### PR TITLE
Filter: connect filter and widget

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -3,112 +3,108 @@
 
 #include <QDoubleSpinBox>
 
-FilterWidget2::FilterWidget2(QWidget* parent)
-: QWidget(parent)
-, ui(new Ui::FilterWidget2())
+FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent)
 {
-	ui->setupUi(this);
+	ui.setupUi(this);
 
 	FilterData data;
-	ui->minRating->setCurrentStars(data.minRating);
-	ui->maxRating->setCurrentStars(data.maxRating);
-	ui->minVisibility->setCurrentStars(data.minVisibility);
-	ui->maxVisibility->setCurrentStars(data.maxVisibility);
-	ui->minAirTemp->setValue(data.minAirTemp);
-	ui->maxAirTemp->setValue(data.maxAirTemp);
-	ui->minWaterTemp->setValue(data.minWaterTemp);
-	ui->maxWaterTemp->setValue(data.maxWaterTemp);
-	ui->planned->setChecked(data.logged);
-	ui->planned->setChecked(data.planned);
+	ui.minRating->setCurrentStars(data.minRating);
+	ui.maxRating->setCurrentStars(data.maxRating);
+	ui.minVisibility->setCurrentStars(data.minVisibility);
+	ui.maxVisibility->setCurrentStars(data.maxVisibility);
+	ui.minAirTemp->setValue(data.minAirTemp);
+	ui.maxAirTemp->setValue(data.maxAirTemp);
+	ui.minWaterTemp->setValue(data.minWaterTemp);
+	ui.maxWaterTemp->setValue(data.maxWaterTemp);
+	ui.planned->setChecked(data.logged);
+	ui.planned->setChecked(data.planned);
 
 	// TODO: unhide this when we discover how to search for equipment.
-	ui->equipment->hide();
-	ui->labelEquipment->hide();
-	ui->invertFilter->hide();
+	ui.equipment->hide();
+	ui.labelEquipment->hide();
+	ui.invertFilter->hide();
 
-	ui->to->setDate(data.to.date());
+	ui.to->setDate(data.to.date());
 
-	connect(ui->maxRating, &StarWidget::valueChanged,
+	connect(ui.maxRating, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->minRating, &StarWidget::valueChanged,
+	connect(ui.minRating, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->maxVisibility, &StarWidget::valueChanged,
+	connect(ui.maxVisibility, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->minVisibility, &StarWidget::valueChanged,
+	connect(ui.minVisibility, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->maxAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.maxAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->minAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.minAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->maxWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.maxWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->minWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.minWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->from, &QDateTimeEdit::dateTimeChanged,
+	connect(ui.from, &QDateTimeEdit::dateTimeChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->to, &QDateTimeEdit::dateTimeChanged,
+	connect(ui.to, &QDateTimeEdit::dateTimeChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->tags, &QLineEdit::textChanged,
+	connect(ui.tags, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->people, &QLineEdit::textChanged,
+	connect(ui.people, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->location, &QLineEdit::textChanged,
+	connect(ui.location, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui->logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
+	connect(ui.logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
 
-	connect(ui->planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
-
+	connect(ui.planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
 }
 
 void FilterWidget2::updateFilter()
 {
 	filterData.validFilter = true;
-	filterData.minVisibility = ui->minVisibility->currentStars();
-	filterData.maxVisibility = ui->maxVisibility->currentStars();
-	filterData.minRating = ui->minRating->currentStars();
-	filterData.maxRating = ui->maxRating->currentStars();
-	filterData.minWaterTemp = ui->minWaterTemp->value();
-	filterData.maxWaterTemp = ui->maxWaterTemp->value();
-	filterData.minAirTemp = ui->minAirTemp->value();
-	filterData.maxWaterTemp = ui->maxWaterTemp->value();
-	filterData.from = ui->from->dateTime();
-	filterData.to = ui->to->dateTime();
-	filterData.tags = ui->tags->text().split(",", QString::SkipEmptyParts);
-	filterData.people = ui->people->text().split(",", QString::SkipEmptyParts);
-	filterData.location = ui->location->text().split(",", QString::SkipEmptyParts);
-	filterData.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
-	filterData.invertFilter = ui->invertFilter->isChecked();
-	filterData.logged = ui->logged->isChecked();
-	filterData.planned = ui->planned->isChecked();
+	filterData.minVisibility = ui.minVisibility->currentStars();
+	filterData.maxVisibility = ui.maxVisibility->currentStars();
+	filterData.minRating = ui.minRating->currentStars();
+	filterData.maxRating = ui.maxRating->currentStars();
+	filterData.minWaterTemp = ui.minWaterTemp->value();
+	filterData.maxWaterTemp = ui.maxWaterTemp->value();
+	filterData.minAirTemp = ui.minAirTemp->value();
+	filterData.maxWaterTemp = ui.maxWaterTemp->value();
+	filterData.from = ui.from->dateTime();
+	filterData.to = ui.to->dateTime();
+	filterData.tags = ui.tags->text().split(",", QString::SkipEmptyParts);
+	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
+	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
+	filterData.equipment = ui.equipment->text().split(",", QString::SkipEmptyParts);
+	filterData.invertFilter = ui.invertFilter->isChecked();
+	filterData.logged = ui.logged->isChecked();
+	filterData.planned = ui.planned->isChecked();
 
 	filterDataChanged(filterData);
 }
 
 void FilterWidget2::updateLogged(int value) {
 	if (value == Qt::Unchecked)
-		ui->planned->setChecked(true);
+		ui.planned->setChecked(true);
 	updateFilter();
 }
 
 void FilterWidget2::updatePlanned(int value) {
 	if (value == Qt::Unchecked)
-		ui->logged->setChecked(true);
+		ui.logged->setChecked(true);
 	updateFilter();
 }
-
 
 void FilterWidget2::showEvent(QShowEvent *event)
 {

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -75,29 +75,26 @@ FilterWidget2::FilterWidget2(QWidget* parent)
 
 void FilterWidget2::updateFilter()
 {
-	FilterData data;
+	filterData.validFilter = true;
+	filterData.minVisibility = ui->minVisibility->currentStars();
+	filterData.maxVisibility = ui->maxVisibility->currentStars();
+	filterData.minRating = ui->minRating->currentStars();
+	filterData.maxRating = ui->maxRating->currentStars();
+	filterData.minWaterTemp = ui->minWaterTemp->value();
+	filterData.maxWaterTemp = ui->maxWaterTemp->value();
+	filterData.minAirTemp = ui->minAirTemp->value();
+	filterData.maxWaterTemp = ui->maxWaterTemp->value();
+	filterData.from = ui->from->dateTime();
+	filterData.to = ui->to->dateTime();
+	filterData.tags = ui->tags->text().split(",", QString::SkipEmptyParts);
+	filterData.people = ui->people->text().split(",", QString::SkipEmptyParts);
+	filterData.location = ui->location->text().split(",", QString::SkipEmptyParts);
+	filterData.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
+	filterData.invertFilter = ui->invertFilter->isChecked();
+	filterData.logged = ui->logged->isChecked();
+	filterData.planned = ui->planned->isChecked();
 
-	data.validFilter = true;
-	data.minVisibility = ui->minVisibility->currentStars();
-	data.maxVisibility = ui->maxVisibility->currentStars();
-	data.minRating = ui->minRating->currentStars();
-	data.maxRating = ui->maxRating->currentStars();
-	data.minWaterTemp = ui->minWaterTemp->value();
-	data.maxWaterTemp = ui->maxWaterTemp->value();
-	data.minAirTemp = ui->minAirTemp->value();
-	data.maxWaterTemp = ui->maxWaterTemp->value();
-	data.from = ui->from->dateTime();
-	data.to = ui->to->dateTime();
-	data.tags = ui->tags->text().split(",", QString::SkipEmptyParts);
-	data.people = ui->people->text().split(",", QString::SkipEmptyParts);
-	data.location = ui->location->text().split(",", QString::SkipEmptyParts);
-	data.equipment = ui->equipment->text().split(",", QString::SkipEmptyParts);
-	data.invertFilter = ui->invertFilter->isChecked();
-	data.logged = ui->logged->isChecked();
-	data.planned = ui->planned->isChecked();
-
-	filterData = data;
-	filterDataChanged(data);
+	filterDataChanged(filterData);
 }
 
 void FilterWidget2::updateLogged(int value) {

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -97,7 +97,7 @@ void FilterWidget2::updateFilter()
 	data.planned = ui->planned->isChecked();
 
 	filterData = data;
-	emit filterDataChanged(data);
+	filterDataChanged(data);
 }
 
 void FilterWidget2::updateLogged(int value) {
@@ -116,12 +116,17 @@ void FilterWidget2::updatePlanned(int value) {
 void FilterWidget2::showEvent(QShowEvent *event)
 {
 	QWidget::showEvent(event);
-	emit filterDataChanged(filterData);
+	filterDataChanged(filterData);
 }
 
 void FilterWidget2::hideEvent(QHideEvent *event)
 {
 	QWidget::hideEvent(event);
 	FilterData data;
-	emit filterDataChanged(data);
+	filterDataChanged(data);
+}
+
+void FilterWidget2::filterDataChanged(const FilterData &data)
+{
+	MultiFilterSortModel::instance()->filterDataChanged(data);
 }

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -24,17 +24,13 @@ protected:
 	void hideEvent(QHideEvent *event) override;
 	void showEvent(QShowEvent *event) override;
 
-signals:
-	void filterDataChanged(const FilterData& data);
-
 public slots:
 	void updatePlanned(int value);
 	void updateLogged(int value);
 
-
-
 private:
 	std::unique_ptr<Ui::FilterWidget2> ui;
+	void filterDataChanged(const FilterData &data);
 	FilterData filterData;
 };
 

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -29,7 +29,7 @@ public slots:
 	void updateLogged(int value);
 
 private:
-	std::unique_ptr<Ui::FilterWidget2> ui;
+	Ui::FilterWidget2 ui;
 	void filterDataChanged(const FilterData &data);
 	FilterData filterData;
 };

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -41,7 +41,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string> Rating</string>
+      <string>Rating</string>
      </property>
     </widget>
    </item>

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -53,7 +53,6 @@
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "desktop-widgets/updatemanager.h"
 #include "desktop-widgets/usersurvey.h"
-#include "desktop-widgets/filterwidget2.h"
 #include "desktop-widgets/simplewidgets.h"
 
 #include "profile-widget/profilewidget2.h"
@@ -146,7 +145,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	divePlannerSettingsWidget = new PlannerSettingsWidget(this);
 	divePlannerWidget = new DivePlannerWidget(this);
 	plannerDetails = new PlannerDetails(this);
-	auto *filterWidget2 = new FilterWidget2();
 
 	// what is a sane order for those icons? we should have the ones the user is
 	// most likely to want towards the top so they are always visible
@@ -195,7 +193,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	registerApplicationState("PlanDive", divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
 	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, diveList, mapWidget );
 	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, diveList, mapWidget);
-	registerApplicationState("FilterDive", mainTab, profileContainer, diveList, filterWidget2);
+	registerApplicationState("FilterDive", mainTab, profileContainer, diveList, &filterWidget2);
 
 	setStateProperties("Default", enabledList, enabledList, enabledList,enabledList);
 	setStateProperties("AddDive", enabledList, enabledList, enabledList,enabledList);

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -17,6 +17,7 @@
 #include "ui_mainwindow.h"
 #include "ui_plannerDetails.h"
 #include "desktop-widgets/notificationwidget.h"
+#include "desktop-widgets/filterwidget2.h"
 #include "core/gpslocation.h"
 #include "core/dive.h"
 
@@ -36,7 +37,6 @@ class ProfileWidget2;
 class PlannerDetails;
 class PlannerSettingsWidget;
 class LocationInformationWidget;
-class FilterWidget2;
 
 typedef std::pair<QByteArray, QVariant> WidgetProperty;
 typedef QVector<WidgetProperty> PropertyList;
@@ -186,6 +186,7 @@ slots:
 
 private:
 	Ui::MainWindow ui;
+	FilterWidget2 filterWidget2;
 	QAction *actionNextDive;
 	QAction *actionPreviousDive;
 	QAction *undoAction;

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -111,10 +111,12 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 
 	// TODO: get the preferences for the imperial vs metric data.
 	// ignore the check if it doesn't makes sense.
-	if (d->watertemp.mkelvin < C_to_mkelvin(filterData.minWaterTemp) || d->watertemp.mkelvin > C_to_mkelvin((filterData.maxWaterTemp)))
+	if (d->watertemp.mkelvin &&
+	    (d->watertemp.mkelvin < C_to_mkelvin(filterData.minWaterTemp) || d->watertemp.mkelvin > C_to_mkelvin((filterData.maxWaterTemp))))
 		return false;
 
-	if (d->airtemp.mkelvin < C_to_mkelvin(filterData.minAirTemp) || d->airtemp.mkelvin > C_to_mkelvin(filterData.maxAirTemp))
+	if (d->airtemp.mkelvin &&
+	    (d->airtemp.mkelvin < C_to_mkelvin(filterData.minAirTemp) || d->airtemp.mkelvin > C_to_mkelvin(filterData.maxAirTemp)))
 		return false;
 
 	if (filterData.from.isValid() && d->when < filterData.from.toTime_t())

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -100,6 +100,10 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 
 bool MultiFilterSortModel::showDive(const struct dive *d) const
 {
+	// If curr_dive_site is set, we are in a special dive-site editing mode.
+	if (curr_dive_site)
+		return d->dive_site == curr_dive_site;
+
 	if (!filterData.validFilter)
 		return true;
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -228,7 +228,7 @@ bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2
 	return DiveTripModelBase::instance()->lessThan(i1, i2);
 }
 
-void MultiFilterSortModel::filterDataChanged(const FilterData& data)
+void MultiFilterSortModel::filterDataChanged(const FilterData &data)
 {
 	filterData = data;
 	myInvalidate();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -51,7 +51,7 @@ slots:
 	void stopFilterDiveSite();
 	void filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles);
 	void resetModel(DiveTripModelBase::Layout layout);
-	void filterDataChanged(const FilterData& data);
+	void filterDataChanged(const FilterData &data);
 
 signals:
 	void filterFinished();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a reopening of #1889. But I can't reopen it, because I force-pushed changes [reopen-then-push works, but push-then-reopen doesn't?].

Sorry for bull-in-a-china-shop mode - at least this allows people to test the widget.

@janmulder: I think I know why #1889 crashes for you on exit - please confirm whether the new commit fixes this. [Note: The fact that the destructor of the QObject base class calls hide() on sub-objects (according Qt's object hierarchy, not the C++ object hierarchy) lets me seriously question their design decisions. The base-object is now in a semi-destructed state and it seems very logical for sub-objects to call into the base-object. Very annoying.]

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Update filter if user enters data.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not for this PR, but the original PR.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not for this PR, but the original PR.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
