### PR TITLE
Please Test: Make DownloadThread subobject of DiveImportedModel [Alternative to #2299]

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3872,7 +3872,7 @@ struct dive *get_dive(int nr)
 	return dive_table.dives[nr];
 }
 
-struct dive *get_dive_from_table(int nr, struct dive_table *dt)
+struct dive *get_dive_from_table(int nr, const struct dive_table *dt)
 {
 	if (nr >= dt->nr || nr < 0)
 		return NULL;

--- a/core/dive.h
+++ b/core/dive.h
@@ -436,15 +436,11 @@ extern void update_setpoint_events(const struct dive *dive, struct divecomputer 
 #ifdef __cplusplus
 }
 
-/* Make pointers to dive, dive_trip, dive_table, trip_table and dive_site_table
- * "Qt metatypes" so that they can be passed through QVariants and through QML.
- * Note: we have to use the typedef "dive_table_t" instead of "struct dive_table",
- * because MOC removes the "struct", but dive_table is already the name of a global
- * variable, leading to compilation errors. Likewise for "struct trip_table" and
- * "struct dive_site_table" (defined in "dive.h" and "divesite.h"). */
+/* Make pointers to dive and dive_trip "Qt metatypes" so that they can be passed through
+ * QVariants and through QML.
+ */
 #include <QObject>
 Q_DECLARE_METATYPE(struct dive *);
-Q_DECLARE_METATYPE(dive_table_t *);
 
 #endif
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -255,7 +255,7 @@ extern struct dive *current_dive;
 #define displayed_dc (get_dive_dc(&displayed_dive, dc_number))
 
 extern struct dive *get_dive(int nr);
-extern struct dive *get_dive_from_table(int nr, struct dive_table *dt);
+extern struct dive *get_dive_from_table(int nr, const struct dive_table *dt);
 extern struct dive_site *get_dive_site_for_dive(const struct dive *dive);
 extern const char *get_dive_country(const struct dive *dive);
 extern const char *get_dive_location(const struct dive *dive);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -753,6 +753,7 @@ static MAKE_GET_IDX(dive_table, struct dive *, dives)
 MAKE_SORT(dive_table, struct dive *, dives, comp_dives)
 MAKE_REMOVE(dive_table, struct dive *, dive)
 MAKE_CLEAR_TABLE(dive_table, dives, dive)
+MAKE_MOVE_TABLE(dive_table, dives)
 
 void insert_dive(struct dive_table *table, struct dive *d)
 {

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -60,6 +60,7 @@ void report_datafile_version(int version);
 int get_dive_id_closest_to(timestamp_t when);
 void clear_dive_file_data();
 void clear_dive_table(struct dive_table *table);
+void move_dive_table(struct dive_table *src, struct dive_table *dst);
 
 #ifdef DEBUG_TRIP
 extern void dump_selection(void);

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -131,6 +131,7 @@ static MAKE_GET_IDX(dive_site_table, struct dive_site *, dive_sites)
 MAKE_SORT(dive_site_table, struct dive_site *, dive_sites, compare_sites)
 static MAKE_REMOVE(dive_site_table, struct dive_site *, dive_site)
 MAKE_CLEAR_TABLE(dive_site_table, dive_sites, dive_site)
+MAKE_MOVE_TABLE(dive_site_table, dive_sites)
 
 int add_dive_site_to_table(struct dive_site *ds, struct dive_site_table *ds_table)
 {

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -71,6 +71,7 @@ unsigned int get_distance(const location_t *loc1, const location_t *loc2);
 struct dive_site *find_or_create_dive_site_with_name(const char *name, struct dive_site_table *ds_table);
 void purge_empty_dive_sites(struct dive_site_table *ds_table);
 void clear_dive_site_table(struct dive_site_table *ds_table);
+void move_dive_site_table(struct dive_site_table *src, struct dive_site_table *dst);
 void add_dive_to_dive_site(struct dive *d, struct dive_site *ds);
 struct dive_site *unregister_dive_from_dive_site(struct dive *d);
 

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -81,7 +81,6 @@ QString constructLocationTags(struct taxonomy_data *taxonomy, bool for_maintab);
 
 /* Make pointer-to-dive_site a "Qt metatype" so that we can pass it through QVariants */
 Q_DECLARE_METATYPE(dive_site *);
-Q_DECLARE_METATYPE(dive_site_table_t *);
 
 #endif
 

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -308,16 +308,6 @@ DCDeviceData *DownloadThread::data()
 	return m_data;
 }
 
-struct dive_table *DownloadThread::table()
-{
-	return &downloadTable;
-}
-
-struct dive_site_table *DownloadThread::sites()
-{
-	return &diveSiteTable;
-}
-
 QString DCDeviceData::vendor() const
 {
 	return data.vendor;

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -58,8 +58,6 @@ private:
 
 class DownloadThread : public QThread {
 	Q_OBJECT
-	Q_PROPERTY(dive_table_t *table READ table CONSTANT)
-	Q_PROPERTY(dive_site_table_t *sites READ sites CONSTANT)
 
 public:
 	DownloadThread();

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -64,13 +64,11 @@ public:
 	void run() override;
 
 	DCDeviceData *data();
-	struct dive_table *table();
-	struct dive_site_table *sites();
 	QString error;
-
-private:
 	struct dive_table downloadTable;
 	struct dive_site_table diveSiteTable;
+
+private:
 	DCDeviceData *m_data;
 };
 

--- a/core/table.h
+++ b/core/table.h
@@ -99,4 +99,15 @@
 		table->nr = 0;							\
 	}
 
+/* Move data of one table to the other - source table is empty after call. */
+#define MAKE_MOVE_TABLE(table_type, array_name)					\
+	void move_##table_type(struct table_type *src, struct table_type *dst)	\
+	{									\
+		clear_##table_type(dst);					\
+		free(dst->array_name);						\
+		*dst = *src;							\
+		src->nr = src->allocated = 0;					\
+		src->array_name = NULL;						\
+	}
+
 #endif

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -25,7 +25,8 @@ QAction *redoAction(QObject *parent);	// Create an redo action.
 // If newNumber is true, the dive is assigned a new number, depending on the
 // insertion position.
 void addDive(dive *d, const bool autogroup, bool newNumber);
-void importDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites, int flags, const QString &source);
+void importDives(struct dive_table *dives, struct trip_table *trips,
+		 struct dive_site_table *sites, int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);
 void shiftTime(const QVector<dive *> &changedDives, int amount);
 void renumberDives(const QVector<QPair<dive *, int>> &divesToRenumber);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -367,7 +367,6 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 		// this means we are retrying - so we better clean out the partial
 		// list of downloaded dives from the last attempt
 		diveImportedModel->clearTable();
-		clear_dive_table(diveImportedModel->thread.table());
 	}
 	updateState(DOWNLOADING);
 
@@ -517,7 +516,7 @@ void DownloadFromDCWidget::on_cancel_clicked()
 		return;
 
 	// now discard all the dives
-	clear_dive_table(diveImportedModel->thread.table());
+	diveImportedModel->clearTable();
 	done(-1);
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -529,14 +529,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 	struct dive_site_table *sites = diveImportedModel->thread.sites();
 
 	// delete non-selected dives
-	int total = table->nr;
-	int j = 0;
-	for (int i = 0; i < total; i++) {
-		if (diveImportedModel->data(diveImportedModel->index(i, 0), Qt::CheckStateRole) == Qt::Checked)
-			j++;
-		else
-			delete_dive_from_table(diveImportedModel->thread.table(), j);
-	}
+	diveImportedModel->deleteDeselected();
 
 	if (table->nr > 0) {
 		auto data = diveImportedModel->thread.data();

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -272,7 +272,7 @@ void DownloadFromDCWidget::updateState(states state)
 			markChildrenAsEnabled();
 			progress_bar_text = "";
 		} else {
-			if (diveImportedModel->thread.table()->nr != 0)
+			if (diveImportedModel->numDives() != 0)
 				progress_bar_text = "";
 			ui.progressBar->setValue(100);
 			markChildrenAsEnabled();

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -11,7 +11,6 @@
 
 #include "core/libdivecomputer.h"
 #include "desktop-widgets/configuredivecomputerdialog.h"
-#include "core/downloadfromdcthread.h"
 
 #include "ui_downloadfromdivecomputer.h"
 
@@ -21,6 +20,7 @@
 
 class QStringListModel;
 class DiveImportedModel;
+class BTDiscovery;
 
 class DownloadFromDCWidget : public QDialog {
 	Q_OBJECT
@@ -72,7 +72,6 @@ private:
 	QStringListModel vendorModel;
 	QStringListModel productModel;
 	Ui::DownloadFromDiveComputer ui;
-	DownloadThread thread;
 	bool downloading;
 
 	int previousLast;

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -24,18 +24,13 @@ Kirigami.Page {
 	property alias product: comboProduct.currentIndex
 	property alias connection: comboConnection.currentIndex
 
-	DCDownloadThread {
-		id: downloadThread
+	DCImportModel {
+		id: importModel
 
-		onFinished : {
-			if (!table || !sites) {
-				console.warn("DCDownloadThread::onFinished(): table or sites is null!")
-				return
-			}
-			importModel.repopulate(table, sites)
+		onDownloadFinished : {
 			progressBar.visible = false
-			if (dcImportModel.rowCount() > 0) {
-				console.log(dcImportModel.rowCount() + " dive downloaded")
+			if (rowCount() > 0) {
+				console.log(rowCount() + " dive downloaded")
 				divesDownloaded = true
 			} else {
 				console.log("no new dives downloaded")
@@ -43,10 +38,6 @@ Kirigami.Page {
 			}
 			manager.appendTextToLog("DCDownloadThread finished")
 		}
-	}
-
-	DCImportModel {
-		id: importModel
 	}
 
 	ColumnLayout {
@@ -295,7 +286,7 @@ Kirigami.Page {
 					message += " downloading " + (manager.DC_forceDownload ? "all" : "only new" ) + " dives";
 					manager.appendTextToLog(message)
 					progressBar.visible = true
-					downloadThread.start()
+					importModel.startDownload()
 				}
 			}
 			SsrfButton {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -175,6 +175,11 @@ std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeT
 	return std::make_pair(dives, sites);
 }
 
+int DiveImportedModel::numDives() const
+{
+	return diveTable->nr;
+}
+
 // Delete non-selected dives
 void DiveImportedModel::deleteDeselected()
 {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -199,14 +199,21 @@ void DiveImportedModel::deleteDeselected()
 // Note: this function is only used from mobile - perhaps move it there or unify.
 void DiveImportedModel::recordDives()
 {
+	deleteDeselected();
+
 	if (diveTable.nr == 0)
 		// nothing to do, just exit
 		return;
 
-	deleteDeselected();
+	// Consume the tables. They will be consumed by add_imported_dives() anyway.
+	// But let's do it in a controlled way with a proper model-reset so that the
+	// model doesn't become inconsistent.
+	std::pair<struct dive_table, struct dive_site_table> tables = consumeTables();
 
 	// TODO: Might want to let the user select IMPORT_ADD_TO_NEW_TRIP
-	add_imported_dives(&diveTable, nullptr, &sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
+	add_imported_dives(&tables.first, nullptr, &tables.second, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
+	free(tables.first.dives);
+	free(tables.second.dive_sites);
 }
 
 QHash<int, QByteArray> DiveImportedModel::roleNames() const {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -8,6 +8,7 @@ DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
 	diveTable(nullptr),
 	sitesTable(nullptr)
 {
+	connect(&thread, &QThread::finished, this, &DiveImportedModel::downloadThreadFinished);
 }
 
 int DiveImportedModel::columnCount(const QModelIndex&) const
@@ -127,6 +128,17 @@ void DiveImportedModel::clearTable()
 	lastIndex = -1;
 	firstIndex = 0;
 	endRemoveRows();
+}
+
+void DiveImportedModel::downloadThreadFinished()
+{
+	repopulate(thread.table(), thread.sites());
+	emit downloadFinished();
+}
+
+void DiveImportedModel::startDownload()
+{
+	thread.start();
 }
 
 void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *sites)

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -155,6 +155,26 @@ void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *
 	endResetModel();
 }
 
+std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeTables()
+{
+	beginResetModel();
+
+	// Move tables to result
+	struct dive_table dives;
+	struct dive_site_table sites;
+	move_dive_table(diveTable, &dives);
+	move_dive_site_table(sitesTable, &sites);
+
+	// Reset indexes
+	firstIndex = 0;
+	lastIndex = -1;
+	checkStates.clear();
+
+	endResetModel();
+
+	return std::make_pair(dives, sites);
+}
+
 // Delete non-selected dives
 void DiveImportedModel::deleteDeselected()
 {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -5,8 +5,8 @@
 DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
 	firstIndex(0),
 	lastIndex(-1),
-	diveTable(nullptr),
-	sitesTable(nullptr)
+	diveTable({ 0 }),
+	sitesTable({ 0 })
 {
 	connect(&thread, &QThread::finished, this, &DiveImportedModel::downloadThreadFinished);
 }
@@ -54,7 +54,7 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 	if (index.row() + firstIndex > lastIndex)
 		return QVariant();
 
-	struct dive *d = get_dive_from_table(index.row() + firstIndex, diveTable);
+	struct dive *d = get_dive_from_table(index.row() + firstIndex, &diveTable);
 	if (!d)
 		return QVariant();
 
@@ -132,7 +132,19 @@ void DiveImportedModel::clearTable()
 
 void DiveImportedModel::downloadThreadFinished()
 {
-	repopulate(thread.table(), thread.sites());
+	beginResetModel();
+
+	// Move the table data from thread to model
+	move_dive_table(&thread.downloadTable, &diveTable);
+	move_dive_site_table(&thread.diveSiteTable, &sitesTable);
+
+	firstIndex = 0;
+	lastIndex = diveTable.nr - 1;
+	checkStates.resize(diveTable.nr);
+	std::fill(checkStates.begin(), checkStates.end(), true);
+
+	endResetModel();
+
 	emit downloadFinished();
 }
 
@@ -141,29 +153,15 @@ void DiveImportedModel::startDownload()
 	thread.start();
 }
 
-void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *sites)
-{
-	beginResetModel();
-
-	diveTable = table;
-	sitesTable = sites;
-	firstIndex = 0;
-	lastIndex = diveTable->nr - 1;
-	checkStates.resize(diveTable->nr);
-	std::fill(checkStates.begin(), checkStates.end(), true);
-
-	endResetModel();
-}
-
 std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeTables()
 {
 	beginResetModel();
 
 	// Move tables to result
-	struct dive_table dives;
-	struct dive_site_table sites;
-	move_dive_table(diveTable, &dives);
-	move_dive_site_table(sitesTable, &sites);
+	struct dive_table dives = { 0 };
+	struct dive_site_table sites = { 0 };
+	move_dive_table(&diveTable, &dives);
+	move_dive_site_table(&sitesTable, &sites);
 
 	// Reset indexes
 	firstIndex = 0;
@@ -177,38 +175,38 @@ std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeT
 
 int DiveImportedModel::numDives() const
 {
-	return diveTable->nr;
+	return diveTable.nr;
 }
 
 // Delete non-selected dives
 void DiveImportedModel::deleteDeselected()
 {
-	int total = diveTable->nr;
+	int total = diveTable.nr;
 	int j = 0;
 	for (int i = 0; i < total; i++) {
 		if (checkStates[i]) {
 			j++;
 		} else {
 			beginRemoveRows(QModelIndex(), j, j);
-			delete_dive_from_table(diveTable, j);
+			delete_dive_from_table(&diveTable, j);
 			endRemoveRows();
 		}
 	}
-	checkStates.resize(diveTable->nr);
+	checkStates.resize(diveTable.nr);
 	std::fill(checkStates.begin(), checkStates.end(), true);
 }
 
 // Note: this function is only used from mobile - perhaps move it there or unify.
 void DiveImportedModel::recordDives()
 {
-	if (diveTable->nr == 0)
+	if (diveTable.nr == 0)
 		// nothing to do, just exit
 		return;
 
 	deleteDeselected();
 
 	// TODO: Might want to let the user select IMPORT_ADD_TO_NEW_TRIP
-	add_imported_dives(diveTable, nullptr, sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
+	add_imported_dives(&diveTable, nullptr, &sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
 }
 
 QHash<int, QByteArray> DiveImportedModel::roleNames() const {

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -3,7 +3,6 @@
 #include "core/divelist.h"
 
 DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
-	firstIndex(0),
 	lastIndex(-1),
 	diveTable({ 0 }),
 	sitesTable({ 0 })
@@ -18,7 +17,7 @@ int DiveImportedModel::columnCount(const QModelIndex&) const
 
 int DiveImportedModel::rowCount(const QModelIndex&) const
 {
-	return lastIndex - firstIndex + 1;
+	return lastIndex + 1;
 }
 
 QVariant DiveImportedModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -51,10 +50,10 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 	if (!index.isValid())
 		return QVariant();
 
-	if (index.row() + firstIndex > lastIndex)
+	if (index.row() > lastIndex)
 		return QVariant();
 
-	struct dive *d = get_dive_from_table(index.row() + firstIndex, &diveTable);
+	struct dive *d = get_dive_from_table(index.row(), &diveTable);
 	if (!d)
 		return QVariant();
 
@@ -93,7 +92,7 @@ void DiveImportedModel::changeSelected(QModelIndex clickedIndex)
 void DiveImportedModel::selectAll()
 {
 	std::fill(checkStates.begin(), checkStates.end(), true);
-	dataChanged(index(0, 0), index(lastIndex - firstIndex, 0), QVector<int>() << Qt::CheckStateRole << Selected);
+	dataChanged(index(0, 0), index(lastIndex, 0), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
 void DiveImportedModel::selectRow(int row)
@@ -105,7 +104,7 @@ void DiveImportedModel::selectRow(int row)
 void DiveImportedModel::selectNone()
 {
 	std::fill(checkStates.begin(), checkStates.end(), false);
-	dataChanged(index(0, 0), index(lastIndex - firstIndex,0 ), QVector<int>() << Qt::CheckStateRole << Selected);
+	dataChanged(index(0, 0), index(lastIndex, 0 ), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
 Qt::ItemFlags DiveImportedModel::flags(const QModelIndex &index) const
@@ -117,16 +116,14 @@ Qt::ItemFlags DiveImportedModel::flags(const QModelIndex &index) const
 
 void DiveImportedModel::clearTable()
 {
-	if (lastIndex < firstIndex) {
+	if (lastIndex < 0) {
 		// just to be sure it's the right numbers
 		// but don't call RemoveRows or Qt in debug mode with trigger an ASSERT
 		lastIndex = -1;
-		firstIndex = 0;
 		return;
 	}
-	beginRemoveRows(QModelIndex(), 0, lastIndex - firstIndex);
+	beginRemoveRows(QModelIndex(), 0, lastIndex);
 	lastIndex = -1;
-	firstIndex = 0;
 	endRemoveRows();
 }
 
@@ -138,7 +135,6 @@ void DiveImportedModel::downloadThreadFinished()
 	move_dive_table(&thread.downloadTable, &diveTable);
 	move_dive_site_table(&thread.diveSiteTable, &sitesTable);
 
-	firstIndex = 0;
 	lastIndex = diveTable.nr - 1;
 	checkStates.resize(diveTable.nr);
 	std::fill(checkStates.begin(), checkStates.end(), true);
@@ -164,7 +160,6 @@ std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeT
 	move_dive_site_table(&sitesTable, &sites);
 
 	// Reset indexes
-	firstIndex = 0;
 	lastIndex = -1;
 	checkStates.clear();
 

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -3,7 +3,6 @@
 #include "core/divelist.h"
 
 DiveImportedModel::DiveImportedModel(QObject *o) : QAbstractTableModel(o),
-	lastIndex(-1),
 	diveTable({ 0 }),
 	sitesTable({ 0 })
 {
@@ -17,7 +16,7 @@ int DiveImportedModel::columnCount(const QModelIndex&) const
 
 int DiveImportedModel::rowCount(const QModelIndex&) const
 {
-	return lastIndex + 1;
+	return diveTable.nr;
 }
 
 QVariant DiveImportedModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -50,7 +49,7 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 	if (!index.isValid())
 		return QVariant();
 
-	if (index.row() > lastIndex)
+	if (index.row() >= diveTable.nr)
 		return QVariant();
 
 	struct dive *d = get_dive_from_table(index.row(), &diveTable);
@@ -92,7 +91,7 @@ void DiveImportedModel::changeSelected(QModelIndex clickedIndex)
 void DiveImportedModel::selectAll()
 {
 	std::fill(checkStates.begin(), checkStates.end(), true);
-	dataChanged(index(0, 0), index(lastIndex, 0), QVector<int>() << Qt::CheckStateRole << Selected);
+	dataChanged(index(0, 0), index(diveTable.nr - 1, 0), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
 void DiveImportedModel::selectRow(int row)
@@ -104,7 +103,7 @@ void DiveImportedModel::selectRow(int row)
 void DiveImportedModel::selectNone()
 {
 	std::fill(checkStates.begin(), checkStates.end(), false);
-	dataChanged(index(0, 0), index(lastIndex, 0 ), QVector<int>() << Qt::CheckStateRole << Selected);
+	dataChanged(index(0, 0), index(diveTable.nr - 1, 0 ), QVector<int>() << Qt::CheckStateRole << Selected);
 }
 
 Qt::ItemFlags DiveImportedModel::flags(const QModelIndex &index) const
@@ -116,15 +115,10 @@ Qt::ItemFlags DiveImportedModel::flags(const QModelIndex &index) const
 
 void DiveImportedModel::clearTable()
 {
-	if (lastIndex < 0) {
-		// just to be sure it's the right numbers
-		// but don't call RemoveRows or Qt in debug mode with trigger an ASSERT
-		lastIndex = -1;
-		return;
-	}
-	beginRemoveRows(QModelIndex(), 0, lastIndex);
-	lastIndex = -1;
-	endRemoveRows();
+	beginResetModel();
+	clear_dive_table(&diveTable);
+	clear_dive_site_table(&sitesTable);
+	endResetModel();
 }
 
 void DiveImportedModel::downloadThreadFinished()
@@ -135,7 +129,6 @@ void DiveImportedModel::downloadThreadFinished()
 	move_dive_table(&thread.downloadTable, &diveTable);
 	move_dive_site_table(&thread.diveSiteTable, &sitesTable);
 
-	lastIndex = diveTable.nr - 1;
 	checkStates.resize(diveTable.nr);
 	std::fill(checkStates.begin(), checkStates.end(), true);
 
@@ -160,7 +153,6 @@ std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeT
 	move_dive_site_table(&sitesTable, &sites);
 
 	// Reset indexes
-	lastIndex = -1;
 	checkStates.clear();
 
 	endResetModel();

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -155,6 +155,24 @@ void DiveImportedModel::repopulate(dive_table_t *table, struct dive_site_table *
 	endResetModel();
 }
 
+// Delete non-selected dives
+void DiveImportedModel::deleteDeselected()
+{
+	int total = diveTable->nr;
+	int j = 0;
+	for (int i = 0; i < total; i++) {
+		if (checkStates[i]) {
+			j++;
+		} else {
+			beginRemoveRows(QModelIndex(), j, j);
+			delete_dive_from_table(diveTable, j);
+			endRemoveRows();
+		}
+	}
+	checkStates.resize(diveTable->nr);
+	std::fill(checkStates.begin(), checkStates.end(), true);
+}
+
 // Note: this function is only used from mobile - perhaps move it there or unify.
 void DiveImportedModel::recordDives()
 {
@@ -162,15 +180,7 @@ void DiveImportedModel::recordDives()
 		// nothing to do, just exit
 		return;
 
-	// delete non-selected dives
-	int total = diveTable->nr;
-	int j = 0;
-	for (int i = 0; i < total; i++) {
-		if (checkStates[i])
-			j++;
-		else
-			delete_dive_from_table(diveTable, j);
-	}
+	deleteDeselected();
 
 	// TODO: Might want to let the user select IMPORT_ADD_TO_NEW_TRIP
 	add_imported_dives(diveTable, nullptr, sitesTable, IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -4,6 +4,7 @@
 #include <QAbstractTableModel>
 #include <vector>
 #include "core/divesite.h"
+#include "core/downloadfromdcthread.h"
 
 class DiveImportedModel : public QAbstractTableModel
 {
@@ -20,8 +21,10 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
-	Q_INVOKABLE void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	Q_INVOKABLE void recordDives();
+	Q_INVOKABLE void startDownload();
+
+	DownloadThread thread;
 public
 slots:
 	void changeSelected(QModelIndex clickedIndex);
@@ -29,7 +32,15 @@ slots:
 	void selectAll();
 	void selectNone();
 
+private
+slots:
+	void downloadThreadFinished();
+
+signals:
+	void downloadFinished();
+
 private:
+	void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	int firstIndex;
 	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -44,7 +44,6 @@ signals:
 	void downloadFinished();
 
 private:
-	int firstIndex;
 	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table diveTable;

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -23,6 +23,7 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
 	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
+
 	int numDives() const;
 	Q_INVOKABLE void recordDives();
 	Q_INVOKABLE void startDownload();
@@ -43,12 +44,11 @@ signals:
 	void downloadFinished();
 
 private:
-	void repopulate(dive_table_t *table, dive_site_table_t *sites);
 	int firstIndex;
 	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
-	struct dive_table *diveTable;
-	struct dive_site_table *sitesTable;
+	struct dive_table diveTable;
+	struct dive_site_table sitesTable;
 };
 
 #endif

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -21,6 +21,7 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
+	void deleteDeselected();
 	Q_INVOKABLE void recordDives();
 	Q_INVOKABLE void startDownload();
 

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -23,6 +23,7 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
 	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
+	int numDives() const;
 	Q_INVOKABLE void recordDives();
 	Q_INVOKABLE void startDownload();
 

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -44,7 +44,6 @@ signals:
 	void downloadFinished();
 
 private:
-	int lastIndex;
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table diveTable;
 	struct dive_site_table sitesTable;

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -22,6 +22,7 @@ public:
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
+	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
 	Q_INVOKABLE void recordDives();
 	Q_INVOKABLE void startDownload();
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -186,7 +186,6 @@ void register_qml_types(QQmlEngine *engine)
 	REGISTER_TYPE(QMLManager, "QMLManager");
 	REGISTER_TYPE(QMLPrefs, "QMLPrefs");
 	REGISTER_TYPE(QMLProfile, "QMLProfile");
-	REGISTER_TYPE(DownloadThread, "DCDownloadThread");
 	REGISTER_TYPE(DiveImportedModel, "DCImportModel");
 #endif // not SUBSURFACE_MOBILE
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an alternative way of implementing #2299: Since downloading goes via the dive-imported model anyway, we might as well make the data flow:
  UI<->Model<->Thread
This gives much less headache than all three modules talking to each other and trying desperately to stay in sync. This should also make debugging much easier as there should be less dreaded QML in the backtraces. This does not go full in: The desktop version still directly accesses the thread in places, for example to read out the error code. We might make this still much cleaner, but it is a start.

Note: this is mostly untested. The first version will crash and burn. Testing would be highly appreciated!

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Make DownloadThread a subobject of DiveImportedModel
2) Don't move table-pointers through QML

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2292 and #2221 report crashes in parts of the code that are removed here. So hopefully this improves the situation!

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Let's wait if this actually fixes something or makes it worse.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: please test if you find time.