### PR TITLE
use QStringRef instead of QString instances as intermediate values

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -25,11 +25,11 @@ static dc_descriptor_t *getDeviceType(QString btName)
 	if (btName.startsWith("OSTC")) {
 		vendor = "Heinrichs Weikamp";
 		if (btName.at(4) == '3') product = "OSTC Plus";
-		else if (btName.mid(4,2) == "s#") product = "OSTC Sport";
-		else if (btName.mid(4,2) == "s ") product = "OSTC Sport";
-		else if (btName.mid(4,2) == "4-") product = "OSTC 4";
-		else if (btName.mid(4,2) == "2-") product = "OSTC 2N";
-		else if (btName.mid(4,2) == "+ ") product = "OSTC 2";
+		else if (btName.midRef(4,2) == "s#") product = "OSTC Sport";
+		else if (btName.midRef(4,2) == "s ") product = "OSTC Sport";
+		else if (btName.midRef(4,2) == "4-") product = "OSTC 4";
+		else if (btName.midRef(4,2) == "2-") product = "OSTC 2N";
+		else if (btName.midRef(4,2) == "+ ") product = "OSTC 2";
 		// all OSTCs are HW_FAMILY_OSTC_3, so when we do not know,
 		// just try this
 		else product = "OSTC 3"; // all OSTCs are HW_FAMILY_OSTC_3

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -24,7 +24,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 
 	if (btName.startsWith("OSTC")) {
 		vendor = "Heinrichs Weikamp";
-		if (btName.mid(4,1) == "3") product = "OSTC Plus";
+		if (btName.at(4) == '3') product = "OSTC Plus";
 		else if (btName.mid(4,2) == "s#") product = "OSTC Sport";
 		else if (btName.mid(4,2) == "s ") product = "OSTC Sport";
 		else if (btName.mid(4,2) == "4-") product = "OSTC 4";

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -376,11 +376,10 @@ void DCDeviceData::setDevName(const QString &devName)
 		int idx1 = devName.indexOf('(');
 		int idx2 = devName.lastIndexOf(')');
 		if (idx1 >= 0 && idx2 >= 0 && idx2 > idx1) {
-			QString front = devName.left(idx1).trimmed();
-			QString back = devName.mid(idx1 + 1, idx2 - idx1 - 1);
-			QString newDevName = back.indexOf(':') >= 0 ? back : front;
+			QStringRef back = devName.midRef(idx1 + 1, idx2 - idx1 - 1);
+			QStringRef newDevName = back.contains(':') ? back : devName.leftRef(idx1).trimmed();
 			qWarning() << "Found invalid bluetooth device" << devName << "corrected to" << newDevName << ".";
-			data.devname = copy_qstring(newDevName);
+			data.devname = copy_qstring(newDevName.toString());
 			return;
 		}
 	}

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -706,9 +706,9 @@ int parseDurationToSeconds(const QString &text)
 	double hours, minutes, seconds = 0;
 	int colon = numOnly.indexOf(':');
 	if (colon >= 0) {
-		hours = numOnly.left(colon).toDouble();
+		hours = numOnly.leftRef(colon).toDouble();
 
-		QString minutesStr = numOnly.mid(colon + 1);
+		QStringRef minutesStr = numOnly.midRef(colon + 1);
 		colon = minutesStr.indexOf(':');
 		if (colon >= 0) {
 			minutes = minutesStr.left(colon).toDouble();

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -699,26 +699,28 @@ QString render_seconds_to_string(int seconds)
 
 int parseDurationToSeconds(const QString &text)
 {
-	int secs;
 	QString numOnly = text;
-	QString hours, minutes, seconds;
-	numOnly.replace(",", ".").remove(QRegExp("[^-0-9.:]"));
+	numOnly.replace(',', '.').remove(QRegExp("[^-0-9.:]"));
 	if (numOnly.isEmpty())
 		return 0;
-	if (numOnly.contains(':')) {
-		hours = numOnly.left(numOnly.indexOf(':'));
-		minutes = numOnly.right(numOnly.length() - hours.length() - 1);
-		if (minutes.contains(':')) {
-			numOnly = minutes;
-			minutes = numOnly.left(numOnly.indexOf(':'));
-			seconds = numOnly.right(numOnly.length() - minutes.length() - 1);
+	double hours, minutes, seconds = 0;
+	int colon = numOnly.indexOf(':');
+	if (colon >= 0) {
+		hours = numOnly.left(colon).toDouble();
+
+		QString minutesStr = numOnly.mid(colon + 1);
+		colon = minutesStr.indexOf(':');
+		if (colon >= 0) {
+			minutes = minutesStr.left(colon).toDouble();
+			seconds = minutesStr.mid(colon + 1).toDouble();
+		} else {
+			minutes = minutesStr.toDouble();
 		}
 	} else {
-		hours = "0";
-		minutes = numOnly;
+		hours = 0;
+		minutes = numOnly.toDouble();
 	}
-	secs = lrint(hours.toDouble() * 3600 + minutes.toDouble() * 60 + seconds.toDouble());
-	return secs;
+	return lrint(hours * 3600 + minutes * 60 + seconds);
 }
 
 int parseLengthToMm(const QString &text)

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -77,8 +77,9 @@ void qPrefDisplay::loadSync(bool doSync)
 void qPrefDisplay::set_divelist_font(const QString &value)
 {
 	QString newValue = value;
-	if (value.contains(","))
-		newValue = value.left(value.indexOf(","));
+	int comma = value.indexOf(',');
+	if (comma >= 0)
+		newValue = value.left(comma);
 
 	if (newValue != prefs.divelist_font &&
 	    !subsurface_ignore_font(qPrintable(newValue))) {

--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -87,7 +87,7 @@ void TagWidget::reparse()
 	QPair<int, int> pos = getCursorTagPosition();
 	QString currentText;
 	if (pos.first >= 0 && pos.second > 0)
-		currentText = text().mid(pos.first, pos.second - pos.first).trimmed();
+		currentText = text().midRef(pos.first, pos.second - pos.first).trimmed().toString();
 
 	if (m_completer) {
 		m_completer->setCompletionPrefix(currentText);

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -33,8 +33,8 @@ void TestGitStorage::initTestCase()
 	qPrefCloudStorage::load();
 
 	QString gitUrl(prefs.cloud_base_url);
-	if (gitUrl.right(1) != "/")
-		gitUrl += "/";
+	if (!gitUrl.endsWith('/'))
+		gitUrl += '/';
 	prefs.cloud_git_url = copy_qstring(gitUrl + "git");
 	prefs.cloud_storage_email_encoded = strdup("ssrftest@hohndel.org");
 	prefs.cloud_storage_password = strdup("geheim");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This avoids allocating temporary strings when the original stays constant so the original memory can be reused. There are also some other minor cleanups along the way, e.g. avoiding to search the string twice for a character position.
