### PR TITLE
Desktop: don't show location-popup button in trip-edit mode

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -468,6 +468,7 @@ void MainTab::updateDiveInfo()
 			ui.timeEdit->setVisible(false);
 			ui.diveTripLocation->show();
 			ui.location->hide();
+			ui.locationPopupButton->hide();
 			ui.editDiveSiteButton->hide();
 			// rename the remaining fields and fill data from selected trip
 			ui.LocationLabel->setText(tr("Trip location"));
@@ -499,6 +500,7 @@ void MainTab::updateDiveInfo()
 			// make all the fields visible writeable
 			ui.diveTripLocation->hide();
 			ui.location->show();
+			ui.locationPopupButton->show();
 			ui.editDiveSiteButton->show();
 			ui.divemaster->setVisible(true);
 			ui.buddy->setVisible(true);


### PR DESCRIPTION
The location fields are hidden in trip mode. Only the location-popup
button was shown. Hide it as well.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a UI big: The recently introduced location-popup was shown in trip-edit mode where it made no sense whatsoever.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.