### PR TITLE
Desktop: display trip time on main-tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: fix display of trip time
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -392,14 +392,25 @@ void MainTab::updateMode(struct dive *d)
 	MainWindow::instance()->graphics->recalcCeiling();
 }
 
-void MainTab::updateDateTime(struct dive *d)
+static QDateTime timestampToDateTime(timestamp_t when)
 {
 	// Subsurface always uses "local time" as in "whatever was the local time at the location"
 	// so all time stamps have no time zone information and are in UTC
-	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000*d->when, Qt::UTC);
+	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * when, Qt::UTC);
 	localTime.setTimeSpec(Qt::UTC);
+	return localTime;
+}
+void MainTab::updateDateTime(const struct dive *d)
+{
+	QDateTime localTime = timestampToDateTime(d->when);
 	ui.dateEdit->setDate(localTime.date());
 	ui.timeEdit->setTime(localTime.time());
+}
+
+void MainTab::updateTripDate(const struct dive_trip *t)
+{
+	QDateTime localTime = timestampToDateTime(trip_date(t));
+	ui.dateEdit->setDate(localTime.date());
 }
 
 void MainTab::updateDiveSite(struct dive *d)
@@ -487,6 +498,7 @@ void MainTab::updateDiveInfo()
 			// rename the remaining fields and fill data from selected trip
 			ui.LocationLabel->setText(tr("Trip location"));
 			ui.diveTripLocation->setText(currentTrip->location);
+			updateTripDate(currentTrip);
 			ui.locationTags->clear();
 			//TODO: Fix this.
 			//ui.location->setText(currentTrip->location);

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -52,7 +52,8 @@ slots:
 	void updateDiveInfo();
 	void updateNotes(const struct dive *d);
 	void updateMode(struct dive *d);
-	void updateDateTime(struct dive *d);
+	void updateDateTime(const struct dive *d);
+	void updateTripDate(const struct dive_trip *t);
 	void updateDiveSite(struct dive *d);
 	void acceptChanges();
 	void rejectChanges();


### PR DESCRIPTION
On the main tab, the trip time was not shown when switching to
a trip. Implement showing of the trip date in a function, as the
undo-code will also have to update the trip date in certain
circumstances.

Fixes #2207

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes bug #2207 - not much more to say, really.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@djunkins 