### PR TITLE
Filter: Negation with '~' [Alternative to #1943]

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -21,7 +21,6 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 	// TODO: unhide this when we discover how to search for equipment.
 	ui.equipment->hide();
 	ui.labelEquipment->hide();
-	ui.invertFilter->hide();
 
 	ui.fromDate->setDisplayFormat(prefs.date_format);
 	ui.fromTime->setDisplayFormat(prefs.time_format);
@@ -167,7 +166,6 @@ void FilterWidget2::updateFilter()
 	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
 	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
 	filterData.equipment = ui.equipment->text().split(",", QString::SkipEmptyParts);
-	filterData.invertFilter = ui.invertFilter->isChecked();
 	filterData.logged = ui.logged->isChecked();
 	filterData.planned = ui.planned->isChecked();
 

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -83,13 +83,18 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 	connect(ui.location, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.logged, SIGNAL(stateChanged(int)), this, SLOT(updateLogged(int)));
+	connect(ui.logged, &QCheckBox::stateChanged,
+		this, &FilterWidget2::updateLogged);
 
-	connect(ui.planned, SIGNAL(stateChanged(int)), this, SLOT(updatePlanned(int)));
+	connect(ui.planned, &QCheckBox::stateChanged,
+		this, &FilterWidget2::updatePlanned);
 
 	// Update temperature fields if user changes temperature-units in preferences.
-	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged, this, &FilterWidget2::temperatureChanged);
-	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged, this, &FilterWidget2::temperatureChanged);
+	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
+		this, &FilterWidget2::temperatureChanged);
+
+	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
+		this, &FilterWidget2::temperatureChanged);
 
 	// Update counts if dives were added / removed
 	connect(MultiFilterSortModel::instance(), &MultiFilterSortModel::countsChanged,

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -62,16 +62,6 @@
    <item row="3" column="6">
     <widget class="QDoubleSpinBox" name="minWaterTemp"/>
    </item>
-   <item row="12" column="2" colspan="7">
-    <widget class="QCheckBox" name="invertFilter">
-     <property name="toolTip">
-      <string>Display dives that will not match the search, only applies to tags, people, location and equipment</string>
-     </property>
-     <property name="text">
-      <string>Invert filter</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="7">
     <widget class="QLabel" name="label_16">
      <property name="text">
@@ -326,7 +316,6 @@
   <tabstop>people</tabstop>
   <tabstop>location</tabstop>
   <tabstop>equipment</tabstop>
-  <tabstop>invertFilter</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -18,10 +18,24 @@
 namespace {
 	// Check if a string-list contains at least one string containing the second argument.
 	// Comparison is non case sensitive and removes white space.
+	// This function has a small twist: if the second argument starts with a "~" character,
+	// that character is removed and the result is negated.
 	bool listContainsSuperstring(const QStringList &list, const QString &s)
 	{
-		return std::any_of(list.begin(), list.end(), [&s](const QString &s2)
-				   { return s2.trimmed().contains(s.trimmed(), Qt::CaseInsensitive); });
+		QString trimmed = s.trimmed();
+		bool negate = false;
+		if (trimmed.startsWith(QChar('~'))) {
+			// Remove '~' and additional whitespace
+			trimmed = trimmed.mid(1).trimmed();
+			negate = true;
+		}
+
+		// Don't bother with empty strings
+		if (trimmed.isEmpty())
+			return true;
+
+		return std::any_of(list.begin(), list.end(), [&trimmed](const QString &s2)
+				   { return s2.trimmed().contains(trimmed, Qt::CaseInsensitive); }) != negate;
 	}
 
 	bool hasTags(const QStringList &tags, const struct dive *d)

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -37,7 +37,6 @@ struct FilterData {
 	QStringList equipment;
 	bool logged = true;
 	bool planned = true;
-	bool invertFilter;
 };
 
 class MultiFilterSortModel : public QSortFilterProxyModel {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As discussed in #1943, this is a finer-grained negation mechanism, which lets the user prepend '~' to filter dives *without* that term.

What we still have is the "substring" problem, where e.g. one buddy name is included in another, so negation would filter out too many dives. Possible solution: Different modes: substring, starts-with, whole-word-match?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement negation by prepending '~'

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1943
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I guess that should be documented, as it is quite obscure!
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @janmulder 