### PR TITLE
GitHub Actions: add Linux Qt 5.12 container build

### DIFF
--- a/.github/workflows/in-container-build.sh
+++ b/.github/workflows/in-container-build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# this gets executed by Travis when building an AppImage for Linux
+# inside of the trusty-qt512 container
+
+export PATH=$QT_ROOT/bin:$PATH # Make sure correct qmake is found on the $PATH for linuxdeployqt
+export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
+export Grantlee5_ROOT=/__w/subsurface/subsurface/install-root
+
+# the container currently has things under / that need to be under /__w/subsurface/subsurface instead
+cp -a /appdir /__w/subsurface/subsurface/
+cp -a /install-root /__w/subsurface/subsurface/
+
+# first make sure that no one broke Subsurface-mobile
+bash -e -x subsurface/scripts/build.sh -mobile -quick
+
+# now build our AppImage
+bash -e -x subsurface/scripts/build.sh -desktop -create-appdir -build-with-webkit -quick
+
+export QT_PLUGIN_PATH=$QT_ROOT/plugins
+export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
+export QT_DEBUG_PLUGINS=1
+
+# set up the appdir
+mkdir -p appdir/usr/plugins/
+
+# mv googlemaps and Grantlee plugins into place
+mv appdir/usr/usr/local/Qt/5.12.4/gcc_64/plugins/* appdir/usr/plugins  # the usr/usr is not a typo, that's where it ends up
+mv appdir/usr/lib/grantlee/ appdir/usr/plugins/
+rm -rf appdir/usr/home/ appdir/usr/include/ appdir/usr/share/man/ # No need to ship developer and man files as part of the AppImage
+rm -rf appdir/usr/usr appdir/usr/lib/cmake appdir/usr/lib/pkgconfig
+cp /ssllibs/libssl.so appdir/usr/lib/libssl.so.1.1
+cp /ssllibs/libcrypto.so appdir/usr/lib/libcrypto.so.1.1
+
+# get the linuxdeployqt tool and run it to collect the libraries
+curl -L -O "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+chmod a+x linuxdeployqt*.AppImage
+unset QTDIR
+unset QT_PLUGIN_PATH
+unset LD_LIBRARY_PATH
+./linuxdeployqt*.AppImage --appimage-extract-and-run ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=./subsurface/map-widget/ -verbose=2
+
+# create the AppImage
+export VERSION=$(cd subsurface/scripts ; ./get-version linux) # linuxdeployqt uses this for naming the file
+./linuxdeployqt*.AppImage --appimage-extract-and-run ./appdir/usr/share/applications/*.desktop -appimage -qmldir=./subsurface/map-widget/ -verbose=2
+
+# copy AppImage to the calling VM
+# with GitHub Actions the /${GITHUB_WORKSPACE} directory is the current working directory at the start of a step
+cp Subsurface*.AppImage* /${GITHUB_WORKSPACE}/Subsurface.AppImage
+ls -l /${GITHUB_WORKSPACE}/Subsurface.AppImage

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -1,0 +1,27 @@
+name: Linux Qt 5.12
+on: push
+
+jobs:
+  buildInContainer:
+    runs-on: ubuntu-latest
+    container:
+      image: docker://dirkhh/trusty-qt512:0.7
+
+    steps:
+    - name: checkout sources
+      run: |
+        echo $pwd
+        git clone git://github.com/${GITHUB_REPOSITORY}
+        cd subsurface
+        git checkout ${GITHUB_SHA}
+
+    - name: run build
+      run: |
+        echo $pwd
+        bash -x subsurface/.github/workflows/in-container-build.sh
+
+    - name: publish result
+      uses: actions/upload-artifact@v1
+      with:
+        name: Subsurface-${{github.sha}}.AppImage
+        path: ./Subsurface.AppImage  # /${GITHUB_WORKSPACE}/ in the container is '.' here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ if (POLICY CMP0071)
 	cmake_policy(SET CMP0071 OLD)
 endif()
 
+# support Packagename_ROOT environment variable
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) # CMake 3.12
+endif ()
+
 # global settings
 
 set(CMAKE_MODULE_PATH


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
adding another GitHub action based build.
I would like to move everything off of Travis as that has become so unreliable that I don't check anymore - which leads to not noticing when a change ACTUALLY breaks a build (like the kirigami one did)

One key thing I still need to figure out (the examples are, umm, confusing) is how to post releases (both for the continuous build as well as for tagged releases) from GitHub Actions. One would think that this would be a care feature, directly supported. If that's the case, I haven't figured out how.