### PR TITLE
[TRIVIAL] Cleanup: remove all Q_NULLPTR instances

### DIFF
--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -24,8 +24,8 @@ MapWidget *MapWidget::m_instance = NULL;
 
 MapWidget::MapWidget(QWidget *parent) : QQuickWidget(parent)
 {
-	m_rootItem = Q_NULLPTR;
-	m_mapHelper = Q_NULLPTR;
+	m_rootItem = nullptr;
+	m_mapHelper = nullptr;
 	setResizeMode(QQuickWidget::SizeRootObjectToView);
 	connect(this, &QQuickWidget::statusChanged, this, &MapWidget::doneLoading);
 	setSource(urlMapWidget);

--- a/desktop-widgets/printoptions.h
+++ b/desktop-widgets/printoptions.h
@@ -69,8 +69,8 @@ public:
 
 private:
 	Ui::PrintOptions ui;
-	struct print_options *printOptions = Q_NULLPTR;
-	struct template_options *templateOptions = Q_NULLPTR;
+	struct print_options *printOptions = nullptr;
+	struct template_options *templateOptions = nullptr;
 	bool hasSetupSlots;
 	QString lastImportExportTemplate;
 	void setupTemplates();

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -259,7 +259,7 @@ void TemplateLayout::writeTemplate(QString template_name, QString grantlee_templ
 
 YearInfo::YearInfo()
 {
-	year = Q_NULLPTR;
+	year = nullptr;
 }
 
 YearInfo::~YearInfo()

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -31,7 +31,7 @@ TankItem::TankItem(QObject *parent) :
 	trimixGradient.setColorAt(1.0, red);
 	trimix = trimixGradient;
 	air = blue;
-	hAxis = Q_NULLPTR;
+	hAxis = nullptr;
 	memset(&diveCylinderStore, 0, sizeof(diveCylinderStore));
 }
 


### PR DESCRIPTION
It expands to nullptr anyway and is inconsitent with the rest of the
code. Let's remove this anachronism.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup, see commit message. Noting more to say, really.