### PR TITLE
Remove MAX_WEIGHTSYSTEMS restriction

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -359,8 +359,8 @@ static void free_dive_structures(struct dive *d)
 	STRUCTURED_LIST_FREE(struct picture, d->picture_list, free_picture);
 	for (int i = 0; i < MAX_CYLINDERS; i++)
 		free((void *)d->cylinder[i].type.description);
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++)
-		free((void *)d->weightsystem[i].description);
+	clear_weightsystem_table(&d->weightsystems);
+	free(d->weightsystems.weightsystems);
 }
 
 void free_dive(struct dive *d)
@@ -391,6 +391,7 @@ static void copy_dive_nodc(const struct dive *s, struct dive *d)
 	 * relevant components that are referenced through pointers,
 	 * so all the strings and the structured lists */
 	*d = *s;
+	memset(&d->weightsystems, 0, sizeof(d->weightsystems));
 	invalidate_dive_cache(d);
 	d->buddy = copy_string(s->buddy);
 	d->divemaster = copy_string(s->divemaster);
@@ -398,8 +399,7 @@ static void copy_dive_nodc(const struct dive *s, struct dive *d)
 	d->suit = copy_string(s->suit);
 	for (int i = 0; i < MAX_CYLINDERS; i++)
 		d->cylinder[i].type.description = copy_string(s->cylinder[i].type.description);
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++)
-		d->weightsystem[i].description = copy_string(s->weightsystem[i].description);
+	copy_weights(&s->weightsystems, &d->weightsystems);
 	STRUCTURED_LIST_COPY(struct picture, s->picture_list, d->picture_list, copy_pl);
 	d->tag_list = taglist_copy(s->tag_list);
 }
@@ -436,15 +436,6 @@ struct dive *move_dive(struct dive *s)
 	if (what._component)                \
 		d->_component = copy_string(s->_component)
 
-void copy_weights(const struct dive *s, struct dive *d)
-{
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
-		free((void *)d->weightsystem[i].description);
-		d->weightsystem[i] = s->weightsystem[i];
-		d->weightsystem[i].description = copy_string(s->weightsystem[i].description);
-	}
-}
-
 // copy elements, depending on bits in what that are set
 void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_components what, bool clear)
 {
@@ -467,7 +458,7 @@ void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_compo
 	if (what.cylinders)
 		copy_cylinders(s, d, false);
 	if (what.weights)
-		copy_weights(s, d);
+		copy_weights(&s->weightsystems, &d->weightsystems);
 }
 #undef CONDITIONAL_COPY_STRING
 
@@ -519,14 +510,7 @@ int nr_cylinders(const struct dive *dive)
 
 int nr_weightsystems(const struct dive *dive)
 {
-	int nr;
-
-	for (nr = MAX_WEIGHTSYSTEMS; nr; --nr) {
-		const weightsystem_t *ws = dive->weightsystem + nr - 1;
-		if (!weightsystem_none(ws))
-			break;
-	}
-	return nr;
+	return dive->weightsystems.nr;
 }
 
 /* copy the equipment data part of the cylinders */
@@ -1570,8 +1554,8 @@ struct dive *fixup_dive(struct dive *dive)
 			cyl->end.mbar = 0;
 	}
 	update_cylinder_related_info(dive);
