### PR TITLE
Mobile: reinstate roleNames function in ConnectionListModel

### DIFF
--- a/core/connectionlistmodel.cpp
+++ b/core/connectionlistmodel.cpp
@@ -7,6 +7,13 @@ ConnectionListModel::ConnectionListModel(QObject *parent) :
 {
 }
 
+QHash <int, QByteArray> ConnectionListModel::roleNames() const
+{
+	QHash<int, QByteArray> roles;
+	roles[Qt::DisplayRole] = "display";
+	return roles;
+}
+
 QVariant ConnectionListModel::data(const QModelIndex &index, int role) const
 {
 	if (index.row() < 0 || index.row() >= m_addresses.count())

--- a/core/connectionlistmodel.h
+++ b/core/connectionlistmodel.h
@@ -7,6 +7,7 @@ class ConnectionListModel : public QAbstractListModel {
 	Q_OBJECT
 public:
 	ConnectionListModel(QObject *parent = nullptr);
+	QHash<int, QByteArray> roleNames() const override;
 	QVariant data(const QModelIndex &index, int role) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	void addAddress(const QString &address);


### PR DESCRIPTION
Commit c69ca4df80c9c74aa842b7f1fb3c44b22ae3232e removed the roleNames
function, which is not needed according to the docs, as a default function
is provided. For unknown reasons this broke the QML combo box.

Reinstate the function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug reported by @dirkhh: connections were not shown on mobile. Why this fixes anything is unclear.
