### PR TITLE
Make air pressure value in Information tab editable

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -456,7 +456,7 @@ double get_weight_units(unsigned int grams, int *frac, const char **units)
 int32_t altitude_to_pressure(int altitude) 		// altitude in meters above sea level
 {						// function returns atmospheric pressure in mbar
 	int i, alt;
-	int pressval[21] = { 1013, 984, 955, 926, 899, 872, 846, 820, 795, 771, 747, 724, 701, 679, 658, 637, 616, 597, 577, 559, 540 };
+	static const int pressval[21] = { 1013, 984, 955, 926, 899, 872, 846, 820, 795, 771, 747, 724, 701, 679, 658, 637, 616, 597, 577, 559, 540 };
 	// Calculated atmospheric pressure values at 250m increments in altitude from sea level to 4999m,
 	// calculated following the US Standard Atmosphere 1976, US Government Printing Office, Washington DC, 1976.
 	// For intermediate altitudes, linear interpolation is performed here.
@@ -1331,7 +1331,7 @@ static struct event *find_previous_event(struct divecomputer *dc, struct event *
 	return previous;
 }
 
-static void fixup_surface_pressure(struct dive *dive)
+void fixup_surface_pressure(struct dive *dive)
 {
 	struct divecomputer *dc;
 	int sum = 0, nr = 0;

--- a/core/dive.c
+++ b/core/dive.c
@@ -453,6 +453,20 @@ double get_weight_units(unsigned int grams, int *frac, const char **units)
 	return value;
 }
 
+int32_t altitude_to_pressure(int altitude) 		// altitude in meters above sea level
+{						// function returns atmospheric pressure in mbar
+	int i, alt;
+	int pressval[21] = { 1013, 984, 955, 926, 899, 872, 846, 820, 795, 771, 747, 724, 701, 679, 658, 637, 616, 597, 577, 559, 540 };
+	// Calculated atmospheric pressure values at 250m increments in altitude from sea level to 4999m,
+	// calculated following the US Standard Atmosphere 1976, US Government Printing Office, Washington DC, 1976.
+	// For intermediate altitudes, linear interpolation is performed here.
+	alt = altitude;
+	if (altitude < 0) alt = 0;
+	if (altitude > 4999) alt = 4999;
+	i = alt/250;
+	return (int32_t)(pressval[i] - ((double)(alt - 250 * i)/250.0)  *  (pressval[i] - pressval[i + 1]));
+}
+
 // we need this to be uniq. oh, and it has no meaning whatsoever
 // - that's why we have the silly initial number and increment by 3 :-)
 int dive_getUniqID()

--- a/core/dive.h
+++ b/core/dive.h
@@ -390,6 +390,7 @@ extern int depth_to_mbar(int depth, const struct dive *dive);
 extern double depth_to_bar(int depth, const struct dive *dive);
 extern double depth_to_atm(int depth, const struct dive *dive);
 extern int rel_mbar_to_depth(int mbar, const struct dive *dive);
+extern int altitude_to_pressure(int altitude);
 extern int mbar_to_depth(int mbar, const struct dive *dive);
 extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct dive *dive, int roundto);
 extern depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto);

--- a/core/dive.h
+++ b/core/dive.h
@@ -389,8 +389,7 @@ extern int calculate_depth_to_mbar(int depth, pressure_t surface_pressure, int s
 extern int depth_to_mbar(int depth, const struct dive *dive);
 extern double depth_to_bar(int depth, const struct dive *dive);
 extern double depth_to_atm(int depth, const struct dive *dive);
-extern int rel_mbar_to_depth(int mbar, const struct dive *dive);
-extern int altitude_to_pressure(int altitude);
+extern int32_t altitude_to_pressure(int altitude);
 extern int mbar_to_depth(int mbar, const struct dive *dive);
 extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct dive *dive, int roundto);
 extern depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto);
@@ -537,6 +536,7 @@ extern void sort_dive_table(struct dive_table *table);
 extern void sort_trip_table(struct trip_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);
+extern void fixup_surface_pressure(struct dive *dive);
 extern int dive_getUniqID();
 extern unsigned int dc_airtemp(const struct divecomputer *dc);
 extern unsigned int dc_watertemp(const struct divecomputer *dc);

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -19,6 +19,7 @@ enum class DiveField {
 	DURATION,
 	AIR_TEMP,
 	WATER_TEMP,
+	ATM_PRESS,
 	DIVESITE,
 	DIVEMASTER,
 	BUDDY,

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -166,6 +166,11 @@ void editWaterTemp(int newValue, bool currentDiveOnly)
 	execute(new EditWaterTemp(newValue, currentDiveOnly));
 }
 
+void editAtmPress(int newValue, bool currentDiveOnly)
+{
+	execute(new EditAtmPress(newValue, currentDiveOnly));
+}
+
 void editDepth(int newValue, bool currentDiveOnly)
 {
 	execute(new EditDepth(newValue, currentDiveOnly));

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -60,6 +60,7 @@ void editRating(int newValue, bool currentDiveOnly);
 void editVisibility(int newValue, bool currentDiveOnly);
 void editAirTemp(int newValue, bool currentDiveOnly);
 void editWaterTemp(int newValue, bool currentDiveOnly);
+void editAtmPress(int newValue, bool currentDiveOnly);
 void editDepth(int newValue, bool currentDiveOnly);
 void editDuration(int newValue, bool currentDiveOnly);
 void editDiveSite(struct dive_site *newValue, bool currentDiveOnly);

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -248,6 +248,27 @@ DiveField EditWaterTemp::fieldId() const
 	return DiveField::WATER_TEMP;
 }
 