-	for (i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
-		weightsystem_t *ws = dive->weightsystem + i;
+	for (i = 0; i < dive->weightsystems.nr; i++) {
+		weightsystem_t *ws = &dive->weightsystems.weightsystems[i];
 		add_weightsystem_description(ws);
 	}
 	/* we should always have a uniq ID as that gets assigned during alloc_dive(),
@@ -1933,14 +1917,6 @@ static void merge_events(struct dive *d, struct divecomputer *res,
 		add_initial_gaschange(d, res, 0, cylinders_map1[0]);
 	if (cylinders_map2[0] > 0)
 		add_initial_gaschange(d, res, offset, cylinders_map2[0]);
-}
-
-static void merge_weightsystem_info(weightsystem_t *res, const weightsystem_t *a, const weightsystem_t *b)
-{
-	if (!a->weight.grams)
-		a = b;
-	res->weight = a->weight;
-	res->description = copy_string(a->description);
 }
 
 /* get_cylinder_idx_by_use(): Find the index of the first cylinder with a particular CCR use type.
@@ -2320,11 +2296,28 @@ static void merge_cylinders(struct dive *res, const struct dive *a, const struct
 	}
 }
 
+/* Check whether a weightsystem table contains a given weightsystem */
+static bool has_weightsystem(const struct weightsystem_table *t, const weightsystem_t w)
+{
+	int i;
+	for (i = 0; i < t->nr; i++) {
+		if (same_weightsystem(w, t->weightsystems[i]))
+			return true;
+	}
+	return false;
+}
+
 static void merge_equipment(struct dive *res, const struct dive *a, const struct dive *b)
 {
 	int i;
-	for (i = 0; i < MAX_WEIGHTSYSTEMS; i++)
-		merge_weightsystem_info(res->weightsystem + i, a->weightsystem + i, b->weightsystem + i);
+	for (i = 0; i < a->weightsystems.nr; i++) {
+		if (!has_weightsystem(&res->weightsystems, a->weightsystems.weightsystems[i]))
+			add_cloned_weightsystem(&res->weightsystems, a->weightsystems.weightsystems[i]);
+	}
+	for (i = 0; i < b->weightsystems.nr; i++) {
+		if (!has_weightsystem(&res->weightsystems, b->weightsystems.weightsystems[i]))
+			add_cloned_weightsystem(&res->weightsystems, b->weightsystems.weightsystems[i]);
+	}
 }
 
 static void merge_temperatures(struct dive *res, const struct dive *a, const struct dive *b)

--- a/core/dive.h
+++ b/core/dive.h
@@ -153,7 +153,7 @@ struct dive {
 	int rating;
 	int visibility; /* 0 - 5 star rating */
 	cylinder_t cylinder[MAX_CYLINDERS];
-	weightsystem_t weightsystem[MAX_WEIGHTSYSTEMS];
+	struct weightsystem_table weightsystems;
 	char *suit;
 	int sac, otu, cns, maxcns;
 
@@ -376,7 +376,6 @@ extern void copy_events(const struct divecomputer *s, struct divecomputer *d);
 extern void free_events(struct event *ev);
 extern void copy_cylinders(const struct dive *s, struct dive *d, bool used_only);
 extern void copy_samples(const struct divecomputer *s, struct divecomputer *d);
-extern void copy_weights(const struct dive *s, struct dive *d);
 extern bool is_cylinder_used(const struct dive *dive, int idx);
 extern bool is_cylinder_prot(const struct dive *dive, int idx);
 extern void fill_default_cylinder(cylinder_t *cyl);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -99,8 +99,8 @@ int total_weight(const struct dive *dive)
 	int i, total_grams = 0;
 
 	if (dive)
-		for (i = 0; i < MAX_WEIGHTSYSTEMS; i++)
-			total_grams += dive->weightsystem[i].weight.grams;
+		for (i = 0; i < dive->weightsystems.nr; i++)
+			total_grams += dive->weightsystems.weightsystems[i].weight.grams;
 	return total_grams;
 }
 

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -16,6 +16,7 @@
 #include "dive.h"
 #include "display.h"
 #include "divelist.h"
+#include "subsurface-string.h"
 
 /* placeholders for a few functions that we need to redesign for the Qt UI */
 void add_cylinder_description(const cylinder_type_t *type)
@@ -56,6 +57,12 @@ void add_weightsystem_description(const weightsystem_t *weightsystem)
 		ws_info[i].name = strdup(desc);
 		ws_info[i].grams = weightsystem->weight.grams;
 	}
+}
+
+bool same_weightsystem(weightsystem_t w1, weightsystem_t w2)
+{
+	return w1->weight.grams == w2->weight.grams &&
+	       same_string(w1->description, w2->description);
 }
 
 bool cylinder_nodata(const cylinder_t *cyl)

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -169,11 +169,6 @@ int find_best_gasmix_match(struct gasmix mix, const cylinder_t array[])
 	return best;
 }
 
