### PR TITLE
[RFC] Cleanup: remove UTF8 macros

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -316,10 +316,10 @@ double get_temp_units(unsigned int mk, const char **units)
 
 	if (units_p->temperature == FAHRENHEIT) {
 		deg = mkelvin_to_F(mk);
-		unit = UTF8_DEGREE "F";
+		unit = "°F";
 	} else {
 		deg = mkelvin_to_C(mk);
-		unit = UTF8_DEGREE "C";
+		unit = "°C";
 	}
 	if (units)
 		*units = unit;

--- a/core/dive.h
+++ b/core/dive.h
@@ -587,15 +587,6 @@ extern int total_weight(const struct dive *);
 
 const char *monthname(int mon);
 
-#define UTF8_DEGREE "\xc2\xb0"
-#define UTF8_DELTA "\xce\x94"
-#define UTF8_UPWARDS_ARROW "\xE2\x86\x91"
-#define UTF8_DOWNWARDS_ARROW "\xE2\x86\x93"
-#define UTF8_AVERAGE "\xc3\xb8"
-#define UTF8_SUBSCRIPT_2 "\xe2\x82\x82"
-#define UTF8_WHITESTAR "\xe2\x98\x86"
-#define UTF8_BLACKSTAR "\xe2\x98\x85"
-
 extern const char *existing_filename;
 extern void subsurface_command_line_init(int *, char ***);
 extern void subsurface_command_line_exit(int *, char ***);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -652,7 +652,6 @@ void update_cylinder_related_info(struct dive *dive)
 }
 
 #define MAX_GAS_STRING 80
-#define UTF8_ELLIPSIS "\xE2\x80\xA6"
 
 /* callers needs to free the string */
 char *get_dive_gas_string(const struct dive *dive)
@@ -670,12 +669,12 @@ char *get_dive_gas_string(const struct dive *dive)
 			if (o2 == o2max)
 				snprintf(buffer, MAX_GAS_STRING, "%d/%d", o2, he);
 			else
-				snprintf(buffer, MAX_GAS_STRING, "%d/%d" UTF8_ELLIPSIS "%d%%", o2, he, o2max);
+				snprintf(buffer, MAX_GAS_STRING, "%d/%d…%d%%", o2, he, o2max);
 		else if (o2)
 			if (o2 == o2max)
 				snprintf(buffer, MAX_GAS_STRING, "%d%%", o2);
 			else
-				snprintf(buffer, MAX_GAS_STRING, "%d" UTF8_ELLIPSIS "%d%%", o2, o2max);
+				snprintf(buffer, MAX_GAS_STRING, "%d…%d%%", o2, o2max);
 		else
 			strcpy(buffer, translate("gettextFromC", "air"));
 	}

