### PR TITLE
qt-ble: return DC_STATUS_TIMEOUT rather than DC_STATUS_IO on timeout

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -211,7 +211,7 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 
 		WAITFOR(!receivedPackets.isEmpty(), timeout);
 		if (receivedPackets.isEmpty())
-			return DC_STATUS_IO;
+			return DC_STATUS_TIMEOUT;
 	}
 
 	QByteArray packet = receivedPackets.takeFirst();


### PR DESCRIPTION
This didn't use to matter, because none of the BLE-using backends did
retry on timeout until recently.

But Jef started doing packet sending retry for the Mares Icon backend,
and now we should make sure to distinguish the "IO failed" from "IO
timed out" cases.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
