### PR TITLE
Cleanup: fix memory management of the plot data

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -398,11 +398,10 @@ static void check_setpoint_events(const struct dive *dive, struct divecomputer *
 }
 
 
-struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer *given_dc)
+static void calculate_max_limits_new(struct dive *dive, struct divecomputer *given_dc, struct plot_info *pi)
 {
 	struct divecomputer *dc = &(dive->dc);
 	bool seen = false;
-	static struct plot_info pi;
 	int maxdepth = dive->maxdepth.mm;
 	int maxtime = 0;
 	int maxpressure = 0, minpressure = INT_MAX;
@@ -478,16 +477,15 @@ struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer
 	if (minhr > maxhr)
 		minhr = maxhr;
 
-	memset(&pi, 0, sizeof(pi));
-	pi.maxdepth = maxdepth;
-	pi.maxtime = maxtime;
-	pi.maxpressure = maxpressure;
-	pi.minpressure = minpressure;
-	pi.minhr = minhr;
-	pi.maxhr = maxhr;
-	pi.mintemp = mintemp;
-	pi.maxtemp = maxtemp;
-	return pi;
+	memset(pi, 0, sizeof(*pi));
+	pi->maxdepth = maxdepth;
+	pi->maxtime = maxtime;
+	pi->maxpressure = maxpressure;
+	pi->minpressure = minpressure;
+	pi->minhr = minhr;
+	pi->maxhr = maxhr;
+	pi->mintemp = mintemp;
+	pi->maxtemp = maxtemp;
 }
 
 /* copy the previous entry (we know this exists), update time and depth
@@ -1337,6 +1335,7 @@ void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plo
 	UNUSED(planner_ds);
 #endif
 	free_plot_info_data(pi);
+	calculate_max_limits_new(dive, dc, pi);
 	get_dive_gas(dive, &o2, &he, &o2max);
 	if (dc->divemode == FREEDIVE){
 		pi->dive_type = FREEDIVE;

--- a/core/profile.h
+++ b/core/profile.h
@@ -73,7 +73,6 @@ struct ev_select {
 	bool plot_ev;
 };
 
-struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer *given_dc);
 void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int bufsize, int sum);
 struct plot_info *analyze_plot_info(struct plot_info *pi);
 void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool fast, struct deco_state *planner_ds);

--- a/core/profile.h
+++ b/core/profile.h
@@ -75,11 +75,11 @@ struct ev_select {
 
 struct plot_info calculate_max_limits_new(struct dive *dive, struct divecomputer *given_dc);
 void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int bufsize, int sum);
-struct plot_data *populate_plot_entries(struct dive *dive, struct divecomputer *dc, struct plot_info *pi);
 struct plot_info *analyze_plot_info(struct plot_info *pi);
 void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool fast, struct deco_state *planner_ds);
 void calculate_deco_information(struct deco_state *ds, const struct deco_state *planner_de, const struct dive *dive, const struct divecomputer *dc, struct plot_info *pi, bool print_mode);
 struct plot_data *get_plot_details_new(struct plot_info *pi, int time, struct membuffer *);
+void free_plot_info_data(struct plot_info *pi);
 
 /*
  * When showing dive profiles, we scale things to the

--- a/core/save-profiledata.c
+++ b/core/save-profiledata.c
@@ -202,7 +202,6 @@ static void save_profiles_buffer(struct membuffer *b, bool select_only)
 	for_each_dive(i, dive) {
 		if (select_only && !dive->selected)
 			continue;
-		pi = calculate_max_limits_new(dive, &dive->dc);
 		create_plot_info_new(dive, &dive->dc, &pi, false, planner_deco_state);
 		put_headers(b);
 		put_format(b, "\n");
@@ -221,7 +220,6 @@ void save_subtitles_buffer(struct membuffer *b, struct dive *dive, int offset, i
 	struct plot_info pi;
 	struct deco_state *planner_deco_state = NULL;
 
-	pi = calculate_max_limits_new(dive, &dive->dc);
 	create_plot_info_new(dive, &dive->dc, &pi, false, planner_deco_state);
 
 	put_format(b, "[Script Info]\n");

--- a/core/save-profiledata.c
+++ b/core/save-profiledata.c
@@ -191,6 +191,7 @@ static void put_st_event(struct membuffer *b, struct plot_data *entry, int offse
 	}
 	put_format(b, "\n");
 }
+
 static void save_profiles_buffer(struct membuffer *b, bool select_only)
 {
 	int i;
@@ -211,6 +212,7 @@ static void save_profiles_buffer(struct membuffer *b, bool select_only)
 			put_format(b, "\n");
 		}
 		put_format(b, "\n");
+		free_plot_info_data(&pi);
 	}
 }
 
@@ -233,6 +235,8 @@ void save_subtitles_buffer(struct membuffer *b, struct dive *dive, int offset, i
 		put_st_event(b, &pi.entry[i], offset, length);
 	}
 	put_format(b, "\n");
+
+	free_plot_info_data(&pi);
 }
 
 int save_profiledata(const char *filename, const bool select_only)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -636,8 +636,7 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 	 * shown.
 	 */
 
-	free_plot_info_data(&plotInfo);
-	plotInfo = calculate_max_limits_new(&displayed_dive, currentdc);
+	// create_plot_info_new() automatically frees old plot data
 #ifndef SUBSURFACE_MOBILE
 	create_plot_info_new(&displayed_dive, currentdc, &plotInfo, !shouldCalculateMaxDepth, &DivePlannerPointsModel::instance()->final_deco_state);
 #else

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -636,6 +636,7 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 	 * shown.
 	 */
 
+	free_plot_info_data(&plotInfo);
 	plotInfo = calculate_max_limits_new(&displayed_dive, currentdc);
 #ifndef SUBSURFACE_MOBILE
 	create_plot_info_new(&displayed_dive, currentdc, &plotInfo, !shouldCalculateMaxDepth, &DivePlannerPointsModel::instance()->final_deco_state);


### PR DESCRIPTION
There was a global variable last_pi_entry_new, which stored the
recently allocated plot data. This was freed when new plot data
was generated.

A very scary proposition: You can never have two plot datas at
the same time! But exactly that happens when you export for
example subtitles.

The only reason why this didn't lead to very crazy behavior
is that at least on my Linux machine, the calloc() call would
just return the previously freed memory.

Fix this mess by removing the global variable and freeing the
data in the callers.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes a variable and also fixes a use after free bug: When making a new plot-info the old data was released even if someone still used it! This worked only out of shear luck: the libc would hand out the just free()d memory on the subsequent calloc() call!

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
