### PR TITLE
Filter: implement imperial units.

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -1,5 +1,7 @@
 #include "desktop-widgets/filterwidget2.h"
 #include "desktop-widgets/simplewidgets.h"
+#include "core/qthelper.h"
+#include "core/settings/qPrefUnit.h"
 
 #include <QDoubleSpinBox>
 
@@ -31,6 +33,9 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent)
 	ui.toTime->setDisplayFormat(prefs.time_format);
 	ui.toDate->setDate(data.toDate.date());
 	ui.toTime->setTime(data.toTime);
+
+	// Initialize temperature fields to display correct unit.
+	temperatureChanged();
 
 	connect(ui.maxRating, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
@@ -80,6 +85,19 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent)
 	connect(ui.logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
 
 	connect(ui.planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
+
+	// Update temperature fields if user changes temperature-units in preferences.
+	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged, this, &FilterWidget2::temperatureChanged);
+	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged, this, &FilterWidget2::temperatureChanged);
+}
+
+void FilterWidget2::temperatureChanged()
+{
+	QString temp = get_temp_unit();
+	ui.minAirTemp->setSuffix(temp);
+	ui.maxAirTemp->setSuffix(temp);
+	ui.minWaterTemp->setSuffix(temp);
+	ui.maxWaterTemp->setSuffix(temp);
 }
 
 void FilterWidget2::updateFilter()

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -10,6 +10,13 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent)
 	ui.setupUi(this);
 
 	FilterData data;
+
+	// Use default values to set minimum and maximum air and water temperature.
+	ui.minAirTemp->setRange(data.minAirTemp, data.maxAirTemp);
+	ui.maxAirTemp->setRange(data.minAirTemp, data.maxAirTemp);
+	ui.minWaterTemp->setRange(data.minWaterTemp, data.maxWaterTemp);
+	ui.maxWaterTemp->setRange(data.minWaterTemp, data.maxWaterTemp);
+
 	ui.minRating->setCurrentStars(data.minRating);
 	ui.maxRating->setCurrentStars(data.maxRating);
 	ui.minVisibility->setCurrentStars(data.minVisibility);

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -27,6 +27,8 @@ protected:
 public slots:
 	void updatePlanned(int value);
 	void updateLogged(int value);
+private slots:
+	void temperatureChanged();
 
 private:
 	Ui::FilterWidget2 ui;

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -104,14 +104,13 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 	if (d->rating < filterData.minRating || d->rating > filterData.maxRating)
 		return false;
 
-	// TODO: get the preferences for the imperial vs metric data.
-	// ignore the check if it doesn't makes sense.
+	auto temp_comp = prefs.units.temperature == units::CELSIUS ? C_to_mkelvin : F_to_mkelvin;
 	if (d->watertemp.mkelvin &&
-	    (d->watertemp.mkelvin < C_to_mkelvin(filterData.minWaterTemp) || d->watertemp.mkelvin > C_to_mkelvin((filterData.maxWaterTemp))))
+	    (d->watertemp.mkelvin < (*temp_comp)(filterData.minWaterTemp) || d->watertemp.mkelvin > (*temp_comp)(filterData.maxWaterTemp)))
 		return false;
 
 	if (d->airtemp.mkelvin &&
-	    (d->airtemp.mkelvin < C_to_mkelvin(filterData.minAirTemp) || d->airtemp.mkelvin > C_to_mkelvin(filterData.maxAirTemp)))
+	    (d->airtemp.mkelvin < (*temp_comp)(filterData.minAirTemp) || d->airtemp.mkelvin > (*temp_comp)(filterData.maxAirTemp)))
 		return false;
 
 	QDateTime t = filterData.fromDate;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -20,10 +20,13 @@ struct FilterData {
 	int maxVisibility = 5;
 	int minRating = 0;
 	int maxRating = 5;
-	double minWaterTemp = 0;
-	double maxWaterTemp = 100;
-	double minAirTemp = 0;
-	double maxAirTemp = 100;
+	// The default minimum and maximum temperatures are set such that all
+	// physically reasonable dives are shown. Note that these values should
+	// work for both Celcius and Fahrenheit scales.
+	double minWaterTemp = -10;
+	double maxWaterTemp = 200;
+	double minAirTemp = -50;
+	double maxAirTemp = 200;
 	QDateTime fromDate;
 	QTime fromTime;
 	QDateTime toDate = QDateTime::currentDateTime();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-   - Describe your pull request in detail. -->
Make the temperature-fields aware of imperial units. This is far from perfect, as the values are not converted and taken as-is. Ultimately, we want the min and max values depend on the selected units. And we probably also want to store the value in a unit-independent way.

But this should make the filter usable for imperial unit users. Please test.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use the correct conversion function
2) Add suffix
3) Extend range of valid temperatures

