### PR TITLE
Filter: implement any-of mode

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -140,10 +140,10 @@ void FilterWidget2::clearFilter()
 	ui.fromTime->setTime(filterData.fromTime);
 	ui.toDate->setDate(filterData.toDate.date());
 	ui.toTime->setTime(filterData.toTime);
-	ui.tagsMode->setCurrentIndex(filterData.tagsNegate ? 1 : 0);
-	ui.peopleMode->setCurrentIndex(filterData.peopleNegate ? 1 : 0);
-	ui.locationMode->setCurrentIndex(filterData.locationNegate ? 1 : 0);
-	ui.equipmentMode->setCurrentIndex(filterData.equipmentNegate ? 1 : 0);
+	ui.tagsMode->setCurrentIndex((int)filterData.tagsMode);
+	ui.peopleMode->setCurrentIndex((int)filterData.peopleMode);
+	ui.locationMode->setCurrentIndex((int)filterData.locationMode);
+	ui.equipmentMode->setCurrentIndex((int)filterData.equipmentMode);
 
 	ignoreSignal = false;
 
@@ -186,10 +186,10 @@ void FilterWidget2::updateFilter()
 	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
 	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
 	filterData.equipment = ui.equipment->text().split(",", QString::SkipEmptyParts);
-	filterData.tagsNegate = ui.tagsMode->currentIndex() == 1;
-	filterData.peopleNegate = ui.peopleMode->currentIndex() == 1;
-	filterData.locationNegate = ui.locationMode->currentIndex() == 1;
-	filterData.equipmentNegate = ui.equipmentMode->currentIndex() == 1;
+	filterData.tagsMode = (FilterData::Mode)ui.tagsMode->currentIndex();
+	filterData.peopleMode = (FilterData::Mode)ui.peopleMode->currentIndex();
+	filterData.locationMode = (FilterData::Mode)ui.locationMode->currentIndex();
+	filterData.equipmentMode = (FilterData::Mode)ui.equipmentMode->currentIndex();
 	filterData.logged = ui.logged->isChecked();
 	filterData.planned = ui.planned->isChecked();
 

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -300,6 +300,11 @@
      </item>
      <item>
       <property name="text">
+       <string>Any of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>None of</string>
       </property>
      </item>
@@ -314,6 +319,11 @@
      </item>
      <item>
       <property name="text">
+       <string>Any of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>None of</string>
       </property>
      </item>
@@ -323,12 +333,17 @@
     <widget class="QComboBox" name="locationMode">
      <item>
       <property name="text">
-       <string>Matches</string>
+       <string>All of</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Doesn't match</string>
+       <string>Any of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>None of</string>
       </property>
      </item>
     </widget>
@@ -338,6 +353,11 @@
      <item>
       <property name="text">
        <string>All of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Any of</string>
       </property>
      </item>
      <item>

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -15,6 +15,13 @@ struct dive;
 struct dive_trip;
 
 struct FilterData {
+	// The mode ids are chosen such that they can be directly converted from / to combobox indices.
+	enum class Mode {
+		ALL_OF = 0,
+		ANY_OF = 1,
+		NONE_OF = 2
+	};
+
 	bool validFilter = false;
 	int minVisibility = 0;
 	int maxVisibility = 5;
@@ -35,10 +42,10 @@ struct FilterData {
 	QStringList people;
 	QStringList location;
 	QStringList equipment;
-	bool tagsNegate = false;
-	bool peopleNegate = false;
-	bool locationNegate = false;
-	bool equipmentNegate = false;
+	Mode tagsMode = Mode::ALL_OF;
+	Mode peopleMode = Mode::ALL_OF;
+	Mode locationMode = Mode::ALL_OF;
+	Mode equipmentMode = Mode::ALL_OF;
 	bool logged = true;
 	bool planned = true;
 };


### PR DESCRIPTION
Add an additional mode to the tags, people and location filters: any_of.
Replace the original invert-bool by an enum.
Move the common code into a distinct function.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Implement any-of mode in filters, as suggested by @willemferguson. This is mostly untested.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope - part of new filter.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I don't think the new filter is already documented.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson: please check with your use-case as described on the mailing list. Thanks.