### PR TITLE
[TEST] DiveObjectHelper: the nuclear option [contains #2242 and #2243]

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1403,6 +1403,23 @@ QString getUUID()
 	return uuidString;
 }
 
+static bool contains(const char *s, const QString &filterstring, Qt::CaseSensitivity cs)
+{
+	return !empty_string(s) && QString(s).contains(filterstring, cs);
+}
+
+bool diveContainsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes)
+{
+	if (!d)
+		return false;
+	return contains(get_dive_location(d), filterstring, cs) ||
+	       (d->divetrip && contains(d->divetrip->location, filterstring, cs)) ||
+	       contains(d->buddy, filterstring, cs) ||
+	       contains(d->divemaster, filterstring, cs) ||
+	       contains(d->suit, filterstring, cs) ||
+	       get_taglist_string(d->tag_list).contains(filterstring, cs) ||
+	       (includeNotes && contains(d->notes, filterstring, cs));
+}
 int parse_seabear_header(const char *filename, char **params, int pnr)
 {
 	QFile f(filename);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -79,6 +79,7 @@ QLocale getLocale();
 QVector<QPair<QString, int>> selectedDivesGasUsed();
 QString getUserAgent();
 QString printGPSCoords(const location_t *loc);
+bool diveContainsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes);
 
 #if defined __APPLE__
 #define TITLE_OR_TEXT(_t, _m) "", _t + "\n" + _m

--- a/core/subsurface-qt/CylinderObjectHelper.cpp
+++ b/core/subsurface-qt/CylinderObjectHelper.cpp
@@ -3,7 +3,7 @@
 #include "../qthelper.h"
 
 static QString EMPTY_CYLINDER_STRING = QStringLiteral("");
-CylinderObjectHelper::CylinderObjectHelper(cylinder_t *cylinder)
+CylinderObjectHelper::CylinderObjectHelper(const cylinder_t *cylinder)
 {
 	if (!cylinder)
 		return;

--- a/core/subsurface-qt/CylinderObjectHelper.h
+++ b/core/subsurface-qt/CylinderObjectHelper.h
@@ -15,7 +15,7 @@ class CylinderObjectHelper {
 	Q_PROPERTY(QString endPressure MEMBER endPressure CONSTANT)
 	Q_PROPERTY(QString gasMix MEMBER gasMix CONSTANT)
 public:
-	CylinderObjectHelper(cylinder_t *cylinder = NULL);
+	CylinderObjectHelper(const cylinder_t *cylinder = NULL);
 	QString description;
 	QString size;
 	QString workingPressure;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -67,16 +67,6 @@ DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 {
 }
 
-DiveObjectHelper::operator bool() const
-{
-	return !!m_dive;
-}
-
-bool DiveObjectHelper::operator!() const
-{
-	return !m_dive;
-}
-
 int DiveObjectHelper::number() const
 {
 	return m_dive->number;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -55,6 +55,13 @@ static QString getPressures(struct dive *dive, int i, enum returnPressureSelecto
 	return fmt;
 }
 
+// Qt's metatype system insists on generating a default constructed object,
+// even if that makes no sense. Usage of this object *will* crash.
+DiveObjectHelper::DiveObjectHelper() :
+	m_dive(nullptr)
+{
+}
+
 DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 	m_dive(d)
 {

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -290,13 +290,6 @@ QStringList DiveObjectHelper::cylinders() const
 	return cylinders;
 }
 
-QString DiveObjectHelper::cylinder(int idx) const
-{
-	if ( (idx < 0) || idx > MAX_CYLINDERS)
-		return QString();
-	return getFormattedCylinder(m_dive, idx);
-}
-
 QVector<CylinderObjectHelper> DiveObjectHelper::cylinderObjects() const
 {
 	QVector<CylinderObjectHelper> res;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -313,11 +313,6 @@ QVector<CylinderObjectHelper> DiveObjectHelper::cylinderObjects() const
 	return res;
 }
 
-QString DiveObjectHelper::tripId() const
-{
-	return m_dive->divetrip ? QString::number((quint64)m_dive->divetrip, 16) : QString();
-}
-
 int DiveObjectHelper::tripNrDives() const
 {
 	struct dive_trip *dt = m_dive->divetrip;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -87,11 +87,6 @@ int DiveObjectHelper::id() const
 	return m_dive->id;
 }
 
-struct dive *DiveObjectHelper::getDive() const
-{
-	return m_dive;
-}
-
 QString DiveObjectHelper::date() const
 {
 	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000*m_dive->when, Qt::UTC);

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -236,7 +236,6 @@ DiveObjectHelper::DiveObjectHelper(const struct dive *d) :
 	singleWeight(d->weightsystems.nr <= 1),
 	suit(d->suit ? d->suit : QString()),
 	cylinders(formatCylinders(d)),
-	cylinderObjects(makeCylinderObjects(d)),
 	maxcns(d->maxcns),
 	otu(d->otu),
 	sumWeight(get_weight_string(weight_t { total_weight(d) }, true)),
@@ -244,6 +243,16 @@ DiveObjectHelper::DiveObjectHelper(const struct dive *d) :
 	startPressure(getStartPressure(d)),
 	endPressure(getEndPressure(d)),
 	firstGas(getFirstGas(d))
+{
+}
+
+DiveObjectHelperGrantlee::DiveObjectHelperGrantlee()
+{
+}
+
+DiveObjectHelperGrantlee::DiveObjectHelperGrantlee(const struct dive *d) :
+	DiveObjectHelper(d),
+	cylinderObjects(makeCylinderObjects(d))
 {
 }
 

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -313,12 +313,6 @@ QVector<CylinderObjectHelper> DiveObjectHelper::cylinderObjects() const
 	return res;
 }
 
-int DiveObjectHelper::tripNrDives() const
-{
-	struct dive_trip *dt = m_dive->divetrip;
-	return dt ? dt->dives.nr : 0;
-}
-
 int DiveObjectHelper::maxcns() const
 {
 	return m_dive->maxcns;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -247,13 +247,6 @@ bool DiveObjectHelper::singleWeight() const
 	return m_dive->weightsystems.nr <= 1;
 }
 
-QString DiveObjectHelper::weight(int idx) const
-{
-	if ((idx < 0) || idx >= m_dive->weightsystems.nr)
-		return QString();
-	return getFormattedWeight(m_dive, idx);
-}
-
 QString DiveObjectHelper::suit() const
 {
 	return m_dive->suit ? m_dive->suit : QString();

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -67,6 +67,16 @@ DiveObjectHelper::DiveObjectHelper(struct dive *d) :
 {
 }
 
+DiveObjectHelper::operator bool() const
+{
+	return !!m_dive;
+}
+
+bool DiveObjectHelper::operator!() const
+{
+	return !m_dive;
+}
+
 int DiveObjectHelper::number() const
 {
 	return m_dive->number;

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -389,15 +389,3 @@ QStringList DiveObjectHelper::firstGas() const
 	}
 	return gas;
 }
-
-// for a full text search / filter function
-QString DiveObjectHelper::fullText() const
-{
-	return fullTextNoNotes() + ":-:" + notes();
-}
-
-QString DiveObjectHelper::fullTextNoNotes() const
-{
-	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : QString();
-	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
-}

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -54,7 +54,6 @@ public:
 	bool operator!() const; // Returns true if this is an invalid default-generated object
 	int number() const;
 	int id() const;
-	struct dive *getDive() const;
 	int rating() const;
 	int visibility() const;
 	QString date() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -74,7 +74,6 @@ public:
 	QString sac() const;
 	QString weightList() const;
 	QStringList weights() const;
-	QString weight(int idx) const;
 	bool singleWeight() const;
 	QString suit() const;
 	QStringList cylinderList() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -40,7 +40,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
 	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(QString tripId READ tripId CONSTANT)
 	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
 	Q_PROPERTY(int otu READ otu CONSTANT)
@@ -83,7 +82,6 @@ public:
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
 	QVector<CylinderObjectHelper> cylinderObjects() const;
-	QString tripId() const;
 	int tripNrDives() const;
 	int maxcns() const;
 	int otu() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -40,7 +40,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
 	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
 	Q_PROPERTY(int otu READ otu CONSTANT)
 	Q_PROPERTY(QString sumWeight READ sumWeight CONSTANT)
@@ -82,7 +81,6 @@ public:
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
 	QVector<CylinderObjectHelper> cylinderObjects() const;
-	int tripNrDives() const;
 	int maxcns() const;
 	int otu() const;
 	QString sumWeight() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -50,6 +50,8 @@ class DiveObjectHelper {
 public:
 	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
 	DiveObjectHelper(struct dive *dive);
+	operator bool() const; // Returns false if this is an invalid default-generated object
+	bool operator!() const; // Returns true if this is an invalid default-generated object
 	int number() const;
 	int id() const;
 	struct dive *getDive() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -78,7 +78,6 @@ public:
 	QString suit() const;
 	QStringList cylinderList() const;
 	QStringList cylinders() const;
-	QString cylinder(int idx) const;
 	QVector<CylinderObjectHelper> cylinderObjects() const;
 	int maxcns() const;
 	int otu() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -50,8 +50,6 @@ class DiveObjectHelper {
 public:
 	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
 	DiveObjectHelper(struct dive *dive);
-	operator bool() const; // Returns false if this is an invalid default-generated object
-	bool operator!() const; // Returns true if this is an invalid default-generated object
 	int number() const;
 	int id() const;
 	int rating() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -39,7 +39,6 @@ class DiveObjectHelper {
 	Q_PROPERTY(QString suit MEMBER suit CONSTANT)
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders MEMBER cylinders CONSTANT)
-	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects MEMBER cylinderObjects CONSTANT)
 	Q_PROPERTY(int maxcns MEMBER maxcns CONSTANT)
 	Q_PROPERTY(int otu MEMBER otu CONSTANT)
 	Q_PROPERTY(QString sumWeight MEMBER sumWeight CONSTANT)
@@ -78,7 +77,6 @@ public:
 	QString suit;
 	QStringList cylinderList() const;
 	QStringList cylinders;
-	QVector<CylinderObjectHelper> cylinderObjects;
 	int maxcns;
 	int otu;
 	QString sumWeight;
@@ -87,6 +85,21 @@ public:
 	QStringList endPressure;
 	QStringList firstGas;
 };
-	Q_DECLARE_METATYPE(DiveObjectHelper)
+
+// This is an extended version of DiveObjectHelper that also keeps track of cylinder data.
+// It is used by grantlee to display structured cylinder data.
+// Note: this grantlee feature is undocumented. If there turns out to be no users, we might
+// want to remove this class.
+class DiveObjectHelperGrantlee : public DiveObjectHelper {
+	Q_GADGET
+	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects MEMBER cylinderObjects CONSTANT)
+public:
+	DiveObjectHelperGrantlee();
+	DiveObjectHelperGrantlee(const struct dive *dive);
+	QVector<CylinderObjectHelper> cylinderObjects;
+};
+
+Q_DECLARE_METATYPE(DiveObjectHelper)
+Q_DECLARE_METATYPE(DiveObjectHelperGrantlee)
 
 #endif

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -9,8 +9,8 @@
 #include <QVector>
 #include <QVariant>
 
-class DiveObjectHelper : public QObject {
-	Q_OBJECT
+class DiveObjectHelper {
+	Q_GADGET
 	Q_PROPERTY(int number READ number CONSTANT)
 	Q_PROPERTY(int id READ id CONSTANT)
 	Q_PROPERTY(int rating READ rating CONSTANT)
@@ -48,6 +48,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
 public:
+	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
 	DiveObjectHelper(struct dive *dive);
 	int number() const;
 	int id() const;
@@ -92,6 +93,6 @@ public:
 private:
 	struct dive *m_dive;
 };
-	Q_DECLARE_METATYPE(DiveObjectHelper *)
+	Q_DECLARE_METATYPE(DiveObjectHelper)
 
 #endif

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -11,84 +11,81 @@
 
 class DiveObjectHelper {
 	Q_GADGET
-	Q_PROPERTY(int number READ number CONSTANT)
-	Q_PROPERTY(int id READ id CONSTANT)
-	Q_PROPERTY(int rating READ rating CONSTANT)
-	Q_PROPERTY(int visibility READ visibility CONSTANT)
+	Q_PROPERTY(int number MEMBER number CONSTANT)
+	Q_PROPERTY(int id MEMBER id CONSTANT)
+	Q_PROPERTY(int rating MEMBER rating CONSTANT)
+	Q_PROPERTY(int visibility MEMBER visibility CONSTANT)
 	Q_PROPERTY(QString date READ date CONSTANT)
 	Q_PROPERTY(QString time READ time CONSTANT)
-	Q_PROPERTY(int timestamp READ timestamp CONSTANT)
-	Q_PROPERTY(QString location READ location CONSTANT)
-	Q_PROPERTY(QString gps READ gps CONSTANT)
-	Q_PROPERTY(QString gps_decimal READ gps_decimal CONSTANT)
-	Q_PROPERTY(QVariant dive_site READ dive_site CONSTANT)
-	Q_PROPERTY(QString duration READ duration CONSTANT)
-	Q_PROPERTY(bool noDive READ noDive CONSTANT)
-	Q_PROPERTY(QString depth READ depth CONSTANT)
-	Q_PROPERTY(QString divemaster READ divemaster CONSTANT)
-	Q_PROPERTY(QString buddy READ buddy CONSTANT)
-	Q_PROPERTY(QString airTemp READ airTemp CONSTANT)
-	Q_PROPERTY(QString waterTemp READ waterTemp CONSTANT)
-	Q_PROPERTY(QString notes READ notes CONSTANT)
-	Q_PROPERTY(QString tags READ tags CONSTANT)
-	Q_PROPERTY(QString gas READ gas CONSTANT)
-	Q_PROPERTY(QString sac READ sac CONSTANT)
-	Q_PROPERTY(QString weightList READ weightList CONSTANT)
-	Q_PROPERTY(QStringList weights READ weights CONSTANT)
-	Q_PROPERTY(bool singleWeight READ singleWeight CONSTANT)
-	Q_PROPERTY(QString suit READ suit CONSTANT)
+	Q_PROPERTY(int timestamp MEMBER timestamp CONSTANT)
+	Q_PROPERTY(QString location MEMBER location CONSTANT)
+	Q_PROPERTY(QString gps MEMBER gps CONSTANT)
+	Q_PROPERTY(QString gps_decimal MEMBER gps_decimal CONSTANT)
+	Q_PROPERTY(QVariant dive_site MEMBER dive_site CONSTANT)
+	Q_PROPERTY(QString duration MEMBER duration CONSTANT)
+	Q_PROPERTY(bool noDive MEMBER noDive CONSTANT)
+	Q_PROPERTY(QString depth MEMBER depth CONSTANT)
+	Q_PROPERTY(QString divemaster MEMBER divemaster CONSTANT)
+	Q_PROPERTY(QString buddy MEMBER buddy CONSTANT)
+	Q_PROPERTY(QString airTemp MEMBER airTemp CONSTANT)
+	Q_PROPERTY(QString waterTemp MEMBER waterTemp CONSTANT)
+	Q_PROPERTY(QString notes MEMBER notes CONSTANT)
+	Q_PROPERTY(QString tags MEMBER tags CONSTANT)
+	Q_PROPERTY(QString gas MEMBER gas CONSTANT)
+	Q_PROPERTY(QString sac MEMBER sac CONSTANT)
+	Q_PROPERTY(QString weightList MEMBER weightList CONSTANT)
+	Q_PROPERTY(QStringList weights MEMBER weights CONSTANT)
+	Q_PROPERTY(bool singleWeight MEMBER singleWeight CONSTANT)
+	Q_PROPERTY(QString suit MEMBER suit CONSTANT)
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
-	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
-	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
-	Q_PROPERTY(int otu READ otu CONSTANT)
-	Q_PROPERTY(QString sumWeight READ sumWeight CONSTANT)
-	Q_PROPERTY(QStringList getCylinder READ getCylinder CONSTANT)
-	Q_PROPERTY(QStringList startPressure READ startPressure CONSTANT)
-	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
-	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
+	Q_PROPERTY(QStringList cylinders MEMBER cylinders CONSTANT)
+	Q_PROPERTY(QVector<CylinderObjectHelper> cylinderObjects MEMBER cylinderObjects CONSTANT)
+	Q_PROPERTY(int maxcns MEMBER maxcns CONSTANT)
+	Q_PROPERTY(int otu MEMBER otu CONSTANT)
+	Q_PROPERTY(QString sumWeight MEMBER sumWeight CONSTANT)
+	Q_PROPERTY(QStringList getCylinder MEMBER getCylinder CONSTANT)
+	Q_PROPERTY(QStringList startPressure MEMBER startPressure CONSTANT)
+	Q_PROPERTY(QStringList endPressure MEMBER endPressure CONSTANT)
+	Q_PROPERTY(QStringList firstGas MEMBER firstGas CONSTANT)
 public:
 	DiveObjectHelper(); // This is only to be used by Qt's metatype system!
-	DiveObjectHelper(struct dive *dive);
-	int number() const;
-	int id() const;
-	int rating() const;
-	int visibility() const;
+	DiveObjectHelper(const struct dive *dive);
+	int number;
+	int id;
+	int rating;
+	int visibility;
 	QString date() const;
-	timestamp_t timestamp() const;
+	timestamp_t timestamp;
 	QString time() const;
-	QString location() const;
-	QString gps() const;
-	QString gps_decimal() const;
-	QVariant dive_site() const;
-	QString duration() const;
-	bool noDive() const;
-	QString depth() const;
-	QString divemaster() const;
-	QString buddy() const;
-	QString airTemp() const;
-	QString waterTemp() const;
-	QString notes() const;
-	QString tags() const;
-	QString gas() const;
-	QString sac() const;
-	QString weightList() const;
-	QStringList weights() const;
-	bool singleWeight() const;
-	QString suit() const;
+	QString location;
+	QString gps;
+	QString gps_decimal;
+	QVariant dive_site;
+	QString duration;
+	bool noDive;
+	QString depth;
+	QString divemaster;
+	QString buddy;
+	QString airTemp;
+	QString waterTemp;
+	QString notes;
+	QString tags;
+	QString gas;
+	QString sac;
+	QString weightList;
+	QStringList weights;
+	bool singleWeight;
+	QString suit;
 	QStringList cylinderList() const;
-	QStringList cylinders() const;
-	QVector<CylinderObjectHelper> cylinderObjects() const;
-	int maxcns() const;
-	int otu() const;
-	QString sumWeight() const;
-	QStringList getCylinder() const;
-	QStringList startPressure() const;
-	QStringList endPressure() const;
-	QStringList firstGas() const;
-
-private:
-	struct dive *m_dive;
+	QStringList cylinders;
+	QVector<CylinderObjectHelper> cylinderObjects;
+	int maxcns;
+	int otu;
+	QString sumWeight;
+	QStringList getCylinder;
+	QStringList startPressure;
+	QStringList endPressure;
+	QStringList firstGas;
 };
 	Q_DECLARE_METATYPE(DiveObjectHelper)
 

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -49,8 +49,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList startPressure READ startPressure CONSTANT)
 	Q_PROPERTY(QStringList endPressure READ endPressure CONSTANT)
 	Q_PROPERTY(QStringList firstGas READ firstGas CONSTANT)
-	Q_PROPERTY(QString fullText READ fullText CONSTANT)
-	Q_PROPERTY(QString fullTextNoNotes READ fullTextNoNotes CONSTANT)
 public:
 	DiveObjectHelper(struct dive *dive);
 	int number() const;
@@ -94,8 +92,6 @@ public:
 	QStringList startPressure() const;
 	QStringList endPressure() const;
 	QStringList firstGas() const;
-	QString fullText() const;
-	QString fullTextNoNotes() const;
 
 private:
 	struct dive *m_dive;

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -134,19 +134,13 @@ QString TemplateLayout::generate()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
-	// Note: Currently, this should not be transformed into a QVector<> or std::vector<>,
-	// as diveList contains pointers to elements in this list. But vectors might relocate
-	// and thus invalidate the pointers! std::list<> is used here, because the new elements
-	// can be directly constructed in the list with the emplace_back() call.
-	// Ultimately, the memory management should be fixed.
-	std::list<DiveObjectHelper> diveObjectList;
 	QVariantList diveList;
 
 	struct dive *dive;
 	if (in_planner()) {
-		diveObjectList.emplace_back(&displayed_dive);
-		diveList.append(QVariant::fromValue(&diveObjectList.back()));
+		diveList.append(QVariant::fromValue(DiveObjectHelper(&displayed_dive)));
 		emit progressUpdated(100.0);
 	} else {
 		int i;
@@ -154,8 +148,7 @@ QString TemplateLayout::generate()
 			//TODO check for exporting selected dives only
 			if (!dive->selected && printOptions->print_selected)
 				continue;
-			diveObjectList.emplace_back(dive);
-			diveList.append(QVariant::fromValue(&diveObjectList.back()));
+			diveList.append(QVariant::fromValue(DiveObjectHelper(dive)));
 			progress++;
 			emit progressUpdated(lrint(progress * 100.0 / totalWork));
 		}
@@ -198,6 +191,7 @@ QString TemplateLayout::generateStatistics()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	QVariantList years;
 

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -100,7 +100,7 @@ TemplateLayout::TemplateLayout(print_options *printOptions, template_options *te
 }
 
 /* a HTML pre-processor stage. acts like a compatibility layer
- * between some Grantlee variables and DiveObjectHelper Q_PROPERTIES:
+ * between some Grantlee variables and DiveObjectHelperGrantlee Q_PROPERTIES:
  *	dive.weights -> dive.weightList
  * 	dive.weight# -> dive.weights.#
  *	dive.cylinders -> dive.cylinderList
@@ -134,13 +134,13 @@ QString TemplateLayout::generate()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
-	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelperGrantlee>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	QVariantList diveList;
 
 	struct dive *dive;
 	if (in_planner()) {
-		diveList.append(QVariant::fromValue(DiveObjectHelper(&displayed_dive)));
+		diveList.append(QVariant::fromValue(DiveObjectHelperGrantlee(&displayed_dive)));
 		emit progressUpdated(100.0);
 	} else {
 		int i;
@@ -148,7 +148,7 @@ QString TemplateLayout::generate()
 			//TODO check for exporting selected dives only
 			if (!dive->selected && printOptions->print_selected)
 				continue;
-			diveList.append(QVariant::fromValue(DiveObjectHelper(dive)));
+			diveList.append(QVariant::fromValue(DiveObjectHelperGrantlee(dive)));
 			progress++;
 			emit progressUpdated(lrint(progress * 100.0 / totalWork));
 		}
@@ -191,7 +191,7 @@ QString TemplateLayout::generateStatistics()
 	Grantlee::registerMetaType<template_options>();
 	Grantlee::registerMetaType<print_options>();
 	Grantlee::registerMetaType<CylinderObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
-	Grantlee::registerMetaType<DiveObjectHelper>(); // TODO: Remove when grantlee supports Q_GADGET
+	Grantlee::registerMetaType<DiveObjectHelperGrantlee>(); // TODO: Remove when grantlee supports Q_GADGET
 
 	QVariantList years;
 

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -139,4 +139,83 @@ if (property == "description") {
 	return object.gasMix;
 }
 GRANTLEE_END_LOOKUP
+
+// TODO: This is currently needed because our grantlee version
+// doesn't support Q_GADGET based classes. A patch to fix this
+// exists. Remove in due course.
+GRANTLEE_BEGIN_LOOKUP(DiveObjectHelper)
+if (property == "number") {
+	return object.number();
+} else if (property == "id") {
+	return object.id();
+} else if (property == "rating") {
+	return object.rating();
+} else if (property == "visibility") {
+	return object.visibility();
+} else if (property == "date") {
+	return object.date();
+} else if (property == "time") {
+	return object.time();
+} else if (property == "timestamp") {
+	return QVariant::fromValue(object.timestamp());
+} else if (property == "location") {
+	return object.location();
+} else if (property == "gps") {
+	return object.gps();
+} else if (property == "gps_decimal") {
+	return object.gps_decimal();
+} else if (property == "dive_site") {
+	return object.dive_site();
+} else if (property == "duration") {
+	return object.duration();
+} else if (property == "noDive") {
+	return object.noDive();
+} else if (property == "depth") {
+	return object.depth();
+} else if (property == "divemaster") {
+	return object.divemaster();
+} else if (property == "buddy") {
+	return object.buddy();
+} else if (property == "airTemp") {
+	return object.airTemp();
+} else if (property == "waterTemp") {
+	return object.waterTemp();
+} else if (property == "notes") {
+	return object.notes();
+} else if (property == "tags") {
+	return object.tags();
+} else if (property == "gas") {
+	return object.gas();
+} else if (property == "sac") {
+	return object.sac();
+} else if (property == "weightList") {
+	return object.weightList();
+} else if (property == "weights") {
+	return object.weights();
+} else if (property == "singleWeight") {
+	return object.singleWeight();
+} else if (property == "suit") {
+	return object.suit();
+} else if (property == "cylinderList") {
+	return object.cylinderList();
+} else if (property == "cylinders") {
+	return object.cylinders();
+} else if (property == "cylinderObjects") {
+	return QVariant::fromValue(object.cylinderObjects());
+} else if (property == "maxcns") {
+	return object.maxcns();
+} else if (property == "otu") {
+	return object.otu();
+} else if (property == "sumWeight") {
+	return object.sumWeight();
+} else if (property == "getCylinder") {
+	return object.getCylinder();
+} else if (property == "startPressure") {
+	return object.startPressure();
+} else if (property == "endPressure") {
+	return object.endPressure();
+} else if (property == "firstGas") {
+	return object.firstGas();
+}
+GRANTLEE_END_LOOKUP
 #endif

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -143,7 +143,7 @@ GRANTLEE_END_LOOKUP
 // TODO: This is currently needed because our grantlee version
 // doesn't support Q_GADGET based classes. A patch to fix this
 // exists. Remove in due course.
-GRANTLEE_BEGIN_LOOKUP(DiveObjectHelper)
+GRANTLEE_BEGIN_LOOKUP(DiveObjectHelperGrantlee)
 if (property == "number") {
 	return object.number;
 } else if (property == "id") {

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -145,77 +145,77 @@ GRANTLEE_END_LOOKUP
 // exists. Remove in due course.
 GRANTLEE_BEGIN_LOOKUP(DiveObjectHelper)
 if (property == "number") {
-	return object.number();
+	return object.number;
 } else if (property == "id") {
-	return object.id();
+	return object.id;
 } else if (property == "rating") {
-	return object.rating();
+	return object.rating;
 } else if (property == "visibility") {
-	return object.visibility();
+	return object.visibility;
 } else if (property == "date") {
 	return object.date();
 } else if (property == "time") {
 	return object.time();
 } else if (property == "timestamp") {
-	return QVariant::fromValue(object.timestamp());
+	return QVariant::fromValue(object.timestamp);
 } else if (property == "location") {
-	return object.location();
+	return object.location;
 } else if (property == "gps") {
-	return object.gps();
+	return object.gps;
 } else if (property == "gps_decimal") {
-	return object.gps_decimal();
+	return object.gps_decimal;
 } else if (property == "dive_site") {
-	return object.dive_site();
+	return object.dive_site;
 } else if (property == "duration") {
-	return object.duration();
+	return object.duration;
 } else if (property == "noDive") {
-	return object.noDive();
+	return object.noDive;
 } else if (property == "depth") {
-	return object.depth();
+	return object.depth;
 } else if (property == "divemaster") {
-	return object.divemaster();
+	return object.divemaster;
 } else if (property == "buddy") {
-	return object.buddy();
+	return object.buddy;
 } else if (property == "airTemp") {
-	return object.airTemp();
+	return object.airTemp;
 } else if (property == "waterTemp") {
-	return object.waterTemp();
+	return object.waterTemp;
 } else if (property == "notes") {
-	return object.notes();
+	return object.notes;
 } else if (property == "tags") {
-	return object.tags();
+	return object.tags;
 } else if (property == "gas") {
-	return object.gas();
+	return object.gas;
 } else if (property == "sac") {
-	return object.sac();
+	return object.sac;
 } else if (property == "weightList") {
-	return object.weightList();
+	return object.weightList;
 } else if (property == "weights") {
-	return object.weights();
+	return object.weights;
 } else if (property == "singleWeight") {
-	return object.singleWeight();
+	return object.singleWeight;
 } else if (property == "suit") {
-	return object.suit();
+	return object.suit;
 } else if (property == "cylinderList") {
 	return object.cylinderList();
 } else if (property == "cylinders") {
-	return object.cylinders();
+	return object.cylinders;
 } else if (property == "cylinderObjects") {
-	return QVariant::fromValue(object.cylinderObjects());
+	return QVariant::fromValue(object.cylinderObjects);
 } else if (property == "maxcns") {
-	return object.maxcns();
+	return object.maxcns;
 } else if (property == "otu") {
-	return object.otu();
+	return object.otu;
 } else if (property == "sumWeight") {
-	return object.sumWeight();
+	return object.sumWeight;
 } else if (property == "getCylinder") {
-	return object.getCylinder();
+	return object.getCylinder;
 } else if (property == "startPressure") {
-	return object.startPressure();
+	return object.startPressure;
 } else if (property == "endPressure") {
-	return object.endPressure();
+	return object.endPressure;
 } else if (property == "firstGas") {
-	return object.firstGas();
+	return object.firstGas;
 }
 GRANTLEE_END_LOOKUP
 #endif

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -240,49 +240,50 @@ Kirigami.Page {
 
 		// set things up for editing - so make sure that the detailsEdit has
 		// all the right data (using the property aliases set up above)
-		dive_id = currentItem.modelData.dive.id
-		number = currentItem.modelData.dive.number
-		date = currentItem.modelData.dive.date + " " + currentItem.modelData.dive.time
-		location = currentItem.modelData.dive.location
-		locationIndex = manager.locationList.indexOf(currentItem.modelData.dive.location)
-		gps = currentItem.modelData.dive.gps
+		var dive = currentItem.modelData.dive
+		dive_id = dive.id
+		number = dive.number
+		date = dive.date + " " + dive.time
+		location = dive.location
+		locationIndex = manager.locationList.indexOf(dive.location)
+		gps = dive.gps
 		gpsCheckbox = false
-		duration = currentItem.modelData.dive.duration
-		depth = currentItem.modelData.dive.depth
-		airtemp = currentItem.modelData.dive.airTemp
-		watertemp = currentItem.modelData.dive.waterTemp
-		suitIndex = manager.suitList.indexOf(currentItem.modelData.dive.suit)
-		if (currentItem.modelData.dive.buddy.indexOf(",") > 0) {
-			buddyIndex = manager.buddyList.indexOf(currentItem.modelData.dive.buddy.split(",", 1).toString())
+		duration = dive.duration
+		depth = dive.depth
+		airtemp = dive.airTemp
+		watertemp = dive.waterTemp
+		suitIndex = manager.suitList.indexOf(dive.suit)
+		if (dive.buddy.indexOf(",") > 0) {
+			buddyIndex = manager.buddyList.indexOf(dive.buddy.split(",", 1).toString())
 		} else {
-			buddyIndex = manager.buddyList.indexOf(currentItem.modelData.dive.buddy)
+			buddyIndex = manager.buddyList.indexOf(dive.buddy)
 		}
-		buddyText = currentItem.modelData.dive.buddy;
-		if (currentItem.modelData.dive.divemaster.indexOf(",") > 0) {
-			divemasterIndex = manager.divemasterList.indexOf(currentItem.modelData.dive.divemaster.split(",", 1).toString())
+		buddyText = dive.buddy;
+		if (dive.divemaster.indexOf(",") > 0) {
+			divemasterIndex = manager.divemasterList.indexOf(dive.divemaster.split(",", 1).toString())
 		} else {
-			divemasterIndex = manager.divemasterList.indexOf(currentItem.modelData.dive.divemaster)
+			divemasterIndex = manager.divemasterList.indexOf(dive.divemaster)
 		}
-		divemasterText = currentItem.modelData.dive.divemaster
-		notes = currentItem.modelData.dive.notes
-		if (currentItem.modelData.dive.singleWeight) {
+		divemasterText = dive.divemaster
+		notes = dive.notes
+		if (dive.singleWeight) {
 			// we have only one weight, go ahead, have fun and edit it
-			weight = currentItem.modelData.dive.sumWeight
+			weight = dive.sumWeight
 		} else {
 			// careful when translating, this text is "magic" in DiveDetailsEdit.qml
 			weight = "cannot edit multiple weight systems"
 		}
-		startpressure = currentItem.modelData.dive.startPressure
-		endpressure = currentItem.modelData.dive.endPressure
-		usedGas = currentItem.modelData.dive.firstGas
-		usedCyl = currentItem.modelData.dive.getCylinder
-		cylinderIndex0 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[0])
-		cylinderIndex1 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[1])
-		cylinderIndex2 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[2])
-		cylinderIndex3 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[3])
-		cylinderIndex4 = currentItem.modelData.dive.cylinderList.indexOf(usedCyl[4])
-		rating = currentItem.modelData.dive.rating
-		visibility = currentItem.modelData.dive.visibility
+		startpressure = dive.startPressure
+		endpressure = dive.endPressure
+		usedGas = dive.firstGas
+		usedCyl = dive.getCylinder
+		cylinderIndex0 = dive.cylinderList.indexOf(usedCyl[0])
+		cylinderIndex1 = dive.cylinderList.indexOf(usedCyl[1])
+		cylinderIndex2 = dive.cylinderList.indexOf(usedCyl[2])
+		cylinderIndex3 = dive.cylinderList.indexOf(usedCyl[3])
+		cylinderIndex4 = dive.cylinderList.indexOf(usedCyl[4])
+		rating = dive.rating
+		visibility = dive.visibility
 
 		diveDetailsPage.state = "edit"
 	}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -41,7 +41,7 @@ Kirigami.ScrollablePage {
 		id: diveDelegate
 		Kirigami.AbstractListItem {
 			// this looks weird, but it's how we can tell that this dive isn't in a trip
-			property bool diveOutsideTrip: dive.tripNrDives === 0
+			property bool diveOutsideTrip: tripNrDives === 0
 			leftPadding: 0
 			topPadding: 0
 			id: innerListItem
@@ -86,7 +86,7 @@ Kirigami.ScrollablePage {
 						}
 						NumberAnimation {
 							property: "height"
-							duration: 200 + 20 * dive.tripNrDives
+							duration: 200 + 20 * tripNrDives
 							easing.type: Easing.InOutQuad
 						}
 					}
@@ -97,7 +97,7 @@ Kirigami.ScrollablePage {
 					SequentialAnimation {
 						NumberAnimation {
 							property: "height"
-							duration: 200 + 20 * dive.tripNrDives
+							duration: 200 + 20 * tripNrDives
 							easing.type: Easing.InOutQuad
 						}
 						NumberAnimation {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -58,7 +58,7 @@ Kirigami.ScrollablePage {
 			states: [
 				State {
 					name: "isHidden";
-					when: dive.tripId !== activeTrip && ! diveOutsideTrip
+					when: tripId !== activeTrip && ! diveOutsideTrip
 					PropertyChanges {
 						target: innerListItem
 						height: 0
@@ -67,7 +67,7 @@ Kirigami.ScrollablePage {
 				},
 				State {
 					name: "isVisible";
-					when: dive.tripId === activeTrip || diveOutsideTrip
+					when: tripId === activeTrip || diveOutsideTrip
 					PropertyChanges {
 						target: innerListItem
 						height: diveListEntry.height + Kirigami.Units.smallSpacing
@@ -130,7 +130,7 @@ Kirigami.ScrollablePage {
 			Item {
 				Rectangle {
 					id: leftBarDive
-					width: dive.tripId == "" ? 0 : Kirigami.Units.smallSpacing
+					width: tripId == "" ? 0 : Kirigami.Units.smallSpacing
 					height: diveListEntry.height * 0.8
 					color: subsurfaceTheme.lightPrimaryColor
 					anchors {
@@ -525,7 +525,7 @@ Kirigami.ScrollablePage {
 		maximumFlickVelocity: parent.height * 5
 		bottomMargin: Kirigami.Units.iconSizes.medium + Kirigami.Units.gridUnit
 		cacheBuffer: 40 // this will increase memory use, but should help with scrolling
-		section.property: "dive.tripId"
+		section.property: "tripId"
 		section.criteria: ViewSection.FullString
 		section.delegate: tripHeading
 		section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -179,7 +179,7 @@ Kirigami.ScrollablePage {
 						}
 						// let's try to show the depth / duration very compact
 						Controls.Label {
-							text: dive.depth + ' / ' + dive.duration
+							text: depthDuration
 							width: Math.max(Kirigami.Units.gridUnit * 3, paintedWidth) // helps vertical alignment throughout listview
 							font.pointSize: subsurfaceTheme.smallPointSize
 							color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -230,11 +230,11 @@ Kirigami.ScrollablePage {
 							copyButtonVisible = false
 							pasteButtonVisible = false
 							timer.stop()
-							manager.copyDiveData(dive.id)
+							manager.copyDiveData(id)
 						}
 						onPressAndHold: {
 								globalDrawer.close()
-								manager.copyDiveData(dive.id)
+								manager.copyDiveData(id)
 								pageStack.push(settingsCopyWindow)
 						}
 					}
@@ -271,7 +271,7 @@ Kirigami.ScrollablePage {
 							copyButtonVisible = false
 							pasteButtonVisible = false
 							timer.stop()
-							manager.pasteDiveData(dive.id)
+							manager.pasteDiveData(id)
 						}
 					}
 				}
@@ -308,7 +308,7 @@ Kirigami.ScrollablePage {
 							copyButtonVisible = false
 							pasteButtonVisible = false
 							timer.stop()
-							manager.deleteDive(dive.id)
+							manager.deleteDive(id)
 						}
 					}
 				}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -172,7 +172,7 @@ Kirigami.ScrollablePage {
 
 						Controls.Label {
 							id: dateLabel
-							text: dive.date + " " + dive.time
+							text: dateTime
 							width: Math.max(locationText.width * 0.45, paintedWidth) // helps vertical alignment throughout listview
 							font.pointSize: subsurfaceTheme.smallPointSize
 							color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -187,7 +187,7 @@ Kirigami.ScrollablePage {
 					}
 					Controls.Label {
 						id: numberText
-						text: "#" + dive.number
+						text: "#" + number
 						font.pointSize: subsurfaceTheme.smallPointSize
 						color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor
 						anchors {

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -148,7 +148,7 @@ Kirigami.ScrollablePage {
 					anchors.left: leftBarDive.right
 					Controls.Label {
 						id: locationText
-						text: dive.location
+						text: location
 						font.weight: Font.Bold
 						font.pointSize: subsurfaceTheme.regularPointSize
 						elide: Text.ElideRight

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -390,8 +390,7 @@ Kirigami.Page {
 					manager.appendTextToLog("Save downloaded dives that were selected")
 					importModel.recordDives()
 					manager.saveChangesLocal()
-					diveModel.clear()
-					diveModel.addAllDives()
+					diveModel.reload()
 					pageStack.pop();
 					download.text = qsTr("Download")
 					divesDownloaded = false

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1156,7 +1156,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		if (newIdx != oldIdx) {
 			DiveListModel::instance()->removeDive(modelIdx);
 			modelIdx += (newIdx - oldIdx);
-			DiveListModel::instance()->insertDive(modelIdx, &myDive);
+			DiveListModel::instance()->insertDive(modelIdx);
 			diveChanged = true; // because we already modified things
 		}
 	}
@@ -1307,7 +1307,7 @@ bool QMLManager::undoDelete(int id)
 		add_dive_to_trip(deletedDive, trip);
 	}
 	record_dive(deletedDive);
-	DiveListModel::instance()->insertDive(get_idx_by_uniq_id(deletedDive->id), nullptr);
+	DiveListModel::instance()->insertDive(get_idx_by_uniq_id(deletedDive->id));
 	changesNeedSaving();
 	deletedDive = NULL;
 	deletedTrip = NULL;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -308,8 +308,7 @@ void QMLManager::openLocalThenRemote(QString url)
 		qPrefTechnicalDetails::set_show_ccr_sensors(git_prefs.show_ccr_sensors);
 		qPrefPartialPressureGas::set_po2(git_prefs.pp_graphs.po2);
 		process_loaded_dives();
-		DiveListModel::instance()->clear();
-		DiveListModel::instance()->addAllDives();
+		DiveListModel::instance()->reload();
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
 	}
@@ -517,7 +516,7 @@ void QMLManager::saveCloudCredentials()
 		getCloudURL(url);
 		manager()->clearAccessCache(); // remove any chached credentials
 		clear_git_id(); // invalidate our remembered GIT SHA
-		DiveListModel::instance()->clear();
+		DiveListModel::instance()->reload();
 		GpsListModel::instance()->clear();
 		setStartPageText(tr("Attempting to open cloud storage with new credentials"));
 		// we therefore know that no one else is already accessing THIS git repo;
@@ -701,8 +700,7 @@ successful_exit:
 	if (noCloudToCloud) {
 		git_storage_update_progress(qPrintable(tr("Loading dives from local storage ('no cloud' mode)")));
 		mergeLocalRepo();
-		DiveListModel::instance()->clear();
-		DiveListModel::instance()->addAllDives();
+		DiveListModel::instance()->reload();
 		appendTextToLog(QStringLiteral("%1 dives loaded after importing nocloud local storage").arg(dive_table.nr));
 		noCloudToCloud = false;
 		mark_divelist_changed(true);
@@ -763,9 +761,8 @@ void QMLManager::consumeFinishedLoad(timestamp_t currentDiveTimestamp)
 	prefs.show_ccr_setpoint = git_prefs.show_ccr_setpoint;
 	prefs.show_ccr_sensors = git_prefs.show_ccr_sensors;
 	prefs.pp_graphs.po2 = git_prefs.pp_graphs.po2;
-	DiveListModel::instance()->clear();
 	process_loaded_dives();
-	DiveListModel::instance()->addAllDives();
+	DiveListModel::instance()->reload();
 	if (currentDiveTimestamp)
 		setUpdateSelectedDive(dlSortModel->getIdxForId(get_dive_id_closest_to(currentDiveTimestamp)));
 	appendTextToLog(QStringLiteral("%1 dives loaded").arg(dive_table.nr));
@@ -776,8 +773,7 @@ void QMLManager::consumeFinishedLoad(timestamp_t currentDiveTimestamp)
 
 void QMLManager::refreshDiveList()
 {
-	DiveListModel::instance()->clear();
-	DiveListModel::instance()->addAllDives();
+	DiveListModel::instance()->reload();
 }
 
 void QMLManager::setupDivesite(struct dive *d, struct dive_site *ds, double lat, double lon, const char *locationtext)
@@ -1311,9 +1307,7 @@ bool QMLManager::undoDelete(int id)
 		add_dive_to_trip(deletedDive, trip);
 	}
 	record_dive(deletedDive);
-	QList<dive *>diveAsList;
-	diveAsList << deletedDive;
-	DiveListModel::instance()->addDive(diveAsList);
+	DiveListModel::instance()->insertDive(get_idx_by_uniq_id(deletedDive->id), nullptr);
 	changesNeedSaving();
 	deletedDive = NULL;
 	deletedTrip = NULL;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -898,8 +898,8 @@ bool QMLManager::checkLocation(const DiveObjectHelper &myDive, struct dive *d, Q
 {
 	bool diveChanged = false;
 	struct dive_site *ds = get_dive_site_for_dive(d);
-	qDebug() << "checkLocation" << location << "gps" << gps << "dive had" << myDive.location() << "gps" << myDive.gas();
-	if (myDive.location() != location) {
+	qDebug() << "checkLocation" << location << "gps" << gps << "dive had" << myDive.location << "gps" << myDive.gas;
+	if (myDive.location != location) {
 		diveChanged = true;
 		ds = get_dive_site_by_name(qPrintable(location), &dive_site_table);
 		if (!ds && !location.isEmpty())
@@ -912,12 +912,12 @@ bool QMLManager::checkLocation(const DiveObjectHelper &myDive, struct dive *d, Q
 	// now make sure that the GPS coordinates match - if the user changed the name but not
 	// the GPS coordinates, this still does the right thing as the now new dive site will
 	// have no coordinates, so the coordinates from the edit screen will get added
-	if (myDive.gps() != gps) {
+	if (myDive.gps != gps) {
 		double lat, lon;
 		if (parseGpsText(gps, &lat, &lon)) {
 			qDebug() << "parsed GPS, using it";
 			// there are valid GPS coordinates - just use them
-			setupDivesite(d, ds, lat, lon, qPrintable(myDive.location()));
+			setupDivesite(d, ds, lat, lon, qPrintable(myDive.location));
 			diveChanged = true;
 		} else if (gps == GPS_CURRENT_POS) {
 			qDebug() << "gps was our default text for no GPS";
@@ -926,7 +926,7 @@ bool QMLManager::checkLocation(const DiveObjectHelper &myDive, struct dive *d, Q
 			if (gpsString != GPS_CURRENT_POS) {
 				qDebug() << "but now I got a valid location" << gpsString;
 				if (parseGpsText(qPrintable(gpsString), &lat, &lon)) {
-					setupDivesite(d, ds, lat, lon, qPrintable(myDive.location()));
+					setupDivesite(d, ds, lat, lon, qPrintable(myDive.location));
 					diveChanged = true;
 				}
 			} else {
@@ -942,7 +942,7 @@ bool QMLManager::checkLocation(const DiveObjectHelper &myDive, struct dive *d, Q
 
 bool QMLManager::checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration)
 {
-	if (myDive.duration() != duration) {
+	if (myDive.duration != duration) {
 		int h = 0, m = 0, s = 0;
 		QRegExp r1(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2[\\s,:]*(\\d*)\\s*%3").arg(tr("h")).arg(tr("min")).arg(tr("sec")), Qt::CaseInsensitive);
 		QRegExp r2(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2").arg(tr("h")).arg(tr("min")), Qt::CaseInsensitive);
@@ -981,7 +981,7 @@ bool QMLManager::checkDuration(const DiveObjectHelper &myDive, struct dive *d, Q
 
 bool QMLManager::checkDepth(const DiveObjectHelper &myDive, dive *d, QString depth)
 {
-	if (myDive.depth() != depth) {
+	if (myDive.depth != depth) {
 		int depthValue = parseLengthToMm(depth);
 		// the QML code should stop negative depth, but massively huge depth can make
 		// the profile extremely slow or even run out of memory and crash, so keep
@@ -1028,15 +1028,15 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 
 	diveChanged |= checkDepth(myDive, d, depth);
 
-	if (myDive.airTemp() != airtemp) {
+	if (myDive.airTemp != airtemp) {
 		diveChanged = true;
 		d->airtemp.mkelvin = parseTemperatureToMkelvin(airtemp);
 	}
-	if (myDive.waterTemp() != watertemp) {
+	if (myDive.waterTemp != watertemp) {
 		diveChanged = true;
 		d->watertemp.mkelvin = parseTemperatureToMkelvin(watertemp);
 	}
-	if (myDive.sumWeight() != weight) {
+	if (myDive.sumWeight != weight) {
 		diveChanged = true;
 		// not sure what we'd do if there was more than one weight system
 		// defined - for now just ignore that case
@@ -1048,7 +1048,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// start and end pressures for first cylinder only
-	if (myDive.startPressure() != startpressure || myDive.endPressure() != endpressure) {
+	if (myDive.startPressure != startpressure || myDive.endPressure != endpressure) {
 		diveChanged = true;
 		for ( int i = 0, j = 0 ; j < startpressure.length() && j < endpressure.length() ; i++ ) {
 			if (state != "add" && !is_cylinder_used(d, i))
@@ -1063,7 +1063,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// gasmix for first cylinder
-	if (myDive.firstGas() != gasmix) {
+	if (myDive.firstGas != gasmix) {
 		for ( int i = 0, j = 0 ; j < gasmix.length() ; i++ ) {
 			if (state != "add" && !is_cylinder_used(d, i))
 				continue;
@@ -1082,7 +1082,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		}
 	}
 	// info for first cylinder
-	if (myDive.getCylinder() != usedCylinder) {
+	if (myDive.getCylinder != usedCylinder) {
 		diveChanged = true;
 		unsigned long i;
 		int size = 0, wp = 0, j = 0, k = 0;
@@ -1108,12 +1108,12 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 			k++;
 		}
 	}
-	if (myDive.suit() != suit) {
+	if (myDive.suit != suit) {
 		diveChanged = true;
 		free(d->suit);
 		d->suit = copy_qstring(suit);
 	}
-	if (myDive.buddy() != buddy) {
+	if (myDive.buddy != buddy) {
 		if (buddy.contains(",")){
 			buddy = buddy.replace(QRegExp("\\s*,\\s*"), ", ");
 		}
@@ -1121,7 +1121,7 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		free(d->buddy);
 		d->buddy = copy_qstring(buddy);
 	}
-	if (myDive.divemaster() != diveMaster) {
+	if (myDive.divemaster != diveMaster) {
 		if (diveMaster.contains(",")){
 			diveMaster = diveMaster.replace(QRegExp("\\s*,\\s*"), ", ");
 		}
@@ -1129,15 +1129,15 @@ void QMLManager::commitChanges(QString diveId, QString date, QString location, Q
 		free(d->divemaster);
 		d->divemaster = copy_qstring(diveMaster);
 	}
-	if (myDive.rating() != rating) {
+	if (myDive.rating != rating) {
 		diveChanged = true;
 		d->rating = rating;
 	}
-	if (myDive.visibility() != visibility) {
+	if (myDive.visibility != visibility) {
 		diveChanged = true;
 		d->visibility = visibility;
 	}
-	if (myDive.notes() != notes) {
+	if (myDive.notes != notes) {
 		diveChanged = true;
 		free(d->notes);
 		d->notes = copy_qstring(notes);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -227,10 +227,10 @@ private:
 	qreal m_lastDevicePixelRatio;
 	QElapsedTimer timer;
 	bool alreadySaving;
-	bool checkDate(DiveObjectHelper *myDive, struct dive * d, QString date);
-	bool checkLocation(DiveObjectHelper *myDive, struct dive *d, QString location, QString gps);
-	bool checkDuration(DiveObjectHelper *myDive, struct dive *d, QString duration);
-	bool checkDepth(DiveObjectHelper *myDive, struct dive *d, QString depth);
+	bool checkDate(const DiveObjectHelper &myDive, struct dive *d, QString date);
+	bool checkLocation(const DiveObjectHelper &myDive, struct dive *d, QString location, QString gps);
+	bool checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration);
+	bool checkDepth(const DiveObjectHelper &myDive, struct dive *d, QString depth);
 	bool currentGitLocalOnly;
 	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -257,6 +257,8 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	case IdRole: return d->id;
 	case NumberRole: return d->number;
 	case LocationRole: return get_dive_location(d);
+	case DepthDurationRole: return QStringLiteral("%1 / %2").arg(get_depth_string(d->dc.maxdepth.mm, true, true),
+								     get_dive_duration_string(d->duration.seconds, gettextFromC::tr("h"), gettextFromC::tr("min")));
 	}
 	return QVariant();
 }
@@ -272,6 +274,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[IdRole] = "id";
 	roles[NumberRole] = "number";
 	roles[LocationRole] = "location";
+	roles[DepthDurationRole] = "depthDuration";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -254,6 +254,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 		return QStringLiteral("%1 %2").arg(localTime.date().toString(prefs.date_format_short),
 						   localTime.time().toString(prefs.time_format));
 		}
+	case IdRole: return d->id;
 	}
 	return QVariant();
 }
@@ -266,6 +267,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[TripIdRole] = "tripId";
 	roles[TripNrDivesRole] = "tripNrDives";
 	roles[DateTimeRole] = "dateTime";
+	roles[IdRole] = "id";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -243,8 +243,6 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
-	case FullTextRole: return curr_dive->fullText();
-	case FullTextNoNotesRole: return curr_dive->fullTextNoNotes();
 	}
 	return QVariant();
 
@@ -255,8 +253,6 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
-	roles[FullTextRole] = "fulltext";
-	roles[FullTextNoNotesRole] = "fulltextnonotes";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -256,6 +256,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 		}
 	case IdRole: return d->id;
 	case NumberRole: return d->number;
+	case LocationRole: return get_dive_location(d);
 	}
 	return QVariant();
 }
@@ -270,6 +271,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[DateTimeRole] = "dateTime";
 	roles[IdRole] = "id";
 	roles[NumberRole] = "number";
+	roles[LocationRole] = "location";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -136,7 +136,7 @@ DiveListModel::DiveListModel(QObject *parent) : QAbstractListModel(parent)
 	m_instance = this;
 }
 
-void DiveListModel::insertDive(int i, DiveObjectHelper *)
+void DiveListModel::insertDive(int i)
 {
 	beginInsertRows(QModelIndex(), i, i);
 	endInsertRows();
@@ -163,7 +163,7 @@ void DiveListModel::updateDive(int i, dive *d)
 	// we need to make sure that QML knows that this dive has changed -
 	// the only reliable way I've found is to remove and re-insert it
 	removeDive(i);
-	insertDive(i, nullptr); // TODO: DiveObjectHelper not needed anymore - remove second argument
+	insertDive(i);
 }
 
 void DiveListModel::reload()
@@ -254,7 +254,7 @@ QString DiveListModel::startAddDive()
 	d->number = nr;
 	d->dc.model = strdup("manually added dive");
 	append_dive(d);
-	insertDive(get_idx_by_uniq_id(d->id), new DiveObjectHelper(d));
+	insertDive(get_idx_by_uniq_id(d->id));
 	return QString::number(d->id);
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -71,10 +71,10 @@ int DiveListSortModel::getIdxForId(int id)
 	return -1;
 }
 
-void DiveListSortModel::clear()
+void DiveListSortModel::reload()
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	mySourceModel->clear();
+	mySourceModel->reload();
 }
 
 // In QML, section headings can only be strings. To identify dives that
@@ -136,25 +136,6 @@ DiveListModel::DiveListModel(QObject *parent) : QAbstractListModel(parent)
 	m_instance = this;
 }
 
-void DiveListModel::addDive(const QList<dive *> &listOfDives)
-{
-	if (listOfDives.isEmpty())
-		return;
-	beginInsertRows(QModelIndex(), rowCount(), rowCount() + listOfDives.count() - 1);
-	endInsertRows();
-}
-
-void DiveListModel::addAllDives()
-{
-	QList<dive *>listOfDives;
-	int i;
-	struct dive *d;
-	for_each_dive (i, d)
-		listOfDives.append(d);
-	addDive(listOfDives);
-
-}
-
 void DiveListModel::insertDive(int i, DiveObjectHelper *)
 {
 	beginInsertRows(QModelIndex(), i, i);
@@ -185,7 +166,7 @@ void DiveListModel::updateDive(int i, dive *d)
 	insertDive(i, nullptr); // TODO: DiveObjectHelper not needed anymore - remove second argument
 }
 
-void DiveListModel::clear()
+void DiveListModel::reload()
 {
 	beginResetModel();
 	endResetModel();

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -197,12 +197,11 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	if(index.row() < 0 || index.row() >= dive_table.nr)
 		return QVariant();
 
-	DiveObjectHelper curr_dive(dive_table.dives[index.row()]);
-	const dive *d = curr_dive.getDive();
+	dive *d = dive_table.dives[index.row()];
 	if (!d)
 		return QVariant();
 	switch(role) {
-	case DiveRole: return QVariant::fromValue<DiveObjectHelper>(curr_dive);
+	case DiveRole: return QVariant::fromValue(DiveObjectHelper(d));
 	case DiveDateRole: return (qlonglong)d->when;
 	case TripIdRole: return d->divetrip ? QString::number((quint64)d->divetrip, 16) : QString();
 	case TripNrDivesRole: return d->divetrip ? d->divetrip->dives.nr : 0;

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -51,8 +51,8 @@ void DiveListSortModel::resetFilter()
 bool DiveListSortModel::filterAcceptsRow(int source_row, const QModelIndex &) const
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	DiveObjectHelper d = mySourceModel->at(source_row);
-	return d && !d.getDive()->hidden_by_filter;
+	const dive *d = mySourceModel->getDive(source_row);
+	return d && !d->hidden_by_filter;
 }
 
 int DiveListSortModel::shown()
@@ -262,11 +262,18 @@ DiveListModel *DiveListModel::instance()
 	return m_instance;
 }
 
-DiveObjectHelper DiveListModel::at(int i)
+struct dive *DiveListModel::getDive(int i)
 {
 	if (i < 0 || i >= dive_table.nr) {
-		qWarning("DiveListModel::at(): accessing invalid dive with id %d", i);
-		return DiveObjectHelper(); // Returns an invalid DiveObjectHelper that will crash on access.
+		qWarning("DiveListModel::getDive(): accessing invalid dive with id %d", i);
+		return nullptr;
 	}
-	return DiveObjectHelper(dive_table.dives[i]);
+	return dive_table.dives[i];
+}
+
+DiveObjectHelper DiveListModel::at(int i)
+{
+	// For an invalid id, returns an invalid DiveObjectHelper that will crash on access.
+	dive *d = getDive(i);
+	return d ? DiveObjectHelper(d) : DiveObjectHelper();
 }

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -245,6 +245,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
 	case TripIdRole: return d->divetrip ? QString::number((quint64)d->divetrip, 16) : QString();
+	case TripNrDivesRole: return d->divetrip ? d->divetrip->dives.nr : 0;
 	}
 	return QVariant();
 
@@ -256,6 +257,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
 	roles[TripIdRole] = "tripId";
+	roles[TripNrDivesRole] = "tripNrDives";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -64,8 +64,8 @@ int DiveListSortModel::getIdxForId(int id)
 {
 	for (int i = 0; i < rowCount(); i++) {
 		QVariant v = data(index(i, 0), DiveListModel::DiveRole);
-		DiveObjectHelper *d = v.value<DiveObjectHelper *>();
-		if (d->id() == id)
+		DiveObjectHelper d = v.value<DiveObjectHelper>();
+		if (d.id() == id)
 			return i;
 	}
 	return -1;
@@ -239,13 +239,13 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	if(index.row() < 0 || index.row() >= m_dives.count())
 		return QVariant();
 
-	DiveObjectHelper *curr_dive = m_dives[index.row()];
-	const dive *d = curr_dive->getDive();
+	DiveObjectHelper &curr_dive = *m_dives[index.row()];
+	const dive *d = curr_dive.getDive();
 	if (!d)
 		return QVariant();
 	switch(role) {
-	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
-	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
+	case DiveRole: return QVariant::fromValue<DiveObjectHelper>(curr_dive);
+	case DiveDateRole: return (qlonglong)d->when;
 	case TripIdRole: return d->divetrip ? QString::number((quint64)d->divetrip, 16) : QString();
 	case TripNrDivesRole: return d->divetrip ? d->divetrip->dives.nr : 0;
 	case DateTimeRole: {
@@ -305,7 +305,7 @@ DiveListModel *DiveListModel::instance()
 	return m_instance;
 }
 
-DiveObjectHelper* DiveListModel::at(int i)
+DiveObjectHelper *DiveListModel::at(int i)
 {
 	return m_dives.at(i);
 }

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -77,13 +77,6 @@ void DiveListSortModel::clear()
 	mySourceModel->clear();
 }
 
-void DiveListSortModel::addAllDives()
-{
-	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	mySourceModel->addAllDives();
-	updateFilterState();
-}
-
 // In QML, section headings can only be strings. To identify dives that
 // belong to the same trip, a string containing the trip-pointer in hexadecimal
 // encoding is passed in. To format the trip heading, the string is then

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -240,9 +240,11 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 		return QVariant();
 
 	DiveObjectHelper *curr_dive = m_dives[index.row()];
+	const dive *d = curr_dive->getDive();
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
+	case TripIdRole: return d->divetrip ? QString::number((quint64)d->divetrip, 16) : QString();
 	}
 	return QVariant();
 
@@ -253,6 +255,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
+	roles[TripIdRole] = "tripId";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -255,6 +255,7 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 						   localTime.time().toString(prefs.time_format));
 		}
 	case IdRole: return d->id;
+	case NumberRole: return d->number;
 	}
 	return QVariant();
 }
@@ -268,6 +269,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[TripNrDivesRole] = "tripNrDives";
 	roles[DateTimeRole] = "dateTime";
 	roles[IdRole] = "id";
+	roles[NumberRole] = "number";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -241,14 +241,21 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 
 	DiveObjectHelper *curr_dive = m_dives[index.row()];
 	const dive *d = curr_dive->getDive();
+	if (!d)
+		return QVariant();
 	switch(role) {
 	case DiveRole: return QVariant::fromValue<QObject*>(curr_dive);
 	case DiveDateRole: return (qlonglong)curr_dive->timestamp();
 	case TripIdRole: return d->divetrip ? QString::number((quint64)d->divetrip, 16) : QString();
 	case TripNrDivesRole: return d->divetrip ? d->divetrip->dives.nr : 0;
+	case DateTimeRole: {
+		QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * d->when, Qt::UTC);
+		localTime.setTimeSpec(Qt::UTC);
+		return QStringLiteral("%1 %2").arg(localTime.date().toString(prefs.date_format_short),
+						   localTime.time().toString(prefs.time_format));
+		}
 	}
 	return QVariant();
-
 }
 
 QHash<int, QByteArray> DiveListModel::roleNames() const
@@ -258,6 +265,7 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[DiveDateRole] = "date";
 	roles[TripIdRole] = "tripId";
 	roles[TripNrDivesRole] = "tripNrDives";
+	roles[DateTimeRole] = "dateTime";
 	return roles;
 }
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -20,19 +20,17 @@ void DiveListSortModel::updateFilterState()
 	bool includeNotes = qPrefGeneral::filterFullTextNotes();
 	Qt::CaseSensitivity cs = qPrefGeneral::filterCaseSensitive() ? Qt::CaseSensitive : Qt::CaseInsensitive;
 
-	// get the underlying model and re-calculate the filter value for each dive
-	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	for (int i = 0; i < mySourceModel->rowCount(); i++) {
-		DiveObjectHelper *d = mySourceModel->at(i);
-		QString fullText = includeNotes? d->fullText() : d->fullTextNoNotes();
-		d->getDive()->hidden_by_filter = !fullText.contains(filterString, cs);
-	}
+	int i;
+	struct dive *d;
+	for_each_dive(i, d)
+		d->hidden_by_filter = !diveContainsText(d, filterString, cs, includeNotes);
 }
 
 void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
 	QSortFilterProxyModel::setSourceModel(sourceModel);
 }
+
 void DiveListSortModel::setFilter(QString f)
 {
 	filterString = f;

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -62,13 +62,12 @@ int DiveListSortModel::shown()
 
 int DiveListSortModel::getIdxForId(int id)
 {
-	for (int i = 0; i < rowCount(); i++) {
-		QVariant v = data(index(i, 0), DiveListModel::DiveRole);
-		DiveObjectHelper d = v.value<DiveObjectHelper>();
-		if (d.id() == id)
-			return i;
-	}
-	return -1;
+	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
+	QModelIndex sourceIdx = mySourceModel->getDiveQIdx(id);
+	if (!sourceIdx.isValid())
+		return -1;
+	QModelIndex localIdx = mapFromSource(sourceIdx);
+	return localIdx.row();
 }
 
 void DiveListSortModel::reload()
@@ -187,9 +186,18 @@ int DiveListModel::rowCount(const QModelIndex &) const
 	return dive_table.nr;
 }
 
+// Get the index of a dive in the global dive list by the dive's unique id. Returns an integer [0..nrdives).
 int DiveListModel::getDiveIdx(int id) const
 {
 	return get_idx_by_uniq_id(id);
+}
+
+// Get an index of a dive. In contrast to getDiveIdx, this returns a Qt model-index,
+// which can be used to access data of a Qt model.
+QModelIndex DiveListModel::getDiveQIdx(int id)
+{
+	int idx = getDiveIdx(id);
+	return idx >= 0 ? createIndex(idx, 0) : QModelIndex();
 }
 
 QVariant DiveListModel::data(const QModelIndex &index, int role) const

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -38,6 +38,7 @@ public:
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
+		TripIdRole,
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -43,6 +43,7 @@ public:
 		DateTimeRole,
 		IdRole,
 		NumberRole,
+		LocationRole,
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -58,6 +58,7 @@ public:
 	struct dive *getDive(int i);
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	int getDiveIdx(int id) const;
+	QModelIndex getDiveQIdx(int id);
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 	QHash<int, QByteArray> roleNames() const;
 	QString startAddDive();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -13,7 +13,6 @@ class DiveListSortModel : public QSortFilterProxyModel
 public:
 	DiveListSortModel(QObject *parent = 0);
 	void setSourceModel(QAbstractItemModel *sourceModel);
-	Q_INVOKABLE void addAllDives();
 	Q_INVOKABLE void clear();
 	Q_INVOKABLE QVariant tripIdToObject(const QString &s);
 	Q_INVOKABLE QString tripTitle(const QVariant &trip);

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -44,6 +44,7 @@ public:
 		IdRole,
 		NumberRole,
 		LocationRole,
+		DepthDurationRole,
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -39,6 +39,7 @@ public:
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
 		TripIdRole,
+		TripNrDivesRole,
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -55,6 +55,7 @@ public:
 	void removeDiveById(int id);
 	void updateDive(int i, dive *d);
 	void reload();
+	struct dive *getDive(int i);
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	int getDiveIdx(int id) const;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -41,7 +41,8 @@ public:
 		TripIdRole,
 		TripNrDivesRole,
 		DateTimeRole,
-		IdRole
+		IdRole,
+		NumberRole,
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -38,8 +38,6 @@ public:
 	enum DiveListRoles {
 		DiveRole = Qt::UserRole + 1,
 		DiveDateRole,
-		FullTextRole,
-		FullTextNoNotesRole
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -50,7 +50,7 @@ public:
 	DiveListModel(QObject *parent = 0);
 	void addDive(const QList<dive *> &listOfDives);
 	void addAllDives();
-	void insertDive(int i, DiveObjectHelper *newDive);
+	void insertDive(int i);
 	void removeDive(int i);
 	void removeDiveById(int id);
 	void updateDive(int i, dive *d);

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -62,9 +62,8 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	QString startAddDive();
 	void resetInternalData();
-	Q_INVOKABLE DiveObjectHelper* at(int i);
+	Q_INVOKABLE DiveObjectHelper at(int i);
 private:
-	QList<DiveObjectHelper*> m_dives;
 	static DiveListModel *m_instance;
 };
 

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -40,7 +40,8 @@ public:
 		DiveDateRole,
 		TripIdRole,
 		TripNrDivesRole,
-		DateTimeRole
+		DateTimeRole,
+		IdRole
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -40,6 +40,7 @@ public:
 		DiveDateRole,
 		TripIdRole,
 		TripNrDivesRole,
+		DateTimeRole
 	};
 
 	static DiveListModel *instance();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -13,7 +13,7 @@ class DiveListSortModel : public QSortFilterProxyModel
 public:
 	DiveListSortModel(QObject *parent = 0);
 	void setSourceModel(QAbstractItemModel *sourceModel);
-	Q_INVOKABLE void clear();
+	Q_INVOKABLE void reload();
 	Q_INVOKABLE QVariant tripIdToObject(const QString &s);
 	Q_INVOKABLE QString tripTitle(const QVariant &trip);
 	Q_INVOKABLE QString tripShortDate(const QVariant &trip);
@@ -54,7 +54,7 @@ public:
 	void removeDive(int i);
 	void removeDiveById(int id);
 	void updateDive(int i, dive *d);
-	void clear();
+	void reload();
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	int getDiveIdx(int id) const;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR is intended for @dirkhh to test the "nuclear option" concerning the mobile crashes that we are observing. This turns DiveObjectHelper into a value type. Yes, the code is crazy and will probably give horrible side effects. But it presents the opportunity to test the theory that the random crashes are due to dangling references concerning DiveObjectHelper and (indirectly) struct dive.

Ideally, we get this PR to act normally and then let it test users who experience these random crashes. Yes, I am aware that the crash data is anonymized, but perhaps we can find such a user. If the data-corruption crashes still happen, then I am really stumped.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn DiveObjectHelper into value-object.

@dirkhh: it would be great if you could find bugs in this PR. In my short testing I didn't hit anything obvious, but I'm not using mobile on a regular basis.

Addendum: apparently undo of dive-deletion doesn't update the list properly, will check that out.