### PR TITLE
Warn on non-executable ffmpeg

### DIFF
--- a/core/videoframeextractor.cpp
+++ b/core/videoframeextractor.cpp
@@ -90,13 +90,11 @@ void VideoFrameExtractor::processItem(QString originalFilename, QString filename
 		// Since we couldn't sart ffmpeg, turn off thumbnailing
 		// TODO: call the proper preferences-functions
 		prefs.extract_video_thumbnails = false;
-		report_error(qPrintable(tr("ffmpeg failed to start - video thumbnail creation suspended")));
-		qDebug() << "Failed to start ffmpeg";
+		report_error(qPrintable(tr("ffmpeg failed to start - video thumbnail creation suspended. To enable video thumbnailing, set working executable in preferences.")));
 		return fail(originalFilename, duration, false);
 	}
 	if (!ffmpeg.waitForFinished()) {
-		qDebug() << "Failed waiting for ffmpeg";
-		report_error(qPrintable(tr("failed waiting for ffmpeg - video thumbnail creation suspended")));
+		report_error(qPrintable(tr("Failed waiting for ffmpeg - video thumbnail creation suspended. To enable video thumbnailing, set working executable in preferences.")));
 		return fail(originalFilename, duration, false);
 	}
 

--- a/desktop-widgets/preferences/preferences_defaults.h
+++ b/desktop-widgets/preferences/preferences_defaults.h
@@ -21,12 +21,14 @@ public slots:
 	void on_btnUseDefaultFile_toggled(bool toggled);
 	void on_localDefaultFile_toggled(bool toggled);
 	void on_ffmpegFile_clicked();
+	void on_ffmpegExecutable_editingFinished();
 	void on_extractVideoThumbnails_toggled(bool toggled);
 	void on_resetSettings_clicked();
 	void on_resetRememberedDCs_clicked();
 
 private:
 	Ui::PreferencesDefaults *ui;
+	void checkFfmpegExecutable();
 };
 
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This warns when the user sets a non-existing ffmpeg. Moreover, the error-message when ffmpeg fails to execute is extended to instruct the user to set the proper executable in the preferences. This is in response to #1922, though probably not exactly what the reporter wanted.

