### PR TITLE
Dive site: close dive site edit widget when dive site is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Desktop: close dive site widget if dive site is removed by undo
 - Desktop: Don't destroy format of planner notes when editing dive notes [#2265]
 - Map: avoid full map reload when clicking on flag
 - Map: highlight all selected dive sites when clicking on flag

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -34,6 +34,7 @@ public slots:
 private slots:
 	void updateLabels();
 	void diveSiteChanged(struct dive_site *ds, int field);
+	void diveSiteDeleted(struct dive_site *ds, int);
 	void unitsChanged();
 private:
 	void keyPressEvent(QKeyEvent *e) override;


### PR DESCRIPTION
The application could be crashed by
1) Create dive site
2) Edit dive site
3) Undo until dive site is removed
4) Continue editing now non-existing dive site

Therefore, hook into the dive-site-deleted signal and if the
currently edited dive site is deleted, close the widget.

When closing the widget, make sure that the potentially
dangling pointer is reset to zero so that there is no
other potential use-after-free bug.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes an easily reproducible crash-condition, where the user could edit a dive site. It survived a small test, so fingers crossed.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Close dive-site-edit widget if currently edited dive site is deleted.
2) Reset pointer-to-dive-site when closing the widget, just in case.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: might be good for 4.9.3. At least it shouldn't make things worse!