### PR TITLE
Undo: make editing of dive number undoable

### DIFF
--- a/core/cochran.c
+++ b/core/cochran.c
@@ -787,7 +787,6 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 	}
 
 	record_dive_to_table(dive, table);
-	mark_divelist_changed(true);
 
 	free(buf);
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -3215,8 +3215,6 @@ static int split_dive_at(const struct dive *dive, int a, int b, struct dive **ou
 			d2->number = 0;
 	}
 
-	mark_divelist_changed(true);
-
 	*out1 = d1;
 	*out2 = d2;
 	return nr;

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -826,7 +826,6 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 	}
 
 	record_dive_to_table(dive, devdata->download_table);
-	mark_divelist_changed(true);
 	return true;
 
 error_exit:

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -424,7 +424,6 @@ static void parse_dives(int log_version, const unsigned char *buf, unsigned int 
 		// End dive
 		record_dive_to_table(dive, table);
 		dive = NULL;
-		mark_divelist_changed(true);
 
 		// Advance ptr for next dive
 		ptr += ps_ptr + 4;

--- a/core/ostctools.c
+++ b/core/ostctools.c
@@ -190,7 +190,6 @@ void ostctools_import(const char *file, struct dive_table *divetable, struct tri
 		add_extra_data(&ostcdive->dc, "Serial", ostcdive->dc.serial);
 	}
 	record_dive_to_table(ostcdive, divetable);
-	mark_divelist_changed(true);
 	sort_dive_table(divetable);
 
 close_out:

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1016,14 +1016,12 @@ static bool process_raw_buffer(device_data_t *devdata, uint32_t deviceid, char *
 		if (done && ++bp < endptr && *bp != '{' && strstr(bp, "{{")) {
 			done = false;
 			record_dive_to_table(dive, devdata->download_table);
-			mark_divelist_changed(true);
 			dive = uemis_start_dive(deviceid);
 		}
 	}
 	if (is_log) {
 		if (dive->dc.diveid) {
 			record_dive_to_table(dive, devdata->download_table);
-			mark_divelist_changed(true);
 		} else { /* partial dive */
 			free(dive);
 			free(buf);

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -163,6 +163,11 @@ int editMode(int index, int newValue, bool currentDiveOnly)
 	return execute_edit(new EditMode(index, newValue, currentDiveOnly));
 }
 
+int editNumber(int newValue, bool currentDiveOnly)
+{
+	return execute_edit(new EditNumber(newValue, currentDiveOnly));
+}
+
 int editSuit(const QString &newValue, bool currentDiveOnly)
 {
 	return execute_edit(new EditSuit(newValue, currentDiveOnly));

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -60,6 +60,7 @@ void purgeUnusedDiveSites();
 int editNotes(const QString &newValue, bool currentDiveOnly);
 int editSuit(const QString &newValue, bool currentDiveOnly);
 int editMode(int index, int newValue, bool currentDiveOnly);
+int editNumber(int newValue, bool currentDiveOnly);
 int editRating(int newValue, bool currentDiveOnly);
 int editVisibility(int newValue, bool currentDiveOnly);
 int editAirTemp(int newValue, bool currentDiveOnly);

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -33,6 +33,13 @@ EditDivesBase::EditDivesBase(bool currentDiveOnly) :
 {
 }
 
+EditDivesBase::EditDivesBase(dive *d) :
+	dives({ d }),
+	selectedDives(getDiveSelection()),
+	current(current_dive)
+{
+}
+
 int EditDivesBase::numDives() const
 {
 	return dives.size();
@@ -41,6 +48,13 @@ int EditDivesBase::numDives() const
 template<typename T>
 EditBase<T>::EditBase(T newValue, bool currentDiveOnly) :
 	EditDivesBase(currentDiveOnly),
+	value(std::move(newValue))
+{
+}
+
+template<typename T>
+EditBase<T>::EditBase(T newValue, dive *d) :
+	EditDivesBase(d),
 	value(std::move(newValue))
 {
 }
@@ -444,6 +458,28 @@ DiveField EditMode::fieldId() const
 {
 	return DiveField::MODE;
 }
+
+// ***** Number *****
+void EditNumber::set(struct dive *d, int number) const
+{
+	d->number = number;
+}
+
+int EditNumber::data(struct dive *d) const
+{
+	return d->number;
+}
+
+QString EditNumber::fieldName() const
+{
+	return tr("number");
+}
+
+DiveField EditNumber::fieldId() const
+{
+	return DiveField::NR;
+}
+
 
 // ***** Tag based commands *****
 EditTagsBase::EditTagsBase(const QStringList &newListIn, bool currentDiveOnly) :

--- a/desktop-widgets/command_edit.h
+++ b/desktop-widgets/command_edit.h
@@ -29,6 +29,7 @@ namespace Command {
 class EditDivesBase : public Base {
 protected:
 	EditDivesBase(bool currentDiveOnly);
+	EditDivesBase(dive *d);
 	std::vector<dive *> dives; // Dives to be edited.
 
 	// On undo, we set the selection and current dive at the time of the operation.
@@ -50,6 +51,7 @@ protected:
 
 public:
 	EditBase(T newValue, bool currentDiveOnly);
+	EditBase(T newValue, dive *d);
 
 protected:
 	// Get and set functions to be overriden by sub-classes.
@@ -169,6 +171,15 @@ class EditMode : public EditBase<int> {
 public:
 	EditMode(int indexIn, int newValue, bool currentDiveOnly);
 	void set(struct dive *d, int i) const override;
+	int data(struct dive *d) const override;
+	QString fieldName() const override;
+	DiveField fieldId() const override;
+};
+
+class EditNumber : public EditBase<int> {
+public:
+	using EditBase<int>::EditBase;	// Use constructor of base class.
+	void set(struct dive *d, int number) const override;
 	int data(struct dive *d) const override;
 	QString fieldName() const override;
 	DiveField fieldId() const override;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -7,6 +7,7 @@
 #include "core/qthelper.h"
 #include "core/subsurface-string.h"
 #include "core/tag.h"
+#include "desktop-widgets/command.h"
 #include <QIcon>
 #include <QDebug>
 #include <memory>
@@ -412,8 +413,7 @@ bool DiveTripModelBase::setData(const QModelIndex &index, const QVariant &value,
 		if (dive->number == v)
 			return false;
 	}
-	d->number = v;
-	mark_divelist_changed(true);
+	Command::editNumber(v, d);
 	return true;
 }
 


### PR DESCRIPTION
When pressing F2 in the dive list, the number can be edited.
Make this action undoable by implementing a EditNumber command.

This command is differs from the other undo commands, as not the
currently selected dives are changed. This means that the EditCommand
needs an alternative constructor taking a single dive. This constructor
was implemented in the base class so that all edit commands can now
be called with a single dive.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Somehow I missed that particular dive-edit command. Make it undoable as well. It *is* well hidden though - it works for me only if I press "F2". That's quite obscure!

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement EditNumber undo command.
2) Use undo command for setting the dive number.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Is the F2 thing noted anywhere?
