### PR TITLE
Leak fix: make ostcFirmwareCheck a unique_ptr

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -22,7 +22,6 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent, Qt::WindowFlags f) :
 	previousLast(0),
 	timer(new QTimer(this)),
 	dumpWarningShown(false),
-	ostcFirmwareCheck(0),
 #if defined (BT_SUPPORT)
 	btd(nullptr),
 #endif
@@ -405,7 +404,7 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 	if ((product == "OSTC 3" || product == "OSTC 3+" || product == "OSTC cR" ||
 	     product == "OSTC Sport" || product == "OSTC 4" || product == "OSTC Plus") &&
 	    !data->saveDump()) {
-		ostcFirmwareCheck = new OstcFirmwareCheck(product);
+		ostcFirmwareCheck.reset(new OstcFirmwareCheck(product));
 	}
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -7,6 +7,7 @@
 #include <QHash>
 #include <QMap>
 #include <QAbstractTableModel>
+#include <memory>
 
 #include "core/libdivecomputer.h"
 #include "desktop-widgets/configuredivecomputerdialog.h"
@@ -79,7 +80,7 @@ private:
 	void fill_device_list(unsigned int transport);
 	QTimer *timer;
 	bool dumpWarningShown;
-	OstcFirmwareCheck *ostcFirmwareCheck;
+	std::unique_ptr<OstcFirmwareCheck> ostcFirmwareCheck;
 	DiveImportedModel *diveImportedModel;
 #if defined(BT_SUPPORT)
 	BtDeviceSelectionDialog *btDeviceSelectionDialog;


### PR DESCRIPTION
ostcFirmwareCheck in DownloadFromDCWidget was neither freed
in the destructor, not freed if a new object was allocated.

Simply make it a unique_ptr<> to do all the work for us.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a leak found by lgtm.com

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh