### PR TITLE
Ubuntu 18.10 LGTM build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,44 +4,14 @@ path_classifiers:
 
 extraction:
     cpp:
-        prepare:
-            packages: 
-            - libxml2-dev
-            - libxslt1-dev
-            - libzip-dev
-            - libsqlite3-dev
-            - libusb-1.0-0-dev
-            - libssl-dev
-            - libssh2-1-dev
-            - libcurl4-gnutls-dev
-            - libkrb5-dev
-            - libhttp-parser-dev
-            - libgit2-dev
-            - libcrypto++-dev
-            - libqt5qml5
-            - libqt5quick5
-            - libqt5svg5-dev
-            - libqt5webkit5-dev
-            - libsqlite3-dev
-            - qml-module-qtlocation
-            - qml-module-qtpositioning
-            - qml-module-qtquick2
-            - qt5-default
-            - qt5-qmake
-            - qtchooser
-            - qtconnectivity5-dev
-            - qtdeclarative5-dev
-            - qtdeclarative5-private-dev
-            - qtlocation5-dev
-            - qtpositioning5-dev
-            - qtscript5-dev
-            - qttools5-dev
-            - qttools5-dev-tools
-            - qtquickcontrols2-5-dev
-        after_prepare:
-            - export INSTALL_ROOT=/opt/out
-            - export PKG_CONFIG_PATH=$INSTALL_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH
-            - bash -x ./scripts/build-libdivecomputer.sh
+        configure:
+            command:
+                - export INSTALL_ROOT=/opt/out
+                - export PKG_CONFIG_PATH=$INSTALL_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH
+                - bash -x ./scripts/build-libdivecomputer.sh
+                - mkdir _lgtm_build_dir
+                - cd _lgtm_build_dir
+                - cmake -DLIBGIT2_DYNAMIC=ON -DNO_DOCS=ON -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
 queries:
     - exclude: "cpp/short-global-name"


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
I'm about to update the build environment on lgtm.com from Ubuntu 18.04 to 18.10, and this breaks your project. It appears that [libgit2 now depends on libmbedtls](https://packages.ubuntu.com/cosmic/libgit2-dev), and it [didn't do this before](https://packages.ubuntu.com/bionic/libgit2-dev). By default, your project links statically with libgit2, but static linking requires specifying all dependencies of the library, and your builds doesn't specify libmbedtls. I'm working around the problem here by passing the `LIBGIT2_DYNAMIC` option to your CMake script, which makes libgit2 dynamically linked, and dynamically linked libraries don't need to have their transitive dependencies specified.

I'm taking this opportunity to make a few more changes to `.lgtm.yml` to prevent problems in the future when we upgrade the build environment.

### Changes made:

1. Pass `-DLIBGIT2_DYNAMIC` to CMake to allow building on Ubuntu 18.10.
2. Pass `-DNO_DOCS=ON` to avoid building things we don't need.
3. Pass `DCMAKE_VERBOSE_MAKEFILE=ON` for ease of debugging build problems.
4. Remove the manual list of dependency packages and instead rely on LGTM's automatic dependency detection. The manual dependency list contained version numbers and was therefore not likely to keep working over time. The automatic dependency detection only works in the `configure` and `index` steps, so I moved some lines from `after_prepare` to `configure`.

### Additional information:

Without this fix, we get linker errors like the following.

```
[2019-03-21 16:14:31] [build] [ 65%] Linking CXX executable subsurface
[2019-03-21 16:14:36] [build] /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libgit2.a(mbedtls.c.o): in function `shutdown_ssl':
[2019-03-21 16:14:36] [build] (.text+0x68): undefined reference to `mbedtls_x509_crt_free'
[2019-03-21 16:14:36] [build] /usr/bin/ld: (.text+0x8b): undefined reference to `mbedtls_ctr_drbg_free'
[2019-03-21 16:14:36] [build] /usr/bin/ld: (.text+0xa7): undefined reference to `mbedtls_ssl_config_free'
[2019-03-21 16:14:36] [build] /usr/bin/ld: (.text+0xcf): undefined reference to `mbedtls_entropy_free'
[2019-03-21 16:14:36] [build] /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/libgit2.a(mbedtls.c.o): in function `verify_server_cert':
[2019-03-21 16:14:36] [build] (.text+0x14d): undefined reference to `mbedtls_ssl_get_verify_result'
...
[2019-03-21 16:14:36] [build] collect2: error: ld returned 1 exit status
```

### Mentions:

@dirkhh
