### PR TITLE
Cloud storage: remove outdated certificate hack

### DIFF
--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -78,24 +78,9 @@ bool CheckCloudConnection::checkServer()
 
 void CheckCloudConnection::sslErrors(const QList<QSslError> &errorList)
 {
-	if (verbose) {
-		qDebug() << "Received error response trying to set up https connection with cloud storage backend:";
-		for (QSslError err: errorList) {
-			qDebug() << err.errorString();
-		}
-	}
-	QSslConfiguration conf = reply->sslConfiguration();
-	QSslCertificate cert = conf.peerCertificate();
-	QByteArray hexDigest = cert.digest().toHex();
-	if (reply->url().toString().contains(prefs.cloud_base_url) &&
-	    hexDigest == "13ff44c62996cfa5cd69d6810675490e") {
-		if (verbose)
-			qDebug() << "Overriding SSL check as I recognize the certificate digest" << hexDigest;
-		reply->ignoreSslErrors();
-	} else {
-		if (verbose)
-			qDebug() << "got invalid SSL certificate with hex digest" << hexDigest;
-	}
+	qDebug() << "Received error response trying to set up https connection with cloud storage backend:";
+	for (QSslError err: errorList)
+		qDebug() << err.errorString();
 }
 
 // helper to be used from C code


### PR DESCRIPTION
The old server certificates where not recognized on some older platform,
so we hardcoded the hex digest of the valid certificate and ignored the
error.

Those certificates have been replaced last week, so there is no point to
this hack anymore - also, we should always show the SSL error, not just
in verbose mode.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We no longer use that certificate, so no point to this anymore

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) remove the override for the certificate that's no longer in use
2) always show the SSL errors, not just in verbose mode

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
This should be an obvious change, but I'd appreciate a quick review, @bstoeger or @atdotde or @neolit123 