### PR TITLE
Android qt - this is just an update to #2175 with a newer Android Qt build container

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -346,4 +346,4 @@ This will download and install the required NDK, SDK and Qt required to build th
 
 After that, you can run: ./subsurface/packaging/android/build.sh everytime you want to build a new version.
 
-This will generate an apk file in ./subsurface-mobile-build-arm/build/outputs/apk/
+This will generate an apk file in ./subsurface-mobile-build-arm/build/outputs/apk/debug

--- a/android-mobile/build.gradle
+++ b/android-mobile/build.gradle
@@ -7,10 +7,11 @@ buildscript {
     repositories {
         jcenter()
         maven { url "https://dl.bintray.com/android/android-tools/" }
+	google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -18,6 +19,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://dl.bintray.com/android/android-tools/" }
+	google()
     }
 }
 

--- a/packaging/android/android-build-wrapper.sh
+++ b/packaging/android/android-build-wrapper.sh
@@ -149,7 +149,7 @@ echo "${BUILDNR}" > ./buildnr.dat
 
 echo "Building Subsurface-mobile for Android, build nr ${BUILDNR}"
 
-rm -f ./subsurface-mobile-build-arm/build/outputs/apk/*.apk
+rm -f ./subsurface-mobile-build-arm/build/outputs/apk/debug/*.apk
 rm -df ./subsurface-mobile-build-arm/AndroidManifest.xml
 
 if [ "$USE_X" ] ; then
@@ -160,5 +160,5 @@ else
 	bash "$SUBSURFACE_SOURCE"/packaging/android/build.sh -buildnr "$BUILDNR" arm64 "$@"
 fi
 
-ls -l ./subsurface-mobile-build-arm/build/outputs/apk/*.apk
+ls -l ./subsurface-mobile-build-arm/build/outputs/apk/debug/*.apk
 

--- a/packaging/android/build.sh
+++ b/packaging/android/build.sh
@@ -87,6 +87,7 @@ export ARCH
 
 # Configure where we can find things here
 export ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT-$SUBSURFACE_SOURCE/../${ANDROID_NDK}}
+export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT
 
 if [ -n "${QT5_ANDROID+X}" ] ; then
 	echo "Using Qt5 in $QT5_ANDROID"
@@ -243,7 +244,6 @@ if [ "$QUICK" = "" ] ; then
 		cp -r openssl/* openssl-build-"$ARCH"
 		pushd openssl-build-"$ARCH"
 		perl -pi -e 's/-mandroid//g' Configure
-		export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT
 		# Use env to make all these temporary, so they don't pollute later builds.
 		env	PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
 			CC=clang \

--- a/packaging/android/build.sh
+++ b/packaging/android/build.sh
@@ -435,7 +435,7 @@ cmake $MOBILE_CMAKE \
 	-DANDROID_NATIVE_LIBCRYPT="$BUILDROOT/ndk-$ARCH/sysroot/usr/lib/libcrypto.so" \
 	-DCMAKE_MAKE_PROGRAM="make" \
 	"$SUBSURFACE_SOURCE"
-	
+
 # set up the version number
 
 rm -f ssrf-version.h

--- a/packaging/android/qt-installer-noninteractive.qs
+++ b/packaging/android/qt-installer-noninteractive.qs
@@ -32,8 +32,8 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent('qt.qt5.5120.android_armv7');
-    widget.selectComponent('qt.qt5.5120.android_arm64_v8a');
+    widget.selectComponent('qt.qt5.5124.android_armv7');
+    widget.selectComponent('qt.qt5.5124.android_arm64_v8a');
 
     gui.clickButton(buttons.NextButton);
 }

--- a/packaging/android/variables.sh
+++ b/packaging/android/variables.sh
@@ -2,10 +2,10 @@
 # When changing Qt version remember to update the 
 # qt-installer-noninteractive file as well.
 QT_VERSION=5.12
-LATEST_QT=5.12.0
+LATEST_QT=5.12.4
 NDK_VERSION=r18b
 SDK_VERSION=4333796
-ANDROID_BUILDTOOLS_REVISION=28.0.2
+ANDROID_BUILDTOOLS_REVISION=28.0.3
 ANDROID_PLATFORM_LEVEL=21
 ANDROID_PLATFORM=android-21
 ANDROID_PLATFORMS=android-27
@@ -13,4 +13,4 @@ ANDROID_NDK=android-ndk-${NDK_VERSION}
 ANDROID_SDK=android-sdk-linux
 # OpenSSL also has an entry in get-dep-lib.sh line 103
 # that needs to be updated as well.
-OPENSSL_VERSION=1.0.2o
+OPENSSL_VERSION=1.1.1c

--- a/scripts/android/after_success.sh
+++ b/scripts/android/after_success.sh
@@ -8,8 +8,8 @@ fi
 source ${TRAVIS_BUILD_DIR}/scripts/release-message.sh
 
 echo "Submitting the folloing apk for continuous build release:"
-ls -lh ../subsurface-mobile-build-docker-arm*/build/outputs/apk/*.apk
+ls -lh ../subsurface-mobile-build-docker-arm*/build/outputs/apk/debug/*.apk
 
 # get and run the upload script
 wget -c https://raw.githubusercontent.com/dirkhh/uploadtool/master/upload.sh
-bash ./upload.sh ../subsurface-mobile-build-docker-arm*/build/outputs/apk/*.apk
+bash ./upload.sh ../subsurface-mobile-build-docker-arm*/build/outputs/apk/debug/*.apk

--- a/scripts/android/before_install.sh
+++ b/scripts/android/before_install.sh
@@ -19,5 +19,5 @@ docker run -v $PWD:/android/subsurface \
 	   -v $PARENT/subsurface-mobile-build-docker-arm64:/android/subsurface-mobile-build-arm64 \
 	   --name=android-builder \
 	   -w /android \
-	   -d dirkhh/android-builder:5.12.04 \
+	   -d dirkhh/android-builder:5.12.04.1 \
 	   /bin/sleep 60m

--- a/scripts/android/before_install.sh
+++ b/scripts/android/before_install.sh
@@ -19,5 +19,5 @@ docker run -v $PWD:/android/subsurface \
 	   -v $PARENT/subsurface-mobile-build-docker-arm64:/android/subsurface-mobile-build-arm64 \
 	   --name=android-builder \
 	   -w /android \
-	   -d dirkhh/android-builder:5.12.03 \
+	   -d dirkhh/android-builder:5.12.04 \
 	   /bin/sleep 60m

--- a/scripts/android/travisbuild.sh
+++ b/scripts/android/travisbuild.sh
@@ -8,4 +8,4 @@ set -e
 # (but of course having the right things in place will save a ton of time)
 docker exec -e TRAVIS="$TRAVIS" -t android-builder subsurface/packaging/android/android-build-wrapper.sh
 
-ls -l ../subsurface-mobile-build-docker-arm*/build/outputs/apk/
+ls -l ../subsurface-mobile-build-docker-arm*/build/outputs/apk/debug

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -54,4 +54,4 @@ RUN cd /android && \
     du -sh *
 RUN apt-get clean
 RUN cd /android/android-ndk-r18b/toolchains && ln -s x86_64-4.9 x86-64-4.9
