### PR TITLE
Negative Pressure

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -65,6 +65,7 @@
 
 // Magentas
 #define MEDIUMREDVIOLET1_HIGHER_TRANS QColor::fromRgbF(0.7, 0.2, 0.7, 0.1)
+#define MAGENTA QColor::fromRgbF(1.0, 0.0, 1.0, 1.0)
 
 #define SAC_COLORS_START_IDX SAC_1
 #define SAC_COLORS 9

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -284,14 +284,19 @@ void DiveCartesianAxis::setTickInterval(double i)
 
 qreal DiveCartesianAxis::valueAt(const QPointF &p) const
 {
+	double fraction;
 	QLineF m = line();
 	QPointF relativePosition = p;
 	relativePosition -= pos(); // normalize p based on the axis' offset on screen
 
-	double retValue = (orientation == LeftToRight || orientation == RightToLeft) ?
-				  max * (relativePosition.x() - m.x1()) / (m.x2() - m.x1()) :
-				  max * (relativePosition.y() - m.y1()) / (m.y2() - m.y1());
-	return retValue;
+	if (orientation == LeftToRight || orientation == RightToLeft)
+		fraction = (relativePosition.x() - m.x1()) / (m.x2() - m.x1());
+	else
+		fraction = (relativePosition.y() - m.y1()) / (m.y2() - m.y1());
+
+	if (orientation == RightToLeft || orientation == BottomToTop)
+			fraction = 1 - fraction;
+	return fraction * (max - min) + min;
 }
 
 qreal DiveCartesianAxis::posAtValue(qreal value)

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -809,7 +809,10 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 				else
 					pen.setBrush(MED_GRAY_HIGH_TRANS);
 			} else {
-				pen.setBrush(getPressureColor(entry->density));
+				if (vAxis->valueAt(poly[i]) < 0)
+					pen.setBrush(MAGENTA);
+				else
+					pen.setBrush(getPressureColor(entry->density));
 			}
 			painter->setPen(pen);
 			painter->drawLine(poly[i - 1], poly[i]);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In the planner, it is possible to plan dives that use more gas than available. In this case, we end up with negative pressures in the cylinder. This information is useful as it gives a rough estimate of how many more cylinders are required.

To alert the user of this fact, this patch colours the pressure line in a highly visible color when this happens.

On the way, a math error for inverted orientations is corrected in diveCartesianAxis::valueAt().

Together with Linus' patch making sure we don't compute gas compressibility for negative pressures this

fixes #2212 

as the hang was just a very long calculation figuring out a huge number of ticks for the pressure axis. Beyond that worksasdesigned.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->