### PR TITLE
[RFC] Merge dives: use higher number

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -918,9 +918,6 @@ MergeDives::MergeDives(const QVector <dive *> &dives)
 	d->divetrip = nullptr;
 	d->dive_site = nullptr;
 
-	// The merged dive gets the number of the first dive
-	d->number = dives[0]->number;
-
 	// We will only renumber the remaining dives if the joined dives are consecutive.
 	// Otherwise all bets are off concerning what the user wanted and doing nothing seems
 	// like the best option.


### PR DESCRIPTION
The merge_dives() function made the output dive use the higher number.

That was overwritten in MergeDives::MergeDives() with the number of
the first dive.

Remove the overwriting and use the number provided by the core.

Fixes #2126

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
On dive merge, don't overwrite the dive-number produced by the core.

This means that the higher number is used. Marking as RFC, since I'm not sure why the old code was there and I'm not sure what the correct policy is. In any case, this moves the decision to the `merge_dives()` function where it should be.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure.

@mturkia @dirkhh 