### PR TITLE
Desktop: fix time editing

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -814,7 +814,7 @@ static void shiftTime(QDateTime &dateTime)
 
 	timestamp_t when = dateTime.toTime_t();
 	if (current_dive && current_dive->when != when) {
-		timestamp_t offset = current_dive->when - when;
+		timestamp_t offset = when - current_dive->when;
 		Command::shiftTime(dives, (int)offset);
 	}
 }


### PR DESCRIPTION
We were shifting in the wrong direction. Which caused the field to be marked as
'edited' again, which meant we shifted the wrong way and twice the distance.
This seems to fix the problem for both date and time editing.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
It felt like we just fixed this, right? I'm confused.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger - I wrote and tested this on the flight (yay for ridiculously overpriced trans-Pacific WiFi).
It seems too simple, but it seems to work :-)