### PR TITLE
Misc fixes for loading/saving

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -23,7 +23,7 @@
  * here */
 struct dive displayed_dive;
 
-const char *cylinderuse_text[] = {
+const char *cylinderuse_text[NUM_GAS_USE] = {
 	QT_TRANSLATE_NOOP("gettextFromC", "OC-gas"), QT_TRANSLATE_NOOP("gettextFromC", "diluent"), QT_TRANSLATE_NOOP("gettextFromC", "oxygen"), QT_TRANSLATE_NOOP("gettextFromC", "not used")
 };
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -23,7 +23,7 @@ extern int last_xml_version;
 
 enum divemode_t {OC, CCR, PSCR, FREEDIVE, NUM_DIVEMODE, UNDEF_COMP_TYPE};	// Flags (Open-circuit and Closed-circuit-rebreather) for setting dive computer type
 
-extern const char *cylinderuse_text[];
+extern const char *cylinderuse_text[NUM_GAS_USE];
 extern const char *divemode_text_ui[];
 extern const char *divemode_text[];
 

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -140,6 +140,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		cylinder_t *cylinder = dive->cylinder + i;
 		int volume = cylinder->type.size.mliter;
 		const char *description = cylinder->type.description;
+		int use = cylinder->cylinder_use;
 
 		put_string(b, "cylinder");
 		if (volume)
@@ -150,8 +151,8 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		put_gasmix(b, cylinder->gasmix);
 		put_pressure(b, cylinder->start, " start=", "bar");
 		put_pressure(b, cylinder->end, " end=", "bar");
-		if (cylinder->cylinder_use != OC_GAS)
-			put_format(b, " use=%s", cylinderuse_text[cylinder->cylinder_use]);
+		if (use > OC_GAS && use < NUM_GAS_USE)
+			show_utf8(b, " use=", cylinderuse_text[use], "");
 		if (cylinder->depth.mm != 0)
 			put_milli(b, " depth=", cylinder->depth.mm, "m");
 		put_string(b, "\n");

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -180,6 +180,7 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		cylinder_t *cylinder = dive->cylinder + i;
 		int volume = cylinder->type.size.mliter;
 		const char *description = cylinder->type.description;
+		int use = cylinder->cylinder_use;
 
 		put_format(b, "  <cylinder");
 		if (volume)
@@ -189,8 +190,8 @@ static void save_cylinder_info(struct membuffer *b, struct dive *dive)
 		put_gasmix(b, cylinder->gasmix);
 		put_pressure(b, cylinder->start, " start='", " bar'");
 		put_pressure(b, cylinder->end, " end='", " bar'");
-		if (cylinder->cylinder_use != OC_GAS)
-			show_utf8(b, cylinderuse_text[cylinder->cylinder_use], " use='", "'", 1);
+		if (use > OC_GAS && use < NUM_GAS_USE)
+			show_utf8(b, cylinderuse_text[use], " use='", "'", 1);
 		if (cylinder->depth.mm != 0)
 			put_milli(b, " depth='", cylinder->depth.mm, " m'");
 		put_format(b, " />\n");

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -277,8 +277,10 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 		put_format(b, " tts='%u:%02u min'", FRACTION(sample->tts.seconds, 60));
 		old->tts = sample->tts;
 	}
-	if (sample->rbt.seconds)
+	if (sample->rbt.seconds != old->rbt.seconds) {
 		put_format(b, " rbt='%u:%02u min'", FRACTION(sample->rbt.seconds, 60));
+		old->rbt = sample->rbt;
+	}
 	if (sample->in_deco != old->in_deco) {
 		put_format(b, " in_deco='%d'", sample->in_deco ? 1 : 0);
 		old->in_deco = sample->in_deco;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes two bugs:

 - avoid a crash when saving invalid cylinder usage information

 - save RBT data properly in the XML format

The RBT data fix came from me testing the "load then save" fix, and noticing that the RBT in the save didn't match the RBT in the load.

Of course, because we mis-saved the RBT data originally, it now means that every old file has bogus RBT data that we will mis-load, but at least going forward we should be ok. And the RBT problem really only happens when RBT goes down to zero, which it obviously newer should - you'd be a bad diver if your dive computer reports RBT as zero.

What can I say? "Palau" and "there were still things to see".

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
