### PR TITLE
Fix dive site selection on Qt 5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Desktop: Don't destroy format of planner notes when editing dive notes [#2265]
+- Map: avoid full map reload when clicking on flag
+- Map: highlight all selected dive sites when clicking on flag
+- Map: fix crash when clicking on flags in Qt 5.9
 - Desktop: fix crash when saving subtitles or profile picture
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/desktop-widgets/command_divesite.cpp
+++ b/desktop-widgets/command_divesite.cpp
@@ -186,19 +186,6 @@ static void swap(char *&c, QString &q)
 	q = s;
 }
 
-// Helper function: collect the dives that are at the given dive site
-static QVector<dive *> getDivesForSite(struct dive_site *ds)
-{
-	QVector<dive *> diveSiteDives;
-	diveSiteDives.reserve(ds->dives.nr);
-
-	for (int i = 0; i < ds->dives.nr; ++i)
-		diveSiteDives.push_back(ds->dives.dives[i]);
-
-	return diveSiteDives;
-}
-
-
 EditDiveSiteName::EditDiveSiteName(dive_site *dsIn, const QString &name) : ds(dsIn),
 	value(name)
 {
@@ -214,7 +201,6 @@ void EditDiveSiteName::redo()
 {
 	swap(ds->name, value);
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::NAME); // Inform frontend of changed dive site.
-	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // dive site name can be shown in the dive list
 }
 
 void EditDiveSiteName::undo()
@@ -286,8 +272,6 @@ void EditDiveSiteCountry::redo()
 	taxonomy_set_country(&ds->taxonomy, copy_qstring(value), taxonomy_origin::GEOMANUAL);
 	value = old;
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::TAXONOMY); // Inform frontend of changed dive site.
-	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // Country can be shown in the dive list
-
 }
 
 void EditDiveSiteCountry::undo()
@@ -315,7 +299,6 @@ void EditDiveSiteLocation::redo()
 {
 	std::swap(value, ds->location);
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::LOCATION); // Inform frontend of changed dive site.
-	emit diveListNotifier.divesChanged(getDivesForSite(ds), DiveField::DIVESITE); // the globe icon in the dive list shows whether we have coordinates
 }
 
 void EditDiveSiteLocation::undo()

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -27,6 +27,7 @@
 #include "qt-models/divepicturemodel.h"
 #include "core/metrics.h"
 #include "desktop-widgets/simplewidgets.h"
+#include "desktop-widgets/mapwidget.h"
 
 DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false),
 	currentLayout(DiveTripModelBase::TREE), dontEmitDiveChangedSignal(false), selectionSaved(false),
@@ -455,6 +456,22 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 			scrollTo(idx.parent());
 		scrollTo(idx);
 	}
+
+	// update the selected-flag for the dive sites.
+	// the actual reloading of the dive sites will be perfomed
+	// by the main-window in response to the divesSelected signal
+	// emitted below.
+	QVector<dive_site *> selectedSites;
+	for (int idx: newDiveSelection) {
+		dive *d = get_dive(idx);
+		if (!d)
+			continue;
+		dive_site *ds = d->dive_site;
+		if (ds && !selectedSites.contains(ds))
+			selectedSites.append(ds);
+	}
+	MapWidget::instance()->setSelected(selectedSites);
+
 	// now that everything is up to date, update the widgets
 	emit divesSelected();
 	dontEmitDiveChangedSignal = false;

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -687,8 +687,20 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 			select_dive(dive);
 		}
 	}
-	if (!dontEmitDiveChangedSignal)
+	if (!dontEmitDiveChangedSignal) {
+		// When receiving the divesSelected signal the main window will
+		// instruct the map to update the flags. Thus, make sure that
+		// the selected maps are registered correctly.
+		QVector<dive_site *> selectedSites;
+		for (QModelIndex index: selectionModel()->selection().indexes()) {
+			const QAbstractItemModel *model = index.model();
+			struct dive *dive = model->data(index, DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
+			if (dive && dive->dive_site)
+				selectedSites.push_back(dive->dive_site);
+		}
+		MapWidget::instance()->setSelected(selectedSites);
 		emit divesSelected();
+	}
 
 	// Display the new, processed, selection
 	QTreeView::selectionChanged(selectionModel()->selection(), newDeselected);

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -183,7 +183,6 @@ void LocationInformationWidget::acceptChanges()
 	MainWindow::instance()->diveList->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
 	MainWindow::instance()->setApplicationState(ApplicationState::Default);
-	MapWidget::instance()->repopulateLabels();
 	MultiFilterSortModel::instance()->stopFilterDiveSites();
 }
 

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -133,7 +133,6 @@ void LocationInformationWidget::diveSiteChanged(struct dive_site *ds, int field)
 	switch (field) {
 	case LocationInformationModel::NAME:
 		ui.diveSiteName->setText(diveSite->name);
-		MapWidget::instance()->repopulateLabels();
 		return;
 	case LocationInformationModel::DESCRIPTION:
 		ui.diveSiteDescription->setText(diveSite->description);
@@ -154,7 +153,7 @@ void LocationInformationWidget::diveSiteChanged(struct dive_site *ds, int field)
 			enableLocationButtons(false);
 			ui.diveSiteCoordinates->clear();
 		}
