### PR TITLE
Core: simplify ConnectionListModel

### DIFF
--- a/core/connectionlistmodel.cpp
+++ b/core/connectionlistmodel.cpp
@@ -7,27 +7,13 @@ ConnectionListModel::ConnectionListModel(QObject *parent) :
 {
 }
 
-QHash <int, QByteArray> ConnectionListModel::roleNames() const
-{
-	QHash<int, QByteArray> roles;
-	roles[AddressRole] = "address";
-	return roles;
-}
-
 QVariant ConnectionListModel::data(const QModelIndex &index, int role) const
 {
 	if (index.row() < 0 || index.row() >= m_addresses.count())
 		return QVariant();
-	if (role != AddressRole)
+	if (role != Qt::DisplayRole)
 		return QVariant();
 	return m_addresses[index.row()];
-}
-
-QString ConnectionListModel::address(int idx) const
-{
-	if (idx < 0 || idx >> m_addresses.count())
-		return QString();
-	return m_addresses[idx];
 }
 
 int ConnectionListModel::rowCount(const QModelIndex&) const

--- a/core/connectionlistmodel.h
+++ b/core/connectionlistmodel.h
@@ -6,13 +6,8 @@
 class ConnectionListModel : public QAbstractListModel {
 	Q_OBJECT
 public:
-	enum CLMRole {
-		AddressRole = Qt::UserRole + 1
-	};
 	ConnectionListModel(QObject *parent = 0);
-	QHash<int, QByteArray> roleNames() const;
-	QVariant data(const QModelIndex &index, int role = AddressRole) const;
-	QString address(int idx) const;
+	QVariant data(const QModelIndex &index, int role) const;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	void addAddress(const QString address);
 	void removeAllAddresses();

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -287,12 +287,8 @@ QStringList DCDeviceData::getProductListFromVendor(const QString &vendor)
 
 int DCDeviceData::getMatchingAddress(const QString &vendor, const QString &product)
 {
-	for (int i = 0; i < connectionListModel.rowCount(); i++) {
-		QString address = connectionListModel.address(i);
-		if (address.contains(product))
-			return i;
-	}
-	return -1;
+	Q_UNUSED(vendor)
+	return connectionListModel.indexOf(product);
 }
 
 DCDeviceData *DownloadThread::data()


### PR DESCRIPTION
The complicated setup with the AddressRole is unnecessary. All we want to be
able to do is get the index of a specific text in the list. In hindsight I am
puzzled why I implemented this in such a complex fashion.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I tried to figure out why I went this route when I created this code two years ago. And I have no idea. The code was complicated and redundant (I did that whole search twice, using two different techniques?). And of course it bothered LGTM - which is of course why I went back to look at it in the first place.
This implementation seems much simpler and painfully obvious.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) remove the AddressRole
2) use the existing indexOf method instead of manually iterating the addresses

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger you are the person with the good taste when it comes to C++ and (my apologies) Qt. Am I missing something here? Or was the existing code just stupid in the first place?