### PR TITLE
make sure to clear dives on dive split failure

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3596,8 +3596,6 @@ static int split_dive_at(const struct dive *dive, int a, int b, struct dive **ou
 	struct divecomputer *dc1, *dc2;
 	struct event *event, **evp;
 
-	*out1 = *out2 = NULL;
-
 	/* if we can't find the dive in the dive list, don't bother */
 	if ((nr = get_divenr(dive)) < 0)
 		return -1;
@@ -3727,6 +3725,7 @@ int split_dive(const struct dive *dive, struct dive **new1, struct dive **new2)
 	int at_surface, surface_start;
 	const struct divecomputer *dc;
 
+	*new1 = *new2 = NULL;
 	if (!dive)
 		return -1;
 
@@ -3768,6 +3767,7 @@ int split_dive_at_time(const struct dive *dive, duration_t time, struct dive **n
 	int i = 0;
 	struct sample *sample = dive->dc.sample;
 
+	*new1 = *new2 = NULL;
 	if (!dive)
 		return -1;
 	while(sample->time.seconds < time.seconds) {


### PR DESCRIPTION
The dive splitting code returns an error code when splitting fails, but
it turns out that the C++ UI code doesn't actually look at the error
code, and instead expected the resulting dives to be NULL if an error
happened and the split didn't succeed for whatever reason.

Which is kind of lazy of it, but we might as well clear the resulting
dives and make the UI code happy.  This should fix the problem that
Celia Marlowe reported on the Subsurface google groups forum.

Reported-by: Celia Marlowe
Acked-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
Fixes: 145f70aab5 ("Undo: implement split-out of dive computer")
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
