### PR TITLE
[DO NOT MERGE] Attempt at keeping the DiveImportedModel consistent (contains #2297)

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -15,7 +15,6 @@ extern QMap<QString, dc_descriptor_t *> descriptorLookup;
 namespace {
 	QHash<QString, QBluetoothDeviceInfo> btDeviceInfo;
 }
-BTDiscovery *BTDiscovery::m_instance = NULL;
 
 static dc_descriptor_t *getDeviceType(QString btName)
 // central function to convert a BT name to a Subsurface known vendor/model pair
@@ -139,11 +138,6 @@ BTDiscovery::BTDiscovery(QObject*) : m_btValid(false),
 	m_showNonDiveComputers(false),
 	discoveryAgent(nullptr)
 {
-	if (m_instance) {
-		qDebug() << "trying to create an additional BTDiscovery object";
-		return;
-	}
-	m_instance = this;
 #if defined(BT_SUPPORT)
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 	BTDiscoveryReDiscover();
@@ -202,17 +196,9 @@ void BTDiscovery::BTDiscoveryReDiscover()
 
 BTDiscovery::~BTDiscovery()
 {
-	m_instance = NULL;
 #if defined(BT_SUPPORT)
 	delete discoveryAgent;
 #endif
-}
-
-BTDiscovery *BTDiscovery::instance()
-{
-	if (!m_instance)
-		m_instance = new BTDiscovery();
-	return m_instance;
 }
 
 #if defined(BT_SUPPORT)

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -10,6 +10,7 @@
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothUuid>
 #include "core/libdivecomputer.h"
+#include "core/singleton.h"
 
 #if defined(Q_OS_ANDROID)
 #include <QAndroidJniObject>
@@ -23,13 +24,12 @@ QString extractBluetoothAddress(const QString &address);
 QString extractBluetoothNameAddress(const QString &address, QString &name);
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr);
 
-class BTDiscovery : public QObject {
+class BTDiscovery : public QObject, public SillySingleton<BTDiscovery> {
 	Q_OBJECT
 
 public:
 	BTDiscovery(QObject *parent = NULL);
 	~BTDiscovery();
-	static BTDiscovery *instance();
 
 	struct btPairedDevice {
 		QString address;
@@ -57,7 +57,6 @@ public:
 	void discoverAddress(QString address);
 
 private:
-	static BTDiscovery *m_instance;
 	bool m_btValid;
 	bool m_showNonDiveComputers;
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -3872,7 +3872,7 @@ struct dive *get_dive(int nr)
 	return dive_table.dives[nr];
 }
 
-struct dive *get_dive_from_table(int nr, struct dive_table *dt)
+struct dive *get_dive_from_table(int nr, const struct dive_table *dt)
 {
 	if (nr >= dt->nr || nr < 0)
 		return NULL;

--- a/core/dive.h
+++ b/core/dive.h
@@ -255,7 +255,7 @@ extern struct dive *current_dive;
 #define displayed_dc (get_dive_dc(&displayed_dive, dc_number))
 
 extern struct dive *get_dive(int nr);
-extern struct dive *get_dive_from_table(int nr, struct dive_table *dt);
+extern struct dive *get_dive_from_table(int nr, const struct dive_table *dt);
 extern struct dive_site *get_dive_site_for_dive(const struct dive *dive);
 extern const char *get_dive_country(const struct dive *dive);
 extern const char *get_dive_location(const struct dive *dive);

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -318,16 +318,6 @@ DCDeviceData *DownloadThread::data()
 	return m_data;
 }
 
-struct dive_table *DownloadThread::table()
-{
-	return &downloadTable;
-}
-
-struct dive_site_table *DownloadThread::sites()
-{
-	return &diveSiteTable;
-}
-
 QString DCDeviceData::vendor() const
 {
 	return data.vendor;

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -117,7 +117,8 @@ void DownloadThread::run()
 
 void DownloadThread::reloadModel()
 {
-	DiveImportedModel::instance()->repopulate(&downloadTable, &diveSiteTable);
+	// Note: this will reset the tables
+	DiveImportedModel::instance()->repopulate(downloadTable, diveSiteTable);
 }
 
 static void fill_supported_mobile_list()

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -58,16 +58,11 @@ private:
 
 class DownloadThread : public QThread {
 	Q_OBJECT
-	Q_PROPERTY(dive_table_t *table READ table CONSTANT)
-	Q_PROPERTY(dive_site_table_t *sites READ sites CONSTANT)
-
 public:
 	DownloadThread();
 	void run() override;
 
 	DCDeviceData *data();
-	struct dive_table *table();
-	struct dive_site_table *sites();
 	QString error;
 
 private slots:

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -70,6 +70,9 @@ public:
 	struct dive_site_table *sites();
 	QString error;
 
+private slots:
+	void reloadModel();
+
 private:
 	struct dive_table downloadTable;
 	struct dive_site_table diveSiteTable;

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -44,11 +44,6 @@ GpsLocation *GpsLocation::instance()
 	return m_Instance;
 }
 
-bool GpsLocation::hasInstance()
-{
-	return m_Instance != NULL;
-}
-
 GpsLocation::~GpsLocation()
 {
 	m_Instance = NULL;

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -15,16 +15,12 @@
 #include <QApplication>
 #include <QTimer>
 
-GpsLocation *GpsLocation::m_Instance = NULL;
-
 GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 	QObject(parent),
 	m_GpsSource(0),
 	waitingForPosition(false),
 	haveSource(UNKNOWN)
 {
-	Q_ASSERT_X(m_Instance == NULL, "GpsLocation", "GpsLocation recreated");
-	m_Instance = this;
 	showMessageCB = showMsgCB;
 	// create a QSettings object that's separate from the main application settings
 	geoSettings = new QSettings(QSettings::NativeFormat, QSettings::UserScope,
@@ -35,18 +31,6 @@ GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 
 	// register changes in time threshold
 	connect(qPrefLocationService::instance(), SIGNAL(time_thresholdChanged(int)), this, SLOT(setGpsTimeThreshold(int)));
-}
-
-GpsLocation *GpsLocation::instance()
-{
-	Q_ASSERT(m_Instance != NULL);
-
-	return m_Instance;
-}
-
-GpsLocation::~GpsLocation()
-{
-	m_Instance = NULL;
 }
 
 void GpsLocation::setGpsTimeThreshold(int seconds)

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -26,7 +26,6 @@ public:
 	GpsLocation(void (*showMsgCB)(const char *msg), QObject *parent);
 	~GpsLocation();
 	static GpsLocation *instance();
-	static bool hasInstance();
 	bool applyLocations();
 	int getGpsNum() const;
 	bool hasLocationsSource();

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -24,8 +24,6 @@ class GpsLocation : public QObject {
 	Q_OBJECT
 public:
 	GpsLocation(void (*showMsgCB)(const char *msg), QObject *parent);
-	~GpsLocation();
-	static GpsLocation *instance();
 	bool applyLocations();
 	int getGpsNum() const;
 	bool hasLocationsSource();
@@ -42,7 +40,6 @@ private:
 	QNetworkReply *reply;
 	QString userAgent;
 	void (*showMessageCB)(const char *msg);
-	static GpsLocation *m_Instance;
 	bool waitingForPosition;
 	QMap<qint64, gpsTracker> m_trackers;
 	QList<gpsTracker> m_deletedTrackers;

--- a/core/singleton.h
+++ b/core/singleton.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * We use singletons in numerous places. In combination with QML this gives
+ * us a very fundamental problem, because QML likes to allocate objects by
+ * itself. There are known workarounds, but currently we use idiosyncratic
+ * singleton classes, which initialize the global instance pointer in the
+ * constructor. Things get even more complicated if the same singleton is used
+ * on mobile and on desktop. The latter might want to simply use the classical
+ * instance() function without having to initialize the singleton first, as
+ * that would beat the purpose of the instance() method.
+ *
+ * The template defined here, SillySingleton, codifies all this. Simply derive
+ * a class from this template:
+ *	class X : public SillySingleton<X> {
+ *		...
+ *	};
+ * This will generate an instance() method. This will do the right thing for
+ * both methods: explicit construction of the singleton via new or implicit
+ * by calling the instance() method. It will also generate warnings if a
+ * singleton class is generated more than once (i.e. first instance() is called
+ * and _then_ new).
+ *
+ * In the long run we should get rid of all users of this class.
+ */
+#ifndef SINGLETON_H
+#define SINGLETON_H
+
+#include <typeinfo>
+#include <QtGlobal>
+
+// 1) Declaration
+template<typename T>
+class SillySingleton {
+	static T *self;
+protected:
+	SillySingleton();
+	~SillySingleton();
+public:
+	static T *instance();
+};
+
+template<typename T>
+T *SillySingleton<T>::self = nullptr;
+
+// 2) Implementation
+
+template<typename T>
+SillySingleton<T>::SillySingleton()
+{
+	if (self)
+		qWarning("Generating second instance of singleton %s", typeid(T).name());
+	self = static_cast<T *>(this);
+	qDebug("Generated singleton %s", typeid(T).name());
+}
+
+template<typename T>
+SillySingleton<T>::~SillySingleton()
+{
+	if (self == this)
+		self = nullptr;
+	else
+		qWarning("Destroying unknown instance of singleton %s", typeid(T).name());
+	qDebug("Destroyed singleton %s", typeid(T).name());
+}
+
+template<typename T>
+T *SillySingleton<T>::instance()
+{
+	if (!self)
+		new T;
+	return self;
+}
+
+#endif

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -25,7 +25,8 @@ QAction *redoAction(QObject *parent);	// Create an redo action.
 // If newNumber is true, the dive is assigned a new number, depending on the
 // insertion position.
 void addDive(dive *d, const bool autogroup, bool newNumber);
-void importDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites, int flags, const QString &source);
+void importDives(struct dive_table *dives, struct trip_table *trips,
+		 struct dive_site_table *sites, int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);
 void shiftTime(const QVector<dive *> &changedDives, int amount);
 void renumberDives(const QVector<QPair<dive *, int>> &divesToRenumber);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -524,22 +524,28 @@ void DownloadFromDCWidget::on_ok_clicked()
 {
 	if (currentState != DONE && currentState != ERRORED)
 		return;
-	struct dive_table *table = thread.table();
-	struct dive_site_table *sites = thread.sites();
 
 	// delete non-selected dives
 	DiveImportedModel *model = DiveImportedModel::instance();
 	model->deleteDeselected();
 
-	if (table->nr > 0) {
+	// TODO: use structured bindings once we go C++17
+	std::pair<struct dive_table, struct dive_site_table> tables = model->consumeTables();
+	if (tables.first.nr > 0) {
 		auto data = thread.data();
 		int flags = IMPORT_IS_DOWNLOADED;
 		if (preferDownloaded())
 			flags |= IMPORT_PREFER_IMPORTED;
 		if (ui.createNewTrip->isChecked())
 			flags |= IMPORT_ADD_TO_NEW_TRIP;
-		Command::importDives(table, nullptr, sites, flags, data->devName());
+		Command::importDives(&tables.first, nullptr, &tables.second, flags, data->devName());
+	} else {
+		clear_dive_site_table(&tables.second);
 	}
+	// The dives and dive sites have been consumed, but the arrays of the tables
+	// still exist. Free them.
+	free(tables.first.dives);
+	free(tables.second.dive_sites);
 
 	if (ostcFirmwareCheck && currentState == DONE)
 		ostcFirmwareCheck->checkLatest(this, thread.data()->internalData());

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -508,7 +508,6 @@ void DownloadFromDCWidget::onDownloadThreadFinished()
 	}
 	ui.downloadCancelRetryButton->setText(tr("Retry download"));
 	ui.downloadCancelRetryButton->setEnabled(true);
-	DiveImportedModel::instance()->repopulate(thread.table(), thread.sites());
 }
 
 void DownloadFromDCWidget::on_cancel_clicked()

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -271,7 +271,7 @@ void DownloadFromDCWidget::updateState(states state)
 			markChildrenAsEnabled();
 			progress_bar_text = "";
 		} else {
-			if (thread.table()->nr != 0)
+			if (DiveImportedModel::instance()->numDives() != 0)
 				progress_bar_text = "";
 			ui.progressBar->setValue(100);
 			markChildrenAsEnabled();

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -528,15 +528,8 @@ void DownloadFromDCWidget::on_ok_clicked()
 	struct dive_site_table *sites = thread.sites();
 
 	// delete non-selected dives
-	int total = table->nr;
-	int j = 0;
 	DiveImportedModel *model = DiveImportedModel::instance();
-	for (int i = 0; i < total; i++) {
-		if (model->data(model->index(i, 0), Qt::CheckStateRole) == Qt::Checked)
-			j++;
-		else
-			delete_dive_from_table(thread.table(), j);
-	}
+	model->deleteDeselected();
 
 	if (table->nr > 0) {
 		auto data = thread.data();

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -366,7 +366,6 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 		// this means we are retrying - so we better clean out the partial
 		// list of downloaded dives from the last attempt
 		DiveImportedModel::instance()->clearTable();
-		clear_dive_table(thread.table());
 	}
 	updateState(DOWNLOADING);
 
@@ -516,7 +515,7 @@ void DownloadFromDCWidget::on_cancel_clicked()
 		return;
 
 	// now discard all the dives
-	clear_dive_table(thread.table());
+	DiveImportedModel::instance()->clearTable();
 	done(-1);
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -81,7 +81,6 @@ private:
 	QTimer *timer;
 	bool dumpWarningShown;
 	std::unique_ptr<OstcFirmwareCheck> ostcFirmwareCheck;
-	DiveImportedModel *diveImportedModel;
 #if defined(BT_SUPPORT)
 	BtDeviceSelectionDialog *btDeviceSelectionDialog;
 	BTDiscovery *btd;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -109,8 +109,6 @@ extern "C" int updateProgress(const char *text)
 	return progressDialogCanceled;
 }
 
-MainWindow *MainWindow::m_Instance = nullptr;
-
 extern "C" void showErrorFromC(char *buf)
 {
 	QString error(buf);
@@ -128,8 +126,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	survey(nullptr),
 	findMovedImagesDialog(nullptr)
 {
-	Q_ASSERT_X(m_Instance == NULL, "MainWindow", "MainWindow recreated!");
-	m_Instance = this;
 	ui.setupUi(this);
 	read_hashes();
 	Command::init();
@@ -357,7 +353,6 @@ MainWindow::MainWindow() : QMainWindow(),
 MainWindow::~MainWindow()
 {
 	write_hashes();
-	m_Instance = nullptr;
 }
 
 void MainWindow::setupSocialNetworkMenu()
@@ -396,11 +391,6 @@ void MainWindow::setDefaultState()
 	setApplicationState(ApplicationState::Default);
 	if (mainTab->isEditing())
 		ui.bottomLeft->currentWidget()->setEnabled(false);
-}
-
-MainWindow *MainWindow::instance()
-{
-	return m_Instance;
 }
 
 // This gets called after one or more dives were added, edited or downloaded for a dive computer

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -21,6 +21,7 @@
 #include "desktop-widgets/filterwidget2.h"
 #include "core/applicationstate.h"
 #include "core/gpslocation.h"
+#include "core/singleton.h"
 
 #define NUM_RECENT_FILES 4
 
@@ -42,7 +43,7 @@ class LocationInformationWidget;
 typedef std::pair<QByteArray, QVariant> WidgetProperty;
 typedef QVector<WidgetProperty> PropertyList;
 
-class MainWindow : public QMainWindow {
+class MainWindow : public QMainWindow, public SillySingleton<MainWindow> {
 	Q_OBJECT
 public:
 	enum {
@@ -61,7 +62,6 @@ public:
 
 	MainWindow();
 	~MainWindow();
-	static MainWindow *instance();
 	void loadRecentFiles();
 	void updateRecentFiles();
 	void updateRecentFilesMenu();
@@ -193,7 +193,6 @@ private:
 	QString filter_open();
 	QString filter_import();
 	QString filter_import_dive_sites();
-	static MainWindow *m_Instance;
 	QString displayedFilename(QString fullFilename);
 	bool askSaveChanges();
 	bool okToClose(QString message);

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -28,11 +28,6 @@ Kirigami.Page {
 		id: downloadThread
 
 		onFinished : {
-			if (!table || !sites) {
-				console.warn("DCDownloadThread::onFinished(): table or sites is null!")
-				return
-			}
-			importModel.repopulate(table, sites)
 			progressBar.visible = false
 			if (dcImportModel.rowCount() > 0) {
 				console.log(dcImportModel.rowCount() + " dive downloaded")

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1556,7 +1556,7 @@ void QMLManager::applyGpsData()
 void QMLManager::populateGpsData()
 {
 	if (GpsListModel::instance())
-		GpsListModel::instance()->update();
+		GpsListModel::instance()->update(QVector<gpsTracker>::fromList(locationProvider->currentGPSInfo().values()));
 }
 
 void QMLManager::clearGpsData()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -44,7 +44,6 @@
 #include "core/settings/qPrefUnit.h"
 #include "core/trip.h"
 
-QMLManager *QMLManager::m_instance = NULL;
 bool noCloudToCloud = false;
 
 #define RED_FONT QLatin1Literal("<font color=\"red\">")
@@ -150,7 +149,6 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_showNonDiveComputers(false)
 {
 	LOG_STP("qmlmgr starting");
-	m_instance = this;
 	m_lastDevicePixelRatio = qApp->devicePixelRatio();
 	timer.start();
 	connect(qobject_cast<QApplication *>(QApplication::instance()), &QApplication::applicationStateChanged, this, &QMLManager::applicationStateChanged);
@@ -451,12 +449,6 @@ QMLManager::~QMLManager()
 	if (appLogFileOpen)
 		appLogFile.close();
 #endif
-	m_instance = NULL;
-}
-
-QMLManager *QMLManager::instance()
-{
-	return m_instance;
 }
 
 #define CLOUDURL QString(prefs.cloud_base_url)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -13,13 +13,14 @@
 #include "core/btdiscovery.h"
 #include "core/gpslocation.h"
 #include "core/downloadfromdcthread.h"
+#include "core/singleton.h"
 #include "qt-models/divelistmodel.h"
 #include "qt-models/completionmodels.h"
 #include "qt-models/divelocationmodel.h"
 
 #define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
 
-class QMLManager : public QObject {
+class QMLManager : public QObject, public SillySingleton<QMLManager> {
 	Q_OBJECT
 	Q_PROPERTY(QString logText READ logText WRITE setLogText NOTIFY logTextChanged)
 	Q_PROPERTY(bool locationServiceEnabled MEMBER m_locationServiceEnabled WRITE setLocationServiceEnabled NOTIFY locationServiceEnabledChanged)
@@ -89,7 +90,6 @@ public:
 	Q_INVOKABLE void setGitLocalOnly(const bool &value);
 	Q_INVOKABLE void setFilter(const QString filterText);
 
-	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);
 	QString consumeError();
 
@@ -219,7 +219,6 @@ private:
 	bool m_verboseEnabled;
 	GpsLocation *locationProvider;
 	bool m_loadFromCloud;
-	static QMLManager *m_instance;
 	struct dive *deletedDive;
 	struct dive_trip *deletedTrip;
 	QString m_notificationText;

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -8,29 +8,12 @@
 
 
 /*** Global and constructors ***/
-QMLPrefs *QMLPrefs::m_instance = NULL;
-
 QMLPrefs::QMLPrefs() :
 	m_credentialStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_oldStatus(qPrefCloudStorage::CS_UNKNOWN),
 	m_showPin(false)
 {
-	// This strange construct is needed because QMLEngine calls new and that
-	// cannot be overwritten
-	if (!m_instance)
-		m_instance = this;
 }
-
-QMLPrefs::~QMLPrefs()
-{
-	m_instance = NULL;
-}
-
-QMLPrefs *QMLPrefs::instance()
-{
-	return m_instance;
-}
-
 
 /*** public functions ***/
 const QString QMLPrefs::cloudPassword() const

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -5,9 +5,9 @@
 #include <QObject>
 #include "core/settings/qPrefCloudStorage.h"
 #include "core/settings/qPrefDisplay.h"
+#include "core/singleton.h"
 
-
-class QMLPrefs : public QObject {
+class QMLPrefs : public QObject, public SillySingleton<QMLPrefs> {
 	Q_OBJECT
 	Q_PROPERTY(QString cloudPassword
 				MEMBER m_cloudPassword
@@ -35,9 +35,6 @@ class QMLPrefs : public QObject {
 				NOTIFY oldStatusChanged)
 public:
 	QMLPrefs();
-	~QMLPrefs();
-
-	static QMLPrefs *instance();
 
 	const QString cloudPassword() const;
 	void setCloudPassword(const QString &cloudPassword);
@@ -66,7 +63,6 @@ private:
 	QString m_cloudPin;
 	QString m_cloudUserName;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
-	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
 	bool m_showPin;
 

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -167,6 +167,11 @@ std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeT
 	return std::make_pair(dives, sites);
 }
 
+int DiveImportedModel::numDives() const
+{
+	return diveTable->nr;
+}
+
 // Delete non-selected dives
 void DiveImportedModel::deleteDeselected()
 {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -143,6 +143,24 @@ void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *
 	endResetModel();
 }
 
+// Delete non-selected dives
+void DiveImportedModel::deleteDeselected()
+{
+	int total = diveTable->nr;
+	int j = 0;
+	for (int i = 0; i < total; i++) {
+		if (checkStates[i]) {
+			j++;
+		} else {
+			beginRemoveRows(QModelIndex(), j, j);
+			delete_dive_from_table(diveTable, j);
+			endRemoveRows();
+		}
+	}
+	checkStates.resize(diveTable->nr);
+	std::fill(checkStates.begin(), checkStates.end(), true);
+}
+
 // Note: this function is only used from mobile - perhaps move it there or unify.
 void DiveImportedModel::recordDives()
 {
@@ -150,15 +168,7 @@ void DiveImportedModel::recordDives()
 		// nothing to do, just exit
 		return;
 
-	// delete non-selected dives
-	int total = diveTable->nr;
-	int j = 0;
-	for (int i = 0; i < total; i++) {
-		if (checkStates[i])
-			j++;
-		else
-			delete_dive_from_table(diveTable, j);
-	}
+	deleteDeselected();
 
 	// TODO: Might want to let the user select IMPORT_ADD_TO_NEW_TRIP
 	add_imported_dives(diveTable, nullptr, sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -143,6 +143,30 @@ void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *
 	endResetModel();
 }
 
+std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeTables()
+{
+	beginResetModel();
+
+	// Copy tables to result
+	struct dive_table dives = *diveTable;
+	struct dive_site_table sites = *sitesTable;
+
+	// Reset original tables
+	diveTable->nr = diveTable->allocated = 0;
+	diveTable->dives = nullptr;
+	sitesTable->nr = sitesTable->allocated = 0;
+	sitesTable->dive_sites = nullptr;
+
+	// Reset indexes
+	firstIndex = 0;
+	lastIndex = -1;
+	checkStates.resize(diveTable->nr);
+
+	endResetModel();
+
+	return std::make_pair(dives, sites);
+}
+
 // Delete non-selected dives
 void DiveImportedModel::deleteDeselected()
 {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -201,14 +201,21 @@ void DiveImportedModel::deleteDeselected()
 // Note: this function is only used from mobile - perhaps move it there or unify.
 void DiveImportedModel::recordDives()
 {
+	deleteDeselected();
+
 	if (diveTable.nr == 0)
 		// nothing to do, just exit
 		return;
 
-	deleteDeselected();
+	// Consume the tables. They will be consumed by add_imported_dives() anyway.
+	// But let's do it in a controlled way with a proper model-reset so that the
+	// model doesn't become inconsistent.
+	std::pair<struct dive_table, struct dive_site_table> tables = consumeTables();
 
 	// TODO: Might want to let the user select IMPORT_ADD_TO_NEW_TRIP
-	add_imported_dives(&diveTable, nullptr, &sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
+	add_imported_dives(&tables.first, nullptr, &tables.second, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
+	free(tables.first.dives);
+	free(tables.second.dive_sites);
 }
 
 QHash<int, QByteArray> DiveImportedModel::roleNames() const {

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -38,7 +38,6 @@ slots:
 	void selectNone();
 
 private:
-	int firstIndex;
 	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table diveTable;

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -24,6 +24,7 @@ public:
 	void deleteDeselected();
 	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
 	void repopulate(dive_table_t *table, dive_site_table_t *sites);
+	int numDives() const;
 	Q_INVOKABLE void recordDives();
 public
 slots:

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -38,7 +38,6 @@ slots:
 	void selectNone();
 
 private:
-	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table diveTable;
 	struct dive_site_table sitesTable;

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -21,7 +21,7 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
-	Q_INVOKABLE void repopulate(dive_table_t *table, dive_site_table_t *sites);
+	void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	Q_INVOKABLE void recordDives();
 public
 slots:

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -21,6 +21,7 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
+	void deleteDeselected();
 	void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	Q_INVOKABLE void recordDives();
 public

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -23,7 +23,11 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
 	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
-	void repopulate(dive_table_t *table, dive_site_table_t *sites);
+
+	// Reset the model.
+	// Warning: this consumes the input tables, i.e. the tables are of zero size
+	// on return of the function.
+	void repopulate(dive_table_t &table, dive_site_table_t &sites);
 	int numDives() const;
 	Q_INVOKABLE void recordDives();
 public
@@ -37,8 +41,8 @@ private:
 	int firstIndex;
 	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
-	struct dive_table *diveTable;
-	struct dive_site_table *sitesTable;
+	struct dive_table diveTable;
+	struct dive_site_table sitesTable;
 };
 
 #endif

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -22,6 +22,7 @@ public:
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
+	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
 	void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	Q_INVOKABLE void recordDives();
 public

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -4,8 +4,9 @@
 #include <QAbstractTableModel>
 #include <vector>
 #include "core/divesite.h"
+#include "core/singleton.h"
 
-class DiveImportedModel : public QAbstractTableModel
+class DiveImportedModel : public QAbstractTableModel, public SillySingleton<DiveImportedModel>
 {
 	Q_OBJECT
 public:

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -134,11 +134,8 @@ QString DiveListSortModel::tripShortDate(const QString &section)
 	return QStringLiteral("%1\n'%2").arg(firstMonth,firstTime.toString("yy"));
 }
 
-DiveListModel *DiveListModel::m_instance = NULL;
-
 DiveListModel::DiveListModel(QObject *parent) : QAbstractListModel(parent)
 {
-	m_instance = this;
 }
 
 void DiveListModel::insertDive(int i)
@@ -272,11 +269,6 @@ QString DiveListModel::startAddDive()
 	append_dive(d);
 	insertDive(get_idx_by_uniq_id(d->id));
 	return QString::number(d->id);
-}
-
-DiveListModel *DiveListModel::instance()
-{
-	return m_instance;
 }
 
 struct dive *DiveListModel::getDive(int i)

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -6,6 +6,7 @@
 #include <QSortFilterProxyModel>
 
 #include "core/subsurface-qt/DiveObjectHelper.h"
+#include "core/singleton.h"
 
 class DiveListSortModel : public QSortFilterProxyModel
 {
@@ -28,7 +29,7 @@ private:
 	void updateFilterState();
 };
 
-class DiveListModel : public QAbstractListModel
+class DiveListModel : public QAbstractListModel, public SillySingleton<DiveListModel>
 {
 	Q_OBJECT
 public:
@@ -45,7 +46,6 @@ public:
 		DepthDurationRole,
 	};
 
-	static DiveListModel *instance();
 	DiveListModel(QObject *parent = 0);
 	void addDive(const QList<dive *> &listOfDives);
 	void addAllDives();
@@ -63,8 +63,6 @@ public:
 	QString startAddDive();
 	void resetInternalData();
 	Q_INVOKABLE DiveObjectHelper at(int i);
-private:
-	static DiveListModel *m_instance;
 };
 
 #endif // DIVELISTMODEL_H

--- a/qt-models/gpslistmodel.cpp
+++ b/qt-models/gpslistmodel.cpp
@@ -7,9 +7,8 @@ GpsListModel::GpsListModel(QObject *parent) : QAbstractListModel(parent)
 {
 }
 
-void GpsListModel::update()
+void GpsListModel::update(QVector<gpsTracker> trackers)
 {
-	QVector<gpsTracker> trackers = QVector<gpsTracker>::fromList(GpsLocation::instance()->currentGPSInfo().values());
 	beginResetModel();
 	m_gpsFixes = trackers;
 	endResetModel();

--- a/qt-models/gpslistmodel.cpp
+++ b/qt-models/gpslistmodel.cpp
@@ -3,11 +3,8 @@
 #include "core/qthelper.h"
 #include <QVector>
 
-GpsListModel *GpsListModel::m_instance = NULL;
-
 GpsListModel::GpsListModel(QObject *parent) : QAbstractListModel(parent)
 {
-	m_instance = this;
 }
 
 void GpsListModel::update()
@@ -62,9 +59,3 @@ QHash<int, QByteArray> GpsListModel::roleNames() const
 	roles[GpsLongitudeRole] = "longitude";
 	return roles;
 }
-
-GpsListModel *GpsListModel::instance()
-{
-	return m_instance;
-}
-

--- a/qt-models/gpslistmodel.h
+++ b/qt-models/gpslistmodel.h
@@ -24,7 +24,7 @@ public:
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	QHash<int, QByteArray> roleNames() const;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-	void update();
+	void update(QVector<gpsTracker> trackers);
 private:
 	QVector<gpsTracker> m_gpsFixes;
 };

--- a/qt-models/gpslistmodel.h
+++ b/qt-models/gpslistmodel.h
@@ -3,10 +3,10 @@
 #define GPSLISTMODEL_H
 
 #include "core/gpslocation.h"
-#include <QObject>
+#include "core/singleton.h"
 #include <QAbstractListModel>
 
-class GpsListModel : public QAbstractListModel
+class GpsListModel : public QAbstractListModel, public SillySingleton<GpsListModel>
 {
 	Q_OBJECT
 public:
@@ -19,7 +19,6 @@ public:
 		GpsWhenRole
 	};
 
-	static GpsListModel *instance();
 	GpsListModel(QObject *parent = 0);
 	void clear();
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
@@ -28,7 +27,6 @@ public:
 	void update();
 private:
 	QVector<gpsTracker> m_gpsFixes;
-	static GpsListModel *m_instance;
 };
 
 #endif // GPSLISTMODEL_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
There were numerous ways in which the DiveImportedModel could go out of sync. For example by sharing a single dive table with the download thread(!). Also the import-functions consume the tables without the model being adapted. I see no obvious way how this can lead to crashes. But let's clean this up as a first step.

This also removes moving pointers via QML, which has us caused terrible problems before.

This is FYI. It is only compile tested. If some brave person compiles and tests download that would be very helpful (desktop and mobile). Currently, I can't test this as I haven't found time to install Bluetooth.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Too many to list in detail, sorry.
1) Make DiveImportedModel the authoritative source of the imported dives.
2) Implement move semantics to move downloaded dives from DownloadThread to DiveImportedModel.
3) Keep model in sync.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Related to #2292 and #2221, but probably doesn't fix them. They should give different backtraces, though.


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: FYI - can't work on this anymore today.