### PR TITLE
let CMake select the language level compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@
 # Uncomment his to see all commands cmake actually executes
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
-project(Subsurface)
 cmake_minimum_required(VERSION 3.1)
+project(Subsurface)
 
 # don't process generated files - this is new in 3.10
 if (POLICY CMP0071)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
 project(Subsurface)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 
 # don't process generated files - this is new in 3.10
 if (POLICY CMP0071)
@@ -65,27 +65,25 @@ endif()
 set(SUBSURFACE_SOURCE ${CMAKE_SOURCE_DIR})
 add_definitions(-DSUBSURFACE_SOURCE="${SUBSURFACE_SOURCE}")
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
 #
 # TODO: This Compilation part should go on the Target specific CMake.
 #
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 ")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 	if ((CMAKE_SYSTEM_NAME MATCHES "Darwin") AND
 	   ((CMAKE_SYSTEM_VERSION MATCHES "11.4.") OR
 	    (CMAKE_OSX_DEPLOYMENT_TARGET MATCHES "10.7") OR
 	    (CMAKE_OSX_DEPLOYMENT_TARGET MATCHES "10.8")))
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-	else()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 	endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 ")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-inconsistent-missing-override")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 	# Warn about possible float conversion errors
 	# Use NOT VERSION_LESS since VERSION_GREATER_EQUAL is not available
 	# in currently used cmake version.
@@ -95,9 +93,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	endif()
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-	# works only for CMake 3.1 and later
-	set(CMAKE_C_STANDARD 99)
-	set(CMAKE_CXX_STANDARD 11)
+  # using Intel C++
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # using Visual Studio C++
 endif()

--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Modified from Subsurface's CMakeLists.txt
 
-project(smtk2ssrf)
 cmake_minimum_required(VERSION 3.1)
+project(smtk2ssrf)
 
 option(COMMANDLINE "Build command line version" OFF)
 

--- a/smtk-import/CMakeLists.txt
+++ b/smtk-import/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Modified from Subsurface's CMakeLists.txt
 
 project(smtk2ssrf)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 
 option(COMMANDLINE "Build command line version" OFF)
 
@@ -9,6 +9,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH FALSE)
 set(SSRF_PATH ../)
 set(CMAKE_MODULE_PATH ${SSRF_PATH}cmake/Modules)
 include(${CMAKE_MODULE_PATH}/MacroOutOfSourceBuild.cmake)
@@ -82,8 +83,11 @@ else()
 endif()
 
 # Set compiler flags and definitions
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set(SMTK_LINK_LIBRARIES ${SMTK_LINK_LIBRARIES} -lssh2 -lz -lpthread)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Require CMake 3.1, which allows selecting the correct compiler flags for C++11 and C99 in a compiler independent way.