-		MapWidget::instance()->repopulateLabels();
+		return;
 	default:
 		return;
 	}

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -464,7 +464,7 @@ void MainWindow::selectionChanged()
 		configureToolbar();
 		enableDisableOtherDCsActions();
 	}
-	MapWidget::instance()->reload();
+	MapWidget::instance()->selectionChanged();
 }
 
 void MainWindow::on_actionNew_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -408,10 +408,10 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 {
 	mainTab->reload();
 	TankInfoModel::instance()->update();
-	MapWidget::instance()->reload();
 	if (doRecreateDiveList)
 		recreateDiveList();
 
+	MapWidget::instance()->reload();
 	setApplicationState(ApplicationState::Default);
 	diveList->setEnabled(true);
 	diveList->setFocus();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -79,6 +79,11 @@ void MapWidget::reload()
 	m_mapHelper->centerOnSelectedDiveSite();
 }
 
+bool MapWidget::editMode() const
+{
+	return isReady && m_mapHelper->editMode();
+}
+
 void MapWidget::selectedDivesChanged(const QList<int> &list)
 {
 	CHECK_IS_READY_RETURN_VOID();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -84,6 +84,13 @@ bool MapWidget::editMode() const
 	return isReady && m_mapHelper->editMode();
 }
 
+void MapWidget::selectionChanged()
+{
+	CHECK_IS_READY_RETURN_VOID();
+	m_mapHelper->selectionChanged();
+	m_mapHelper->centerOnSelectedDiveSite();
+}
+
 void MapWidget::selectedDivesChanged(const QList<int> &list)
 {
 	CHECK_IS_READY_RETURN_VOID();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -84,6 +84,12 @@ bool MapWidget::editMode() const
 	return isReady && m_mapHelper->editMode();
 }
 
+void MapWidget::setSelected(const QVector<dive_site *> &divesites)
+{
+	CHECK_IS_READY_RETURN_VOID();
+	m_mapHelper->setSelected(divesites);
+}
+
 void MapWidget::selectionChanged()
 {
 	CHECK_IS_READY_RETURN_VOID();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -66,12 +66,6 @@ void MapWidget::centerOnIndex(const QModelIndex& idx)
 		centerOnDiveSite(ds);
 }
 
-void MapWidget::repopulateLabels()
-{
-	CHECK_IS_READY_RETURN_VOID();
-	m_mapHelper->reloadMapLocations();
-}
-
 void MapWidget::reload()
 {
 	CHECK_IS_READY_RETURN_VOID();

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -24,6 +24,7 @@ public:
 	static MapWidget *instance();
 	void reload();
 	void selectionChanged();
+	void setSelected(const QVector<dive_site *> &divesites);
 	bool editMode() const;
 
 public slots:

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -23,6 +23,7 @@ public:
 
 	static MapWidget *instance();
 	void reload();
+	void selectionChanged();
 	bool editMode() const;
 
 public slots:

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -23,6 +23,7 @@ public:
 
 	static MapWidget *instance();
 	void reload();
+	bool editMode() const;
 
 public slots:
 	void centerOnDiveSite(struct dive_site *);

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -30,7 +30,6 @@ public:
 public slots:
 	void centerOnDiveSite(struct dive_site *);
 	void centerOnIndex(const QModelIndex& idx);
-	void repopulateLabels();
 	void selectedDivesChanged(const QList<int> &);
 	void coordinatesChanged(struct dive_site *ds, const location_t &);
 	void doneLoading(QQuickWidget::Status status);

--- a/desktop-widgets/tab-widgets/TabDiveSite.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveSite.cpp
@@ -95,14 +95,9 @@ QVector<dive_site *> TabDiveSite::selectedDiveSites()
 	return sites;
 }
 
-void TabDiveSite::updateFilter()
-{
-	MultiFilterSortModel::instance()->setFilterDiveSite(selectedDiveSites());
-}
-
 void TabDiveSite::selectionChanged(const QItemSelection &, const QItemSelection &)
 {
-	updateFilter();
+	MultiFilterSortModel::instance()->setFilterDiveSite(selectedDiveSites());
 }
 
 void TabDiveSite::showEvent(QShowEvent *)

--- a/desktop-widgets/tab-widgets/TabDiveSite.h
+++ b/desktop-widgets/tab-widgets/TabDiveSite.h
@@ -23,7 +23,6 @@ private:
 	Ui::TabDiveSite ui;
 	DiveSiteSortedModel model;
 	QVector<dive_site *> selectedDiveSites();
