### PR TITLE
Update libdivecomputer to support the Aqualung i200c

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -78,9 +78,28 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		product = "Quad";
 	}
 
+	// The Pelagic dive computers (generally branded as Oceanic or Aqualung)
+	// show up with a two-byte model code followed by six bytes of serial
+	// number. The model code matches the hex model (so "FQ" is 0x4651,
+	// where 'F' is 46h and 'Q' is 51h in ASCII).
+	if (btName.contains(QRegularExpression("^FI\\d{6}$"))) {
+		vendor = "Aqualung";
+		product = "i200c";
+	}
+
+	if (btName.contains(QRegularExpression("^FH\\d{6}$"))) {
+		vendor = "Aqualung";
+		product = "i300c";
+	}
+
 	if (btName.contains(QRegularExpression("^FQ\\d{6}$"))) {
 		vendor = "Aqualung";
 		product = "i770R";
+	}
+
+	if (btName.contains(QRegularExpression("^FR\\d{6}$"))) {
+		vendor = "Aqualung";
+		product = "i550c";
 	}
 
 	if (btName.contains(QRegularExpression("^ER\\d{6}$"))) {
@@ -93,6 +112,8 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		product = "Geo 4.0";
 	}
 
+	// The Ratio bluetooth name looks like the Pelagic ones,
+	// but that seems to be just happenstance.
 	if (btName.contains(QRegularExpression("^DS\\d{6}"))) {
 		vendor = "Ratio";
 		product = "iX3M GPS Easy"; // we don't know which of the GPS models, so set one


### PR DESCRIPTION
I got confirmation from Tiago Thedim Dias that my libdivecomputer patch
makes BLE downloading work from the i200c, and already pushed out the
libdivecomputer changes earlier.  This updates the subproject in
subsurface to have those changes.

This also adds the bluetooth name patterns for the i300c and a few other
Aqualung dive computers we hadn't added yet.  That should make them show
up in the bleutooth device list even without having to check the "Show
all bluetooth devices" check-box.

Tiago claims he didn't need that, and I wonder if we have some overly
permissive match somewhere, but it's the right thing to do regardless.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
