### PR TITLE
Android: fix BT/BLE dowload for arm64 by upgrading Qt, OpenSSL

### DIFF
--- a/android-mobile/build.gradle
+++ b/android-mobile/build.gradle
@@ -7,10 +7,11 @@ buildscript {
     repositories {
         jcenter()
         maven { url "https://dl.bintray.com/android/android-tools/" }
+	google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -18,6 +19,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://dl.bintray.com/android/android-tools/" }
+	google()
     }
 }
 

--- a/packaging/android/qt-installer-noninteractive.qs
+++ b/packaging/android/qt-installer-noninteractive.qs
@@ -32,8 +32,8 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent('qt.qt5.5120.android_armv7');
-    widget.selectComponent('qt.qt5.5120.android_arm64_v8a');
+    widget.selectComponent('qt.qt5.5124.android_armv7');
+    widget.selectComponent('qt.qt5.5124.android_arm64_v8a');
 
     gui.clickButton(buttons.NextButton);
 }

--- a/packaging/android/variables.sh
+++ b/packaging/android/variables.sh
@@ -2,10 +2,10 @@
 # When changing Qt version remember to update the 
 # qt-installer-noninteractive file as well.
 QT_VERSION=5.12
-LATEST_QT=5.12.0
+LATEST_QT=5.12.4
 NDK_VERSION=r18b
 SDK_VERSION=4333796
-ANDROID_BUILDTOOLS_REVISION=28.0.2
+ANDROID_BUILDTOOLS_REVISION=28.0.3
 ANDROID_PLATFORM_LEVEL=21
 ANDROID_PLATFORM=android-21
 ANDROID_PLATFORMS=android-27
@@ -13,4 +13,4 @@ ANDROID_NDK=android-ndk-${NDK_VERSION}
 ANDROID_SDK=android-sdk-linux
 # OpenSSL also has an entry in get-dep-lib.sh line 103
 # that needs to be updated as well.
-OPENSSL_VERSION=1.0.2o
+OPENSSL_VERSION=1.1.1c

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -103,7 +103,7 @@ fi
 
 # FIX FOR ANDROID,
 if [ "$PLATFORM" == "singleAndroid" ] ; then
-	CURRENT_OPENSSL="OpenSSL_1_0_2o"
+	CURRENT_OPENSSL="OpenSSL_1_1_1c"
 # If changing the openSSL version here, make sure to change it in versions.sh also.
 fi
 # no curl and old libs (never version breaks)


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This set of commits upgrades the Qt version for Android build to 5.12.4. All the remaining work can be considered fallout.

The Travis build will fail, as this PR does not upgrade Travis and Docker work needed. 

Notice that the generated apks show up in a slightly different place (1 directory deeper, making distinction in debug ans release builds).

### Changes made:
See commits

### Related issues:
No official open issue, but this fixes BT/BLE download on arm64 builds. Which is required by Google soon.

### Additional information:
Travis/Docker work to be done (@dirkhh)

### Release note:
No