-	void updateFilter();
 	void hideEvent(QHideEvent *) override;
 	void showEvent(QShowEvent *) override;
 };

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -69,10 +69,8 @@ Item {
 						drag.target: (mapHelper.editMode && mapHelper.model.isSelected(model.divesite)) ? mapItem : undefined
 						anchors.fill: parent
 						onClicked: {
-							if (!mapHelper.editMode && model.divesite) {
-								mapHelper.model.setSelected(model.divesite)
+							if (!mapHelper.editMode && model.divesite)
 								mapHelper.selectedLocationChanged(model.divesite)
-							}
 						}
 						onDoubleClicked: map.doubleClickHandler(mapItem.coordinate)
 						onReleased: {

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -69,8 +69,10 @@ Item {
 						drag.target: (mapHelper.editMode && mapHelper.model.isSelected(model.divesite)) ? mapItem : undefined
 						anchors.fill: parent
 						onClicked: {
-							if (!mapHelper.editMode && model.divesite)
-								mapHelper.model.setSelected(model.divesite, true)
+							if (!mapHelper.editMode && model.divesite) {
+								mapHelper.model.setSelected(model.divesite)
+								mapHelper.selectedLocationChanged(model.divesite)
+							}
 						}
 						onDoubleClicked: map.doubleClickHandler(mapItem.coordinate)
 						onReleased: {

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -56,7 +56,7 @@ Item {
 				anchorPoint.x: 0
 				anchorPoint.y: mapItemImage.height
 				coordinate:  model.coordinate
-				z: mapHelper.model.isSelected(model.divesite) ? mapHelper.model.count - 1 : 0
+				z: model.z
 				sourceItem: Image {
 					id: mapItemImage
 					source: model.pixmap

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -66,7 +66,7 @@ Item {
 						PropertyAnimation { target: mapItemImage; property: "scale"; from: 0.7; to: 1.0; duration: 80 }
 					}
 					MouseArea {
-						drag.target: (mapHelper.editMode && mapHelper.model.isSelected(model.divesite)) ? mapItem : undefined
+						drag.target: (mapHelper.editMode && model.isSelected) ? mapItem : undefined
 						anchors.fill: parent
 						onClicked: {
 							if (!mapHelper.editMode && model.divesite)
@@ -74,7 +74,7 @@ Item {
 						}
 						onDoubleClicked: map.doubleClickHandler(mapItem.coordinate)
 						onReleased: {
-							if (mapHelper.editMode && mapHelper.model.isSelected(model.divesite)) {
+							if (mapHelper.editMode && model.isSelected) {
 								mapHelper.updateCurrentDiveSiteCoordinatesFromMap(model.divesite, mapItem.coordinate)
 							}
 						}
@@ -94,7 +94,7 @@ Item {
 							id: mapItemText
 							text: model.name
 							font.pointSize: 11.0
-							color: mapHelper.model.isSelected(model.divesite) ? "white" : "lightgrey"
+							color: model.isSelected ? "white" : "lightgrey"
 						}
 					}
 				}

--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -59,7 +59,7 @@ Item {
 				z: mapHelper.model.isSelected(model.divesite) ? mapHelper.model.count - 1 : 0
 				sourceItem: Image {
 					id: mapItemImage
-					source: "qrc:///dive-location-marker" + (mapHelper.model.isSelected(model.divesite) ? "-selected" : (mapHelper.editMode ? "-inactive" : "")) + "-icon"
+					source: model.pixmap
 					SequentialAnimation {
 						id: mapItemImageAnimation
 						PropertyAnimation { target: mapItemImage; property: "scale"; from: 1.0; to: 0.7; duration: 120 }

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -11,6 +11,7 @@
 #include "qt-models/divelocationmodel.h"
 #ifndef SUBSURFACE_MOBILE
 #include "qt-models/filtermodels.h"
+#include "desktop-widgets/mapwidget.h"
 #endif
 
 #define SMALL_CIRCLE_RADIUS_PX            26.0
@@ -233,6 +234,11 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *
 void MapWidgetHelper::diveSiteChanged(struct dive_site *ds, int field)
 {
 	centerOnDiveSite(ds);
+}
+
+bool MapWidgetHelper::editMode() const
+{
+	return m_editMode;
 }
 
 QString MapWidgetHelper::pluginObject()

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -135,7 +135,7 @@ void MapWidgetHelper::selectedLocationChanged(struct dive_site *ds_in)
 	MapLocation *location = m_mapLocationModel->getMapLocation(ds_in);
 	if (!location)
 		return;
-	QGeoCoordinate locationCoord = location->coordinate();
+	QGeoCoordinate locationCoord = location->coordinate;
 
 	for_each_dive (idx, dive) {
 		struct dive_site *ds = get_dive_site_for_dive(dive);
@@ -149,7 +149,7 @@ void MapWidgetHelper::selectedLocationChanged(struct dive_site *ds_in)
 			selectedDiveIds.append(idx);
 	}
 #else // the mobile version doesn't support multi-dive selection
-		if (ds == location->divesite())
+		if (ds == location->divesite)
 			selectedDiveIds.append(dive->id); // use id here instead of index
 	}
 	int last; // get latest dive chronologically
@@ -237,7 +237,7 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *
 {
 	MapLocation *loc = m_mapLocationModel->getMapLocation(ds);
 	if (loc)
-		loc->setCoordinate(coord);
+		loc->coordinate = coord;
 	location_t location = mk_location(coord);
 	emit coordinatesChanged(ds, location);
 }

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -96,16 +96,21 @@ void MapWidgetHelper::centerOnSelectedDiveSite()
 	}
 }
 
-void MapWidgetHelper::reloadMapLocations()
+void MapWidgetHelper::updateEditMode()
 {
 #ifndef SUBSURFACE_MOBILE
 	// The filter being set to dive site is the signal that we are in dive site edit mode.
 	// This is the case when either the dive site edit tab or the dive site list tab are active.
-	if (MultiFilterSortModel::instance()->diveSiteMode())
-		enterEditMode();
-	else
-		exitEditMode();
+	bool old = m_editMode;
+	m_editMode = MultiFilterSortModel::instance()->diveSiteMode();
+	if (old != m_editMode)
+		emit editModeChanged();
 #endif
+}
+
+void MapWidgetHelper::reloadMapLocations()
+{
+	updateEditMode();
 	m_mapLocationModel->reload(m_map);
 }
 
@@ -223,23 +228,6 @@ void MapWidgetHelper::updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *
 void MapWidgetHelper::diveSiteChanged(struct dive_site *ds, int field)
 {
 	centerOnDiveSite(ds);
-}
-
-void MapWidgetHelper::exitEditMode()
-{
-	if (!m_editMode)
-		return;
-	m_editMode = false;
-	emit editModeChanged();
-}
-
-void MapWidgetHelper::enterEditMode()
-{
-	if (m_editMode)
-		return;
-
-	m_editMode = true;
-	emit editModeChanged();
 }
 
 QString MapWidgetHelper::pluginObject()

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -113,6 +113,11 @@ void MapWidgetHelper::reloadMapLocations()
 	m_mapLocationModel->reload(m_map);
 }
 
+void MapWidgetHelper::selectionChanged()
+{
+	m_mapLocationModel->selectionChanged();
+}
+
 void MapWidgetHelper::selectedLocationChanged(struct dive_site *ds_in)
 {
 	int idx;

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -46,6 +46,11 @@ void MapWidgetHelper::centerOnDiveSite(struct dive_site *ds)
 	}
 }
 
+void MapWidgetHelper::setSelected(const QVector<dive_site *> &divesites)
+{
+	m_mapLocationModel->setSelected(divesites);
+}
+
 void MapWidgetHelper::centerOnSelectedDiveSite()
 {
 	QVector<struct dive_site *> selDS = m_mapLocationModel->selectedDs();
@@ -115,6 +120,7 @@ void MapWidgetHelper::reloadMapLocations()
 
 void MapWidgetHelper::selectionChanged()
 {
+	updateEditMode();
 	m_mapLocationModel->selectionChanged();
 }
 

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -35,6 +35,7 @@ public:
 	Q_INVOKABLE void calculateSmallCircleRadius(QGeoCoordinate coord);
 	Q_INVOKABLE void updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *ds, QGeoCoordinate coord);
 	Q_INVOKABLE void selectVisibleLocations();
+	Q_INVOKABLE void selectedLocationChanged(struct dive_site *ds);
 	QString pluginObject();
 
 private:
@@ -45,7 +46,6 @@ private:
 	bool m_editMode;
 
 private slots:
-	void selectedLocationChanged(MapLocation *);
 	void diveSiteChanged(struct dive_site *ds, int field);
 
 signals:

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -37,6 +37,7 @@ public:
 	Q_INVOKABLE void selectVisibleLocations();
 	Q_INVOKABLE void selectedLocationChanged(struct dive_site *ds);
 	void selectionChanged();
+	void setSelected(const QVector<dive_site *> &divesites);
 	QString pluginObject();
 	bool editMode() const;
 

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -36,6 +36,7 @@ public:
 	Q_INVOKABLE void updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *ds, QGeoCoordinate coord);
 	Q_INVOKABLE void selectVisibleLocations();
 	Q_INVOKABLE void selectedLocationChanged(struct dive_site *ds);
+	void selectionChanged();
 	QString pluginObject();
 	bool editMode() const;
 

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -38,8 +38,7 @@ public:
 	QString pluginObject();
 
 private:
-	void enterEditMode();
-	void exitEditMode();
+	void updateEditMode();
 	QObject *m_map;
 	MapLocationModel *m_mapLocationModel;
 	qreal m_smallCircleRadius;

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -37,6 +37,7 @@ public:
 	Q_INVOKABLE void selectVisibleLocations();
 	Q_INVOKABLE void selectedLocationChanged(struct dive_site *ds);
 	QString pluginObject();
+	bool editMode() const;
 
 private:
 	void updateEditMode();

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -106,6 +106,7 @@ public slots:
 	void divesAdded(dive_trip *trip, bool addTrip, const QVector<dive *> &dives);
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
+	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives, dive *current);
@@ -170,6 +171,7 @@ class DiveTripModelList : public DiveTripModelBase
 public slots:
 	void divesAdded(dive_trip *trip, bool addTrip, const QVector<dive *> &dives);
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
+	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -12,6 +12,7 @@
 #if !defined(SUBSURFACE_MOBILE)
 #include "desktop-widgets/divelistview.h"
 #include "desktop-widgets/mainwindow.h"
+#include "desktop-widgets/mapwidget.h"
 #endif
 
 #include <QDebug>
@@ -263,6 +264,11 @@ void MultiFilterSortModel::myInvalidate()
 		DiveTripModelBase::instance()->filterFinished();
 		countsChanged();
 	}
+
+#if !defined(SUBSURFACE_MOBILE)
+	// The shown maps may have changed -> reload the map widget.
+	MapWidget::instance()->reload();
+#endif
 
 	emit filterFinished();
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -229,6 +229,11 @@ void MapLocationModel::setSelected(struct dive_site *ds)
 		m_selectedDs.append(ds);
 }
 
+void MapLocationModel::setSelected(const QVector<dive_site *> &divesites)
+{
+	m_selectedDs = divesites;
+}
+
 bool MapLocationModel::isSelected(const QVariant &dsVariant) const
 {
 	dive_site *ds = dsVariant.value<dive_site *>();

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -150,6 +150,15 @@ static bool hasSelectedDive(const dive_site *ds)
 			   [] (const dive *d) { return d->selected; });
 }
 
