### PR TITLE
Dive list: cache shown flag in model (quick-fix for undo-crash)

### DIFF
--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -52,15 +52,7 @@ signals:
 	// Trip edited signal
 	void tripChanged(dive_trip *trip, TripField field);
 
-	// Selection-signals come in two kinds:
-	//  - divesSelected and currentDiveChanged are are used by the dive-list
-	//    model and view to correctly highlight the correct dives.
-	//  - selectionChanged() is called once at the end of commands if either the selection
-	//    or the current dive changed. It is used by the main-window / profile to update
-	//    their data.
-	void divesSelected(const QVector<dive *> &dives);
-	void currentDiveChanged();
-	void selectionChanged();
+	void divesSelected(const QVector<dive *> &dives, dive *current);
 
 	// Dive site signals. Add and delete events are sent per dive site and
 	// provide an index into the global dive site table.

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -37,39 +37,29 @@ enum class TripField {
 class DiveListNotifier : public QObject {
 	Q_OBJECT
 signals:
-
-	// Note that there are no signals for trips being added / created / time-shifted,
-	// because these events never happen without a dive being added / created / time-shifted.
-
-	// We send one divesAdded, divesDeleted, divesChanged and divesTimeChanged, divesSelected
-	// signal per trip (non-associated dives being considered part of the null trip). This is
-	// ideal for the tree-view, but might be not-so-perfect for the list view, if trips intermingle
-	// or the deletion spans multiple trips. But most of the time only dives of a single trip
-	// will be affected and trips don't overlap, so these considerations are moot.
-	// Notes:
-	// - The dives are always sorted by according to the dives_less_than() function of the core.
-	// - The "trip" arguments are null for top-level-dives.
+	// Note that there are no signals for trips being added and created
+	// because these events never happen without a dive being added, removed or moved.
+	// The dives are always sorted according to the dives_less_than() function of the core.
 	void divesAdded(dive_trip *trip, bool addTrip, const QVector<dive *> &dives);
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
-	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesTimeChanged(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 
-	void cylindersReset(dive_trip *trip, const QVector<dive *> &dives);
-	void weightsystemsReset(dive_trip *trip, const QVector<dive *> &dives);
+	void cylindersReset(const QVector<dive *> &dives);
+	void weightsystemsReset(const QVector<dive *> &dives);
 
 	// Trip edited signal
 	void tripChanged(dive_trip *trip, TripField field);
 
 	// Selection-signals come in two kinds:
-	//  - divesSelected, divesDeselected and currentDiveChanged are finer grained and are
-	//    called batch-wise per trip (except currentDiveChanged, of course). These signals
-	//    are used by the dive-list model and view to correctly highlight the correct dives.
+	//  - divesSelected, divesDeselected and currentDiveChanged are are used by the dive-list
+	//    model and view to correctly highlight the correct dives.
 	//  - selectionChanged() is called once at the end of commands if either the selection
 	//    or the current dive changed. It is used by the main-window / profile to update
 	//    their data.
-	void divesSelected(dive_trip *trip, const QVector<dive *> &dives);
-	void divesDeselected(dive_trip *trip, const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives);
+	void divesDeselected(const QVector<dive *> &dives);
 	void currentDiveChanged();
 	void selectionChanged();
 

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -53,13 +53,12 @@ signals:
 	void tripChanged(dive_trip *trip, TripField field);
 
 	// Selection-signals come in two kinds:
-	//  - divesSelected, divesDeselected and currentDiveChanged are are used by the dive-list
+	//  - divesSelected and currentDiveChanged are are used by the dive-list
 	//    model and view to correctly highlight the correct dives.
 	//  - selectionChanged() is called once at the end of commands if either the selection
 	//    or the current dive changed. It is used by the main-window / profile to update
 	//    their data.
 	void divesSelected(const QVector<dive *> &dives);
-	void divesDeselected(const QVector<dive *> &dives);
 	void currentDiveChanged();
 	void selectionChanged();
 

--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -614,6 +614,9 @@ void ShiftTime::redoit()
 	emit diveListNotifier.divesTimeChanged(timeChanged, diveList);
 	emit diveListNotifier.divesChanged(diveList, DiveField::DATETIME);
 
+	// Select the changed dives
+	restoreSelection(diveList.toStdVector(), diveList[0]);
+
 	// Negate the time-shift so that the next call does the reverse
 	timeChanged = -timeChanged;
 }
@@ -638,6 +641,13 @@ RenumberDives::RenumberDives(const QVector<QPair<dive *, int>> &divesToRenumberI
 void RenumberDives::undoit()
 {
 	renumberDives(divesToRenumber);
+
+	// Select the changed dives
+	std::vector<dive *> dives;
+	dives.reserve(divesToRenumber.size());
+	for (const QPair<dive *, int> &item: divesToRenumber)
+		dives.push_back(item.first);
+	restoreSelection(dives, dives[0]);
 }
 
 bool RenumberDives::workToBeDone()
@@ -660,6 +670,13 @@ void TripBase::redoit()
 {
 	moveDivesBetweenTrips(divesToMove);
 	sort_trip_table(&trip_table); // Though unlikely, moving dives may reorder trips
+
+	// Select the moved dives
+	std::vector<dive *> dives;
+	dives.reserve(divesToMove.divesToMove.size());
+	for (const DiveToTrip &item: divesToMove.divesToMove)
+		dives.push_back(item.dive);
+	restoreSelection(dives, dives[0]);
 }
 
 void TripBase::undoit()

--- a/desktop-widgets/command_divelist.h
+++ b/desktop-widgets/command_divelist.h
@@ -49,17 +49,13 @@ struct DivesToTrip
 	std::vector<OwningTripPtr> tripsToAdd;
 };
 
-// All divelist commands derive from a common base class, which has a flag
-// for when then selection changed. In such a case, in the redo() and undo()
-// methods a signal will be sent. The base-class implements redo() and undo(),
-// which resets the flag and sends a signal. Derived classes implement the
-// virtual methods redoit() and undoit() [Yes, the names could be more expressive].
-// Moreover, the class implements helper methods, which set the selectionChanged
-// flag accordingly.
+// All divelist commands derive from a common base class. It keeps track
+// of dive site counts that may have changed.
+// Derived classes implement the virtual methods redoit() and undoit()
+// [Yes, the names could be more expressive].
 class DiveListBase : public Base {
 protected:
-	// These are helper functions to add / remove dive from the C-core structures,
-	// which set the selectionChanged flag if the added / removed dive was selected.
+	// These are helper functions to add / remove dive from the C-core structures.
 	DiveToAdd removeDive(struct dive *d, std::vector<OwningTripPtr> &tripsToAdd);
 	dive *addDive(DiveToAdd &d);
 	DivesAndTripsToAdd removeDives(DivesAndSitesToRemove &divesAndSitesToDelete);
@@ -68,20 +64,11 @@ protected:
 	// Register dive sites where counts changed so that we can signal the frontend later.
 	void diveSiteCountChanged(struct dive_site *ds);
 
-	// Set the selection to a given state. Set the selectionChanged flag if anything changed.
-	void restoreSelection(const std::vector<dive *> &selection, dive *currentDive);
-
-	// Commands set this flag if the selection changed on first execution.
-	// Only then, a new the divelist will be scanned again after the command.
-	// If this flag is set on first execution, a selectionChanged signal will
-	// be sent.
-	bool selectionChanged;
-
 private:
 	// Keep track of dive sites where the number of dives changed
 	std::vector<dive_site *> sitesCountChanged;
-	void initWork(); // reset selectionChanged flag
-	void finishWork(); // emit signals if selection or dive site counts changed
+	void initWork();
+	void finishWork(); // update dive site counts
 	void undo() override;
 	void redo() override;
 	virtual void redoit() = 0;

--- a/desktop-widgets/command_divesite.cpp
+++ b/desktop-widgets/command_divesite.cpp
@@ -18,7 +18,7 @@ namespace Command {
 static std::vector<dive_site *> addDiveSites(std::vector<OwningDiveSitePtr> &sites)
 {
 	std::vector<dive_site *> res;
-	std::vector<dive *> changedDives;
+	QVector<dive *> changedDives;
 	res.reserve(sites.size());
 
 	for (OwningDiveSitePtr &ds: sites) {
@@ -36,9 +36,7 @@ static std::vector<dive_site *> addDiveSites(std::vector<OwningDiveSitePtr> &sit
 		emit diveListNotifier.diveSiteAdded(res.back(), idx); // Inform frontend of new dive site.
 	}
 
-	processByTrip(changedDives, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVESITE);
-	});
+	emit diveListNotifier.divesChanged(changedDives, DiveField::DIVESITE);
 
 	// Clear vector of unused owning pointers
 	sites.clear();
@@ -52,7 +50,7 @@ static std::vector<dive_site *> addDiveSites(std::vector<OwningDiveSitePtr> &sit
 static std::vector<OwningDiveSitePtr> removeDiveSites(std::vector<dive_site *> &sites)
 {
 	std::vector<OwningDiveSitePtr> res;
-	std::vector<dive *> changedDives;
+	QVector<dive *> changedDives;
 	res.reserve(sites.size());
 
 	for (dive_site *ds: sites) {
@@ -69,9 +67,7 @@ static std::vector<OwningDiveSitePtr> removeDiveSites(std::vector<dive_site *> &
 		emit diveListNotifier.diveSiteDeleted(ds, idx); // Inform frontend of removed dive site.
 	}
 
-	processByTrip(changedDives, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVESITE);
-	});
+	emit diveListNotifier.divesChanged(changedDives, DiveField::DIVESITE);
 
 	sites.clear();
 
@@ -363,7 +359,7 @@ void MergeDiveSites::redo()
 	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
 
 	// Remember which dives changed so that we can send a single dives-edited signal
-	std::vector<dive *> divesChanged;
+	QVector<dive *> divesChanged;
 
 	// The dives of the above dive sites were reset to no dive sites.
 	// Add them to the merged-into dive site. Thankfully, we remember
@@ -374,15 +370,13 @@ void MergeDiveSites::redo()
 			divesChanged.push_back(site->dives.dives[i]);
 		}
 	}
-	processByTrip(divesChanged, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVESITE);
-	});
+	emit diveListNotifier.divesChanged(divesChanged, DiveField::DIVESITE);
 }
 
 void MergeDiveSites::undo()
 {
 	// Remember which dives changed so that we can send a single dives-edited signal
-	std::vector<dive *> divesChanged;
+	QVector<dive *> divesChanged;
 
 	// Before readding the dive sites, unregister the corresponding dives so that they can be
 	// readded to their old dive sites.
@@ -395,9 +389,7 @@ void MergeDiveSites::undo()
 
 	sitesToRemove = std::move(addDiveSites(sitesToAdd));
 
-	processByTrip(divesChanged, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVESITE);
-	});
+	emit diveListNotifier.divesChanged(divesChanged, DiveField::DIVESITE);
 }
 
 } // namespace Command

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -97,9 +97,7 @@ void EditBase<T>::undo()
 
 	// Send signals.
 	DiveField id = fieldId();
