### PR TITLE
Mobile: add checkbox to force downloading all dives

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -82,6 +82,7 @@ void DownloadThread::run()
 		internalData->devname = "ftdi";
 #endif
 	qDebug() << "Starting download from " << (internalData->bluetooth_mode ? "BT" : internalData->devname);
+	qDebug() << "downloading" << (internalData->force_download ? "all" : "only new") << "dives";
 	clear_table(&downloadTable);
 	clear_dive_site_table(&diveSiteTable);
 

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -255,7 +255,7 @@ Kirigami.Page {
 		RowLayout {
 			id: buttonBar
 			Layout.fillWidth: true
-			Layout.topMargin: Kirigami.Units.smallSpacing * 2
+			Layout.topMargin: Kirigami.Units.smallSpacing
 			spacing: Kirigami.Units.smallSpacing
 			SsrfButton {
 				id: download
@@ -286,7 +286,9 @@ Kirigami.Page {
 						manager.DC_bluetoothMode = false;
 						manager.DC_devName = connectionString;
 					}
-					manager.appendTextToLog("DCDownloadThread started for " + manager.DC_vendor + " " + manager.DC_product + " on "+ manager.DC_devName)
+					var message = "DCDownloadThread started for " + manager.DC_vendor + " " + manager.DC_product + " on " + manager.DC_devName;
+					message += " downloading " + (manager.DC_forceDownload ? "all" : "only new" ) + " dives";
+					manager.appendTextToLog(message)
 					progressBar.visible = true
 					downloadThread.start()
 				}
@@ -318,6 +320,31 @@ Kirigami.Page {
 				Layout.fillWidth: true
 				text: divesDownloaded ? qsTr(" Downloaded dives") :
 							(manager.progressMessage != "" ? qsTr("Info:") + " " + manager.progressMessage : btMessage)
+				wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+			}
+		}
+
+		RowLayout {
+			id: downloadOptions
+			Layout.fillWidth: true
+			Layout.topMargin: 0
+			spacing: Kirigami.Units.smallSpacing
+			SsrfCheckBox {
+				id: forceAll
+				checked: manager.DC_forceDownload
+				enabled: forceAllLabel.visible
+				visible: enabled
+				height: forceAllLabel.height - Kirigami.Units.smallSpacing;
+				width: height
+				onClicked: {
+					manager.DC_forceDownload = !manager.DC_forceDownload;
+				}
+			}
+			Controls.Label {
+				id: forceAllLabel
+				text: qsTr("force downloading all dives")
+				visible: comboVendor.currentIndex != -1 && comboProduct.currentIndex != -1 &&
+					 comboConnection.currentIndex != -1
 				wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			}
 		}


### PR DESCRIPTION
This has been a feature people have asked for quite frequently. It is
taking up some valuable screen real estate - so the question could
become if there should be a switch to enable / disable it.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Simply expose that flag with a simple UI

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Ah, yeah, should update the CHANGELOG.md file, I guess

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Would be nice to have this in the manual

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
