### PR TITLE
Desktop: update information tab on dive edit

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -52,7 +52,6 @@ void TabDiveInformation::updateProfile()
 	volume_t sac;
 	QString gaslist, SACs, separator;
 
-	gaslist = ""; SACs = ""; volumes = ""; separator = "";
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		if (!is_cylinder_used(current_dive, i))
 			continue;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -37,47 +37,50 @@ void TabDiveInformation::clear()
 
 void TabDiveInformation::updateData()
 {
-	clear();
+	if (!current_dive) {
+		clear();
+		return;
+	}
 
-	ui->maxcnsText->setText(QString("%1\%").arg(displayed_dive.maxcns));
-	ui->otuText->setText(QString("%1").arg(displayed_dive.otu));
-	ui->maximumDepthText->setText(get_depth_string(displayed_dive.maxdepth, true));
-	ui->averageDepthText->setText(get_depth_string(displayed_dive.meandepth, true));
-	ui->dateText->setText(get_short_dive_date_string(displayed_dive.when));
-	ui->waterTemperatureText->setText(get_temperature_string(displayed_dive.watertemp, true));
-	ui->airTemperatureText->setText(get_temperature_string(displayed_dive.airtemp, true));
+	ui->maxcnsText->setText(QString("%1\%").arg(current_dive->maxcns));
+	ui->otuText->setText(QString("%1").arg(current_dive->otu));
+	ui->maximumDepthText->setText(get_depth_string(current_dive->maxdepth, true));
+	ui->averageDepthText->setText(get_depth_string(current_dive->meandepth, true));
+	ui->dateText->setText(get_short_dive_date_string(current_dive->when));
+	ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
+	ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
 
 	volume_t gases[MAX_CYLINDERS] = {};
-	get_gas_used(&displayed_dive, gases);
+	get_gas_used(current_dive, gases);
 	QString volumes;
 	int mean[MAX_CYLINDERS], duration[MAX_CYLINDERS];
-	per_cylinder_mean_depth(&displayed_dive, select_dc(&displayed_dive), mean, duration);
+	per_cylinder_mean_depth(current_dive, select_dc(current_dive), mean, duration);
 	volume_t sac;
 	QString gaslist, SACs, separator;
 
 	gaslist = ""; SACs = ""; volumes = ""; separator = "";
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
-		if (!is_cylinder_used(&displayed_dive, i))
+		if (!is_cylinder_used(current_dive, i))
 			continue;
 		gaslist.append(separator); volumes.append(separator); SACs.append(separator);
 		separator = "\n";
 
-		gaslist.append(gasname(displayed_dive.cylinder[i].gasmix));
+		gaslist.append(gasname(current_dive->cylinder[i].gasmix));
 		if (!gases[i].mliter)
 			continue;
 		volumes.append(get_volume_string(gases[i], true));
 		if (duration[i]) {
-			sac.mliter = lrint(gases[i].mliter / (depth_to_atm(mean[i], &displayed_dive) * duration[i] / 60));
+			sac.mliter = lrint(gases[i].mliter / (depth_to_atm(mean[i], current_dive) * duration[i] / 60));
 			SACs.append(get_volume_string(sac, true).append(tr("/min")));
 		}
 	}
 	ui->gasUsedText->setText(volumes);
 	ui->oxygenHeliumText->setText(gaslist);
 
-	ui->diveTimeText->setText(get_dive_duration_string(displayed_dive.duration.seconds, tr("h"), tr("min"), tr("sec"),
-			" ", displayed_dive.dc.divemode == FREEDIVE));
+	ui->diveTimeText->setText(get_dive_duration_string(current_dive->duration.seconds, tr("h"), tr("min"), tr("sec"),
+			" ", current_dive->dc.divemode == FREEDIVE));
 
-	timestamp_t surface_interval = get_surface_interval(displayed_dive.when);
+	timestamp_t surface_interval = get_surface_interval(current_dive->when);
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else
@@ -85,13 +88,13 @@ void TabDiveInformation::updateData()
 
 	ui->sacText->setText( mean[0] ? SACs : QString());
 
