### PR TITLE
Add stats by max depth and min temp to yearly statistics widget

### DIFF
--- a/core/statistics.h
+++ b/core/statistics.h
@@ -12,6 +12,11 @@
 #include "core/units.h"
 #include "core/dive.h"	// For MAX_CYLINDERS
 
+#define STATS_MAX_DEPTH 300	/* Max depth for stats bucket is 300m */
+#define STATS_DEPTH_BUCKET 10	/* Size of buckets for depth range */
+#define STATS_MAX_TEMP 40		/* Max temp for stats bucket is 40C */
+#define STATS_TEMP_BUCKET 5 /* Size of buckets for temp range */
+
 typedef struct
 {
 	int period;
@@ -44,6 +49,8 @@ struct stats_summary {
 	stats_t *stats_monthly;
 	stats_t *stats_by_trip;
 	stats_t *stats_by_type;
+	stats_t *stats_by_depth;
+	stats_t *stats_by_temp;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

Adds breakdown by Max Depth and by Min Temperature to the Yearly statistics widget. Dives are added to the stats buckets based on the maximum depth of the dive and on the minimum temperature of the dive. Buckets are allocated based on the constants STATS_MAX_DEPTH, STATS_DEPTH_BUCKET, STATS_MAX_TEMP, and STATS_TEMP_BUCKET defined in core/statistics.h


<!-- Describe your pull request in detail. -->

### Changes made:

In core/statistics.c:

1) allocate memory for stats_t structures for both depth and temperature and initialize the memory blocks to zeros.

2) Process each dive in the dive list and to add the dive to the appropriate depth or temperature bucket. Dives with depth or temperature that exceed the maximums defined are included in the last bucket.

3) After the dive list is processed, identify the buckets that have at least one dive in them to be displayed by setting is_trip=true.

In qt-models/yearlystatisticsmodel.cpp:

4) Add labels for the depth and temperature buckets in the location field

5) Add a line to the statistics display for each of the buckets that have at least one line added.

<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:

Translation fields have not been updated for the labels included for the depth and temperature statistics, but the units are set based on the unit preferences.
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->