### PR TITLE
Travis: don't build all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,6 @@ after_success:
     - source ${TRAVIS_BUILD_DIR}/scripts/${SUBSURFACE_PLATFORM}/after_success.sh
 
 branches:
-  except:
-    - # Do not build tags that we create when we upload to GitHub Releases
-    - /^(?i:continuous)/
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?$/


### PR DESCRIPTION
Otherwise PRs from people who create branches in the main repo will always
trigger two builds.

The second entry should ensure that we do build releases.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
use safelist with master and releases instead of blacklist