-bool weightsystem_none(const weightsystem_t *ws)
-{
-	return !ws->weight.grams && !ws->description;
-}
-
 /*
  * We hardcode the most common standard cylinders,
  * we should pick up any other names from the dive

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -17,6 +17,29 @@
 #include "display.h"
 #include "divelist.h"
 #include "subsurface-string.h"
+#include "table.h"
+
+static void free_weightsystem(weightsystem_t w)
+{
+	free((void *)w.description);
+}
+
+void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d)
+{
+	clear_weightsystem_table(d);
+	for (int i = 0; i < s->nr; i++)
+		add_cloned_weightsystem(d, s->weightsystems[i]);
+}
+
+/* weightsystem table functions */
+//static MAKE_GET_IDX(weightsystem_table, weightsystem_t, weightsystems)
+static MAKE_GROW_TABLE(weightsystem_table, weightsystem_t, weightsystems)
+//static MAKE_GET_INSERTION_INDEX(weightsystem_table, weightsystem_t, weightsystems, weightsystem_less_than)
+MAKE_ADD_TO(weightsystem_table, weightsystem_t, weightsystems)
+MAKE_REMOVE_FROM(weightsystem_table, weightsystems)
+//MAKE_SORT(weightsystem_table, weightsystem_t, weightsystems, comp_weightsystems)
+//MAKE_REMOVE(weightsystem_table, weightsystem_t, weightsystem)
+MAKE_CLEAR_TABLE(weightsystem_table, weightsystems, weightsystem)
 
 /* placeholders for a few functions that we need to redesign for the Qt UI */
 void add_cylinder_description(const cylinder_type_t *type)
@@ -38,6 +61,7 @@ void add_cylinder_description(const cylinder_type_t *type)
 		tank_info[i].bar = type->workingpressure.mbar / 1000;
 	}
 }
+
 void add_weightsystem_description(const weightsystem_t *weightsystem)
 {
 	const char *desc;
@@ -59,10 +83,18 @@ void add_weightsystem_description(const weightsystem_t *weightsystem)
 	}
 }
 
+/* Add a clone of a weightsystem to the end of a weightsystem table.
+ * Cloned in means that the description-string is copied. */
+void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws)
+{
+	weightsystem_t w_clone = { ws.weight, copy_string(ws.description) };
+	add_to_weightsystem_table(t, t->nr, w_clone);
+}
+
 bool same_weightsystem(weightsystem_t w1, weightsystem_t w2)
 {
-	return w1->weight.grams == w2->weight.grams &&
-	       same_string(w1->description, w2->description);
+	return w1.weight.grams == w2.weight.grams &&
+	       same_string(w1.description, w2.description);
 }
 
 bool cylinder_nodata(const cylinder_t *cyl)
@@ -226,10 +258,7 @@ void remove_cylinder(struct dive *dive, int idx)
 
 void remove_weightsystem(struct dive *dive, int idx)
 {
-	weightsystem_t *ws = dive->weightsystem + idx;
-	int nr = MAX_WEIGHTSYSTEMS - idx - 1;
-	memmove(ws, ws + 1, nr * sizeof(*ws));
-	memset(ws + nr, 0, sizeof(*ws));
+	remove_from_weightsystem_table(&dive->weightsystems, idx);
 }
 
 /* when planning a dive we need to make sure that all cylinders have a sane depth assigned

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -39,11 +39,24 @@ typedef struct
 	const char *description; /* "integrated", "belt", "ankle" */
 } weightsystem_t;
 
+/* Table of weightsystems. Attention: this stores weightsystems,
+ * *not* pointers * to weightsystems. This has two crucial
+ * consequences:
+ * 1) Pointers to weightsystems are not stable. They may be
+ *    invalidated if the table is reallocated.
+ * 2) add_to_weightsystem_table(), etc. takes ownership of the
+ *    weightsystem. Notably of the description string */
+struct weightsystem_table {
+	int nr, allocated;
+	weightsystem_t *weightsystems;
+};
+
 #define MAX_CYLINDERS (20)
