### PR TITLE
Filter panel: add suit and notes search fields

### DIFF
--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -99,6 +99,18 @@ FilterWidget2::FilterWidget2(QWidget* parent) :
 	connect(ui.locationMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
 		this, &FilterWidget2::updateFilter);
 
+	connect(ui.suit, &QLineEdit::textChanged,
+		this, &FilterWidget2::updateFilter);
+
+	connect(ui.suitMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+		this, &FilterWidget2::updateFilter);
+
+	connect(ui.dnotes, &QLineEdit::textChanged,
+		this, &FilterWidget2::updateFilter);
+
+	connect(ui.dnotesMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+		this, &FilterWidget2::updateFilter);
+
 	connect(ui.logged, &QCheckBox::stateChanged,
 		this, &FilterWidget2::updateLogged);
 
@@ -136,6 +148,8 @@ void FilterWidget2::clearFilter()
 	ui.planned->setChecked(filterData.planned);
 	ui.people->clear();
 	ui.location->clear();
+	ui.suit->clear();
+	ui.dnotes->clear();
 	ui.equipment->clear();
 	ui.tags->clear();
 	ui.fromDate->setDate(filterData.fromDate.date());
@@ -145,6 +159,8 @@ void FilterWidget2::clearFilter()
 	ui.tagsMode->setCurrentIndex((int)filterData.tagsMode);
 	ui.peopleMode->setCurrentIndex((int)filterData.peopleMode);
 	ui.locationMode->setCurrentIndex((int)filterData.locationMode);
+	ui.suitMode->setCurrentIndex((int)filterData.suitMode);
+	ui.dnotesMode->setCurrentIndex((int)filterData.dnotesMode);
 	ui.equipmentMode->setCurrentIndex((int)filterData.equipmentMode);
 
 	ignoreSignal = false;
@@ -187,10 +203,12 @@ void FilterWidget2::updateFilter()
 	filterData.tags = ui.tags->text().split(",", QString::SkipEmptyParts);
 	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
 	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
+	filterData.suit = ui.suit->text().split(",", QString::SkipEmptyParts);
+	filterData.dnotes = ui.dnotes->text().split(",", QString::SkipEmptyParts);
 	filterData.equipment = ui.equipment->text().split(",", QString::SkipEmptyParts);
 	filterData.tagsMode = (FilterData::Mode)ui.tagsMode->currentIndex();
 	filterData.peopleMode = (FilterData::Mode)ui.peopleMode->currentIndex();
-	filterData.locationMode = (FilterData::Mode)ui.locationMode->currentIndex();
+	filterData.suitMode = (FilterData::Mode)ui.suitMode->currentIndex();
 	filterData.equipmentMode = (FilterData::Mode)ui.equipmentMode->currentIndex();
 	filterData.logged = ui.logged->isChecked();
 	filterData.planned = ui.planned->isChecked();

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -124,7 +124,13 @@
    <item row="10" column="4" colspan="2">
     <widget class="QLineEdit" name="location"/>
    </item>
-   <item row="11" column="0">
+   <item row="11" column="4" colspan="2">
+    <widget class="QLineEdit" name="suit"/>
+   </item>
+   <item row="12" column="4" colspan="2">
+    <widget class="QLineEdit" name="dnotes"/>
+   </item>
+   <item row="13" column="0">
     <widget class="QLabel" name="labelEquipment">
      <property name="text">
       <string>Equipment</string>
@@ -161,6 +167,20 @@
     <widget class="QLabel" name="label_9">
      <property name="text">
       <string>Location</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Suit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_19">
+     <property name="text">
+      <string>Notes</string>
      </property>
     </widget>
    </item>
@@ -349,6 +369,44 @@
     </widget>
    </item>
    <item row="11" column="1" colspan="2">
+    <widget class="QComboBox" name="suitMode">
+     <item>
+      <property name="text">
+       <string>All of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Any of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>None of</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="12" column="1" colspan="2">
+    <widget class="QComboBox" name="dnotesMode">
+     <item>
+      <property name="text">
+       <string>All of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Any of</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>None of</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="13" column="1" colspan="2">
     <widget class="QComboBox" name="equipmentMode">
      <item>
       <property name="text">
@@ -367,7 +425,7 @@
      </item>
     </widget>
    </item>
-   <item row="12" column="0">
+   <item row="13" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -73,6 +73,27 @@ namespace {
 	{
 		return true;
 	}
+
+	bool hasSuits(const QStringList &suits, const struct dive *d, FilterData::Mode mode)
+	{
+		if (suits.isEmpty())
+			return true;
+		QStringList diveSuits;
+		if (d->suit)
+			diveSuits.push_back(QString(d->suit));
+		return check(suits, diveSuits, mode);
+	}
+
+	bool hasNotes(const QStringList &dnotes, const struct dive *d, FilterData::Mode mode)
+	{
+		if (dnotes.isEmpty())
+			return true;
+		QStringList diveNotes;
+		if (d->notes)
+			diveNotes.push_back(QString(d->notes));
+		return check(dnotes, diveNotes, mode);
+	}
+
 }
 
 MultiFilterSortModel *MultiFilterSortModel::instance()
@@ -146,6 +167,14 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 
 	// Location
 	if (!hasLocations(filterData.location, d, filterData.locationMode))
+		return false;
+
+	// Suit
+	if (!hasSuits(filterData.suit, d, filterData.suitMode))
+		return false;
+
+	// Notes
+	if (!hasNotes(filterData.dnotes, d, filterData.dnotesMode))
 		return false;
 
 	if (!hasEquipment(filterData.equipment, d, filterData.equipmentMode))

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -41,10 +41,14 @@ struct FilterData {
 	QStringList tags;
 	QStringList people;
 	QStringList location;
+	QStringList suit;
+	QStringList dnotes;
 	QStringList equipment;
 	Mode tagsMode = Mode::ALL_OF;
 	Mode peopleMode = Mode::ALL_OF;
 	Mode locationMode = Mode::ALL_OF;
+	Mode dnotesMode = Mode::ALL_OF;
+	Mode suitMode = Mode::ALL_OF;
 	Mode equipmentMode = Mode::ALL_OF;
 	bool logged = true;
 	bool planned = true;


### PR DESCRIPTION
All the fields in the Notes Panel of the main window are now supported
for filtering. This needs some testing especially for the Notes field that
may contain markup. It appears ok to me for single term searches.
One would like to think about the default search option for the Notes.
There is a vertical spacer in the Filter panel that I moved downwards
and whose function I am not quite sure of.

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
In filterwidget2.ui, two rows of items are added to provide for searching the Suit
and Notes fields of the dive structure. Methods were added to enable the
filtering for these two fields to take place.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger, @dirkhh, @tcanabrava 