-	processByTrip(dives, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, id);
-	});
+	emit diveListNotifier.divesChanged(QVector<dive *>::fromStdVector(dives), id);
 
 	if (setSelection(selectedDives, current))
 		emit diveListNotifier.selectionChanged(); // If the selection changed -> tell the frontend
@@ -539,9 +537,7 @@ void EditTagsBase::undo()
 
 	// Send signals.
 	DiveField id = fieldId();
-	processByTrip(dives, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesChanged(trip, divesInTrip, id);
-	});
+	emit diveListNotifier.divesChanged(QVector<dive *>::fromStdVector(dives), id);
 
 	if (setSelection(selectedDives, current))
 		emit diveListNotifier.selectionChanged(); // If the selection changed -> tell the frontend
@@ -750,7 +746,7 @@ void PasteDives::undo()
 	}
 	ownedDiveSites.clear();
 
-	std::vector<dive *> divesToNotify; // Remember dives so that we can send signals later
+	QVector<dive *> divesToNotify; // Remember dives so that we can send signals later
 	divesToNotify.reserve(dives.size());
 	for (PasteState &state: dives) {
 		divesToNotify.push_back(state.d);
@@ -780,28 +776,26 @@ void PasteDives::undo()
 	// TODO: We send one signal per changed field. This means that the dive list may
 	// update the entry numerous times. Perhaps change the field-id into flags?
 	// There seems to be a number of enums / flags describing dive fields. Perhaps unify them all?
-	processByTrip(divesToNotify, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		if (what.notes)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::NOTES);
-		if (what.divemaster)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVEMASTER);
-		if (what.buddy)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::BUDDY);
-		if (what.suit)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::SUIT);
-		if (what.rating)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::RATING);
-		if (what.visibility)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::VISIBILITY);
-		if (what.divesite)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::DIVESITE);
-		if (what.tags)
-			emit diveListNotifier.divesChanged(trip, divesInTrip, DiveField::TAGS);
-		if (what.cylinders)
-			emit diveListNotifier.cylindersReset(trip, divesInTrip);
-		if (what.weights)
-			emit diveListNotifier.weightsystemsReset(trip, divesInTrip);
-	});
+	if (what.notes)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::NOTES);
+	if (what.divemaster)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::DIVEMASTER);
+	if (what.buddy)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::BUDDY);
+	if (what.suit)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::SUIT);
+	if (what.rating)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::RATING);
+	if (what.visibility)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::VISIBILITY);
+	if (what.divesite)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::DIVESITE);
+	if (what.tags)
+		emit diveListNotifier.divesChanged(divesToNotify, DiveField::TAGS);
+	if (what.cylinders)
+		emit diveListNotifier.cylindersReset(divesToNotify);
+	if (what.weights)
+		emit diveListNotifier.weightsystemsReset(divesToNotify);
 
 	if (diveSiteListChanged)
 		MapWidget::instance()->reload();

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -99,8 +99,7 @@ void EditBase<T>::undo()
 	DiveField id = fieldId();
 	emit diveListNotifier.divesChanged(QVector<dive *>::fromStdVector(dives), id);
 
