### PR TITLE
 Fix broken windows build with latest MXE

### DIFF
--- a/core/configuredivecomputer.h
+++ b/core/configuredivecomputer.h
@@ -26,7 +26,7 @@ public:
 		FWUPDATE,
 		CANCELLING,
 		CANCELLED,
-		ERROR,
+		ERRORED,
 		DONE,
 	};
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -3404,7 +3404,7 @@ void set_informational_units(const char *units)
 		if (strstr(units, "PSI"))
 			git_prefs.units.pressure = PSI;
 		if (strstr(units, "PASCAL"))
-			git_prefs.units.pressure = PASCAL;
+			git_prefs.units.pressure = PASCALS;
 		if (strstr(units, "CELSIUS"))
 			git_prefs.units.temperature = CELSIUS;
 		if (strstr(units, "FAHRENHEIT"))

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -145,7 +145,7 @@ static void divetags(char *buffer, struct tag_entry **tags)
 
 enum number_type {
 	NEITHER,
-	FLOAT
+	FLOATVAL
 };
 
 static enum number_type parse_float(const char *buffer, double *res, const char **endp)
@@ -172,7 +172,7 @@ static enum number_type parse_float(const char *buffer, double *res, const char 
 	}
 
 	*res = val;
-	return FLOAT;
+	return FLOATVAL;
 }
 
 union int_or_float {
@@ -191,12 +191,12 @@ static void pressure(char *buffer, pressure_t *pressure, struct parser_state *st
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		/* Just ignore zero values */
 		if (!val.fp)
 			break;
 		switch (state->xml_parsing_units.pressure) {
-		case PASCAL:
+		case PASCALS:
 			mbar = val.fp / 100;
 			break;
 		case BAR:
@@ -233,7 +233,7 @@ static void salinity(char *buffer, int *salinity)
 {
 	union int_or_float val;
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		*salinity = lrint(val.fp * 10.0);
 		break;
 	default:
@@ -246,7 +246,7 @@ static void depth(char *buffer, depth_t *depth, struct parser_state *state)
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		switch (state->xml_parsing_units.length) {
 		case METERS:
 			depth->mm = lrint(val.fp * 1000);
@@ -281,7 +281,7 @@ static void weight(char *buffer, weight_t *weight, struct parser_state *state)
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		switch (state->xml_parsing_units.weight) {
 		case KG:
 			weight->grams = lrint(val.fp * 1000);
@@ -301,7 +301,7 @@ static void temperature(char *buffer, temperature_t *temperature, struct parser_
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		switch (state->xml_parsing_units.temperature) {
 		case KELVIN:
 			temperature->mkelvin = lrint(val.fp * 1000);
@@ -383,7 +383,7 @@ static void percent(char *buffer, fraction_t *fraction)
 	const char *end;
 
 	switch (parse_float(buffer, &val, &end)) {
-	case FLOAT:
+	case FLOATVAL:
 		/* Turn fractions into percent unless explicit.. */
 		if (val <= 1.0) {
 			while (isspace(*end))
@@ -424,7 +424,7 @@ static void cylindersize(char *buffer, volume_t *volume)
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		volume->mliter = lrint(val.fp * 1000);
 		break;
 
@@ -600,7 +600,7 @@ static void fahrenheit(char *buffer, temperature_t *temperature)
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		if (IS_FP_SAME(val.fp, 32.0))
 			break;
 		if (val.fp < 32.0)
@@ -638,7 +638,7 @@ static void psi_or_bar(char *buffer, pressure_t *pressure)
 	union int_or_float val;
 
 	switch (integer_or_float(buffer, &val)) {
-	case FLOAT:
+	case FLOATVAL:
 		if (val.fp > 400)
 			pressure->mbar = psi_to_mbar(val.fp);
 		else
@@ -1530,7 +1530,7 @@ static void uddf_importer(struct parser_state *state)
 {
 	state->import_source = UDDF;
 	state->xml_parsing_units = SI_units;
-	state->xml_parsing_units.pressure = PASCAL;
+	state->xml_parsing_units.pressure = PASCALS;
 	state->xml_parsing_units.temperature = KELVIN;
 }
 

--- a/core/units.c
+++ b/core/units.c
@@ -9,7 +9,7 @@ int get_pressure_units(int mb, const char **units)
 	const struct units *units_p = get_units();
 
 	switch (units_p->pressure) {
-	case PASCAL:
+	case PASCALS:
 		pressure = mb * 100;
 		unit = translate("gettextFromC", "pascal");
 		break;

--- a/core/units.h
+++ b/core/units.h
@@ -271,9 +271,6 @@ static inline int32_t pressure_to_altitude(int32_t pressure)	// pressure in mbar
  * keeps track of those units.
  */
 /* turns out in Win32 PASCAL is defined as a calling convention */
-#ifdef WIN32
-#undef PASCAL
-#endif
 struct units {
 	enum LENGTH {
 		METERS,
@@ -286,7 +283,7 @@ struct units {
 	enum PRESSURE {
 		BAR,
 		PSI,
-		PASCAL
+		PASCALS
 	} pressure;
 	enum TEMPERATURE {
 		CELSIUS,

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -244,7 +244,7 @@ void DownloadFromDCWidget::updateState(states state)
 
 	// user pressed cancel but the application isn't doing anything.
 	// means close the window
-	else if ((currentState == INITIAL || currentState == DONE || currentState == ERROR) && state == CANCELLING) {
+	else if ((currentState == INITIAL || currentState == DONE || currentState == ERRORED) && state == CANCELLING) {
 		timer->stop();
 		reject();
 	}
@@ -294,7 +294,7 @@ void DownloadFromDCWidget::updateState(states state)
 	}
 
 	// got an error
-	else if (state == ERROR) {
+	else if (state == ERRORED) {
 		timer->stop();
 
 		QMessageBox::critical(this, TITLE_OR_TEXT(tr("Error"), thread.error), QMessageBox::Ok);
@@ -503,7 +503,7 @@ void DownloadFromDCWidget::onDownloadThreadFinished()
 		if (thread.error.isEmpty())
 			updateState(DONE);
 		else
-			updateState(ERROR);
+			updateState(ERRORED);
 	} else if (currentState == CANCELLING) {
 		updateState(DONE);
 	}
@@ -524,7 +524,7 @@ void DownloadFromDCWidget::on_cancel_clicked()
 
 void DownloadFromDCWidget::on_ok_clicked()
 {
-	if (currentState != DONE && currentState != ERROR)
+	if (currentState != DONE && currentState != ERRORED)
 		return;
 	struct dive_table *table = thread.table();
 	struct dive_site_table *sites = thread.sites();

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -32,7 +32,7 @@ public:
 		INITIAL,
 		DOWNLOADING,
 		CANCELLING,
-		ERROR,
+		ERRORED,
 		DONE,
 	};
 

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -438,7 +438,7 @@ void MainTab::updateDiveInfo()
 	for (int i = 0; i < extraWidgets.size() - 1; ++i)
 		extraWidgets[i]->setEnabled(enabled);
 
-	editMode = IGNORE; // don't trigger on changes to the widgets
+	editMode = IGNORE_MODE; // don't trigger on changes to the widgets
 
 	for (TabBase *widget: extraWidgets)
 		widget->updateData();
@@ -619,7 +619,7 @@ void MainTab::acceptChanges()
 		stealFocus();
 
 	EditMode lastMode = editMode;
-	editMode = IGNORE;
+	editMode = IGNORE_MODE;
 	tabBar()->setTabIcon(0, QIcon()); // Notes
 	tabBar()->setTabIcon(1, QIcon()); // Equipment
 	ui.dateEdit->setEnabled(true);
@@ -746,7 +746,7 @@ static QStringList stringToList(const QString &s)
 
 void MainTab::on_buddy_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	divesEdited(Command::editBuddies(stringToList(ui.buddy->toPlainText()), false));
@@ -754,7 +754,7 @@ void MainTab::on_buddy_editingFinished()
 
 void MainTab::on_divemaster_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	divesEdited(Command::editDiveMaster(stringToList(ui.divemaster->toPlainText()), false));
@@ -762,7 +762,7 @@ void MainTab::on_divemaster_editingFinished()
 
 void MainTab::on_duration_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	// Duration editing is special: we only edit the current dive.
@@ -771,7 +771,7 @@ void MainTab::on_duration_editingFinished()
 
 void MainTab::on_depth_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	// Depth editing is special: we only edit the current dive.
@@ -783,14 +783,14 @@ void MainTab::on_airtemp_editingFinished()
 	// If the field wasn't modified by the user, don't post a new undo command.
 	// Owing to rounding errors, this might lead to undo commands that have
 	// no user visible effects. These can be very confusing.
-	if (editMode == IGNORE || !ui.airtemp->isModified() || !current_dive)
+	if (editMode == IGNORE_MODE || !ui.airtemp->isModified() || !current_dive)
 		return;
 	divesEdited(Command::editAirTemp(parseTemperatureToMkelvin(ui.airtemp->text()), false));
 }
 
 void MainTab::divetype_Changed(int index)
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 	divesEdited(Command::editMode(dc_number, (enum divemode_t)index, false));
 }
@@ -800,7 +800,7 @@ void MainTab::on_watertemp_editingFinished()
 	// If the field wasn't modified by the user, don't post a new undo command.
 	// Owing to rounding errors, this might lead to undo commands that have
 	// no user visible effects. These can be very confusing.
-	if (editMode == IGNORE || !ui.watertemp->isModified() || !current_dive)
+	if (editMode == IGNORE_MODE || !ui.watertemp->isModified() || !current_dive)
 		return;
 	divesEdited(Command::editWaterTemp(parseTemperatureToMkelvin(ui.watertemp->text()), false));
 }
@@ -826,7 +826,7 @@ static void shiftTime(QDateTime &dateTime)
 
 void MainTab::on_dateEdit_dateChanged(const QDate &date)
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
 	dateTime.setTimeSpec(Qt::UTC);
@@ -836,7 +836,7 @@ void MainTab::on_dateEdit_dateChanged(const QDate &date)
 
 void MainTab::on_timeEdit_timeChanged(const QTime &time)
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
 	dateTime.setTimeSpec(Qt::UTC);
@@ -846,7 +846,7 @@ void MainTab::on_timeEdit_timeChanged(const QTime &time)
 
 void MainTab::on_tagWidget_editingFinished()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	divesEdited(Command::editTags(ui.tagWidget->getBlockStringList(), false));
@@ -854,7 +854,7 @@ void MainTab::on_tagWidget_editingFinished()
 
 void MainTab::on_location_diveSiteSelected()
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	struct dive_site *newDs = ui.location->currDiveSite();
@@ -892,7 +892,7 @@ void MainTab::on_notes_editingFinished()
 
 void MainTab::on_rating_valueChanged(int value)
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	divesEdited(Command::editRating(value, false));
@@ -900,7 +900,7 @@ void MainTab::on_rating_valueChanged(int value)
 
 void MainTab::on_visibility_valueChanged(int value)
 {
-	if (editMode == IGNORE || !current_dive)
+	if (editMode == IGNORE_MODE || !current_dive)
 		return;
 
 	divesEdited(Command::editVisibility(value, false));

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -30,7 +30,7 @@ public:
 		NONE,
 		DIVE,
 		MANUALLY_ADDED_DIVE,
-		IGNORE
+		IGNORE_MODE
 	};
 
 	MainTab(QWidget *parent = 0);


### PR DESCRIPTION
Replaces some enums with names that do not clash with windows #defines.
Specifically:
ERROR -> ERRORED, PASCAL->PASCALS, IGNORE->IGNORED,FLOAT->FLOATVAL

Signed-off-by Paul Buxton paulbuxton.mail@googlemail.com

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The MXE build for windows pulls in preprocessor defines for ERROR, IGNORE, FLOAT and PASCAL which override the enumerated type definitions. This patch renames the conflicting enums to avoid this. We also remove the #undef PASCAL which was presumably the original attempt to avoid this problem for the PASCAL case.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