+void MapLocationModel::selectionChanged()
+{
+	if (m_mapLocations.isEmpty())
+		return;
+	for(MapLocation *m: m_mapLocations)
+		m->m_selected = m_selectedDs.contains(m->divesite());
+	emit dataChanged(createIndex(0, 0), createIndex(m_mapLocations.size() - 1, 0));
+}
+
 void MapLocationModel::reload(QObject *map)
 {
 	beginResetModel();

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -63,12 +63,6 @@ QGeoCoordinate MapLocation::coordinate()
 void MapLocation::setCoordinate(QGeoCoordinate coord)
 {
 	m_coordinate = coord;
-	emit coordinateChanged();
-}
-
-void MapLocation::setCoordinateNoEmit(QGeoCoordinate coord)
-{
-	m_coordinate = coord;
 }
 
 struct dive_site *MapLocation::divesite()
@@ -246,7 +240,7 @@ void MapLocationModel::diveSiteChanged(struct dive_site *ds, int field)
 			const qreal latitude_r = ds->location.lat.udeg * 0.000001;
 			const qreal longitude_r = ds->location.lon.udeg * 0.000001;
 			QGeoCoordinate coord(latitude_r, longitude_r);
-			m_mapLocations[row]->setCoordinateNoEmit(coord);
+			m_mapLocations[row]->setCoordinate(coord);
 		}
 		break;
 	case LocationInformationModel::NAME:

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -116,11 +116,6 @@ int MapLocationModel::rowCount(const QModelIndex&) const
 	return m_mapLocations.size();
 }
 
