### PR TITLE
Fix  path of machine-id in dbus library appimage.

### DIFF
--- a/scripts/docker/trusty-qt512/Dockerfile
+++ b/scripts/docker/trusty-qt512/Dockerfile
@@ -55,7 +55,8 @@ RUN rm -rf qtwebkit
 ADD dbus-1.12.16.tar.gz .
 RUN mkdir dbus-1.12.16/build && \
     cd dbus-1.12.16/build && \
-    cmake ../cmake -DDBUS_INSTALL_SYSTEM_LIBS=1 && \
+    sed -inline 's/${CMAKE_INSTALL_FULL_LOCALSTATEDIR}\/lib\/dbus\/machine-id/\/var\/lib\/dbus\/machine-id/' ../cmake/CMakeLists.txt  && \
+    cmake ../cmake -DDBUS_INSTALL_SYSTEM_LIBS=1  && \
     make install && \
     ldconfig
 


### PR DESCRIPTION
When building dbus within the appimage, cmake picks up the installation
path of various files dbus uses through the GNUInstallDirs package,
however this doesn't work under the appimage build.
So we replace the variable with the normal location of this file.

Signed-off-by: Paul Buxton <paubuxton.mail@googlemail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
On the mailing list David Tillotson raised an issue with the Appimage running on Devuan distribution. Where dbus was failling to locate the file machine-id. This file is normally created by systemd and is located in /etc/machine-id. If dbus is installed on a system without this file it will generate a machine-id in /var/lib/dbus/machine-id. 

The root cause of this is that it looks like dbus doesn't typically get built/installed using the default  gnu install paths, specifically it is built with --localstatedir=/var 
see http://www.linuxfromscratch.org/lfs/view/systemd/chapter06/dbus.html

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
