### PR TITLE
Git: handle excess of cylinders or weightsystems gracefully

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -391,6 +391,9 @@ static void parse_dive_cylinder(char *line, struct membuffer *str, void *_dive)
 	struct dive *dive = _dive;
 	cylinder_t *cylinder = dive->cylinder + cylinder_index;
 
+	if (cylinder_index >= MAX_CYLINDERS)
+		return;
+
 	cylinder->type.description = get_utf8(str);
 	for (;;) {
 		char c;
@@ -422,6 +425,9 @@ static void parse_dive_weightsystem(char *line, struct membuffer *str, void *_di
 {
 	struct dive *dive = _dive;
 	weightsystem_t *ws = dive->weightsystem + weightsystem_index;
+
+	if (weightsystem_index >= MAX_WEIGHTSYSTEMS)
+		return;
 
 	weightsystem_index++;
 	ws->description = get_utf8(str);


### PR DESCRIPTION
Currently, the git parser happily trashes memory if a git repository
contains too many weightsystems or cylinders. This should only happen
in testing, but nevertheless try to handle it gracefully and ignore
excess cylinders / weightsystems.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This caught me by surprise: My local test repository, which I used for the unlimited-weightsystems PR, made the old code crash. Let's try to be more resilient in such a case.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Ignore excess weightsystems / cylinders.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 