-int MapLocationModel::count()
-{
-	return m_mapLocations.size();
-}
-
 void MapLocationModel::add(MapLocation *location)
 {
 	beginInsertRows(QModelIndex(), m_mapLocations.size(), m_mapLocations.size());

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -121,13 +121,6 @@ int MapLocationModel::count()
 	return m_mapLocations.size();
 }
 
-MapLocation *MapLocationModel::get(int row)
-{
-	if (row < 0 || row >= m_mapLocations.size())
-		return NULL;
-	return m_mapLocations.at(row);
-}
-
 void MapLocationModel::add(MapLocation *location)
 {
 	beginInsertRows(QModelIndex(), m_mapLocations.size(), m_mapLocations.size());

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -48,6 +48,8 @@ QVariant MapLocation::getRole(int role) const
 				    QString("qrc:///dive-location-marker-icon");
 	case Roles::RoleZ:
 		return m_selected ? 1 : 0;
+	case Roles::RoleIsSelected:
+		return QVariant::fromValue(m_selected);
 	default:
 		return QVariant();
 	}
@@ -105,6 +107,7 @@ QHash<int, QByteArray> MapLocationModel::roleNames() const
 	roles[MapLocation::Roles::RoleName] = "name";
 	roles[MapLocation::Roles::RolePixmap] = "pixmap";
 	roles[MapLocation::Roles::RoleZ] = "z";
+	roles[MapLocation::Roles::RoleIsSelected] = "isSelected";
 	return roles;
 }
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -12,10 +12,6 @@
 
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
 
-MapLocation::MapLocation() : divesite(nullptr), selected(false)
-{
-}
-
 MapLocation::MapLocation(struct dive_site *dsIn, QGeoCoordinate coordIn, QString nameIn, bool selectedIn) :
     divesite(dsIn), coordinate(coordIn), name(nameIn), selected(selectedIn)
 {

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -10,12 +10,6 @@
 #include <QDebug>
 #include <algorithm>
 
-const char *MapLocation::PROPERTY_NAME_COORDINATE = "coordinate";
-const char *MapLocation::PROPERTY_NAME_DIVESITE   = "divesite";
-const char *MapLocation::PROPERTY_NAME_NAME       = "name";
-const char *MapLocation::PROPERTY_NAME_PIXMAP     = "pixmap";
-const char *MapLocation::PROPERTY_NAME_Z          = "z";
-
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
 
 MapLocation::MapLocation() : m_ds(nullptr), m_selected(false)
@@ -87,11 +81,6 @@ QVariant MapLocation::divesiteVariant()
 
 MapLocationModel::MapLocationModel(QObject *parent) : QAbstractListModel(parent)
 {
-	m_roles[MapLocation::Roles::RoleDivesite] = MapLocation::PROPERTY_NAME_DIVESITE;
-	m_roles[MapLocation::Roles::RoleCoordinate] = MapLocation::PROPERTY_NAME_COORDINATE;
-	m_roles[MapLocation::Roles::RoleName] = MapLocation::PROPERTY_NAME_NAME;
-	m_roles[MapLocation::Roles::RolePixmap] = MapLocation::PROPERTY_NAME_PIXMAP;
-	m_roles[MapLocation::Roles::RoleZ] = MapLocation::PROPERTY_NAME_Z;
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &MapLocationModel::diveSiteChanged);
 }
 
