### PR TITLE
[RFC] First stab at multi-edit warning

### DIFF
--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -81,6 +81,12 @@ signals:
 	void diveSiteDiveCountChanged(dive_site *ds);
 	void diveSiteChanged(dive_site *ds, int field); // field according to LocationInformationModel
 	void diveSiteDivesChanged(dive_site *ds); // The dives associated with that site changed
+
+	// This signal is emited every time a command is executed.
+	// This is used to hide an old multi-dives-edited warning message.
+	// This is necessary, so that the user can't click on the "undo" button and undo
+	// an unrelated command.
+	void commandExecuted();
 public:
 	// Desktop uses the QTreeView class to present the list of dives. The layout
 	// of this class gives us a very fundamental problem, as we can not easily

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -148,9 +148,8 @@ void purgeUnusedDiveSites()
 // Execute an edit-command and return number of edited dives
 static int execute_edit(EditDivesBase *cmd)
 {
-	int res = cmd->numDives();
-	execute(cmd);
-	return res;
+	int count = cmd->numDives();
+	return execute(cmd) ? count : 0;
 }
 
 // Dive editing related commands

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -234,6 +234,7 @@ void pasteDives(const dive *d, dive_components what)
 	execute(new PasteDives(d, what));
 }
 
+// Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {
 	execute(new EditTripLocation(trip, s));

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -145,80 +145,88 @@ void purgeUnusedDiveSites()
 	execute(new PurgeUnusedDiveSites);
 }
 
+// Execute an edit-command and return number of edited dives
+static int execute_edit(EditDivesBase *cmd)
+{
+	int res = cmd->numDives();
+	execute(cmd);
+	return res;
+}
+
 // Dive editing related commands
-void editNotes(const QString &newValue, bool currentDiveOnly)
+int editNotes(const QString &newValue, bool currentDiveOnly)
 {
-	execute(new EditNotes(newValue, currentDiveOnly));
+	return execute_edit(new EditNotes(newValue, currentDiveOnly));
 }
 
-void editMode(int index, int newValue, bool currentDiveOnly)
+int editMode(int index, int newValue, bool currentDiveOnly)
 {
-	execute(new EditMode(index, newValue, currentDiveOnly));
+	return execute_edit(new EditMode(index, newValue, currentDiveOnly));
 }
 
-void editSuit(const QString &newValue, bool currentDiveOnly)
+int editSuit(const QString &newValue, bool currentDiveOnly)
 {
-	execute(new EditSuit(newValue, currentDiveOnly));
+	return execute_edit(new EditSuit(newValue, currentDiveOnly));
 }
 
-void editRating(int newValue, bool currentDiveOnly)
+int editRating(int newValue, bool currentDiveOnly)
 {
-	execute(new EditRating(newValue, currentDiveOnly));
+	return execute_edit(new EditRating(newValue, currentDiveOnly));
 }
 
-void editVisibility(int newValue, bool currentDiveOnly)
+int editVisibility(int newValue, bool currentDiveOnly)
 {
-	execute(new EditVisibility(newValue, currentDiveOnly));
+	return execute_edit(new EditVisibility(newValue, currentDiveOnly));
 }
 
-void editAirTemp(int newValue, bool currentDiveOnly)
+int editAirTemp(int newValue, bool currentDiveOnly)
 {
-	execute(new EditAirTemp(newValue, currentDiveOnly));
+	return execute_edit(new EditAirTemp(newValue, currentDiveOnly));
 }
 
-void editWaterTemp(int newValue, bool currentDiveOnly)
+int editWaterTemp(int newValue, bool currentDiveOnly)
 {
-	execute(new EditWaterTemp(newValue, currentDiveOnly));
+	return execute_edit(new EditWaterTemp(newValue, currentDiveOnly));
 }
 
-void editAtmPress(int newValue, bool currentDiveOnly)
+int editAtmPress(int newValue, bool currentDiveOnly)
 {
-	execute(new EditAtmPress(newValue, currentDiveOnly));
+	return execute_edit(new EditAtmPress(newValue, currentDiveOnly));
 }
 
-void editDepth(int newValue, bool currentDiveOnly)
+int editDepth(int newValue, bool currentDiveOnly)
 {
-	execute(new EditDepth(newValue, currentDiveOnly));
+	return execute_edit(new EditDepth(newValue, currentDiveOnly));
 }
 
