### PR TITLE
Cleanup: remove default argument from DiveObjectHelper constructor

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -58,6 +58,8 @@ static QString getPressures(struct dive *dive, int i, enum returnPressureSelecto
 DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 	m_dive(d)
 {
+	if (!m_dive)
+		qWarning("Creating DiveObjectHelper from NULL dive");
 	m_cyls.clear();
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		//Don't add blank cylinders, only those that have been defined.

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -51,7 +51,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString fullText READ fullText CONSTANT)
 	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
-	DiveObjectHelper(struct dive *dive = NULL);
+	DiveObjectHelper(struct dive *dive);
 	~DiveObjectHelper();
 	int number() const;
 	int id() const;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes the default argument from the DiveObjectHelper constructor. This is only a documentation thing - setting the default argument to NULL suggests that this is a valid argument, when clearly it will crash immediately.