-#define MAX_WEIGHTSYSTEMS (6)
 #define MAX_TANK_INFO (100)
 #define MAX_WS_INFO (100)
 
+extern void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d);
+extern void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws);
 extern void add_cylinder_description(const cylinder_type_t *);
 extern void add_weightsystem_description(const weightsystem_t *);
 extern bool same_weightsystem(weightsystem_t w1, weightsystem_t w2);
@@ -58,6 +71,10 @@ extern int find_best_gasmix_match(struct gasmix mix, const cylinder_t array[]);
 #ifdef DEBUG_CYL
 extern void dump_cylinders(struct dive *dive, bool verbose);
 #endif
+
+/* Weightsystem table functions */
+extern void clear_weightsystem_table(struct weightsystem_table *);
+extern void add_to_weightsystem_table(struct weightsystem_table *, int idx, weightsystem_t ws);
 
 void get_gas_string(struct gasmix gasmix, char *text, int len);
 const char *gasname(struct gasmix gasmix);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -46,6 +46,7 @@ typedef struct
 
 extern void add_cylinder_description(const cylinder_type_t *);
 extern void add_weightsystem_description(const weightsystem_t *);
+extern bool same_weightsystem(weightsystem_t w1, weightsystem_t w2);
 extern bool cylinder_nodata(const cylinder_t *cyl);
 extern bool cylinder_none(const cylinder_t *cyl);
 extern bool weightsystem_none(const weightsystem_t *ws);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -62,7 +62,6 @@ extern void add_weightsystem_description(const weightsystem_t *);
 extern bool same_weightsystem(weightsystem_t w1, weightsystem_t w2);
 extern bool cylinder_nodata(const cylinder_t *cyl);
 extern bool cylinder_none(const cylinder_t *cyl);
-extern bool weightsystem_none(const weightsystem_t *ws);
 extern void remove_cylinder(struct dive *dive, int idx);
 extern void remove_weightsystem(struct dive *dive, int idx);
 extern void reset_cylinders(struct dive *dive, bool track_gas);

--- a/core/import-divinglog.c
+++ b/core/import-divinglog.c
@@ -311,8 +311,8 @@ static int divinglog_dive(void *param, int columns, char **data, char **column)
 		state->cur_dive->watertemp.mkelvin = C_to_mkelvin(atol(data[9]));
 
 	if (data[10]) {
-		state->cur_dive->weightsystem[0].weight.grams = atol(data[10]) * 1000;
-		state->cur_dive->weightsystem[0].description = strdup(translate("gettextFromC", "unknown"));
+		weightsystem_t ws = { { atol(data[10]) * 1000 }, translate("gettextFromC", "unknown") };
+		add_cloned_weightsystem(&state->cur_dive->weightsystems, ws);
 	}
 
 	if (data[11])

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1309,14 +1309,12 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH_STATE("airpressure.dive", pressure, &dive->surface_pressure))
 		return;
-	if (state->cur_ws_index < MAX_WEIGHTSYSTEMS) {
-		if (MATCH("description.weightsystem", utf8_string, &dive->weightsystem[state->cur_ws_index].description))
-			return;
-		if (MATCH_STATE("weight.weightsystem", weight, &dive->weightsystem[state->cur_ws_index].weight))
-			return;
-		if (MATCH_STATE("weight", weight, &dive->weightsystem[state->cur_ws_index].weight))
-			return;
-	}
+	if (MATCH("description.weightsystem", utf8_string, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].description))
+		return;
+	if (MATCH_STATE("weight.weightsystem", weight, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].weight))
+		return;
+	if (MATCH_STATE("weight", weight, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].weight))
+		return;
 	if (state->cur_cylinder_index < MAX_CYLINDERS) {
 		if (MATCH("size.cylinder", cylindersize, &dive->cylinder[state->cur_cylinder_index].type.size))
 			return;

--- a/core/parse.c
+++ b/core/parse.c
@@ -257,7 +257,6 @@ void dive_end(struct parser_state *state)
 	state->cur_location.lat.udeg = 0;
 	state->cur_location.lon.udeg = 0;
 	state->cur_cylinder_index = 0;
-	state->cur_ws_index = 0;
 }
 
 void trip_start(struct parser_state *state)
