### PR TITLE
Mobile: decouple full text search from DiveObjectHelper

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -409,3 +409,21 @@ QString DiveObjectHelper::fullTextNoNotes() const
 	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : QString();
 	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
 }
+
+static bool contains(const char *s, const QString &filterstring, Qt::CaseSensitivity cs)
+{
+	return !empty_string(s) && QString(s).contains(filterstring, cs);
+}
+
+bool DiveObjectHelper::containsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes)
+{
+	if (!d)
+		return false;
+	return contains(get_dive_location(d), filterstring, cs) ||
+	       (d->divetrip && contains(d->divetrip->location, filterstring, cs)) ||
+	       contains(d->buddy, filterstring, cs) ||
+	       contains(d->divemaster, filterstring, cs) ||
+	       contains(d->suit, filterstring, cs) ||
+	       get_taglist_string(d->tag_list).contains(filterstring, cs) ||
+	       (includeNotes && contains(d->notes, filterstring, cs));
+}

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -398,18 +398,6 @@ QStringList DiveObjectHelper::firstGas() const
 	return gas;
 }
 
-// for a full text search / filter function
-QString DiveObjectHelper::fullText() const
-{
-	return fullTextNoNotes() + ":-:" + notes();
-}
-
-QString DiveObjectHelper::fullTextNoNotes() const
-{
-	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : QString();
-	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
-}
-
 static bool contains(const char *s, const QString &filterstring, Qt::CaseSensitivity cs)
 {
 	return !empty_string(s) && QString(s).contains(filterstring, cs);

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -96,6 +96,7 @@ public:
 	QStringList firstGas() const;
 	QString fullText() const;
 	QString fullTextNoNotes() const;
+	static bool containsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes);
 
 private:
 	struct dive *m_dive;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -48,8 +48,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QString fullText READ fullText CONSTANT)
-	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive);
 	~DiveObjectHelper();
@@ -94,8 +92,6 @@ public:
 	QStringList startPressure() const;
 	QStringList endPressure() const;
 	QStringList firstGas() const;
-	QString fullText() const;
-	QString fullTextNoNotes() const;
 	static bool containsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes);
 
 private:

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -243,8 +243,6 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
-	case FullTextRole: return curr_dive->fullText();
-	case FullTextNoNotesRole: return curr_dive->fullTextNoNotes();
 	}
 	return QVariant();
 
@@ -255,8 +253,6 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
-	roles[FullTextRole] = "fulltext";
-	roles[FullTextNoNotesRole] = "fulltextnonotes";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -20,19 +20,17 @@ void DiveListSortModel::updateFilterState()
 	bool includeNotes = qPrefGeneral::filterFullTextNotes();
 	Qt::CaseSensitivity cs = qPrefGeneral::filterCaseSensitive() ? Qt::CaseSensitive : Qt::CaseInsensitive;
 
-	// get the underlying model and re-calculate the filter value for each dive
-	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	for (int i = 0; i < mySourceModel->rowCount(); i++) {
-		DiveObjectHelper *d = mySourceModel->at(i);
-		QString fullText = includeNotes? d->fullText() : d->fullTextNoNotes();
-		d->getDive()->hidden_by_filter = !fullText.contains(filterString, cs);
-	}
+	int i;
+	struct dive *d;
+	for_each_dive(i, d)
+		d->hidden_by_filter = !DiveObjectHelper::containsText(d, filterString, cs, includeNotes);
 }
 
 void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
 	QSortFilterProxyModel::setSourceModel(sourceModel);
 }
+
 void DiveListSortModel::setFilter(QString f)
 {
 	filterString = f;

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -38,8 +38,6 @@ public:
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
-		FullTextRole,
-		FullTextNoNotesRole
 	};
 
 	static DiveListModel *instance();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This avoids generating DiveObjectHelpers for the purpose of full text search. The reason is actually twofold:
1) If we turn DiveObjectHelper into a value-based object we don't want to generate tons of them in a tight loop. Conceptually, they represent the full data of a dive, as displayed on the dive-details tab or on print-templates. Not temporary throw-away objects.
2) In the longer run we want to move full text search to the core, where we can build a classical word-index and thus also make it available for the desktop app.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: please check.