@@ -110,7 +99,13 @@ QVariant MapLocationModel::data(const QModelIndex & index, int role) const
 
 QHash<int, QByteArray> MapLocationModel::roleNames() const
 {
-	return m_roles;
+	QHash<int, QByteArray> roles;
+	roles[MapLocation::Roles::RoleDivesite] = "divesite";
+	roles[MapLocation::Roles::RoleCoordinate] = "coordinate";
+	roles[MapLocation::Roles::RoleName] = "name";
+	roles[MapLocation::Roles::RolePixmap] = "pixmap";
+	roles[MapLocation::Roles::RoleZ] = "z";
+	return roles;
 }
 
 int MapLocationModel::rowCount(const QModelIndex&) const

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -193,14 +193,11 @@ void MapLocationModel::reload(QObject *map)
 	endResetModel();
 }
 
-void MapLocationModel::setSelected(struct dive_site *ds, bool fromClick)
+void MapLocationModel::setSelected(struct dive_site *ds)
 {
 	m_selectedDs.clear();
-	if (!ds)
-		return;
-	m_selectedDs.append(ds);
-	if (fromClick)
-		emit selectedLocationChanged(getMapLocation(ds));
+	if (ds)
+		m_selectedDs.append(ds);
 }
 
 bool MapLocationModel::isSelected(const QVariant &dsVariant) const

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -236,12 +236,6 @@ void MapLocationModel::setSelected(const QVector<dive_site *> &divesites)
 	m_selectedDs = divesites;
 }
 
-bool MapLocationModel::isSelected(const QVariant &dsVariant) const
-{
-	dive_site *ds = dsVariant.value<dive_site *>();
-	return ds && m_selectedDs.contains(ds);
-}
-
 MapLocation *MapLocationModel::getMapLocation(const struct dive_site *ds)
 {
 	MapLocation *location;

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -7,9 +7,6 @@
 #include "desktop-widgets/mapwidget.h"
 #endif
 
-#include <QDebug>
-#include <algorithm>
-
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
 
 MapLocation::MapLocation(struct dive_site *dsIn, QGeoCoordinate coordIn, QString nameIn, bool selectedIn) :

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -29,19 +29,19 @@ static bool inEditMode()
 QVariant MapLocation::getRole(int role) const
 {
 	switch (role) {
-	case Roles::RoleDivesite:
+	case RoleDivesite:
 		return QVariant::fromValue(divesite);
-	case Roles::RoleCoordinate:
+	case RoleCoordinate:
 		return QVariant::fromValue(coordinate);
-	case Roles::RoleName:
+	case RoleName:
 		return QVariant::fromValue(name);
-	case Roles::RolePixmap:
+	case RolePixmap:
 		return selected ? QString("qrc:///dive-location-marker-selected-icon") :
 		       inEditMode() ? QString("qrc:///dive-location-marker-inactive-icon") :
 				    QString("qrc:///dive-location-marker-icon");
-	case Roles::RoleZ:
+	case RoleZ:
 		return selected ? 1 : 0;
-	case Roles::RoleIsSelected:
+	case RoleIsSelected:
 		return QVariant::fromValue(selected);
 	default:
 		return QVariant();
@@ -69,12 +69,12 @@ QVariant MapLocationModel::data(const QModelIndex & index, int role) const
 QHash<int, QByteArray> MapLocationModel::roleNames() const
 {
 	QHash<int, QByteArray> roles;
-	roles[MapLocation::Roles::RoleDivesite] = "divesite";
-	roles[MapLocation::Roles::RoleCoordinate] = "coordinate";
-	roles[MapLocation::Roles::RoleName] = "name";
-	roles[MapLocation::Roles::RolePixmap] = "pixmap";
-	roles[MapLocation::Roles::RoleZ] = "z";
-	roles[MapLocation::Roles::RoleIsSelected] = "isSelected";
+	roles[MapLocation::RoleDivesite] = "divesite";
+	roles[MapLocation::RoleCoordinate] = "coordinate";
+	roles[MapLocation::RoleName] = "name";
+	roles[MapLocation::RolePixmap] = "pixmap";
+	roles[MapLocation::RoleZ] = "z";
+	roles[MapLocation::RoleIsSelected] = "isSelected";
 	return roles;
 }
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -14,6 +14,7 @@ const char *MapLocation::PROPERTY_NAME_COORDINATE = "coordinate";
 const char *MapLocation::PROPERTY_NAME_DIVESITE   = "divesite";
 const char *MapLocation::PROPERTY_NAME_NAME       = "name";
 const char *MapLocation::PROPERTY_NAME_PIXMAP     = "pixmap";
+const char *MapLocation::PROPERTY_NAME_Z          = "z";
 
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
 
@@ -51,6 +52,8 @@ QVariant MapLocation::getRole(int role) const
 		return m_selected ? QString("qrc:///dive-location-marker-selected-icon") :
 		       inEditMode() ? QString("qrc:///dive-location-marker-inactive-icon") :
 				    QString("qrc:///dive-location-marker-icon");
+	case Roles::RoleZ:
+		return m_selected ? 1 : 0;
 	default:
 		return QVariant();
 	}
@@ -88,6 +91,7 @@ MapLocationModel::MapLocationModel(QObject *parent) : QAbstractListModel(parent)
 	m_roles[MapLocation::Roles::RoleCoordinate] = MapLocation::PROPERTY_NAME_COORDINATE;
 	m_roles[MapLocation::Roles::RoleName] = MapLocation::PROPERTY_NAME_NAME;
 	m_roles[MapLocation::Roles::RolePixmap] = MapLocation::PROPERTY_NAME_PIXMAP;
+	m_roles[MapLocation::Roles::RoleZ] = MapLocation::PROPERTY_NAME_Z;
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &MapLocationModel::diveSiteChanged);
 }
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -76,11 +76,6 @@ struct dive_site *MapLocation::divesite()
 	return m_ds;
 }
 
