### PR TITLE
if only one dive, max depth show in average field

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -47,13 +47,14 @@ void TabDiveStatistics::updateData()
 	stats_t stats_selection;
 	calculate_stats_selected(&stats_selection);
 	clear();
-	ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true));
 	if (amount_selected > 1) {
+		ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true));
 		ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true));
 		ui->depthLimits->setAverage(get_depth_string(stats_selection.combined_max_depth.mm / stats_selection.selection_size, true));
 	} else {
+		ui->depthLimits->setMaximum("");
 		ui->depthLimits->setMinimum("");
-		ui->depthLimits->setAverage("");
+		ui->depthLimits->setAverage(get_depth_string(stats_selection.max_depth, true));
 	}
 
 	if (stats_selection.max_sac.mliter && (stats_selection.max_sac.mliter != stats_selection.avg_sac.mliter))


### PR DESCRIPTION
Signed-off-by: Fabio Rueda <avances123@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
To be coherent with the other statistics, when only one dive is selected, every data is show in the Avg section, max depth was been shown in Max field whit only one dive

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
https://github.com/Subsurface-divelog/subsurface/pull/2289

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
