### PR TITLE
Filter: change default mode for location to any-of

### DIFF
--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -44,7 +44,7 @@ struct FilterData {
 	QStringList equipment;
 	Mode tagsMode = Mode::ALL_OF;
 	Mode peopleMode = Mode::ALL_OF;
-	Mode locationMode = Mode::ALL_OF;
+	Mode locationMode = Mode::ANY_OF;
 	Mode equipmentMode = Mode::ALL_OF;
 	bool logged = true;
 	bool planned = true;


### PR DESCRIPTION
Since a dive has only one location all-of makes little sense. It
*can* make sense if the user enters two substrings (e.g. Tofo and Reef),
but generally it won't. Therefore change the default to any-of.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Change default for location-filtering from all-of to any-of. Since a dive can have only one location, the latter seems a much more common use-case than the former.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson 