### PR TITLE
[RFC] Dive merge: don't use unset dive numbers

### DIFF
--- a/desktop-widgets/command_divelist.cpp
+++ b/desktop-widgets/command_divelist.cpp
@@ -918,8 +918,13 @@ MergeDives::MergeDives(const QVector <dive *> &dives)
 	d->divetrip = nullptr;
 	d->dive_site = nullptr;
 
-	// The merged dive gets the number of the first dive
-	d->number = dives[0]->number;
+	// The merged dive gets the number of the first dive with a non-zero number
+	for (const dive *dive: dives) {
+		if (dive->number) {
+			d->number = dive->number;
+			break;
+		}
+	}
 
 	// We will only renumber the remaining dives if the joined dives are consecutive.
 	// Otherwise all bets are off concerning what the user wanted and doing nothing seems


### PR DESCRIPTION
On merging, don't use the number of the first dive if it is 0.
Use the first non-zero number.

Fixes #2126

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Use the first non-0 number when merging dives.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Maybe?

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia @dirkhh 