### PR TITLE
Implement undo of dive computer addition / moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Add undo functionality for dive computer movement and deletion
 - Import: Small enhancements on Suunto SDE import
 - Desktop: Add import dive site menu option and site selection dialog
 - Core: Sort dives by number if at the same date

--- a/core/dive.c
+++ b/core/dive.c
@@ -637,7 +637,7 @@ static void copy_dive_onedc(const struct dive *s, const struct divecomputer *sdc
  * this is specifically so we can create a dive in the displayed_dive and then
  * add it to the divelist.
  * Note the difference to copy_dive() / clean_dive() */
-struct dive *clone_dive(struct dive *s)
+struct dive *move_dive(struct dive *s)
 {
 	struct dive *dive = alloc_dive();
 	*dive = *s;			   // so all the pointers in dive point to the things s pointed to

--- a/core/dive.c
+++ b/core/dive.c
@@ -4189,11 +4189,10 @@ struct dive *make_first_dc(const struct dive *d, int dc_number)
 	return res;
 }
 
-/* always acts on the current dive */
-unsigned int count_divecomputers(void)
+int count_divecomputers(const struct dive *d)
 {
 	int ret = 1;
-	struct divecomputer *dc = current_dive->dc.next;
+	struct divecomputer *dc = d->dc.next;
 	while (dc) {
 		ret++;
 		dc = dc->next;
@@ -4229,7 +4228,7 @@ static void delete_divecomputer(struct dive *d, int num)
 
 	/* If this is the currently displayed dive, we might have to adjust
 	 * the currently displayed dive computer. */
-	if (d == current_dive && dc_number >= count_divecomputers())
+	if (d == current_dive && dc_number >= count_divecomputers(d))
 		dc_number--;
 	invalidate_dive_cache(d);
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -4234,10 +4234,22 @@ static void delete_divecomputer(struct dive *d, int num)
 	invalidate_dive_cache(d);
 }
 
-/* always acts on the current dive */
-void delete_current_divecomputer(void)
+/* Clone a dive and delete goven dive computer */
+struct dive *clone_delete_divecomputer(const struct dive *d, int dc_number)
 {
-	delete_divecomputer(current_dive, dc_number);
+	struct dive *res;
+
+	/* copy the dive */
+	res = alloc_dive();
+	copy_dive(d, res);
+
+	/* make a new unique id, since we still can't handle two equal ids */
+	res->id = dive_getUniqID();
+	invalidate_dive_cache(res);
+
+	delete_divecomputer(res, dc_number);
+
+	return res;
 }
 
 /*

--- a/core/dive.h
+++ b/core/dive.h
@@ -517,7 +517,7 @@ extern void record_dive(struct dive *dive);
 extern void clear_dive(struct dive *dive);
 extern void copy_dive(const struct dive *s, struct dive *d);
 extern void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_components what, bool clear);
-extern struct dive *clone_dive(struct dive *s);
+extern struct dive *move_dive(struct dive *s);
 
 extern void alloc_samples(struct divecomputer *dc, int num);
 extern void free_samples(struct divecomputer *dc);

--- a/core/dive.h
+++ b/core/dive.h
@@ -436,7 +436,7 @@ extern timestamp_t dive_endtime(const struct dive *dive);
 
 extern struct dive *make_first_dc(const struct dive *d, int dc_number);
 extern unsigned int count_divecomputers(void);
-extern void delete_current_divecomputer(void);
+extern struct dive *clone_delete_divecomputer(const struct dive *d, int dc_number);
 void split_divecomputer(const struct dive *src, int num, struct dive **out1, struct dive **out2);
 
 /*

--- a/core/dive.h
+++ b/core/dive.h
@@ -434,7 +434,7 @@ extern unsigned int number_of_computers(const struct dive *dive);
 extern struct divecomputer *get_dive_dc(struct dive *dive, int nr);
 extern timestamp_t dive_endtime(const struct dive *dive);
 
-extern void make_first_dc(void);
+extern struct dive *make_first_dc(const struct dive *d, int dc_number);
 extern unsigned int count_divecomputers(void);
 extern void delete_current_divecomputer(void);
 void split_divecomputer(const struct dive *src, int num, struct dive **out1, struct dive **out2);

--- a/core/dive.h
+++ b/core/dive.h
@@ -435,7 +435,7 @@ extern struct divecomputer *get_dive_dc(struct dive *dive, int nr);
 extern timestamp_t dive_endtime(const struct dive *dive);
 
 extern struct dive *make_first_dc(const struct dive *d, int dc_number);
-extern unsigned int count_divecomputers(void);
+extern int count_divecomputers(const struct dive *d);
 extern struct dive *clone_delete_divecomputer(const struct dive *d, int dc_number);
 void split_divecomputer(const struct dive *src, int num, struct dive **out1, struct dive **out2);
 

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -79,6 +79,11 @@ void moveDiveComputerToFront(dive *d, int dc_num)
 	execute(new MoveDiveComputerToFront(d, dc_num));
 }
 
+void deleteDiveComputer(dive *d, int dc_num)
+{
+	execute(new DeleteDiveComputer(d, dc_num));
+}
+
 void mergeDives(const QVector <dive *> &dives)
 {
 	execute(new MergeDives(dives));

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -74,6 +74,11 @@ void splitDiveComputer(dive *d, int dc_num)
 	execute(new SplitDiveComputer(d, dc_num));
 }
 
+void moveDiveComputerToFront(dive *d, int dc_num)
+{
+	execute(new MoveDiveComputerToFront(d, dc_num));
+}
+
 void mergeDives(const QVector <dive *> &dives)
 {
 	execute(new MergeDives(dives));

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -37,6 +37,7 @@ void mergeTrips(dive_trip *trip1, dive_trip *trip2);
 void splitDives(dive *d, duration_t time);
 void splitDiveComputer(dive *d, int dc_num);
 void moveDiveComputerToFront(dive *d, int dc_num);
+void deleteDiveComputer(dive *d, int dc_num);
 void mergeDives(const QVector <dive *> &dives);
 
 // 3) Dive-site related commands

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -36,6 +36,7 @@ void autogroupDives();
 void mergeTrips(dive_trip *trip1, dive_trip *trip2);
 void splitDives(dive *d, duration_t time);
 void splitDiveComputer(dive *d, int dc_num);
+void moveDiveComputerToFront(dive *d, int dc_num);
 void mergeDives(const QVector <dive *> &dives);
 
 // 3) Dive-site related commands

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -802,7 +802,8 @@ SplitDiveComputer::SplitDiveComputer(dive *d, int dc_num) : SplitDivesBase(d, sp
 	setText(tr("split dive computer"));
 }
 
-DiveComputerBase::DiveComputerBase(dive *old_dive, dive *new_dive)
+DiveComputerBase::DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_after_in) : dc_nr_before(dc_number),
+	dc_nr_after(dc_nr_after_in)
 {
 	if (!new_dive)
 		return;
@@ -840,7 +841,8 @@ void DiveComputerBase::redoit()
 	restoreSelection(diveToRemove.dives, diveToRemove.dives[0]);
 
 	// Update the profile to show the first dive computer
-	dc_number = 0;
+	dc_number = dc_nr_after;
+	std::swap(dc_nr_before, dc_nr_after);
 	MainWindow::instance()->graphics->replot(current_dive);
 }
 
@@ -851,13 +853,13 @@ void DiveComputerBase::undoit()
 }
 
 MoveDiveComputerToFront::MoveDiveComputerToFront(dive *d, int dc_num)
-	: DiveComputerBase(d, make_first_dc(d, dc_num))
+	: DiveComputerBase(d, make_first_dc(d, dc_num), 0)
 {
 	setText(tr("move dive computer to front"));
 }
 
 DeleteDiveComputer::DeleteDiveComputer(dive *d, int dc_num)
-	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num))
+	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num), std::min(count_divecomputers(d) - 1, dc_num))
 {
 	setText(tr("delete dive computer"));
 }

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -382,7 +382,7 @@ AddDive::AddDive(dive *d, bool autogroup, bool newNumber)
 	fixup_dive(d);
 
 	// Get an owning pointer to a moved dive.
-	OwningDivePtr divePtr(clone_dive(d));
+	OwningDivePtr divePtr(move_dive(d));
 	divePtr->selected = false; // If we clone a planned dive, it might have been selected.
 				   // We have to clear the flag, as selections will be managed
 				   // on dive-addition.

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -381,8 +381,7 @@ AddDive::AddDive(dive *d, bool autogroup, bool newNumber)
 	d->dc.maxdepth.mm = 0;
 	fixup_dive(d);
 
-	// Get an owning pointer to a copied or moved dive
-	// Note: if move is true, this destroys the old dive!
+	// Get an owning pointer to a moved dive.
 	OwningDivePtr divePtr(clone_dive(d));
 	divePtr->selected = false; // If we clone a planned dive, it might have been selected.
 				   // We have to clear the flag, as selections will be managed

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -236,6 +236,23 @@ public:
 	SplitDiveComputer(dive *d, int dc_num);
 };
 
+// When moving the dive computer to the front, we go the ineffective,
+// but easy way: We keep two full copies of the dive (before and after).
+// Removing and readding assures that the dive stays at the correct
+// position in the list (the dive computer list is used for sorting dives).
+class MoveDiveComputerToFront : public DiveListBase {
+public:
+	MoveDiveComputerToFront(dive *d, int dc_num);
+private:
+	void undoit() override;
+	void redoit() override;
+	bool workToBeDone() override;
+
+	// For redo and undo
+	DivesAndTripsToAdd	diveToAdd;
+	DivesAndSitesToRemove	diveToRemove;
+};
+
 class MergeDives : public DiveListBase {
 public:
 	MergeDives(const QVector<dive *> &dives);

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -236,21 +236,34 @@ public:
 	SplitDiveComputer(dive *d, int dc_num);
 };
 
-// When moving the dive computer to the front, we go the ineffective,
-// but easy way: We keep two full copies of the dive (before and after).
+// When manipulating dive computers (moving, deleting) we go the ineffective,
+// but simple and robust way: We keep two full copies of the dive (before and after).
 // Removing and readding assures that the dive stays at the correct
 // position in the list (the dive computer list is used for sorting dives).
-class MoveDiveComputerToFront : public DiveListBase {
-public:
-	MoveDiveComputerToFront(dive *d, int dc_num);
+class DiveComputerBase : public DiveListBase {
+protected:
+	// old_dive must be a dive known to the core.
+	// new_dive must be new dive whose ownership is taken.
+	DiveComputerBase(dive *old_dive, dive *new_dive);
 private:
 	void undoit() override;
 	void redoit() override;
 	bool workToBeDone() override;
 
+protected:
 	// For redo and undo
 	DivesAndTripsToAdd	diveToAdd;
 	DivesAndSitesToRemove	diveToRemove;
+};
+
+class MoveDiveComputerToFront : public DiveComputerBase {
+public:
+	MoveDiveComputerToFront(dive *d, int dc_num);
+};
+
+class DeleteDiveComputer : public DiveComputerBase {
+public:
+	DeleteDiveComputer(dive *d, int dc_num);
 };
 
 class MergeDives : public DiveListBase {

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -244,7 +244,7 @@ class DiveComputerBase : public DiveListBase {
 protected:
 	// old_dive must be a dive known to the core.
 	// new_dive must be new dive whose ownership is taken.
-	DiveComputerBase(dive *old_dive, dive *new_dive);
+	DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_after);
 private:
 	void undoit() override;
 	void redoit() override;
@@ -254,6 +254,7 @@ protected:
 	// For redo and undo
 	DivesAndTripsToAdd	diveToAdd;
 	DivesAndSitesToRemove	diveToRemove;
+	int			dc_nr_before, dc_nr_after;
 };
 
 class MoveDiveComputerToFront : public DiveComputerBase {

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1590,14 +1590,7 @@ void ProfileWidget2::splitCurrentDC()
 
 void ProfileWidget2::makeFirstDC()
 {
-	make_first_dc();
-	mark_divelist_changed(true);
-	// this is now the first DC, so we need to redraw the profile and refresh the dive list
-	// (and no, it's not just enough to rewrite the text - the first DC is special so values in the
-	// dive list may change).
-	// As a side benefit, this returns focus to the dive list.
-	dc_number = 0;
-	emit refreshDisplay(true);
+	Command::moveDiveComputerToFront(current_dive, dc_number);
 }
 
 void ProfileWidget2::hideEvents()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1575,12 +1575,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 
 void ProfileWidget2::deleteCurrentDC()
 {
-	delete_current_divecomputer();
-	mark_divelist_changed(true);
-	// we need to force it since it's likely the same dive and same dc_number - but that's a different dive computer now
-	plotDive(0, true, false);
-
-	emit refreshDisplay(true);
+	Command::deleteDiveComputer(current_dive, dc_number);
 }
 
 void ProfileWidget2::splitCurrentDC()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1430,13 +1430,13 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 			parentItem = parentItem->parentItem();
 		}
 		if (isDCName) {
-			if (dc_number == 0 && count_divecomputers() == 1)
+			if (dc_number == 0 && count_divecomputers(current_dive) == 1)
 				// nothing to do, can't delete or reorder
 				return;
 			// create menu to show when right clicking on dive computer name
 			if (dc_number > 0)
 				m.addAction(tr("Make first dive computer"), this, SLOT(makeFirstDC()));
-			if (count_divecomputers() > 1) {
+			if (count_divecomputers(current_dive) > 1) {
 				m.addAction(tr("Delete this dive computer"), this, SLOT(deleteCurrentDC()));
 				m.addAction(tr("Split this dive computer into own dive"), this, SLOT(splitCurrentDC()));
 			}

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -733,8 +733,6 @@ void DiveTripModelTree::addDivesToTrip(int trip, const QVector<dive *> &dives)
 	// Construct the parent index, ie. the index of the trip.
 	QModelIndex parent = createIndex(trip, 0, noParent);
 
-	// Either this is outside of a trip or we're in list mode.
-	// Thus, add dives at the top-level in batches
 	addInBatches(items[trip].dives, dives,
 		     [](dive *d, dive *d2) { return dive_less_than(d, d2); }, // comp
 		     [&](std::vector<dive *> &items, const QVector<dive *> &dives, int idx, int from, int to) { // inserter
@@ -1061,7 +1059,7 @@ void DiveTripModelTree::currentDiveChanged()
 		int diveIdx = findDiveInTrip(idx, current_dive);
 		if (diveIdx < 0) {
 			// We don't know this dive. Something is wrong. Warn and bail.
-			qWarning() << "DiveTripModelTree::currentDiveChanged(): unknown top-level dive";
+			qWarning() << "DiveTripModelTree::currentDiveChanged(): unknown dive";
 			emit newCurrentDive(QModelIndex());
 			return;
 		}
@@ -1226,7 +1224,6 @@ void DiveTripModelList::currentDiveChanged()
 		return;
 	}
 
-	// Either this is outside of a trip or we're in list mode.
 	auto it = std::find(items.begin(), items.end(), current_dive);
 	if (it == items.end()) {
 		// We don't know this dive. Something is wrong. Warn and bail.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a tiny step in undoization: Make dive computer moving / deletion undoable. Code is primitive, but should be quite robust: Two copies of the dives are kept. This is distinctly easier than manipulating the dives and moving them in the list if necessary. Let's see how it fares.

Also contains minor cleanups.

@dirkhh: I'll be away for 4 weeks (writing this from a TGV), but will be reading emails. Trying to implement the basics of your suggestion concerning multi-edit is the next point I'll attempt.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make dive computer moving undoable
2) Make dive computer deletion undoable
3) Minor cleanups

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Probably not needed...