### PR TITLE
Map: create correct index in updateMapLocationCoordinates()

### DIFF
--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -155,7 +155,7 @@ void MapLocationModel::updateMapLocationCoordinates(const struct dive_site *ds, 
 	foreach(location, m_mapLocations) {
 		if (ds == location->divesite()) {
 			location->setCoordinateNoEmit(coord);
-			emit dataChanged(createIndex(0, row), createIndex(0, row));
+			emit dataChanged(createIndex(row, 0), createIndex(row, 0));
 			return;
 		}
 		row++;


### PR DESCRIPTION
When updating the coordinates of a dive site, the MapLocationModel
is updated. The code created a (col, row) index with col = 0.
[The idea of course being col = x, row = y]. Alas, that's not
how Qt works - its models want (row, col) indices. The code
worked, because the only time when the dive site locations were
updated was in dive site edit mode, when only one site is visible,
i.e. there is only one row leading to the correct (0, 0) index.

Fix this so that we can also change dive site positions if more
than one site is displayed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Found a funny big when playing with dive site undo. Description is in the commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix bug in map code, that was hidden up to now.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No, not user visible.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No, not user visible.