-void editDuration(int newValue, bool currentDiveOnly)
+int editDuration(int newValue, bool currentDiveOnly)
 {
-	execute(new EditDuration(newValue, currentDiveOnly));
+	return execute_edit(new EditDuration(newValue, currentDiveOnly));
 }
 
-void editDiveSite(struct dive_site *newValue, bool currentDiveOnly)
+int editDiveSite(struct dive_site *newValue, bool currentDiveOnly)
 {
-	execute(new EditDiveSite(newValue, currentDiveOnly));
+	return execute_edit(new EditDiveSite(newValue, currentDiveOnly));
 }
 
-void editDiveSiteNew(const QString &newName, bool currentDiveOnly)
+int editDiveSiteNew(const QString &newName, bool currentDiveOnly)
 {
-	execute(new EditDiveSiteNew(newName, currentDiveOnly));
+	return execute_edit(new EditDiveSiteNew(newName, currentDiveOnly));
 }
 
-void editTags(const QStringList &newList, bool currentDiveOnly)
+int editTags(const QStringList &newList, bool currentDiveOnly)
 {
-	execute(new EditTags(newList, currentDiveOnly));
+	return execute_edit(new EditTags(newList, currentDiveOnly));
 }
 
-void editBuddies(const QStringList &newList, bool currentDiveOnly)
+int editBuddies(const QStringList &newList, bool currentDiveOnly)
 {
-	execute(new EditBuddies(newList, currentDiveOnly));
+	return execute_edit(new EditBuddies(newList, currentDiveOnly));
 }
 
-void editDiveMaster(const QStringList &newList, bool currentDiveOnly)
+int editDiveMaster(const QStringList &newList, bool currentDiveOnly)
 {
-	execute(new EditDiveMaster(newList, currentDiveOnly));
+	return execute_edit(new EditDiveMaster(newList, currentDiveOnly));
 }
 
 void pasteDives(const dive *d, dive_components what)

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -56,21 +56,21 @@ void purgeUnusedDiveSites();
 
 // 4) Dive editing related commands
 
-void editNotes(const QString &newValue, bool currentDiveOnly);
-void editSuit(const QString &newValue, bool currentDiveOnly);
-void editMode(int index, int newValue, bool currentDiveOnly);
-void editRating(int newValue, bool currentDiveOnly);
-void editVisibility(int newValue, bool currentDiveOnly);
-void editAirTemp(int newValue, bool currentDiveOnly);
-void editWaterTemp(int newValue, bool currentDiveOnly);
-void editAtmPress(int newValue, bool currentDiveOnly);
-void editDepth(int newValue, bool currentDiveOnly);
-void editDuration(int newValue, bool currentDiveOnly);
-void editDiveSite(struct dive_site *newValue, bool currentDiveOnly);
-void editDiveSiteNew(const QString &newName, bool currentDiveOnly);
-void editTags(const QStringList &newList, bool currentDiveOnly);
-void editBuddies(const QStringList &newList, bool currentDiveOnly);
-void editDiveMaster(const QStringList &newList, bool currentDiveOnly);
+int editNotes(const QString &newValue, bool currentDiveOnly);
+int editSuit(const QString &newValue, bool currentDiveOnly);
+int editMode(int index, int newValue, bool currentDiveOnly);
+int editRating(int newValue, bool currentDiveOnly);
+int editVisibility(int newValue, bool currentDiveOnly);
+int editAirTemp(int newValue, bool currentDiveOnly);
+int editWaterTemp(int newValue, bool currentDiveOnly);
+int editAtmPress(int newValue, bool currentDiveOnly);
+int editDepth(int newValue, bool currentDiveOnly);
+int editDuration(int newValue, bool currentDiveOnly);
+int editDiveSite(struct dive_site *newValue, bool currentDiveOnly);
+int editDiveSiteNew(const QString &newName, bool currentDiveOnly);
+int editTags(const QStringList &newList, bool currentDiveOnly);
+int editBuddies(const QStringList &newList, bool currentDiveOnly);
+int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
 
 // 4) Trip editing commands

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -10,6 +10,7 @@
 namespace Command {
 
 // 1) General commands
+
 void init();				// Setup signals to inform frontend of clean status.
 void clear();				// Reset the undo stack. Delete all commands.
 void setClean();			// Call after save - this marks a state where no changes need to be saved.
@@ -73,7 +74,8 @@ int editBuddies(const QStringList &newList, bool currentDiveOnly);
 int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
 
-// 4) Trip editing commands
+// 5) Trip editing commands
+
 void editTripLocation(dive_trip *trip, const QString &s);
 void editTripNotes(dive_trip *trip, const QString &s);
 

--- a/desktop-widgets/command_base.cpp
+++ b/desktop-widgets/command_base.cpp
@@ -38,12 +38,15 @@ QAction *redoAction(QObject *parent)
 	return undoStack.createRedoAction(parent, QCoreApplication::translate("Command", "&Redo"));
 }
 
