### PR TITLE
Mobile: fix editing of weight system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Mobile: allow editing weights for dives that have no weight
 - Desktop: fix display of trip time
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -254,7 +254,7 @@ QStringList DiveObjectHelper::weights() const
 
 bool DiveObjectHelper::singleWeight() const
 {
-	return m_dive->weightsystems.nr == 1;
+	return m_dive->weightsystems.nr <= 1;
 }
 
 QString DiveObjectHelper::weight(int idx) const

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1030,11 +1030,14 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		diveChanged = true;
 		d->watertemp.mkelvin = parseTemperatureToMkelvin(watertemp);
 	}
-	// not sure what we'd do if there was more than one weight system
-	// defined - for now just ignore that case
-	if (d->weightsystems.nr == 1) {
-		if (myDive->sumWeight() != weight) {
-			diveChanged = true;
+	if (myDive->sumWeight() != weight) {
+		diveChanged = true;
+		// not sure what we'd do if there was more than one weight system
+		// defined - for now just ignore that case
+		if (d->weightsystems.nr == 0) {
+			weightsystem_t ws = { { parseWeightToGrams(weight) } , "" };
+			add_cloned_weightsystem(&d->weightsystems, ws);
+		} else if (d->weightsystems.nr == 1) {
 			d->weightsystems.weightsystems[0].weight.grams = parseWeightToGrams(weight);
 		}
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -481,7 +481,7 @@ void QMLManager::saveCloudCredentials()
 	}
 
 	cloudCredentialsChanged |= !same_string(prefs.cloud_storage_password,
-								qPrintable(QMLPrefs::instance()->cloudPassword()));
+						qPrintable(QMLPrefs::instance()->cloudPassword()));
 
 	if (QMLPrefs::instance()->credentialStatus() != qPrefCloudStorage::CS_NOCLOUD &&
 		!cloudCredentialsChanged) {
@@ -1035,8 +1035,8 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		// not sure what we'd do if there was more than one weight system
 		// defined - for now just ignore that case
 		if (d->weightsystems.nr == 0) {
-			weightsystem_t ws = { { parseWeightToGrams(weight) } , "" };
-			add_cloned_weightsystem(&d->weightsystems, ws);
+			weightsystem_t ws = { { parseWeightToGrams(weight) } , strdup(qPrintable(tr("weight"))) };
+			add_to_weightsystem_table(&d->weightsystems, 0, ws); // takes ownership of the string
 		} else if (d->weightsystems.nr == 1) {
 			d->weightsystems.weightsystems[0].weight.grams = parseWeightToGrams(weight);
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removal of MAX_WEIGHTSYSTEM made it impossible to edit the weight on mobile for dives that had no weightsystem set (e.g. newly created dives). This PR fixes this.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Enable editing of weight for 0-weightsystem dives.
2) Add a new weightsystem for 0-weightsystem dives.