-QVariant MapLocation::divesiteVariant()
-{
-	return QVariant::fromValue(m_ds);
-}
-
 MapLocationModel::MapLocationModel(QObject *parent) : QAbstractListModel(parent)
 {
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &MapLocationModel::diveSiteChanged);

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -18,12 +18,6 @@ class MapLocation : public QObject
 	Q_PROPERTY(QString name MEMBER m_name)
 
 public:
-	static const char *PROPERTY_NAME_COORDINATE;
-	static const char *PROPERTY_NAME_DIVESITE;
-	static const char *PROPERTY_NAME_NAME;
-	static const char *PROPERTY_NAME_PIXMAP;
-	static const char *PROPERTY_NAME_Z;
-
 	explicit MapLocation();
 	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);
 
@@ -86,7 +80,6 @@ private slots:
 
 private:
 	QVector<MapLocation *> m_mapLocations;
-	QHash<int, QByteArray> m_roles;
 	QVector<dive_site *> m_selectedDs;
 
 signals:

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -22,6 +22,7 @@ public:
 	static const char *PROPERTY_NAME_DIVESITE;
 	static const char *PROPERTY_NAME_NAME;
 	static const char *PROPERTY_NAME_PIXMAP;
+	static const char *PROPERTY_NAME_Z;
 
 	explicit MapLocation();
 	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);
@@ -37,7 +38,8 @@ public:
 		RoleDivesite = Qt::UserRole + 1,
 		RoleCoordinate,
 		RoleName,
-		RolePixmap
+		RolePixmap,
+		RoleZ
 	};
 
 private:

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -68,6 +68,7 @@ public:
 	// If map is not null, it will be used to place new dive sites without GPS location at the center of the map
 	void reload(QObject *map);
 	void selectionChanged();
+	void setSelected(const QVector<dive_site *> &divesites);
 	MapLocation *getMapLocation(const struct dive_site *ds);
 	const QVector<dive_site *> &selectedDs() const;
 	Q_INVOKABLE void setSelected(struct dive_site *ds);

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -65,7 +65,7 @@ public:
 	void reload(QObject *map);
 	MapLocation *getMapLocation(const struct dive_site *ds);
 	const QVector<dive_site *> &selectedDs() const;
-	Q_INVOKABLE void setSelected(struct dive_site *ds, bool fromClick = true);
+	Q_INVOKABLE void setSelected(struct dive_site *ds);
 	// The dive site is passed as a QVariant, because a null-QVariant is not automatically
 	// transformed into a null pointer and warning messages are spewed onto the console.
 	Q_INVOKABLE bool isSelected(const QVariant &ds) const;
@@ -83,7 +83,6 @@ private:
 
 signals:
 	void countChanged(int c);
-	void selectedLocationChanged(MapLocation *);
 };
 
 #endif

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -21,7 +21,6 @@ public:
 	QVariant getRole(int role) const;
 	QGeoCoordinate coordinate();
 	void setCoordinate(QGeoCoordinate coord);
-	void setCoordinateNoEmit(QGeoCoordinate coord);
 	struct dive_site *divesite();
 
 	enum Roles {
@@ -39,9 +38,6 @@ private:
 	QString m_name;
 public:
 	bool m_selected = false;
-
-signals:
-	void coordinateChanged();
 };
 
 class MapLocationModel : public QAbstractListModel

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -69,9 +69,6 @@ public:
 	MapLocation *getMapLocation(const struct dive_site *ds);
 	const QVector<dive_site *> &selectedDs() const;
 	Q_INVOKABLE void setSelected(struct dive_site *ds);
-	// The dive site is passed as a QVariant, because a null-QVariant is not automatically
-	// transformed into a null pointer and warning messages are spewed onto the console.
-	Q_INVOKABLE bool isSelected(const QVariant &ds) const;
 
 protected:
 	QHash<int, QByteArray> roleNames() const override;

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -10,10 +10,8 @@
 #include <QAbstractListModel>
 #include <QGeoCoordinate>
 
