### PR TITLE
Fix the dive site XML saving

### DIFF
--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -623,7 +623,8 @@ void save_dives_buffer(struct membuffer *b, const bool select_only, bool anonymi
 				if (t->category != TC_NONE && t->value) {
 					put_format(b, "  <geo cat='%d'", t->category);
 					put_format(b, " origin='%d'", t->origin);
-					show_utf8_blanked(b, t->value, " value='", "'/>\n", 1, anonymize);
+					show_utf8_blanked(b, t->value, " value='", "'", 1, anonymize);
+					put_format(b, "/>\n");
 				}
 			}
 		}
@@ -837,7 +838,8 @@ void save_dive_sites_buffer(struct membuffer *b, const bool select_only, bool an
 				if (t->category != TC_NONE && t->value) {
 					put_format(b, "  <geo cat='%d'", t->category);
 					put_format(b, " origin='%d'", t->origin);
-					show_utf8_blanked(b, t->value, " value='", "'/>\n", 1, anonymize);
+					show_utf8_blanked(b, t->value, " value='", "'", 1, anonymize);
+					put_format(b, "/>\n");
 				}
 			}
 		}


### PR DESCRIPTION
It turns out that the dive site saving was subtly but horribly buggy.
To save the value of the dive site, it did

    show_utf8_blanked(b, t->value, " value='", "'/>\n", 1, anonymize);

which looks sane on the face of it, but the problem is that it puts the
final closing xml marker in the 'append this at the end' case.

That means that if the value is empty, the value won't be saved, but
neither will the closing tag.  Resulting in an xml line that looks like
this:

  <geo cat='3' origin='0'  <geo cat='5' origin='0' value='Other name'/>

where the first geo tag was saved without the ending marker.

That then makes all the xml nesting entirely wrong, and the whole file
fails to save.

Now, the code around it does check that 't->value' is not NULL, but it
doesn't check for a value that is empty or all spaces (which also will
make 'show_utf8()' just skip it.

Fix it by saving the end marker separately:

    show_utf8_blanked(b, t->value, " value='", "'", 1, anonymize);
    put_format(b, "/>\n");

so that the xml is valid even if the goe marker value wasn'r.

Reported-by: Bob Barker <barkerb1965@gmail.com>
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
