### PR TITLE
Import dive sites from XML into dive site table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Add import dive site menu option and site selection dialog
 - Core: fix bug in get_distance() to correctly compute spherical distance
 - Desktop: For videos, add save data export as subtitle file
 - Desktop: make dive sites 1st class citizens with their own dive site table

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1292,7 +1292,7 @@ void clear_table(struct dive_table *table)
 	table->nr = 0;
 }
 
-static void clear_trip_table(struct trip_table *table)
+void clear_trip_table(struct trip_table *table)
 {
 	for (int i = 0; i < table->nr; i++)
 		free_trip(table->trips[i]);

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -69,6 +69,7 @@ void report_datafile_version(int version);
 int get_dive_id_closest_to(timestamp_t when);
 void clear_dive_file_data();
 void clear_table(struct dive_table *table);
+void clear_trip_table(struct trip_table *table);
 
 typedef enum {PO2VAL, SINGLE_EXP, SINGLE_SLOPE, DAILY_EXP, DAILY_SLOPE, NO_COLUMNS} cns_table_headers;
 

--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -22,6 +22,7 @@ set (SUBSURFACE_UI
 	divecomputermanagementdialog.ui
 	divelogexportdialog.ui
 	divelogimportdialog.ui
+	divesiteimportdialog.ui
 	diveplanner.ui
 	diveshareexportdialog.ui
 	downloadfromdivecomputer.ui
@@ -87,6 +88,8 @@ set(SUBSURFACE_INTERFACE
 	diveplanner.h
 	diveshareexportdialog.cpp
 	diveshareexportdialog.h
+	divesiteimportdialog.cpp
+	divesiteimportdialog.h
 	downloadfromdivecomputer.cpp
 	downloadfromdivecomputer.h
 	filterwidget2.cpp

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -120,6 +120,11 @@ void addDiveSite(const QString &name)
 	execute(new AddDiveSite(name));
 }
 
+void importDiveSites(struct dive_site_table *sites, const QString &source)
+{
+	execute(new ImportDiveSites(sites, source));
+}
+
 void mergeDiveSites(dive_site *ds, const QVector<dive_site *> &sites)
 {
 	execute(new MergeDiveSites(ds, sites));

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -48,6 +48,7 @@ void editDiveSiteCountry(dive_site *ds, const QString &value);
 void editDiveSiteLocation(dive_site *ds, location_t value);
 void editDiveSiteTaxonomy(dive_site *ds, taxonomy_data &value); // value is consumed (i.e. will be erased after call)!
 void addDiveSite(const QString &name);
+void importDiveSites(struct dive_site_table *sites, const QString &source);
 void mergeDiveSites(dive_site *ds, const QVector<dive_site *> &sites);
 void purgeUnusedDiveSites();
 

--- a/desktop-widgets/command_divesite.h
+++ b/desktop-widgets/command_divesite.h
@@ -21,10 +21,26 @@ private:
 
 	// Note: we only add one dive site. Nevertheless, we use vectors so that we
 	// can reuse the dive site deletion code.
-	// For redo
+	// For undo
 	std::vector<dive_site *> sitesToRemove;
 
+	// For redo
+	std::vector<OwningDiveSitePtr> sitesToAdd;
+};
+
+class ImportDiveSites : public Base {
+public:
+	// Note: the dive site table is consumed after the call it will be empty.
+	ImportDiveSites(struct dive_site_table *sites, const QString &source);
+private:
+	bool workToBeDone() override;
+	void undo() override;
+	void redo() override;
+
 	// For undo
+	std::vector<dive_site *> sitesToRemove;
+
+	// For redo
 	std::vector<OwningDiveSitePtr> sitesToAdd;
 };
 

--- a/desktop-widgets/divesiteimportdialog.cpp
+++ b/desktop-widgets/divesiteimportdialog.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "desktop-widgets/divesiteimportdialog.h"
+#include "desktop-widgets/command.h"
+#include "core/display.h"
+#include "core/qthelper.h"
+#include "core/metrics.h"
+#include "core/subsurface-string.h"
+#include "desktop-widgets/mainwindow.h"
+#include "qt-models/divesiteimportmodel.h"
+#include "qt-models/models.h"
+
+#include <QShortcut>
+
+// Caller keeps ownership of "imported". The contents of "imported" will be consumed on execution of the dialog.
+// On return, it will be empty.
+DivesiteImportDialog::DivesiteImportDialog(struct dive_site_table &imported, QString source, QWidget *parent) : QDialog(parent),
+	importedSource(source)
+{
+	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
+	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+
+	divesiteImportedModel = new DivesiteImportedModel(this);
+
+	int startingWidth = defaultModelFont().pointSize();
+
+	ui.setupUi(this);
+	ui.importedDivesitesView->setModel(divesiteImportedModel);
+	ui.importedDivesitesView->setSelectionBehavior(QAbstractItemView::SelectRows);
+	ui.importedDivesitesView->setSelectionMode(QAbstractItemView::SingleSelection);
+	ui.importedDivesitesView->horizontalHeader()->setStretchLastSection(true);
+	ui.importedDivesitesView->verticalHeader()->setVisible(false);
+	ui.importedDivesitesView->setColumnWidth(0, startingWidth * 14);
+	ui.importedDivesitesView->setColumnWidth(1, startingWidth * 12);
+	ui.importedDivesitesView->setColumnWidth(2, startingWidth * 8);
+	ui.importedDivesitesView->setColumnWidth(3, startingWidth * 14);
+	ui.selectAllButton->setEnabled(true);
+	ui.unselectAllButton->setEnabled(true);
+
+	connect(ui.importedDivesitesView, &QTableView::clicked, divesiteImportedModel, &DivesiteImportedModel::changeSelected);
+	connect(ui.selectAllButton, &QPushButton::clicked, divesiteImportedModel, &DivesiteImportedModel::selectAll);
+	connect(ui.unselectAllButton, &QPushButton::clicked, divesiteImportedModel, &DivesiteImportedModel::selectNone);
+	connect(close, SIGNAL(activated()), this, SLOT(close()));
+	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
+
+	ui.ok->setEnabled(true);
+
+	importedSites = imported;
+	imported.nr = imported.allocated = 0;
+	imported.dive_sites = nullptr;
+
+	divesiteImportedModel->repopulate(&importedSites);
+}
+
+DivesiteImportDialog::~DivesiteImportDialog()
+{
+	clear_dive_site_table(&importedSites);
+}
+
+void DivesiteImportDialog::on_cancel_clicked()
+{
+	clear_dive_site_table(&importedSites);
+	done(-1);
+}
+
+void DivesiteImportDialog::on_ok_clicked()
+{
+	// delete non-selected dive sites
+	struct dive_site_table selectedSites = { 0 };
+	for (int i = 0; i < importedSites.nr; i++)
+		if (divesiteImportedModel->data(divesiteImportedModel->index(i, 0), Qt::CheckStateRole) == Qt::Checked) {
+			struct dive_site *newSite = alloc_dive_site();
+			copy_dive_site(importedSites.dive_sites[i], newSite);
+			add_dive_site_to_table(newSite, &selectedSites);
+		}
+
+	Command::importDiveSites(&selectedSites, importedSource);
+	clear_dive_site_table(&selectedSites);
+	clear_dive_site_table(&importedSites);
+	accept();
+}

--- a/desktop-widgets/divesiteimportdialog.h
+++ b/desktop-widgets/divesiteimportdialog.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef DIVESITEIMPORTDIALOG_H
+#define DIVESITEIMPORTDIALOG_H
+
+#include <QDialog>
+#include <QThread>
+#include <QHash>
+#include <QMap>
+#include <QAbstractTableModel>
+#include <memory>
+
+#include "ui_divesiteimportdialog.h"
+#include "core/divesite.h"
+
+namespace Ui {
+	class DivesiteImportDialog;
+}
+
+class DivesiteImportedModel;
+
+class DivesiteImportDialog : public QDialog {
+	Q_OBJECT
+public:
+	DivesiteImportDialog(struct dive_site_table &imported, QString source, QWidget *parent = 0 );
+	~DivesiteImportDialog();
+
+public
+slots:
+	void on_ok_clicked();
+	void on_cancel_clicked();
+
+private:
+	Ui::DivesiteImportDialog ui;
+	struct dive_site_table importedSites;
+	QString importedSource;
+
+	DivesiteImportedModel *divesiteImportedModel;
+};
+
+#endif // DIVESITEIMPORTDIALOG_H

--- a/desktop-widgets/divesiteimportdialog.ui
+++ b/desktop-widgets/divesiteimportdialog.ui
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DivesiteImportDialog</class>
+ <widget class="QDialog" name="DivesiteImportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>747</width>
+    <height>535</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select dive sites to import</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:subsurface-icon</normalon>
+   </iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="labelSelectAllNoneLayout">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="selectAllButton">
+       <property name="text">
+        <string>Select all</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+        <widget class="QPushButton" name="unselectAllButton">
+         <property name="text">
+          <string>Unselect all</string>
+         </property>
+        </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableView" name="importedDivesitesView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonBoxLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ok">
+       <property name="text">
+        <string>OK</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -139,6 +139,7 @@ slots:
 	void initialUiSetup();
 
 	void on_actionImportDiveLog_triggered();
+	void on_actionImportDiveSites_triggered();
 
 	/* TODO: Move those slots below to it's own class */
 	void on_actionExport_triggered();
@@ -192,6 +193,7 @@ private:
 	CurrentState stateBeforeEdit;
 	QString filter_open();
 	QString filter_import();
+	QString filter_import_dive_sites();
 	static MainWindow *m_Instance;
 	QString displayedFilename(QString fullFilename);
 	bool askSaveChanges();

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -130,6 +130,7 @@
     </property>
     <addaction name="actionDownloadDC"/>
     <addaction name="actionImportDiveLog"/>
+    <addaction name="actionImportDiveSites"/>
     <addaction name="actionDivelogs_de"/>
    </widget>
    <widget class="QMenu" name="menu_Edit">
@@ -379,6 +380,17 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+I</string>
+   </property>
+  </action>
+  <action name="actionImportDiveSites">
+   <property name="text">
+    <string>&amp;Import dive sites</string>
+   </property>
+   <property name="toolTip">
+    <string>Import dive sites from other users</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+J</string>
    </property>
   </action>
   <action name="actionDivelogs_de">

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
 	divepicturemodel.h
 	diveplannermodel.cpp
 	diveplannermodel.h
+	divesiteimportmodel.cpp
+	divesiteimportmodel.h
 	divetripmodel.cpp
 	divetripmodel.h
 	filtermodels.cpp

--- a/qt-models/divesiteimportmodel.cpp
+++ b/qt-models/divesiteimportmodel.cpp
@@ -1,0 +1,142 @@
+#include "divesiteimportmodel.h"
+#include "core/qthelper.h"
+#include "core/taxonomy.h"
+
+DivesiteImportedModel::DivesiteImportedModel(QObject *o) : QAbstractTableModel(o),
+	firstIndex(0),
+	lastIndex(-1),
+	importedSitesTable(nullptr)
+{
+}
+
+int DivesiteImportedModel::columnCount(const QModelIndex &) const
+{
+	return 5;
+}
+
+int DivesiteImportedModel::rowCount(const QModelIndex &) const
+{
+	return lastIndex - firstIndex + 1;
+}
+
+QVariant DivesiteImportedModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	if (orientation == Qt::Vertical)
+		return QVariant();
+
+	if (role == Qt::DisplayRole) {
+		switch (section) {
+		case NAME:
+			return tr("Name");
+		case LOCATION:
+			return tr("Location");
+		case COUNTRY:
+			return tr("Country");
+		case NEAREST:
+			return tr("Nearest\nExisting Site");
+		case DISTANCE:
+			return tr("Distance");
+		}
+	}
+	return QVariant();
+}
+
+QVariant DivesiteImportedModel::data(const QModelIndex &index, int role) const
+{
+	if (!index.isValid())
+		return QVariant();
+
+	if (index.row() + firstIndex > lastIndex)
+		return QVariant();
+
+	struct dive_site *ds = get_dive_site(index.row() + firstIndex, importedSitesTable);
+	if (!ds)
+		return QVariant();
+
+	// widgets access the model via index.column()
+	// Not supporting QML access via roles
+	if (role == Qt::DisplayRole) {
+		switch (index.column()) {
+		case NAME:
+			return ds->name;
+		case LOCATION:
+			return printGPSCoords(&ds->location);
+		case COUNTRY:
+			return taxonomy_get_country(&ds->taxonomy);
+		case NEAREST: {
+			// 40075000 is circumference of the earth in meters
+			struct dive_site *nearest_ds =
+				get_dive_site_by_gps_proximity(&ds->location,
+				40075000, &dive_site_table);
+			if (nearest_ds)
+				return nearest_ds->name;
+			else
+				return QString();
+		}
+		case DISTANCE: {
+			unsigned int distance = 0;
+			struct dive_site *nearest_ds =
+				get_dive_site_by_gps_proximity(&ds->location,
+				40075000, &dive_site_table);
+			if (nearest_ds)
+				distance = get_distance(&ds->location,
+					&nearest_ds->location);
+			return distance_string(distance);
+		}
+		case SELECTED:
+			return checkStates[index.row()];
+		}
+	}
+	if (role == Qt::CheckStateRole) {
+		if (index.column() == 0)
+			return checkStates[index.row()] ? Qt::Checked : Qt::Unchecked;
+	}
+	return QVariant();
+}
+
+void DivesiteImportedModel::changeSelected(QModelIndex clickedIndex)
+{
+	checkStates[clickedIndex.row()] = !checkStates[clickedIndex.row()];
+	dataChanged(index(clickedIndex.row(), 0), index(clickedIndex.row(), 0), QVector<int>() << Qt::CheckStateRole << SELECTED);
+}
+
+void DivesiteImportedModel::selectAll()
+{
+	std::fill(checkStates.begin(), checkStates.end(), true);
+	dataChanged(index(0, 0), index(lastIndex - firstIndex, 0), QVector<int>() << Qt::CheckStateRole << SELECTED);
+}
+
+void DivesiteImportedModel::selectRow(int row)
+{
+	checkStates[row] = !checkStates[row];
+	dataChanged(index(row, 0), index(row, 0), QVector<int>() << Qt::CheckStateRole << SELECTED);
+}
+
+void DivesiteImportedModel::selectNone()
+{
+	std::fill(checkStates.begin(), checkStates.end(), false);
+	dataChanged(index(0, 0), index(lastIndex - firstIndex,0 ), QVector<int>() << Qt::CheckStateRole << SELECTED);
+}
+
+Qt::ItemFlags DivesiteImportedModel::flags(const QModelIndex &index) const
+{
+	if (index.column() != 0)
+		return QAbstractTableModel::flags(index);
+	return QAbstractTableModel::flags(index) | Qt::ItemIsUserCheckable;
+}
+
+void DivesiteImportedModel::repopulate(struct dive_site_table *sites)
+{
+	beginResetModel();
+
+	importedSitesTable = sites;
+	firstIndex = 0;
+	lastIndex = importedSitesTable->nr - 1;
+	checkStates.resize(importedSitesTable->nr);
+	for (int row = 0; row < importedSitesTable->nr; row++)
+		if (get_dive_site_by_gps(&importedSitesTable->dive_sites[row]->location, &dive_site_table))
+			checkStates[row] = false;
+		else
+			checkStates[row] = true;
+	endResetModel();
+}

--- a/qt-models/divesiteimportmodel.h
+++ b/qt-models/divesiteimportmodel.h
@@ -1,0 +1,35 @@
+#ifndef DIVESITEIMPORTEDMODEL_H
+#define DIVESITEIMPORTEDMODEL_H
+
+#include <QAbstractTableModel>
+#include <vector>
+#include "core/divesite.h"
+
+class DivesiteImportedModel : public QAbstractTableModel
+{
+	Q_OBJECT
+public:
+	enum columnNames { NAME, LOCATION, COUNTRY, NEAREST, DISTANCE, SELECTED };
+
+	DivesiteImportedModel(QObject *parent = 0);
+	int columnCount(const QModelIndex& index = QModelIndex()) const;
+	int rowCount(const QModelIndex& index = QModelIndex()) const;
+	QVariant data(const QModelIndex& index, int role) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+	void repopulate(dive_site_table_t *sites);
+public
+slots:
+	void changeSelected(QModelIndex clickedIndex);
+	void selectRow(int row);
+	void selectAll();
+	void selectNone();
+
+private:
+	int firstIndex;
+	int lastIndex;
+	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
+	struct dive_site_table *importedSitesTable;
+};
+
+#endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Adds feature to import dive sites from an XML file (or multiple files) into the dive site table for a user. A dialog box is provided to allow the user to select which dive sites to import with sites that are in the same location as existing sites automatically deselected. The nearest existing site and distance to that site are shown in the dialog.
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Menu option for "Import dive sites" is added under the Import menu
2) Files are parsed to add imported sites to a dive site table
2) File selection window appears to selected the XML files to import sites from
3) Dialog box is added to select the sites to import.
4) Selected sites are added to the core dive_site_table with undo/redo commands

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
CHANGELOG.md has been updated.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 