@@ -299,11 +298,12 @@ void cylinder_end(struct parser_state *state)
 
 void ws_start(struct parser_state *state)
 {
+	weightsystem_t w = { {0}, "" };
+	add_cloned_weightsystem(&state->cur_dive->weightsystems, w);
 }
 
 void ws_end(struct parser_state *state)
 {
-	state->cur_ws_index++;
 }
 
 /*

--- a/core/parse.h
+++ b/core/parse.h
@@ -54,7 +54,7 @@ struct parser_state {
 	bool in_settings;
 	bool in_userid;
 	struct tm cur_tm;
-	int cur_cylinder_index, cur_ws_index;
+	int cur_cylinder_index;
 	int lastcylinderindex, next_o2_sensor;
 	int o2pressure_sensor;
 	int sample_rate;

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -164,9 +164,9 @@ static void save_weightsystem_info(struct membuffer *b, struct dive *dive)
 
 	nr = nr_weightsystems(dive);
 	for (i = 0; i < nr; i++) {
-		weightsystem_t *ws = dive->weightsystem + i;
-		int grams = ws->weight.grams;
-		const char *description = ws->description;
+		weightsystem_t ws = dive->weightsystems.weightsystems[i];
+		int grams = ws.weight.grams;
+		const char *description = ws.description;
 
 		put_string(b, "weightsystem");
 		put_milli(b, " weight=", grams, "kg");

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -106,9 +106,9 @@ static void put_weightsystem_HTML(struct membuffer *b, struct dive *dive)
 	char *separator = "";
 
 	for (i = 0; i < nr; i++) {
-		weightsystem_t *ws = dive->weightsystem + i;
-		int grams = ws->weight.grams;
-		const char *description = ws->description;
+		weightsystem_t ws = dive->weightsystems.weightsystems[i];
+		int grams = ws.weight.grams;
+		const char *description = ws.description;
 
 		put_string(b, separator);
 		separator = ", ";

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -204,9 +204,9 @@ static void save_weightsystem_info(struct membuffer *b, struct dive *dive)
 	nr = nr_weightsystems(dive);
 
 	for (i = 0; i < nr; i++) {
-		weightsystem_t *ws = dive->weightsystem + i;
-		int grams = ws->weight.grams;
-		const char *description = ws->description;
+		weightsystem_t ws = dive->weightsystems.weightsystems[i];
+		int grams = ws.weight.grams;
+		const char *description = ws.description;
 
 		put_format(b, "  <weightsystem");
 		put_milli(b, " weight='", grams, " kg'");

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -14,7 +14,7 @@ enum returnPressureSelector {START_PRESSURE, END_PRESSURE};
 
 static QString getFormattedWeight(struct dive *dive, unsigned int idx)
 {
-	weightsystem_t *weight = &dive->weightsystem[idx];
+	weightsystem_t *weight = &dive->weightsystems.weightsystems[idx];
 	if (!weight->description)
 		return QString();
 	QString fmt = QString(weight->description);
@@ -231,7 +231,7 @@ QString DiveObjectHelper::sac() const
 QString DiveObjectHelper::weightList() const
 {
 	QString weights;
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
+	for (int i = 0; i < m_dive->weightsystems.nr; i++) {
 		QString w = getFormattedWeight(m_dive, i);
 		if (w.isEmpty())
 			continue;
@@ -243,7 +243,7 @@ QString DiveObjectHelper::weightList() const
 QStringList DiveObjectHelper::weights() const
 {
 	QStringList weights;
-	for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
+	for (int i = 0; i < m_dive->weightsystems.nr; i++) {
 		QString w = getFormattedWeight(m_dive, i);
 		if (w.isEmpty())
 			continue;
@@ -254,12 +254,12 @@ QStringList DiveObjectHelper::weights() const
 
 bool DiveObjectHelper::singleWeight() const
 {
-	return weightsystem_none(&m_dive->weightsystem[1]);
+	return m_dive->weightsystems.nr == 1;
 }
 
 QString DiveObjectHelper::weight(int idx) const
 {
-	if ( (idx < 0) || idx > MAX_WEIGHTSYSTEMS )
+	if ((idx < 0) || idx >= m_dive->weightsystems.nr)
 		return QString();
 	return getFormattedWeight(m_dive, idx);
 }

--- a/core/table.h
+++ b/core/table.h
@@ -50,13 +50,13 @@
 		}									\
 	}
 
-#define MAKE_REMOVE_FROM(table_type, array_name)				\
-	void remove_from_##table_type(struct table_type *table, int idx)	\
-	{									\
-		int i;								\
-		for (i = idx; i < table->nr - 1; i++)				\
-			table->array_name[i] = table->array_name[i + 1];	\
-		table->array_name[--table->nr] = NULL;				\
+#define MAKE_REMOVE_FROM(table_type, array_name)						\
+	void remove_from_##table_type(struct table_type *table, int idx)			\
+	{											\
+		int i;										\
+		for (i = idx; i < table->nr - 1; i++)						\
+			table->array_name[i] = table->array_name[i + 1];			\
+		memset(&table->array_name[--table->nr], 0, sizeof(table->array_name[0]));	\
 	}
 
 #define MAKE_GET_IDX(table_type, item_type, array_name)						\

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -194,7 +194,7 @@ static void uemis_get_weight(char *buffer, weightsystem_t *weight, int diveid)
 	weight->weight.grams = uemis_get_weight_unit(diveid) ?
 		lbs_to_grams(ascii_strtod(buffer, NULL)) :
 		lrint(ascii_strtod(buffer, NULL) * 1000);
-	weight->description = strdup(translate("gettextFromC", "unknown"));
+	weight->description = translate("gettextFromC", "unknown");
 }
 
 static struct dive *uemis_start_dive(uint32_t deviceid)
@@ -815,7 +815,9 @@ static void parse_tag(struct dive *dive, char *tag, char *val)
 	} else if (!strcmp(tag, "altitude")) {
 		uemis_get_index(val, &dive->dc.surface_pressure.mbar);
 	} else if (!strcmp(tag, "f32Weight")) {
-		uemis_get_weight(val, &dive->weightsystem[0], dive->dc.diveid);
+		weightsystem_t ws;
+		uemis_get_weight(val, &ws, dive->dc.diveid);
+		add_cloned_weightsystem(&dive->weightsystems, ws);
 	} else if (!strcmp(tag, "notes")) {
 		uemis_add_string(val, &dive->notes, " ");
 	} else if (!strcmp(tag, "u8DiveSuit")) {

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -654,7 +654,7 @@ PasteState::PasteState(dive *dIn, const dive *data, dive_components what) : d(dI
 	tags(nullptr)
 {
 	memset(&cylinders[0], 0, sizeof(cylinders));
-	memset(&weightsystems[0], 0, sizeof(weightsystems));
+	clear_weightsystem_table(&weightsystems);
 	if (what.notes)
 		notes = data->notes;
 	if (what.divemaster)
@@ -675,12 +675,8 @@ PasteState::PasteState(dive *dIn, const dive *data, dive_components what) : d(dI
 		for (int i = 0; i < MAX_CYLINDERS; ++i)
 			copy_cylinder(data->cylinder[i], cylinders[i]);
 	}
-	if (what.weights) {
-		for (int i = 0; i < MAX_WEIGHTSYSTEMS; ++i) {
-			weightsystems[i] = data->weightsystem[i];
-			weightsystems[i].description = copy_string(data->weightsystem[i].description);
-		}
-	}
+	if (what.weights)
+		copy_weights(&data->weightsystems, &weightsystems);
 }
 
 PasteState::~PasteState()
@@ -688,8 +684,8 @@ PasteState::~PasteState()
 	taglist_free(tags);
 	for (cylinder_t &c: cylinders)
 		free((void *)c.type.description);
-	for (weightsystem_t &w: weightsystems)
-		free((void *)w.description);
+	clear_weightsystem_table(&weightsystems);
+	free(weightsystems.weightsystems);
 }
 
 void PasteState::swap(dive_components what)
@@ -713,7 +709,7 @@ void PasteState::swap(dive_components what)
 	if (what.cylinders)
 		std::swap(cylinders, d->cylinder);
 	if (what.weights)
-		std::swap(weightsystems, d->weightsystem);
+		std::swap(weightsystems, d->weightsystems);
 }
 
 // ***** Paste *****

--- a/desktop-widgets/command_edit.h
+++ b/desktop-widgets/command_edit.h
@@ -236,7 +236,7 @@ struct PasteState {
 	int visibility;
 	tag_entry *tags;
 	cylinder_t cylinders[MAX_CYLINDERS];
-	weightsystem_t weightsystems[MAX_WEIGHTSYSTEMS];
+	struct weightsystem_table weightsystems;
 
 	PasteState(dive *d, const dive *data, dive_components what); // Read data from dive data for dive d
 	~PasteState();

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -447,16 +447,12 @@ void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_o
 		put_format(&buf, "\n%% Weighting information:\n");
 		qty_weight = 0;
 		total_weight = 0;
-		for (i = 0; i < MAX_WEIGHTSYSTEMS; i++){
-			if (dive->weightsystem[i].weight.grams){
-				put_format(&buf, "\\def\\%sweight%ctype{%s}\n", ssrf, 'a' + i, dive->weightsystem[i].description);
-				put_format(&buf, "\\def\\%sweight%camt{%.3f\\%sweightunit}\n", ssrf, 'a' + i, get_weight_units(dive->weightsystem[i].weight.grams, NULL, &unit), ssrf);
-				qty_weight += 1;
-				total_weight += get_weight_units(dive->weightsystem[i].weight.grams, NULL, &unit);
-			} else {
-				put_format(&buf, "\\def\\%sweight%ctype{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%sweight%camt{}\n", ssrf, 'a' + i);
-			}
+		for (i = 0; i < dive->weightsystems.nr; i++) {
+			weightsystem_t w = dive->weightsystems.weightsystems[i];
+			put_format(&buf, "\\def\\%sweight%ctype{%s}\n", ssrf, 'a' + i, w.description);
+			put_format(&buf, "\\def\\%sweight%camt{%.3f\\%sweightunit}\n", ssrf, 'a' + i, get_weight_units(w.weight.grams, NULL, &unit), ssrf);
+			qty_weight += 1;
+			total_weight += get_weight_units(w.weight.grams, NULL, &unit);
 		}
 		put_format(&buf, "\\def\\%sqtyweights{%d}\n", ssrf, qty_weight);
 		put_format(&buf, "\\def\\%stotalweight{%.2f\\%sweightunit}\n", ssrf, total_weight, ssrf);

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -517,9 +517,9 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		if (what->weights) {
 			int w;
 			text << tr("Weights:\n");
-			for (w = 0; w < MAX_WEIGHTSYSTEMS; w++) {
-				if (displayed_dive.weightsystem[w].weight.grams)
-					text << displayed_dive.weightsystem[w].description << displayed_dive.weightsystem[w].weight.grams / 1000 << "kg\n";
+			for (w = 0; w < displayed_dive.weightsystems.nr; w++) {
+				weightsystem_t ws = displayed_dive.weightsystems.weightsystems[w];
+				text << ws.description << ws.weight.grams / 1000 << "kg\n";
 			}
 		}
 		clipboard->setText(cliptext);

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -172,6 +172,10 @@ static QVector<dive *> getSelectedDivesCurrentLast()
 	return res;
 }
 
+// TODO: This is only a temporary function until undo of weightsystems is implemented.
+// Therefore it is not worth putting it in a header.
+extern bool weightsystems_equal(const dive *d1, const dive *d2);
+
 void TabDiveEquipment::acceptChanges()
 {
 	bool do_replot = false;
@@ -232,17 +236,10 @@ void TabDiveEquipment::acceptChanges()
 	if (weightModel->changed) {
 		mark_divelist_changed(true);
 		MODIFY_DIVES(selectedDives,
-			for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
-				if (mydive != cd && (same_string(mydive->weightsystem[i].description, cd->weightsystem[i].description))) {
-					mydive->weightsystem[i] = displayed_dive.weightsystem[i];
-					mydive->weightsystem[i].description = copy_string(displayed_dive.weightsystem[i].description);
-				}
-			}
+			if (weightsystems_equal(mydive, cd))
+				copy_weights(&displayed_dive.weightsystems, &mydive->weightsystems);
 		);
-		for (int i = 0; i < MAX_WEIGHTSYSTEMS; i++) {
-			cd->weightsystem[i] = displayed_dive.weightsystem[i];
-			cd->weightsystem[i].description = copy_string(displayed_dive.weightsystem[i].description);
-		}
+		copy_weights(&displayed_dive.weightsystems, &cd->weightsystems);
 	}
 
 	if (do_replot)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -676,6 +676,17 @@ void MainTab::acceptChanges()
 	editMode = NONE;
 }
 
+bool weightsystems_equal(const dive *d1, const dive *d2)
+{
+	if (d1->weightsystems.nr != d2->weightsystems.nr)
+		return false;
+	for (int i = 0; i < d1->weightsystems.nr; ++i) {
+		if (!same_weightsystem(d1->weightsystems.weightsystems[0], d2->weightsystems.weightsystems[i]))
+			return false;
+	}
+	return true;
+}
+
 void MainTab::rejectChanges()
 {
 	EditMode lastMode = editMode;
@@ -683,7 +694,7 @@ void MainTab::rejectChanges()
 	if (lastMode != NONE && current_dive &&
 	    (modified ||
 	     memcmp(&current_dive->cylinder[0], &displayed_dive.cylinder[0], sizeof(cylinder_t) * MAX_CYLINDERS) ||
-	     memcmp(&current_dive->weightsystem[0], &displayed_dive.weightsystem[0], sizeof(weightsystem_t) * MAX_WEIGHTSYSTEMS))) {
+	     !weightsystems_equal(current_dive, &displayed_dive))) {
 		if (QMessageBox::warning(MainWindow::instance(), TITLE_OR_TEXT(tr("Discard the changes?"),
 									       tr("You are about to discard your changes.")),
 					 QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard) != QMessageBox::Discard) {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1031,10 +1031,10 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 	}
 	// not sure what we'd do if there was more than one weight system
 	// defined - for now just ignore that case
-	if (weightsystem_none(&d->weightsystem[1])) {
+	if (d->weightsystems.nr == 1) {
 		if (myDive->sumWeight() != weight) {
 			diveChanged = true;
-			d->weightsystem[0].weight.grams = parseWeightToGrams(weight);
+			d->weightsystems.weightsystems[0].weight.grams = parseWeightToGrams(weight);
 		}
 	}
 	// start and end pressures for first cylinder only

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -1063,7 +1063,8 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 
 		/* No DC related data */
 		smtkdive->visibility = strtod(col[coln(VISIBILITY)]->bind_ptr, NULL) > 25 ? 5 : lrint(strtod(col[13]->bind_ptr, NULL) / 5);
-		smtkdive->weightsystem[0].weight.grams = lrint(strtod(col[coln(WEIGHT)]->bind_ptr, NULL) * 1000);
+		weightsystem_t ws = { {lrint(strtod(col[coln(WEIGHT)]->bind_ptr, NULL) * 1000)}, "" };
+		add_cloned_weightsystem(&smtkdive->weightsystems, ws);
 		smtkdive->suit = copy_string(suit_list[atoi(col[coln(SUITIDX)]->bind_ptr) - 1]);
 		smtk_build_location(mdb_clon, col[coln(SITEIDX)]->bind_ptr, &smtkdive->dive_site);
 		smtkdive->buddy = smtk_locate_buddy(mdb_clon, col[0]->bind_ptr, buddy_list);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes the restriction to 6 weightsystems. It is a small first step in undoization of the equipment tab.

A side effect is that it temporarily makes the edit of multiple dives more strict: The dive will only be changed if the weightsystems correspond precisely to the shown dive. The old system appeared very ill defined, concerning addition / removal of weightsystems, so I wonder if anybody used that? This will have to be rethought in more detail when implementing undo.

Also note that this is only tested very superficially.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Should do?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh