### PR TITLE
Desktop: work around crash during MainWindow destruction

### DIFF
--- a/core/qt-gui.h
+++ b/core/qt-gui.h
@@ -4,6 +4,7 @@
 
 void init_qt_late();
 void init_ui();
+extern bool m_mainWindowValid;
 
 void run_ui();
 void exit_ui();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -2,6 +2,7 @@
 #include "qt-models/filtermodels.h"
 #include "qt-models/models.h"
 #include "core/display.h"
+#include "core/qt-gui.h"
 #include "core/qthelper.h"
 #include "core/divesite.h"
 #include "core/subsurface-string.h"
@@ -225,6 +226,12 @@ void MultiFilterSortModel::myInvalidate()
 {
 	int i;
 	struct dive *d;
+
+	// hack around what seems like a Qt bug: when the MainWindow is destroyed
+	// it's hiding its children and this causes the filter invalidation to be
+	// called which then dereferences partially destroyed objects
+	if (!m_mainWindowValid)
+		return;
 
 	divesDisplayed = 0;
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -30,6 +30,8 @@
 #ifndef SUBSURFACE_TEST_DATA
 QObject *qqWindowObject = NULL;
 
+bool m_mainWindowValid = false;
+
 // Forward declaration
 static void register_qml_types(QQmlEngine *);
 static void register_meta_types();
@@ -42,12 +44,14 @@ void init_ui()
 	register_qml_types(NULL);
 
 	MainWindow *window = new MainWindow();
+	m_mainWindowValid = true;
 	window->setTitle();
 #endif // SUBSURFACE_MOBILE
 }
 
 void exit_ui()
 {
+	m_mainWindowValid = false;
 #ifndef SUBSURFACE_MOBILE
 	delete MainWindow::instance();
 #endif // SUBSURFACE_MOBILE


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
    This feels like it's a Qt bug, we shouldn't try to hide the child widgets
    and subsequently invalidate the filter, but I can easily reproduce a crash
    like this on exit:
 ```   
    1  MainTab::updateDiveInfo()
    2  MainWindow::selectionChanged()
    3  QMetaObject::activate(QObject *, int, int, void * *)
    4  QMetaObject::activate(QObject *, int, int, void * *)
    5  MultiFilterSortModel::myInvalidate()
    6  QWidget::event(QEvent *)
    7  QApplicationPrivate::notify_helper(QObject *, QEvent *)
    8  QApplication::notify(QObject *, QEvent *)
    9  QCoreApplication::notifyInternal2(QObject *, QEvent *)
    10 QWidgetPrivate::hideChildren(bool)
     ... same symbol
    17 QWidgetPrivate::hideChildren(bool)
    18 QWidgetPrivate::hide_helper()
    19 QWidget::setVisible(bool)
    20 QWidgetPrivate::close_helper(QWidgetPrivate::CloseMode)
    21 QWidget::~QWidget()
    22 MainWindow::~MainWindow()
    23 MainWindow::~MainWindow()
    24 exit_ui()
    ```
    Adding this variable is clumsy, but it works around the issue.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
add a flag variable whether we believe our MainWindow to be valid

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2046 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger this includes the stack trace you asked for. :-)