### PR TITLE
Cleanup: fix printGPSCoords signature and leaks

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -137,7 +137,9 @@ QString GpsLocation::currentPosition()
 		if (delta < 300) {
 			// we can simply use the last position that we tracked
 			gpsTracker gt = m_trackers.last();
-			QString gpsString = printGPSCoords(&gt.location);
+			char *gps = printGPSCoords(&gt.location);
+			QString gpsString = gps;
+			free(gps);
 			qDebug() << "returning last position" << gpsString;
 			return gpsString;
 		} else {

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -164,10 +164,10 @@ static void parse_dive_gps(char *line, struct membuffer *str, void *_dive)
 			dive->dive_site = ds;
 	} else {
 		if (dive_site_has_gps_location(ds) && !same_location(&ds->location, &location)) {
-			const char *coords = printGPSCoords(&location);
+			char *coords = printGPSCoords(&location);
 			// we have a dive site that already has GPS coordinates
 			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
-			free((void *)coords);
+			free(coords);
 		}
 		ds->location = location;
 	}

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1201,9 +1201,9 @@ static void gps_in_dive(char *buffer, struct dive *dive, struct parser_state *st
 			fprintf(stderr, "dive site uuid in dive, but gps location (%10.6f/%10.6f) different from dive location (%10.6f/%10.6f)\n",
 				ds->location.lat.udeg / 1000000.0, ds->location.lon.udeg / 1000000.0,
 				location.lat.udeg / 1000000.0, location.lon.udeg / 1000000.0);
-			const char *coords = printGPSCoords(&location);
+			char *coords = printGPSCoords(&location);
 			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
-			free((void *)coords);
+			free(coords);
 		} else {
 			ds->location = location;
 		}

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -72,7 +72,7 @@ QString distance_string(int distanceInMeters)
 	return str;
 }
 
-extern "C" const char *printGPSCoords(const location_t *location)
+extern "C" char *printGPSCoords(const location_t *location)
 {
 	int lat = location->lat.udeg;
 	int lon = location->lon.udeg;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -123,7 +123,7 @@ void moveInVector(Vector &v, int rangeBegin, int rangeEnd, int destination)
 extern "C" {
 #endif
 
-const char *printGPSCoords(const location_t *loc);
+char *printGPSCoords(const location_t *loc);
 bool in_planner();
 bool getProxyString(char **buffer);
 bool canReachCloudServer();

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -112,7 +112,12 @@ QString DiveObjectHelper::location() const
 QString DiveObjectHelper::gps() const
 {
 	struct dive_site *ds = m_dive->dive_site;
-	return ds ? QString(printGPSCoords(&ds->location)) : QString();
+	if (!ds)
+		return QString();
+	char *gps = printGPSCoords(&ds->location);
+	QString res = gps;
+	free(gps);
+	return res;
 }
 
 QString DiveObjectHelper::gps_decimal() const

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -114,9 +114,9 @@ void LocationInformationWidget::updateLabels()
 	else
 		ui.diveSiteNotes->clear();
 	if (has_location(&diveSite->location)) {
-		const char *coords = printGPSCoords(&diveSite->location);
+		char *coords = printGPSCoords(&diveSite->location);
 		ui.diveSiteCoordinates->setText(coords);
-		free((void *)coords);
+		free(coords);
 	} else {
 		ui.diveSiteCoordinates->clear();
 	}
@@ -138,10 +138,10 @@ void LocationInformationWidget::updateGpsCoordinates(const location_t &location)
 {
 	QString oldText = ui.diveSiteCoordinates->text();
 
-	const char *coords = printGPSCoords(&location);
+	char *coords = printGPSCoords(&location);
 	ui.diveSiteCoordinates->setText(coords);
 	enableLocationButtons(has_location(&location));
-	free((void *)coords);
+	free(coords);
 	if (oldText != ui.diveSiteCoordinates->text())
 		markChangedWidget(ui.diveSiteCoordinates);
 }

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -484,9 +484,9 @@ void LocationFilterDelegate::paint(QPainter *painter, const QStyleOptionViewItem
 	}
 
 	if (bottomText.isEmpty()) {
-		const char *gpsCoords = printGPSCoords(&ds->location);
+		char *gpsCoords = printGPSCoords(&ds->location);
 		bottomText = QString(gpsCoords);
-		free( (void*) gpsCoords);
+		free(gpsCoords);
 	}
 
 	if (dive_site_has_gps_location(ds) && currentDiveSiteHasGPS) {

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -411,9 +411,9 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.locationTags->setText(constructLocationTags(&ds->taxonomy, true));
 
 			if (ui.locationTags->text().isEmpty() && has_location(&ds->location)) {
-				const char *coords = printGPSCoords(&ds->location);
+				char *coords = printGPSCoords(&ds->location);
 				ui.locationTags->setText(coords);
-				free((void *)coords);
+				free(coords);
 			}
 		} else {
 			ui.location->clear();

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -246,10 +246,10 @@ void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool form
 	bool savep = prefs.coordinates_traditional;
 	prefs.coordinates_traditional = formatTraditional;
 	location_t location = mk_location(coord);
-	const char *coordinates = printGPSCoords(&location);
+	char *coordinates = printGPSCoords(&location);
 	QApplication::clipboard()->setText(QString(coordinates), QClipboard::Clipboard);
 
-	free((void *)coordinates);
+	free(coordinates);
 	prefs.coordinates_traditional = savep;
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1602,9 +1602,12 @@ QString QMLManager::getGpsFromSiteName(const QString& siteName)
 	struct dive_site *ds;
 
 	ds = get_dive_site_by_name(qPrintable(siteName));
-	if (ds)
-		return QString(printGPSCoords(&ds->location));
-	return QString();
+	if (!ds)
+		return QString();
+	char *gps = printGPSCoords(&ds->location);
+	QString res = gps;
+	free(gps);
+	return res;
 }
 
 void QMLManager::setNotificationText(QString text)


### PR DESCRIPTION
The printGPSCoords() function returns a copied C-style string. Since
the owndership is transferred to the caller, the correct return type
is "char *" instead of "const char *".

Thus a number of casts when calling free can be removed.

Moreover a number of callers didn't free the string and thus were
leaking memory. Fix them. Ultimately we might want two versions
of the function: one for QString, one for C-style strings.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes return code of `printGPSCoords` and a few leaks.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make `printGPSCoords` return `char *`.
2) Free memory returned by `printGPSCoords`.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
