### PR TITLE
Mobile: don't pass string-encoded trip pointers through QML

### DIFF
--- a/core/trip.c
+++ b/core/trip.c
@@ -122,7 +122,9 @@ void remove_dive_from_trip(struct dive *dive, struct trip_table *trip_table_arg)
 
 dive_trip_t *alloc_trip(void)
 {
-	return calloc(1, sizeof(dive_trip_t));
+	dive_trip_t *res = calloc(1, sizeof(dive_trip_t));
+	res->id = dive_getUniqID();
+	return res;
 }
 
 /* insert the trip into the trip table */

--- a/core/trip.h
+++ b/core/trip.h
@@ -13,6 +13,7 @@ typedef struct dive_trip
 	char *location;
 	char *notes;
 	struct dive_table dives;
+	int id; /* unique ID for this trip: used to pass trips through QML. */
 	/* Used by the io-routines to mark trips that have already been written. */
 	bool saved;
 	bool autogen;

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -353,8 +353,7 @@ Kirigami.ScrollablePage {
 					}
 					Controls.Label {
 						text: {
-							var trip = diveListView.model.tripIdToObject(section);
-							diveListView.model.tripShortDate(trip);
+							diveListView.model.tripShortDate(section)
 						}
 						color: subsurfaceTheme.primaryTextColor
 						font.pointSize: subsurfaceTheme.smallPointSize
@@ -379,8 +378,7 @@ Kirigami.ScrollablePage {
 				Controls.Label {
 					id: sectionText
 					text: {
-						var trip = diveListView.model.tripIdToObject(section);
-						diveListView.model.tripTitle(trip);
+						diveListView.model.tripTitle(section)
 					}
 					wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 					visible: text !== ""

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -79,26 +79,26 @@ void DiveListSortModel::reload()
 // In QtQuick ListView, section headings can only be strings. To identify dives
 // that belong to the same trip, a string containing the trip-id is passed in.
 // To format the trip heading, the string is then converted back with this function.
-QVariant DiveListSortModel::tripIdToObject(const QString &s)
+static dive_trip *tripIdToObject(const QString &s)
 {
 	if (s.isEmpty())
-		return QVariant();
+		return nullptr;
 	int id = s.toInt();
 	dive_trip **trip = std::find_if(&trip_table.trips[0], &trip_table.trips[trip_table.nr],
 				        [id] (const dive_trip *t) { return t->id == id; });
 	if (trip == &trip_table.trips[trip_table.nr]) {
 		fprintf(stderr, "Warning: unknown trip id passed through QML: %d\n", id);
-		return QVariant();
+		return nullptr;
 	}
-	return QVariant::fromValue(*trip);
+	return *trip;
 }
 
 // the trip title is designed to be location (# dives)
 // or, if there is no location name date range (# dives)
 // where the date range is given as "month year" or "month-month year" or "month year - month year"
-QString DiveListSortModel::tripTitle(const QVariant &tripIn)
+QString DiveListSortModel::tripTitle(const QString &section)
 {
-	dive_trip *dt = tripIn.value<dive_trip *>();
+	const dive_trip *dt = tripIdToObject(section);
 	if (!dt)
 		return QString();
 	QString numDives = tr("(%n dive(s))", "", dt->dives.nr);
@@ -124,9 +124,9 @@ QString DiveListSortModel::tripTitle(const QVariant &tripIn)
 	return QStringLiteral("%1 %2%3").arg(title, numDives, shownDives);
 }
 
-QString DiveListSortModel::tripShortDate(const QVariant &tripIn)
+QString DiveListSortModel::tripShortDate(const QString &section)
 {
-	dive_trip *dt = tripIn.value<dive_trip *>();
+	const dive_trip *dt = tripIdToObject(section);
 	if (!dt)
 		return QString();
 	QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -14,9 +14,8 @@ public:
 	DiveListSortModel(QObject *parent = 0);
 	void setSourceModel(QAbstractItemModel *sourceModel);
 	Q_INVOKABLE void reload();
-	Q_INVOKABLE QVariant tripIdToObject(const QString &s);
-	Q_INVOKABLE QString tripTitle(const QVariant &trip);
-	Q_INVOKABLE QString tripShortDate(const QVariant &trip);
+	Q_INVOKABLE QString tripTitle(const QString &trip);
+	Q_INVOKABLE QString tripShortDate(const QString &trip);
 public slots:
 	int getIdxForId(int id);
 	void setFilter(QString f);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a desperate attempt at fixing #2224. I doubt that it will do so, but it should make the code more robust. At least we will be sure that there are no stale pointers flying around. If the crash still happens, we have confirmation of data corruption of the core structures.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add a unique id to trips.
2) Pass unique ids instead of pointers through QML.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 