### PR TITLE
Support for Scubapro G2 HUD discovery via bluetooth

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -56,9 +56,10 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		product = "EON Core";
 	}
 
-	if (btName.startsWith("G2")  || btName.startsWith("Aladin")) {
+	if (btName.startsWith("G2")  || btName.startsWith("Aladin") || btName.startsWith("HUD")) {
 		vendor = "Scubapro";
 		if (btName.startsWith("G2")) product = "G2";
+		if (btName.startsWith("HUD")) product = "G2 HUD";
 		if (btName.startsWith("Aladin")) product = "Aladin Sport Matrix";
 	}
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This is a small patch that adds bluetooth discovery of the new Scubapro G2 HUD computer.  Unfortunately the device name is simply 'HUD' with no other references to G2 or Scubapro.

### Changes made:
1) Simply look for the 'HUD' tag in bluetooth discovery and mark it as a possible 'G2 HUD'  product from vendor 'Scubapro'.
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
Adding a new dive computer seems worthy of an entry in the changelog.

<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
Would need to add G2 HUD to the list of supported bluetooth dive computers 
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@torvalds 
