### PR TITLE
[WIP] Make disclaimer removal work again

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -35,7 +35,6 @@ static int decostoplevels_imperial[] = { 0, 3048, 6096, 9144, 12192, 15240, 1828
 					182880, 193040, 203200, 223520, 243840, 264160, 284480, 304800,
 					325120, 345440, 365760, 386080 };
 
-char *disclaimer;
 #if DEBUG_PLAN
 void dump_plan(struct diveplan *diveplan)
 {

--- a/core/planner.h
+++ b/core/planner.h
@@ -56,7 +56,6 @@ extern char *get_planner_disclaimer_formatted();
 extern void free_dps(struct diveplan *diveplan);
 extern struct dive *planned_dive;
 extern char *cache_data;
-extern char *disclaimer;
 
 struct divedatapoint *plan_add_segment(struct diveplan *diveplan, int duration, int depth, int cylinderid, int po2, bool entered, enum divemode_t divemode);
 struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po2);

--- a/core/planner.h
+++ b/core/planner.h
@@ -50,6 +50,7 @@ extern int get_cylinderid_at_time(struct dive *dive, struct divecomputer *dc, du
 extern int get_gasidx(struct dive *dive, struct gasmix mix);
 extern bool diveplan_empty(struct diveplan *diveplan);
 extern void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error);
+extern const char *get_planner_disclaimer();
 
 extern void free_dps(struct diveplan *diveplan);
 extern struct dive *planned_dive;

--- a/core/planner.h
+++ b/core/planner.h
@@ -51,6 +51,7 @@ extern int get_gasidx(struct dive *dive, struct gasmix mix);
 extern bool diveplan_empty(struct diveplan *diveplan);
 extern void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error);
 extern const char *get_planner_disclaimer();
+extern char *get_planner_disclaimer_formatted();
 
 extern void free_dps(struct diveplan *diveplan);
 extern struct dive *planned_dive;

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -82,11 +82,21 @@ const char *get_planner_disclaimer()
 			 "PLAN DIVES SIMPLY BASED ON THE RESULTS GIVEN HERE.");
 }
 
+/* Returns newly allocated buffer. Must be freed by caller */
+char *get_planner_disclaimer_formatted()
+{
+	struct membuffer buf = { 0 };
+	const char *deco = decoMode() == VPMB ? translate("gettextFromC", "VPM-B")
+					      : translate("gettextFromC", "BUHLMANN");
+	put_format(&buf, get_planner_disclaimer(), deco);
+	return detach_buffer(&buf);
+}
+
 void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error)
 {
 	struct membuffer buf = { 0 };
 	struct membuffer icdbuf = { 0 };
-	const char *deco, *segmentsymbol;
+	const char *segmentsymbol;
 	int lastdepth = 0, lasttime = 0, lastsetpoint = -1, newdepth = 0, lastprintdepth = 0, lastprintsetpoint = -1;
 	struct gasmix lastprintgasmix = gasmix_invalid;
 	struct divedatapoint *dp = diveplan->dp;
@@ -106,12 +116,6 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	struct icd_data icdvalues;
 	char *temp;
 
-	if (decoMode() == VPMB) {
-		deco = translate("gettextFromC", "VPM-B");
-	} else {
-		deco = translate("gettextFromC", "BUHLMANN");
-	}
-
 	if (!dp)
 		return;
 
@@ -123,9 +127,11 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	}
 
 	if (show_disclaimer) {
+		char *disclaimer = get_planner_disclaimer_formatted();
 		put_string(&buf, "<div><b>");
-		put_format(&buf, get_planner_disclaimer(), deco);
+		put_string(&buf, disclaimer);
 		put_string(&buf, "</b><br></div>");
+		free(disclaimer);
 	}
 
 	if (diveplan->surface_interval < 0) {

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -74,6 +74,14 @@ static void add_icd_entry(struct membuffer *b, struct icd_data *icdvalues, bool 
 		ambientpressure_mbar * -icdvalues->dHe / 5e6f, translate("gettextFromC", "bar"));
 }
 