-class MapLocation : public QObject
+class MapLocation
 {
-	Q_OBJECT
-
 public:
 	explicit MapLocation();
 	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -13,9 +13,6 @@
 class MapLocation : public QObject
 {
 	Q_OBJECT
-	Q_PROPERTY(QVariant divesite READ divesiteVariant)
-	Q_PROPERTY(QGeoCoordinate coordinate READ coordinate WRITE setCoordinate NOTIFY coordinateChanged)
-	Q_PROPERTY(QString name MEMBER m_name)
 
 public:
 	explicit MapLocation();
@@ -25,7 +22,6 @@ public:
 	QGeoCoordinate coordinate();
 	void setCoordinate(QGeoCoordinate coord);
 	void setCoordinateNoEmit(QGeoCoordinate coord);
-	QVariant divesiteVariant();
 	struct dive_site *divesite();
 
 	enum Roles {

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -33,7 +33,8 @@ public:
 		RoleCoordinate,
 		RoleName,
 		RolePixmap,
-		RoleZ
+		RoleZ,
+		RoleIsSelected
 	};
 
 private:

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -51,7 +51,6 @@ signals:
 class MapLocationModel : public QAbstractListModel
 {
 	Q_OBJECT
-	Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
 	MapLocationModel(QObject *parent = NULL);
@@ -59,7 +58,6 @@ public:
 
 	QVariant data(const QModelIndex &index, int role) const override;
 	int rowCount(const QModelIndex &parent) const override;
-	int count();
 	void add(MapLocation *);
 	// If map is not null, it will be used to place new dive sites without GPS location at the center of the map
 	void reload(QObject *map);
@@ -78,9 +76,6 @@ private slots:
 private:
 	QVector<MapLocation *> m_mapLocations;
 	QVector<dive_site *> m_selectedDs;
-
-signals:
-	void countChanged(int c);
 };
 
 #endif

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -67,6 +67,7 @@ public:
 	void add(MapLocation *);
 	// If map is not null, it will be used to place new dive sites without GPS location at the center of the map
 	void reload(QObject *map);
+	void selectionChanged();
 	MapLocation *getMapLocation(const struct dive_site *ds);
 	const QVector<dive_site *> &selectedDs() const;
 	Q_INVOKABLE void setSelected(struct dive_site *ds);

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -21,9 +21,10 @@ public:
 	static const char *PROPERTY_NAME_COORDINATE;
 	static const char *PROPERTY_NAME_DIVESITE;
 	static const char *PROPERTY_NAME_NAME;
+	static const char *PROPERTY_NAME_PIXMAP;
 
 	explicit MapLocation();
-	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name);
+	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);
 
 	QVariant getRole(int role) const;
 	QGeoCoordinate coordinate();
@@ -35,13 +36,16 @@ public:
 	enum Roles {
 		RoleDivesite = Qt::UserRole + 1,
 		RoleCoordinate,
-		RoleName
+		RoleName,
+		RolePixmap
 	};
 
 private:
 	struct dive_site *m_ds;
 	QGeoCoordinate m_coordinate;
 	QString m_name;
+public:
+	bool m_selected = false;
 
 signals:
 	void coordinateChanged();

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -57,7 +57,6 @@ public:
 	MapLocationModel(QObject *parent = NULL);
 	~MapLocationModel();
 
-	Q_INVOKABLE MapLocation *get(int row);
 	QVariant data(const QModelIndex &index, int role) const override;
 	int rowCount(const QModelIndex &parent) const override;
 	int count();

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -19,9 +19,6 @@ public:
 	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);
 
 	QVariant getRole(int role) const;
-	QGeoCoordinate coordinate();
-	void setCoordinate(QGeoCoordinate coord);
-	struct dive_site *divesite();
 
 	enum Roles {
 		RoleDivesite = Qt::UserRole + 1,
@@ -32,12 +29,10 @@ public:
 		RoleIsSelected
 	};
 
-private:
-	struct dive_site *m_ds;
-	QGeoCoordinate m_coordinate;
-	QString m_name;
-public:
-	bool m_selected = false;
+	struct dive_site *divesite;
+	QGeoCoordinate coordinate;
+	QString name;
+	bool selected = false;
 };
 
 class MapLocationModel : public QAbstractListModel

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -13,7 +13,6 @@
 class MapLocation
 {
 public:
-	explicit MapLocation();
 	explicit MapLocation(struct dive_site *ds, QGeoCoordinate coord, QString name, bool selected);
 
 	QVariant getRole(int role) const;
@@ -30,7 +29,7 @@ public:
 	struct dive_site *divesite;
 	QGeoCoordinate coordinate;
 	QString name;
-	bool selected = false;
+	bool selected;
 };
 
 class MapLocationModel : public QAbstractListModel

--- a/qt-models/maplocationmodel.h
+++ b/qt-models/maplocationmodel.h
@@ -68,7 +68,7 @@ public:
 	void setSelected(const QVector<dive_site *> &divesites);
 	MapLocation *getMapLocation(const struct dive_site *ds);
 	const QVector<dive_site *> &selectedDs() const;
-	Q_INVOKABLE void setSelected(struct dive_site *ds);
+	void setSelected(struct dive_site *ds);
 
 protected:
 	QHash<int, QByteArray> roleNames() const override;

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -164,6 +164,5 @@ void register_qml_types(QQmlEngine *engine)
 
 	REGISTER_TYPE(MapWidgetHelper, "MapWidgetHelper");
 	REGISTER_TYPE(MapLocationModel, "MapLocationModel");
-	REGISTER_TYPE(MapLocation, "MapLocation");
 #endif // not SUBSURFACE_TEST_DATA
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at fixing the crashes when clicking on a dive site with Qt 5.9. The thing is to not reset the model, which apparently trashes Qt's internal state, but posting a dataChanged() signal.

Notes:
1) I detest the code that I have written here - but let's be pragmatic for now.
2) Currently this makes editing of dive sites impossible - I will have to check that out.
3) I still have to look at mobile - I'm certain that this will be messed up as well.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
See commit messages.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Hopefully fixes #2248
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@Saviq: FYI