### PR TITLE
Dive site edit fix

### DIFF
--- a/desktop-widgets/command_divesite.cpp
+++ b/desktop-widgets/command_divesite.cpp
@@ -186,6 +186,18 @@ static void swap(char *&c, QString &q)
 	q = s;
 }
 
+// Helper function: collect the dives that are at the given dive site
+static QVector<dive *> getDivesForSite(struct dive_site *ds)
+{
+	QVector<dive *> diveSiteDives;
+
+	for (int i = 0; i < ds->dives.nr; ++i)
+		diveSiteDives.push_back(ds->dives.dives[i]);
+
+	return diveSiteDives;
+}
+
+
 EditDiveSiteName::EditDiveSiteName(dive_site *dsIn, const QString &name) : ds(dsIn),
 	value(name)
 {
@@ -201,6 +213,7 @@ void EditDiveSiteName::redo()
 {
 	swap(ds->name, value);
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::NAME); // Inform frontend of changed dive site.
+	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // dive site name can be shown in the dive list
 }
 
 void EditDiveSiteName::undo()
@@ -272,6 +285,8 @@ void EditDiveSiteCountry::redo()
 	taxonomy_set_country(&ds->taxonomy, copy_qstring(value), taxonomy_origin::GEOMANUAL);
 	value = old;
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::TAXONOMY); // Inform frontend of changed dive site.
+	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // Country can be shown in the dive list
+
 }
 
 void EditDiveSiteCountry::undo()
@@ -299,6 +314,7 @@ void EditDiveSiteLocation::redo()
 {
 	std::swap(value, ds->location);
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::LOCATION); // Inform frontend of changed dive site.
+	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // the globe icon in the dive list shows whether we have coordinates
 }
 
 void EditDiveSiteLocation::undo()

--- a/desktop-widgets/command_divesite.cpp
+++ b/desktop-widgets/command_divesite.cpp
@@ -190,6 +190,7 @@ static void swap(char *&c, QString &q)
 static QVector<dive *> getDivesForSite(struct dive_site *ds)
 {
 	QVector<dive *> diveSiteDives;
+	diveSiteDives.reserve(ds->dives.nr);
 
 	for (int i = 0; i < ds->dives.nr; ++i)
 		diveSiteDives.push_back(ds->dives.dives[i]);

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -203,9 +203,8 @@ void LocationInformationWidget::initFields(dive_site *ds)
 
 void LocationInformationWidget::on_diveSiteCoordinates_editingFinished()
 {
-	if (!diveSite)
-		return;
-	Command::editDiveSiteLocation(diveSite, parseGpsText(ui.diveSiteCoordinates->text()));
+	if (diveSite)
+		Command::editDiveSiteLocation(diveSite, parseGpsText(ui.diveSiteCoordinates->text()));
 }
 
 void LocationInformationWidget::on_diveSiteCountry_editingFinished()

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -133,6 +133,7 @@ void LocationInformationWidget::diveSiteChanged(struct dive_site *ds, int field)
 	switch (field) {
 	case LocationInformationModel::NAME:
 		ui.diveSiteName->setText(diveSite->name);
+		MapWidget::instance()->repopulateLabels();
 		return;
 	case LocationInformationModel::DESCRIPTION:
 		ui.diveSiteDescription->setText(diveSite->description);
@@ -153,6 +154,7 @@ void LocationInformationWidget::diveSiteChanged(struct dive_site *ds, int field)
 			enableLocationButtons(false);
 			ui.diveSiteCoordinates->clear();
 		}
+		MapWidget::instance()->repopulateLabels();
 	default:
 		return;
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
Make sure that edits to dive sites are correctly reflected both in the dive list and on the map

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
First a silly consistency fix
Second commit makes sure the map gets notified if a dive site is changed by the undo command
Third commit makes sure that the dive list is notified as well - this one seems a bit odd as we now notify the dive list about both the changes and dive sites and the fact that this changes the dives at these dive sites. I wasn't sure if I wanted to add the code that does that here or on the signal receiving end (i.e. in the DIveTripModel). I ended up doing it here since the code seemed much simpler this way.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2135 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger - I'd love to hear your thoughts about sending two signals vs. making the `DiveTripModel` a recipient of the `diveSiteChanged` signal and doing the handling there