### PR TITLE
Desktop: update BT selection when picking remembered dive computer

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -131,6 +131,27 @@ int DownloadFromDCWidget::deviceIndex(QString deviceText)
 }
 
 // DC button slots
+// we need two versions as one of the helper functions used is only available if
+// Bluetooth support is enabled
+#ifdef BT_SUPPORT
+#define DCBUTTON(num) \
+void DownloadFromDCWidget::DC##num##Clicked() \
+{ \
+	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
+	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
+	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
+	ui.bluetoothMode->setChecked(isBluetoothAddress(qPrefDiveComputer::device##num())); \
+	if (ui.device->currentIndex() == -1) \
+		ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
+	if (QSysInfo::kernelType() == "darwin") { \
+		/* it makes no sense that this would be needed on macOS but not Linux */ \
+		QCoreApplication::processEvents(); \
+		ui.vendor->update(); \
+		ui.product->update(); \
+		ui.device->update(); \
+	} \
+}
+#else
 #define DCBUTTON(num) \
 void DownloadFromDCWidget::DC##num##Clicked() \
 { \
@@ -146,6 +167,9 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 		ui.device->update(); \
 	} \
 }
+#endif
+
+
 
 DCBUTTON(1)
 DCBUTTON(2)


### PR DESCRIPTION
When switching to a BT dive computer, the device selection dialog is opened,
when switching away from BT, the device address is set.

Fixes #2139

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 