### PR TITLE
Desktop: invalidate dive cache on equipment edit

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -152,6 +152,7 @@ void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
 #define MODIFY_DIVES(DIVES, WHAT)                            \
 	do {                                                 \
 		for (dive *mydive: DIVES) {                  \
+			invalidate_dive_cache(mydive);       \
 			WHAT;                                \
 		}					     \
 		mark_divelist_changed(true);                 \


### PR DESCRIPTION
Owing to the recent undo-changes, the git id was not invalidated
when accepting changes to cylinders and weights.

Do this in the MODIFY_DIVES macro for now.

Reported-by: Jan Iversen <jani@apache.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Bug fix for phenomenon reported in #2066.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Invalidate git id when changing weights / cylinders.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Bug introduced in current release cycle..?
(Though not the original report I believe.)