-	if (setSelection(selectedDives, current))
-		emit diveListNotifier.selectionChanged(); // If the selection changed -> tell the frontend
+	setSelection(selectedDives, current);
 }
 
 // We have to manually instantiate the constructors of the EditBase class,
@@ -539,8 +538,7 @@ void EditTagsBase::undo()
 	DiveField id = fieldId();
 	emit diveListNotifier.divesChanged(QVector<dive *>::fromStdVector(dives), id);
 
-	if (setSelection(selectedDives, current))
-		emit diveListNotifier.selectionChanged(); // If the selection changed -> tell the frontend
+	setSelection(selectedDives, current);
 }
 
 // Undo and redo do the same as just the stored value is exchanged

--- a/desktop-widgets/command_private.cpp
+++ b/desktop-widgets/command_private.cpp
@@ -42,7 +42,7 @@ static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &s
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
 // null if "seletion" is empty). Return true if the selection or current dive changed.
-bool setSelection(const std::vector<dive *> &selection, dive *currentDive)
+void setSelection(const std::vector<dive *> &selection, dive *currentDive)
 {
 	// To do so, generate vectors of dives to be selected and deselected.
 	// We send signals batched by trip, so keep track of trip/dive pairs.
@@ -102,8 +102,9 @@ bool setSelection(const std::vector<dive *> &selection, dive *currentDive)
 		emit diveListNotifier.currentDiveChanged();
 	}
 
-	// return true if selection of current dive changed
-	return selectionChanged || currentDiveChanged;
+	// If the selection changed -> tell the frontend
+	if (selectionChanged || currentDiveChanged)
+		emit diveListNotifier.selectionChanged();
 }
 
 // Turn current selection into a vector.

--- a/desktop-widgets/command_private.cpp
+++ b/desktop-widgets/command_private.cpp
@@ -46,8 +46,8 @@ bool setSelection(const std::vector<dive *> &selection, dive *currentDive)
 {
 	// To do so, generate vectors of dives to be selected and deselected.
 	// We send signals batched by trip, so keep track of trip/dive pairs.
-	std::vector<std::pair<dive_trip *, dive *>> divesToSelect;
-	std::vector<std::pair<dive_trip *, dive *>> divesToDeselect;
+	QVector<dive *> divesToSelect;
+	QVector<dive *> divesToDeselect;
 
 	// TODO: We might want to keep track of selected dives in a more efficient way!
 	int i;
@@ -73,20 +73,16 @@ bool setSelection(const std::vector<dive *> &selection, dive *currentDive)
 		if (newState && !d->selected) {
 			d->selected = true;
 			++amount_selected;
-			divesToSelect.push_back({ d->divetrip, d });
+			divesToSelect.push_back(d);
 		} else if (!newState && d->selected) {
 			d->selected = false;
-			divesToDeselect.push_back({ d->divetrip, d });
+			divesToDeselect.push_back(d);
 		}
 	}
 
 	// Send the select and deselect signals
