### PR TITLE
Desktop: correct tooltip for filter close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- fix incorrect tool tip for the button closing the filter panel
 - fix crash when (re-)loading maps
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -307,7 +307,7 @@
        <item row="0" column="2">
         <widget class="QToolButton" name="close">
          <property name="toolTip">
-          <string>Close and reset filters</string>
+          <string>Close filters</string>
          </property>
          <property name="icon">
           <iconset>


### PR DESCRIPTION
This button only closes the filter panel but doesn't clear it.

Reported-by: Adric Norris <landstander668@gmail.com>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
included

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
none

