### PR TITLE
Android qt5.13.1

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1399,7 +1399,7 @@ QString getUUID()
 		uuidString = uuid.toString();
 		qPrefUpdateManager::set_uuidString(uuidString);
 	}
-	uuidString.replace("{", "p").replace("}", "");
+	uuidString.replace("{", "").replace("}", "");
 	return uuidString;
 }
 

--- a/packaging/android/qt-installer-noninteractive.qs
+++ b/packaging/android/qt-installer-noninteractive.qs
@@ -32,8 +32,8 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent('qt.qt5.5124.android_armv7');
-    widget.selectComponent('qt.qt5.5124.android_arm64_v8a');
+    widget.selectComponent('qt.qt5.5131.android_armv7');
+    widget.selectComponent('qt.qt5.5131.android_arm64_v8a');
 
     gui.clickButton(buttons.NextButton);
 }

--- a/packaging/android/variables.sh
+++ b/packaging/android/variables.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # When changing Qt version remember to update the 
 # qt-installer-noninteractive file as well.
-QT_VERSION=5.12
-LATEST_QT=5.12.4
+QT_VERSION=5.13
+LATEST_QT=5.13.1
 NDK_VERSION=r18b
 SDK_VERSION=4333796
 ANDROID_BUILDTOOLS_REVISION=28.0.3

--- a/packaging/android/variables.sh
+++ b/packaging/android/variables.sh
@@ -13,4 +13,4 @@ ANDROID_NDK=android-ndk-${NDK_VERSION}
 ANDROID_SDK=android-sdk-linux
 # OpenSSL also has an entry in get-dep-lib.sh line 103
 # that needs to be updated as well.
-OPENSSL_VERSION=1.1.1c
+OPENSSL_VERSION=1.1.1d

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update  && \
 # install, NDK and SDK there, plus the three files from the Subsurface
 # sources that we need to get the prep routines to run
 RUN mkdir -p /android
-ADD qt-opensource-linux-x64-5.12.4.run /android/
+ADD qt-opensource-linux-x64-5.13.1.run /android/
 ADD android-ndk-r*-linux-x86_64.zip /android/
 ADD sdk-tools-linux-*.zip /android/
 ADD android-build-wrapper.sh variables.sh qt-installer-noninteractive.qs /android/

--- a/scripts/docker/android-build-container/download.sh
+++ b/scripts/docker/android-build-container/download.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wget https://download.qt.io/official_releases/qt/5.13/5.13.1/qt-opensource-linux-x64-5.13.1.run
+wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
+wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+wget https://ftp.osuosl.org/pub/blfs/conglomeration/cmake/cmake-3.13.2.tar.gz

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -103,7 +103,7 @@ fi
 
 # FIX FOR ANDROID,
 if [ "$PLATFORM" == "singleAndroid" ] ; then
-	CURRENT_OPENSSL="OpenSSL_1_1_1c"
+	CURRENT_OPENSSL="OpenSSL_1_1_1d"
 # If changing the openSSL version here, make sure to change it in packaging/android/variables.sh also.
 fi
 # no curl and old libs (never version breaks)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Update the docker container and the scripts to use Qt 5.13.1
Implement the workaround suggested in https://doc.qt.io/qt-5/android-openssl-support.html for the OpenSSL issue on Android 5.x (what the document doesn't mention is that you need at least Qt 5.12.5 or 5.13 for this to work - that took me a LONG time to figure out...)

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2311 
Several similar reports in the user forum and mailing list

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This PR is already included in the current Android Beta

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@janmulder @glance- 