### PR TITLE
Cleanup: Remove unused function calls in main tab

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -9,7 +9,6 @@
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/mapwidget.h"
 #include "core/qthelper.h"
-#include "core/statistics.h"
 #include "core/trip.h"
 #include "qt-models/diveplannermodel.h"
 #include "desktop-widgets/divelistview.h"
@@ -563,12 +562,6 @@ void MainTab::updateDiveInfo()
 		}
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
-
-		int mean[MAX_CYLINDERS], duration[MAX_CYLINDERS];
-		per_cylinder_mean_depth(&displayed_dive, select_dc(&displayed_dive), mean, duration);
-
-		volume_t o2_tot = {}, he_tot = {};
-		selected_dives_gas_parts(&o2_tot, &he_tot);
 
 		if(ui.locationTags->text().isEmpty())
 			ui.locationTags->hide();


### PR DESCRIPTION
per_cylinder_mean_depth() and selected_dives_gas_parts() are used
in the dive-information and statistics tab, respectively. Nevertheless,
these functions are called on the main tab as well and the result is
trashed. Therefore remove the calls. Must have been an artifact.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup, see commit description. Nothing more to say, really.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unnecessary function calls.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.