-	processByTrip(divesToSelect, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesSelected(trip, divesInTrip);
-	});
-	processByTrip(divesToDeselect, [&](dive_trip *trip, const QVector<dive *> &divesInTrip) {
-		emit diveListNotifier.divesDeselected(trip, divesInTrip);
-	});
+	emit diveListNotifier.divesSelected(divesToSelect);
+	emit diveListNotifier.divesDeselected(divesToDeselect);
 
 	bool currentDiveChanged = false;
 	if (!currentDive) {

--- a/desktop-widgets/command_private.h
+++ b/desktop-widgets/command_private.h
@@ -12,50 +12,6 @@
 
 namespace Command {
 
-// Generally, signals are sent in batches per trip. To avoid writing the same loop
-// again and again, this template takes a vector of trip / dive pairs, sorts it
-// by trip and then calls a function-object with trip and a QVector of dives in that trip.
-// The dives are sorted by the dive_less_than() function defined in the core.
-// Input parameters:
-//	- dives: a vector of trip,dive pairs, which will be sorted and processed in batches by trip.
-//	- action: a function object, taking a trip-pointer and a QVector of dives, which will be called for each batch.
-template<typename Function>
-void processByTrip(std::vector<std::pair<dive_trip *, dive *>> &dives, Function action)
-{
-	// Use std::tie for lexicographical sorting of trip, then start-time
-	std::sort(dives.begin(), dives.end(),
-		  [](const std::pair<dive_trip *, dive *> &e1, const std::pair<dive_trip *, dive *> &e2)
-		  { return e1.first == e2.first ? dive_less_than(e1.second, e2.second) : e1.first < e2.first; });
-
-	// Then, process the dives in batches by trip
-	size_t i, j; // Begin and end of batch
-	for (i = 0; i < dives.size(); i = j) {
-		dive_trip *trip = dives[i].first;
-		for (j = i + 1; j < dives.size() && dives[j].first == trip; ++j)
-			; // pass
-		// Copy dives into a QVector. Some sort of "range_view" would be ideal, but Qt doesn't work this way.
-		QVector<dive *> divesInTrip(j - i);
-		for (size_t k = i; k < j; ++k)
-			divesInTrip[k - i] = dives[k].second;
-
-		// Finally, emit the signal
-		action(trip, divesInTrip);
-	}
-}
-
-// The processByTrip() function above takes a vector if (trip, dive) pairs.
-// This overload takes a vector of dives.
-template<typename Vector, typename Function>
-void processByTrip(Vector &divesIn, Function action)
-{
-	std::vector<std::pair<dive_trip *, dive *>> dives;
-	dives.reserve(divesIn.size());
-	for (dive *d: divesIn)
-		dives.push_back({ d->divetrip, d });
-	processByTrip(dives, action);
-
-}
-
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
 // null if "seletion" is empty). Return true if the selection or current dive changed.

--- a/desktop-widgets/command_private.h
+++ b/desktop-widgets/command_private.h
@@ -15,7 +15,7 @@ namespace Command {
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
 // null if "seletion" is empty). Return true if the selection or current dive changed.
-bool setSelection(const std::vector<dive *> &selection, dive *currentDive);
+void setSelection(const std::vector<dive *> &selection, dive *currentDive);
 
 // Get currently selectd dives
 std::vector<dive *> getDiveSelection();

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -448,7 +448,7 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 		scrollTo(idx);
 	}
 	// now that everything is up to date, update the widgets
-	emit diveListNotifier.selectionChanged();
+	emit divesSelected();
 	dontEmitDiveChangedSignal = false;
 	return;
 }
@@ -663,7 +663,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 		}
 	}
 	if (!dontEmitDiveChangedSignal)
-		emit diveListNotifier.selectionChanged();
+		emit divesSelected();
 
 	// Display the new, processed, selection
 	QTreeView::selectionChanged(selectionModel()->selection(), newDeselected);
@@ -1063,7 +1063,7 @@ void DiveListView::filterFinished()
 	// If there are no more selected dives, select the first visible dive
 	if (!selectionModel()->hasSelection())
 		selectFirstDive();
-	emit diveListNotifier.selectionChanged();
+	emit divesSelected();
 }
 
 QString DiveListView::lastUsedImageDir()

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -192,13 +192,11 @@ void DiveListView::reset()
 }
 
 // If items were selected, inform the selection model
