### PR TITLE
Desktop: don't use planner to manually add dive

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -965,18 +965,17 @@ void MainWindow::on_actionAddDive_triggered()
 
 	// create a dive an hour from now with a default depth (15m/45ft) and duration (40 minutes)
 	// as a starting point for the user to edit
-	clear_dive(&displayed_dive);
-	displayed_dive.id = dive_getUniqID();
-	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
-	displayed_dive.dc.duration.seconds = 40 * 60;
-	displayed_dive.dc.maxdepth.mm = M_OR_FT(15, 45);
-	displayed_dive.dc.meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
-	displayed_dive.dc.model = strdup("manually added dive"); // don't translate! this is stored in the XML file
-	displayed_dive.duration = displayed_dive.dc.duration;
-	fake_dc(&displayed_dive.dc);
-	fixup_dive(&displayed_dive);
+	struct dive d = { 0 };
+	d.id = dive_getUniqID();
+	d.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
+	d.dc.duration.seconds = 40 * 60;
+	d.dc.maxdepth.mm = M_OR_FT(15, 45);
+	d.dc.meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
+	d.dc.model = strdup("manually added dive"); // don't translate! this is stored in the XML file
+	fake_dc(&d.dc);
+	fixup_dive(&d);
 
-	Command::addDive(&displayed_dive, autogroup, true);
+	Command::addDive(&d, autogroup, true);
 
 	// Plot dive actually copies current_dive to displayed_dive and therefore ensures that the
 	// correct data are displayed!


### PR DESCRIPTION
Instead of calling into the planner, simply create the dive computer
information right there, using the existing helper function we have to
create simple profiles.

Fixes #2128

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
As the todo in the comment said - calling into the planner really didn't make any sense there.
Instead we create the initial dive (and profile) right there.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2128 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
not needed

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson 