### PR TITLE
Cleanup: use pointer-to-member-function in addAction() calls [requires #2321]

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -948,18 +948,18 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 			}
 		}
 		if (needs_expand)
-			popup.addAction(tr("Expand all"), this, SLOT(expandAll()));
+			popup.addAction(tr("Expand all"), this, &QTreeView::expandAll);
 		if (needs_collapse)
-			popup.addAction(tr("Collapse all"), this, SLOT(collapseAll()));
+			popup.addAction(tr("Collapse all"), this, &QTreeView::collapseAll);
 
 		// verify if there`s a need for collapse others
 		if (expanded_nodes > 1)
-			collapseAction = popup.addAction(tr("Collapse others"), this, SLOT(collapseAll()));
+			collapseAction = popup.addAction(tr("Collapse others"), this, &QTreeView::collapseAll);
 
 
 		if (d) {
-			popup.addAction(tr("Remove dive(s) from trip"), this, SLOT(removeFromTrip()));
-			popup.addAction(tr("Create new trip above"), this, SLOT(newTripAbove()));
+			popup.addAction(tr("Remove dive(s) from trip"), this, &DiveListView::removeFromTrip);
+			popup.addAction(tr("Create new trip above"), this, &DiveListView::newTripAbove);
 			if (!d->divetrip) {
 				struct dive *top = d;
 				struct dive *bottom = d;
@@ -974,30 +974,30 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 					}
 				}
 				if (is_trip_before_after(top, (currentOrder == Qt::AscendingOrder)))
-					popup.addAction(tr("Add dive(s) to trip immediately above"), this, SLOT(addToTripAbove()));
+					popup.addAction(tr("Add dive(s) to trip immediately above"), this, &DiveListView::addToTripAbove);
 				if (is_trip_before_after(bottom, (currentOrder == Qt::DescendingOrder)))
-					popup.addAction(tr("Add dive(s) to trip immediately below"), this, SLOT(addToTripBelow()));
+					popup.addAction(tr("Add dive(s) to trip immediately below"), this, &DiveListView::addToTripBelow);
 			}
 		}
 		if (trip) {
-			popup.addAction(tr("Merge trip with trip above"), this, SLOT(mergeTripAbove()));
-			popup.addAction(tr("Merge trip with trip below"), this, SLOT(mergeTripBelow()));
+			popup.addAction(tr("Merge trip with trip above"), this, &DiveListView::mergeTripAbove);
+			popup.addAction(tr("Merge trip with trip below"), this, &DiveListView::mergeTripBelow);
 		}
 	}
 	if (d) {
-		popup.addAction(tr("Delete dive(s)"), this, SLOT(deleteDive()));
+		popup.addAction(tr("Delete dive(s)"), this, &DiveListView::deleteDive);
 #if 0
-		popup.addAction(tr("Mark dive(s) invalid", this, SLOT(markDiveInvalid())));
+		popup.addAction(tr("Mark dive(s) invalid", this, &DiveListView::markDiveInvalid);
 #endif
 	}
 	if (amount_selected > 1 && consecutive_selected())
-		popup.addAction(tr("Merge selected dives"), this, SLOT(mergeDives()));
+		popup.addAction(tr("Merge selected dives"), this, &DiveListView::mergeDives);
 	if (amount_selected >= 1) {
-		popup.addAction(tr("Renumber dive(s)"), this, SLOT(renumberDives()));
-		popup.addAction(tr("Shift dive times"), this, SLOT(shiftTimes()));
-		popup.addAction(tr("Split selected dives"), this, SLOT(splitDives()));
-		popup.addAction(tr("Load media from file(s)"), this, SLOT(loadImages()));
-		popup.addAction(tr("Load media from web"), this, SLOT(loadWebImages()));
+		popup.addAction(tr("Renumber dive(s)"), this, &DiveListView::renumberDives);
+		popup.addAction(tr("Shift dive times"), this, &DiveListView::shiftTimes);
+		popup.addAction(tr("Split selected dives"), this, &DiveListView::splitDives);
+		popup.addAction(tr("Load media from file(s)"), this, &DiveListView::loadImages);
+		popup.addAction(tr("Load media from web"), this, &DiveListView::loadWebImages);
 	}
 
 	// "collapse all" really closes all trips,

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -63,7 +63,7 @@ void DiveHandler::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 	// don't allow removing the last point
 	if (plannerModel->rowCount() > 1) {
 		m.addSeparator();
-		m.addAction(gettextFromC::tr("Remove this point"), this, SLOT(selfRemove()));
+		m.addAction(gettextFromC::tr("Remove this point"), this, &DiveHandler::selfRemove);
 		m.exec(event->screenPos());
 	}
 }

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -57,7 +57,7 @@ bool LocationInformationWidget::eventFilter(QObject *object, QEvent *ev)
 	if (ev->type() == QEvent::ContextMenu) {
 		QContextMenuEvent *ctx = (QContextMenuEvent *)ev;
 		QMenu contextMenu;
-		contextMenu.addAction(tr("Merge into current site"), this, SLOT(mergeSelectedDiveSites()));
+		contextMenu.addAction(tr("Merge into current site"), this, &LocationInformationWidget::mergeSelectedDiveSites);
 		contextMenu.exec(ctx->globalPos());
 		return true;
 	}

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -52,14 +52,14 @@ void TabDivePhotos::clear()
 void TabDivePhotos::contextMenuEvent(QContextMenuEvent *event)
 {
 	QMenu popup(this);
-	popup.addAction(tr("Load media from file(s)"), this, SLOT(addPhotosFromFile()));
-	popup.addAction(tr("Load media file(s) from web"), this, SLOT(addPhotosFromURL()));
+	popup.addAction(tr("Load media from file(s)"), this, &TabDivePhotos::addPhotosFromFile);
+	popup.addAction(tr("Load media file(s) from web"), this, &TabDivePhotos::addPhotosFromURL);
 	popup.addSeparator();
-	popup.addAction(tr("Delete selected media files"), this, SLOT(removeSelectedPhotos()));
-	popup.addAction(tr("Delete all media files"), this, SLOT(removeAllPhotos()));
-	popup.addAction(tr("Open folder of selected media files"), this, SLOT(openFolderOfSelectedFiles()));
-	popup.addAction(tr("Recalculate selected thumbnails"), this, SLOT(recalculateSelectedThumbnails()));
-	popup.addAction(tr("Save dive data as subtitles"), this, SLOT(saveSubtitles()));
+	popup.addAction(tr("Delete selected media files"), this, &TabDivePhotos::removeSelectedPhotos);
+	popup.addAction(tr("Delete all media files"), this, &TabDivePhotos::removeAllPhotos);
+	popup.addAction(tr("Open folder of selected media files"), this, &TabDivePhotos::openFolderOfSelectedFiles);
+	popup.addAction(tr("Recalculate selected thumbnails"), this, &TabDivePhotos::recalculateSelectedThumbnails);
+	popup.addAction(tr("Save dive data as subtitles"), this, &TabDivePhotos::saveSubtitles);
 	popup.exec(event->globalPos());
 	event->accept();
 }

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1432,10 +1432,10 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 				return;
 			// create menu to show when right clicking on dive computer name
 			if (dc_number > 0)
