### PR TITLE
Filter: Implement counts, reset button and close button

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -141,14 +141,6 @@ std::vector<dive *> DiveListBase::addDives(DivesAndTripsToAdd &toAdd)
 	std::vector<dive *> res;
 	res.resize(toAdd.dives.size());
 
-	// First, tell the filters that new dives are added. We do this here
-	// instead of later by signals, so that the filter can set the
-	// checkboxes of the new rows to its liking. The added dives will
-	// then appear in the correct shown/hidden state.
-	QVector<dive *> divesForFilter;
-	for (const DiveToAdd &entry: toAdd.dives)
-		divesForFilter.push_back(entry.dive.get());
-
 	// Now, add the dives
 	// Note: the idiomatic STL-way would be std::transform, but let's use a loop since
 	// that is closer to classical C-style.

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -96,6 +96,10 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent)
 	// Update temperature fields if user changes temperature-units in preferences.
 	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged, this, &FilterWidget2::temperatureChanged);
 	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged, this, &FilterWidget2::temperatureChanged);
+
+	// Update counts if dives were added / removed
+	connect(MultiFilterSortModel::instance(), &MultiFilterSortModel::countsChanged,
+		this, &FilterWidget2::countsChanged);
 }
 
 void FilterWidget2::temperatureChanged()
@@ -161,7 +165,11 @@ void FilterWidget2::hideEvent(QHideEvent *event)
 void FilterWidget2::filterDataChanged(const FilterData &data)
 {
 	MultiFilterSortModel::instance()->filterDataChanged(data);
+	countsChanged();
+}
 
+void FilterWidget2::countsChanged()
+{
 	ui.filterText->setText(tr("%L1/%L2 shown").arg(MultiFilterSortModel::instance()->divesDisplayed)
 						  .arg(dive_table.nr));
 }

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -1,5 +1,6 @@
 #include "desktop-widgets/filterwidget2.h"
 #include "desktop-widgets/simplewidgets.h"
+#include "desktop-widgets/mainwindow.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefUnit.h"
 
