### PR TITLE
Update tabs correctly when replanning dive [supersedes #2281]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 Mobile: add support for editing the dive number of a dive
+Desktop: make dive replanning undoable
+Desktop: update statistics tab on undo or redo
+Planner: update dive details when replanning dive [#2280]
 Export: when exporting dive sites in dive site mode, export selected dive sites [#2275]
 Mobile: fix several bugs in the handling of incorrect or unverified cloud credentials
 Mobile: try to adjust the UI for cases with large default font relative to screen size

--- a/core/dive.c
+++ b/core/dive.c
@@ -339,6 +339,14 @@ static void copy_pl(struct picture *sp, struct picture *dp)
 	dp->filename = copy_string(sp->filename);
 }
 
+/* The first divecomputer is embedded in the dive structure. Free its data but not
+ * the structure itself. For all remainding dcs in the list, free data *and* structures. */
+void free_dive_dcs(struct divecomputer *dc)
+{
+	free_dc_contents(dc);
+	STRUCTURED_LIST_FREE(struct divecomputer, dc->next, free_dc);
+}
+
 static void free_dive_structures(struct dive *d)
 {
 	if (!d)
@@ -350,8 +358,7 @@ static void free_dive_structures(struct dive *d)
 	free(d->suit);
 	/* free tags, additional dive computers, and pictures */
 	taglist_free(d->tag_list);
-	free_dc_contents(&d->dc);
-	STRUCTURED_LIST_FREE(struct divecomputer, d->dc.next, free_dc);
+	free_dive_dcs(&d->dc);
 	STRUCTURED_LIST_FREE(struct picture, d->picture_list, free_picture);
 	for (int i = 0; i < MAX_CYLINDERS; i++)
 		free((void *)d->cylinder[i].type.description);

--- a/core/dive.h
+++ b/core/dive.h
@@ -326,6 +326,7 @@ extern void utc_mkdate(timestamp_t, struct tm *tm);
 
 extern struct dive *alloc_dive(void);
 extern void free_dive(struct dive *);
+extern void free_dive_dcs(struct divecomputer *dc);
 extern void record_dive_to_table(struct dive *dive, struct dive_table *table);
 extern void record_dive(struct dive *dive);
 extern void clear_dive(struct dive *dive);

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -9,30 +9,59 @@
 
 #include <QObject>
 
-// Dive and trip fields that can be edited.
-// Use "enum class" to not polute the global name space.
-enum class DiveField {
-	NR,
-	DATETIME,
-	DEPTH,
-	DURATION,
-	AIR_TEMP,
-	WATER_TEMP,
-	ATM_PRESS,
-	DIVESITE,
-	DIVEMASTER,
-	BUDDY,
-	RATING,
-	VISIBILITY,
-	SUIT,
-	TAGS,
-	MODE,
-	NOTES,
-	SALINITY
+// Dive and trip fields that can be edited. Use bit fields so that we can pass multiple fields at once.
+// Provides an inlined flag-based constructur because sadly C-style designated initializers are only supported since C++20.
+struct DiveField {
+	// Note: using int instead of the more natural bool, because gcc produces significantly worse code with
+	// bool. clang, on the other hand, does fine.
+	unsigned int nr : 1;
+	unsigned int datetime : 1;
+	unsigned int depth : 1;
+	unsigned int duration : 1;
+	unsigned int air_temp : 1;
+	unsigned int water_temp : 1;
+	unsigned int atm_press : 1;
+	unsigned int divesite : 1;
+	unsigned int divemaster : 1;
+	unsigned int buddy : 1;
+	unsigned int rating : 1;
+	unsigned int visibility : 1;
+	unsigned int suit : 1;
+	unsigned int tags : 1;
+	unsigned int mode : 1;
+	unsigned int notes : 1;
+	unsigned int salinity : 1;
+	enum Flags {
+		NONE = 0,
+		NR = 1 << 0,
+		DATETIME = 1 << 1,
+		DEPTH = 1 << 2,
+		DURATION = 1 << 3,
+		AIR_TEMP = 1 << 4,
+		WATER_TEMP = 1 << 5,
+		ATM_PRESS = 1 << 6,
+		DIVESITE = 1 << 7,
+		DIVEMASTER = 1 << 8,
+		BUDDY = 1 << 9,
+		RATING = 1 << 10,
+		VISIBILITY = 1 << 11,
+		SUIT = 1 << 12,
+		TAGS = 1 << 13,
+		MODE = 1 << 14,
+		NOTES = 1 << 15,
+		SALINITY = 1 << 16
+	};
+	DiveField(int flags);
 };
-enum class TripField {
-	LOCATION,
-	NOTES
+struct TripField {
+	unsigned int location : 1;
+	unsigned int notes : 1;
+	enum Flags {
+		NONE = 0,
+		LOCATION = 1 << 0,
+		NOTES = 1 << 1
+	};
+	TripField(int flags);
 };
 
 class DiveListNotifier : public QObject {
@@ -130,4 +159,30 @@ inline DiveListNotifier::InCommandMarker DiveListNotifier::enterCommand()
 	return InCommandMarker(*this);
 }
 
+inline DiveField::DiveField(int flags) :
+	nr((flags & NR) != 0),
+	datetime((flags & DATETIME) != 0),
+	depth((flags & DEPTH) != 0),
+	duration((flags & DURATION) != 0),
+	air_temp((flags & AIR_TEMP) != 0),
+	water_temp((flags & WATER_TEMP) != 0),
+	atm_press((flags & ATM_PRESS) != 0),
+	divesite((flags & DIVESITE) != 0),
+	divemaster((flags & DIVEMASTER) != 0),
+	buddy((flags & BUDDY) != 0),
+	rating((flags & RATING) != 0),
+	visibility((flags & VISIBILITY) != 0),
+	suit((flags & SUIT) != 0),
+	tags((flags & TAGS) != 0),
+	mode((flags & MODE) != 0),
+	notes((flags & NOTES) != 0),
+	salinity((flags & SALINITY) != 0)
+{
+}
+
+inline TripField::TripField(int flags) :
+	location((flags & LOCATION) != 0),
+	notes((flags & NOTES) != 0)
+{
+}
 #endif

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -28,6 +28,7 @@ enum class DiveField {
 	TAGS,
 	MODE,
 	NOTES,
+	SALINITY
 };
 enum class TripField {
 	LOCATION,

--- a/desktop-widgets/command.cpp
+++ b/desktop-widgets/command.cpp
@@ -238,6 +238,11 @@ void pasteDives(const dive *d, dive_components what)
 	execute(new PasteDives(d, what));
 }
 
+void replanDive(dive *d)
+{
+	execute(new ReplanDive(d));
+}
+
 // Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {

--- a/desktop-widgets/command.h
+++ b/desktop-widgets/command.h
@@ -75,6 +75,7 @@ int editTags(const QStringList &newList, bool currentDiveOnly);
 int editBuddies(const QStringList &newList, bool currentDiveOnly);
 int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
+void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
 
 // 5) Trip editing commands
 

--- a/desktop-widgets/command_edit.cpp
+++ b/desktop-widgets/command_edit.cpp
@@ -803,25 +803,16 @@ void PasteDives::undo()
 	}
 
 	// Send signals.
-	// TODO: We send one signal per changed field. This means that the dive list may
-	// update the entry numerous times. Perhaps change the field-id into flags?
-	// There seems to be a number of enums / flags describing dive fields. Perhaps unify them all?
-	if (what.notes)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::NOTES);
-	if (what.divemaster)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::DIVEMASTER);
-	if (what.buddy)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::BUDDY);
-	if (what.suit)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::SUIT);
-	if (what.rating)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::RATING);
-	if (what.visibility)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::VISIBILITY);
-	if (what.divesite)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::DIVESITE);
-	if (what.tags)
-		emit diveListNotifier.divesChanged(divesToNotify, DiveField::TAGS);
+	DiveField fields(DiveField::NONE);
+	fields.notes = what.notes;
+	fields.divemaster = what.divemaster;
+	fields.buddy = what.buddy;
+	fields.suit = what.suit;
+	fields.rating = what.rating;
+	fields.visibility = what.visibility;
+	fields.divesite = what.divesite;
+	fields.tags = what.tags;
+	emit diveListNotifier.divesChanged(divesToNotify, fields);
 	if (what.cylinders)
 		emit diveListNotifier.cylindersReset(divesToNotify);
 	if (what.weights)
