### PR TITLE
Desktop: enable clearing of dive site

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -432,9 +432,8 @@ bool DiveLocationLineEdit::eventFilter(QObject *, QEvent *e)
 
 void DiveLocationLineEdit::focusOutEvent(QFocusEvent *ev)
 {
-	if (!view->isVisible()) {
+	if (!view->isVisible())
 		QLineEdit::focusOutEvent(ev);
-	}
 }
 
 void DiveLocationLineEdit::itemActivated(const QModelIndex &index)
@@ -601,7 +600,8 @@ DiveLocationLineEdit::DiveSiteType DiveLocationLineEdit::currDiveSiteType() cons
 
 struct dive_site *DiveLocationLineEdit::currDiveSite() const
 {
-	return currDs;
+	// If there is no text, this corresponds to the empty dive site
+	return text().trimmed().isEmpty() ? nullptr : currDs;
 }
 
 DiveLocationListView::DiveLocationListView(QWidget*)

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -364,7 +364,6 @@ DiveLocationLineEdit::DiveLocationLineEdit(QWidget *parent) : QLineEdit(parent),
 							      proxy(new DiveLocationFilterProxyModel()),
 							      model(new DiveLocationModel()),
 							      view(new DiveLocationListView()),
-							      currType(NO_DIVE_SITE),
 							      currDs(nullptr)
 {
 	proxy->setSourceModel(model);
@@ -443,13 +442,8 @@ void DiveLocationLineEdit::itemActivated(const QModelIndex &index)
 		idx = index.model()->index(index.row(), LocationInformationModel::NAME);
 
 	dive_site *ds = index.model()->index(index.row(), LocationInformationModel::DIVESITE).data().value<dive_site *>();
-	currType = ds == RECENTLY_ADDED_DIVESITE ? NEW_DIVE_SITE : EXISTING_DIVE_SITE;
 	currDs = ds;
 	setText(idx.data().toString());
-	if (currType == NEW_DIVE_SITE)
-		qDebug() << "Setting a New dive site";
-	else
-		qDebug() << "Setting a Existing dive site";
 	if (view->isVisible())
 		view->hide();
 	emit diveSiteSelected();
@@ -509,12 +503,10 @@ void DiveLocationLineEdit::keyPressEvent(QKeyEvent *ev)
 	    ev->key() != Qt::Key_Escape &&
 	    ev->key() != Qt::Key_Return) {
 
-		if (ev->key() != Qt::Key_Up && ev->key() != Qt::Key_Down) {
-			currType = NEW_DIVE_SITE;
+		if (ev->key() != Qt::Key_Up && ev->key() != Qt::Key_Down)
 			currDs = RECENTLY_ADDED_DIVESITE;
-		} else {
+		else
 			showPopup();
-		}
 	} else if (ev->key() == Qt::Key_Escape) {
 		view->hide();
 	}
@@ -561,12 +553,10 @@ void DiveLocationLineEdit::setCurrentDiveSite(struct dive *d)
 {
 	struct dive_site *ds = get_dive_site_for_dive(d);
 	currDs = ds;
-	if (!currDs) {
-		currType = NO_DIVE_SITE;
+	if (!currDs)
 		clear();
-	} else {
+	else
 		setText(ds->name);
-	}
 
 	location_t currentLocation = d ? dive_get_gps_location(d) : location_t{0, 0};
 	proxy->setCurrentLocation(currentLocation);
@@ -591,11 +581,6 @@ void DiveLocationLineEdit::showAllSites()
 		// typing to activate the full-text filter.
 		selectAll();
 	}
-}
-
-DiveLocationLineEdit::DiveSiteType DiveLocationLineEdit::currDiveSiteType() const
-{
-	return currType;
 }
 
 struct dive_site *DiveLocationLineEdit::currDiveSite() const

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -83,13 +83,11 @@ signals:
 class DiveLocationLineEdit : public QLineEdit {
 	Q_OBJECT
 public:
-	enum DiveSiteType { NO_DIVE_SITE, NEW_DIVE_SITE, EXISTING_DIVE_SITE };
 	DiveLocationLineEdit(QWidget *parent =0 );
 	void refreshDiveSiteCache();
 	void setTemporaryDiveSiteName(const QString& s);
 	bool eventFilter(QObject*, QEvent*);
 	void itemActivated(const QModelIndex& index);
-	DiveSiteType currDiveSiteType() const;
 	struct dive_site *currDiveSite() const;
 	void fixPopupPosition();
 	void setCurrentDiveSite(struct dive *d);
@@ -111,7 +109,6 @@ private:
 	DiveLocationModel *model;
 	DiveLocationListView *view;
 	LocationFilterDelegate delegate;
-	DiveSiteType currType;
 	struct dive_site *currDs;
 };
 

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -86,6 +86,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	connect(ui.editDiveSiteButton, &QToolButton::clicked, MainWindow::instance(), &MainWindow::startDiveSiteEdit);
 	connect(ui.location, &DiveLocationLineEdit::entered, MapWidget::instance(), &MapWidget::centerOnIndex);
 	connect(ui.location, &DiveLocationLineEdit::currentChanged, MapWidget::instance(), &MapWidget::centerOnIndex);
+	connect(ui.location, &DiveLocationLineEdit::editingFinished, this, &MainTab::on_location_diveSiteSelected);
 
 	QAction *action = new QAction(tr("Apply changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(acceptChanges()));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This hopefully enables the clearing of dive sites by connecting to the appropriate signal and recognizing the empty string as "no dive site". The whole thing is scary an I am certainly not a UI programmer and never will be.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Connect the editingFinished signal of the location edit to the locationSelected slot.
2) When the text is empty return no-dive site instead of newly added dive site.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
(Hopefully) fixes #2148

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No, bug not in release.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@kittykat