### PR TITLE
Only show dive computers

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -82,7 +82,12 @@ static dc_descriptor_t *getDeviceType(QString btName)
 	if (!vendor.isEmpty() && !product.isEmpty())
 		return descriptorLookup.value(vendor + product);
 
-	return NULL;
+	return nullptr;
+}
+
+bool matchesKnownDiveComputerNames(QString btName)
+{
+	return getDeviceType(btName) != nullptr;
 }
 
 BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -91,6 +91,7 @@ bool matchesKnownDiveComputerNames(QString btName)
 }
 
 BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
+	m_showNonDiveComputers(false),
 	discoveryAgent(nullptr)
 {
 	if (m_instance) {
@@ -102,6 +103,11 @@ BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 	BTDiscoveryReDiscover();
 #endif
+}
+
+void BTDiscovery::showNonDiveComputers(bool show)
+{
+	m_showNonDiveComputers = show;
 }
 
 void BTDiscovery::BTDiscoveryReDiscover()
@@ -232,7 +238,9 @@ void BTDiscovery::btDeviceDiscoveredMain(const btPairedDevice &device)
 		connectionListModel.addAddress(newDevice + " " + device.address);
 		return;
 	}
-	connectionListModel.addAddress(device.address);
+	// Do we want only devices we recognize as dive computers?
+	if (m_showNonDiveComputers)
+		connectionListModel.addAddress(device.address);
 	qDebug() << "Not recognized as dive computer";
 }
 

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -18,6 +18,7 @@
 
 void saveBtDeviceInfo(const QString &devaddr, QBluetoothDeviceInfo deviceInfo);
 bool isBluetoothAddress(const QString &address);
+bool matchesKnownDiveComputerNames(QString btName);
 QString extractBluetoothAddress(const QString &address);
 QString extractBluetoothNameAddress(const QString &address, QString &name);
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr);

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -46,6 +46,8 @@ public:
 	void btDeviceDiscovered(const QBluetoothDeviceInfo &device);
 	void btDeviceDiscoveredMain(const btPairedDevice &device);
 	bool btAvailable() const;
+	void showNonDiveComputers(bool show);
+
 #if defined(Q_OS_ANDROID)
 	void getBluetoothDevices();
 #endif
@@ -57,6 +59,7 @@ public:
 private:
 	static BTDiscovery *m_instance;
 	bool m_btValid;
