### PR TITLE
build-system: LGTM: don't warn about short global names

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -42,3 +42,6 @@ extraction:
             - export INSTALL_ROOT=/opt/out
             - export PKG_CONFIG_PATH=$INSTALL_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH
             - bash -x ./scripts/build-libdivecomputer.sh
+
+queries:
+    - exclude: "cpp/short-global-name"


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This warning seems just too silly to me. `css` is a perfectly fine global variable name, IMHO.
(also, this shows others how to disable warnings, if they feel so inclined)

Feel free to argue with me that we should change the variable name instead, I'm ok with that, too.