### PR TITLE
Mobile: fix bound check in DiveListModel::data()

### DIFF
--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -238,7 +238,7 @@ int DiveListModel::getDiveIdx(int id) const
 
 QVariant DiveListModel::data(const QModelIndex &index, int role) const
 {
-	if(index.row() < 0 || index.row() > m_dives.count())
+	if(index.row() < 0 || index.row() >= m_dives.count())
 		return QVariant();
 
 	DiveObjectHelper *curr_dive = m_dives[index.row()];


### PR DESCRIPTION
Indexes go from 0 to count - 1. Thus, the comparison for invalid
indexes has to read ">= count", not "> count".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix off-by-one error in testing index. See commit description. Should not change anything, but for correctness' sake...