@@ -888,14 +879,8 @@ void ReplanDive::undo()
 	fixup_dive(d);
 
 	QVector<dive *> divesToNotify = { d };
-	// TODO: Turn field into flags to avoid multiple signals
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DATETIME);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DURATION);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DEPTH);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::MODE);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::NOTES);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::SALINITY);
-	emit diveListNotifier.divesChanged(divesToNotify, DiveField::ATM_PRESS);
+	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DATETIME | DiveField::DURATION | DiveField::DEPTH | DiveField::MODE |
+							  DiveField::NOTES | DiveField::SALINITY | DiveField::ATM_PRESS);
 	emit diveListNotifier.cylindersReset(divesToNotify);
 }
 

--- a/desktop-widgets/command_edit.h
+++ b/desktop-widgets/command_edit.h
@@ -254,13 +254,34 @@ struct PasteState {
 	void swap(dive_components what); // Exchange values here and in dive
 };
 
-class PasteDives  : public Base {
+class PasteDives : public Base {
 	dive_components what;
 	std::vector<PasteState> dives;
 	std::vector<OwningDiveSitePtr> ownedDiveSites;
 	dive *current;
 public:
 	PasteDives(const dive *d, dive_components what);
+private:
+	void undo() override;
+	void redo() override;
+	bool workToBeDone() override;
+};
+
+class ReplanDive : public Base {
+	dive *d;
+
+	// Exchange these data with current dive
+	timestamp_t when;
+	depth_t maxdepth, meandepth;
+	cylinder_t cylinders[MAX_CYLINDERS];
+	struct divecomputer dc;
+	char *notes;
+	pressure_t surface_pressure;
+	duration_t duration;
+	int salinity;
+public:
+	ReplanDive(dive *source); // Dive computer(s) and cylinders(s) of the source dive will be reset!
+	~ReplanDive();
 private:
 	void undo() override;
 	void redo() override;

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -104,7 +104,7 @@ void MapWidget::coordinatesChanged(struct dive_site *ds, const location_t &locat
 
 void MapWidget::divesChanged(const QVector<dive *> &, DiveField field)
 {
-	if (field == DiveField::DIVESITE)
+	if (field.divesite)
 		reload();
 }
 

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -108,13 +108,8 @@ void TabDiveEquipment::divesChanged(const QVector<dive *> &dives, DiveField fiel
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
-	switch(field) {
-	case DiveField::SUIT:
+	if (field.suit)
 		ui.suit->setText(QString(current_dive->suit));
-		break;
-	default:
-		break;
-	}
 }
 
 void TabDiveEquipment::toggleTriggeredColumn()

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -106,6 +106,14 @@ void TabDiveInformation::updateWhen()
 		ui->surfaceIntervalText->clear();
 }
 
+void TabDiveInformation::updateSalinity()
+{
+	if (current_dive->salinity)
+		ui->salinityText->setText(QString("%1g/ℓ").arg(current_dive->salinity / 10.0));
+	else
+		ui->salinityText->clear();
+}
+
 void TabDiveInformation::updateData()
 {
 	if (!current_dive) {
@@ -117,11 +125,7 @@ void TabDiveInformation::updateData()
 	updateWhen();
 	ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
 	ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
-
-	if (current_dive->salinity)
-		ui->salinityText->setText(QString("%1g/ℓ").arg(current_dive->salinity / 10.0));
-	else
-		ui->salinityText->clear();
+	updateSalinity();
 
 	ui->atmPressType->setEditable(true);
 	ui->atmPressType->setItemText(1, get_depth_unit());  // Check for changes in depth unit (imperial/metric)
@@ -154,6 +158,9 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		break;
 	case DiveField::DATETIME:
 		updateWhen();
+		break;
+	case DiveField::SALINITY:
+		updateSalinity();
 		break;
 	default:
 		break;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -141,30 +141,18 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
-	switch(field) {
-	case DiveField::DURATION:
-	case DiveField::DEPTH:
-	case DiveField::MODE:
+	if (field.duration || field.depth || field.mode)
 		updateProfile();
-		break;
-	case DiveField::AIR_TEMP:
+	if (field.air_temp)
 		ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
-		break;
-	case DiveField::WATER_TEMP:
+	if (field.water_temp)
 		ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
-		break;
-	case DiveField::ATM_PRESS:
+	if (field.atm_press)
 		ui->atmPressVal->setText(ui->atmPressVal->text().sprintf("%d",current_dive->surface_pressure.mbar));
-		break;
-	case DiveField::DATETIME:
+	if (field.datetime)
 		updateWhen();
-		break;
-	case DiveField::SALINITY:
+	if (field.salinity)
 		updateSalinity();
-		break;
-	default:
-		break;
-	}
 }
 
 void TabDiveInformation::on_atmPressType_currentIndexChanged(int index) { updateTextBox(COMBO_CHANGED); }

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -23,6 +23,7 @@ private slots:
 private:
 	Ui::TabDiveInformation *ui;
 	void updateProfile();
+	void updateSalinity();
 	void updateWhen();
 	int pressTypeIndex;
 	void updateTextBox(int event);

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -53,17 +53,8 @@ void TabDiveStatistics::divesChanged(const QVector<dive *> &dives, DiveField fie
 		return;
 
 	// TODO: make this more fine grained. Currently, the core can only calculate *all* statistics.
-	switch(field) {
-	case DiveField::DURATION:
-	case DiveField::DEPTH:
-	case DiveField::MODE:
-	case DiveField::AIR_TEMP:
-	case DiveField::WATER_TEMP:
+	if (field.duration || field.depth || field.mode || field.air_temp || field.water_temp)
 		updateData();
-		break;
-	default:
-		break;
-	}
 }
 
 void TabDiveStatistics::updateData()

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -21,6 +21,8 @@ TabDiveStatistics::TabDiveStatistics(QWidget *parent) : TabBase(parent), ui(new 
 	ui->timeLimits->overrideMinToolTipText(tr("Shortest dive"));
 	ui->timeLimits->overrideAvgToolTipText(tr("Average length of all selected dives"));
 
+	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveStatistics::divesChanged);
+
 	const auto l = findChildren<QLabel *>(QString(), Qt::FindDirectChildrenOnly);
 	for (QLabel *label: l) {
 		label->setAlignment(Qt::AlignHCenter);
@@ -40,6 +42,28 @@ void TabDiveStatistics::clear()
 	ui->tempLimits->clear();
 	ui->totalTimeAllText->clear();
 	ui->timeLimits->clear();
+}
+
+// This function gets called if a field gets updated by an undo command.
+// Refresh the corresponding UI field.
+void TabDiveStatistics::divesChanged(const QVector<dive *> &dives, DiveField field)
+{
+	// If none of the changed dives is selected, do nothing
+	if (std::none_of(dives.begin(), dives.end(), [] (const dive *d) { return d->selected; }))
+		return;
+
+	// TODO: make this more fine grained. Currently, the core can only calculate *all* statistics.
+	switch(field) {
+	case DiveField::DURATION:
+	case DiveField::DEPTH:
+	case DiveField::MODE:
+	case DiveField::AIR_TEMP:
+	case DiveField::WATER_TEMP:
+		updateData();
+		break;
+	default:
+		break;
+	}
 }
 
 void TabDiveStatistics::updateData()

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.h
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.h
@@ -3,6 +3,7 @@
 #define TAB_DIVE_STATISTICS_H
 
 #include "TabBase.h"
+#include "core/subsurface-qt/DiveListNotifier.h"
 
 namespace Ui {
 	class TabDiveStatistics;
@@ -15,6 +16,9 @@ public:
 	~TabDiveStatistics();
 	void updateData() override;
 	void clear() override;
+
+private slots:
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 
 private:
 	Ui::TabDiveStatistics *ui;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -284,53 +284,39 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
-	switch(field) {
-	case DiveField::DURATION:
+	if (field.duration)
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
-		profileFromDive(current_dive);
-		break;
-	case DiveField::DEPTH:
+	if (field.depth)
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
-		profileFromDive(current_dive);
-		break;
-	case DiveField::AIR_TEMP:
+	if (field.air_temp)
 		ui.airtemp->setText(get_temperature_string(current_dive->airtemp, true));
-		break;
-	case DiveField::WATER_TEMP:
+	if (field.water_temp)
 		ui.watertemp->setText(get_temperature_string(current_dive->watertemp, true));
-		break;
-	case DiveField::RATING:
+	if (field.rating)
 		ui.rating->setCurrentStars(current_dive->rating);
-		break;
-	case DiveField::VISIBILITY:
+	if (field.visibility)
 		ui.visibility->setCurrentStars(current_dive->visibility);
-		break;
-	case DiveField::NOTES:
+	if (field.notes)
 		updateNotes(current_dive);
-		break;
-	case DiveField::MODE:
+	if (field.mode)
 		updateMode(current_dive);
-		break;
-	case DiveField::DATETIME:
+	if (field.datetime) {
 		updateDateTime(current_dive);
 		MainWindow::instance()->graphics->dateTimeChanged();
 		DivePlannerPointsModel::instance()->getDiveplan().when = current_dive->when;
-		break;
-	case DiveField::DIVESITE:
-		updateDiveSite(current_dive);
-		break;
-	case DiveField::TAGS:
-		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
-		break;
-	case DiveField::BUDDY:
-		ui.buddy->setText(current_dive->buddy);
-		break;
-	case DiveField::DIVEMASTER:
-		ui.divemaster->setText(current_dive->divemaster);
-		break;
-	default:
-		break;
 	}
+	if (field.divesite)
+		updateDiveSite(current_dive);
+	if (field.tags)
+		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
+	if (field.buddy)
+		ui.buddy->setText(current_dive->buddy);
+	if (field.divemaster)
+		ui.divemaster->setText(current_dive->divemaster);
+
+	// If duration or depth changed, the profile needs to be replotted
+	if (field.duration || field.depth)
+		profileFromDive(current_dive);
 }
 
 void MainTab::diveSiteEdited(dive_site *ds, int)
@@ -347,16 +333,10 @@ void MainTab::tripChanged(dive_trip *trip, TripField field)
 	if (currentTrip != trip)
 		return;
 
-	switch(field) {
-	case TripField::NOTES:
+	if (field.notes)
 		ui.notes->setText(currentTrip->notes);
-		break;
-	case TripField::LOCATION:
+	if (field.location)
 		ui.diveTripLocation->setText(currentTrip->location);
-		break;
-	default:
-		break;
-	}
 }
 
 void MainTab::nextInputField(QKeyEvent *event)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -264,18 +264,6 @@ void MainTab::enableEdition(EditMode newEditMode)
 	editMode = newEditMode != NONE ? newEditMode : DIVE;
 }
 
-static void profileFromDive(struct dive *d)
-{
-	// TODO: We have to put these manipulations into a setPlanState()/setProfileState() pair,
-	// because otherwise the DivePlannerPointsModel and the profile get out of sync.
-	// This can lead to crashes. Let's try to detangle these subtleties.
-	MainWindow::instance()->graphics->setPlanState();
-	DivePlannerPointsModel::instance()->loadFromDive(d);
-	MainWindow::instance()->graphics->setReplot(true);
-	MainWindow::instance()->graphics->plotDive(current_dive, true);
-	MainWindow::instance()->graphics->setProfileState();
-}
-
 // This function gets called if a field gets updated by an undo command.
 // Refresh the corresponding UI field.
 void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
@@ -316,7 +304,7 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 
 	// If duration or depth changed, the profile needs to be replotted
 	if (field.duration || field.depth)
-		profileFromDive(current_dive);
+		MainWindow::instance()->graphics->plotDive(current_dive, true);
 }
 
 void MainTab::diveSiteEdited(dive_site *ds, int)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -6,7 +6,6 @@
 #include "qt-models/models.h"
 #include "core/device.h"
 #include "core/qthelper.h"
-#include "core/divelist.h" // for mark_divelist_changed()
 #include "core/settings/qPrefDivePlanner.h"
 #include "desktop-widgets/command.h"
 #include "core/gettextfromc.h"
@@ -1176,8 +1175,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 		Command::addDive(&displayed_dive, false, false);
 	} else {
 		// we were planning an old dive and rewrite the plan
-		mark_divelist_changed(true);
-		copy_dive(&displayed_dive, current_dive);
+		Command::replanDive(&displayed_dive);
 	}
 
 	// Remove and clean the diveplan, so we don't delete


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at fixing #2280: update the dive information tab when replanning a dive. It also fixes a bug that the statistics tab was not properly updated on undo/redo.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement ReplanDive undo command.
2) Update statistics tab when dive changed.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2280.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79: please test - this was only quickly hacked together.