### PR TITLE
[RFC] Alternative fix to #2221

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -28,6 +28,10 @@ Kirigami.Page {
 		id: downloadThread
 
 		onFinished : {
+			if (!table || !sites) {
+				console.warn("DCDownloadThread::onFinished(): table or sites is null!")
+				return
+			}
 			importModel.repopulate(table, sites)
 			progressBar.visible = false
 			if (dcImportModel.rowCount() > 0) {


### PR DESCRIPTION
There are reported crashes on Android that suggest a null
"tables" attribute in DownloadDCThread. This should never
happen, as the table() function connected to this attribute
returns the address of a subobject. Thus, even if the original
DownloadThread is null, this would not return a null pointer
(the subobject is not at address 0).

Catch these null-object accesses and write a warning message
to the console. Hopefully, this will help in localizing the
problem.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
@dirkhh: Could you please try this alternative fix to #2221? I'm currently travelling and have no device to test on. :( This QML stuff is mind-boggling.