### PR TITLE
Cleanup: provide our own qOverload<> implementation.

### DIFF
--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -116,6 +116,21 @@ void moveInVector(Vector &v, int rangeBegin, int rangeEnd, int destination)
 		std::rotate(it + destination, it + rangeBegin, it + rangeEnd);
 }
 
+// Qt overloads some signals(!) which can't therefore be used in connect() calls with
+// pointers-to-member functions where the signatures of signal and slot don't match perfectly.
+// For this case, Qt 5.7 provides the qOverload<> helper.
+// Since we still support Qt 5.5 let's reimplement it here.
+#if QT_VERSION < 0x050700
+template <typename... Args>
+struct QOverload {
+	template <typename Ret, typename Class>
+	static Ret (Class::*of(Ret (Class::*fun)(Args...)))(Args...)
+	{
+		return fun;
+	}
+};
+#endif
+
 #endif
 
 // 3) Functions visible to C and C++

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -52,21 +52,16 @@ FilterWidget2::FilterWidget2(QWidget* parent) :
 	connect(ui.minVisibility, &StarWidget::valueChanged,
 		this, &FilterWidget2::updateFilter);
 
-	// We need these insane casts because Qt decided to function-overload some of their signals(!).
-	// QDoubleSpinBox::valueChanged() sends double and QString using the same signal name.
-	// QComboBox::currentIndexChanged() sends int and QString using the same signal name.
-	// Qt 5.7 provides a "convenient" helper that hides this, but only if compiling in C++14
-	// or higher. One can then write: "QOverload<double>(&QDoubleSpinBox::valueChanged)", etc.
-	connect(ui.maxAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.maxAirTemp, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.minAirTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.minAirTemp, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.maxWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.maxWaterTemp, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.minWaterTemp, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+	connect(ui.minWaterTemp, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.fromDate, &QDateTimeEdit::dateChanged,
@@ -84,25 +79,25 @@ FilterWidget2::FilterWidget2(QWidget* parent) :
 	connect(ui.tags, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.tagsMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+	connect(ui.tagsMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.people, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.peopleMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+	connect(ui.peopleMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.location, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.locationMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+	connect(ui.locationMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.suit, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
-	connect(ui.suitMode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+	connect(ui.suitMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
 		this, &FilterWidget2::updateFilter);
 
 	connect(ui.dnotes, &QLineEdit::textChanged,


### PR DESCRIPTION
This is only in Qt 5.7 and therefore can't be used in Qt 5.5 and 5.6
builds. Moreover, we can't simply reuse Qt's version owing to
licensing concerns.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Hide that horrible and unwieldy `static_cast` hack to resolve the connect-mess caused by function overloading of signals.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement a trivial alternative to qOverload without all the special cases.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2036
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@DerDakon @dirkhh 