### PR TITLE
Desktop: ensure cloud storage email address is all lower case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: make sure cloud storage email addresses are lower case only
 - Desktop: Fix editing of dive-time [#1975]
 - Bluetooth: only show recognized dive computers by default
 - Desktop: Add export option for profile picture [#1962]

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -53,7 +53,7 @@ void PreferencesNetwork::syncSettings()
 	proxy->set_proxy_user(ui->proxyUsername->text());
 	proxy->set_proxy_pass(ui->proxyPassword->text());
 
-	QString email = ui->cloud_storage_email->text();
+	QString email = ui->cloud_storage_email->text().toLower();
 	QString password = ui->cloud_storage_password->text();
 	QString newpassword = ui->cloud_storage_new_passwd->text();
 


### PR DESCRIPTION
We already do that on mobile and I was certain we used to do this for
desktop as well, but apparently that got lost somewhere...

This should solve the problems we are seeing for people with mixed case
email addresses.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Simply force the email string to contain no upper case letters

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

