### PR TITLE
Desktop: put dive site table in "row selection mode"

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveSite.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveSite.cpp
@@ -18,6 +18,7 @@ TabDiveSite::TabDiveSite(QWidget *parent) : TabBase(parent)
 	ui.diveSites->view()->setSortingEnabled(true);
 	ui.diveSites->view()->horizontalHeader()->setSectionResizeMode(LocationInformationModel::NAME, QHeaderView::Stretch);
 	ui.diveSites->view()->horizontalHeader()->setSectionResizeMode(LocationInformationModel::DESCRIPTION, QHeaderView::Stretch);
+	ui.diveSites->view()->setSelectionBehavior(QAbstractItemView::SelectRows);
 
 	// Show only the first few columns
 	for (int i = LocationInformationModel::LOCATION; i < LocationInformationModel::COLUMNS; ++i)


### PR DESCRIPTION
This feels more natural than selecting a single cell. Still,
the "delete" cell is not visibly selected, which give a
strange impression.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a tiny improvement to the dive site table: Go into row selection mode. Still, the trashcan icon sticks out for reasons I don't know.
