### PR TITLE
[TRIVIAL] Cleanup: remove TankItem::diveCylinderStore

### DIFF
--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -32,14 +32,6 @@ TankItem::TankItem(QObject *parent) :
 	trimix = trimixGradient;
 	air = blue;
 	hAxis = nullptr;
-	memset(&diveCylinderStore, 0, sizeof(diveCylinderStore));
-}
-
-TankItem::~TankItem()
-{
-	// Should this be clear_dive(diveCylinderStore)?
-	for (int i = 0; i < MAX_CYLINDERS; i++)
-		free((void *)diveCylinderStore.cylinder[i].type.description);
 }
 
 void TankItem::setData(DivePlotDataModel *model, struct plot_info *plotInfo, struct dive *d)
@@ -51,7 +43,6 @@ void TankItem::setData(DivePlotDataModel *model, struct plot_info *plotInfo, str
 	pInfoEntry = (struct plot_data *)malloc(size);
 	pInfoNr = plotInfo->nr;
 	memcpy(pInfoEntry, plotInfo->entry, size);
-	copy_cylinders(d, &diveCylinderStore, false);
 	dataModel = model;
 	connect(dataModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(modelDataChanged(QModelIndex, QModelIndex)), Qt::UniqueConnection);
 	modelDataChanged();

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -15,7 +15,6 @@ class TankItem : public QObject, public QGraphicsRectItem
 
 public:
 	explicit TankItem(QObject *parent = 0);
-	~TankItem();
 	void setHorizontalAxis(DiveCartesianAxis *horizontal);
 	void setData(DivePlotDataModel *model, struct plot_info *plotInfo, struct dive *d);
 
@@ -28,7 +27,6 @@ private:
 	void createBar(qreal x, qreal w, struct gasmix gas);
 	DivePlotDataModel *dataModel;
 	DiveCartesianAxis *hAxis;
-	struct dive diveCylinderStore;
 	struct plot_data *pInfoEntry;
 	int pInfoNr;
 	qreal height;


### PR DESCRIPTION
The last user of this member variable was removed in commit
96ed09bf145a5e108ca8098a1a5814784bcbebd2.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup: remove an unused member variable.
