### PR TITLE
Desktop: reduce minimum vertical size

### DIFF
--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -13,438 +13,467 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="filterButtonExplanation">
-     <property name="text">
-      <string>Reset / close</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="4" colspan="2">
-    <widget class="QLineEdit" name="tags"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>People</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QLabel" name="label_13">
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Rating</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Tags</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QDoubleSpinBox" name="minWaterTemp"/>
-   </item>
-   <item row="2" column="4">
-    <widget class="QLabel" name="label_16">
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>From</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>To</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="5">
-    <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Visibility</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="label_14">
-     <property name="text">
-      <string>Min</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QLabel" name="label_15">
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="4" colspan="2">
-    <widget class="QLineEdit" name="location"/>
-   </item>
-   <item row="11" column="4" colspan="2">
-    <widget class="QLineEdit" name="suit"/>
-   </item>
-   <item row="12" column="4" colspan="2">
-    <widget class="QLineEdit" name="dnotes"/>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="labelEquipment">
-     <property name="text">
-      <string>Equipment</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2">
-    <widget class="QDoubleSpinBox" name="minAirTemp"/>
-   </item>
-   <item row="4" column="5">
-    <widget class="QDoubleSpinBox" name="maxAirTemp"/>
-   </item>
-   <item row="11" column="4" colspan="2">
-    <widget class="QLineEdit" name="equipment"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Water Temp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="4" colspan="2">
-    <widget class="QLineEdit" name="people"/>
-   </item>
-   <item row="4" column="4">
-    <widget class="QLabel" name="label_18">
-     <property name="text">
-      <string>Max</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Location</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Suit</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_19">
-     <property name="text">
-      <string>Notes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Air Temp</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="5">
-    <widget class="StarWidget" name="maxVisibility" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="StarWidget" name="minVisibility" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="StarWidget" name="minRating" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="5">
-    <widget class="StarWidget" name="maxRating" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QCheckBox" name="logged">
-     <property name="text">
-      <string>Logged</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="4">
-    <widget class="QCheckBox" name="planned">
-     <property name="text">
-      <string>Planned</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="4">
-    <widget class="QTimeEdit" name="fromTime"/>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QDateTimeEdit" name="fromDate">
-     <property name="calendarPopup">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QDateTimeEdit" name="toDate">
-     <property name="calendarPopup">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="4">
-    <widget class="QTimeEdit" name="toTime"/>
-   </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="close">
-     <property name="toolTip">
-      <string>Close and reset filters</string>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>:filter-close</normaloff>:filter-close</iconset>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="clear">
-     <property name="toolTip">
-      <string>Reset filters</string>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>:edit-clear-icon</normaloff>:edit-clear-icon</iconset>
-     </property>
-     <property name="autoRaise">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QComboBox" name="tagsMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+  <widget class="QScrollArea" name="scrollArea">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>510</width>
+     <height>200</height>
+    </rect>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::NoFrame</enum>
+   </property>
+   <property name="frameShadow">
+    <enum>QFrame::Plain</enum>
+   </property>
+   <property name="widgetResizable">
+    <bool>true</bool>
+   </property>
+   <widget class="QWidget" name="scrollAreaWidgetContents">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>510</width>
+      <height>200</height>
+     </rect>
+    </property>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="filterButtonExplanation">
+       <property name="text">
+        <string>Reset / close</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="8" column="4" colspan="2">
+      <widget class="QLineEdit" name="tags"/>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
      </item>
-    </widget>
-   </item>
-   <item row="9" column="1" colspan="2">
-    <widget class="QComboBox" name="peopleMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>People</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="3" column="4">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Rating</string>
+       </property>
+      </widget>
      </item>
-    </widget>
-   </item>
-   <item row="10" column="1" colspan="2">
-    <widget class="QComboBox" name="locationMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Tags</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="3" column="2">
+      <widget class="QDoubleSpinBox" name="minWaterTemp"/>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="2" column="4">
+      <widget class="QLabel" name="label_16">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
      </item>
