### PR TITLE
Import: use TRIP_THRESHOLD when checking for trip-overlap

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1032,19 +1032,6 @@ static bool try_to_merge_into(struct dive *dive_to_add, int idx, struct dive_tab
 	return true;
 }
 
-/* Check if two trips overlap time-wise. */
-static bool trips_overlap(const struct dive_trip *t1, const struct dive_trip *t2)
-{
-	/* First, handle the empty-trip cases. */
-	if (t1->dives.nr == 0 || t2->dives.nr == 0)
-		return 0;
-
-	if (trip_date(t1) < trip_date(t2))
-		return trip_enddate(t1) >= trip_date(t2);
-	else
-		return trip_enddate(t2) >= trip_date(t1);
-}
-
 /* Check if a dive is ranked after the last dive of the global dive list */
 static bool dive_is_after_last(struct dive *d)
 {

--- a/core/trip.c
+++ b/core/trip.c
@@ -192,6 +192,19 @@ dive_trip_t *get_trip_for_new_dive(struct dive *new_dive, bool *allocated)
 	return trip;
 }
 
+/* Check if two trips overlap time-wise up to trip threshold. */
+bool trips_overlap(const struct dive_trip *t1, const struct dive_trip *t2)
+{
+	/* First, handle the empty-trip cases. */
+	if (t1->dives.nr == 0 || t2->dives.nr == 0)
+		return 0;
+
+	if (trip_date(t1) < trip_date(t2))
+		return trip_enddate(t1) + TRIP_THRESHOLD >= trip_date(t2);
+	else
+		return trip_enddate(t2) + TRIP_THRESHOLD >= trip_date(t1);
+}
+
 /*
  * Collect dives for auto-grouping. Pass in first dive which should be checked.
  * Returns range of dives that should be autogrouped and trip it should be

--- a/core/trip.h
+++ b/core/trip.h
@@ -42,6 +42,7 @@ extern dive_trip_t *create_trip_from_dive(struct dive *dive);
 extern dive_trip_t *create_and_hookup_trip_from_dive(struct dive *dive, struct trip_table *trip_table_arg);
 extern dive_trip_t *get_dives_to_autogroup(struct dive_table *table, int start, int *from, int *to, bool *allocated);
 extern dive_trip_t *get_trip_for_new_dive(struct dive *new_dive, bool *allocated);
+extern bool trips_overlap(const struct dive_trip *t1, const struct dive_trip *t2);
 
 extern void select_dives_in_trip(struct dive_trip *trip);
 extern void deselect_dives_in_trip(struct dive_trip *trip);


### PR DESCRIPTION
When checking for trip-overlap on import, only really overlapping trips
have been considered, i.e. when dives had overlapping times.

Instead use the TRIP_THRESHOLD so that on download dives are added to
the same trip if in a two-days time frame.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Consider the TRIP_THRESHOLD when downloading dives. Fixes a bug reported by @mturkia and @dirkhh.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Hopefully not in release?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @mturkia 