### PR TITLE
Export: fix pictures in profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Export: fix picture thumbnails [#1963]
 - Desktop: remove support for the "Share on Facebook" feature.
   Rationale: It is fairly easy to share images on Facebook, thus it was decided
   that this feature is redundant and should be removed from Subsurface.

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -31,9 +31,13 @@ public:
 	static Thumbnailer *instance();
 
 	// Schedule a thumbnail for fetching or calculation.
-	// Returns a placeholder thumbnail. The actual thumbnail will be sent
-	// via a signal later.
-	QImage fetchThumbnail(const QString &filename);
+	// If synchronous is false, returns a placeholder thumbnail.
+	// The actual thumbnail will be sent via a signal later.
+	// If synchronous is true, try to fetch the actual thumbnail.
+	// In this mode only precalculated thumbnails or thumbnails
+	// from pictures are returned. Video extraction and remote
+	// images are not supported.
+	QImage fetchThumbnail(const QString &filename, bool synchronous);
 
 	// Schedule multiple thumbnails for forced recalculation
 	void calculateThumbnails(const QVector<QString> &filenames);

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -287,7 +287,7 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 			continue;
 
 		ProfileWidget2 *profile = MainWindow::instance()->graphics;
-		profile->plotDive(dive, true);
+		profile->plotDive(dive, true, false, true);
 		profile->setToolTipVisibile(false);
 		QPixmap pix = QPixmap::grabWidget(profile);
 		profile->setToolTipVisibile(true);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -827,7 +827,7 @@ void ProfileWidget2::plotDive(struct dive *d, bool force, bool doClearPictures, 
 	if (doClearPictures)
 		clearPictures();
 	else
-		plotPicturesInternal(plotPicturesSynchronously);
+		plotPicturesInternal(d, plotPicturesSynchronously);
 
 	toolTipItem->refresh(mapToScene(mapFromGlobal(QCursor::pos())));
 #endif
@@ -2228,21 +2228,21 @@ void ProfileWidget2::updateThumbnailXPos(PictureEntry &e)
 // This function resets the picture thumbnails of the current dive.
 void ProfileWidget2::plotPictures()
 {
-	plotPicturesInternal(false);
+	plotPicturesInternal(current_dive, false);
 }
 
-void ProfileWidget2::plotPicturesInternal(bool synchronous)
+void ProfileWidget2::plotPicturesInternal(struct dive *d, bool synchronous)
 {
 	pictures.clear();
 	if (currentState == ADD || currentState == PLAN)
 		return;
 
-	// Fetch all pictures of the current dive, but consider only those that are within the dive time.
+	// Fetch all pictures of the dive, but consider only those that are within the dive time.
 	// For each picture, create a PictureEntry object in the pictures-vector.
 	// emplace_back() constructs an object at the end of the vector. The parameters are passed directly to the constructor.
-	// Note that FOR_EACH_PICTURE handles current_dive being null gracefully.
-	FOR_EACH_PICTURE(current_dive) {
-		if (picture->offset.seconds > 0 && picture->offset.seconds <= current_dive->duration.seconds)
+	// Note that FOR_EACH_PICTURE handles d being null gracefully.
+	FOR_EACH_PICTURE(d) {
+		if (picture->offset.seconds > 0 && picture->offset.seconds <= d->duration.seconds)
 			pictures.emplace_back(picture->offset, QString(picture->filename), scene(), synchronous);
 	}
 	if (pictures.empty())

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -173,7 +173,7 @@ private: /*methods*/
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
-	void plotPicturesInternal(bool synchronous);
+	void plotPicturesInternal(struct dive *d, bool synchronous);
 private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -75,7 +75,7 @@ public:
 	ProfileWidget2(QWidget *parent = 0);
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
-	void plotDive(struct dive *d = 0, bool force = false, bool clearPictures = false);
+	void plotDive(struct dive *d = 0, bool force = false, bool clearPictures = false, bool plotPicturesSynchronously = false);
 	void setupItem(AbstractProfilePolygonItem *item, DiveCartesianAxis *vAxis, int vData, int hData, int zValue);
 	void setPrintMode(bool mode, bool grayscale = false);
 	bool getPrintMode();
@@ -173,6 +173,7 @@ private: /*methods*/
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
+	void plotPicturesInternal(bool synchronous);
 private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;
@@ -240,7 +241,7 @@ private:
 		std::unique_ptr<DivePictureItem> thumbnail;
 		// For videos with known duration, we represent the duration of the video by a line
 		std::unique_ptr<QGraphicsRectItem> durationLine;
-		PictureEntry (offset_t offsetIn, const QString &filenameIn, QGraphicsScene *scene);
+		PictureEntry (offset_t offsetIn, const QString &filenameIn, QGraphicsScene *scene, bool synchronous);
 		bool operator< (const PictureEntry &e) const;
 	};
 	void updateThumbnailXPos(PictureEntry &e);

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -42,7 +42,7 @@ void DivePictureModel::updateThumbnails()
 {
 	updateZoom();
 	for (PictureEntry &entry: pictures)
-		entry.image = Thumbnailer::instance()->fetchThumbnail(entry.filename);
+		entry.image = Thumbnailer::instance()->fetchThumbnail(entry.filename, false);
 }
 
 void DivePictureModel::updateDivePictures()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes two issues with profile export:
1) Only placeholders were shown
2) All profiles had the same pictures
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add a synchronous mode, that immediately fetches the thumbnails from the cache or calculates image thumbnails. Video thumbnails will not be freshly extracted.
2) Add a dive argument to the plot-pictures function.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#1963 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 