### PR TITLE
Desktop: clear notes on empty dive

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -589,6 +589,7 @@ void MainTab::updateDiveInfo()
 		ui.buddy->clear();
 		ui.airtemp->clear();
 		ui.watertemp->clear();
+		ui.notes->clear();
 		/* set date and time to minimums which triggers showing the special value text */
 		ui.dateEdit->setSpecialValueText(QString("-"));
 		ui.dateEdit->setMinimumDate(QDate(1, 1, 1));


### PR DESCRIPTION
If no dive is set, all fields except the note field were cleared.
Also clear notes.

Fixes #2172

Reported-by: Anton Lundin <glance@acc.umu.se>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes #2172. Commit message says it all.

@glance-