-void execute(Base *cmd)
+bool execute(Base *cmd)
 {
-	if (cmd->workToBeDone())
+	if (cmd->workToBeDone()) {
 		undoStack.push(cmd);
-	else
+		return true;
+	} else {
 		delete cmd;
+		return false;
+	}
 }
 
 } // namespace Command

--- a/desktop-widgets/command_base.cpp
+++ b/desktop-widgets/command_base.cpp
@@ -2,6 +2,7 @@
 
 #include "command_base.h"
 #include "core/qthelper.h" // for updateWindowTitle()
+#include "core/subsurface-qt/DiveListNotifier.h"
 
 namespace Command {
 
@@ -42,6 +43,7 @@ bool execute(Base *cmd)
 {
 	if (cmd->workToBeDone()) {
 		undoStack.push(cmd);
+		emit diveListNotifier.commandExecuted();
 		return true;
 	} else {
 		delete cmd;

--- a/desktop-widgets/command_base.h
+++ b/desktop-widgets/command_base.h
@@ -168,8 +168,8 @@ public:
 
 // Put a command on the undoStack (and take ownership), but test whether there
 // is something to be done beforehand by calling the workToBeDone() function.
-// If nothing is to be done, the command will be deleted.
-void execute(Base *cmd);
+// If nothing is to be done, the command will be deleted and false is returned.
+bool execute(Base *cmd);
 
 } // namespace Command
 

--- a/desktop-widgets/command_base.h
+++ b/desktop-widgets/command_base.h
@@ -166,9 +166,9 @@ public:
 	virtual bool workToBeDone() = 0;
 };
 
-// Put a command on the undoStack, but test whether there is something to be done
-// beforehand by calling the workToBeDone() function. If nothing is to be done,
-// the command will be deleted.
+// Put a command on the undoStack (and take ownership), but test whether there
+// is something to be done beforehand by calling the workToBeDone() function.
+// If nothing is to be done, the command will be deleted.
 void execute(Base *cmd);
 
 } // namespace Command

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -25,12 +25,22 @@ static std::vector<dive *> getDives(bool currentDiveOnly)
 	return res;
 }
 
-template<typename T>
-EditBase<T>::EditBase(T newValue, bool currentDiveOnly) :
-	value(std::move(newValue)),
+EditDivesBase::EditDivesBase(bool currentDiveOnly) :
 	dives(getDives(currentDiveOnly)),
 	selectedDives(getDiveSelection()),
 	current(current_dive)
+{
+}
+
+int EditDivesBase::numDives() const
+{
+	return dives.size();
+}
+
+template<typename T>
+EditBase<T>::EditBase(T newValue, bool currentDiveOnly) :
+	EditDivesBase(currentDiveOnly),
+	value(std::move(newValue))
 {
 }
 
@@ -439,9 +449,7 @@ DiveField EditMode::fieldId() const
 
 // ***** Tag based commands *****
 EditTagsBase::EditTagsBase(const QStringList &newListIn, bool currentDiveOnly) :
-	dives(getDives(currentDiveOnly)),
-	selectedDives(getDiveSelection()),
-	current(current_dive),
+	EditDivesBase(currentDiveOnly),
 	newList(newListIn)
 {
 }

