### PR TITLE
Cleanup: Unify code for idiosyncratic singletons

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -15,7 +15,6 @@ extern QMap<QString, dc_descriptor_t *> descriptorLookup;
 namespace {
 	QHash<QString, QBluetoothDeviceInfo> btDeviceInfo;
 }
-BTDiscovery *BTDiscovery::m_instance = NULL;
 
 static dc_descriptor_t *getDeviceType(QString btName)
 // central function to convert a BT name to a Subsurface known vendor/model pair
@@ -139,11 +138,6 @@ BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
 	m_showNonDiveComputers(false),
 	discoveryAgent(nullptr)
 {
-	if (m_instance) {
-		qDebug() << "trying to create an additional BTDiscovery object";
-		return;
-	}
-	m_instance = this;
 #if defined(BT_SUPPORT)
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 	BTDiscoveryReDiscover();
@@ -202,17 +196,9 @@ void BTDiscovery::BTDiscoveryReDiscover()
 
 BTDiscovery::~BTDiscovery()
 {
-	m_instance = NULL;
 #if defined(BT_SUPPORT)
 	delete discoveryAgent;
 #endif
-}
-
-BTDiscovery *BTDiscovery::instance()
-{
-	if (!m_instance)
-		m_instance = new BTDiscovery();
-	return m_instance;
 }
 
 #if defined(BT_SUPPORT)

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -10,6 +10,7 @@
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothUuid>
 #include "core/libdivecomputer.h"
+#include "core/singleton.h"
 
 #if defined(Q_OS_ANDROID)
 #include <QAndroidJniObject>
@@ -23,13 +24,12 @@ QString extractBluetoothAddress(const QString &address);
 QString extractBluetoothNameAddress(const QString &address, QString &name);
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr);
 