-	if (displayed_dive.surface_pressure.mbar) 	/* this is ALWAYS displayed in mbar */
-		ui->airPressureText->setText(QString("%1mbar").arg(displayed_dive.surface_pressure.mbar));
+	if (current_dive->surface_pressure.mbar) 	/* this is ALWAYS displayed in mbar */
+		ui->airPressureText->setText(QString("%1mbar").arg(current_dive->surface_pressure.mbar));
 	else
 		ui->airPressureText->clear();
 
-	if (displayed_dive.salinity)
-		ui->salinityText->setText(QString("%1g/ℓ").arg(displayed_dive.salinity / 10.0));
+	if (current_dive->salinity)
+		ui->salinityText->setText(QString("%1g/ℓ").arg(current_dive->salinity / 10.0));
 	else
 		ui->salinityText->clear();
 

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -10,6 +10,7 @@
 TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveInformation())
 {
 	ui->setupUi(this);
+	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveInformation::divesChanged);
 }
 
 TabDiveInformation::~TabDiveInformation()
@@ -35,20 +36,13 @@ void TabDiveInformation::clear()
 	ui->salinityText->clear();
 }
 
-void TabDiveInformation::updateData()
+// Update fields that depend on the dive profile
+void TabDiveInformation::updateProfile()
 {
-	if (!current_dive) {
-		clear();
-		return;
-	}
-
 	ui->maxcnsText->setText(QString("%1\%").arg(current_dive->maxcns));
 	ui->otuText->setText(QString("%1").arg(current_dive->otu));
 	ui->maximumDepthText->setText(get_depth_string(current_dive->maxdepth, true));
 	ui->averageDepthText->setText(get_depth_string(current_dive->meandepth, true));
-	ui->dateText->setText(get_short_dive_date_string(current_dive->when));
-	ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
-	ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
 
 	volume_t gases[MAX_CYLINDERS] = {};
 	get_gas_used(current_dive, gases);
@@ -80,13 +74,31 @@ void TabDiveInformation::updateData()
 	ui->diveTimeText->setText(get_dive_duration_string(current_dive->duration.seconds, tr("h"), tr("min"), tr("sec"),
 			" ", current_dive->dc.divemode == FREEDIVE));
 
+	ui->sacText->setText( mean[0] ? SACs : QString());
+}
+
+// Update fields that depend on start of dive
+void TabDiveInformation::updateWhen()
+{
+	ui->dateText->setText(get_short_dive_date_string(current_dive->when));
 	timestamp_t surface_interval = get_surface_interval(current_dive->when);
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else
 		ui->surfaceIntervalText->clear();
+}
 
-	ui->sacText->setText( mean[0] ? SACs : QString());
+void TabDiveInformation::updateData()
+{
+	if (!current_dive) {
+		clear();
+		return;
+	}
+
+	updateProfile();
+	updateWhen();
+	ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
+	ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
 
 	if (current_dive->surface_pressure.mbar) 	/* this is ALWAYS displayed in mbar */
 		ui->airPressureText->setText(QString("%1mbar").arg(current_dive->surface_pressure.mbar));
@@ -97,5 +109,32 @@ void TabDiveInformation::updateData()
 		ui->salinityText->setText(QString("%1g/ℓ").arg(current_dive->salinity / 10.0));
 	else
 		ui->salinityText->clear();
+}
 
+// This function gets called if a field gets updated by an undo command.
+// Refresh the corresponding UI field.
+void TabDiveInformation::divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field)
+{
+	// If the current dive is not in list of changed dives, do nothing
+	if (!current_dive || !dives.contains(current_dive))
+		return;
+
+	switch(field) {
+	case DiveField::DURATION:
+	case DiveField::DEPTH:
+	case DiveField::MODE:
+		updateProfile();
+		break;
+	case DiveField::AIR_TEMP:
+		ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
+		break;
+	case DiveField::WATER_TEMP:
+		ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
+		break;
+	case DiveField::DATETIME:
+		updateWhen();
+		break;
+	default:
+		break;
+	}
 }

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -3,6 +3,7 @@
 #define TAB_DIVE_INFORMATION_H
 
 #include "TabBase.h"