-void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indexes, bool select)
+void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indexes)
 {
+	clearSelection();
 	MultiFilterSortModel *m = MultiFilterSortModel::instance();
 	QItemSelectionModel *s = selectionModel();
-	auto flags = select ?
-		QItemSelectionModel::Rows | QItemSelectionModel::Select :
-		QItemSelectionModel::Rows | QItemSelectionModel::Deselect;
 	for (const QModelIndex &index: indexes) {
 		// We have to transform the indices into local indices, since
 		// there might be sorting or filtering in effect.
@@ -210,10 +208,10 @@ void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indexes, boo
 		if (!localIndex.isValid())
 			continue;
 
-		s->select(localIndex, flags);
+		s->select(localIndex, QItemSelectionModel::Rows | QItemSelectionModel::Select);
 
 		// If an item of a not-yet expanded trip is selected, expand the trip.
-		if (select && localIndex.parent().isValid() && !isExpanded(localIndex.parent())) {
+		if (localIndex.parent().isValid() && !isExpanded(localIndex.parent())) {
 			setAnimated(false);
 			expand(localIndex.parent());
 			setAnimated(true);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -63,7 +63,7 @@ slots:
 	void shiftTimes();
 	void loadImages();
 	void loadWebImages();
-	void diveSelectionChanged(const QVector<QModelIndex> &indexes, bool select);
+	void diveSelectionChanged(const QVector<QModelIndex> &indexes);
 	void currentDiveChanged(QModelIndex index);
 	void filterFinished();
 	void tripChanged(dive_trip *trip, TripField);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -42,6 +42,8 @@ public:
 	QList<dive_trip *> selectedTrips();
 	static QString lastUsedImageDir();
 	static void updateLastUsedImageDir(const QString &s);
+signals:
+	void divesSelected();
 public
 slots:
 	void toggleColumnVisibilityByIndex();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -190,7 +190,8 @@ MainWindow::MainWindow() : QMainWindow(),
 	if (!QIcon::hasThemeIcon("window-close")) {
 		QIcon::setThemeName("subsurface");
 	}
-	connect(&diveListNotifier, &DiveListNotifier::selectionChanged, this, &MainWindow::selectionChanged);
+	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &MainWindow::selectionChanged);
+	connect(diveList, &DiveListView::divesSelected, this, &MainWindow::selectionChanged);
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(update()));
 	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(reloadHeaderActions()));

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -12,7 +12,6 @@
 #include "mainwindow.h"
 #include "divelistview.h"
 #include "command.h"
-#include "core/trip.h" // TODO: Needed because divesChanged uses a trip parameter -> remove that!
 
 static const QUrl urlMapWidget = QUrl(QStringLiteral("qrc:/qml/MapWidget.qml"));
 static const QUrl urlMapWidgetError = QUrl(QStringLiteral("qrc:/qml/MapWidgetError.qml"));
@@ -91,7 +90,7 @@ void MapWidget::coordinatesChanged(struct dive_site *ds, const location_t &locat
 	Command::editDiveSiteLocation(ds, location);
 }
 
-void MapWidget::divesChanged(dive_trip *, const QVector<dive *> &, DiveField field)
+void MapWidget::divesChanged(const QVector<dive *> &, DiveField field)
 {
 	if (field == DiveField::DIVESITE)
 		reload();

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -31,7 +31,7 @@ public slots:
 	void selectedDivesChanged(const QList<int> &);
 	void coordinatesChanged(struct dive_site *ds, const location_t &);
 	void doneLoading(QQuickWidget::Status status);
-	void divesChanged(dive_trip *, const QVector<dive *> &, DiveField field);
+	void divesChanged(const QVector<dive *> &, DiveField field);
 
 private:
 	static MapWidget *m_instance;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -5,7 +5,6 @@
 #include "core/units.h"
 #include "core/dive.h"
 #include "desktop-widgets/command.h"
-#include "core/trip.h" // TODO: Needed because divesChanged uses a trip parameter -> remove that!
 #include "core/qthelper.h"
 #include "core/statistics.h"
 #include "core/display.h"
@@ -131,7 +130,7 @@ void TabDiveInformation::updateData()
 
 // This function gets called if a field gets updated by an undo command.
 // Refresh the corresponding UI field.
-void TabDiveInformation::divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field)
+void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField field)
 {
 	// If the current dive is not in list of changed dives, do nothing
 	if (!current_dive || !dives.contains(current_dive))

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -17,7 +17,7 @@ public:
 	void updateData() override;
 	void clear() override;
 private slots:
-	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void on_atmPressVal_editingFinished();
 	void on_atmPressType_currentIndexChanged(int index);
 private:

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -281,7 +281,7 @@ static void profileFromDive(struct dive *d)
 
 // This function gets called if a field gets updated by an undo command.
 // Refresh the corresponding UI field.
-void MainTab::divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field)
+void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 {
 	// If the current dive is not in list of changed dives, do nothing
 	if (!current_dive || !dives.contains(current_dive))

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -46,7 +46,7 @@ public:
 
 public
 slots:
-	void divesChanged(dive_trip *trip, const QVector<dive *> &dives, DiveField field);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void diveSiteEdited(dive_site *ds, int field);
 	void tripChanged(dive_trip *trip, TripField field);
 	void updateDiveInfo();

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -7,7 +7,6 @@
 #include "qt-models/diveplannermodel.h"
 #include "core/gettextfromc.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
-#include "core/trip.h" // TODO: Needed because cylindersReset uses a trip parameter -> remove that!
 
 CylindersModel::CylindersModel(QObject *parent) :
 	CleanerTableModel(parent),
@@ -619,7 +618,7 @@ bool CylindersModel::updateBestMixes()
 	return gasUpdated;
 }
 
