### PR TITLE
Map: catch null divesites in map widget selection code

### DIFF
--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -69,7 +69,7 @@ Item {
 						drag.target: (mapHelper.editMode && mapHelper.model.isSelected(model.divesite)) ? mapItem : undefined
 						anchors.fill: parent
 						onClicked: {
-							if (!mapHelper.editMode)
+							if (!mapHelper.editMode && model.divesite)
 								mapHelper.model.setSelected(model.divesite, true)
 						}
 						onDoubleClicked: map.doubleClickHandler(mapItem.coordinate)

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -196,6 +196,8 @@ void MapLocationModel::reload(QObject *map)
 void MapLocationModel::setSelected(struct dive_site *ds, bool fromClick)
 {
 	m_selectedDs.clear();
+	if (!ds)
+		return;
 	m_selectedDs.append(ds);
 	if (fromClick)
 		emit selectedLocationChanged(getMapLocation(ds));


### PR DESCRIPTION
Just to be sure, refuse to add null divesites to the selection.

Moreover, refuse to call the setSelected function on a null-divesite.
I got an unfriendly Qt-Warning there:

"Passing incompatible arguments to C++ functions from JavaScript is
dangerous and deprecated."
"This will throw a JavaScript TypeError in future releases of Qt!"

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is supposed to make handling of the map selection code a bit more robust. I doubt that it fixes the crash reported for snap packages (#2248). Ultimately we probably should switch back to a `QVariant` instead of a `divesite *` parameter. The C++ to QML interface is a real pain. :(

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Related to #2248 but I'm nearly certain that this isn't the problem.