--- a/desktop-widgets/command_edit.h
+++ b/desktop-widgets/command_edit.h
@@ -23,8 +23,23 @@
 // We put everything in a namespace, so that we can shorten names without polluting the global namespace
 namespace Command {
 
+// Base class for commands that have a list of dives.
+// This is used for extracting the number of dives and show a
+// warning message when multiple dives are edited.
+class EditDivesBase : public Base {
+protected:
+	EditDivesBase(bool currentDiveOnly);
+	std::vector<dive *> dives; // Dives to be edited.
+
+	// On undo, we set the selection and current dive at the time of the operation.
+	std::vector<dive *> selectedDives;
+	struct dive *current;
+public:
+	int numDives() const;
+};
+
 template <typename T>
-class EditBase : public Base {
+class EditBase : public EditDivesBase {
 protected:
 	T value; // Value to be set
 	T old; // Previous value
@@ -33,10 +48,6 @@ protected:
 	void redo() override;
 	bool workToBeDone() override;
 
-	std::vector<dive *> dives; // Dives to be edited.
-	// On undo, we set the selection and current dive at the time of the operation.
-	std::vector<dive *> selectedDives;
-	struct dive *current;
 public:
 	EditBase(T newValue, bool currentDiveOnly);
 
@@ -166,16 +177,9 @@ public:
 // Fields that work with tag-lists (tags, buddies, divemasters) work differently and therefore
 // have their own base class. In this case, it's not a template, as all these lists are base
 // on strings.
-class EditTagsBase : public Base {
+class EditTagsBase : public EditDivesBase {
 	bool workToBeDone() override;
 
-	// Dives to be edited. For historical reasons, the *last* entry was
-	// the active dive when the user initialized the action. This dive
-	// will be made the current dive on redo / undo.
-	std::vector<dive *> dives;
-	// On undo, we set the selection and current dive at the time of the operation.
-	std::vector<dive *> selectedDives;
-	struct dive *current;
 	QStringList newList;	// Temporary until initialized
 public:
 	EditTagsBase(const QStringList &newList, bool currentDiveOnly);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -93,6 +93,10 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(rejectChanges()));
 	ui.diveNotesMessage->addAction(action);
 
+	action = new QAction(tr("OK"), this);
+	connect(action, &QAction::triggered, this, &MainTab::closeWarning);
+	ui.multiDiveWarningMessage->addAction(action);
+
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::Key_Escape), this);
 	connect(closeKey, SIGNAL(activated()), this, SLOT(escDetected()));
 
@@ -126,6 +130,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	ui.suit->setCompleter(completers.suit);
 	ui.tagWidget->setCompleter(completers.tags);
 	ui.diveNotesMessage->hide();
+	ui.multiDiveWarningMessage->hide();
 	ui.depth->hide();
 	ui.depthLabel->hide();
 	ui.duration->hide();
@@ -168,6 +173,8 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 	connect(ui.diveNotesMessage, &KMessageWidget::showAnimationFinished,
 					ui.location, &DiveLocationLineEdit::fixPopupPosition);
+	connect(ui.multiDiveWarningMessage, &KMessageWidget::showAnimationFinished,
+					ui.location, &DiveLocationLineEdit::fixPopupPosition);
 
 	// enable URL clickability in notes:
 	new TextHyperlinkEventFilter(ui.notes);//destroyed when ui.notes is destroyed
@@ -189,6 +196,11 @@ void MainTab::closeMessage()
 {
 	hideMessage();
 	ui.diveNotesMessage->setCloseButtonVisible(false);
+}
+
+void MainTab::closeWarning()
+{
+	ui.multiDiveWarningMessage->animatedHide();
 }
 
 void MainTab::displayMessage(QString str)
@@ -702,6 +714,16 @@ void MainTab::rejectChanges()
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 }
 
+void MainTab::divesEdited(int i)
+{
+	// No warning if only one dive was edited
+	if (i <= 1)
+		return;
+	ui.multiDiveWarningMessage->setCloseButtonVisible(false);
+	ui.multiDiveWarningMessage->setText(tr("Warning: edited %1 dives").arg(i));
+	ui.multiDiveWarningMessage->animatedShow();
+}
+
 static QStringList stringToList(const QString &s)
 {
 	QStringList res = s.split(",", QString::SkipEmptyParts);
@@ -715,7 +737,7 @@ void MainTab::on_buddy_editingFinished()
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editBuddies(stringToList(ui.buddy->toPlainText()), false);
+	divesEdited(Command::editBuddies(stringToList(ui.buddy->toPlainText()), false));
 }
 
 void MainTab::on_divemaster_editingFinished()
@@ -723,7 +745,7 @@ void MainTab::on_divemaster_editingFinished()
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editDiveMaster(stringToList(ui.divemaster->toPlainText()), false);
+	divesEdited(Command::editDiveMaster(stringToList(ui.divemaster->toPlainText()), false));
 }
 
 void MainTab::on_duration_editingFinished()
@@ -732,7 +754,7 @@ void MainTab::on_duration_editingFinished()
 		return;
 
 	// Duration editing is special: we only edit the current dive.
-	Command::editDuration(parseDurationToSeconds(ui.duration->text()), true);
+	divesEdited(Command::editDuration(parseDurationToSeconds(ui.duration->text()), true));
 }
 
 void MainTab::on_depth_editingFinished()
@@ -741,28 +763,28 @@ void MainTab::on_depth_editingFinished()
 		return;
 
 	// Depth editing is special: we only edit the current dive.
-	Command::editDepth(parseLengthToMm(ui.depth->text()), true);
+	divesEdited(Command::editDepth(parseLengthToMm(ui.depth->text()), true));
 }
 
 void MainTab::on_airtemp_editingFinished()
 {
 	if (editMode == IGNORE || !current_dive)
 		return;
-	Command::editAirTemp(parseTemperatureToMkelvin(ui.airtemp->text()), false);
+	divesEdited(Command::editAirTemp(parseTemperatureToMkelvin(ui.airtemp->text()), false));
 }
 
 void MainTab::divetype_Changed(int index)
 {
 	if (editMode == IGNORE || !current_dive)
 		return;
-	Command::editMode(dc_number, (enum divemode_t)index, false);
+	divesEdited(Command::editMode(dc_number, (enum divemode_t)index, false));
 }
 
 void MainTab::on_watertemp_editingFinished()
 {
 	if (editMode == IGNORE || !current_dive)
 		return;
-	Command::editWaterTemp(parseTemperatureToMkelvin(ui.watertemp->text()), false);
+	divesEdited(Command::editWaterTemp(parseTemperatureToMkelvin(ui.watertemp->text()), false));
 }
 
 // Editing of the dive time is different. If multiple dives are edited,
@@ -809,7 +831,7 @@ void MainTab::on_tagWidget_editingFinished()
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editTags(ui.tagWidget->getBlockStringList(), false);
+	divesEdited(Command::editTags(ui.tagWidget->getBlockStringList(), false));
 }
 
 void MainTab::on_location_diveSiteSelected()
@@ -819,9 +841,9 @@ void MainTab::on_location_diveSiteSelected()
 
 	struct dive_site *newDs = ui.location->currDiveSite();
 	if (newDs == RECENTLY_ADDED_DIVESITE)
-		Command::editDiveSiteNew(ui.location->text(), false);
+		divesEdited(Command::editDiveSiteNew(ui.location->text(), false));
 	else
-		Command::editDiveSite(newDs, false);
+		divesEdited(Command::editDiveSite(newDs, false));
 }
 
 void MainTab::on_locationPopupButton_clicked()
@@ -841,7 +863,7 @@ void MainTab::on_suit_editingFinished()
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editSuit(ui.suit->text(), false);
+	divesEdited(Command::editSuit(ui.suit->text(), false));
 }
 
 void MainTab::on_notes_editingFinished()
@@ -855,7 +877,7 @@ void MainTab::on_notes_editingFinished()
 	if (currentTrip)
 		Command::editTripNotes(currentTrip, notes);
 	else
-		Command::editNotes(notes, false);
+		divesEdited(Command::editNotes(notes, false));
 }
 
 void MainTab::on_rating_valueChanged(int value)
@@ -863,7 +885,7 @@ void MainTab::on_rating_valueChanged(int value)
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editRating(value, false);
+	divesEdited(Command::editRating(value, false));
 }
 
 void MainTab::on_visibility_valueChanged(int value)
@@ -871,7 +893,7 @@ void MainTab::on_visibility_valueChanged(int value)
 	if (editMode == IGNORE || !current_dive)
 		return;
 
-	Command::editVisibility(value, false);
+	divesEdited(Command::editVisibility(value, false));
 }
 
 // Remove focus from any active field to update the corresponding value in the dive.

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -87,11 +87,11 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 	QAction *action = new QAction(tr("Apply changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(acceptChanges()));
-	addMessageAction(action);
+	ui.diveNotesMessage->addAction(action);
 
 	action = new QAction(tr("Discard changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(rejectChanges()));
-	addMessageAction(action);
+	ui.diveNotesMessage->addAction(action);
 
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::Key_Escape), this);
 	connect(closeKey, SIGNAL(activated()), this, SLOT(escDetected()));
@@ -177,11 +177,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 MainTab::~MainTab()
 {
-}
-
-void MainTab::addMessageAction(QAction *action)
-{
-	ui.diveNotesMessage->addAction(action);
 }
 
 void MainTab::hideMessage()

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -80,6 +80,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &MainTab::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &MainTab::tripChanged);
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &MainTab::diveSiteEdited);
+	connect(&diveListNotifier, &DiveListNotifier::commandExecuted, this, &MainTab::closeWarning);
 
 	connect(ui.editDiveSiteButton, &QToolButton::clicked, MainWindow::instance(), &MainWindow::startDiveSiteEdit);
 	connect(ui.location, &DiveLocationLineEdit::entered, MapWidget::instance(), &MapWidget::centerOnIndex);
@@ -200,7 +201,7 @@ void MainTab::closeMessage()
 
 void MainTab::closeWarning()
 {
-	ui.multiDiveWarningMessage->animatedHide();
+	ui.multiDiveWarningMessage->hide();
 }
 
 void MainTab::displayMessage(QString str)
@@ -721,7 +722,7 @@ void MainTab::divesEdited(int i)
 		return;
 	ui.multiDiveWarningMessage->setCloseButtonVisible(false);
 	ui.multiDiveWarningMessage->setText(tr("Warning: edited %1 dives").arg(i));
-	ui.multiDiveWarningMessage->animatedShow();
+	ui.multiDiveWarningMessage->show();
 }
 
 static QStringList stringToList(const QString &s)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -98,6 +98,11 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	connect(action, &QAction::triggered, this, &MainTab::closeWarning);
 	ui.multiDiveWarningMessage->addAction(action);
 
+	action = new QAction(tr("Undo"), this);
+	connect(action, &QAction::triggered, Command::undoAction(this), &QAction::trigger);
+	connect(action, &QAction::triggered, this, &MainTab::closeWarning);
+	ui.multiDiveWarningMessage->addAction(action);
+
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::Key_Escape), this);
 	connect(closeKey, SIGNAL(activated()), this, SLOT(escDetected()));
 

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -75,6 +75,7 @@ slots:
 	void on_tagWidget_editingFinished();
 	void hideMessage();
 	void closeMessage();
+	void closeWarning();
 	void displayMessage(QString str);
 	void enableEdition(EditMode newEditMode = NONE);
 	void updateTextLabels(bool showUnits = true);
@@ -92,6 +93,7 @@ private:
 	int lastTabSelectedDiveTrip;
 	dive_trip_t *currentTrip;
 	QList<TabBase*> extraWidgets;
+	void divesEdited(int num); // Opens a warning window if more than one dive was edited
 };
 
 #endif // MAINTAB_H

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -73,7 +73,6 @@ slots:
 	void on_rating_valueChanged(int value);
 	void on_visibility_valueChanged(int value);
 	void on_tagWidget_editingFinished();
-	void addMessageAction(QAction *action);
 	void hideMessage();
 	void closeMessage();
 	void displayMessage(QString str);

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -18,6 +18,9 @@
     <widget class="KMessageWidget" name="diveNotesMessage"/>
    </item>
    <item>
+    <widget class="KMessageWidget" name="multiDiveWarningMessage"/>
+   </item>
+   <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a first attempt at showing a warning when multiple dives are edited.

It uses a KMessageWidget. Sadly, the animated show/hide can't be used as it seems to be buggy: an animatedHide()/animatedShow() pair may actually *hide* the widget! Therefore the UI experience has to be improved. This is mostly meant to sketch how a solution could look like. Someone feels like improving the UI?

During testing I found a fundamental problem, which is in my opinion a release-blocker:

1) Go to a dive where the water-temperature was rounded (e.g. multiple dive computers or °F-to-°C conversion).
2) Edit air-temperature, press tab -> the air-temperature is edited focus switches to water-temperature
3) Try to undo the air-temperature editin via the application menu
3a) The water-temperature field loses focus
3b) We get an editing-finished signal
3c) Since only one decimal place is shown this gives a differently rounded value than the recorded one and is interpreted as a real edit
3d) An undo command is created
3e) By chosing undo, the invisible edit is undone!
4) User confused since nothing happened -> goto 3). Endless loop!

I was thinking about always rounding to a single decimal place in the undo-command. But that would mean that the command is aware of F vs. C setting. So currently I'm planning to create an input field that only sends editing-finished signals if the value changed compared to the last setting of the value! Sounds like a crazy proposition, but probably the easiest way out...?

PS: Using my mobile as hot-spot, therefore very brief.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Perhaps needed?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh