### PR TITLE
[TEST]Pass DiveObjectHelper as values and remove DiveListModel indirection (Contains #2238)

### DIFF
--- a/core/subsurface-qt/CylinderObjectHelper.cpp
+++ b/core/subsurface-qt/CylinderObjectHelper.cpp
@@ -3,36 +3,16 @@
 #include "../qthelper.h"
 
 static QString EMPTY_CYLINDER_STRING = QStringLiteral("");
-CylinderObjectHelper::CylinderObjectHelper(cylinder_t *cylinder) :
-	m_cyl(cylinder) {
-}
+CylinderObjectHelper::CylinderObjectHelper(cylinder_t *cylinder)
+{
+	if (!cylinder)
+		return;
 
-CylinderObjectHelper::~CylinderObjectHelper() {
-}
-
-QString CylinderObjectHelper::description() const {
-	if (!m_cyl->type.description)
-		return QString(EMPTY_CYLINDER_STRING);
-	else
-		return QString(m_cyl->type.description);
-}
-
-QString CylinderObjectHelper::size() const {
-	return get_volume_string(m_cyl->type.size, true);
-}
-
-QString CylinderObjectHelper::workingPressure() const {
-	return get_pressure_string(m_cyl->type.workingpressure, true);
-}
-
-QString CylinderObjectHelper::startPressure() const {
-	return get_pressure_string(m_cyl->start, true);
-}
-
-QString CylinderObjectHelper::endPressure() const {
-	return get_pressure_string(m_cyl->end, true);
-}
-
-QString CylinderObjectHelper::gasMix() const {
-	return get_gas_string(m_cyl->gasmix);
+	description = cylinder->type.description ? cylinder->type.description:
+						   EMPTY_CYLINDER_STRING;
+	size = get_volume_string(cylinder->type.size, true);
+	workingPressure = get_pressure_string(cylinder->type.workingpressure, true);
+	startPressure = get_pressure_string(cylinder->start, true);
+	endPressure = get_pressure_string(cylinder->end, true);
+	gasMix = get_gas_string(cylinder->gasmix);
 }

--- a/core/subsurface-qt/CylinderObjectHelper.h
+++ b/core/subsurface-qt/CylinderObjectHelper.h
@@ -6,27 +6,24 @@
 #include <QObject>
 #include <QString>
 
-class CylinderObjectHelper : public QObject {
-	Q_OBJECT
-	Q_PROPERTY(QString description READ description CONSTANT)
-	Q_PROPERTY(QString size READ size CONSTANT)
-	Q_PROPERTY(QString workingPressure READ workingPressure CONSTANT)
-	Q_PROPERTY(QString startPressure READ startPressure CONSTANT)
-	Q_PROPERTY(QString endPressure READ endPressure CONSTANT)
-	Q_PROPERTY(QString gasMix READ gasMix CONSTANT)
+class CylinderObjectHelper {
+	Q_GADGET
+	Q_PROPERTY(QString description MEMBER description CONSTANT)
+	Q_PROPERTY(QString size MEMBER size CONSTANT)
+	Q_PROPERTY(QString workingPressure MEMBER workingPressure CONSTANT)
+	Q_PROPERTY(QString startPressure MEMBER startPressure CONSTANT)
+	Q_PROPERTY(QString endPressure MEMBER endPressure CONSTANT)
+	Q_PROPERTY(QString gasMix MEMBER gasMix CONSTANT)
 public:
 	CylinderObjectHelper(cylinder_t *cylinder = NULL);
-	~CylinderObjectHelper();
-	QString description() const;
-	QString size() const;
-	QString workingPressure() const;
-	QString startPressure() const;
-	QString endPressure() const;
-	QString gasMix() const;
-
-private:
-	cylinder_t *m_cyl;
+	QString description;
+	QString size;
+	QString workingPressure;
+	QString startPressure;
+	QString endPressure;
+	QString gasMix;
 };
 
-	Q_DECLARE_METATYPE(CylinderObjectHelper *)
+Q_DECLARE_METATYPE(CylinderObjectHelper)
+
 #endif

--- a/core/subsurface-qt/CylinderObjectHelper.h
+++ b/core/subsurface-qt/CylinderObjectHelper.h
@@ -2,7 +2,7 @@
 #ifndef CYLINDER_QOBJECT_H
 #define CYLINDER_QOBJECT_H
 
-#include "../dive.h"
+#include "../equipment.h"
 #include <QObject>
 #include <QString>
 

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -55,6 +55,13 @@ static QString getPressures(struct dive *dive, int i, enum returnPressureSelecto
 	return fmt;
 }
 
+// Qt's metatype system insists on generating a default constructed object,
+// even if that makes no sense. Usage of this object *will* crash.
+DiveObjectHelper::DiveObjectHelper() :
+	m_dive(nullptr)
+{
+}
+
 DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 	m_dive(d)
 {

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -67,6 +67,16 @@ DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 {
 }
 
+DiveObjectHelper::operator bool() const
+{
+	return !!m_dive;
+}
+
+bool DiveObjectHelper::operator!() const
+{
+	return !m_dive;
+}
+
 int DiveObjectHelper::number() const
 {
 	return m_dive->number;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -60,18 +60,11 @@ DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 {
 	if (!m_dive)
 		qWarning("Creating DiveObjectHelper from NULL dive");
-	m_cyls.clear();
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		//Don't add blank cylinders, only those that have been defined.
 		if (m_dive->cylinder[i].type.description)
-			m_cyls.append(new CylinderObjectHelper(&m_dive->cylinder[i]));
+			m_cyls.append(CylinderObjectHelper(&m_dive->cylinder[i]));
 	}
-}
-
-DiveObjectHelper::~DiveObjectHelper()
-{
-while (!m_cyls.isEmpty())
-	delete m_cyls.takeFirst();
 }
 
 int DiveObjectHelper::number() const
@@ -316,7 +309,7 @@ QString DiveObjectHelper::cylinder(int idx) const
 	return getFormattedCylinder(m_dive, idx);
 }
 
-QList<CylinderObjectHelper*> DiveObjectHelper::cylinderObjects() const
+QVector<CylinderObjectHelper> DiveObjectHelper::cylinderObjects() const
 {
 	return m_cyls;
 }

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -58,13 +58,6 @@ static QString getPressures(struct dive *dive, int i, enum returnPressureSelecto
 DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 	m_dive(d)
 {
-	if (!m_dive)
-		qWarning("Creating DiveObjectHelper from NULL dive");
-	for (int i = 0; i < MAX_CYLINDERS; i++) {
-		//Don't add blank cylinders, only those that have been defined.
-		if (m_dive->cylinder[i].type.description)
-			m_cyls.append(CylinderObjectHelper(&m_dive->cylinder[i]));
-	}
 }
 
 int DiveObjectHelper::number() const
@@ -311,7 +304,13 @@ QString DiveObjectHelper::cylinder(int idx) const
 
 QVector<CylinderObjectHelper> DiveObjectHelper::cylinderObjects() const
 {
-	return m_cyls;
+	QVector<CylinderObjectHelper> res;
+	for (int i = 0; i < MAX_CYLINDERS; i++) {
+		//Don't add blank cylinders, only those that have been defined.
+		if (m_dive->cylinder[i].type.description)
+			res.append(CylinderObjectHelper(&m_dive->cylinder[i])); // no emplace for QVector. :(
+	}
+	return res;
 }
 
 QString DiveObjectHelper::tripId() const

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -9,8 +9,8 @@
 #include <QVector>
 #include <QVariant>
 
-class DiveObjectHelper : public QObject {
-	Q_OBJECT
+class DiveObjectHelper {
+	Q_GADGET
 	Q_PROPERTY(int number READ number CONSTANT)
 	Q_PROPERTY(int id READ id CONSTANT)
 	Q_PROPERTY(int rating READ rating CONSTANT)
@@ -52,6 +52,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString fullText READ fullText CONSTANT)
 	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
+	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
 	DiveObjectHelper(struct dive *dive);
 	int number() const;
 	int id() const;
@@ -100,6 +101,6 @@ public:
 private:
 	struct dive *m_dive;
 };
-	Q_DECLARE_METATYPE(DiveObjectHelper *)
+	Q_DECLARE_METATYPE(DiveObjectHelper)
 
 #endif

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -99,7 +99,6 @@ public:
 
 private:
 	struct dive *m_dive;
-	QVector<CylinderObjectHelper> m_cyls;
 };
 	Q_DECLARE_METATYPE(DiveObjectHelper *)
 

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -54,6 +54,8 @@ class DiveObjectHelper {
 public:
 	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
 	DiveObjectHelper(struct dive *dive);
+	operator bool() const; // Returns false if this is an invalid default-generated object
+	bool operator!() const; // Returns true if this is an invalid default-generated object
 	int number() const;
 	int id() const;
 	struct dive *getDive() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QVector>
 #include <QVariant>
 
 class DiveObjectHelper : public QObject {
@@ -38,7 +39,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString suit READ suit CONSTANT)
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
-	Q_PROPERTY(QList<CylinderObjectHelper*> cylinderObjects READ cylinderObjects CONSTANT)
+	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects READ cylinderObjects CONSTANT)
 	Q_PROPERTY(QString tripId READ tripId CONSTANT)
 	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
@@ -52,7 +53,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive);
-	~DiveObjectHelper();
 	int number() const;
 	int id() const;
 	struct dive *getDive() const;
@@ -84,7 +84,7 @@ public:
 	QStringList cylinderList() const;
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
-	QList<CylinderObjectHelper*> cylinderObjects() const;
+	QVector<CylinderObjectHelper> cylinderObjects() const;
 	QString tripId() const;
 	int tripNrDives() const;
 	int maxcns() const;
@@ -99,7 +99,7 @@ public:
 
 private:
 	struct dive *m_dive;
-	QList<CylinderObjectHelper*> m_cyls;
+	QVector<CylinderObjectHelper> m_cyls;
 };
 	Q_DECLARE_METATYPE(DiveObjectHelper *)
 

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -134,19 +134,13 @@ QString TemplateLayout::generate()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
-	// Note: Currently, this should not be transformed into a QVector<> or std::vector<>,
-	// as diveList contains pointers to elements in this list. But vectors might relocate
-	// and thus invalidate the pointers! std::list<> is used here, because the new elements
-	// can be directly constructed in the list with the emplace_back() call.
-	// Ultimately, the memory management should be fixed.
-	std::list<DiveObjectHelper> diveObjectList;
 	QVariantList diveList;
 
 	struct dive *dive;
 	if (in_planner()) {
-		diveObjectList.emplace_back(&displayed_dive);
-		diveList.append(QVariant::fromValue(&diveObjectList.back()));
+		diveList.append(QVariant::fromValue(DiveObjectHelper(&displayed_dive)));
 		emit progressUpdated(100.0);
 	} else {
 		int i;
@@ -154,8 +148,7 @@ QString TemplateLayout::generate()
 			//TODO check for exporting selected dives only
 			if (!dive->selected && printOptions->print_selected)
 				continue;
-			diveObjectList.emplace_back(dive);
-			diveList.append(QVariant::fromValue(&diveObjectList.back()));
+			diveList.append(QVariant::fromValue(DiveObjectHelper(dive)));
 			progress++;
 			emit progressUpdated(lrint(progress * 100.0 / totalWork));
 		}
@@ -198,6 +191,7 @@ QString TemplateLayout::generateStatistics()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	QVariantList years;
 

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -133,6 +133,7 @@ QString TemplateLayout::generate()
 	Grantlee::Engine engine(this);
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
+	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	// Note: Currently, this should not be transformed into a QVector<> or std::vector<>,
 	// as diveList contains pointers to elements in this list. But vectors might relocate
@@ -196,6 +197,7 @@ QString TemplateLayout::generateStatistics()
 	Grantlee::registerMetaType<YearInfo>();
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
+	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	QVariantList years;
 

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -9,6 +9,7 @@
 #include "core/statistics.h"
 #include "core/qthelper.h"
 #include "core/subsurface-qt/DiveObjectHelper.h"
+#include "core/subsurface-qt/CylinderObjectHelper.h" // TODO: remove once grantlee supports Q_GADGET objects
 
 int getTotalWork(print_options *printOptions);
 void find_all_templates();
@@ -120,4 +121,22 @@ if (property == "year") {
 }
 GRANTLEE_END_LOOKUP
 
+// TODO: This is currently needed because our grantlee version
+// doesn't support Q_GADGET based classes. A patch to fix this
+// exists. Remove in due course.
+GRANTLEE_BEGIN_LOOKUP(CylinderObjectHelper)
+if (property == "description") {
+	return object.description;
+} else if (property == "size") {
+	return object.size;
+} else if (property == "workingPressure") {
+	return object.workingPressure;
+} else if (property == "startPressure") {
+	return object.startPressure;
+} else if (property == "endPressure") {
+	return object.endPressure;
+} else if (property == "gasMix") {
+	return object.gasMix;
+}
+GRANTLEE_END_LOOKUP
 #endif

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -139,4 +139,91 @@ if (property == "description") {
 	return object.gasMix;
 }
 GRANTLEE_END_LOOKUP
+
+// TODO: This is currently needed because our grantlee version
+// doesn't support Q_GADGET based classes. A patch to fix this
+// exists. Remove in due course.
+GRANTLEE_BEGIN_LOOKUP(DiveObjectHelper)
+if (property == "number") {
+	return object.number();
+} else if (property == "id") {
+	return object.id();
+} else if (property == "rating") {
+	return object.rating();
+} else if (property == "visibility") {
+	return object.visibility();
+} else if (property == "date") {
+	return object.date();
+} else if (property == "time") {
+	return object.time();
+} else if (property == "timestamp") {
+	return QVariant::fromValue(object.timestamp());
+} else if (property == "location") {
+	return object.location();
+} else if (property == "gps") {
+	return object.gps();
+} else if (property == "gps_decimal") {
+	return object.gps_decimal();
+} else if (property == "dive_site") {
+	return object.dive_site();
+} else if (property == "duration") {
+	return object.duration();
+} else if (property == "noDive") {
+	return object.noDive();
+} else if (property == "depth") {
+	return object.depth();
+} else if (property == "divemaster") {
+	return object.divemaster();
+} else if (property == "buddy") {
+	return object.buddy();
+} else if (property == "airTemp") {
+	return object.airTemp();
+} else if (property == "waterTemp") {
+	return object.waterTemp();
+} else if (property == "notes") {
+	return object.notes();
+} else if (property == "tags") {
+	return object.tags();
+} else if (property == "gas") {
+	return object.gas();
+} else if (property == "sac") {
+	return object.sac();
+} else if (property == "weightList") {
+	return object.weightList();
+} else if (property == "weights") {
+	return object.weights();
+} else if (property == "singleWeight") {
+	return object.singleWeight();
+} else if (property == "suit") {
+	return object.suit();
+} else if (property == "cylinderList") {
+	return object.cylinderList();
+} else if (property == "cylinders") {
+	return object.cylinders();
+} else if (property == "cylinderObjects") {
+	return QVariant::fromValue(object.cylinderObjects());
+} else if (property == "tripId") {
+	return object.tripId();
+} else if (property == "tripNrDives") {
+	return object.tripNrDives();
+} else if (property == "maxcns") {
+	return object.maxcns();
+} else if (property == "otu") {
+	return object.otu();
+} else if (property == "sumWeight") {
+	return object.sumWeight();
+} else if (property == "getCylinder") {
+	return object.getCylinder();
+} else if (property == "startPressure") {
+	return object.startPressure();
+} else if (property == "endPressure") {
+	return object.endPressure();
+} else if (property == "firstGas") {
+	return object.firstGas();
+} else if (property == "fullText") {
+	return object.fullText();
+} else if (property == "fullTextNoNotes") {
+	return object.fullTextNoNotes();
+}
+GRANTLEE_END_LOOKUP
 #endif

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1160,7 +1160,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		if (newIdx != oldIdx) {
 			DiveListModel::instance()->removeDive(modelIdx);
 			modelIdx += (newIdx - oldIdx);
-			DiveListModel::instance()->insertDive(modelIdx, &myDive);
+			DiveListModel::instance()->insertDive(modelIdx);
 			diveChanged = true; // because we already modified things
 		}
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -793,9 +793,9 @@ void QMLManager::setupDivesite(struct dive *d, struct dive_site *ds, double lat,
 	}
 }
 