+const char *get_planner_disclaimer()
+{
+	return translate("gettextFromC", "DISCLAIMER / WARNING: THIS IMPLEMENTATION OF THE %s "
+			 "ALGORITHM AND A DIVE PLANNER IMPLEMENTATION BASED ON THAT HAS "
+			 "RECEIVED ONLY A LIMITED AMOUNT OF TESTING. WE STRONGLY RECOMMEND NOT TO "
+			 "PLAN DIVES SIMPLY BASED ON THE RESULTS GIVEN HERE.");
+}
+
 void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error)
 {
 	struct membuffer buf = { 0 };
@@ -116,10 +124,7 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 
 	if (show_disclaimer) {
 		put_string(&buf, "<div><b>");
-		put_format(&buf, translate("gettextFromC", "DISCLAIMER / WARNING: THIS IMPLEMENTATION OF THE %s "
-			"ALGORITHM AND A DIVE PLANNER IMPLEMENTATION BASED ON THAT HAS "
-			"RECEIVED ONLY A LIMITED AMOUNT OF TESTING. WE STRONGLY RECOMMEND NOT TO "
-			"PLAN DIVES SIMPLY BASED ON THE RESULTS GIVEN HERE."), deco);
+		put_format(&buf, get_planner_disclaimer(), deco);
 		put_string(&buf, "</b><br></div>");
 	}
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -850,8 +850,10 @@ void MainWindow::updateVariations(QString variations)
 void MainWindow::printPlan()
 {
 #ifndef NO_PRINTING
-	QString diveplan = plannerDetails->divePlanOutput()->toHtml();
-	QString withDisclaimer = QString("<img height=50 src=\":subsurface-icon\"> ") + diveplan + QString(disclaimer);
+	char *disclaimer = get_planner_disclaimer_formatted();
+	QString diveplan = QStringLiteral("<img height=50 src=\":subsurface-icon\"> ") +
+			   QString(disclaimer) + plannerDetails->divePlanOutput()->toHtml();
+	free(disclaimer);
 
 	QPrinter printer;
 	QPrintDialog *dialog = new QPrintDialog(&printer, this);
@@ -885,9 +887,9 @@ void MainWindow::printPlan()
 	QBuffer buffer(&byteArray);
 	pixmap.save(&buffer, "PNG");
 	QString profileImage = QString("<img src=\"data:image/png;base64,") + byteArray.toBase64() + "\"/><br><br>";
-	withDisclaimer = profileImage + withDisclaimer;
+	diveplan = profileImage + diveplan;
 
-	plannerDetails->divePlanOutput()->setHtml(withDisclaimer);
+	plannerDetails->divePlanOutput()->setHtml(diveplan);
 	plannerDetails->divePlanOutput()->print(&printer);
 	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
 #endif

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1127,11 +1127,24 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		QTextDocument notesDocument;
 		notesDocument.setHtml(current_dive->notes);
 		QString oldnotes(notesDocument.toPlainText());
-		int disclaimerPosition = oldnotes.indexOf(disclaimer);
-		if (disclaimerPosition == 0)
-			oldnotes.clear();
-		else if (disclaimerPosition >= 1)
-			oldnotes.truncate(disclaimerPosition-1);
+		QString disclaimer = get_planner_disclaimer();
+		int disclaimerMid = disclaimer.indexOf("%s");
+		QString disclaimerBegin, disclaimerEnd;
+		if (disclaimerMid >= 0) {
+			disclaimerBegin = disclaimer.left(disclaimerMid);
+			disclaimerEnd = disclaimer.mid(disclaimerMid + 2);
+		} else {
+			disclaimerBegin = disclaimer;
+		}
+		int disclaimerPositionStart = oldnotes.indexOf(disclaimerBegin);
+		if (disclaimerPositionStart >= 0) {
+			if (oldnotes.indexOf(disclaimerEnd, disclaimerPositionStart) >= 0) {
+				// We found a disclaimer according to the current locale.
+				// Remove the disclaimer and anything after the disclaimer, because
+				// that's supposedly the old planner notes.
+				oldnotes = oldnotes.left(disclaimerPositionStart);
+			}
+		}
 		// Deal with line breaks
 		oldnotes.replace("\n", "<br>");
 		oldnotes.append(displayed_dive.notes);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
There was code that removed the old disclaimer from the planner notes. The functionality was unintentionally removed. Reinstate it, but instead of using a global variable with the recently generated disclaimer be smarter and recognize disclaimers with different deco models.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Reinstate removal of dislaimer
2) Remove global variable
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2264
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do once finished.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79: Please check this out. It is different from the old code as it only removes the disclaimer, not the whole thing. You know best what to do, so feel free to adapt.