### PR TITLE
Simplification of application-state code

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -37,6 +37,8 @@ endif()
 
 # compile the core library part in C, part in C++
 set(SUBSURFACE_CORE_LIB_SRCS
+	applicationstate.cpp
+	applicationstate.h
 	checkcloudconnection.cpp
 	checkcloudconnection.h
 	cloudstorage.cpp

--- a/core/applicationstate.cpp
+++ b/core/applicationstate.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "applicationstate.h"
+
+static ApplicationState appState = (ApplicationState)-1; // Set to an invalid value
+
+ApplicationState getAppState()
+{
+	return appState;
+}
+
+void setAppState(ApplicationState state)
+{
+	appState = state;
+}
+

--- a/core/applicationstate.h
+++ b/core/applicationstate.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef APPLICATIONSTATE_H
+#define APPLICATIONSTATE_H
+
+// By using an enum class, the enum entries don't polute the global namespace.
+// Moreover, they are strongly typed. This means that they are not auto-converted
+// to integer types if e.g. used as array-indices.
+enum class ApplicationState {
+	Default,
+	EditDive,
+	PlanDive,
+	EditPlannedDive,
+	EditDiveSite,
+	FilterDive,
+	Count
+};
+
+ApplicationState getAppState();
+void setAppState(ApplicationState state);
+
+#endif

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -12,6 +12,7 @@
 #include "divecomputer.h"
 #include "time.h"
 #include "gettextfromc.h"
+#include "applicationstate.h"
 #include "metadata.h"
 #include <sys/time.h>
 #include "exif.h"
@@ -1362,21 +1363,9 @@ extern "C" void parse_display_units(char *line)
 	qDebug() << line;
 }
 
