### PR TITLE
Move the Suit text box from the Notes tab to the Equipment tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -4,20 +4,23 @@
 #include "desktop-widgets/mainwindow.h" // TODO: Only used temporarilly for edit mode changes
 #include "desktop-widgets/simplewidgets.h" // For isGnome3Session()
 #include "desktop-widgets/modeldelegates.h"
-
+#include "desktop-widgets/command.h"
 #include "profile-widget/profilewidget2.h"
 
 #include "qt-models/cylindermodel.h"
 #include "qt-models/weightmodel.h"
 
-#include "core/divelist.h"
 #include "core/subsurface-string.h"
+#include "core/divelist.h"
 
 #include <QSettings>
+#include <QCompleter>
+
 TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	cylindersModel(new CylindersModel(this)),
 	weightModel(new WeightModel(this))
 {
+	QCompleter *suitCompleter;
 	ui.setupUi(this);
 
 	// This makes sure we only delete the models
@@ -29,6 +32,7 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	ui.cylinders->setModel(cylindersModel);
 	ui.weights->setModel(weightModel);
 
+	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveEquipment::divesChanged);
 	connect(ui.cylinders->view(), &QTableView::clicked, this, &TabDiveEquipment::editCylinderWidget);
 	connect(ui.weights->view(), &QTableView::clicked, this, &TabDiveEquipment::editWeightWidget);
 
@@ -53,6 +57,17 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	ui.weights->setBtnToolTip(tr("Add weight system"));
 	connect(ui.weights, &TableView::addButtonClicked, this, &TabDiveEquipment::addWeight_clicked);
 
+	QAction *action = new QAction(tr("OK"), this);
+	connect(action, &QAction::triggered, this, &TabDiveEquipment::closeWarning);
+	ui.multiDiveWarningMessage->addAction(action);
+
+	action = new QAction(tr("Undo"), this);
+	connect(action, &QAction::triggered, Command::undoAction(this), &QAction::trigger);
+	connect(action, &QAction::triggered, this, &TabDiveEquipment::closeWarning);
+	ui.multiDiveWarningMessage->addAction(action);
+
+	ui.multiDiveWarningMessage->hide();
+
 	QSettings s;
 	s.beginGroup("cylinders_dialog");
 	for (int i = 0; i < CylindersModel::COLUMNS; i++) {
@@ -67,9 +82,11 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 		ui.cylinders->view()->setColumnHidden(i, checked);
 		ui.cylinders->view()->horizontalHeader()->addAction(action);
 	}
-
 	ui.cylinders->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
 	ui.weights->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
+	suitCompleter = new QCompleter(&suitModel, ui.suit);
+	suitCompleter->setCaseSensitivity(Qt::CaseInsensitive);
+	ui.suit->setCompleter(suitCompleter);
 }
 
 TabDiveEquipment::~TabDiveEquipment()
@@ -80,6 +97,23 @@ TabDiveEquipment::~TabDiveEquipment()
 		if ((i == CylindersModel::REMOVE) || (i == CylindersModel::TYPE))
 			continue;
 		s.setValue(QString("column%1_hidden").arg(i), ui.cylinders->view()->isColumnHidden(i));
+	}
+}
+
+// This function gets called if a field gets updated by an undo command.
+// Refresh the corresponding UI field.
+void TabDiveEquipment::divesChanged(const QVector<dive *> &dives, DiveField field)
+{
+	// If the current dive is not in list of changed dives, do nothing
+	if (!current_dive || !dives.contains(current_dive))
+		return;
+
+	switch(field) {
+	case DiveField::SUIT:
+		ui.suit->setText(QString(current_dive->suit));
+		break;
+	default:
+		break;
 	}
 }
 
@@ -101,18 +135,24 @@ void TabDiveEquipment::updateData()
 {
 	cylindersModel->updateDive();
 	weightModel->updateDive();
+	suitModel.updateModel();
 
 	ui.cylinders->view()->hideColumn(CylindersModel::DEPTH);
 	if (get_dive_dc(&displayed_dive, dc_number)->divemode == CCR)
 		ui.cylinders->view()->showColumn(CylindersModel::USE);
 	else
 		ui.cylinders->view()->hideColumn(CylindersModel::USE);
+	if (current_dive && current_dive->suit)
+		ui.suit->setText(QString(current_dive->suit));
+	else
+		ui.suit->clear();
 }
 
 void TabDiveEquipment::clear()
 {
 	cylindersModel->clear();
 	weightModel->clear();
+	ui.suit->clear();
 }
 
 void TabDiveEquipment::addCylinder_clicked()
