### PR TITLE
Dive site: display proper text for the two special options

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -299,12 +299,13 @@ QVariant DiveLocationModel::data(const QModelIndex &index, int role) const
 		case Qt::DisplayRole:
 			return new_ds_value[index.row()];
 		case Qt::ToolTipRole:
-			return displayed_dive.dive_site ?
+			return current_dive && current_dive->dive_site ?
 				tr("Create a new dive site, copying relevant information from the current dive.") :
 				tr("Create a new dive site with this name");
 		case Qt::DecorationRole:
 			return plusIcon;
 		}
+		return QVariant();
 	}
 
 	// The dive sites are -2 because of the first two items.


### PR DESCRIPTION
The dive-site line edit box features two special entries for adding
new dive sites. These should display different texts depending on
whether the current dive has a dive site or not.

The current check is wrong, because it used displayed_dive, but
since the last set of undo-changes, this might not be filled out
correctly anymore. Instead the code should check the actual current
dive.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a very minor bug, but still a bug. The dive site box might have shown the wrong text in specific circumstances (create dive site, vs. create dive site from current site).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) use current_dive to fill out text in dive site box.