### PR TITLE
Cleanup: remove includes from extern "C" block

### DIFF
--- a/core/save-html.h
+++ b/core/save-html.h
@@ -2,12 +2,12 @@
 #ifndef HTML_SAVE_H
 #define HTML_SAVE_H
 
+#include "dive.h"
+#include "membuffer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "dive.h"
-#include "membuffer.h"
 
 void put_HTML_date(struct membuffer *b, struct dive *dive, const char *pre, const char *post);
 void put_HTML_depth(struct membuffer *b, struct dive *dive, const char *pre, const char *post);


### PR DESCRIPTION
In "core/save-html.h", the "core/dive.h" header was included in the
extern "C" block. This is invalid, because "core/dive.h" included
from C++ code contains Qt macros that expand to C++ templates. These
in turn must not have extern "C" linkage, since a plain C-linker
cannot handle such things.

The only reason this worked is that in all cases "core/save-html.h"
was included after "core/dive.h". The include of the latter in the
former had therefore not effect.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an invalid chain of includes, see commit message.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.