### PR TITLE
Planner: copy deco state before passing it to worker thread

### DIFF
--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -117,7 +117,8 @@ private:
 	void createPlan(bool replanCopy);
 	struct diveplan diveplan;
 	struct divedatapoint *cloneDiveplan(struct diveplan *plan_src, struct diveplan *plan_copy);
-	void computeVariations(struct diveplan *diveplan, struct deco_state *ds);
+	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
+	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
 	Mode mode;
 	bool recalc;


### PR DESCRIPTION
The planner has a computeVariations() function that can be run
in a worker thread. The code was not thread safe: a deco_state
object allocated on the stack of the caller was passed down to
the worker thread. It's well possible that the object would go
out of scope before the thread run.

Therefore, when running in the background, copy the object first
and free it in the worker thread.

Side note: Qt makes proper memory management again as difficult
as possible: You can't pass a std::unique_ptr<> to QtConcurrent::run,
because move-only objects are not supported. Not very friendly!

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When (re)planning a dive I got a valgrind alert:
```
==6818== Invalid read of size 8
==6818==    at 0x399E6F: DivePlannerPointsModel::computeVariations(diveplan*, deco_state*) (diveplannermodel.cpp:1016)
==6818==    by 0x39EEF4: non-virtual thunk to QtConcurrent::RunFunctionTask<void>::run() (qtconcurrentrunbase.h:140)
==6818==    by 0x9712BD0: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.12.2)
==6818==    by 0x970F611: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.12.2)
==6818==    by 0x4C89181: start_thread (pthread_create.c:486)
==6818==    by 0x9FE3B1E: clone (clone.S:95)
==6818==  Address 0x1ffeffde20 is on thread 1's stack
==6818==  1248 bytes below stack pointer
```

If I'm reading the code correctly, then valgrind is correct - the code is not thread safe. I suppose that `QtConcurrent` runs the member function independently in a different thread. If this is not the case, this PR can be rejected.

This is a quick-fix which tries to not touch other code-paths. With this, I don't get the alert anymore.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Copy deco_state and free in worker-thread.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - too obscure.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde: You might want to check this out.