### PR TITLE
Desktop: remove edit-check in tag-widget completer

### DIFF
--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -89,14 +89,6 @@ void TagWidget::reparse()
 	if (pos.first >= 0 && pos.second > 0)
 		currentText = text().mid(pos.first, pos.second - pos.first).trimmed();
 
-	/*
-	 * Do not show the completer when not in edit mode - basically
-	 * this returns when we are accepting or discarding the changes.
-	 */
-	if (MainWindow::instance()->mainTab->isEditing() == false) {
-		return;
-	}
-
 	if (m_completer) {
 		m_completer->setCompletionPrefix(currentText);
 		if (m_completer->completionCount() == 1) {


### PR DESCRIPTION
The tag-widget was only showing the completer if we were in edit mode.
The edit mode does not exist anymore - therefore remove the check.
Hopefully this has no unintended consequences, like the completer
not disappearing when it should.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The completer was not shown when editing tags. This hopefully fixes it without follow-up bugs.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove check for edit mode in tag-widget completer.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Bug not in release.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

No.