### PR TITLE
A few dive site selection widget cleanups, e. g. enable sorting

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -262,6 +262,7 @@ void DiveLocationFilterProxyModel::setFilter(const QString &filterIn)
 {
 	filter = filterIn;
 	invalidate();
+	sort(LocationInformationModel::NAME);
 }
 
 bool DiveLocationFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex&) const
@@ -275,7 +276,10 @@ bool DiveLocationFilterProxyModel::filterAcceptsRow(int source_row, const QModel
 
 bool DiveLocationFilterProxyModel::lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const
 {
-	return source_left.data().toString() < source_right.data().toString();
+	// The first two entries are special - we never want to change their order
+	if (source_left.row() <= 1 || source_right.row() <= 1)
+		return source_left.row() < source_right.row();
+	return source_left.data().toString().compare(source_right.data().toString(), Qt::CaseInsensitive) < 0;
 }
 
 DiveLocationModel::DiveLocationModel(QObject *)
@@ -367,7 +371,7 @@ DiveLocationLineEdit::DiveLocationLineEdit(QWidget *parent) : QLineEdit(parent),
 	connect(view, &DiveLocationListView::currentIndexChanged, this, &DiveLocationLineEdit::currentChanged);
 }
 
-bool DiveLocationLineEdit::eventFilter(QObject*, QEvent *e)
+bool DiveLocationLineEdit::eventFilter(QObject *, QEvent *e)
 {
 	if (e->type() == QEvent::KeyPress) {
 		QKeyEvent *keyEv = (QKeyEvent *)e;
@@ -553,6 +557,7 @@ void DiveLocationLineEdit::showPopup()
 	if (!view->isVisible()) {
 		setTemporaryDiveSiteName(text());
 		proxy->invalidate();
+		proxy->sort(LocationInformationModel::NAME);
 		view->show();
 	}
 }

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -267,6 +267,11 @@ void DiveLocationFilterProxyModel::setFilter(const QString &filterIn)
 
 bool DiveLocationFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex&) const
 {
+	// We don't want to show the first two entries (add dive site with that name)
+	// if there is no filter text.
+	if (filter.isEmpty() && source_row <= 1)
+		return false;
+
 	if (source_row == 0)
 		return true;
 

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -194,10 +194,8 @@ void LocationInformationWidget::initFields(dive_site *ds)
 		filter_model.set(ds, ds->location);
 		updateLabels();
 		enableLocationButtons(dive_site_has_gps_location(ds));
-		QSortFilterProxyModel *m = qobject_cast<QSortFilterProxyModel *>(ui.diveSiteListView->model());
 		MultiFilterSortModel::instance()->startFilterDiveSites(QVector<dive_site *>{ ds });
-		if (m)
-			m->invalidate();
+		filter_model.invalidate();
 	} else {
 		filter_model.set(0, location_t { degrees_t{ 0 }, degrees_t{ 0 } });
 		clearLabels();

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -45,10 +45,12 @@ private:
 
 class DiveLocationFilterProxyModel : public QSortFilterProxyModel {
 	Q_OBJECT
+	QString filter;
 public:
 	DiveLocationFilterProxyModel(QObject *parent = 0);
 	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
 	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
+	void setFilter(const QString &filter);
 };
 
 class DiveLocationModel : public QAbstractTableModel {


### PR DESCRIPTION
DiveLocationLineEdit stored a pointer to itself in a global variable
so that the DiveLocationModel can access it to access the filter text.

Instead, on change simply pass the filter text down from DiveLocationLineEdit
to DiveLocationModel.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This removes a hack that has irked me for the longest time. Removes a global variable by passing down a filter text instead of letting the filter access the parent object via dubious methods.