+// ***** Atmospheric pressure *****
+void EditAtmPress::set(struct dive *d, int value) const
+{
+	d->surface_pressure.mbar = value > 0 ? (uint32_t)value : 0u;
+}
+
+int EditAtmPress::data(struct dive *d) const
+{
+	return (int)d->surface_pressure.mbar;
+}
+
+QString EditAtmPress::fieldName() const
+{
+	return tr("Atm. pressure");
+}
+
+DiveField EditAtmPress::fieldId() const
+{
+	return DiveField::ATM_PRESS;
+}
+
 // ***** Duration *****
 void EditDuration::set(struct dive *d, int value) const
 {

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -5,6 +5,7 @@
 #include "core/divelist.h"
 #include "core/qthelper.h" // for copy_qstring
 #include "core/subsurface-string.h"
+#include "core/dive.h" // for surface_pressure
 #include "desktop-widgets/mapwidget.h" // TODO: Replace desktop-dependency by signal
 
 namespace Command {
@@ -251,7 +252,9 @@ DiveField EditWaterTemp::fieldId() const
 // ***** Atmospheric pressure *****
 void EditAtmPress::set(struct dive *d, int value) const
 {
-	d->surface_pressure.mbar = value > 0 ? (uint32_t)value : 0u;
+	divecomputer *dc = get_dive_dc(d,dc_number); 
+	dc->surface_pressure.mbar = value > 0 ? (uint32_t)value : 0u;
+	fixup_surface_pressure(d);  // create new dive->surface-pressure
 }
 
 int EditAtmPress::data(struct dive *d) const

--- a/desktop-widgets/command_edit.h
+++ b/desktop-widgets/command_edit.h
@@ -102,6 +102,15 @@ public:
 	DiveField fieldId() const override;
 };
 
+class EditAtmPress : public EditBase<int> {
+public:
+	using EditBase<int>::EditBase;	// Use constructor of base class.
+	void set(struct dive *d, int value) const override;
+	int data(struct dive *d) const override;
+	QString fieldName() const override;
+	DiveField fieldId() const override;
+};
+
 class EditDuration : public EditBase<int> {
 public:
 	using EditBase<int>::EditBase;	// Use constructor of base class.

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -13,9 +13,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 {
 	ui->setupUi(this);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveInformation::divesChanged);
-	QStringList atmPressTypes = QStringList();
-	atmPressTypes.append("mbar");
-	atmPressTypes.append(get_depth_unit());
+	QStringList atmPressTypes { "mbar", get_depth_unit() };
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
 }
@@ -148,10 +146,6 @@ void TabDiveInformation::divesChanged(dive_trip *trip, const QVector<dive *> &di
 		break;
 	case DiveField::ATM_PRESS:
 		ui->atmPressVal->setText(ui->atmPressVal->text().sprintf("%d",current_dive->surface_pressure.mbar));
-
-//get_temperature_string(current_dive->surface_pressure, true));
-//pressStr.sprintf("%d",atmpress);
-
 		break;
 	case DiveField::DATETIME:
 		updateWhen();
@@ -163,21 +157,19 @@ void TabDiveInformation::divesChanged(dive_trip *trip, const QVector<dive *> &di
 
 void TabDiveInformation::on_atmPressVal_editingFinished()
 {
-	int32_t atmpress = 0;
-	QString pressStr;
+	int32_t atmpress;
 	if (current_dive) {
 		if (ui->atmPressType->currentIndex() == 1) {		// If altitude has been specified:
 			atmpress = (int)(0.5 + ui->atmPressVal->text().toFloat());	// get altitude from text box
 			if (prefs.units.length == units::FEET)		// if altitude in feet
 				atmpress = (int)(atmpress / 3.28084); 	// 	convert feet -> meters
 			atmpress = altitude_to_pressure(atmpress);	// convert altitude to pressure
-			pressStr.sprintf("%d",atmpress);
-			ui->atmPressVal->setText(pressStr);		// Write pressure to text box
-			ui->atmPressType->setCurrentIndex(0);		// set combobox to mbar
-		}
-		else
+			ui->atmPressVal->setText(ui->atmPressVal->text().sprintf("%d",atmpress));
+			ui->atmPressType->setCurrentIndex(0);		// reset combobox to mbar
+		} else {
 			atmpress = ui->atmPressVal->text().toInt();	// get pressure that has been specified
-		Command::editAtmPress(atmpress, false);
+		}
+		Command::editAtmPress(atmpress, false);			// and save the pressure
 	}
 }
 

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -18,10 +18,12 @@ public:
 	void clear() override;
 private slots:
 	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
+	void on_atmPressVal_editingFinished();
 private:
 	Ui::TabDiveInformation *ui;
 	void updateProfile();
 	void updateWhen();
+	int pressTypeIndex;
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -224,25 +224,37 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="2">
+
+       <item row="2" column="2" colspan="1">
         <widget class="QGroupBox" name="groupBox_10">
          <property name="title">
-          <string>Air pressure</string>
+          <string>Atm. pressure</string>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
          <layout class="QHBoxLayout" name="diveInfoAirPressureLayout">
           <item>
-           <widget class="QLabel" name="airPressureText">
-            <property name="text">
-             <string/>
+           <widget class="QLineEdit" name="atmPressVal">
+            <property name="readOnly">
+             <bool>false</bool>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="atmPressType">
            </widget>
           </item>
          </layout>
         </widget>
        </item>
+
        <item row="3" column="2">
         <widget class="QGroupBox" name="groupBox_9">
          <property name="title">


### PR DESCRIPTION
The air pressure of a dive is shown in the Information tab.
Make this value editable, including its undo-ability

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @dirkhh 