-bool QMLManager::checkDate(DiveObjectHelper *myDive, struct dive * d, QString date)
+bool QMLManager::checkDate(const DiveObjectHelper &myDive, struct dive * d, QString date)
 {
-	QString oldDate = myDive->date() + " " + myDive->time();
+	QString oldDate = myDive.date() + " " + myDive.time();
 	if (date != oldDate) {
 		QDateTime newDate;
 		// what a pain - Qt will not parse dates if the day of the week is incorrect
@@ -898,12 +898,12 @@ parsed:
 	return false;
 }
 
-bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString location, QString gps)
+bool QMLManager::checkLocation(const DiveObjectHelper &myDive, struct dive *d, QString location, QString gps)
 {
 	bool diveChanged = false;
 	struct dive_site *ds = get_dive_site_for_dive(d);
-	qDebug() << "checkLocation" << location << "gps" << gps << "dive had" << myDive->location() << "gps" << myDive->gas();
-	if (myDive->location() != location) {
+	qDebug() << "checkLocation" << location << "gps" << gps << "dive had" << myDive.location() << "gps" << myDive.gas();
+	if (myDive.location() != location) {
 		diveChanged = true;
 		ds = get_dive_site_by_name(qPrintable(location), &dive_site_table);
 		if (!ds && !location.isEmpty())
@@ -916,12 +916,12 @@ bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString
 	// now make sure that the GPS coordinates match - if the user changed the name but not
 	// the GPS coordinates, this still does the right thing as the now new dive site will
 	// have no coordinates, so the coordinates from the edit screen will get added
-	if (myDive->gps() != gps) {
+	if (myDive.gps() != gps) {
 		double lat, lon;
 		if (parseGpsText(gps, &lat, &lon)) {
 			qDebug() << "parsed GPS, using it";
 			// there are valid GPS coordinates - just use them
-			setupDivesite(d, ds, lat, lon, qPrintable(myDive->location()));
+			setupDivesite(d, ds, lat, lon, qPrintable(myDive.location()));
 			diveChanged = true;
 		} else if (gps == GPS_CURRENT_POS) {
 			qDebug() << "gps was our default text for no GPS";
@@ -930,7 +930,7 @@ bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString
 			if (gpsString != GPS_CURRENT_POS) {
 				qDebug() << "but now I got a valid location" << gpsString;
 				if (parseGpsText(qPrintable(gpsString), &lat, &lon)) {
-					setupDivesite(d, ds, lat, lon, qPrintable(myDive->location()));
+					setupDivesite(d, ds, lat, lon, qPrintable(myDive.location()));
 					diveChanged = true;
 				}
 			} else {
@@ -944,9 +944,9 @@ bool QMLManager::checkLocation(DiveObjectHelper *myDive, struct dive *d, QString
 	return diveChanged;
 }
 
-bool QMLManager::checkDuration(DiveObjectHelper *myDive, struct dive *d, QString duration)
+bool QMLManager::checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration)
 {
-	if (myDive->duration() != duration) {
+	if (myDive.duration() != duration) {
 		int h = 0, m = 0, s = 0;
 		QRegExp r1(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2[\\s,:]*(\\d*)\\s*%3").arg(tr("h")).arg(tr("min")).arg(tr("sec")), Qt::CaseInsensitive);
 		QRegExp r2(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2").arg(tr("h")).arg(tr("min")), Qt::CaseInsensitive);
@@ -983,9 +983,9 @@ bool QMLManager::checkDuration(DiveObjectHelper *myDive, struct dive *d, QString
 	return false;
 }
 
-bool QMLManager::checkDepth(DiveObjectHelper *myDive, dive *d, QString depth)
+bool QMLManager::checkDepth(const DiveObjectHelper &myDive, dive *d, QString depth)
 {
-	if (myDive->depth() != depth) {
+	if (myDive.depth() != depth) {
 		int depthValue = parseLengthToMm(depth);
 		// the QML code should stop negative depth, but massively huge depth can make
 		// the profile extremely slow or even run out of memory and crash, so keep
@@ -1014,7 +1014,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		return;
 	}
 
-	DiveObjectHelper *myDive = new DiveObjectHelper(d);
+	DiveObjectHelper myDive(d);
 
 	// notes comes back as rich text - let's convert this into plain text
 	QTextDocument doc;
@@ -1032,15 +1032,15 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 
 	diveChanged |= checkDepth(myDive, d, depth);
 
-	if (myDive->airTemp() != airtemp) {
+	if (myDive.airTemp() != airtemp) {
 		diveChanged = true;
 		d->airtemp.mkelvin = parseTemperatureToMkelvin(airtemp);
 	}
-	if (myDive->waterTemp() != watertemp) {
+	if (myDive.waterTemp() != watertemp) {
 		diveChanged = true;
 		d->watertemp.mkelvin = parseTemperatureToMkelvin(watertemp);
 	}
-	if (myDive->sumWeight() != weight) {
+	if (myDive.sumWeight() != weight) {
 		diveChanged = true;
 		// not sure what we'd do if there was more than one weight system
 		// defined - for now just ignore that case
@@ -1052,7 +1052,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// start and end pressures for first cylinder only
-	if (myDive->startPressure() != startpressure || myDive->endPressure() != endpressure) {
+	if (myDive.startPressure() != startpressure || myDive.endPressure() != endpressure) {
 		diveChanged = true;
 		for ( int i = 0, j = 0 ; j < startpressure.length() && j < endpressure.length() ; i++ ) {
 			if (state != "add" && !is_cylinder_used(d, i))
@@ -1067,7 +1067,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// gasmix for first cylinder
-	if (myDive->firstGas() != gasmix) {
+	if (myDive.firstGas() != gasmix) {
 		for ( int i = 0, j = 0 ; j < gasmix.length() ; i++ ) {
 			if (state != "add" && !is_cylinder_used(d, i))
 				continue;
@@ -1086,7 +1086,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// info for first cylinder
-	if (myDive->getCylinder() != usedCylinder) {
+	if (myDive.getCylinder() != usedCylinder) {
 		diveChanged = true;
 		unsigned long i;
 		int size = 0, wp = 0, j = 0, k = 0;
@@ -1112,12 +1112,12 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 			k++;
 		}
 	}
-	if (myDive->suit() != suit) {
+	if (myDive.suit() != suit) {
 		diveChanged = true;
 		free(d->suit);
 		d->suit = copy_qstring(suit);
 	}
-	if (myDive->buddy() != buddy) {
+	if (myDive.buddy() != buddy) {
 		if (buddy.contains(",")){
 			buddy = buddy.replace(QRegExp("\\s*,\\s*"), ", ");
 		}
@@ -1125,7 +1125,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		free(d->buddy);
 		d->buddy = copy_qstring(buddy);
 	}
-	if (myDive->divemaster() != diveMaster) {
+	if (myDive.divemaster() != diveMaster) {
 		if (diveMaster.contains(",")){
 			diveMaster = diveMaster.replace(QRegExp("\\s*,\\s*"), ", ");
 		}
@@ -1133,15 +1133,15 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		free(d->divemaster);
 		d->divemaster = copy_qstring(diveMaster);
 	}
-	if (myDive->rating() != rating) {
+	if (myDive.rating() != rating) {
 		diveChanged = true;
 		d->rating = rating;
 	}
-	if (myDive->visibility() != visibility) {
+	if (myDive.visibility() != visibility) {
 		diveChanged = true;
 		d->visibility = visibility;
 	}
-	if (myDive->notes() != notes) {
+	if (myDive.notes() != notes) {
 		diveChanged = true;
 		free(d->notes);
 		d->notes = copy_qstring(notes);
@@ -1160,7 +1160,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		if (newIdx != oldIdx) {
 			DiveListModel::instance()->removeDive(modelIdx);
 			modelIdx += (newIdx - oldIdx);
-			DiveListModel::instance()->insertDive(modelIdx, myDive);
+			DiveListModel::instance()->insertDive(modelIdx, &myDive);
 			diveChanged = true; // because we already modified things
 		}
 	}

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -227,10 +227,10 @@ private:
 	qreal m_lastDevicePixelRatio;
 	QElapsedTimer timer;
 	bool alreadySaving;
-	bool checkDate(DiveObjectHelper *myDive, struct dive * d, QString date);
-	bool checkLocation(DiveObjectHelper *myDive, struct dive *d, QString location, QString gps);
-	bool checkDuration(DiveObjectHelper *myDive, struct dive *d, QString duration);
-	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
+	bool checkDate(const DiveObjectHelper &myDive, struct dive *d, QString date);
+	bool checkLocation(const DiveObjectHelper &myDive, struct dive *d, QString location, QString gps);
+	bool checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration);
+	bool checkDepth(const DiveObjectHelper &myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
 	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -165,7 +165,7 @@ void DiveListModel::addAllDives()
 
 }
 
-void DiveListModel::insertDive(int i, DiveObjectHelper *)
+void DiveListModel::insertDive(int i)
 {
 	beginInsertRows(QModelIndex(), i, i);
 	endInsertRows();
@@ -192,7 +192,7 @@ void DiveListModel::updateDive(int i, dive *d)
 	// we need to make sure that QML knows that this dive has changed -
 	// the only reliable way I've found is to remove and re-insert it
 	removeDive(i);
-	insertDive(i, nullptr); // TODO: DiveObjectHelper not needed anymore - remove second argument
+	insertDive(i);
 }
 
 void DiveListModel::clear()
@@ -265,7 +265,7 @@ QString DiveListModel::startAddDive()
 	d->number = nr;
 	d->dc.model = strdup("manually added dive");
 	append_dive(d);
-	insertDive(get_idx_by_uniq_id(d->id), new DiveObjectHelper(d));
+	insertDive(get_idx_by_uniq_id(d->id));
 	return QString::number(d->id);
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -33,6 +33,7 @@ void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
 	QSortFilterProxyModel::setSourceModel(sourceModel);
 }
+
 void DiveListSortModel::setFilter(QString f)
 {
 	filterString = f;
@@ -66,8 +67,8 @@ int DiveListSortModel::getIdxForId(int id)
 {
 	for (int i = 0; i < rowCount(); i++) {
 		QVariant v = data(index(i, 0), DiveListModel::DiveRole);
-		DiveObjectHelper *d = v.value<DiveObjectHelper *>();
-		if (d->id() == id)
+		DiveObjectHelper d = v.value<DiveObjectHelper>();
+		if (d.id() == id)
 			return i;
 	}
 	return -1;
@@ -241,12 +242,12 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	if(index.row() < 0 || index.row() >= m_dives.count())
 		return QVariant();
 
-	DiveObjectHelper *curr_dive = m_dives[index.row()];
+	DiveObjectHelper &curr_dive = *m_dives[index.row()];
 	switch(role) {
-	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
-	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
-	case FullTextRole: return curr_dive->fullText();
-	case FullTextNoNotesRole: return curr_dive->fullTextNoNotes();
+	case DiveRole: return QVariant::fromValue<DiveObjectHelper>(curr_dive);
+	case DiveDateRole: return (qlonglong)curr_dive.timestamp();
+	case FullTextRole: return curr_dive.fullText();
+	case FullTextNoNotesRole: return curr_dive.fullTextNoNotes();
 	}
 	return QVariant();
 
@@ -289,7 +290,7 @@ DiveListModel *DiveListModel::instance()
 	return m_instance;
 }
 
-DiveObjectHelper* DiveListModel::at(int i)
+DiveObjectHelper *DiveListModel::at(int i)
 {
 	return m_dives.at(i);
 }

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -23,9 +23,9 @@ void DiveListSortModel::updateFilterState()
 	// get the underlying model and re-calculate the filter value for each dive
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
 	for (int i = 0; i < mySourceModel->rowCount(); i++) {
-		DiveObjectHelper *d = mySourceModel->at(i);
-		QString fullText = includeNotes? d->fullText() : d->fullTextNoNotes();
-		d->getDive()->hidden_by_filter = !fullText.contains(filterString, cs);
+		DiveObjectHelper d = mySourceModel->at(i);
+		QString fullText = includeNotes? d.fullText() : d.fullTextNoNotes();
+		d.getDive()->hidden_by_filter = !fullText.contains(filterString, cs);
 	}
 }
 
@@ -54,8 +54,8 @@ void DiveListSortModel::resetFilter()
 bool DiveListSortModel::filterAcceptsRow(int source_row, const QModelIndex &) const
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	DiveObjectHelper *d = mySourceModel->at(source_row);
-	return d && !d->getDive()->hidden_by_filter;
+	DiveObjectHelper d = mySourceModel->at(source_row);
+	return d && !d.getDive()->hidden_by_filter;
 }
 
 int DiveListSortModel::shown()
@@ -151,9 +151,6 @@ void DiveListModel::addDive(const QList<dive *> &listOfDives)
 	if (listOfDives.isEmpty())
 		return;
 	beginInsertRows(QModelIndex(), rowCount(), rowCount() + listOfDives.count() - 1);
-	for (dive *d: listOfDives) {
-		m_dives.append(new DiveObjectHelper(d));
-	}
 	endInsertRows();
 }
 
@@ -168,25 +165,22 @@ void DiveListModel::addAllDives()
 
 }
 
-void DiveListModel::insertDive(int i, DiveObjectHelper *newDive)
+void DiveListModel::insertDive(int i, DiveObjectHelper *)
 {
 	beginInsertRows(QModelIndex(), i, i);
-	m_dives.insert(i, newDive);
 	endInsertRows();
 }
 
 void DiveListModel::removeDive(int i)
 {
 	beginRemoveRows(QModelIndex(), i, i);
-	delete m_dives.at(i);
-	m_dives.removeAt(i);
 	endRemoveRows();
 }
 
 void DiveListModel::removeDiveById(int id)
 {
-	for (int i = 0; i < rowCount(); i++) {
-		if (m_dives.at(i)->id() == id) {
+	for (int i = 0; i < dive_table.nr; i++) {
+		if (dive_table.dives[i]->id == id) {
 			removeDive(i);
 			return;
 		}
@@ -195,21 +189,16 @@ void DiveListModel::removeDiveById(int id)
 
 void DiveListModel::updateDive(int i, dive *d)
 {
-	DiveObjectHelper *newDive = new DiveObjectHelper(d);
 	// we need to make sure that QML knows that this dive has changed -
 	// the only reliable way I've found is to remove and re-insert it
 	removeDive(i);
-	insertDive(i, newDive);
+	insertDive(i, nullptr); // TODO: DiveObjectHelper not needed anymore - remove second argument
 }
 
 void DiveListModel::clear()
 {
-	if (m_dives.count()) {
-		beginRemoveRows(QModelIndex(), 0, m_dives.count() - 1);
-		qDeleteAll(m_dives);
-		m_dives.clear();
-		endRemoveRows();
-	}
+	beginResetModel();
+	endResetModel();
 }
 
 void DiveListModel::resetInternalData()
@@ -224,25 +213,20 @@ void DiveListModel::resetInternalData()
 
 int DiveListModel::rowCount(const QModelIndex &) const
 {
-	return m_dives.count();
+	return dive_table.nr;
 }
 
 int DiveListModel::getDiveIdx(int id) const
 {
-	int i;
-	for (i = 0; i < m_dives.count(); i++) {
-		if (m_dives.at(i)->id() == id)
-			return i;
-	}
-	return -1;
+	return get_idx_by_uniq_id(id);
 }
 
 QVariant DiveListModel::data(const QModelIndex &index, int role) const
 {
-	if(index.row() < 0 || index.row() >= m_dives.count())
+	if(index.row() < 0 || index.row() >= dive_table.nr)
 		return QVariant();
 
-	DiveObjectHelper &curr_dive = *m_dives[index.row()];
+	DiveObjectHelper curr_dive(dive_table.dives[index.row()]);
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<DiveObjectHelper>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive.timestamp();
@@ -290,7 +274,11 @@ DiveListModel *DiveListModel::instance()
 	return m_instance;
 }
 
-DiveObjectHelper *DiveListModel::at(int i)
+DiveObjectHelper DiveListModel::at(int i)
 {
-	return m_dives.at(i);
+	if (i < 0 || i >= dive_table.nr) {
+		qWarning("DiveListModel::at(): accessing invalid dive with id %d", i);
+		return DiveObjectHelper(); // Returns an invalid DiveObjectHelper that will crash on access.
+	}
+	return DiveObjectHelper(dive_table.dives[i]);
 }

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -57,9 +57,8 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	QString startAddDive();
 	void resetInternalData();
-	Q_INVOKABLE DiveObjectHelper* at(int i);
+	Q_INVOKABLE DiveObjectHelper at(int i);
 private:
-	QList<DiveObjectHelper*> m_dives;
 	static DiveListModel *m_instance;
 };
 

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -46,7 +46,7 @@ public:
 	DiveListModel(QObject *parent = 0);
 	void addDive(const QList<dive *> &listOfDives);
 	void addAllDives();
-	void insertDive(int i, DiveObjectHelper *newDive);
+	void insertDive(int i);
 	void removeDive(int i);
 	void removeDiveById(int id);
 	void updateDive(int i, dive *d);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This does two things:
1) Turns DiveObjectHelper into a Q_GADGET object and pass it around as value, not as a reference.
2) Remove the list of DiveObjectHelpers in DiveListModel and generate the DiveObjectHelpers on-demand.

This should make the possibility of DiveObjectHelper corruption impossible (unless I missed places where DiveObjectHelper is passed around as pointers).

But even though I believe that this is a step in the right direction, please note that:
1) This does not solve the fundamental problem: DiveObjectHelper is a thin wrapper around "dive *". This means that it represents a reference to a dive that may be freed and we have no control over DiveObjectHelpers existing in QML.
2) Code that transformed QVariants into `DiveObjectHelper *` will now get default-initialized DiveObjectHelper objects and crash. If these fragments still exist (I didn't find any) they have to be converted to cast to `DiveObjectHelper`.
3) We now have to be very careful that core and DiveListModel do not get out of sync. Otherwise this will lead to invalid DiveObjectHelpers. But at least these crash immediately and shouldn't give strange memory corruption bugs.


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: If you find time during your travels, it would be very helpful if you could find crashes or weird behavior in this PR during usual work (download, new, edit, delete dives, etc). This is not yet a solution, but it would be good to see if it is a realistic route. For some reason bluez doesn't run on my new laptop and starting the mobile app takes a minute or two, making testing a pain.