### PR TITLE
Keep text field that user wants to edit visible

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -187,7 +187,8 @@ Kirigami.Page {
 
 	actions.main: Kirigami.Action {
 		icon {
-			name: state !== "view" ? ":/icons/document-save.svg" : ":/icons/document-edit.svg"
+			name: state !== "view" ? ":/icons" + subsurfaceTheme.iconStyle + "/document-save.svg" :
+						 ":/icons" + subsurfaceTheme.iconStyle + "/document-edit.svg"
 			color: subsurfaceTheme.primaryColor
 		}
 		text: state !== "view" ? qsTr("Save edits") : qsTr("Edit dive")

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -163,13 +163,10 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtDate;
 				Layout.fillWidth: true
-				onEditingFinished: {
-					focus = false
-				}
-				color: subsurfaceTheme.textColor
+				flickable: detailsEditFlickable
 			}
 			Controls.Label {
 				Layout.alignment: Qt.AlignRight
@@ -201,13 +198,10 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtGps
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -238,14 +232,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtDepth
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /[^-]*/ }
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 			Controls.Label {
 				Layout.alignment: Qt.AlignRight
@@ -253,14 +244,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtDuration
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /[^-]*/ }
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -269,13 +257,10 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtAirTemp
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -284,13 +269,10 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtWaterTemp
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -363,14 +345,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtWeight
 				readOnly: text === "cannot edit multiple weight systems"
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 // all cylinder info should be able to become dynamic instead of this blob of code.
 // first cylinder
@@ -395,15 +374,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtGasMix0
 				text: usedGas[0] != null ? usedGas[0] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -412,14 +388,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtStartPressure0
 				text: startpressure[0] != null ? startpressure[0] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -428,14 +401,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				id: txtEndPressure0
 				text: endpressure[0] != null ? endpressure[0] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 //second cylinder
 			Controls.Label {
@@ -462,16 +432,13 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtGasMix1
 				text: usedGas[1] != null ? usedGas[1] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -481,15 +448,12 @@ Item {
 				color: subsurfaceTheme.textColor
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtStartPressure1
 				text: startpressure[1] != null ? startpressure[1] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -499,15 +463,12 @@ Item {
 				color: subsurfaceTheme.textColor
 				font.pointSize: subsurfaceTheme.smallPointSize
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[1] != null ? true : false
 				id: txtEndPressure1
-				text: endpressure[1] != null ? endpressure[1] : null 
+				text: endpressure[1] != null ? endpressure[1] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 // third cylinder
 			Controls.Label {
@@ -535,16 +496,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtGasMix2
 				text: usedGas[2] != null ? usedGas[2] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				onEditingFinished: {
-					focus = false
-				}
 			}
 
 			Controls.Label {
@@ -554,15 +511,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtStartPressure2
 				text: startpressure[2] != null ? startpressure[2] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -572,15 +526,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[2] != null ? true : false
 				id: txtEndPressure2
 				text: endpressure[2] != null ? endpressure[2] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 // fourth cylinder
 			Controls.Label {
@@ -608,16 +559,13 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtGasMix3
 				text: usedGas[3] != null ? usedGas[3] : null
 				Layout.fillWidth: true
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -627,15 +575,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtStartPressure3
 				text: startpressure[3] != null ? startpressure[3] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -645,15 +590,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[3] != null ? true : false
 				id: txtEndPressure3
 				text: endpressure[3] != null ? endpressure[3] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 // fifth cylinder
 			Controls.Label {
@@ -681,16 +623,13 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtGasMix4
 				text: usedGas[4] != null ? usedGas[4] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
 				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -700,15 +639,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtStartPressure4
 				text: startpressure[4] != null ? startpressure[4] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -718,15 +654,12 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
-			Controls.TextField {
+			SsrfTextField {
 				visible: usedCyl[4] != null ? true : false
 				id: txtEndPressure4
 				text: endpressure[4] != null ? endpressure[4] : null
 				Layout.fillWidth: true
-				color: subsurfaceTheme.textColor
-				onEditingFinished: {
-					focus = false
-				}
+				flickable: detailsEditFlickable
 			}
 
 			Controls.Label {
@@ -775,6 +708,31 @@ Item {
 				Layout.minimumHeight: Kirigami.Units.gridUnit * 6
 				selectByMouse: true
 				wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
+				property bool firstTime: true
+				onPressed: waitForKeyboard.start()
+
+				// we repeat the Timer / Function from the SsrfTextField here (no point really in creating a matching customized TextArea)
+				function ensureVisible(yDest) {
+					detailsEditFlickable.contentY = yDest
+				}
+
+				// give the OS enough time to actually resize the flickable
+				Timer {
+					id: waitForKeyboard
+					interval: 300 // 300ms seems like FOREVER
+					onTriggered: {
+						if (!Qt.inputMethod.visible) {
+							if (firstTime) {
+								firstTime = false
+								restart()
+							}
+							return
+						}
+						// make sure at least half the Notes field is visible
+						if (txtNotes.y + txtNotes.height / 2 > detailsEditFlickable.contentY + detailsEditFlickable.height - 3 * Kirigami.Units.gridUnit || txtNotes.y < detailsEditFlickable.contentY)
+							txtNotes.ensureVisible(Math.max(0, 3 * Kirigami.Units.gridUnit + txtNotes.y + txtNotes.height / 2 - detailsEditFlickable.height))
+					}
+				}
 			}
 		}
 		Item {

--- a/mobile-widgets/qml/SsrfTextField.qml
+++ b/mobile-widgets/qml/SsrfTextField.qml
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.2
+import QtQuick.Controls 2.2 as Controls
+import org.kde.kirigami 2.4 as Kirigami
+
+Controls.TextField {
+	/**
+	 * set the flickable property to the Flickable this TextField is part of and
+	 * when the user starts editing the text this should stay visible
+	 */
+	property var flickable
+	property bool firstTime: true
+
+	id: stf
+
+	// while we are at it, let's put some common settings here into the shared element
+	color: subsurfaceTheme.textColor
+	onEditingFinished: {
+		focus = false
+		firstTime = true
+	}
+
+	// that's when a user taps on the field to start entering text
+	onPressed: {
+		if (flickable !== undefined) {
+			waitForKeyboard.start()
+		} else {
+			console.log("flickable is undefined")
+		}
+	}
+
+	// give the OS enough time to actually resize the flickable
+	Timer {
+		id: waitForKeyboard
+		interval: 300 // 300ms seems like FOREVER, but even that sometimes isn't long enough on Android
+
+		onTriggered: {
+			if (!Qt.inputMethod.visible) {
+				if (firstTime) {
+					firstTime = false
+					restart()
+				}
+				return
+			}
+			// make sure there's enough space for the input field above the keyboard and action button (and that it's not too far up, either)
+			if (stf.y + stf.height > flickable.contentY + flickable.height - 3 * Kirigami.Units.gridUnit || y < flickable.contentY)
+				ensureVisible(Math.max(0, 3 * Kirigami.Units.gridUnit + stf.y + stf.height - flickable.height))
+		}
+	}
+
+	// scroll the flickable to the desired position if the keyboard has shown up
+	// this didn't work when setting it from within the Timer, but calling this function works.
+	// go figure.
+	function ensureVisible(yDest) {
+		flickable.contentY = yDest
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -460,6 +460,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.blueSecondaryTextColor
 		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
 		subsurfaceTheme.drawerColor = subsurfaceTheme.lightDrawerColor
+		subsurfaceTheme.iconStyle = "-dark"
 	}
 
 	function pinkTheme() {
@@ -477,6 +478,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.pinkSecondaryTextColor
 		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
 		subsurfaceTheme.drawerColor = subsurfaceTheme.lightDrawerColor
+		subsurfaceTheme.iconStyle = ""
 	}
 
 	function darkTheme() {
@@ -494,6 +496,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.darkSecondaryTextColor
 		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
 		subsurfaceTheme.drawerColor = subsurfaceTheme.darkDrawerColor
+		subsurfaceTheme.iconStyle = "-dark"
 	}
 
 	function setupUnits() {
@@ -537,6 +540,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		property double titlePointSize: regularPointSize * 1.5
 		property double headingPointSize: regularPointSize * 1.2
 		property double smallPointSize: regularPointSize * 0.8
+
+		// icon Theme
+		property string iconStyle: ""
 
 		// colors currently in use
 		property string currentTheme

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -21,6 +21,7 @@
 		<file>SsrfButton.qml</file>
 		<file>SsrfCheckBox.qml</file>
 		<file>SsrfSwitch.qml</file>
+		<file>SsrfTextField.qml</file>
 
 		<!-- ********** pictures ********** -->
 		<file>icons/dive.jpg</file>

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -67,7 +67,9 @@
 		<file alias="icons/dialog-cancel.svg">kirigami/icons/dialog-cancel.svg</file>
 		<file alias="icons/distribute-horizontal-x.svg">kirigami/icons/distribute-horizontal-x.svg</file>
 		<file alias="icons/document-edit.svg">kirigami/icons/document-edit.svg</file>
+		<file alias="icons-dark/document-edit.svg">kirigami/icons-dark/document-edit.svg</file>
 		<file alias="icons/document-save.svg">kirigami/icons/document-save.svg</file>
+		<file alias="icons-dark/document-save.svg">kirigami/icons-dark/document-save.svg</file>
 		<file alias="icons/go-up.svg">kirigami/icons/go-up.svg</file>
 		<file alias="icons/gps.svg">kirigami/icons/gps.svg</file>
 		<file alias="icons/handle-left.svg">kirigami/icons/handle-left.svg</file>

--- a/scripts/mobilecomponents.sh
+++ b/scripts/mobilecomponents.sh
@@ -30,6 +30,7 @@ BREEZE=../breeze-icons
 
 rm -rf $MC
 mkdir -p $MC/icons
+mkdir -p $MC/icons-dark
 cp -R $PMMC/* $MC/
 
 cp $BREEZE/icons/actions/22/map-globe.svg $MC/icons
@@ -37,6 +38,8 @@ cp $BREEZE/icons/actions/24/dialog-cancel.svg $MC/icons
 cp $BREEZE/icons/actions/24/distribute-horizontal-x.svg $MC/icons
 cp $BREEZE/icons/actions/24/document-edit.svg $MC/icons
 cp $BREEZE/icons/actions/24/document-save.svg $MC/icons
+cp $BREEZE/icons-dark/actions/24/document-edit.svg $MC/icons-dark
+cp $BREEZE/icons-dark/actions/24/document-save.svg $MC/icons-dark
 cp $BREEZE/icons/actions/24/go-next.svg $MC/icons
 cp $BREEZE/icons/actions/24/go-previous.svg $MC/icons
 cp $BREEZE/icons/actions/24/go-up.svg $MC/icons


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
One of my main frustration editing dives on mobile has always been that I tap on a field, the keyboard pops up and hides the field I wanted to edit. Grmbl.
I figured out how to prevent that.
Testing this ONLY makes sense on device - you can't really see the effect when running Mobile-on-Desktop

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) create our own TextField that sets some of the repetitive defaults (because of this the net lines added by this PR is tiny)
2) create a timer that triggers 300/600ms after we tap on the text field and makes sure that the text field is indeed visible
3) redo those changes for the TextArea on the DiveDetailsEdit page (we have only one, so I didn't create a new type for that)

