### PR TITLE
Desktop: improve recognition of HTML-notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: Don't destroy format of planner notes when editing dive notes [#2265]
 - Desktop: fix crash when saving subtitles or profile picture
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -369,11 +369,15 @@ bool MainTab::isEditing()
 	return editMode != NONE;
 }
 
+static bool isHtml(const QString &s)
+{
+	return s.contains("<div", Qt::CaseInsensitive) || s.contains("<table", Qt::CaseInsensitive);
+}
+
 void MainTab::updateNotes(const struct dive *d)
 {
 	QString tmp(d->notes);
-	if (tmp.indexOf("<div") != -1) {
-		tmp.replace(QString("\n"), QString("<br>"));
+	if (isHtml(tmp)) {
 		ui.notes->setHtml(tmp);
 	} else {
 		ui.notes->setPlainText(tmp);
@@ -881,8 +885,8 @@ void MainTab::on_notes_editingFinished()
 	if (!currentTrip && !current_dive)
 		return;
 
-	QString notes = ui.notes->toHtml().indexOf("<div") != -1 ?
-		ui.notes->toHtml() : ui.notes->toPlainText();
+	QString html = ui.notes->toHtml();
+	QString notes = isHtml(html) ? html : ui.notes->toPlainText();
 
 	if (currentTrip)
 		Command::editTripNotes(currentTrip, notes);


### PR DESCRIPTION
To recognize HTML-notes the text was scanned for <div> tags. But
apparently the planner notes do not feature such a thing. Therefore
extend recognition of HTML to these tags.

Note we can't use the <html> or <span> tags, because these are
*always* produced by the QTextEdit::toHtml() function.

Fixes #2265

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Commit description says it all: be smarted when recognizing HTML notes.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79 
@dirkhh, @torvalds: It's horrible, but maybe we should simply always write HTML notes? With Qt's QTextEdit widget I cannot fathom any solution that isn't very brittle.