### PR TITLE
[snap] add removable-media plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Snap: add `removable-media` plug for access to /media and /mnt paths
 - Desktop: Add undo functionality for dive computer movement and deletion
 - Import: Small enhancements on Suunto SDE import
 - Desktop: Add import dive site menu option and site selection dialog

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
     - network
     - opengl
     - raw-usb
+    - removable-media
     - unity7
 
 parts:


### PR DESCRIPTION
### Describe the pull request:
- [x] Build system change

### Pull request long description:
This optionally allows accessing data in /media/ folders, if the user
issues:

snap connect subsurface:removable-media

https://docs.snapcraft.io/removable-media-interface
### Changes made:
1) add `removable-media` as a snap plug

### Release note:
With the snap, you can now use locations in `/media`, `/mnt` and `/run/media` for your dive logs, provided you issue `snap connect subsurface:removable-media` to allow this, first.

### Documentation change:
With the snap, use `snap connect subsurface:removable-media` to allow access to locations in `/media`, `/mnt` and `/run/media`.