@@ -33,6 +34,9 @@ FilterWidget2::FilterWidget2(QWidget* parent) : QWidget(parent), ignoreSignal(fa
 
 	connect(ui.clear, &QToolButton::clicked,
 		this, &FilterWidget2::clearFilter);
+
+	connect(ui.close, &QToolButton::clicked,
+		this, &FilterWidget2::closeFilter);
 
 	connect(ui.maxRating, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
@@ -122,6 +126,11 @@ void FilterWidget2::clearFilter()
 	filterDataChanged(filterData);
 }
 
+void FilterWidget2::closeFilter()
+{
+	MainWindow::instance()->setApplicationState("Default");
+}
+
 void FilterWidget2::temperatureChanged()
 {
 	QString temp = get_temp_unit();
@@ -181,8 +190,7 @@ void FilterWidget2::showEvent(QShowEvent *event)
 void FilterWidget2::hideEvent(QHideEvent *event)
 {
 	QWidget::hideEvent(event);
-	FilterData data;
-	filterDataChanged(data);
+	clearFilter();
 }
 
 void FilterWidget2::filterDataChanged(const FilterData &data)

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -161,4 +161,7 @@ void FilterWidget2::hideEvent(QHideEvent *event)
 void FilterWidget2::filterDataChanged(const FilterData &data)
 {
 	MultiFilterSortModel::instance()->filterDataChanged(data);
+
+	ui.filterText->setText(tr("%L1/%L2 shown").arg(MultiFilterSortModel::instance()->divesDisplayed)
+						  .arg(dive_table.nr));
 }

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -29,6 +29,7 @@ public slots:
 	void updateLogged(int value);
 private slots:
 	void temperatureChanged();
+	void countsChanged();
 
 private:
 	Ui::FilterWidget2 ui;

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -29,6 +29,7 @@ public slots:
 	void updateLogged(int value);
 private slots:
 	void clearFilter();
+	void closeFilter();
 	void temperatureChanged();
 	void countsChanged();
 

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -28,10 +28,12 @@ public slots:
 	void updatePlanned(int value);
 	void updateLogged(int value);
 private slots:
+	void clearFilter();
 	void temperatureChanged();
 	void countsChanged();
 
 private:
+	bool ignoreSignal;
 	Ui::FilterWidget2 ui;
 	void filterDataChanged(const FilterData &data);
 	FilterData filterData;

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -14,10 +14,17 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="8" column="1" colspan="4">
+   <item row="0" column="0">
+    <widget class="QLabel" name="filterText">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2" colspan="7">
     <widget class="QLineEdit" name="tags"/>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Min</string>
@@ -31,7 +38,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="3">
+   <item row="3" column="7">
     <widget class="QLabel" name="label_13">
      <property name="text">
       <string>Max</string>
@@ -52,10 +59,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="3" column="6">
     <widget class="QDoubleSpinBox" name="minWaterTemp"/>
    </item>
-   <item row="12" column="1" colspan="4">
+   <item row="12" column="2" colspan="7">
     <widget class="QCheckBox" name="invertFilter">
      <property name="toolTip">
       <string>Display dives that will not match the search, only applies to tags, people, location and equipment</string>
@@ -65,14 +72,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="3">
+   <item row="2" column="7">
     <widget class="QLabel" name="label_16">
      <property name="text">
       <string>Max</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="3" column="2">
     <widget class="QLabel" name="label_12">
      <property name="text">
       <string>Min</string>
@@ -93,14 +100,14 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="4" column="2">
     <widget class="QLabel" name="label_17">
      <property name="text">
       <string>Min</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="4">
+   <item row="3" column="8">
     <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
    </item>
    <item row="2" column="0">
@@ -110,21 +117,21 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <widget class="QLabel" name="label_14">
      <property name="text">
       <string>Min</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="7">
     <widget class="QLabel" name="label_15">
      <property name="text">
       <string>Max</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="4">
+   <item row="10" column="2" colspan="7">
     <widget class="QLineEdit" name="location"/>
    </item>
    <item row="11" column="0">
@@ -134,13 +141,13 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
+   <item row="4" column="6">
     <widget class="QDoubleSpinBox" name="minAirTemp"/>
    </item>
-   <item row="4" column="4">
+   <item row="4" column="8">
     <widget class="QDoubleSpinBox" name="maxAirTemp"/>
    </item>
-   <item row="11" column="1" colspan="4">
+   <item row="11" column="2" colspan="7">
     <widget class="QLineEdit" name="equipment"/>
    </item>
    <item row="3" column="0">
@@ -150,10 +157,10 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1" colspan="4">
+   <item row="9" column="2" colspan="7">
     <widget class="QLineEdit" name="people"/>
    </item>
-   <item row="4" column="3">
+   <item row="4" column="7">
     <widget class="QLabel" name="label_18">
      <property name="text">
       <string>Max</string>
@@ -174,7 +181,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
+   <item row="2" column="8">
     <widget class="StarWidget" name="maxVisibility" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -187,7 +194,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="6">
     <widget class="StarWidget" name="minVisibility" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -200,7 +207,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="6">
     <widget class="StarWidget" name="minRating" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -213,7 +220,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
+   <item row="1" column="8">
     <widget class="StarWidget" name="maxRating" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -226,7 +233,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="7" column="2">
     <widget class="QCheckBox" name="logged">
      <property name="text">
       <string>Logged</string>
@@ -236,7 +243,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="7" column="6">
     <widget class="QCheckBox" name="planned">
      <property name="text">
       <string>Planned</string>
@@ -246,25 +253,53 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="3">
+   <item row="5" column="7">
     <widget class="QTimeEdit" name="fromTime"/>
    </item>
-   <item row="5" column="1" colspan="2">
+   <item row="5" column="2" colspan="5">
     <widget class="QDateTimeEdit" name="fromDate">
      <property name="calendarPopup">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="2">
+   <item row="6" column="2" colspan="5">
     <widget class="QDateTimeEdit" name="toDate">
      <property name="calendarPopup">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="7">
     <widget class="QTimeEdit" name="toTime"/>
+   </item>
+   <item row="0" column="3">
+    <widget class="QToolButton" name="close">
+     <property name="toolTip">
+      <string>Close and reset filters</string>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>:filter-close</normaloff>:filter-close</iconset>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="clear">
+     <property name="toolTip">
+      <string>Reset filters</string>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>:edit-clear-icon</normaloff>:edit-clear-icon</iconset>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -79,6 +79,9 @@ MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyMo
 {
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+	connect(&diveListNotifier, &DiveListNotifier::divesAdded, this, &MultiFilterSortModel::divesAdded);
+	connect(&diveListNotifier, &DiveListNotifier::divesDeleted, this, &MultiFilterSortModel::divesDeleted);
 }
 
 void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
@@ -234,4 +237,22 @@ void MultiFilterSortModel::filterDataChanged(const FilterData &data)
 {
 	filterData = data;
 	myInvalidate();
+}
+
+void MultiFilterSortModel::divesAdded(dive_trip *, bool, const QVector<dive *> &dives)
+{
+	for (dive *d: dives) {
+		if (!d->hidden_by_filter)
+			++divesDisplayed;
+	}
+	emit countsChanged();
+}
+
+void MultiFilterSortModel::divesDeleted(dive_trip *, bool, const QVector<dive *> &dives)
+{
+	for (dive *d: dives) {
+		if (!d->hidden_by_filter)
+			--divesDisplayed;
+	}
+	emit countsChanged();
 }

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -27,8 +27,8 @@ struct FilterData {
 	double maxWaterTemp = 200;
 	double minAirTemp = -50;
 	double maxAirTemp = 200;
-	QDateTime fromDate;
-	QTime fromTime;
+	QDateTime fromDate = QDateTime(QDate(1980,1,1));
+	QTime fromTime = QTime(0,0);
 	QDateTime toDate = QDateTime::currentDateTime();
 	QTime toTime = QTime::currentTime();
 	QStringList tags;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -57,9 +57,12 @@ slots:
 	void filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles);
 	void resetModel(DiveTripModelBase::Layout layout);
 	void filterDataChanged(const FilterData &data);
+	void divesAdded(struct dive_trip *, bool, const QVector<dive *> &dives);
+	void divesDeleted(struct dive_trip *, bool, const QVector<dive *> &dives);
 
 signals:
 	void filterFinished();
+	void countsChanged();
 
 private:
 	MultiFilterSortModel(QObject *parent = 0);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Reimplements functionality of the old filter. This is all more hairy and than one would think:

1) The counts have to be actualized on addition / removal of dives (think undo while filter is active).
2) Resetting text fields causes signals which have to be ignored.
3) The from date has to be set explicitly to make reset of from date work.
4) One can't simply hide the widget, one has to reset the "application state".

All in all not fun at all.

UI is horrible, but I don't know how to handle that grid layout. Help, please.

Note: for undo I noticed a horrible UI behavior where on pressing CTRL^Z, the text field in the filter *and* the last dive action were undone. This is not acceptable and it seems that we're doing something wrong concerning hooking to CTRL^Z.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement counts
2) Update counts on dive addition / removal
3) Implement reset
4) Implement close
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
