### PR TITLE
Autogroup: make notrip flag work again.

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -754,8 +754,12 @@ RemoveDivesFromTrip::RemoveDivesFromTrip(const QVector<dive *> &divesToRemove)
 {
 	setText(tr("remove %n dive(s) from trip", "", divesToRemove.size()));
 	divesToMove.divesToMove.reserve(divesToRemove.size());
-	for (dive *d: divesToRemove)
+	for (dive *d: divesToRemove) {
+		// If a user manually removes a dive from a trip, don't autogroup this dive.
+		// The flag will not be reset on undo, but that should be acceptable.
+		d->notrip = true;
 		divesToMove.divesToMove.push_back( {d, nullptr} );
+	}
 }
 
 RemoveAutogenTrips::RemoveAutogenTrips()


### PR DESCRIPTION
6bf4120dbbf7be1b9267e0e86f3948b77870ea71 replaced the trip flag by
a notrip boolean. This was supposed to signal that the user removed
the dive from a trip and therefore it shouldn't be autogrouped again.

Sadly, the commit removed the feature. Reinstate it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a regression: The notrip flag was not set when the user removed a dive from a trip. Thus, the dive would be autogrouped on load again. The flag is not cleared on undo, but that seems acceptable for now.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Set notrip flag if user removes dive from trip.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
As a regression - maybe?
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