-static QByteArray currentApplicationState;
-
-QByteArray getCurrentAppState()
-{
-	return currentApplicationState;
-}
-
-void setCurrentAppState(const QByteArray &state)
-{
-	currentApplicationState = state;
-}
-
 extern "C" bool in_planner()
 {
-	return currentApplicationState == "PlanDive" || currentApplicationState == "EditPlannedDive";
+	return getAppState() == ApplicationState::PlanDive || getAppState() == ApplicationState::EditPlannedDive;
 }
 
 extern "C" enum deco_mode decoMode()

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -40,8 +40,6 @@ volume_t string_to_volume(const char *str, pressure_t workp);
 fraction_t string_to_fraction(const char *str);
 int getCloudURL(QString &filename);
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
-QByteArray getCurrentAppState();
-void setCurrentAppState(const QByteArray &state);
 void init_proxy();
 QString getUUID();
 extern const QStringList videoExtensionsList;

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -161,7 +161,7 @@ void FilterWidget2::clearFilter()
 
 void FilterWidget2::closeFilter()
 {
-	MainWindow::instance()->setApplicationState("Default");
+	MainWindow::instance()->setApplicationState(ApplicationState::Default);
 }
 
 void FilterWidget2::temperatureChanged()

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -181,7 +181,7 @@ void LocationInformationWidget::acceptChanges()
 {
 	MainWindow::instance()->diveList->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
-	MainWindow::instance()->setApplicationState("Default");
+	MainWindow::instance()->setApplicationState(ApplicationState::Default);
 	MapWidget::instance()->repopulateLabels();
 	MultiFilterSortModel::instance()->stopFilterDiveSites();
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -178,20 +178,20 @@ MainWindow::MainWindow() : QMainWindow(),
 	enabledList.push_back(enabled);
 	disabledList.push_back(disabled);
 
-	registerApplicationState("Default", mainTab.get(), profileContainer, diveList, mapWidget );
-	registerApplicationState("EditDive", mainTab.get(), profileContainer, diveList, mapWidget );
-	registerApplicationState("PlanDive", divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
-	registerApplicationState("EditPlannedDive", divePlannerWidget, profileContainer, diveList, mapWidget );
-	registerApplicationState("EditDiveSite", diveSiteEdit, profileContainer, diveList, mapWidget);
-	registerApplicationState("FilterDive", mainTab.get(), profileContainer, diveList, &filterWidget2);
+	registerApplicationState(ApplicationState::Default, mainTab.get(), profileContainer, diveList, mapWidget );
+	registerApplicationState(ApplicationState::EditDive, mainTab.get(), profileContainer, diveList, mapWidget );
+	registerApplicationState(ApplicationState::PlanDive, divePlannerWidget, profileContainer, divePlannerSettingsWidget, plannerDetails );
+	registerApplicationState(ApplicationState::EditPlannedDive, divePlannerWidget, profileContainer, diveList, mapWidget );
+	registerApplicationState(ApplicationState::EditDiveSite, diveSiteEdit, profileContainer, diveList, mapWidget);
+	registerApplicationState(ApplicationState::FilterDive, mainTab.get(), profileContainer, diveList, &filterWidget2);
 
-	setStateProperties("Default", enabledList, enabledList, enabledList, enabledList);
-	setStateProperties("EditDive", enabledList, enabledList, enabledList, enabledList);
-	setStateProperties("PlanDive", enabledList, enabledList, enabledList, enabledList);
-	setStateProperties("EditPlannedDive", enabledList, enabledList, enabledList, enabledList);
-	setStateProperties("EditDiveSite", enabledList, disabledList, disabledList, enabledList);
-	setStateProperties("FilterDive", enabledList, enabledList, enabledList, enabledList);
-	setApplicationState("Default");
+	setStateProperties(ApplicationState::Default, enabledList, enabledList, enabledList, enabledList);
+	setStateProperties(ApplicationState::EditDive, enabledList, enabledList, enabledList, enabledList);
+	setStateProperties(ApplicationState::PlanDive, enabledList, enabledList, enabledList, enabledList);
+	setStateProperties(ApplicationState::EditPlannedDive, enabledList, enabledList, enabledList, enabledList);
+	setStateProperties(ApplicationState::EditDiveSite, enabledList, disabledList, disabledList, enabledList);
+	setStateProperties(ApplicationState::FilterDive, enabledList, enabledList, enabledList, enabledList);
+	setApplicationState(ApplicationState::Default);
 
 	setWindowIcon(QIcon(":subsurface-icon"));
 	if (!QIcon::hasThemeIcon("window-close")) {
@@ -369,9 +369,9 @@ void MainWindow::setupSocialNetworkMenu()
 {
 }
 
-void MainWindow::setStateProperties(const QByteArray& state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl, const PropertyList& br)
+void MainWindow::setStateProperties(ApplicationState state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl, const PropertyList& br)
 {
-	stateProperties[state] = PropertiesForQuadrant(tl, tr, bl, br);
+	stateProperties[(int)state] = PropertiesForQuadrant(tl, tr, bl, br);
 }
 
 void MainWindow::editDiveSite(dive_site *ds)
@@ -379,7 +379,7 @@ void MainWindow::editDiveSite(dive_site *ds)
 	if (!ds)
 		return;
 	diveSiteEdit->initFields(ds);
-	setApplicationState("EditDiveSite");
+	setApplicationState(ApplicationState::EditDiveSite);
 }
 
 void MainWindow::startDiveSiteEdit()
@@ -403,7 +403,7 @@ void MainWindow::enableDisableOtherDCsActions()
 
 void MainWindow::setDefaultState()
 {
-	setApplicationState("Default");
+	setApplicationState(ApplicationState::Default);
 	if (mainTab->isEditing())
 		ui.bottomLeft->currentWidget()->setEnabled(false);
 }
@@ -422,7 +422,7 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 	if (doRecreateDiveList)
 		recreateDiveList();
 
-	setApplicationState("Default");
+	setApplicationState(ApplicationState::Default);
 	diveList->setEnabled(true);
 	diveList->setFocus();
 	WSInfoModel::instance()->update();
@@ -713,7 +713,7 @@ void MainWindow::on_actionClose_triggered()
 	if (okToClose(tr("Please save or cancel the current dive edit before closing the file."))) {
 		closeCurrentFile();
 		DivePictureModel::instance()->updateDivePictures();
-		setApplicationState("Default");
+		setApplicationState(ApplicationState::Default);
 		recreateDiveList();
 	}
 }
@@ -753,7 +753,7 @@ void MainWindow::showProfile()
 {
 	enableShortcuts();
 	graphics->setProfileState();
-	setApplicationState("Default");
+	setApplicationState(ApplicationState::Default);
 }
 
 void MainWindow::on_actionPreferences_triggered()
@@ -839,7 +839,7 @@ void MainWindow::planCreated()
 {
 	// make sure our UI is in a consistent state
 	showProfile();
-	setApplicationState("Default");
+	setApplicationState(ApplicationState::Default);
 	diveList->setEnabled(true);
 	diveList->setFocus();
 }
@@ -931,7 +931,7 @@ void MainWindow::on_actionReplanDive_triggered()
 
 	graphics->setPlanState();
 	graphics->clearHandlers();
-	setApplicationState("PlanDive");
+	setApplicationState(ApplicationState::PlanDive);
 	divePlannerWidget->setReplanButton(true);
 	divePlannerWidget->setupStartTime(QDateTime::fromMSecsSinceEpoch(1000 * current_dive->when, Qt::UTC));
 	if (current_dive->surface_pressure.mbar)
@@ -950,7 +950,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 
 	// put us in PLAN mode
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-	setApplicationState("PlanDive");
+	setApplicationState(ApplicationState::PlanDive);
 
 	graphics->setPlanState();
 
@@ -1808,16 +1808,16 @@ void MainWindow::editCurrentDive()
 	if (defaultDC == "manually added dive") {
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
 		graphics->setAddState();
-		setApplicationState("EditDive");
+		setApplicationState(ApplicationState::EditDive);
 		DivePlannerPointsModel::instance()->loadFromDive(d);
 		mainTab->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else if (defaultDC == "planned dive") {
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-		setApplicationState("EditPlannedDive");
+		setApplicationState(ApplicationState::EditPlannedDive);
 		DivePlannerPointsModel::instance()->loadFromDive(d);
 		mainTab->enableEdition(MainTab::MANUALLY_ADDED_DIVE);
 	} else {
-		setApplicationState("EditDive");
+		setApplicationState(ApplicationState::EditDive);
 		mainTab->enableEdition();
 	}
 }
@@ -1863,14 +1863,14 @@ void MainWindow::on_paste_triggered()
 
 void MainWindow::on_actionFilterTags_triggered()
 {
-	setApplicationState(getCurrentAppState() == "FilterDive" ? "Default" : "FilterDive");
+	setApplicationState(getAppState() == ApplicationState::FilterDive ? ApplicationState::Default : ApplicationState::FilterDive);
 	if (state == LIST_MAXIMIZED)
 		showFilterIfEnabled();
 }
 
 void MainWindow::showFilterIfEnabled()
 {
-	if (getCurrentAppState() == "FilterDive") {
+	if (getAppState() == ApplicationState::FilterDive) {
 		const int appW = qApp->desktop()->size().width();
 		QList<int> profileFilterSizes = { round_int(appW * 0.7), round_int(appW * 0.3) };
 		ui.bottomSplitter->setSizes(profileFilterSizes);
@@ -1878,9 +1878,9 @@ void MainWindow::showFilterIfEnabled()
 		ui.bottomSplitter->setSizes({ EXPANDED, COLLAPSED });
 	}
 }
-void MainWindow::registerApplicationState(const QByteArray& state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight)
+void MainWindow::registerApplicationState(ApplicationState state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight)
 {
-	applicationState[state] = WidgetForQuadrant(topLeft, topRight, bottomLeft, bottomRight);
+	applicationState[(int)state] = WidgetForQuadrant(topLeft, topRight, bottomLeft, bottomRight);
 	if (ui.topLeft->indexOf(topLeft) == -1 && topLeft) {
 		ui.topLeft->addWidget(topLeft);
 	}
@@ -1895,38 +1895,35 @@ void MainWindow::registerApplicationState(const QByteArray& state, QWidget *topL
 	}
 }
 
-void MainWindow::setApplicationState(const QByteArray &state)
+void MainWindow::setApplicationState(ApplicationState state)
 {
-	if (!applicationState.keys().contains(state))
+	if (getAppState() == state)
 		return;
 
-	if (getCurrentAppState() == state)
-		return;
-
-	setCurrentAppState(state);
+	setAppState(state);
 
 #define SET_CURRENT_INDEX( X ) \
-	if (applicationState[state].X) { \
-		ui.X->setCurrentWidget( applicationState[state].X); \
+	if (applicationState[(int)state].X) { \
+		ui.X->setCurrentWidget( applicationState[(int)state].X); \
 		ui.X->show(); \
 	} else { \
 		ui.X->hide(); \
 	}
 
 	SET_CURRENT_INDEX( topLeft )
-	Q_FOREACH(const WidgetProperty& p, stateProperties[state].topLeft) {
+	Q_FOREACH(const WidgetProperty& p, stateProperties[(int)state].topLeft) {
 		ui.topLeft->currentWidget()->setProperty( p.first.data(), p.second);
 	}
 	SET_CURRENT_INDEX( topRight )
-	Q_FOREACH(const WidgetProperty& p, stateProperties[state].topRight) {
+	Q_FOREACH(const WidgetProperty& p, stateProperties[(int)state].topRight) {
 		ui.topRight->currentWidget()->setProperty( p.first.data(), p.second);
 	}
 	SET_CURRENT_INDEX( bottomLeft )
-	Q_FOREACH(const WidgetProperty& p, stateProperties[state].bottomLeft) {
+	Q_FOREACH(const WidgetProperty& p, stateProperties[(int)state].bottomLeft) {
 		ui.bottomLeft->currentWidget()->setProperty( p.first.data(), p.second);
 	}
 	SET_CURRENT_INDEX( bottomRight )
-	Q_FOREACH(const WidgetProperty& p, stateProperties[state].bottomRight) {
+	Q_FOREACH(const WidgetProperty& p, stateProperties[(int)state].bottomRight) {
 		ui.bottomRight->currentWidget()->setProperty( p.first.data(), p.second);
 	}
 #undef SET_CURRENT_INDEX

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -19,6 +19,7 @@
 #include "ui_plannerDetails.h"
 #include "desktop-widgets/notificationwidget.h"
 #include "desktop-widgets/filterwidget2.h"
+#include "core/applicationstate.h"
 #include "core/gpslocation.h"
 #include "core/dive.h"
 
@@ -56,7 +57,7 @@ public:
 		INFO_MAXIMIZED,
 		PROFILE_MAXIMIZED,
 		LIST_MAXIMIZED,
-		EDIT
+		EDIT,
 	};
 
 	MainWindow();
@@ -75,8 +76,8 @@ public:
 	void setToolButtonsEnabled(bool enabled);
 	void printPlan();
 	void checkSurvey();
-	void setApplicationState(const QByteArray& state);
-	void setStateProperties(const QByteArray& state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl,const PropertyList& br);
+	void setApplicationState(ApplicationState state);
+	void setStateProperties(ApplicationState state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl,const PropertyList& br);
 	bool inPlanner();
 	NotificationWidget *getNotificationWidget();
 	void enableDisableCloudActions();
@@ -212,7 +213,7 @@ private:
 	void toggleCollapsible(bool toggle);
 	void showFilterIfEnabled();
 	void updateLastUsedDir(const QString &s);
-	void registerApplicationState(const QByteArray& state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight);
+	void registerApplicationState(ApplicationState state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight);
 	void enterState(CurrentState);
 	bool filesAsArguments;
 	UpdateManager *updateManager;
@@ -249,8 +250,8 @@ private:
 		PropertyList bottomRight;
 	};
 
-	QHash<QByteArray, WidgetForQuadrant> applicationState;
-	QHash<QByteArray, PropertiesForQuadrant> stateProperties;
+	WidgetForQuadrant applicationState[(size_t)ApplicationState::Count];
+	PropertiesForQuadrant stateProperties[(size_t)ApplicationState::Count];
 
 	GpsLocation *locationProvider;
 	QMenu *connections;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -77,7 +77,6 @@ public:
 	void printPlan();
 	void checkSurvey();
 	void setApplicationState(ApplicationState state);
-	void setStateProperties(ApplicationState state, const PropertyList& tl, const PropertyList& tr, const PropertyList& bl,const PropertyList& br);
 	bool inPlanner();
 	NotificationWidget *getNotificationWidget();
 	void enableDisableCloudActions();
@@ -213,7 +212,6 @@ private:
 	void toggleCollapsible(bool toggle);
 	void showFilterIfEnabled();
 	void updateLastUsedDir(const QString &s);
-	void registerApplicationState(ApplicationState state, QWidget *topLeft, QWidget *topRight, QWidget *bottomLeft, QWidget *bottomRight);
 	void enterState(CurrentState);
 	bool filesAsArguments;
 	UpdateManager *updateManager;
@@ -231,27 +229,27 @@ private:
 	QStringList recentFiles;
 	QAction *actionsRecent[NUM_RECENT_FILES];
 
-	struct WidgetForQuadrant {
-		WidgetForQuadrant(QWidget *tl = 0, QWidget *tr = 0, QWidget *bl = 0, QWidget *br = 0) :
-			topLeft(tl), topRight(tr), bottomLeft(bl), bottomRight(br) {}
-		QWidget *topLeft;
-		QWidget *topRight;
-		QWidget *bottomLeft;
-		QWidget *bottomRight;
+	enum {
+		FLAG_NONE = 0,
+		FLAG_DISABLED = 1
 	};
 
-	struct PropertiesForQuadrant {
-		PropertiesForQuadrant(){}
-		PropertiesForQuadrant(const PropertyList& tl, const PropertyList& tr,const PropertyList& bl,const PropertyList& br) :
-			topLeft(tl), topRight(tr), bottomLeft(bl), bottomRight(br) {}
-		PropertyList topLeft;
-		PropertyList topRight;
-		PropertyList bottomLeft;
-		PropertyList bottomRight;
+	struct Quadrant {
+		QWidget *widget;
+		int flags;
 	};
 
-	WidgetForQuadrant applicationState[(size_t)ApplicationState::Count];
-	PropertiesForQuadrant stateProperties[(size_t)ApplicationState::Count];
+	struct Quadrants {
+		Quadrant topLeft;
+		Quadrant topRight;
+		Quadrant bottomLeft;
+		Quadrant bottomRight;
+	};
+
+	Quadrants applicationState[(size_t)ApplicationState::Count];
+	static void setQuadrant(const Quadrant &, QStackedWidget *);
+	static void addWidgets(const Quadrant &, QStackedWidget *);
+	void registerApplicationState(ApplicationState state, Quadrants q);
 
 	GpsLocation *locationProvider;
 	QMenu *connections;

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -18,6 +18,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/qtserialbluetooth.cpp \
 	../../core/plannernotes.c \
 	../../core/uemis-downloader.c \
+	../../core/applicationstate.cpp \
 	../../core/qthelper.cpp \
 	../../core/checkcloudconnection.cpp \
 	../../core/color.cpp \

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -5,6 +5,7 @@
 #include "core/qthelper.h"
 #include "core/subsurfacestartup.h"
 #include "core/units.h"
+#include "core/applicationstate.h"
 #include <QDebug>
 
 #define DEBUG 1
@@ -469,7 +470,7 @@ void TestPlan::testVpmbMetric45m30minTx()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb45m30mTx(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -500,7 +501,7 @@ void TestPlan::testVpmbMetric60m10minTx()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m10mTx(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -531,7 +532,7 @@ void TestPlan::testVpmbMetric60m30minAir()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minAir(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -562,7 +563,7 @@ void TestPlan::testVpmbMetric60m30minEan50()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minEan50(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -599,7 +600,7 @@ void TestPlan::testVpmbMetric60m30minTx()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minTx(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -636,7 +637,7 @@ void TestPlan::testVpmbMetric100m60min()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m60min(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -680,7 +681,7 @@ void TestPlan::testMultipleGases()
 	struct diveplan testPlan = {};
 
 	setupPlanSeveralGases(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -706,7 +707,7 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmbMultiLevelAir(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -737,7 +738,7 @@ void TestPlan::testVpmbMetric100m10min()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m10min(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 
@@ -784,7 +785,7 @@ void TestPlan::testVpmbMetricRepeat()
 
 	struct diveplan testPlan = {};
 	setupPlanVpmb30m20min(&testPlan);
-	setCurrentAppState("PlanDive");
+	setAppState(ApplicationState::PlanDive);
 
 	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This tries to make the app-state thing a bit more explicit and less dynamic.

The backstory: It's three times that I had to figure our how the widgets are disabled in dive-site-edit mode. It's clever, but very hard to follow: dynamic property lists in arrays. And since we only use a single property (enabled) over-engineered.

I replaced that by some old-fashioned flags and Boolean expressions. Boring, yes.

Moreover, I replaced the QByteArray index by a simple enum. Thus, typos will be caught at runtime.

The use of an `enum class` construct may be questionable to some, as it means that it has to be cast to int to be used as an array index. We could also use something like:

```
struct ApplicationState {
	enum State {
		...
	};
};
```
The disadvantage here would be that the type of the enum is `ApplicationState::State`. I'm a bit undecided on that point.

Overall, the new code is not very pretty, but at least to me it is more palatable. YMMV.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn application state index from QByteArray to enum.
2) Use boring flags instead of property lists to enable widgets.
3) Use function instead of macro to set the individual quadrants.