--- a/core/profile.c
+++ b/core/profile.c
@@ -1418,9 +1418,9 @@ static void plot_string(struct plot_info *pi, struct plot_data *entry, struct me
 	if (entry->cns)
 		put_format_loc(b, translate("gettextFromC", "CNS: %u%%\n"), entry->cns);
 	if (prefs.pp_graphs.po2 && entry->pressures.o2 > 0)
-		put_format_loc(b, translate("gettextFromC", "pO%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.o2);
+		put_format_loc(b, translate("gettextFromC", "pO₂: %.2fbar\n"), entry->pressures.o2);
 	if (prefs.pp_graphs.pn2 && entry->pressures.n2 > 0)
-		put_format_loc(b, translate("gettextFromC", "pN%s: %.2fbar\n"), UTF8_SUBSCRIPT_2, entry->pressures.n2);
+		put_format_loc(b, translate("gettextFromC", "pN₂: %.2fbar\n"), entry->pressures.n2);
 	if (prefs.pp_graphs.phe && entry->pressures.he > 0)
 		put_format_loc(b, translate("gettextFromC", "pHe: %.2fbar\n"), entry->pressures.he);
 	if (prefs.mod && entry->mod > 0) {
@@ -1625,42 +1625,42 @@ void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int 
 	avg_depth /= stop->sec - start->sec;
 	avg_speed /= stop->sec - start->sec;
 
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%sT:%d:%02dmin"), UTF8_DELTA, delta_time / 60, delta_time % 60);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "ΔT:%d:%02dmin"), delta_time / 60, delta_time % 60);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(delta_depth, NULL, &depth_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DELTA, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ΔD:%.1f%s"), buf2, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(min_depth, NULL, &depth_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_DOWNWARDS_ARROW, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ↓D:%.1f%s"), buf2, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(max_depth, NULL, &depth_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s"), buf2, UTF8_UPWARDS_ARROW, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ↑D:%.1f%s"), buf2, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	depthvalue = get_depth_units(avg_depth, NULL, &depth_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sD:%.1f%s\n"), buf2, UTF8_AVERAGE, depthvalue, depth_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s øD:%.1f%s\n"), buf2, depthvalue, depth_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(max_desc_speed), NULL, &vertical_speed_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s%sV:%.2f%s"), buf2, UTF8_DOWNWARDS_ARROW, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ↓V:%.2f%s"), buf2, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(max_asc_speed), NULL, &vertical_speed_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_UPWARDS_ARROW, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ↑V:%.2f%s"), buf2, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	speedvalue = get_vertical_speed_units(abs(avg_speed), NULL, &vertical_speed_unit);
-	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sV:%.2f%s"), buf2, UTF8_AVERAGE, speedvalue, vertical_speed_unit);
+	snprintf_loc(buf, bufsize, translate("gettextFromC", "%s øV:%.2f%s"), buf2, speedvalue, vertical_speed_unit);
 	memcpy(buf2, buf, bufsize);
 
 	/* Only print if gas has been used */
 	if (bar_used) {
 		pressurevalue = get_pressure_units(bar_used, &pressure_unit);
 		memcpy(buf2, buf, bufsize);
-		snprintf_loc(buf, bufsize, translate("gettextFromC", "%s %sP:%d%s"), buf2, UTF8_DELTA, pressurevalue, pressure_unit);
+		snprintf_loc(buf, bufsize, translate("gettextFromC", "%s ΔP:%d%s"), buf2, pressurevalue, pressure_unit);
 		cylinder_t *cyl = displayed_dive.cylinder + 0;
 		/* if we didn't cross a tank change and know the cylidner size as well, show SAC rate */
 		if (!crossed_tankchange && cyl->type.size.mliter) {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -98,9 +98,9 @@ QString printGPSCoords(const location_t *location)
 		lonmin = (lon % 1000000U) * 60U;
 		latsec = (latmin % 1000000) * 60;
 		lonsec = (lonmin % 1000000) * 60;
-		result.sprintf("%u%s%02d\'%06.3f\"%s %u%s%02d\'%06.3f\"%s",
-			       latdeg, UTF8_DEGREE, latmin / 1000000, latsec / 1000000, qPrintable(lath),
-			       londeg, UTF8_DEGREE, lonmin / 1000000, lonsec / 1000000, qPrintable(lonh));
+		result.sprintf("%u°%02d\'%06.3f\"%s %u°%02d\'%06.3f\"%s",
+			       latdeg, latmin / 1000000, latsec / 1000000, qPrintable(lath),
+			       londeg, lonmin / 1000000, lonsec / 1000000, qPrintable(lonh));
 	} else {
 		result.sprintf("%f %f", (double) lat / 1000000.0, (double) lon / 1000000.0);
 	}
@@ -577,19 +577,19 @@ QString get_temperature_string(temperature_t temp, bool showunit)
 		return ""; //temperature not defined
 	} else if (prefs.units.temperature == units::CELSIUS) {
 		double celsius = mkelvin_to_C(temp.mkelvin);
-		return QString("%L1%2%3").arg(celsius, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? gettextFromC::tr("C") : QString());
+		return QString("%L1%2%3").arg(celsius, 0, 'f', 1).arg(showunit ? "°" : "").arg(showunit ? gettextFromC::tr("C") : QString());
 	} else {
 		double fahrenheit = mkelvin_to_F(temp.mkelvin);
-		return QString("%L1%2%3").arg(fahrenheit, 0, 'f', 1).arg(showunit ? (UTF8_DEGREE) : "").arg(showunit ? gettextFromC::tr("F") : QString());
+		return QString("%L1%2%3").arg(fahrenheit, 0, 'f', 1).arg(showunit ? "°" : "").arg(showunit ? gettextFromC::tr("F") : QString());
 	}
 }
 
 QString get_temp_unit()
 {
 	if (prefs.units.temperature == units::CELSIUS)
-		return QString(UTF8_DEGREE "C");
+		return QString("°C");
 	else
-		return QString(UTF8_DEGREE "F");
+		return QString("°F");
 }
 
 QString get_volume_string(int mliter, bool showunit)

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -982,7 +982,7 @@ void PartialPressureGasItem::modelDataChanged(const QModelIndex &topLeft, const 
 	}
 	setPolygon(poly);
 	/*
-	createPPLegend(trUtf8("pN" UTF8_SUBSCRIPT_2),getColor(PN2), legendPos);
+	createPPLegend(trUtf8("pN₂"), getColor(PN2), legendPos);
 	*/
 }
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -213,7 +213,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		case DURATION:
 			return tr("Duration");
 		case TEMPERATURE:
-			return tr("Temp.(%1%2)").arg(UTF8_DEGREE).arg((get_units()->temperature == units::CELSIUS) ? "C" : "F");
+			return tr("Temp.(°%1)").arg((get_units()->temperature == units::CELSIUS) ? "C" : "F");
 		case TOTALWEIGHT:
 			return tr("Weight(%1)").arg((get_units()->weight == units::KG) ? tr("kg") : tr("lbs"));
 		case SUIT:
@@ -320,7 +320,7 @@ QVariant DiveTripModelBase::headerData(int section, Qt::Orientation orientation,
 		case DURATION:
 			return tr("Duration");
 		case TEMPERATURE:
-			return tr("Temp.(%1%2)").arg(UTF8_DEGREE).arg((get_units()->temperature == units::CELSIUS) ? "C" : "F");
+			return tr("Temp.(°%1)").arg((get_units()->temperature == units::CELSIUS) ? "C" : "F");
 		case TOTALWEIGHT:
 			return tr("Weight(%1)").arg((get_units()->weight == units::KG) ? tr("kg") : tr("lbs"));
 		case SUIT:


### PR DESCRIPTION
At some places we use UTF8 string literals. Therefore, we effectively
only support UTF8 build systems. We might just as well remove all
the other UTF_* macros and use direct string literals.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In some places we depend on UTF-8 string literals. Therefore, we might just remove the UTF8_* macros altogether, isn't it. I'm not sure how this works with strings that are translated, though...
