### PR TITLE
If only one dive selected, only one temperature in stats tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -69,8 +69,10 @@ void TabDiveStatistics::updateData()
 	else
 		ui->sacLimits->setAverage("");
 
-	ui->tempLimits->setMaximum(get_temperature_string(stats_selection.max_temp, true));
-	ui->tempLimits->setMinimum(get_temperature_string(stats_selection.min_temp, true));
+	if (stats_selection.combined_count > 1){
+		ui->tempLimits->setMaximum(get_temperature_string(stats_selection.max_temp, true));
+		ui->tempLimits->setMinimum(get_temperature_string(stats_selection.min_temp, true));
+	}
 	if (stats_selection.combined_temp.mkelvin && stats_selection.combined_count) {
 		temperature_t avg_temp;
 		avg_temp.mkelvin = stats_selection.combined_temp.mkelvin / stats_selection.combined_count;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In stats tab, when only one dive is selected,
on one stat, only average is shown, except temperature which
3 same temps for max, min and avg are shown.

### Changes made:
Check if combined_count is more than one to show max/min temp

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
