### PR TITLE
Edit: use correct offset when changing dive times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Fix editing of dive-time [#1975]
 - Desktop: Add export option for profile picture [#1962]
 - Export: fix picture thumbnails [#1963]
 - Desktop: remove support for the "Share on Facebook" feature.

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -892,11 +892,9 @@ void MainTab::acceptChanges()
 			}
 		}
 
-		if (displayed_dive.when != cd->when) {
-			timestamp_t offset = cd->when - displayed_dive.when;
-			if (offset)
-				Command::shiftTime(selectedDives, (int)offset);
-		}
+		timestamp_t offset = displayed_dive.when - cd->when;
+		if (offset)
+			Command::shiftTime(selectedDives, (int)offset);
 	}
 	if (editMode == MANUALLY_ADDED_DIVE) {
 		// we just added or edited the dive, let fixup_dive() make


### PR DESCRIPTION
The undo-work reversed the direction of the offset. This was apparently
only fixed when using the menu entry, but not when editing dives directly.
Invert the offset to get the correct time.

While doing so, remove a redundant if: First it checked whether the
dates are the same, then whether the offset is non-zero.

Fixes #1975.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Editing the date or time shifted the dive-time in the wrong direction. Invert the offset and remove a redundant conditional.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix direction of time-offset.
2) Remove redundant if-clause.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1975.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Yes, probably.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->