### PR TITLE
Cleanup: move equipment-tab into separate files

### DIFF
--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -48,6 +48,7 @@ set (SUBSURFACE_UI
 	tab-widgets/TabDiveInformation.ui
 	tab-widgets/TabDivePhotos.ui
 	tab-widgets/TabDiveExtraInfo.ui
+	tab-widgets/TabDiveEquipment.ui
 	tab-widgets/TabDiveSite.ui
 )
 
@@ -118,6 +119,8 @@ set(SUBSURFACE_INTERFACE
 	tab-widgets/TabBase.h
 	tab-widgets/TabDiveExtraInfo.cpp
 	tab-widgets/TabDiveExtraInfo.h
+	tab-widgets/TabDiveEquipment.cpp
+	tab-widgets/TabDiveEquipment.h
 	tab-widgets/TabDiveInformation.cpp
 	tab-widgets/TabDiveInformation.h
 	tab-widgets/TabDivePhotos.cpp

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -404,7 +404,7 @@ void MainWindow::enableDisableOtherDCsActions()
 void MainWindow::setDefaultState()
 {
 	setApplicationState("Default");
-	if (mainTab->getEditMode() != MainTab::NONE)
+	if (mainTab->isEditing())
 		ui.bottomLeft->currentWidget()->setEnabled(false);
 }
 

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "TabDiveEquipment.h"
+#include "maintab.h"
+#include "desktop-widgets/mainwindow.h" // TODO: Only used temporarilly for edit mode changes
+#include "desktop-widgets/simplewidgets.h" // For isGnome3Session()
+#include "desktop-widgets/modeldelegates.h"
+
+#include "profile-widget/profilewidget2.h"
+
+#include "qt-models/cylindermodel.h"
+#include "qt-models/weightmodel.h"
+
+#include "core/divelist.h"
+#include "core/subsurface-string.h"
+
+#include <QSettings>
+TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
+	cylindersModel(new CylindersModel(this)),
+	weightModel(new WeightModel(this))
+{
+	ui.setupUi(this);
+
+	// This makes sure we only delete the models
+	// after the destructor of the tables,
+	// this is needed to save the column sizes.
+	cylindersModel->setParent(ui.cylinders);
+	weightModel->setParent(ui.weights);
+
+	ui.cylinders->setModel(cylindersModel);
+	ui.weights->setModel(weightModel);
+
+	connect(ui.cylinders->view(), &QTableView::clicked, this, &TabDiveEquipment::editCylinderWidget);
+	connect(ui.weights->view(), &QTableView::clicked, this, &TabDiveEquipment::editWeightWidget);
+
+	// Current display of things on Gnome3 looks like shit, so
+	// let's fix that.
+	if (isGnome3Session()) {
+		QPalette p;
+		p.setColor(QPalette::Window, QColor(Qt::white));
+		ui.scrollArea->viewport()->setPalette(p);
+	}
+
+	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
+	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, new TankUseDelegate(this));
+	ui.weights->view()->setItemDelegateForColumn(WeightModel::TYPE, new WSInfoDelegate(this));
+	ui.cylinders->view()->setColumnHidden(CylindersModel::DEPTH, true);
+
+	ui.cylinders->setTitle(tr("Cylinders"));
+	ui.cylinders->setBtnToolTip(tr("Add cylinder"));
+	connect(ui.cylinders, &TableView::addButtonClicked, this, &TabDiveEquipment::addCylinder_clicked);
+
+	ui.weights->setTitle(tr("Weights"));
+	ui.weights->setBtnToolTip(tr("Add weight system"));
+	connect(ui.weights, &TableView::addButtonClicked, this, &TabDiveEquipment::addWeight_clicked);
+
+	QSettings s;
+	s.beginGroup("cylinders_dialog");
+	for (int i = 0; i < CylindersModel::COLUMNS; i++) {
+		if ((i == CylindersModel::REMOVE) || (i == CylindersModel::TYPE))
+			continue;
+		bool checked = s.value(QString("column%1_hidden").arg(i)).toBool();
+		QAction *action = new QAction(cylindersModel->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString(), ui.cylinders->view());
+		action->setCheckable(true);
+		action->setData(i);
+		action->setChecked(!checked);
+		connect(action, &QAction::triggered, this, &TabDiveEquipment::toggleTriggeredColumn);
+		ui.cylinders->view()->setColumnHidden(i, checked);
+		ui.cylinders->view()->horizontalHeader()->addAction(action);
+	}
+
+	ui.cylinders->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
+	ui.weights->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
+}
+
+TabDiveEquipment::~TabDiveEquipment()
+{
+	QSettings s;
+	s.beginGroup("cylinders_dialog");
+	for (int i = 0; i < CylindersModel::COLUMNS; i++) {
+		if ((i == CylindersModel::REMOVE) || (i == CylindersModel::TYPE))
+			continue;
+		s.setValue(QString("column%1_hidden").arg(i), ui.cylinders->view()->isColumnHidden(i));
+	}
+}
+
+void TabDiveEquipment::toggleTriggeredColumn()
+{
+	QAction *action = qobject_cast<QAction *>(sender());
+	int col = action->data().toInt();
+	QTableView *view = ui.cylinders->view();
+
+	if (action->isChecked()) {
+		view->showColumn(col);
+		if (view->columnWidth(col) <= 15)
+			view->setColumnWidth(col, 80);
+	} else
+		view->hideColumn(col);
+}
+
+void TabDiveEquipment::updateData()
+{
+	cylindersModel->updateDive();
+	weightModel->updateDive();
+
+	ui.cylinders->view()->hideColumn(CylindersModel::DEPTH);
+	if (get_dive_dc(&displayed_dive, dc_number)->divemode == CCR)
+		ui.cylinders->view()->showColumn(CylindersModel::USE);
+	else
+		ui.cylinders->view()->hideColumn(CylindersModel::USE);
+}
+
+void TabDiveEquipment::clear()
+{
+	cylindersModel->clear();
+	weightModel->clear();
+}
+
+void TabDiveEquipment::addCylinder_clicked()
+{
+	MainWindow::instance()->mainTab->enableEdition();
+	cylindersModel->add();
+}
+
+void TabDiveEquipment::addWeight_clicked()
+{
+	MainWindow::instance()->mainTab->enableEdition();
+	weightModel->add();
+}
+
+void TabDiveEquipment::editCylinderWidget(const QModelIndex &index)
+{
+	if (cylindersModel->changed && !MainWindow::instance()->mainTab->isEditing()) {
+		MainWindow::instance()->mainTab->enableEdition();
+		return;
+	}
+	if (index.isValid() && index.column() != CylindersModel::REMOVE) {
+		MainWindow::instance()->mainTab->enableEdition();
+		ui.cylinders->edit(index);
+	}
+}
+
+void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
+{
+	MainWindow::instance()->mainTab->enableEdition();
+
+	if (index.isValid() && index.column() != WeightModel::REMOVE)
+		ui.weights->edit(index);
+}
+
+// tricky little macro to edit all the selected dives
+// loop ove all DIVES and do WHAT.
+#define MODIFY_DIVES(DIVES, WHAT)                            \
+	do {                                                 \
+		for (dive *mydive: DIVES) {                  \
+			WHAT;                                \
+		}					     \
+		mark_divelist_changed(true);                 \
+	} while (0)
+
+// Get the list of selected dives, but put the current dive at the last position of the vector
+static QVector<dive *> getSelectedDivesCurrentLast()
+{
+	QVector<dive *> res;
+	struct dive *d;
+	int i;
+	for_each_dive (i, d) {
+		if (d->selected && d != current_dive)
+			res.append(d);
+	}
+	res.append(current_dive);
+	return res;
+}
+
+void TabDiveEquipment::acceptChanges()
+{
+	bool do_replot = false;
+
+	// now check if something has changed and if yes, edit the selected dives that
+	// were identical with the master dive shown (and mark the divelist as changed)
+	struct dive *cd = current_dive;
+
+	// Get list of selected dives, but put the current dive last;
+	// this is required in case the invocation wants to compare things
+	// to the original value in current_dive like it should
+	QVector<dive *> selectedDives = getSelectedDivesCurrentLast();
+
+	if (cylindersModel->changed) {
+		mark_divelist_changed(true);
+		MODIFY_DIVES(selectedDives,
+			for (int i = 0; i < MAX_CYLINDERS; i++) {
+				if (mydive != cd) {
+					if (same_string(mydive->cylinder[i].type.description, cd->cylinder[i].type.description)) {
+						// if we started out with the same cylinder description (for multi-edit) or if we do copt & paste
+						// make sure that we have the same cylinder type and copy the gasmix, but DON'T copy the start
+						// and end pressures (those are per dive after all)
+						if (!same_string(mydive->cylinder[i].type.description, displayed_dive.cylinder[i].type.description)) {
+							free((void*)mydive->cylinder[i].type.description);
+							mydive->cylinder[i].type.description = copy_string(displayed_dive.cylinder[i].type.description);
+						}
+						mydive->cylinder[i].type.size = displayed_dive.cylinder[i].type.size;
+						mydive->cylinder[i].type.workingpressure = displayed_dive.cylinder[i].type.workingpressure;
+						mydive->cylinder[i].gasmix = displayed_dive.cylinder[i].gasmix;
+						mydive->cylinder[i].cylinder_use = displayed_dive.cylinder[i].cylinder_use;
+						mydive->cylinder[i].depth = displayed_dive.cylinder[i].depth;
+					}
+				}
+			}
+		);
+		for (int i = 0; i < MAX_CYLINDERS; i++) {
+			// copy the cylinder but make sure we have our own copy of the strings
+			free((void*)cd->cylinder[i].type.description);
+			cd->cylinder[i] = displayed_dive.cylinder[i];
+			cd->cylinder[i].type.description = copy_string(displayed_dive.cylinder[i].type.description);
+		}
+		/* if cylinders changed we may have changed gas change events
+		 * and sensor idx in samples as well
+		 * - so far this is ONLY supported for a single selected dive */
+		struct divecomputer *tdc = &current_dive->dc;
+		struct divecomputer *sdc = &displayed_dive.dc;
+		while(tdc && sdc) {
+			free_events(tdc->events);
+			copy_events(sdc, tdc);
+			free(tdc->sample);
+			copy_samples(sdc, tdc);
+			tdc = tdc->next;
+			sdc = sdc->next;
+		}
+		do_replot = true;
+	}
+
+	if (weightModel->changed) {
+		mark_divelist_changed(true);
+		MODIFY_DIVES(selectedDives,
+			for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
+				if (mydive != cd && (same_string(mydive->weightsystem[i].description, cd->weightsystem[i].description))) {
+					mydive->weightsystem[i] = displayed_dive.weightsystem[i];
+					mydive->weightsystem[i].description = copy_string(displayed_dive.weightsystem[i].description);
+				}
+			}
+		);
+		for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
+			cd->weightsystem[i] = displayed_dive.weightsystem[i];
+			cd->weightsystem[i].description = copy_string(displayed_dive.weightsystem[i].description);
+		}
+	}
+
+	if (do_replot)
+		MainWindow::instance()->graphics->replot();
+
+	cylindersModel->changed = false;
+	weightModel->changed = false;
+}
+
+void TabDiveEquipment::rejectChanges()
+{
+	cylindersModel->changed = false;
+	weightModel->changed = false;
+	cylindersModel->updateDive();
+	weightModel->updateDive();
+}

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TAB_DIVE_EQUIPMENT_H
+#define TAB_DIVE_EQUIPMENT_H
+
+#include "TabBase.h"
+#include "ui_TabDiveEquipment.h"
+
+namespace Ui {
+	class TabDiveEquipment;
+};
+
+class WeightModel;
+class CylindersModel;
+
+class TabDiveEquipment : public TabBase {
+	Q_OBJECT
+public:
+	TabDiveEquipment(QWidget *parent = 0);
+	~TabDiveEquipment();
+	void updateData() override;
+	void clear() override;
+	void acceptChanges();
+	void rejectChanges();
+private slots:
+	void addCylinder_clicked();
+	void addWeight_clicked();
+	void toggleTriggeredColumn();
+	void editCylinderWidget(const QModelIndex &index);
+	void editWeightWidget(const QModelIndex &index);
+private:
+	Ui::TabDiveEquipment ui;
+
+	CylindersModel *cylindersModel;
+	WeightModel *weightModel;
+};
+
+#endif // TAB_DIVE_EQUIPMENT_H

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.ui
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TabDiveEquipment</class>
+ <widget class="QWidget" name="equipmentTab">
+  <attribute name="title">
+   <string>Equipment</string>
+  </attribute>
+  <layout class="QVBoxLayout" name="verticalLayout_10">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>523</width>
+        <height>739</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="equipmentTabScrollAreaLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <item row="1" column="0">
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QVBoxLayout" name="cylinderWeightsLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QSplitter" name="splitter">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <widget class="TableView" name="cylinders" native="true"/>
+            <widget class="TableView" name="weights" native="true"/>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
@@ -19,6 +19,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TableView</class>
+   <extends>QWidget</extends>
+   <header>desktop-widgets/tableview.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -41,6 +41,13 @@
 #include <QDesktopServices>
 #include <QStringList>
 
+struct Completers {
+	QCompleter *divemaster;
+	QCompleter *buddy;
+	QCompleter *suit;
+	QCompleter *tags;
+};
+
 MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	editMode(NONE),
 	lastSelectedDive(true),
@@ -105,6 +112,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	ui.DiveType->insertItems(0, types);
 	connect(ui.DiveType, SIGNAL(currentIndexChanged(int)), this, SLOT(divetype_Changed(int)));
 
+	Completers completers;
 	completers.buddy = new QCompleter(&buddyModel, ui.buddy);
 	completers.divemaster = new QCompleter(&diveMasterModel, ui.divemaster);
 	completers.suit = new QCompleter(&suitModel, ui.suit);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -704,11 +704,6 @@ void MainTab::reload()
 		mark_divelist_changed(true);                 \
 	} while (0)
 
-MainTab::EditMode MainTab::getEditMode() const
-{
-	return editMode;
-}
-
 void MainTab::refreshDisplayedDiveSite()
 {
 	struct dive_site *ds = get_dive_site_for_dive(current_dive);

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -97,7 +97,6 @@ slots:
 	void toggleTriggeredColumn();
 	void updateTextLabels(bool showUnits = true);
 	void escDetected(void);
-	EditMode getEditMode() const;
 private:
 	Ui::MainTab ui;
 	WeightModel *weightModel;

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -19,8 +19,6 @@
 #include "core/dive.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 
-class WeightModel;
-class CylindersModel;
 class ExtraDataModel;
 class DivePictureModel;
 class QCompleter;
@@ -46,7 +44,6 @@ public:
 	MainTab(QWidget *parent = 0);
 	~MainTab();
 	void clearTabs();
-	void clearEquipment();
 	void reload();
 	void initialUiSetup();
 	bool isEditing();
@@ -62,8 +59,6 @@ slots:
 	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
 	void diveSiteEdited(dive_site *ds, int field);
 	void tripChanged(dive_trip *trip, TripField field);
-	void addCylinder_clicked();
-	void addWeight_clicked();
 	void updateDiveInfo();
 	void updateNotes(const struct dive *d);
 	void updateMode(struct dive *d);
@@ -87,20 +82,15 @@ slots:
 	void on_rating_valueChanged(int value);
 	void on_visibility_valueChanged(int value);
 	void on_tagWidget_editingFinished();
-	void editCylinderWidget(const QModelIndex &index);
-	void editWeightWidget(const QModelIndex &index);
 	void addMessageAction(QAction *action);
 	void hideMessage();
 	void closeMessage();
 	void displayMessage(QString str);
 	void enableEdition(EditMode newEditMode = NONE);
-	void toggleTriggeredColumn();
 	void updateTextLabels(bool showUnits = true);
 	void escDetected(void);
 private:
 	Ui::MainTab ui;
-	WeightModel *weightModel;
-	CylindersModel *cylindersModel;
 	EditMode editMode;
 	BuddyCompletionModel buddyModel;
 	DiveMasterCompletionModel diveMasterModel;

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -21,14 +21,6 @@
 
 class ExtraDataModel;
 class DivePictureModel;
-class QCompleter;
-
-struct Completers {
-	QCompleter *divemaster;
-	QCompleter *buddy;
-	QCompleter *suit;
-	QCompleter *tags;
-};
 
 class TabBase;
 class MainTab : public QTabWidget {
@@ -96,7 +88,6 @@ private:
 	DiveMasterCompletionModel diveMasterModel;
 	SuitCompletionModel suitModel;
 	TagCompletionModel tagModel;
-	Completers completers;
 	bool modified;
 	bool lastSelectedDive;
 	int lastTabSelectedDive;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -491,83 +491,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="equipmentTab">
-      <attribute name="title">
-       <string>Equipment</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_10">
-       <item>
-        <widget class="QScrollArea" name="scrollArea_2">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents2">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>523</width>
-            <height>739</height>
-           </rect>
-          </property>
-          <layout class="QGridLayout" name="equipmentTabScrollAreaLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <property name="spacing">
-            <number>2</number>
-           </property>
-           <item row="1" column="0">
-            <widget class="QWidget" name="widget" native="true">
-             <layout class="QVBoxLayout" name="cylinderWeightsLayout">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QSplitter" name="splitter">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <widget class="TableView" name="cylinders" native="true"/>
-                <widget class="TableView" name="weights" native="true"/>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
     </widget>
    </item>
   </layout>
@@ -583,12 +506,6 @@
    <class>StarWidget</class>
    <extends>QWidget</extends>
    <header>desktop-widgets/starwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>TableView</class>
-   <extends>QWidget</extends>
-   <header>desktop-widgets/tableview.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Before starting with undo of equipment, let's move the equipment-tab into its own files, just like the other tabs. This makes things more isolated and more clear.

Currently this needs some ugly hacks for communication between the main and the equipment tabs. But these all concern edit mode, which will not be used by the equipment-tab once undo is implemented. Therefore, I'd prefer not introduce the necessary infrastructure just to remove it in the not-so-distant future.

This needs some testing.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move equipment tab into own files.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

No user-visible change (knock wood).

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

No user-visible change (knock wood).

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 