### PR TITLE
Limit gas compressibility argument range to halfway sane values

### DIFF
--- a/core/gas-model.c
+++ b/core/gas-model.c
@@ -47,6 +47,14 @@ double gas_compressibility_factor(struct gasmix gas, double bar)
 	double x1, x2, x3;
 	double Z;
 
+	/*
+	 * The curve fitting range is only [0,500] bar.
+	 * Anything else is way out of range for cylinder
+	 * pressures.
+	 */
+	if (bar < 0) bar = 0;
+	if (bar > 500) bar = 500;
+
 	o2 = get_o2(gas);
 	he = get_he(gas);
 


### PR DESCRIPTION
The curve fitting for our gas compressibility was only done in the sane
range of 0-500 bar, which is what a scuba cylinder can reasonably be
expected to perhaps have.

But the planner ends up happily using negative cylinder pressures when
you run out of gas, and then the compressibility gives nonsensical
results.

That's clearly a planner bug, but the nonsensical gas compressibility
values made it harder to see what could be wrong.

So we just clamp the inpot range to the range we have verified against
experimental data.  If you try to get compressibility for negative
pressures, you get the compressibility for an ideal and imaginary gas.
And if you try to get compressibility for pressures over 500 bar, we'll
just assume that it's 500 bar.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
