### PR TITLE
Printing: use regexp in preprocessTemplate()

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -3,7 +3,6 @@
 #include "core/qthelper.h"
 #include "core/settings/qPrefDiveComputer.h"
 #include <QDebug>
-#include <QRegularExpression>
 #if defined(Q_OS_ANDROID)
 #include "core/subsurface-string.h"
 #endif

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -333,14 +333,13 @@ void BtDeviceSelectionDialog::pairingFinished(const QBluetoothAddress &address, 
 
 	// Find the items which represent the BTH device and update their state
 	QList<QListWidgetItem *> items = ui->discoveredDevicesList->findItems(remoteDeviceStringAddress, Qt::MatchContains);
-	QRegularExpression pairingExpression = QRegularExpression(QString("%1|%2|%3").arg(tr("PAIRED"),
-											  tr("AUTHORIZED_PAIRED"),
-											  tr("UNPAIRED")));
+	QRegularExpression pairingExpression(QString("%1|%2|%3").arg(tr("PAIRED"),
+								     tr("AUTHORIZED_PAIRED"),
+								     tr("UNPAIRED")));
 
 	for (int i = 0; i < items.count(); ++i) {
 		QListWidgetItem *item = items.at(i);
-		QString updatedDeviceLabel = item->text().replace(QRegularExpression(pairingExpression),
-								  pairingStatusLabel);
+		QString updatedDeviceLabel = item->text().replace(pairingExpression, pairingStatusLabel);
 
 		item->setText(updatedDeviceLabel);
 		item->setBackgroundColor(pairingColor);


### PR DESCRIPTION
preprocessTemplate() replaces variables of the kind "dive.weight0"
by "dive.weights.0". Replace the old code by regexps. This not
only makes the code significantly shorter, it also makes it independent
from the name of the dive variable (i.e. "dive").

Moreover, it removes a dependency on MAX_WEIGHTSYSTEMS and MAX_CYLINDERS,
which might help in removing these restrictions.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This replaces the manual variable-replacement code in templatelayout.cpp by regular expressions.
Not only is the resulting code shorter, it is also more flexible in two ways:
1) Can use other dive variables than `dive`
2) Is independent of MAX_WEIGHTSYSTEMS and MAX_CYLINDERS, should we decide to make these dynamic. (BTW: This is the actual reason for the patch.)

But to be honest, I don't see the point in these replacements at all. Why can't the user simply write `weights.5` instead? And wouldn't it be more logical to simply loop over `weights` than to access them individually (and thus fail if MAX_WEIGHTSYSTEMS is increased)? I'd really like to deprecate these substitutions.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Should at least replace weight0-weight5 by weight0-weightn.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 