### PR TITLE
Don't go into UI deadlock when creating a new site

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -653,6 +653,7 @@ void MainWindow::cleanUpEmpty()
 	diveList->reload();
 	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
 	MapWidget::instance()->reload();
+	LocationInformationModel::instance()->update();
 	if (!existing_filename)
 		setTitle();
 	disableShortcuts();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -491,10 +491,15 @@ void MainTab::updateDiveInfo()
 	// don't execute this while adding / planning a dive
 	if (editMode == MANUALLY_ADDED_DIVE || MainWindow::instance()->graphics->isPlanner())
 		return;
-	if (!isEnabled() && current_dive)
-		setEnabled(true);
-	if (isEnabled() && !current_dive)
-		setEnabled(false);
+
+	// If there is no current dive, disable all widgets except the last, which is the dive site tab.
+	// TODO: Conceptually, the dive site tab shouldn't even be a tab here!
+	bool enabled = current_dive != nullptr;
+	ui.equipmentTab->setEnabled(enabled);
+	ui.notesTab->setEnabled(enabled);
+	for (int i = 0; i < extraWidgets.size() - 1; ++i)
+		extraWidgets[i]->setEnabled(enabled);
+
 	editMode = IGNORE; // don't trigger on changes to the widgets
 
 	for (auto widget : extraWidgets) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a quick-fix for the bug reported in #2045. It is not ideal, because the fundamental problem is that the dive site list is implemented as a dive tab, when it isn't. The "fix" is to disable all tabs but the dive site tab.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't disable all tabs when no dive is selected.
2) Reset dive location mode on file-close.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2045
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@djunkins @dirkhh 