-void CylindersModel::cylindersReset(dive_trip *trip, const QVector<dive *> &dives)
+void CylindersModel::cylindersReset(const QVector<dive *> &dives)
 {
 	// This model only concerns the currently displayed dive. If this is not among the
 	// dives that had their cylinders reset, exit.

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -48,7 +48,7 @@ public:
 public
 slots:
 	void remove(const QModelIndex &index);
-	void cylindersReset(dive_trip *trip, const QVector<dive *> &dives);
+	void cylindersReset(const QVector<dive *> &dives);
 	bool updateBestMixes();
 
 private:

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -89,18 +89,12 @@ signals:
 	// into QModelIndexes according to the current view (tree/list). Finally, the DiveListView transforms these
 	// indexes into local indexes according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
-	void selectionChanged(const QVector<QModelIndex> &indexes, bool select);
+	void selectionChanged(const QVector<QModelIndex> &indexes);
 	void newCurrentDive(QModelIndex index);
-protected slots:
-	void divesSelected(const QVector<dive *> &dives);
-	void divesDeselected(const QVector<dive *> &dives);
 protected:
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);
 	static QVariant tripData(const dive_trip *trip, int column, int role);
-
-	// Select or deselect dives
-	virtual void changeDiveSelection(const QVector<dive *> &dives, bool select) = 0;
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 };
@@ -114,6 +108,7 @@ public slots:
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesChanged(const QVector<dive *> &dives);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives);
 	void currentDiveChanged();
 	void tripChanged(dive_trip *trip, TripField);
 
@@ -126,8 +121,7 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
-	void changeDiveSelection(const QVector<dive *> &dives, bool select) override;
-	void changeDiveSelectionTrip(dive_trip *trip, const QVector<dive *> &dives, bool select);
+	void divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &);
 	dive *diveOrNull(const QModelIndex &index) const override;
 	bool setShown(const QModelIndex &idx, bool shown);
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
@@ -181,6 +175,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives);
 	void currentDiveChanged();
 
 public:
@@ -192,7 +187,6 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
-	void changeDiveSelection(const QVector<dive *> &dives, bool select) override;
 	dive *diveOrNull(const QModelIndex &index) const override;
 	bool setShown(const QModelIndex &idx, bool shown);
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -52,6 +52,7 @@ public:
 		DIVE_ROLE,
 		TRIP_ROLE,
 		DIVE_IDX,
+		SHOWN_ROLE,
 		SELECTED_ROLE
 	};
 	enum Layout {
@@ -74,6 +75,7 @@ public:
 	DiveTripModelBase(QObject *parent = 0);
 	int columnCount(const QModelIndex&) const;
 	virtual void filterFinished() = 0;
+	virtual bool setShown(const QModelIndex &idx, bool shown) = 0;
 
 	// Used for sorting. This is a bit of a layering violation, as sorting should be performed
 	// by the higher-up QSortFilterProxyModel, but it makes things so much easier!
@@ -126,6 +128,7 @@ private:
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	void changeDiveSelection(dive_trip *trip, const QVector<dive *> &dives, bool select) override;
 	dive *diveOrNull(const QModelIndex &index) const override;
+	bool setShown(const QModelIndex &idx, bool shown);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"
@@ -138,6 +141,7 @@ private:
 	struct Item {
 		dive_or_trip		d_or_t;
 		std::vector<dive *>	dives;			// std::vector<> instead of QVector for insert() with three iterators
+		bool			shown;
 		Item(dive_trip *t, const QVector<dive *> &dives);
 		Item(dive_trip *t, dive *d);			// Initialize a trip with one dive
 		Item(dive *d);					// Initialize a top-level dive
@@ -187,6 +191,7 @@ private:
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	void changeDiveSelection(dive_trip *trip, const QVector<dive *> &dives, bool select) override;
 	dive *diveOrNull(const QModelIndex &index) const override;
+	bool setShown(const QModelIndex &idx, bool shown);
 
 	std::vector<dive *> items;				// TODO: access core data directly
 };

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -92,15 +92,15 @@ signals:
 	void selectionChanged(const QVector<QModelIndex> &indexes, bool select);
 	void newCurrentDive(QModelIndex index);
 protected slots:
-	void divesSelected(dive_trip *trip, const QVector<dive *> &dives);
-	void divesDeselected(dive_trip *trip, const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives);
+	void divesDeselected(const QVector<dive *> &dives);
 protected:
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);
 	static QVariant tripData(const dive_trip *trip, int column, int role);
 
 	// Select or deselect dives
