### PR TITLE
Cleanup: free dive table in trips and dive sites

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -715,6 +715,7 @@ void free_trip(dive_trip_t *trip)
 	if (trip) {
 		free(trip->location);
 		free(trip->notes);
+		free(trip->dives.dives);
 		free(trip);
 	}
 }

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -207,6 +207,7 @@ void free_dive_site(struct dive_site *ds)
 		free(ds->name);
 		free(ds->notes);
 		free(ds->description);
+		free(ds->dives.dives);
 		free_taxonomy(&ds->taxonomy);
 		free(ds);
 	}


### PR DESCRIPTION
Trips and dive sites were changed to use dive tables instead
of linked lists. But the memory used for the tables wasn't freed.
Do this.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes two memory leaks that were introduced when switching from linked lists to dive tables, respectively when keeping track of dives at dive sites.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Free dive table of dive trips.
2) Free dive table of dive sites.