@@ -259,3 +299,27 @@ void TabDiveEquipment::rejectChanges()
 	cylindersModel->updateDive();
 	weightModel->updateDive();
 }
+
+void TabDiveEquipment::divesEdited(int i)
+{
+	// No warning if only one dive was edited
+	if (i <= 1)
+		return;
+	ui.multiDiveWarningMessage->setCloseButtonVisible(false);
+	ui.multiDiveWarningMessage->setText(tr("Warning: edited %1 dives").arg(i));
+	ui.multiDiveWarningMessage->show();
+}
+
+void TabDiveEquipment::on_suit_editingFinished()
+{
+	if (!current_dive)
+		return;
+	divesEdited(Command::editSuit(ui.suit->text(), false));
+}
+
+void TabDiveEquipment::closeWarning()
+{
+	ui.multiDiveWarningMessage->hide();
+}
+
+

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -4,6 +4,8 @@
 
 #include "TabBase.h"
 #include "ui_TabDiveEquipment.h"
+#include "qt-models/completionmodels.h"
+#include "desktop-widgets/divelistview.h"
 
 namespace Ui {
 	class TabDiveEquipment;
@@ -21,15 +23,21 @@ public:
 	void clear() override;
 	void acceptChanges();
 	void rejectChanges();
+	void divesEdited(int i);
+	void closeWarning();
+
 private slots:
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void addCylinder_clicked();
 	void addWeight_clicked();
 	void toggleTriggeredColumn();
 	void editCylinderWidget(const QModelIndex &index);
 	void editWeightWidget(const QModelIndex &index);
+	void on_suit_editingFinished();
+
 private:
 	Ui::TabDiveEquipment ui;
-
+	SuitCompletionModel suitModel;
 	CylindersModel *cylindersModel;
 	WeightModel *weightModel;
 };

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.ui
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.ui
@@ -7,6 +7,9 @@
   </attribute>
   <layout class="QVBoxLayout" name="verticalLayout_10">
    <item>
+    <widget class="KMessageWidget" name="multiDiveWarningMessage"/>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -61,11 +64,21 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QSplitter" name="splitter">
+            <widget class="QSplitter" name="splitter">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
             <widget class="TableView" name="cylinders" native="true"/>
+            <widget class="QLabel" name="suitText">
+             <property name="text">
+              <string>Suit</string>
+             </property>
+            </widget>
+            <widget class="QLineEdit" name="suit">
+             <property name="readOnly">
+              <bool>false</bool>
+             </property>
+            </widget>
             <widget class="TableView" name="weights" native="true"/>
            </widget>
           </item>

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -45,7 +45,6 @@
 struct Completers {
 	QCompleter *divemaster;
 	QCompleter *buddy;
-	QCompleter *suit;
 	QCompleter *tags;
 };
 
@@ -127,15 +126,12 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	Completers completers;
 	completers.buddy = new QCompleter(&buddyModel, ui.buddy);
 	completers.divemaster = new QCompleter(&diveMasterModel, ui.divemaster);
-	completers.suit = new QCompleter(&suitModel, ui.suit);
 	completers.tags = new QCompleter(&tagModel, ui.tagWidget);
 	completers.buddy->setCaseSensitivity(Qt::CaseInsensitive);
 	completers.divemaster->setCaseSensitivity(Qt::CaseInsensitive);
-	completers.suit->setCaseSensitivity(Qt::CaseInsensitive);
 	completers.tags->setCaseSensitivity(Qt::CaseInsensitive);
 	ui.buddy->setCompleter(completers.buddy);
 	ui.divemaster->setCompleter(completers.divemaster);
-	ui.suit->setCompleter(completers.suit);
 	ui.tagWidget->setCompleter(completers.tags);
 	ui.diveNotesMessage->hide();
 	ui.multiDiveWarningMessage->hide();
@@ -309,9 +305,6 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 	case DiveField::VISIBILITY:
 		ui.visibility->setCurrentStars(current_dive->visibility);
 		break;
-	case DiveField::SUIT:
-		ui.suit->setText(QString(current_dive->suit));
-		break;
 	case DiveField::NOTES:
 		updateNotes(current_dive);
 		break;