+#include "core/subsurface-qt/DiveListNotifier.h"
 
 namespace Ui {
 	class TabDiveInformation;
@@ -15,10 +16,12 @@ public:
 	~TabDiveInformation();
 	void updateData() override;
 	void clear() override;
-
+private slots:
+	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
 private:
 	Ui::TabDiveInformation *ui;
+	void updateProfile();
+	void updateWhen();
 };
-
 
 #endif

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -361,18 +361,6 @@ void MainTab::nextInputField(QKeyEvent *event)
 	keyPressEvent(event);
 }
 
-#define UPDATE_TEXT(field)                    \
-	if (!current_dive || !current_dive->field)     \
-		ui.field->setText(QString()); \
-	else                                  \
-		ui.field->setText(current_dive->field)
-
-#define UPDATE_TEMP(field)                             \
-	if (!current_dive || current_dive->field.mkelvin == 0) \
-		ui.field->setText("");                 \
-	else                                           \
-		ui.field->setText(get_temperature_string(current_dive->field, true))
-
 bool MainTab::isEditing()
 {
 	return editMode != NONE;
@@ -442,17 +430,7 @@ void MainTab::updateDiveInfo()
 	for (TabBase *widget: extraWidgets)
 		widget->updateData();
 
-	UPDATE_TEXT(suit);
-	UPDATE_TEXT(divemaster);
-	UPDATE_TEXT(buddy);
-	UPDATE_TEMP(airtemp);
-	UPDATE_TEMP(watertemp);
-
 	if (current_dive) {
-		updateNotes(current_dive);
-		updateMode(current_dive);
-		updateDiveSite(current_dive);
-		updateDateTime(current_dive);
 		if (MainWindow::instance() && MainWindow::instance()->diveList->selectedTrips().count() == 1) {
 			// Remember the tab selected for last dive
 			if (lastSelectedDive)
@@ -555,6 +533,16 @@ void MainTab::updateDiveInfo()
 			ui.depthLabel->setVisible(isManual);
 			ui.duration->setVisible(isManual);
 			ui.durationLabel->setVisible(isManual);
+
+			updateNotes(current_dive);
+			updateMode(current_dive);
+			updateDiveSite(current_dive);
+			updateDateTime(current_dive);
+			ui.suit->setText(current_dive->suit);
+			ui.divemaster->setText(current_dive->divemaster);
+			ui.buddy->setText(current_dive->buddy);
+			ui.airtemp->setText(get_temperature_string(current_dive->airtemp, true));
+			ui.watertemp->setText(get_temperature_string(current_dive->watertemp, true));
 		}
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
@@ -581,6 +569,11 @@ void MainTab::updateDiveInfo()
 		ui.rating->setCurrentStars(0);
 		ui.visibility->setCurrentStars(0);
 		ui.location->clear();
+		ui.suit->clear();
+		ui.divemaster->clear();
+		ui.buddy->clear();
+		ui.airtemp->clear();
+		ui.watertemp->clear();
 		/* set date and time to minimums which triggers showing the special value text */
 		ui.dateEdit->setSpecialValueText(QString("-"));
 		ui.dateEdit->setMinimumDate(QDate(1, 1, 1));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a problem introduced with the recent undo work: The information tab was only updated when switching between dives, not when editing dives.

This could also be a preparation for making some fields of the information tab editable, as planned by @willemferguson.

I hope I got the dependencies of the fields right! This might need some adjustments.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use current_dive instead of displayed_dive in TabDiveInformation
2) Hook into DiveListNotifier::divesChanged to update the appropriate fields
3) Minor cleanups

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson