### PR TITLE
Undo: don't create spurious undo commands for temperature fields

### DIFF
--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -63,7 +63,7 @@ bool EditBase<T>::workToBeDone()
 	// Create a text for the menu entry. In the case of multiple dives add the number
 	size_t num_dives = dives.size();
 	if (num_dives > 0)
-		//: remove the part in parantheses for %n = 1
+		//: remove the part in parentheses for %n = 1
 		setText(tr("Edit %1 (%n dive(s))", "", num_dives).arg(fieldName()));
 
 	return num_dives > 0;
@@ -501,7 +501,7 @@ bool EditTagsBase::workToBeDone()
 	// Create a text for the menu entry. In the case of multiple dives add the number
 	size_t num_dives = dives.size();
 	if (num_dives > 0)
-		//: remove the part in parantheses for %n = 1
+		//: remove the part in parentheses for %n = 1
 		setText(tr("Edit %1 (%n dive(s))", "", num_dives).arg(fieldName()));
 
 	return num_dives != 0;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -751,7 +751,10 @@ void MainTab::on_depth_editingFinished()
 
 void MainTab::on_airtemp_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	// If the field wasn't modified by the user, don't post a new undo command.
+	// Owing to rounding errors, this might lead to undo commands that have
+	// no user visible effects. These can be very confusing.
+	if (editMode == IGNORE || !ui.airtemp->isModified() || !current_dive)
 		return;
 	Command::editAirTemp(parseTemperatureToMkelvin(ui.airtemp->text()), false);
 }
@@ -765,7 +768,10 @@ void MainTab::divetype_Changed(int index)
 
 void MainTab::on_watertemp_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	// If the field wasn't modified by the user, don't post a new undo command.
+	// Owing to rounding errors, this might lead to undo commands that have
+	// no user visible effects. These can be very confusing.
+	if (editMode == IGNORE || !ui.watertemp->isModified() || !current_dive)
 		return;
 	Command::editWaterTemp(parseTemperatureToMkelvin(ui.watertemp->text()), false);
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug in discussed in #2106.
See commit message. I'm on mobile hot spot, so not much comment.
I'm not sure if the altitude field introduced by @willemferguson needs a similar treatment.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.
