### PR TITLE
Profile: properly initialize plot_info structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+- Desktop: fix crash when saving subtitles or profile picture
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/core/profile.c
+++ b/core/profile.c
@@ -1319,11 +1319,22 @@ static void debug_print_profiledata(struct plot_info *pi)
 #endif
 
 /*
+ * Initialize a plot_info structure to all-zeroes
+ */
+void init_plot_info(struct plot_info *pi)
+{
+	memset(pi, 0, sizeof(*pi));
+}
+
+/*
  * Create a plot-info with smoothing and ranged min/max
  *
  * This also makes sure that we have extra empty events on both
  * sides, so that you can do end-points without having to worry
  * about it.
+ *
+ * The old data will be freed. Before the first call, the plot
+ * info must be initialized with init_plot_info().
  */
 void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool fast, struct deco_state *planner_ds)
 {

--- a/core/profile.h
+++ b/core/profile.h
@@ -80,6 +80,7 @@ struct ev_select {
 
 extern void compare_samples(struct plot_data *e1, struct plot_data *e2, char *buf, int bufsize, int sum);
 extern struct plot_info *analyze_plot_info(struct plot_info *pi);
+extern void init_plot_info(struct plot_info *pi);
 extern void create_plot_info_new(struct dive *dive, struct divecomputer *dc, struct plot_info *pi, bool fast, struct deco_state *planner_ds);
 extern void calculate_deco_information(struct deco_state *ds, const struct deco_state *planner_de, const struct dive *dive, const struct divecomputer *dc, struct plot_info *pi, bool print_mode);
 extern struct plot_data *get_plot_details_new(struct plot_info *pi, int time, struct membuffer *);

--- a/core/save-profiledata.c
+++ b/core/save-profiledata.c
@@ -199,6 +199,7 @@ static void save_profiles_buffer(struct membuffer *b, bool select_only)
 	struct plot_info pi;
 	struct deco_state *planner_deco_state = NULL;
 
+	init_plot_info(&pi);
 	for_each_dive(i, dive) {
 		if (select_only && !dive->selected)
 			continue;
@@ -220,6 +221,7 @@ void save_subtitles_buffer(struct membuffer *b, struct dive *dive, int offset, i
 	struct plot_info pi;
 	struct deco_state *planner_deco_state = NULL;
 
+	init_plot_info(&pi);
 	create_plot_info_new(dive, &dive->dc, &pi, false, planner_deco_state);
 
 	put_format(b, "[Script Info]\n");

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -148,7 +148,7 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	// would like to be able to ASSERT here that PreferencesDialog::loadSettings has been called.
 	isPlotZoomed = prefs.zoomed_plot; // now it seems that 'prefs' has loaded our preferences
 
-	memset(&plotInfo, 0, sizeof(plotInfo));
+	init_plot_info(&plotInfo);
 
 	setupSceneAndFlags();
 	setupItemSizes();

--- a/profile-widget/ruleritem.cpp
+++ b/profile-widget/ruleritem.cpp
@@ -17,7 +17,7 @@ RulerNodeItem2::RulerNodeItem2() :
 	timeAxis(NULL),
 	depthAxis(NULL)
 {
-	memset(&pInfo, 0, sizeof(pInfo));
+	init_plot_info(&pInfo);
 	setRect(-8, -8, 16, 16);
 	setBrush(QColor(0xff, 0, 0, 127));
 	setPen(QColor(Qt::red));

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -10,7 +10,7 @@ DivePlotDataModel::DivePlotDataModel(QObject *parent) :
 	diveId(0),
 	dcNr(0)
 {
-	memset(&pInfo, 0, sizeof(pInfo));
+	init_plot_info(&pInfo);
 	memset(&plot_deco_state, 0, sizeof(struct deco_state));
 }
 


### PR DESCRIPTION
The create_plot_info_new() function releases old plot data. This
can only work if the plot_info structure was initialized previously.
The ProfileWidget2 did that by a memset, but other parts of the code
did not.

Therefore, introduce a init_plot_info() function and call that when
generating a plot_info struct. Constructors would make this so much
easier - but since this is called from C, we can't use them.

Fixes #2251

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a crash when exporting subtitles or profile plots.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Initialize plot_info structures before use
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: please include in 4.9.2 release - this fixes a nasty crash.