+	bool m_showNonDiveComputers;
 
 	QList<struct btVendorProduct> btDCs;		// recognized DCs
 	QList<struct btVendorProduct> btAllDevices;	// all paired BT stuff

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -172,6 +172,9 @@ void BtDeviceSelectionDialog::hostModeStateChanged(QBluetoothLocalDevice::HostMo
 
 void BtDeviceSelectionDialog::addRemoteDevice(const QBluetoothDeviceInfo &remoteDeviceInfo)
 {
+	// are we supposed to show all devices or just dive computers?
+	if (!ui->showNonDivecomputers->isChecked() && !matchesKnownDiveComputerNames(remoteDeviceInfo.name()))
+		return;
 #if defined(Q_OS_WIN)
 	// On Windows we cannot obtain the pairing status so we set only the name and the address of the device
 	QString deviceLabel = QString("%1 (%2)").arg(remoteDeviceInfo.name(),

--- a/desktop-widgets/btdeviceselectiondialog.ui
+++ b/desktop-widgets/btdeviceselectiondialog.ui
@@ -216,6 +216,19 @@
       </layout>
      </item>
      <item>
+      <widget class="QCheckBox" name="showNonDivecomputers">
+       <property name="toolTip">
+        <string>even if not recognized as dive computer</string>
+       </property>
+       <property name="text">
+        <string>Show all BT devices</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QVBoxLayout" name="scanningControls">
        <item>
         <widget class="QPushButton" name="scan">

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -531,6 +531,41 @@ Kirigami.ScrollablePage {
 		}
 
 		GridLayout {
+			id: whichBluetoothDevices
+			columns: 2
+			Controls.Label {
+				text: qsTr("Bluetooth")
+				font.pointSize: subsurfaceTheme.headingPointSize
+				font.weight: Font.Light
+				color: subsurfaceTheme.textColor
+				Layout.topMargin: Kirigami.Units.largeSpacing
+				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+				Layout.columnSpan: 2
+			}
+
+			Controls.Label {
+				text: qsTr("Show all bluetooth devices \neven if not recognized as dive computers")
+				font.pointSize: subsurfaceTheme.regularPointSize
+				Layout.preferredWidth: gridWidth * 0.75
+			}
+			SsrfSwitch {
+				id: nonDCButton
+				checked: manager.showNonDiveComputers
+				Layout.preferredWidth: gridWidth * 0.25
+				onClicked: {
+					manager.showNonDiveComputers = checked
+				}
+			}
+		}
+
+		Rectangle {
+			color: subsurfaceTheme.darkerPrimaryColor
+			height: 1
+			opacity: 0.5
+			Layout.fillWidth: true
+		}
+
+		GridLayout {
 			id: developer
 			columns: 2
 			Controls.Label {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -144,7 +144,8 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_updateSelectedDive(-1),
 	m_selectedDiveTimestamp(0),
 	alreadySaving(false),
-	m_pluggedInDeviceName("")
+	m_pluggedInDeviceName(""),
+	m_showNonDiveComputers(false)
 {
 	LOG_STP("qmlmgr starting");
 	m_instance = this;
@@ -1977,6 +1978,12 @@ void QMLManager::setFilter(const QString filterText)
 				dlSortModel->setFilter(filterText);
 				QMetaObject::invokeMethod(qmlWindow, "hideBusy");
 			  });
+}
+
+void QMLManager::setShowNonDiveComputers(bool show)
+{
+	m_showNonDiveComputers = show;
+	BTDiscovery::instance()->showNonDiveComputers(show);
 }
 
 #if defined(Q_OS_ANDROID)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -48,6 +48,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool DC_saveDump READ DC_saveDump WRITE DC_setSaveDump)
 	Q_PROPERTY(int DC_deviceId READ DC_deviceId WRITE DC_setDeviceId)
 	Q_PROPERTY(QString pluggedInDeviceName MEMBER m_pluggedInDeviceName NOTIFY pluggedInDeviceNameChanged)
+	Q_PROPERTY(bool showNonDiveComputers MEMBER m_showNonDiveComputers WRITE setShowNonDiveComputers NOTIFY showNonDiveComputersChanged)
 public:
 	QMLManager();
 	~QMLManager();
@@ -125,6 +126,8 @@ public:
 
 	bool btEnabled() const;
 	void setBtEnabled(bool value);
+
+	void setShowNonDiveComputers(bool show);
 
 	DiveListSortModel *dlSortModel;
 
@@ -234,6 +237,7 @@ private:
 	bool m_btEnabled;
 	void updateAllGlobalLists();
 	QString m_pluggedInDeviceName;
+	bool m_showNonDiveComputers;
 	struct dive *m_copyPasteDive = NULL;
 	struct dive_components what;
 
@@ -262,6 +266,7 @@ signals:
 	void locationListChanged();
 	void waitingForPositionChanged();
 	void pluggedInDeviceNameChanged();
+	void showNonDiveComputersChanged();
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This had bugged me for a while, but it became especially annoying when Linus and I were trying to track down a bug in a libdivecomputer merge that caused a crash on a Teric. We were at the linux.conf.au conference and Subsurface found 200+ devices and the device selection dialog became completely unusable. But why are we showing all these devices - in most typical circumstances we know which devices are the potential dive computers. So let's just show those (and add a way to temporarily override this on both desktop and mobile.


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Not sure if this might help with #1862 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Yeah, this would have to be added to the CHANGELOG

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
... and to the documentation

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
I'd love some feedback @bstoeger @janmulder @atdotde @willemferguson @glance- 
This is LIGHTLY tested...