### PR TITLE
Import: fix infinite loop

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1673,7 +1673,7 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
 			    struct dive_table *dives_to_add, struct dive_table *dives_to_remove,
 			    struct trip_table *trips_to_add)
 {
-	int i, nr, start_renumbering_at = 0;
+	int i, j, nr, start_renumbering_at = 0;
 	struct dive_trip *trip_import, *new_trip;
 	int preexisting;
 	bool sequence_changed = false;
@@ -1740,8 +1740,8 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
 
 		/* If no trip to merge-into was found, add trip as-is.
 		 * First, add dives to list of dives to add */
-		for (i = 0; i < trip_import->dives.nr; i++) {
-			struct dive *d = trip_import->dives.dives[i];
+		for (j = 0; j < trip_import->dives.nr; j++) {
+			struct dive *d = trip_import->dives.dives[j];
 
 			/* Add dive to list of dives to-be-added. */
 			insert_dive(dives_to_add, d);


### PR DESCRIPTION
Owing to a variable reuse in a nested loop, importing dive logs
with new trips could lead to an infinite loop. Use a fresh index "j".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a very stupid bug, which would lead to an infinite loop on import. :(
We really should enhance our tests to test all these corner-cases...

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Should probably do, yes.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
