### PR TITLE
Desktop: destroy maintab before destructing mainwindow

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -133,7 +133,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	// widgets will change on the mainwindow.
 
 	// for the "default" mode
-	mainTab = new MainTab(this);
+	mainTab.reset(new MainTab);
 	diveList = new DiveListView(this);
 	graphics = new ProfileWidget2(this);
 	MapWidget *mapWidget = MapWidget::instance();
@@ -177,12 +177,12 @@ MainWindow::MainWindow() : QMainWindow(),
 	enabledList.push_back(enabled);
 	disabledList.push_back(disabled);
 
-	registerApplicationState("Default", mainTab, profileContainer, diveList, mapWidget );
-	registerApplicationState("EditDive", mainTab, profileContainer, diveList, mapWidget );
+	registerApplicationState("Default", mainTab.get(), profileContainer, diveList, mapWidget );
+	registerApplicationState("EditDive", mainTab.get(), profileContainer, diveList, mapWidget );
 	registerApplicationState("PlanDive", divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
 	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, diveList, mapWidget );
 	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, diveList, mapWidget);
-	registerApplicationState("FilterDive", mainTab, profileContainer, diveList, &filterWidget2);
+	registerApplicationState("FilterDive", mainTab.get(), profileContainer, diveList, &filterWidget2);
 
 	setStateProperties("Default", enabledList, enabledList, enabledList, enabledList);
 	setStateProperties("EditDive", enabledList, enabledList, enabledList, enabledList);
@@ -200,7 +200,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(update()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(reloadHeaderActions()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), mainTab, SLOT(updateDiveInfo()));
+	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), mainTab.get(), SLOT(updateDiveInfo()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget, SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget, SLOT(settingsChanged()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
@@ -215,7 +215,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCanceled()), this, SLOT(planCanceled()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(variationsComputed(QString)), this, SLOT(updateVariations(QString)));
 	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget, SLOT(printDecoPlan()));
-	connect(mainTab, &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
+	connect(mainTab.get(), &MainTab::diveSiteChanged, mapWidget, &MapWidget::centerOnSelectedDiveSite);
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);
@@ -327,7 +327,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
 	connect(graphics, &ProfileWidget2::refreshDisplay, this, &MainWindow::refreshDisplay);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
-	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab, &MainTab::updateDiveInfo);
+	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab.get(), &MainTab::updateDiveInfo);
 
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), graphics, SLOT(settingsChanged()));
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -13,6 +13,7 @@
 #include <QUrl>
 #include <QUuid>
 #include <QProgressDialog>
+#include <memory>
 
 #include "ui_mainwindow.h"
 #include "ui_plannerDetails.h"
@@ -84,7 +85,7 @@ public:
 	void exitEditState();
 	void editDiveSite(dive_site *ds);
 
-	MainTab *mainTab;
+	std::unique_ptr<MainTab> mainTab;
 	PlannerDetails *plannerDetails;
 	PlannerSettingsWidget *divePlannerSettingsWidget;
 	ProfileWidget2 *graphics;


### PR DESCRIPTION
Apparently, in some Qt-versions the destructor of the base class
calls hide on child-objects (according to Qt's object hierarchy).
This is obviously called after the derived class has been destructed.

In a concrete case, the base class of the destructed MainWindow
would hide the TabDiveSite object. That would reset the filtering
if a dive site was selected, which would indirectly access the
MainWindow, which is already partially destroyed.

Therefore, destroy the MainTab before destroying the MainWindow.
Do this by keeping it as a std::unique_ptr subobject. Thus, it
will be destroyed before the MainWindow and remove itself from
Qt's object hierarchy.

Reported-by: Dirk Hohndel <dirk@hohndel.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at fixing #2046. I can't reproduce the crash, so this is blindfold-mode. Moreover I believe we had problems with `std::unique_ptr`, where on some platforms you had to include the full class definition of the pointed-to object. That would be very unfortunate, as it would mean that including MainWindow.hpp would suck in MainTab.hpp, which is also not exactly light.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make MainTab a smart-pointer to have it deleted *before* the mainwindow.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2046
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Bug not in release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @djunkins 
Please test, I'm only guessing here.