-				m.addAction(tr("Make first dive computer"), this, SLOT(makeFirstDC()));
+				m.addAction(tr("Make first dive computer"), this, &ProfileWidget2::makeFirstDC);
 			if (count_divecomputers(current_dive) > 1) {
-				m.addAction(tr("Delete this dive computer"), this, SLOT(deleteCurrentDC()));
-				m.addAction(tr("Split this dive computer into own dive"), this, SLOT(splitCurrentDC()));
+				m.addAction(tr("Delete this dive computer"), this, &ProfileWidget2::deleteCurrentDC);
+				m.addAction(tr("Split this dive computer into own dive"), this, &ProfileWidget2::splitCurrentDC);
 			}
 			m.exec(event->globalPos());
 			// don't show the regular profile context menu
@@ -1457,11 +1457,11 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 			gasChange->addAction(action);
 		}
 	}
-	QAction *setpointAction = m.addAction(tr("Add setpoint change"), this, SLOT(addSetpointChange()));
+	QAction *setpointAction = m.addAction(tr("Add setpoint change"), this, &ProfileWidget2::addSetpointChange);
 	setpointAction->setData(event->globalPos());
-	QAction *action = m.addAction(tr("Add bookmark"), this, SLOT(addBookmark()));
+	QAction *action = m.addAction(tr("Add bookmark"), this, &ProfileWidget2::addBookmark);
 	action->setData(event->globalPos());
-	QAction *splitAction = m.addAction(tr("Split dive into two"), this, SLOT(splitDive()));
+	QAction *splitAction = m.addAction(tr("Split dive into two"), this, &ProfileWidget2::splitDive);
 	splitAction->setData(event->globalPos());
 	const struct event *ev = NULL;
 	enum divemode_t divemode = UNDEF_COMP_TYPE;
@@ -1564,7 +1564,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 		}
 	}
 	if (some_hidden) {
-		action = m.addAction(tr("Unhide all events"), this, SLOT(unhideEvents()));
+		action = m.addAction(tr("Unhide all events"), this, &ProfileWidget2::unhideEvents);
 		action->setData(event->globalPos());
 	}
 	m.exec(event->globalPos());


### PR DESCRIPTION
Since requiring Qt >= 5.9.1, we can use the pointer-to-member-function
overloads of addAction (introduced in Qt 5.6). This has the advantage
of compile-time checking of the signal/slot parameters.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
To celebrate the deprecation of Qt < 5.9, this makes `addAction()` calls use pointer-to-member arguments.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Remove SLOT(...) macro runtime-dispatching weirdness.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2321

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - trivial cleanup.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No - trivial cleanup.

