### PR TITLE
Cleanup: replace macro by inline function in gas-model.c

### DIFF
--- a/core/gas-model.c
+++ b/core/gas-model.c
@@ -6,7 +6,10 @@
 #include "dive.h"
 
 /* "Virial minus one" - the virial cubic form without the initial 1.0 */
-#define virial_m1(C, x1, x2, x3) (C[0]*x1+C[1]*x2+C[2]*x3)
+static double virial_m1(const double coeff[], double x)
+{
+	return x*coeff[0] + x*x*coeff[1] + x*x*x*coeff[2];
+}
 
 /*
  * Z = pV/nRT
@@ -44,17 +47,14 @@ double gas_compressibility_factor(struct gasmix gas, double bar)
 		+5.33304543646e-11
 	};
 	int o2, he;
-	double x1, x2, x3;
 	double Z;
 
 	o2 = get_o2(gas);
 	he = get_he(gas);
 
-	x1 = bar; x2 = x1*x1; x3 = x2*x1;
-
-	Z = virial_m1(o2_coefficients, x1, x2, x3) * o2 +
-	    virial_m1(he_coefficients, x1, x2, x3) * he +
-	    virial_m1(n2_coefficients, x1, x2, x3) * (1000 - o2 - he);
+	Z = virial_m1(o2_coefficients, bar) * o2 +
+	    virial_m1(he_coefficients, bar) * he +
+	    virial_m1(n2_coefficients, bar) * (1000 - o2 - he);
 
 	/*
 	 * We add the 1.0 at the very end - the linear mixing of the


### PR DESCRIPTION
Replace a macro calculating a degree-three polynomial by an
inline function.

Moreover, calculate the powers 1, 2 and 3 of the pressure inside
the function. The compiler will be smart enough to optimize this
to the same code. The only important thing is to write "x*x*x*coeff"
instead of "coeff*x*x*x". The compiler can't optimize the latter
because ... wonderful floating point semantics.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A tiny code-cosmetics thing: turn macro into inline function don't do the compilers job. I verified that both versions produce the same assembly on compiler explorer. The crucial point is just to write x*x*x*coeff instead of coeff*x*x*x. The joys of floating point calculations!

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 