### PR TITLE
Uemis: remove trip deletion on dive deletion [+additional minor cleanups]

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -257,7 +257,6 @@ void show_computer_list()
 DCDeviceData::DCDeviceData()
 {
 	memset(&data, 0, sizeof(data));
-	data.trip = nullptr;
 	data.download_table = nullptr;
 	data.diveid = 0;
 	data.deviceid = 0;

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -70,7 +70,6 @@ public:
 
 private:
 	struct dive_table downloadTable;
-	struct trip_table tripTable;
 	DCDeviceData *m_data;
 };
 

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -38,7 +38,6 @@ typedef struct dc_user_device_t
 	dc_device_t *device;
 	dc_context_t *context;
 	dc_iostream_t *iostream;
-	struct dive_trip *trip;
 	int preexisting;
 	bool force_download;
 	bool libdc_log;

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -38,7 +38,6 @@ typedef struct dc_user_device_t
 	dc_device_t *device;
 	dc_context_t *context;
 	dc_iostream_t *iostream;
-	int preexisting;
 	bool force_download;
 	bool libdc_log;
 	bool libdc_dump;

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -24,8 +24,6 @@
 extern "C" {
 #endif
 
-/* don't forget to include the UI toolkit specific display-XXX.h first
-   to get the definition of progressbar_t */
 typedef struct dc_user_device_t
 {
 	dc_descriptor_t *descriptor;

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -847,8 +847,6 @@ static bool uemis_delete_dive(device_data_t *devdata, uint32_t diveid)
 	}
 	if (dive) {
 		devdata->download_table->dives[--devdata->download_table->nr] = NULL;
-		if (dive->notrip)
-			remove_dive_from_trip(dive, &trip_table);
 
 		free(dive->dc.sample);
 		free((void *)dive->notes);


### PR DESCRIPTION
Since ff9506b21bbb9910256841dcb577bcb2e19047e8 the downloaders don't
add dives to a new trip, but the import code does. Remove the
code in the Uemis downloader that would remove a dive from the trip.
The code has been broken recently anyway (instead of testing for trip,
it tested for the notrip flag, which make no sense whatsoever).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A tiny cleanup that fixes a fallout of the import-undo code: The downloaders don't add dives to trips anymore, so there is no point in the uemis downloader removing a dive from a trip, should the dive be deleted.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove (hopefully) dead code.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
