### PR TITLE
Travis: build macOS test against Qt 5.12.3 and switch cloud storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
     - env: SUBSURFACE_PLATFORM='mac'
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode9.2
       language: c++
       addons:
         homebrew:

--- a/scripts/ios/before_install.sh
+++ b/scripts/ios/before_install.sh
@@ -31,7 +31,7 @@ pushd ${TRAVIS_BUILD_DIR}/..
 
 echo "Get custom Qt build and unpack it"
 curl --output ./Qt-5.11.1-ios.tar.xz \
-                https://storage.googleapis.com/travis-cache/Qt-5.11.1-ios.tar.xz
+                https://f002.backblazeb2.com/file/Subsurface-Travis/Qt-5.11.1-ios.tar.xz
 md5 ./Qt-5.11.1-ios.tar.xz
 
 mkdir -p Qt/5.11.1

--- a/scripts/mac/before_install.sh
+++ b/scripts/mac/before_install.sh
@@ -23,12 +23,11 @@ git describe
 
 pushd ${TRAVIS_BUILD_DIR}
 
-mkdir -p Qt/5.11.1
+mkdir -p Qt/5.12.3
 
 echo "Get custom Qt build and unpack it"
-curl --output Qt-5.11.1-mac.tar.xz \
-                https://storage.googleapis.com/travis-cache/Qt-5.11.1-mac.tar.xz
-md5 Qt-5.11.1-mac.tar.xz
+curl --output Qt-5.12.3-mac.tar.xz \
+		https://storage.googleapis.com/travis-cache/Qt-5.12.3-mac.tar.xz
 
-tar -xJ -C Qt/5.11.1 -f Qt-5.11.1-mac.tar.xz
+tar -xJ -C Qt/5.12.3 -f Qt-5.12.3-mac.tar.xz
 

--- a/scripts/mac/before_install.sh
+++ b/scripts/mac/before_install.sh
@@ -27,7 +27,7 @@ mkdir -p Qt/5.12.3
 
 echo "Get custom Qt build and unpack it"
 curl --output Qt-5.12.3-mac.tar.xz \
-		https://storage.googleapis.com/travis-cache/Qt-5.12.3-mac.tar.xz
+		https://f002.backblazeb2.com/file/Subsurface-Travis/Qt-5.12.3-mac.tar.xz
 
 tar -xJ -C Qt/5.12.3 -f Qt-5.12.3-mac.tar.xz
 

--- a/scripts/mac/travisbuild.sh
+++ b/scripts/mac/travisbuild.sh
@@ -6,7 +6,7 @@ set -e
 # this gets executed by Travis when building an App for Mac
 # it gets started from inside the subsurface directory
 
-export QT_ROOT=${TRAVIS_BUILD_DIR}/Qt/5.11.1/clang_64
+export QT_ROOT=${TRAVIS_BUILD_DIR}/Qt/5.12.3/clang_64
 export PATH=$QT_ROOT/bin:$PATH # Make sure correct qmake is found on the $PATH
 export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH


### PR DESCRIPTION
The .app.zip should once again run on any Mac (ignoring the security issue of
unsigned binaries).

The download location has changed to free storage on Google Drive (not sure how
well that will work). The Qt binaries in that archive include the jpeg and png
libraries that were missing in the Qt 5.11.1 binaries we used until now.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I created a new archive with a highly customized Qt 5.12.3 install (including QtWebKit, excluding all debug libraries, excluding anything outside of the `clang_64` directory). The QtWebKit version in that install was modified to use the also included `libjpeg` and `libpng`. As a result the `.app.zip` created as part of a Travis build should once again work on any Mac (10.13 or newer - that's a Qt requirement).
