### PR TITLE
Cleanup: provide printGPSCoords in C and C++ versions

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -137,9 +137,7 @@ QString GpsLocation::currentPosition()
 		if (delta < 300) {
 			// we can simply use the last position that we tracked
 			gpsTracker gt = m_trackers.last();
-			char *gps = printGPSCoords(&gt.location);
-			QString gpsString = gps;
-			free(gps);
+			QString gpsString = printGPSCoords(&gt.location);
 			qDebug() << "returning last position" << gpsString;
 			return gpsString;
 		} else {

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -164,7 +164,7 @@ static void parse_dive_gps(char *line, struct membuffer *str, void *_dive)
 			dive->dive_site = ds;
 	} else {
 		if (dive_site_has_gps_location(ds) && !same_location(&ds->location, &location)) {
-			char *coords = printGPSCoords(&location);
+			char *coords = printGPSCoordsC(&location);
 			// we have a dive site that already has GPS coordinates
 			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
 			free(coords);

--- a/core/membuffer.c
+++ b/core/membuffer.c
@@ -278,7 +278,7 @@ void put_quoted(struct membuffer *b, const char *text, int is_attribute, int is_
 	}
 }
 
-char *add_to_string_va(const char *old, const char *fmt, va_list args)
+char *add_to_string_va(char *old, const char *fmt, va_list args)
 {
 	char *res;
 	struct membuffer o = { 0 }, n = { 0 };
@@ -296,7 +296,7 @@ char *add_to_string_va(const char *old, const char *fmt, va_list args)
  * WARNING - this will free(old), the intended pattern is
  * string = add_to_string(string, fmt, ...)
  */
-char *add_to_string(const char *old, const char *fmt, ...)
+char *add_to_string(char *old, const char *fmt, ...)
 {
 	char *res;
 	va_list args;

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -71,8 +71,8 @@ extern __printf(2, 0) void put_vformat(struct membuffer *, const char *, va_list
 extern __printf(2, 0) void put_vformat_loc(struct membuffer *, const char *, va_list);
 extern __printf(2, 3) void put_format(struct membuffer *, const char *fmt, ...);
 extern __printf(2, 3) void put_format_loc(struct membuffer *, const char *fmt, ...);
-extern __printf(2, 0) char *add_to_string_va(const char *old, const char *fmt, va_list args);
-extern __printf(2, 3) char *add_to_string(const char *old, const char *fmt, ...);
+extern __printf(2, 0) char *add_to_string_va(char *old, const char *fmt, va_list args);
+extern __printf(2, 3) char *add_to_string(char *old, const char *fmt, ...);
 
 /* Helpers that use membuffers internally */
 extern __printf(1, 0) char *vformat_string(const char *, va_list);

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1201,7 +1201,7 @@ static void gps_in_dive(char *buffer, struct dive *dive, struct parser_state *st
 			fprintf(stderr, "dive site uuid in dive, but gps location (%10.6f/%10.6f) different from dive location (%10.6f/%10.6f)\n",
 				ds->location.lat.udeg / 1000000.0, ds->location.lon.udeg / 1000000.0,
 				location.lat.udeg / 1000000.0, location.lon.udeg / 1000000.0);
-			char *coords = printGPSCoords(&location);
+			char *coords = printGPSCoordsC(&location);
 			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
 			free(coords);
 		} else {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -72,7 +72,7 @@ QString distance_string(int distanceInMeters)
 	return str;
 }
 
-extern "C" char *printGPSCoords(const location_t *location)
+QString printGPSCoords(const location_t *location)
 {
 	int lat = location->lat.udeg;
 	int lon = location->lon.udeg;
@@ -82,7 +82,7 @@ extern "C" char *printGPSCoords(const location_t *location)
 	QString lath, lonh, result;
 
 	if (!has_location(location))
-		return strdup("");
+		return QString();
 
 	if (prefs.coordinates_traditional) {
 		lath = lat >= 0 ? gettextFromC::tr("N") : gettextFromC::tr("S");
@@ -101,7 +101,12 @@ extern "C" char *printGPSCoords(const location_t *location)
 	} else {
 		result.sprintf("%f %f", (double) lat / 1000000.0, (double) lon / 1000000.0);
 	}
-	return copy_qstring(result);
+	return result;
+}
+
+extern "C" char *printGPSCoordsC(const location_t *location)
+{
+	return copy_qstring(printGPSCoords(location));
 }
 
 /**

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -82,6 +82,7 @@ QString uiLanguage(QLocale *callerLoc);
 QLocale getLocale();
 void selectedDivesGasUsed(QVector<QPair<QString, int> > &gasUsed);
 QString getUserAgent();
+QString printGPSCoords(const location_t *loc);
 
 #if defined __APPLE__
 #define TITLE_OR_TEXT(_t, _m) "", _t + "\n" + _m
@@ -123,7 +124,7 @@ void moveInVector(Vector &v, int rangeBegin, int rangeEnd, int destination)
 extern "C" {
 #endif
 
-char *printGPSCoords(const location_t *loc);
+char *printGPSCoordsC(const location_t *loc);
 bool in_planner();
 bool getProxyString(char **buffer);
 bool canReachCloudServer();

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -114,10 +114,7 @@ QString DiveObjectHelper::gps() const
 	struct dive_site *ds = m_dive->dive_site;
 	if (!ds)
 		return QString();
-	char *gps = printGPSCoords(&ds->location);
-	QString res = gps;
-	free(gps);
-	return res;
+	return printGPSCoords(&ds->location);
 }
 
 QString DiveObjectHelper::gps_decimal() const

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -113,13 +113,10 @@ void LocationInformationWidget::updateLabels()
 		ui.diveSiteNotes->setPlainText(diveSite->notes);
 	else
 		ui.diveSiteNotes->clear();
-	if (has_location(&diveSite->location)) {
-		char *coords = printGPSCoords(&diveSite->location);
-		ui.diveSiteCoordinates->setText(coords);
-		free(coords);
-	} else {
+	if (has_location(&diveSite->location))
+		ui.diveSiteCoordinates->setText(printGPSCoords(&diveSite->location));
+	else
 		ui.diveSiteCoordinates->clear();
-	}
 
 	ui.locationTags->setText(constructLocationTags(&taxonomy, false));
 }
@@ -138,10 +135,8 @@ void LocationInformationWidget::updateGpsCoordinates(const location_t &location)
 {
 	QString oldText = ui.diveSiteCoordinates->text();
 
-	char *coords = printGPSCoords(&location);
-	ui.diveSiteCoordinates->setText(coords);
+	ui.diveSiteCoordinates->setText(printGPSCoords(&location));
 	enableLocationButtons(has_location(&location));
-	free(coords);
 	if (oldText != ui.diveSiteCoordinates->text())
 		markChangedWidget(ui.diveSiteCoordinates);
 }

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -483,11 +483,8 @@ void LocationFilterDelegate::paint(QPainter *painter, const QStyleOptionViewItem
 		bottomText += QString(ds->taxonomy.category[idx].value);
 	}
 
-	if (bottomText.isEmpty()) {
-		char *gpsCoords = printGPSCoords(&ds->location);
-		bottomText = QString(gpsCoords);
-		free(gpsCoords);
-	}
+	if (bottomText.isEmpty())
+		bottomText = printGPSCoords(&ds->location);
 
 	if (dive_site_has_gps_location(ds) && currentDiveSiteHasGPS) {
 		// so we are showing a completion and both the current dive site and the completion

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -410,11 +410,8 @@ void MainTab::updateDiveInfo(bool clear)
 			ui.location->setCurrentDiveSite(ds);
 			ui.locationTags->setText(constructLocationTags(&ds->taxonomy, true));
 
-			if (ui.locationTags->text().isEmpty() && has_location(&ds->location)) {
-				char *coords = printGPSCoords(&ds->location);
-				ui.locationTags->setText(coords);
-				free(coords);
-			}
+			if (ui.locationTags->text().isEmpty() && has_location(&ds->location))
+				ui.locationTags->setText(printGPSCoords(&ds->location));
 		} else {
 			ui.location->clear();
 			ui.locationTags->clear();

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -246,10 +246,8 @@ void MapWidgetHelper::copyToClipboardCoordinates(QGeoCoordinate coord, bool form
 	bool savep = prefs.coordinates_traditional;
 	prefs.coordinates_traditional = formatTraditional;
 	location_t location = mk_location(coord);
-	char *coordinates = printGPSCoords(&location);
-	QApplication::clipboard()->setText(QString(coordinates), QClipboard::Clipboard);
+	QApplication::clipboard()->setText(printGPSCoords(&location), QClipboard::Clipboard);
 
-	free(coordinates);
 	prefs.coordinates_traditional = savep;
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1604,10 +1604,7 @@ QString QMLManager::getGpsFromSiteName(const QString& siteName)
 	ds = get_dive_site_by_name(qPrintable(siteName));
 	if (!ds)
 		return QString();
-	char *gps = printGPSCoords(&ds->location);
-	QString res = gps;
-	free(gps);
-	return res;
+	return printGPSCoords(&ds->location);
 }
 
 void QMLManager::setNotificationText(QString text)

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -211,7 +211,7 @@ static  MdbTableDef *smtk_open_table(MdbHandle *mdb, char *tablename, MdbColumn 
  * This is based in add_to_string() and add_to_string_va(), and, as its parents
  * frees the original string.
  */
-static char *smtk_concat_str(const char *orig, const char *sep, const char *fmt, ...)
+static char *smtk_concat_str(char *orig, const char *sep, const char *fmt, ...)
 {
 	char *str;
 	va_list args;
@@ -229,7 +229,7 @@ static char *smtk_concat_str(const char *orig, const char *sep, const char *fmt,
 
 	free_buffer(&out);
 	free_buffer(&in);
-	free((void *)orig);
+	free(orig);
 
 	return str;
 }


### PR DESCRIPTION
printGPSCoords() returned a newly allocated C-style string. Most
callers simply made a QString out of it and freed the C-style string.
This is paradox, as printGPSCoords internally works with QStrings
and converts them to C-style on return.

Therefore, let printGPSCoords() return a QString and create a
printGPSCoordsC() wrapper for the two C-callers.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As discussed in #2025: Simplify C++ code by providing a C++ version of printGPSCoordinates.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

#2025 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.