### PR TITLE
[RFC] Planner: When re-planning a dive update old dive and display correctly

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -9,6 +9,7 @@
 #include "core/divelist.h" // for mark_divelist_changed()
 #include "core/settings/qPrefDivePlanner.h"
 #include "desktop-widgets/command.h"
+#include "desktop-widgets/mainwindow.h"
 #include "core/gettextfromc.h"
 #include "core/deco.h"
 #include <QApplication>
@@ -1154,8 +1155,13 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		Command::addDive(&displayed_dive, false, false);
 	} else {
 		// we were planning an old dive and rewrite the plan
-		mark_divelist_changed(true);
+		displayed_dive.maxdepth.mm = 0;
+		displayed_dive.dc.maxdepth.mm = 0;
+		fixup_dive(&displayed_dive);
 		copy_dive(&displayed_dive, current_dive);
+		mark_divelist_changed(true);
+		emit updateDiveInfo();
+		MainWindow::instance()->refreshDisplay();
 	}
 
 	// Remove and clean the diveplan, so we don't delete

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -111,6 +111,7 @@ signals:
 	void recreationChanged(bool);
 	void calculatedPlanNotes();
 	void variationsComputed(QString);
+	void updateDiveInfo();
 
 private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When editing an existing dive in the planner and after some updates
overwrite the existing dive by pressing "Save" the old dive is
"re-planned".
When doing this, update the old dive correctly and also update the
display of the main window.

Proposal to fix #2280 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2280 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @atdotde 