### PR TITLE
Cleanup: simplify dive list undo structure by removing insertion index

### DIFF
--- a/core/divelist.h
+++ b/core/divelist.h
@@ -34,7 +34,7 @@ extern char *get_dive_gas_string(const struct dive *dive);
 extern struct dive **grow_dive_table(struct dive_table *table);
 extern int dive_table_get_insertion_index(struct dive_table *table, struct dive *dive);
 extern void add_to_dive_table(struct dive_table *table, int idx, struct dive *dive);
-extern void add_single_dive(int idx, struct dive *dive);
+extern void append_dive(struct dive *dive);
 extern void get_dive_gas(const struct dive *dive, int *o2_p, int *he_p, int *o2low_p);
 extern int get_divenr(const struct dive *dive);
 extern struct dive_trip *unregister_dive_from_trip(struct dive *dive);

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -16,7 +16,6 @@ struct DiveToAdd {
 	OwningDivePtr	 dive;		// Dive to add
 	dive_trip	*trip;		// Trip the dive belongs to, may be null
 	dive_site	*site;		// Site the dive is associated with, may be null
-	int		 idx;		// Position in divelist
 };
 
 // Multiple trips, dives and dive sites that have to be added for a command

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -278,7 +278,7 @@ QString DiveListModel::startAddDive()
 	nr++;
 	d->number = nr;
 	d->dc.model = strdup("manually added dive");
-	add_single_dive(dive_table.nr, d);
+	append_dive(d);
 	insertDive(get_idx_by_uniq_id(d->id), new DiveObjectHelper(d));
 	return QString::number(d->id);
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Before tackling more undo, let's do some simple cleanups. This one remove a premature optimization and makes the dive list undo code more robust. The insertion index is now calculated on execution. Moreover, a function is renamed.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove insertion index from undo commands
2) Rename add_single_dive to append_dive

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

