### PR TITLE
Filter: quick implementation of negation

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -92,13 +92,18 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 	connect(ui.locationNegate, &QToolButton::toggled,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
+	connect(ui.logged, &QCheckBox::stateChanged,
+		this, &FilterWidget2::updateLogged);
 
-	connect(ui.planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
+	connect(ui.planned, &QCheckBox::stateChanged,
+		this, &FilterWidget2::updatePlanned);
 
 	// Update temperature fields if user changes temperature-units in preferences.
-	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged, this, &FilterWidget2::temperatureChanged);
-	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged, this, &FilterWidget2::temperatureChanged);
+	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
+		this, &FilterWidget2::temperatureChanged);
+
+	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
+		this, &FilterWidget2::temperatureChanged);
 
 	// Update counts if dives were added / removed
 	connect(MultiFilterSortModel::instance(), &MultiFilterSortModel::countsChanged,

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -20,8 +20,8 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 
 	// TODO: unhide this when we discover how to search for equipment.
 	ui.equipment->hide();
+	ui.equipmentNegate->hide();
 	ui.labelEquipment->hide();
-	ui.invertFilter->hide();
 
 	ui.fromDate->setDisplayFormat(prefs.date_format);
 	ui.fromTime->setDisplayFormat(prefs.time_format);
@@ -77,10 +77,19 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 	connect(ui.tags, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
+	connect(ui.tagsNegate, &QToolButton::toggled,
+		this, &FilterWidget2::updateFilter);
+
 	connect(ui.people, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
+	connect(ui.peopleNegate, &QToolButton::toggled,
+		this, &FilterWidget2::updateFilter);
+
 	connect(ui.location, &QLineEdit::textChanged,
+		this, &FilterWidget2::updateFilter);
+
+	connect(ui.locationNegate, &QToolButton::toggled,
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
@@ -121,6 +130,10 @@ void FilterWidget2::clearFilter()
 	ui.fromTime->setTime(filterData.fromTime);
 	ui.toDate->setDate(filterData.toDate.date());
 	ui.toTime->setTime(filterData.toTime);
+	ui.tagsNegate->setChecked(filterData.tagsNegate);
+	ui.peopleNegate->setChecked(filterData.peopleNegate);
+	ui.locationNegate->setChecked(filterData.locationNegate);
+	ui.equipmentNegate->setChecked(filterData.equipmentNegate);
 	ignoreSignal = false;
 
 	filterDataChanged(filterData);
@@ -162,7 +175,10 @@ void FilterWidget2::updateFilter()
 	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
 	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
 	filterData.equipment = ui.equipment->text().split(",", QString::SkipEmptyParts);
-	filterData.invertFilter = ui.invertFilter->isChecked();
+	filterData.tagsNegate = ui.tagsNegate->isChecked();
+	filterData.peopleNegate = ui.peopleNegate->isChecked();
+	filterData.locationNegate = ui.locationNegate->isChecked();
+	filterData.equipmentNegate = ui.equipmentNegate->isChecked();
 	filterData.logged = ui.logged->isChecked();
 	filterData.planned = ui.planned->isChecked();
 

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="2" colspan="7">
+   <item row="8" column="2" colspan="6">
     <widget class="QLineEdit" name="tags"/>
    </item>
    <item row="1" column="2">
@@ -61,16 +61,6 @@
    </item>
    <item row="3" column="6">
     <widget class="QDoubleSpinBox" name="minWaterTemp"/>
-   </item>
-   <item row="12" column="2" colspan="7">
-    <widget class="QCheckBox" name="invertFilter">
-     <property name="toolTip">
-      <string>Display dives that will not match the search, only applies to tags, people, location and equipment</string>
-     </property>
-     <property name="text">
-      <string>Invert filter</string>
-     </property>
-    </widget>
    </item>
    <item row="2" column="7">
     <widget class="QLabel" name="label_16">
@@ -131,7 +121,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="2" colspan="7">
+   <item row="10" column="2" colspan="6">
     <widget class="QLineEdit" name="location"/>
    </item>
    <item row="11" column="0">
@@ -147,7 +137,7 @@
    <item row="4" column="8">
     <widget class="QDoubleSpinBox" name="maxAirTemp"/>
    </item>
-   <item row="11" column="2" colspan="7">
+   <item row="11" column="2" colspan="6">
     <widget class="QLineEdit" name="equipment"/>
    </item>
    <item row="3" column="0">
@@ -157,7 +147,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="2" colspan="7">
+   <item row="9" column="2" colspan="6">
     <widget class="QLineEdit" name="people"/>
    </item>
    <item row="4" column="7">
@@ -301,6 +291,46 @@
      </property>
     </widget>
    </item>
+   <item row="8" column="8">
+    <widget class="QToolButton" name="tagsNegate">
+     <property name="text">
+      <string>¬</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="8">
+    <widget class="QToolButton" name="peopleNegate">
+     <property name="text">
+      <string>¬</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="8">
+    <widget class="QToolButton" name="locationNegate">
+     <property name="text">
+      <string>¬</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="8">
+    <widget class="QToolButton" name="equipmentNegate">
+     <property name="text">
+      <string>¬</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -326,7 +356,6 @@
   <tabstop>people</tabstop>
   <tabstop>location</tabstop>
   <tabstop>equipment</tabstop>
-  <tabstop>invertFilter</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -35,9 +35,12 @@ struct FilterData {
 	QStringList people;
 	QStringList location;
 	QStringList equipment;
+	bool tagsNegate = false;
+	bool peopleNegate = false;
+	bool locationNegate = false;
+	bool equipmentNegate = false;
 	bool logged = true;
 	bool planned = true;
-	bool invertFilter;
 };
 
 class MultiFilterSortModel : public QSortFilterProxyModel {


### PR DESCRIPTION
Add negate buttons to the Tags, People, Location and Equipment
filters. Currently, if nothing is entered the filter is ignored
whether negate is on or off. One might think about filtering all
dives without tags, etc. instead.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Quick & Dirty implementation of individual negate buttons in the filter. See commit-message. I didn't find out how to properly align the UI fields.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add negate buttons to four filter items.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @janmulder 