### PR TITLE
Undo: properly reference-count dive sites

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -715,12 +715,20 @@ SplitDivesBase::SplitDivesBase(dive *d, std::array<dive *, 2> newDives)
 	newDives[0]->selected = false;
 	newDives[1]->selected = false;
 
+	// The new dives will be registered to the dive site using the site member
+	// of the DiveToAdd structure. For this to work, we must set the dive's
+	// dive_site member to null. Yes, that's subtle!
+	newDives[0]->dive_site = nullptr;
+	newDives[1]->dive_site = nullptr;
+
 	diveToSplit.dives.push_back(d);
 	splitDives.dives.resize(2);
 	splitDives.dives[0].dive.reset(newDives[0]);
 	splitDives.dives[0].trip = d->divetrip;
+	splitDives.dives[0].site = d->dive_site;
 	splitDives.dives[1].dive.reset(newDives[1]);
 	splitDives.dives[1].trip = d->divetrip;
+	splitDives.dives[1].site = d->dive_site;
 }
 
 bool SplitDivesBase::workToBeDone()
@@ -863,6 +871,7 @@ MergeDives::MergeDives(const QVector <dive *> &dives)
 	mergedDive.dives.resize(1);
 	mergedDive.dives[0].dive = std::move(d);
 	mergedDive.dives[0].trip = preferred_trip;
+	mergedDive.dives[0].site = preferred_site;
 	divesToMerge.dives = dives.toStdVector();
 }
 


### PR DESCRIPTION
Recently, the undo code was changed to consider dive sites.
The undo code uses a DiveToAdd structure, which was extended
by the dive site to which the dive should be added.

The split and merge commands were not adapted and therefore
the dive counts of the dive sites were wrong after split
and merge.

Fix this by properly setting the dive site field and removing
the reference in the dive structure (in the split case, the merge
case already cleared the reference).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a reference-counting bug on dive split and merge, which comes from the recent dive site undoization efforts. See commit message.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.