### PR TITLE
[RFC] Use actual GPS data in dive site handling

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -452,9 +452,6 @@ void split_divecomputer(const struct dive *src, int num, struct dive **out1, str
 #define for_each_dc(_dive, _dc) \
 	for (_dc = &_dive->dc; _dc; _dc = _dc->next)
 
-#define for_each_gps_location(_i, _x) \
-	for ((_i) = 0; ((_x) = get_gps_location(_i, &gps_location_table)) != NULL; (_i)++)
-
 extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
 extern bool dive_site_has_gps_location(const struct dive_site *ds);

--- a/core/dive.h
+++ b/core/dive.h
@@ -456,6 +456,7 @@ extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
 extern bool dive_site_has_gps_location(const struct dive_site *ds);
 extern int dive_has_gps_location(const struct dive *dive);
+extern location_t dive_get_gps_location(const struct dive *d);
 
 extern int report_error(const char *fmt, ...);
 extern void set_error_cb(void(*cb)(char *));	// Callback takes ownership of passed string

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -570,8 +570,6 @@ static void set_dc_serial(struct divecomputer *dc, const char *serial)
 		dc->deviceid = calculate_string_hash(serial);
 }
 
-extern void parse_location(char *, location_t *);
-
 static void parse_string_field(device_data_t *devdata, struct dive *dive, dc_field_string_t *str)
 {
 	// Our dive ID is the string hash of the "Dive ID" string

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -31,7 +31,6 @@ struct keyword_action {
 };
 #define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
-extern void parse_location(char *buf, location_t *);
 git_blob *git_tree_entry_blob(git_repository *repo, const git_tree_entry *entry);
 
 static char *get_utf8(struct membuffer *b)

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1088,7 +1088,7 @@ static int uddf_dive_match(struct dive *dive, const char *name, char *buf, struc
  * We don't do exponentials etc, if somebody does
  * GPS locations in that format, they are insane.
  */
-static degrees_t parse_degrees(char *buf, char **end)
+static degrees_t parse_degrees(const char *buf, const char **end)
 {
 	int sign = 1, decimals = 6, value = 0;
 	degrees_t ret;
@@ -1133,7 +1133,7 @@ static degrees_t parse_degrees(char *buf, char **end)
 
 static void gps_lat(char *buffer, struct dive *dive, struct parser_state *state)
 {
-	char *end;
+	const char *end;
 	location_t location = { };
 	struct dive_site *ds = get_dive_site_for_dive(dive);
 
@@ -1149,7 +1149,7 @@ static void gps_lat(char *buffer, struct dive *dive, struct parser_state *state)
 
 static void gps_long(char *buffer, struct dive *dive, struct parser_state *state)
 {
-	char *end;
+	const char *end;
 	location_t location = { };
 	struct dive_site *ds = get_dive_site_for_dive(dive);
 
@@ -1164,9 +1164,9 @@ static void gps_long(char *buffer, struct dive *dive, struct parser_state *state
 }
 
 /* We allow either spaces or a comma between the decimal degrees */
-void parse_location(char *buffer, location_t *loc)
+void parse_location(const char *buffer, location_t *loc)
 {
-	char *end;
+	const char *end;
 	loc->lat = parse_degrees(buffer, &end);
 	if (*end == ',') end++;
 	loc->lon = parse_degrees(end, &end);

--- a/core/units.h
+++ b/core/units.h
@@ -138,6 +138,8 @@ typedef struct pos {
 	degrees_t lat, lon;
 } location_t;
 
+extern void parse_location(const char *, location_t *);
+
 static inline bool has_location(const location_t *loc)
 {
 	return loc->lat.udeg || loc->lon.udeg;

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -341,6 +341,14 @@ static struct dive_site *createDiveSite(const QString &name)
 		copy_dive_site(old, ds);
 		free(ds->name); // Free name, as we will overwrite it with our own version
 	}
+
+	// If the current dive has a location, use that as location for the new dive site
+	if (current_dive) {
+		location_t loc = dive_get_gps_location(current_dive);
+		if (has_location(&loc))
+			ds->location = loc;
+	}
+
 	ds->name = copy_qstring(name);
 	return ds;
 }

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -373,7 +373,7 @@ DiveLocationLineEdit::DiveLocationLineEdit(QWidget *parent) : QLineEdit(parent),
 
 	view->setModel(proxy);
 	view->setModelColumn(LocationInformationModel::NAME);
-	view->setItemDelegate(new LocationFilterDelegate());
+	view->setItemDelegate(&delegate);
 	view->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	view->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -572,6 +572,7 @@ void DiveLocationLineEdit::setCurrentDiveSite(struct dive *d)
 
 	location_t currentLocation = d ? dive_get_gps_location(d) : location_t{0, 0};
 	proxy->setCurrentLocation(currentLocation);
+	delegate.setCurrentLocation(currentLocation);
 }
 
 void DiveLocationLineEdit::showPopup()

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -577,13 +577,8 @@ void DiveLocationLineEdit::setCurrentDiveSite(struct dive *d)
 
 void DiveLocationLineEdit::showPopup()
 {
-	fixPopupPosition();
-	if (!view->isVisible()) {
+	if (!view->isVisible())
 		setTemporaryDiveSiteName(text());
-		proxy->invalidate();
-		proxy->sort(LocationInformationModel::NAME);
-		view->show();
-	}
 }
 
 DiveLocationLineEdit::DiveSiteType DiveLocationLineEdit::currDiveSiteType() const

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -581,6 +581,20 @@ void DiveLocationLineEdit::showPopup()
 		setTemporaryDiveSiteName(text());
 }
 
+void DiveLocationLineEdit::showAllSites()
+{
+	if (!view->isVisible()) {
+		// By setting the "temporary dive site name" to the empty string,
+		// all dive sites are shown sorted by distance from the site of
+		// the current dive.
+		setTemporaryDiveSiteName(QString());
+
+		// By selecting the whole text, the user can immediately start
+		// typing to activate the full-text filter.
+		selectAll();
+	}
+}
+
 DiveLocationLineEdit::DiveSiteType DiveLocationLineEdit::currDiveSiteType() const
 {
 	return currType;

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -51,6 +51,9 @@ public:
 	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
 	bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
 	void setFilter(const QString &filter);
+	void setCurrentLocation(location_t loc);
+private:
+	location_t currentLocation; // Sort by distance to that location
 };
 
 class DiveLocationModel : public QAbstractTableModel {
@@ -88,7 +91,7 @@ public:
 	DiveSiteType currDiveSiteType() const;
 	struct dive_site *currDiveSite() const;
 	void fixPopupPosition();
-	void setCurrentDiveSite(struct dive_site *ds);
+	void setCurrentDiveSite(struct dive *d);
 
 signals:
 	void diveSiteSelected();

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -93,6 +93,7 @@ public:
 	struct dive_site *currDiveSite() const;
 	void fixPopupPosition();
 	void setCurrentDiveSite(struct dive *d);
+	void showAllSites();
 
 signals:
 	void diveSiteSelected();

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -5,6 +5,7 @@
 #include "core/units.h"
 #include "core/divesite.h"
 #include "ui_locationinformation.h"
+#include "modeldelegates.h"
 #include "qt-models/divelocationmodel.h"
 #include <stdint.h>
 #include <QAbstractListModel>
@@ -108,6 +109,7 @@ private:
 	DiveLocationFilterProxyModel *proxy;
 	DiveLocationModel *model;
 	DiveLocationListView *view;
+	LocationFilterDelegate delegate;
 	DiveSiteType currType;
 	struct dive_site *currDs;
 };

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -2,6 +2,8 @@
 #ifndef MODELDELEGATES_H
 #define MODELDELEGATES_H
 
+#include "core/units.h"
+
 #include <QStyledItemDelegate>
 #include <QComboBox>
 class QPainter;
@@ -130,6 +132,9 @@ public:
 	LocationFilterDelegate(QObject *parent = 0);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setCurrentLocation(location_t loc);
+private:
+	location_t currentLocation;
 };
 
 #endif // MODELDELEGATES_H

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -829,6 +829,11 @@ void MainTab::on_location_diveSiteSelected()
 		Command::editDiveSite(newDs, false);
 }
 
+void MainTab::on_locationPopupButton_clicked()
+{
+	ui.location->showAllSites();
+}
+
 void MainTab::on_diveTripLocation_editingFinished()
 {
 	if (!currentTrip)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -396,15 +396,14 @@ void MainTab::updateDateTime(struct dive *d)
 void MainTab::updateDiveSite(struct dive *d)
 {
 	struct dive_site *ds = d->dive_site;
+	ui.location->setCurrentDiveSite(d);
 	if (ds) {
-		ui.location->setCurrentDiveSite(ds);
 		ui.locationTags->setText(constructLocationTags(&ds->taxonomy, true));
 
 		if (ui.locationTags->text().isEmpty() && has_location(&ds->location))
 			ui.locationTags->setText(printGPSCoords(&ds->location));
 		ui.editDiveSiteButton->setEnabled(true);
 	} else {
-		ui.location->clear();
 		ui.locationTags->clear();
 		ui.editDiveSiteButton->setEnabled(false);
 	}
@@ -601,9 +600,7 @@ void MainTab::reload()
 
 void MainTab::refreshDisplayedDiveSite()
 {
-	struct dive_site *ds = get_dive_site_for_dive(current_dive);
-	if (ds)
-		ui.location->setCurrentDiveSite(ds);
+	ui.location->setCurrentDiveSite(current_dive);
 }
 
 void MainTab::acceptChanges()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -59,6 +59,7 @@ slots:
 	void acceptChanges();
 	void rejectChanges();
 	void on_location_diveSiteSelected();
+	void on_locationPopupButton_clicked();
 	void on_divemaster_editingFinished();
 	void on_buddy_editingFinished();
 	void on_suit_editingFinished();

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -217,6 +217,13 @@
                 <widget class="DiveLocationLineEdit" name="location"/>
                </item>
                <item>
+                <widget class="QToolButton" name="locationPopupButton">
+                 <property name="text">
+                  <string>...</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QToolButton" name="editDiveSiteButton">
                  <property name="toolTip">
                   <string>Edit dive site</string>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This changes the way new dive sites are added and dive sites are sorted in the dive site selection widget:

1) If there is a GPS1 extra data entry, new dive sites will be created with that entry.
2) If there is such an entry, dive sites will be sorted by distance to this entry.

This can be extended to divecomputer events. Because such an operation is slow, it is only done sparingly, e.g. when changing the current dive.

The use case I had in mind is the following:
1) Download dives from a place where you haven't been. Go through dives and add new dive site names. These will automatically get correct GPS data.
2) Download dives from a place where you have been. To select the correct dive site, press the new button (currently only labeled with "...") and choose the appropriate site. The best fitting site should be at the top.

I don't have a GPS-enabled dive computer, therefore this needs testing / feedback.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create function that extracts the GPS1 extra data and falls back to the current dive site
2) Use this function to set location for new dive sites.
3) Use this function to sort dive sites with respect to distance to current dive site.
4) A few minor cleanups.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Should be done, yes.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Perhaps.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @torvalds (pinged via webmail).