-    </widget>
-   </item>
-   <item row="11" column="1" colspan="2">
-    <widget class="QComboBox" name="suitMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>From</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>To</string>
+       </property>
+      </widget>
      </item>
-    </widget>
-   </item>
-   <item row="12" column="1" colspan="2">
-    <widget class="QComboBox" name="dnotesMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_17">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="3" column="5">
+      <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Visibility</string>
+       </property>
+      </widget>
      </item>
-    </widget>
-   </item>
-   <item row="13" column="1" colspan="2">
-    <widget class="QComboBox" name="equipmentMode">
-     <item>
-      <property name="text">
-       <string>All of</string>
-      </property>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_14">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>Any of</string>
-      </property>
+     <item row="1" column="4">
+      <widget class="QLabel" name="label_15">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
      </item>
-     <item>
-      <property name="text">
-       <string>None of</string>
-      </property>
+     <item row="10" column="4" colspan="2">
+      <widget class="QLineEdit" name="location"/>
      </item>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-  </layout>
+     <item row="11" column="4" colspan="2">
+      <widget class="QLineEdit" name="suit"/>
+     </item>
+     <item row="12" column="4" colspan="2">
+      <widget class="QLineEdit" name="dnotes"/>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="labelEquipment">
+       <property name="text">
+        <string>Equipment</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QDoubleSpinBox" name="minAirTemp"/>
+     </item>
+     <item row="4" column="5">
+      <widget class="QDoubleSpinBox" name="maxAirTemp"/>
+     </item>
+     <item row="11" column="4" colspan="2">
+      <widget class="QLineEdit" name="equipment"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>Water Temp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="4" colspan="2">
+      <widget class="QLineEdit" name="people"/>
+     </item>
+     <item row="4" column="4">
+      <widget class="QLabel" name="label_18">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Location</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Suit</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="label_19">
+       <property name="text">
+        <string>Notes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Air Temp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="StarWidget" name="maxVisibility" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="StarWidget" name="minVisibility" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="StarWidget" name="minRating" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="StarWidget" name="maxRating" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QCheckBox" name="logged">
+       <property name="text">
+        <string>Logged</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="4">
+      <widget class="QCheckBox" name="planned">
+       <property name="text">
+        <string>Planned</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="4">
+      <widget class="QTimeEdit" name="fromTime"/>
+     </item>
+     <item row="5" column="1" colspan="2">
+      <widget class="QDateTimeEdit" name="fromDate">
+       <property name="calendarPopup">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="2">
+      <widget class="QDateTimeEdit" name="toDate">
+       <property name="calendarPopup">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="4">
+      <widget class="QTimeEdit" name="toTime"/>
+     </item>
+     <item row="0" column="2">
+      <widget class="QToolButton" name="close">
+       <property name="toolTip">
+        <string>Close and reset filters</string>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:filter-close</normaloff>:filter-close</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QToolButton" name="clear">
+       <property name="toolTip">
+        <string>Reset filters</string>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:edit-clear-icon</normaloff>:edit-clear-icon</iconset>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1" colspan="2">
+      <widget class="QComboBox" name="tagsMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="9" column="1" colspan="2">
+      <widget class="QComboBox" name="peopleMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="10" column="1" colspan="2">
+      <widget class="QComboBox" name="locationMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="11" column="1" colspan="2">
+      <widget class="QComboBox" name="suitMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="12" column="1" colspan="2">
+      <widget class="QComboBox" name="dnotesMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="13" column="1" colspan="2">
+      <widget class="QComboBox" name="equipmentMode">
+       <item>
+        <property name="text">
+         <string>All of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Any of</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>None of</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </widget>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>
    <class>StarWidget</class>
    <extends>QWidget</extends>
-   <header location="global">desktop-widgets/starwidget.h</header>
+   <header>desktop-widgets/starwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
The Filter widget really needed to be scrollable as it is very tall.

Fixes #2152

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Simply add a scroll area around the widget

