### PR TITLE
FTDI support: ignore case when comparing magic device name

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1297,7 +1297,7 @@ dc_status_t divecomputer_device_open(device_data_t *data)
 
 	if (transports & DC_TRANSPORT_SERIAL) {
 #ifdef SERIAL_FTDI
-		if (!strcmp(data->devname, "ftdi"))
+		if (!strcasecmp(data->devname, "ftdi"))
 			return ftdi_open(&data->iostream, context);
 #endif
 		rc = dc_serial_open(&data->iostream, context, data->devname);


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
as the title says, simply ignore case when comparing with "ftdi"
