### PR TITLE
Core: consider dive-number on sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Import: Small enhancements on Suunto SDE import
 - Desktop: Add import dive site menu option and site selection dialog
+- Core: Sort dives by number if at the same date
 - Core: fix bug in get_distance() to correctly compute spherical distance
 - Desktop: For videos, add save data export as subtitle file
 - Desktop: make dive sites 1st class citizens with their own dive site table

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -780,7 +780,7 @@ struct dive *last_selected_dive()
  * After editing a key used in this sort-function, the order of
  * the dives must be re-astablished.
  * Currently, this does a lexicographic sort on the
- * (start-time, trip-time, id) tuple.
+ * (start-time, trip-time, number, id) tuple.
  * trip-time is defined such that dives that do not belong to
  * a trip are sorted *after* dives that do. Thus, in the default
  * chronologically-descending sort order, they are shown *before*.
@@ -805,6 +805,10 @@ static int comp_dives(const struct dive *a, const struct dive *b)
 		if (trip_date(a->divetrip) > trip_date(b->divetrip))
 			return 1;
 	}
+	if (a->number < b->number)
+		return -1;
+	if (a->number > b->number)
+		return 1;
 	if (a->id < b->id)
 		return -1;
 	if (a->id > b->id)


### PR DESCRIPTION
A user reports a problem when dives have the same time but different
numbers. The dives appear sorted randomly (effectively they are sorted
by an internal unique-id).

Try to sort by number for dives at the same date in this case.

Fixes #2086

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Sorts dives by number if on same date, as requested by @RasmusAaen.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2086

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@RasmusAaen