-	virtual void changeDiveSelection(dive_trip *trip, const QVector<dive *> &dives, bool select) = 0;
+	virtual void changeDiveSelection(const QVector<dive *> &dives, bool select) = 0;
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 };
@@ -111,9 +111,9 @@ class DiveTripModelTree : public DiveTripModelBase
 public slots:
 	void divesAdded(dive_trip *trip, bool addTrip, const QVector<dive *> &dives);
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
-	void divesChanged(dive_trip *trip, const QVector<dive *> &dives);
-	void divesTimeChanged(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
+	void divesChanged(const QVector<dive *> &dives);
+	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void currentDiveChanged();
 	void tripChanged(dive_trip *trip, TripField);
 
@@ -126,9 +126,12 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
-	void changeDiveSelection(dive_trip *trip, const QVector<dive *> &dives, bool select) override;
+	void changeDiveSelection(const QVector<dive *> &dives, bool select) override;
+	void changeDiveSelectionTrip(dive_trip *trip, const QVector<dive *> &dives, bool select);
 	dive *diveOrNull(const QModelIndex &index) const override;
 	bool setShown(const QModelIndex &idx, bool shown);
+	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
+	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"
@@ -174,8 +177,8 @@ class DiveTripModelList : public DiveTripModelBase
 public slots:
 	void divesAdded(dive_trip *trip, bool addTrip, const QVector<dive *> &dives);
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
-	void divesChanged(dive_trip *trip, const QVector<dive *> &dives);
-	void divesTimeChanged(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
+	void divesChanged(const QVector<dive *> &dives);
+	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void currentDiveChanged();
@@ -189,7 +192,7 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
-	void changeDiveSelection(dive_trip *trip, const QVector<dive *> &dives, bool select) override;
+	void changeDiveSelection(const QVector<dive *> &dives, bool select) override;
 	dive *diveOrNull(const QModelIndex &index) const override;
 	bool setShown(const QModelIndex &idx, bool shown);
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -108,8 +108,7 @@ public slots:
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesChanged(const QVector<dive *> &dives);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives);
-	void currentDiveChanged();
+	void divesSelected(const QVector<dive *> &dives, dive *current);
 	void tripChanged(dive_trip *trip, TripField);
 
 public:
@@ -175,8 +174,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives);
-	void currentDiveChanged();
+	void divesSelected(const QVector<dive *> &dives, dive *current);
 
 public:
 	DiveTripModelList(QObject *parent = nullptr);

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -6,7 +6,6 @@
 #include "core/qthelper.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "qt-models/weightsysteminfomodel.h"
-#include "core/trip.h" // TODO: Needed because weightsystemsReset uses a trip parameter -> remove that!
 
 WeightModel::WeightModel(QObject *parent) : CleanerTableModel(parent),
 	changed(false),
@@ -168,7 +167,7 @@ void WeightModel::updateDive()
 	}
 }
 
-void WeightModel::weightsystemsReset(dive_trip *trip, const QVector<dive *> &dives)
+void WeightModel::weightsystemsReset(const QVector<dive *> &dives)
 {
 	// This model only concerns the currently displayed dive. If this is not among the
 	// dives that had their cylinders reset, exit.

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -32,7 +32,7 @@ public:
 public
 slots:
 	void remove(const QModelIndex &index);
-	void weightsystemsReset(dive_trip *trip, const QVector<dive *> &dives);
+	void weightsystemsReset(const QVector<dive *> &dives);
 
 private:
 	int rows;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a quick-fix for an easily reproduced crash condition. The details are in the first commit-message. The code is appalling, but seems to be the easy way out for now. We really have to get rid of the duplication of code in core and qt-model and the QSortFilterProxyModel. This is just not viable.

This unifies selection behavior for a better UI experience. And pushes the batching of signals by trips to the place where it is needed (the tree view).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Cache the shown flag in the qt-models.
2) Access the shown flag via qt-models, not directly in core.
3) Remove batching of signals by trip.
4) Unify selection in divelist commands.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: I only slightly tested this - but you said you were able to reproduce the crash, so hopefully you can confirm that this fixes it.