### PR TITLE
[TRIVIAL] Cleanup: remove redundant conditional

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -815,7 +815,7 @@ void MainTab::acceptChanges()
 		saveTaggedStrings(selectedDives);
 		saveTags(selectedDives);
 
-		if (editMode != ADD && cylindersModel->changed) {
+		if (cylindersModel->changed) {
 			mark_divelist_changed(true);
 			MODIFY_DIVES(selectedDives,
 				for (int i = 0; i < MAX_CYLINDERS; i++) {


### PR DESCRIPTION
In MainTab::acceptChanges there was a "editMode != ADD" condition
inside a else block to "editMode == ADD", which is therefore
redundant. Remove.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial code-cleanup that removes an always-true conditional.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove tautological conditional.