-class BTDiscovery : public QObject {
+class BTDiscovery : public QObject, public SillySingleton<BTDiscovery> {
 	Q_OBJECT
 
 public:
 	BTDiscovery(QObject *parent = NULL);
 	~BTDiscovery();
-	static BTDiscovery *instance();
 
 	struct btPairedDevice {
 		QString address;
@@ -57,7 +57,6 @@ public:
 	void discoverAddress(QString address);
 
 private:
-	static BTDiscovery *m_instance;
 	bool m_btValid;
 	bool m_showNonDiveComputers;
 

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -44,11 +44,6 @@ GpsLocation *GpsLocation::instance()
 	return m_Instance;
 }
 
-bool GpsLocation::hasInstance()
-{
-	return m_Instance != NULL;
-}
-
 GpsLocation::~GpsLocation()
 {
 	m_Instance = NULL;

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -15,16 +15,12 @@
 #include <QApplication>
 #include <QTimer>
 
-GpsLocation *GpsLocation::m_Instance = NULL;
-
 GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 	QObject(parent),
 	m_GpsSource(0),
 	waitingForPosition(false),
 	haveSource(UNKNOWN)
 {
-	Q_ASSERT_X(m_Instance == NULL, "GpsLocation", "GpsLocation recreated");
-	m_Instance = this;
 	showMessageCB = showMsgCB;
 	// create a QSettings object that's separate from the main application settings
 	geoSettings = new QSettings(QSettings::NativeFormat, QSettings::UserScope,
@@ -35,18 +31,6 @@ GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 
 	// register changes in time threshold
 	connect(qPrefLocationService::instance(), SIGNAL(time_thresholdChanged(int)), this, SLOT(setGpsTimeThreshold(int)));
-}
-
-GpsLocation *GpsLocation::instance()
-{
-	Q_ASSERT(m_Instance != NULL);
-
-	return m_Instance;
-}
-
-GpsLocation::~GpsLocation()
-{
-	m_Instance = NULL;
 }
 
 void GpsLocation::setGpsTimeThreshold(int seconds)

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -26,7 +26,6 @@ public:
 	GpsLocation(void (*showMsgCB)(const char *msg), QObject *parent);
 	~GpsLocation();
 	static GpsLocation *instance();
-	static bool hasInstance();
 	bool applyLocations();
 	int getGpsNum() const;
 	bool hasLocationsSource();

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -24,8 +24,6 @@ class GpsLocation : public QObject {
 	Q_OBJECT
 public:
 	GpsLocation(void (*showMsgCB)(const char *msg), QObject *parent);
-	~GpsLocation();
-	static GpsLocation *instance();
 	bool applyLocations();
 	int getGpsNum() const;
 	bool hasLocationsSource();
@@ -42,7 +40,6 @@ private:
 	QNetworkReply *reply;
 	QString userAgent;
 	void (*showMessageCB)(const char *msg);
-	static GpsLocation *m_Instance;
 	bool waitingForPosition;
 	QMap<qint64, gpsTracker> m_trackers;
 	QList<gpsTracker> m_deletedTrackers;

--- a/core/singleton.h
+++ b/core/singleton.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * We use singletons in numerous places. In combination with QML this gives
+ * us a very fundamental problem, because QML likes to allocate objects by
+ * itself. There are known workarounds, but currently we use idiosyncratic
+ * singleton classes, which initialize the global instance pointer in the
+ * constructor. Things get even more complicated if the same singleton is used
+ * on mobile and on desktop. The latter might want to simply use the classical
+ * instance() function without having to initialize the singleton first, as
+ * that would beat the purpose of the instance() method.
+ *
+ * The template defined here, SillySingleton, codifies all this. Simply derive
+ * a class from this template:
+ *	class X : public SillySingleton<X> {
+ *		...
+ *	};
+ * This will generate an instance() method. This will do the right thing for
+ * both methods: explicit construction of the singleton via new or implicit
+ * by calling the instance() method. It will also generate warnings if a
+ * singleton class is generated more than once (i.e. first instance() is called
+ * and _then_ new).
+ *
+ * In the long run we should get rid of all users of this class.
+ */
+#ifndef SINGLETON_H
+#define SINGLETON_H
+
+#include <typeinfo>
+#include <QtGlobal>
+
+// 1) Declaration
+template<typename T>
+class SillySingleton {
+	static T *self;
+protected:
+	SillySingleton();
+	~SillySingleton();
+public:
+	static T *instance();
+};
+
+template<typename T>
+T *SillySingleton<T>::self = nullptr;
+
+// 2) Implementation
+
+template<typename T>
+SillySingleton<T>::SillySingleton()
+{
+	if (self)
+		qWarning("Generating second instance of singleton %s", typeid(T).name());
+	self = static_cast<T *>(this);
+	qDebug("Generated singleton %s", typeid(T).name());
+}
+
+template<typename T>
+SillySingleton<T>::~SillySingleton()
+{
+	if (self == this)
+		self = nullptr;
+	else
+		qWarning("Destroying unknown instance of singleton %s", typeid(T).name());
+	qDebug("Destroyed singleton %s", typeid(T).name());
+}
+
+template<typename T>
+T *SillySingleton<T>::instance()
+{
+	if (!self)
+		new T;
+	return self;
+}
+
+#endif

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -109,8 +109,6 @@ extern "C" int updateProgress(const char *text)
 	return progressDialogCanceled;
 }
 
-MainWindow *MainWindow::m_Instance = nullptr;
-
 extern "C" void showErrorFromC(char *buf)
 {
 	QString error(buf);
@@ -128,8 +126,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	survey(nullptr),
 	findMovedImagesDialog(nullptr)
 {
-	Q_ASSERT_X(m_Instance == NULL, "MainWindow", "MainWindow recreated!");
-	m_Instance = this;
 	ui.setupUi(this);
 	read_hashes();
 	Command::init();
@@ -357,7 +353,6 @@ MainWindow::MainWindow() : QMainWindow(),
 MainWindow::~MainWindow()
 {
 	write_hashes();
-	m_Instance = nullptr;
 }
 
 void MainWindow::setupSocialNetworkMenu()
@@ -396,11 +391,6 @@ void MainWindow::setDefaultState()
 	setApplicationState(ApplicationState::Default);
 	if (mainTab->isEditing())
 		ui.bottomLeft->currentWidget()->setEnabled(false);
-}
-
-MainWindow *MainWindow::instance()
-{
-	return m_Instance;
 }
 
 // This gets called after one or more dives were added, edited or downloaded for a dive computer

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -21,6 +21,7 @@
 #include "desktop-widgets/filterwidget2.h"
 #include "core/applicationstate.h"
 #include "core/gpslocation.h"
+#include "core/singleton.h"
 
 #define NUM_RECENT_FILES 4
 
@@ -42,7 +43,7 @@ class LocationInformationWidget;
 typedef std::pair<QByteArray, QVariant> WidgetProperty;
 typedef QVector<WidgetProperty> PropertyList;
 
-class MainWindow : public QMainWindow {
+class MainWindow : public QMainWindow, public SillySingleton<MainWindow> {
 	Q_OBJECT
 public:
 	enum {
@@ -61,7 +62,6 @@ public:
 
 	MainWindow();
 	~MainWindow();
-	static MainWindow *instance();
 	void loadRecentFiles();
 	void updateRecentFiles();
 	void updateRecentFilesMenu();
@@ -193,7 +193,6 @@ private:
 	QString filter_open();
 	QString filter_import();
 	QString filter_import_dive_sites();
-	static MainWindow *m_Instance;
 	QString displayedFilename(QString fullFilename);
 	bool askSaveChanges();
 	bool okToClose(QString message);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1556,7 +1556,7 @@ void QMLManager::applyGpsData()
 void QMLManager::populateGpsData()
 {
 	if (GpsListModel::instance())
-		GpsListModel::instance()->update();
+		GpsListModel::instance()->update(QVector<gpsTracker>::fromList(locationProvider->currentGPSInfo().values()));
 }
 
 void QMLManager::clearGpsData()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -44,7 +44,6 @@
 #include "core/settings/qPrefUnit.h"
 #include "core/trip.h"
 
-QMLManager *QMLManager::m_instance = NULL;
 bool noCloudToCloud = false;
 
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
@@ -150,7 +149,6 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_showNonDiveComputers(false)
 {
 	LOG_STP("qmlmgr starting");
-	m_instance = this;
 	m_lastDevicePixelRatio = qApp->devicePixelRatio();
 	timer.start();
 	connect(qobject_cast<QApplication *>(QApplication::instance()), &QApplication::applicationStateChanged, this, &QMLManager::applicationStateChanged);
@@ -451,12 +449,6 @@ QMLManager::~QMLManager()
 	if (appLogFileOpen)
 		appLogFile.close();
 #endif
-	m_instance = NULL;
-}
-
-QMLManager *QMLManager::instance()
-{
-	return m_instance;
 }
 
 #define CLOUDURL QString(prefs.cloud_base_url)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -13,13 +13,14 @@
 #include "core/btdiscovery.h"
 #include "core/gpslocation.h"
 #include "core/downloadfromdcthread.h"
+#include "core/singleton.h"
 #include "qt-models/divelistmodel.h"
 #include "qt-models/completionmodels.h"
 #include "qt-models/divelocationmodel.h"
 
 #define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
 
-class QMLManager : public QObject {
+class QMLManager : public QObject, public SillySingleton<QMLManager> {
 	Q_OBJECT
 	Q_PROPERTY(QString logText READ logText WRITE setLogText NOTIFY logTextChanged)
 	Q_PROPERTY(bool locationServiceEnabled MEMBER m_locationServiceEnabled WRITE setLocationServiceEnabled NOTIFY locationServiceEnabledChanged)
@@ -89,7 +90,6 @@ public:
 	Q_INVOKABLE void setGitLocalOnly(const bool &value);
 	Q_INVOKABLE void setFilter(const QString filterText);
 
-	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);
 	QString consumeError();
 
@@ -219,7 +219,6 @@ private:
 	bool m_verboseEnabled;
 	GpsLocation *locationProvider;
 	bool m_loadFromCloud;
-	static QMLManager *m_instance;
 	struct dive *deletedDive;
 	struct dive_trip *deletedTrip;
 	QString m_notificationText;

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -8,29 +8,12 @@
 
 
 /*** Global and constructors ***/
-QMLPrefs *QMLPrefs::m_instance = NULL;
-
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_showPin(false)
 {
-	// This strange construct is needed because QMLEngine calls new and that
-	// cannot be overwritten
-	if (!m_instance)
-		m_instance = this;
 }
-
-QMLPrefs::~QMLPrefs()
-{
-	m_instance = NULL;
-}
-
-QMLPrefs *QMLPrefs::instance()
-{
-	return m_instance;
-}
-
 
 /*** public functions ***/
 const QString QMLPrefs::cloudPassword() const

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -5,9 +5,9 @@
 #include <QObject>
 #include "core/settings/qPrefCloudStorage.h"
 #include "core/settings/qPrefDisplay.h"
+#include "core/singleton.h"
 
-
-class QMLPrefs : public QObject {
+class QMLPrefs : public QObject, public SillySingleton<QMLPrefs> {
 	Q_OBJECT
 	Q_PROPERTY(QString cloudPassword
 				MEMBER m_cloudPassword
@@ -35,9 +35,6 @@ class QMLPrefs : public QObject {
 				NOTIFY oldStatusChanged)
 public:
 	QMLPrefs();
-	~QMLPrefs();
-
-	static QMLPrefs *instance();
 
 	const QString cloudPassword() const;
 	void setCloudPassword(const QString &cloudPassword);
@@ -66,7 +63,6 @@ private:
 	QString m_cloudPin;
 	QString m_cloudUserName;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
-	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
 	bool m_showPin;
 

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -134,11 +134,8 @@ QString DiveListSortModel::tripShortDate(const QString &section)
 	return QStringLiteral("%1\n'%2").arg(firstMonth,firstTime.toString("yy"));
 }
 
-DiveListModel *DiveListModel::m_instance = NULL;
-
 DiveListModel::DiveListModel(QObject *parent) : QAbstractListModel(parent)
 {
-	m_instance = this;
 }
 
 void DiveListModel::insertDive(int i)
@@ -272,11 +269,6 @@ QString DiveListModel::startAddDive()
 	append_dive(d);
 	insertDive(get_idx_by_uniq_id(d->id));
 	return QString::number(d->id);
-}
-
-DiveListModel *DiveListModel::instance()
-{
-	return m_instance;
 }
 
 struct dive *DiveListModel::getDive(int i)

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -6,6 +6,7 @@
 #include <QSortFilterProxyModel>
 
 #include "core/subsurface-qt/DiveObjectHelper.h"
+#include "core/singleton.h"
 
 class DiveListSortModel : public QSortFilterProxyModel
 {
@@ -28,7 +29,7 @@ private:
 	void updateFilterState();
 };
 
-class DiveListModel : public QAbstractListModel
+class DiveListModel : public QAbstractListModel, public SillySingleton<DiveListModel>
 {
 	Q_OBJECT
 public:
@@ -45,7 +46,6 @@ public:
 		DepthDurationRole,
 	};
 
-	static DiveListModel *instance();
 	DiveListModel(QObject *parent = 0);
 	void addDive(const QList<dive *> &listOfDives);
 	void addAllDives();
@@ -63,8 +63,6 @@ public:
 	QString startAddDive();
 	void resetInternalData();
 	Q_INVOKABLE DiveObjectHelper at(int i);
-private:
-	static DiveListModel *m_instance;
 };
 
 #endif // DIVELISTMODEL_H

--- a/qt-models/gpslistmodel.cpp
+++ b/qt-models/gpslistmodel.cpp
@@ -7,9 +7,8 @@ GpsListModel::GpsListModel(QObject *parent) : QAbstractListModel(parent)
 {
 }
 
-void GpsListModel::update()
+void GpsListModel::update(QVector<gpsTracker> trackers)
 {
-	QVector<gpsTracker> trackers = QVector<gpsTracker>::fromList(GpsLocation::instance()->currentGPSInfo().values());
 	beginResetModel();
 	m_gpsFixes = trackers;
 	endResetModel();

--- a/qt-models/gpslistmodel.cpp
+++ b/qt-models/gpslistmodel.cpp
@@ -3,11 +3,8 @@
 #include "core/qthelper.h"
 #include <QVector>
 
-GpsListModel *GpsListModel::m_instance = NULL;
-
 GpsListModel::GpsListModel(QObject *parent) : QAbstractListModel(parent)
 {
-	m_instance = this;
 }
 
 void GpsListModel::update()
@@ -62,9 +59,3 @@ QHash<int, QByteArray> GpsListModel::roleNames() const
 	roles[GpsLongitudeRole] = "longitude";
 	return roles;
 }
-
-GpsListModel *GpsListModel::instance()
-{
-	return m_instance;
-}
-

--- a/qt-models/gpslistmodel.h
+++ b/qt-models/gpslistmodel.h
@@ -24,7 +24,7 @@ public:
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	QHash<int, QByteArray> roleNames() const;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	void update();
+	void update(QVector<gpsTracker> trackers);
 private:
 	QVector<gpsTracker> m_gpsFixes;
 };

--- a/qt-models/gpslistmodel.h
+++ b/qt-models/gpslistmodel.h
@@ -3,10 +3,10 @@
 #define GPSLISTMODEL_H
 
 #include "core/gpslocation.h"
-#include <QObject>
+#include "core/singleton.h"
 #include <QAbstractListModel>
 
-class GpsListModel : public QAbstractListModel
+class GpsListModel : public QAbstractListModel, public SillySingleton<GpsListModel>
 {
 	Q_OBJECT
 public:
@@ -19,7 +19,6 @@ public:
 		GpsWhenRole
 	};
 
-	static GpsListModel *instance();
 	GpsListModel(QObject *parent = 0);
 	void clear();
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
@@ -28,7 +27,6 @@ public:
 	void update();
 private:
 	QVector<gpsTracker> m_gpsFixes;
-	static GpsListModel *m_instance;
 };
 
 #endif // GPSLISTMODEL_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We have these weird singletons owing to the way we use them in QML: The instance pointer is set in the constructor. This PR generates a base-class for these singletons. This is done for two reasons:
1) Documentation. It is hoped that we replace these in the long run.
2) Improved debugging. We will now see wanted and unwanted generation of these singletons in the log.

This is a preparation-PR for an attempt to avoid passing table-pointers through QML. The idea is that the download thread updates the model of the downloaded dives itself. But for that the latter has to be one of these strange singletons because it is used from QML and from desktop.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement a singleton class that allows generation via new and instance()
2) Convert the weird singletons
3) Un-singletonize GpsLocation


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: this could need some testing, though it seemed to run properly for me (download not tested as I still don't have working BT).