-RUN touch /android/finished-`date`
+RUN touch /android/finished-"`date`"

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -53,4 +53,5 @@ RUN cd /android && \
     ls -l && \
     du -sh *
 RUN apt-get clean
+RUN cd /android/android-ndk-r18b/toolchains && ln -s x86_64-4.9 x86-64-4.9
 RUN touch /android/finished-`date`

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update  && \
 # install, NDK and SDK there, plus the three files from the Subsurface
 # sources that we need to get the prep routines to run
 RUN mkdir -p /android
-ADD qt-opensource-linux-x64-5.*.run /android/
+ADD qt-opensource-linux-x64-5.12.4.run /android/
 ADD android-ndk-r*-linux-x86_64.zip /android/
 ADD sdk-tools-linux-*.zip /android/
 ADD android-build-wrapper.sh variables.sh qt-installer-noninteractive.qs /android/

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -103,7 +103,7 @@ fi
 
 # FIX FOR ANDROID,
 if [ "$PLATFORM" == "singleAndroid" ] ; then
-	CURRENT_OPENSSL="OpenSSL_1_0_2o"
+	CURRENT_OPENSSL="OpenSSL_1_1_1c"
 # If changing the openSSL version here, make sure to change it in versions.sh also.
 fi
 # no curl and old libs (never version breaks)

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -104,7 +104,7 @@ fi
 # FIX FOR ANDROID,
 if [ "$PLATFORM" == "singleAndroid" ] ; then
 	CURRENT_OPENSSL="OpenSSL_1_1_1c"
-# If changing the openSSL version here, make sure to change it in versions.sh also.
+# If changing the openSSL version here, make sure to change it in packaging/android/variables.sh also.
 fi
 # no curl and old libs (never version breaks)
 # check whether to use curl or wget


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This set of commits upgrades the Qt version for Android build to 5.12.4. All the remaining work can be considered fallout.

The Travis build will fail, as this PR does not upgrade Travis and Docker work needed. 

Notice that the generated apks show up in a slightly different place (1 directory deeper, making distinction in debug and release builds).

### Changes made:
See commits

### Related issues:
No official open issue, but this fixes BT/BLE download on arm64 builds. Which is required by Google soon.

### Additional information:
Travis/Docker work to be done (@dirkhh)

### Release note:
No

### Mentions
@janmulder I think you should be able to push to this branch as well - assuming that the build gets any further. A local build against this container completed...