### PR TITLE
Import: fix erroneous flag

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -518,7 +518,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 		auto data = thread.data();
 		int flags = IMPORT_IS_DOWNLOADED;
 		if (preferDownloaded())
-			flags |= IMPORT_IS_DOWNLOADED;
+			flags |= IMPORT_PREFER_IMPORTED;
 		if (ui.createNewTrip->isChecked())
 			flags |= IMPORT_ADD_TO_NEW_TRIP;
 		Command::importDives(table, nullptr, flags, data->devName());


### PR DESCRIPTION
In 891fcbf520f28ef6016d6171eba83c6773efca00 boolean parameters were
replaced by flags. Fix an error in this commit: IMPORT_IS_DOWNLOADED
should be IMPORT_PREFER_IMPORTED.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a silly typo - not much more to say.