### PR TITLE
Avoid possible crash while loading maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- fix crash when (re-)loading maps
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -140,7 +140,7 @@ void MapLocationModel::reload(QObject *map)
 	m_selectedDs.clear();
 
 	QMap<QString, MapLocation *> locationNameMap;
-	MapLocation *location;
+	MapLocation *location = nullptr;
 
 #ifdef SUBSURFACE_MOBILE
 	bool diveSiteMode = false;
@@ -180,6 +180,8 @@ void MapLocationModel::reload(QObject *map)
 			// at least MIN_DISTANCE_BETWEEN_DIVE_SITES_M apart
 			if (locationNameMap.contains(name)) {
 				MapLocation *existingLocation = locationNameMap[name];
+				if (!existingLocation)
+					continue;
 				QGeoCoordinate coord = existingLocation->coordinate();
 				if (dsCoord.distanceTo(coord) < MIN_DISTANCE_BETWEEN_DIVE_SITES_M)
 					continue;


### PR DESCRIPTION
We ended up with a NULL location and happily dereferenced it. Not good.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Using the dive data from one of the reporters of the 4.9 crash I was able to reproduce the crash and this fixes it
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger  would you do a sanity check, please?