### PR TITLE
Split dive computer into distinct dive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Splitting of individual dive computers into distinct dives
 - Planner: Allow for a final segment at the surface to display further desaturation
 - Desktop: Add stats by depth and temperature ranges to yearly stats [#1996]
 - Desktop: make sure cloud storage email addresses are lower case only

--- a/core/dive.h
+++ b/core/dive.h
@@ -440,6 +440,7 @@ extern timestamp_t dive_endtime(const struct dive *dive);
 extern void make_first_dc(void);
 extern unsigned int count_divecomputers(void);
 extern void delete_current_divecomputer(void);
+void split_divecomputer(const struct dive *src, int num, struct dive **out1, struct dive **out2);
 
 /*
  * Iterate over each dive, with the first parameter being the index

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -66,6 +66,11 @@ void splitDives(dive *d, duration_t time)
 	execute(new SplitDives(d, time));
 }
 
+void splitDiveComputer(dive *d, int dc_num)
+{
+	execute(new SplitDiveComputer(d, dc_num));
+}
+
 void mergeDives(const QVector <dive *> &dives)
 {
 	execute(new MergeDives(dives));

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -32,6 +32,7 @@ void createTrip(const QVector<dive *> &divesToAddIn);
 void autogroupDives();
 void mergeTrips(dive_trip *trip1, dive_trip *trip2);
 void splitDives(dive *d, duration_t time);
+void splitDiveComputer(dive *d, int dc_num);
 void mergeDives(const QVector <dive *> &dives);
 
 } // namespace Command

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -185,10 +185,9 @@ struct MergeTrips : public TripBase {
 	MergeTrips(dive_trip *trip1, dive_trip *trip2);
 };
 
-class SplitDives : public DiveListBase {
-public:
-	// If time is < 0, split at first surface interval
-	SplitDives(dive *d, duration_t time);
+class SplitDivesBase : public DiveListBase {
+protected:
+	SplitDivesBase(dive *old, std::array<dive *, 2> newDives);
 private:
 	void undoit() override;
 	void redoit() override;
@@ -207,6 +206,18 @@ private:
 	// that we can reuse the multi-dive functions of the other commands.
 	DivesAndTripsToAdd	unsplitDive;
 	std::vector<dive *>	divesToUnsplit;
+};
+
+class SplitDives : public SplitDivesBase {
+public:
+	// If time is < 0, split at first surface interval
+	SplitDives(dive *d, duration_t time);
+};
+
+class SplitDiveComputer : public SplitDivesBase {
+public:
+	// If time is < 0, split at first surface interval
+	SplitDiveComputer(dive *d, int dc_num);
 };
 
 class MergeDives : public DiveListBase {

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1436,8 +1436,10 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 			// create menu to show when right clicking on dive computer name
 			if (dc_number > 0)
 				m.addAction(tr("Make first dive computer"), this, SLOT(makeFirstDC()));
-			if (count_divecomputers() > 1)
+			if (count_divecomputers() > 1) {
 				m.addAction(tr("Delete this dive computer"), this, SLOT(deleteCurrentDC()));
+				m.addAction(tr("Split this dive computer into own dive"), this, SLOT(splitCurrentDC()));
+			}
 			m.exec(event->globalPos());
 			// don't show the regular profile context menu
 			return;
@@ -1579,6 +1581,11 @@ void ProfileWidget2::deleteCurrentDC()
 	plotDive(0, true, false);
 
 	emit refreshDisplay(true);
+}
+
+void ProfileWidget2::splitCurrentDC()
+{
+	Command::splitDiveComputer(current_dive, dc_number);
 }
 
 void ProfileWidget2::makeFirstDC()

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -126,6 +126,7 @@ slots: // Necessary to call from QAction's signals.
 	void editName();
 	void makeFirstDC();
 	void deleteCurrentDC();
+	void splitCurrentDC();
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
 	void updateThumbnail(QString filename, QImage thumbnail, duration_t duration);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a first stab at implementing splitting out of dive computer. I'm not a fan of this extreme code-reuse by sub classing, but it was the most efficient thing to do.

Moreover it turned out that saving the insertion index in the undo-command is quite painful. This premature optimization should be removed in a clean-up commit. But only after the huge undo changes!

This is based on code by @torvalds.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement splitting out of dive computer.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Probably, yes...?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@torvalds