### PR TITLE
Desktop: fix index in weightsystems_equal()

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -674,7 +674,7 @@ bool weightsystems_equal(const dive *d1, const dive *d2)
 	if (d1->weightsystems.nr != d2->weightsystems.nr)
 		return false;
 	for (int i = 0; i < d1->weightsystems.nr; ++i) {
-		if (!same_weightsystem(d1->weightsystems.weightsystems[0], d2->weightsystems.weightsystems[i]))
+		if (!same_weightsystem(d1->weightsystems.weightsystems[i], d2->weightsystems.weightsystems[i]))
 			return false;
 	}
 	return true;


### PR DESCRIPTION
The weightsystem_equal() function compares weightsystems of two dives
to decide whether the "commit changes" message should be shown and
to decide which dives are edited when changing multiple dives.

Due to an index mixup the function returned wrong results for
more than two weightsystems. Fix it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an embarrassing bug. Should be pretty obvious.