@@ -464,8 +457,6 @@ void MainTab::updateDiveInfo()
 			ui.DivemasterLabel->setVisible(false);
 			ui.buddy->setVisible(false);
 			ui.BuddyLabel->setVisible(false);
-			ui.suit->setVisible(false);
-			ui.SuitLabel->setVisible(false);
 			ui.rating->setVisible(false);
 			ui.RatingLabel->setVisible(false);
 			ui.visibility->setVisible(false);
@@ -519,8 +510,6 @@ void MainTab::updateDiveInfo()
 			ui.editDiveSiteButton->show();
 			ui.divemaster->setVisible(true);
 			ui.buddy->setVisible(true);
-			ui.suit->setVisible(true);
-			ui.SuitLabel->setVisible(true);
 			ui.rating->setVisible(true);
 			ui.RatingLabel->setVisible(true);
 			ui.visibility->setVisible(true);
@@ -555,7 +544,6 @@ void MainTab::updateDiveInfo()
 			updateMode(current_dive);
 			updateDiveSite(current_dive);
 			updateDateTime(current_dive);
-			ui.suit->setText(current_dive->suit);
 			ui.divemaster->setText(current_dive->divemaster);
 			ui.buddy->setText(current_dive->buddy);
 			ui.airtemp->setText(get_temperature_string(current_dive->airtemp, true));
@@ -584,7 +572,6 @@ void MainTab::updateDiveInfo()
 		ui.rating->setCurrentStars(0);
 		ui.visibility->setCurrentStars(0);
 		ui.location->clear();
-		ui.suit->clear();
 		ui.divemaster->clear();
 		ui.buddy->clear();
 		ui.airtemp->clear();
@@ -607,7 +594,6 @@ void MainTab::updateDiveInfo()
 
 void MainTab::reload()
 {
-	suitModel.updateModel();
 	buddyModel.updateModel();
 	diveMasterModel.updateModel();
 	tagModel.updateModel();
@@ -871,14 +857,6 @@ void MainTab::on_diveTripLocation_editingFinished()
 	if (!currentTrip)
 		return;
 	Command::editTripLocation(currentTrip, ui.diveTripLocation->text());
-}
-
-void MainTab::on_suit_editingFinished()
-{
-	if (editMode == IGNORE || !current_dive)
-		return;
-
-	divesEdited(Command::editSuit(ui.suit->text(), false));
 }
 
 void MainTab::on_notes_editingFinished()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -60,7 +60,6 @@ slots:
 	void on_locationPopupButton_clicked();
 	void on_divemaster_editingFinished();
 	void on_buddy_editingFinished();
-	void on_suit_editingFinished();
 	void on_diveTripLocation_editingFinished();
 	void on_notes_editingFinished();
 	void on_airtemp_editingFinished();
@@ -85,7 +84,6 @@ private:
 	EditMode editMode;
 	BuddyCompletionModel buddyModel;
 	DiveMasterCompletionModel diveMasterModel;
-	SuitCompletionModel suitModel;
 	TagCompletionModel tagModel;
 	bool modified;
 	bool lastSelectedDive;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -337,13 +337,6 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="SuitLabel">
-               <property name="text">
-                <string>Suit</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="0" alignment="Qt::AlignVCenter">
               <widget class="StarWidget" name="rating" native="true">
                <property name="sizePolicy">
@@ -371,17 +364,20 @@
               </widget>
              </item>
              <item row="1" column="2">
-              <widget class="QLineEdit" name="suit">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
                </property>
-               <property name="readOnly">
-                <bool>false</bool>
+               <property name="sizeType">
+                 <enum>QSizePolicy::Expanding</enum>
                </property>
-              </widget>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </item>


### PR DESCRIPTION
This change moves the Suit text box from the Notes tab to the Equipment tab. 

The suit information is now with the other equipment information. Now, we have all the equipment information in one place. The Suit textbox is removed from the Notes tab and the resulting empty space is not filled with something else.

The undo facility is retained thanks to the already-existing undo infrastructure in command.cpp that was written for the Notes tab. The multi-dive edit warning also works for the Suit textbox. The auto-completion is also retained. However, this is achieved by creating in tabDiveEquipment.cpp a very similar auto-completion infrastructure as found in maintab.cpp. A more parsimonious route would be to create new .cpp and header files that contain this common code (used in maintab.cpp and tabDiveEquipment.cpp). The same applies for the function that displays a message : "Warning: Edited 2 dives" when editing more than one dive. For the moment I chose not to create extra files.

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @dirkhh @janmulder