### PR TITLE
Core: unconditionally include stdio.h in libdivecomputer.h

### DIFF
--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -3,9 +3,7 @@
 #define LIBDIVECOMPUTER_H
 
 #include <stdint.h>
-#if defined(Q_OS_IOS)
 #include <stdio.h>
-#endif
 
 /* libdivecomputer */
 


### PR DESCRIPTION
Header files should compile regardless of order of inclusion.
Since libdivecomputer.h uses FILE unconditional include of
stdio.h is the correct thing to do.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Small cleanup, see commit description.
