### PR TITLE
Crash fix: prevent crash in MapLocationModel::reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+- fix crash when (re-)loading maps
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -140,7 +140,6 @@ void MapLocationModel::reload(QObject *map)
 	m_selectedDs.clear();
 
 	QMap<QString, MapLocation *> locationNameMap;
-	MapLocation *location;
 
 #ifdef SUBSURFACE_MOBILE
 	bool diveSiteMode = false;
@@ -184,10 +183,11 @@ void MapLocationModel::reload(QObject *map)
 				if (dsCoord.distanceTo(coord) < MIN_DISTANCE_BETWEEN_DIVE_SITES_M)
 					continue;
 			}
-			locationNameMap[name] = location;
 		}
-		location = new MapLocation(ds, dsCoord, name);
+		MapLocation *location = new MapLocation(ds, dsCoord, name);
 		m_mapLocations.append(location);
+		if (!diveSiteMode)
+			locationNameMap[name] = location;
 	}
 
 	endResetModel();


### PR DESCRIPTION
Commit 0c387549164d7eec3ea6647c54ada2fba7f8d5e6 introduced a
bug in MapLocationModel::reload() by setting an entry in the
name-to-location map before the location was initialized.

Move the setting of the map entry back where it was before:
after the assignment of the location variable.

Moreover, define the location variable directly on allocation
of the location to avoid thus bugs in the future.

Why did we not get a "might be used unitialized" warning
anyway?

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Attempt at crash-fix as requested in #2196.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh