### PR TITLE
Mobile: Don't access dive-id via DiveObjectHelper

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -397,7 +397,7 @@ Item {
 		}
 		Component.onCompleted: {
 			qmlProfile.setMargin(Kirigami.Units.smallSpacing)
-			qmlProfile.diveId = model.dive.id;
+			qmlProfile.diveId = model.id;
 			qmlProfile.update();
 		}
 	}

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -391,7 +391,7 @@ Kirigami.Page {
 					manager.appendTextToLog("Save downloaded dives that were selected")
 					importModel.recordDives()
 					manager.saveChangesLocal()
-					diveModel.reload()
+					diveModel.resetInternaData()
 					pageStack.pop();
 					download.text = qsTr("Download")
 					divesDownloaded = false

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -275,7 +275,7 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 
 void QMLManager::openLocalThenRemote(QString url)
 {
-	clear_dive_file_data();
+	DiveListModel::instance()->clear();
 	setNotificationText(tr("Open local dive data file"));
 	QByteArray fileNamePrt = QFile::encodeName(url);
 	bool glo = git_local_only;
@@ -722,7 +722,7 @@ void QMLManager::loadDivesWithValidCredentials()
 	// if we aren't switching from no-cloud mode, let's clear the dive data
 	if (!noCloudToCloud) {
 		appendTextToLog("Clear out in memory dive data");
-		clear_dive_file_data();
+		DiveListModel::instance()->clear();
 	} else {
 		appendTextToLog("Switching from no cloud mode; keep in memory dive data");
 	}

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -168,6 +168,13 @@ void DiveListModel::updateDive(int i, dive *d)
 	insertDive(i);
 }
 
+void DiveListModel::clear()
+{
+	beginResetModel();
+	clear_dive_file_data();
+	endResetModel();
+}
+
 void DiveListModel::reload()
 {
 	beginResetModel();

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -73,7 +73,7 @@ int DiveListSortModel::getIdxForId(int id)
 void DiveListSortModel::reload()
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
-	mySourceModel->reload();
+	mySourceModel->resetInternalData();
 }
 
 // In QtQuick ListView, section headings can only be strings. To identify dives
@@ -177,8 +177,16 @@ void DiveListModel::clear()
 
 void DiveListModel::reload()
 {
-	beginResetModel();
-	endResetModel();
+	// Note: instead of doing a (logical) beginResetModel()/endResetModel(),
+	// we add the rows (if any). The reason is that a beginResetModel()/endResetModel()
+	// pair resulted in the DiveDetailsPage being renedered for *every* dive in
+	// the list. It is unclear whether this is a Qt-bug or intended insanity.
+	// Therefore, this function must only be called after having called clear().
+	// Otherwise the model will become inconsistent!
+	if (dive_table.nr > 0) {
+		beginInsertRows(QModelIndex(), 0, dive_table.nr - 1);
+		endInsertRows();
+	}
 }
 
 void DiveListModel::resetInternalData()

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -62,6 +62,7 @@ public:
 	QHash<int, QByteArray> roleNames() const;
 	QString startAddDive();
 	void resetInternalData();
+	void clear(); // Clear all dives in core
 	Q_INVOKABLE DiveObjectHelper at(int i);
 };
 

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -53,7 +53,7 @@ public:
 	void removeDive(int i);
 	void removeDiveById(int id);
 	void updateDive(int i, dive *d);
-	void reload();
+	void reload(); // Only call after clearing the model!
 	struct dive *getDive(int i);
 	int rowCount(const QModelIndex &parent = QModelIndex()) const;
 	int getDiveIdx(int id) const;


### PR DESCRIPTION
There is already a role to do that. Query the model directly to
avoid creating a full DiveHelperObject.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Avoid creating an unnecessary DiveObjectHelper just to fetch the dive-id. The id is already exported by the model.