### PR TITLE
avoid creating hundreds of DiveObjectHelpers

### DIFF
--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -10,6 +10,14 @@
 #include "core/subsurface-string.h"
 #include "qt-models/tankinfomodel.h"
 
+#if defined(DEBUG_DOH)
+#include <execinfo.h>
+#include <stdio.h>
+#include <unistd.h>
+static int callCounter = 0;
+#endif /* defined(DEBUG_DOH) */
+
+
 enum returnPressureSelector {START_PRESSURE, END_PRESSURE};
 
 static QString getFormattedWeight(const struct dive *dive, unsigned int idx)
@@ -169,7 +177,7 @@ static QVector<CylinderObjectHelper> makeCylinderObjects(const dive *d)
 
 static QStringList formatGetCylinder(const dive *d)
 {
-	QStringList getCylinder; 
+	QStringList getCylinder;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
 		if (is_cylinder_used(d, i))
 			getCylinder << d->cylinder[i].type.description;
@@ -246,6 +254,17 @@ DiveObjectHelper::DiveObjectHelper(const struct dive *d) :
 	endPressure(getEndPressure(d)),
 	firstGas(getFirstGas(d))
 {
+#if defined(DEBUG_DOH)
+	void *array[4];
+	size_t size;
+
+	// get void*'s for all entries on the stack
+	size = backtrace(array, 4);
+
+	// print out all the frames to stderr
+	fprintf(stderr, "\n\nCalling DiveObjectHelper constructor for dive %d - call #%d\n", d->number, ++callCounter);
+	backtrace_symbols_fd(array, size, STDERR_FILENO);
+#endif /* defined(DEBUG_DOH) */
 }
 
 DiveObjectHelperGrantlee::DiveObjectHelperGrantlee()

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -63,7 +63,7 @@ static QString getPressures(const struct dive *dive, int i, enum returnPressureS
 	return fmt;
 }
 
-static QString format_gps_decimal(const dive *d)
+QString format_gps_decimal(const dive *d)
 {
 	bool savep = prefs.coordinates_traditional;
 
@@ -73,7 +73,7 @@ static QString format_gps_decimal(const dive *d)
 	return val;
 }
 
-static QString formatNotes(const dive *d)
+QString formatNotes(const dive *d)
 {
 	QString tmp = d->notes ? QString::fromUtf8(d->notes) : QString();
 	if (is_dc_planner(&d->dc)) {
@@ -118,7 +118,7 @@ static QString formatGas(const dive *d)
 	return gases;
 }
 
-static QString formatSac(const dive *d)
+QString formatSac(const dive *d)
 {
 	if (!d->sac)
 		return QString();
@@ -152,7 +152,7 @@ static QStringList formatWeights(const dive *d)
 	return weights;
 }
 
-static QStringList formatCylinders(const dive *d)
+QStringList formatCylinders(const dive *d)
 {
 	QStringList cylinders;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
@@ -175,7 +175,7 @@ static QVector<CylinderObjectHelper> makeCylinderObjects(const dive *d)
 	return res;
 }
 
-static QStringList formatGetCylinder(const dive *d)
+QStringList formatGetCylinder(const dive *d)
 {
 	QStringList getCylinder;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
@@ -185,7 +185,7 @@ static QStringList formatGetCylinder(const dive *d)
 	return getCylinder;
 }
 
-static QStringList getStartPressure(const dive *d)
+QStringList getStartPressure(const dive *d)
 {
 	QStringList startPressure;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
@@ -195,7 +195,7 @@ static QStringList getStartPressure(const dive *d)
 	return startPressure;
 }
 
-static QStringList getEndPressure(const dive *d)
+QStringList getEndPressure(const dive *d)
 {
 	QStringList endPressure;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {
@@ -205,7 +205,7 @@ static QStringList getEndPressure(const dive *d)
 	return endPressure;
 }
 
-static QStringList getFirstGas(const dive *d)
+QStringList getFirstGas(const dive *d)
 {
 	QStringList gas;
 	for (int i = 0; i < MAX_CYLINDERS; i++) {

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -215,6 +215,32 @@ QStringList getFirstGas(const dive *d)
 	return gas;
 }
 
+QStringList getFullCylinderList()
+{
+	QStringList cylinders;
+	int i = 0;
+	struct dive *d;
+	for_each_dive (i, d) {
+		for (int j = 0; j < MAX_CYLINDERS; j++) {
+			QString cyl = d->cylinder[j].type.description;
+			if (cyl.isEmpty())
+				continue;
+			cylinders << cyl;
+		}
+	}
+
+	for (int ti = 0; ti < MAX_TANK_INFO && tank_info[ti].name != NULL; ti++) {
+		QString cyl = tank_info[ti].name;
+		if (cyl.isEmpty())
+			continue;
+		cylinders << cyl;
+	}
+
+	cylinders.removeDuplicates();
+	cylinders.sort();
+	return cylinders;
+}
+
 // Qt's metatype system insists on generating a default constructed object, even if that makes no sense.
 DiveObjectHelper::DiveObjectHelper()
 {
@@ -293,26 +319,5 @@ QString DiveObjectHelper::time() const
 
 QStringList DiveObjectHelper::cylinderList() const
 {
-	QStringList cylinders;
-	int i = 0;
-	struct dive *d;
-	for_each_dive (i, d) {
-		for (int j = 0; j < MAX_CYLINDERS; j++) {
-			QString cyl = d->cylinder[j].type.description;
-			if (cyl.isEmpty())
-				continue;
-			cylinders << cyl;
-		}
-	}
-
-	for (int ti = 0; ti < MAX_TANK_INFO && tank_info[ti].name != NULL; ti++) {
-		QString cyl = tank_info[ti].name;
-		if (cyl.isEmpty())
-			continue;
-		cylinders << cyl;
-	}
-
-	cylinders.removeDuplicates();
-	cylinders.sort();
-	return cylinders;
+	return getFullCylinderList();
 }

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -216,7 +216,7 @@ Kirigami.Page {
 
 	onCurrentItemChanged: {
 		// why do we do this? What consumes this?
-		manager.selectedDiveTimestamp = currentItem.modelData.dive.timestamp
+		manager.selectedDiveTimestamp = currentItem.modelData.date
 		// make sure the core data structures reflect that this dive is selected
 		manager.selectDive(currentItem.modelData.id)
 		// update the map to show the highlighted flag and center on it
@@ -284,15 +284,15 @@ Kirigami.Page {
 			// careful when translating, this text is "magic" in DiveDetailsEdit.qml
 			weight = "cannot edit multiple weight systems"
 		}
-		startpressure = dive.startPressure
-		endpressure = dive.endPressure
-		usedGas = dive.firstGas
-		usedCyl = dive.getCylinder
-		cylinderIndex0 = dive.cylinderList.indexOf(usedCyl[0])
-		cylinderIndex1 = dive.cylinderList.indexOf(usedCyl[1])
-		cylinderIndex2 = dive.cylinderList.indexOf(usedCyl[2])
-		cylinderIndex3 = dive.cylinderList.indexOf(usedCyl[3])
-		cylinderIndex4 = dive.cylinderList.indexOf(usedCyl[4])
+		startpressure = modelData.startPressure
+		endpressure = modelData.endPressure
+		usedGas = modelData.firstGas
+		usedCyl = modelData.getCylinder
+		cylinderIndex0 = modelData.cylinderList.indexOf(usedCyl[0])
+		cylinderIndex1 = modelData.cylinderList.indexOf(usedCyl[1])
+		cylinderIndex2 = modelData.cylinderList.indexOf(usedCyl[2])
+		cylinderIndex3 = modelData.cylinderList.indexOf(usedCyl[3])
+		cylinderIndex4 = modelData.cylinderList.indexOf(usedCyl[4])
 		rating = modelData.rating
 		visibility = modelData.viz
 

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -52,7 +52,7 @@ Kirigami.Page {
 	property alias cylinderModel3: detailsEdit.cylinderModel3
 	property alias cylinderModel4: detailsEdit.cylinderModel4
 
-	title: currentItem && currentItem.modelData ? currentItem.modelData.dive.location : qsTr("Dive details")
+	title: currentItem && currentItem.modelData ? currentItem.modelData.location : qsTr("Dive details")
 	state: "view"
 	leftPadding: 0
 	topPadding: Kirigami.Units.gridUnit / 2
@@ -68,7 +68,7 @@ Kirigami.Page {
 				target: diveDetailsPage;
 				actions {
 					right: deleteAction
-					left: currentItem ? (currentItem.modelData && currentItem.modelData.dive.gps !== "" ? mapAction : null) : null
+					left: currentItem ? (currentItem.modelData && currentItem.modelData.gps !== "" ? mapAction : null) : null
 				}
 			}
 		},
@@ -153,7 +153,7 @@ Kirigami.Page {
 			name: ":/icons/trash-empty.svg"
 		}
 		onTriggered: {
-			var deletedId = currentItem.modelData.dive.id
+			var deletedId = currentItem.modelData.id
 			var deletedIndex = diveDetailsListView.currentIndex
 			manager.deleteDive(deletedId)
 			pageStack.pop()
@@ -181,7 +181,7 @@ Kirigami.Page {
 		}
 		onTriggered: {
 			showMap()
-			mapPage.centerOnDiveSite(currentItem.modelData.dive.dive_site)
+			mapPage.centerOnDiveSite(currentItem.modelData.diveSite)
 		}
 	}
 
@@ -218,11 +218,11 @@ Kirigami.Page {
 		// why do we do this? What consumes this?
 		manager.selectedDiveTimestamp = currentItem.modelData.dive.timestamp
 		// make sure the core data structures reflect that this dive is selected
-		manager.selectDive(currentItem.modelData.dive.id)
+		manager.selectDive(currentItem.modelData.id)
 		// update the map to show the highlighted flag and center on it
 		if (rootItem.pageIndex(mapPage) !== -1) {
 			mapPage.reloadMap()
-			mapPage.centerOnDiveSite(currentItem.modelData.dive.dive_site)
+			mapPage.centerOnDiveSite(currentItem.modelData.diveSite)
 		}
 	}
 
@@ -251,34 +251,35 @@ Kirigami.Page {
 		// set things up for editing - so make sure that the detailsEdit has
 		// all the right data (using the property aliases set up above)
 		var dive = currentItem.modelData.dive
-		dive_id = dive.id
-		number = dive.number
-		date = dive.date + " " + dive.time
-		location = dive.location
-		locationIndex = manager.locationList.indexOf(dive.location)
-		gps = dive.gps
+		var modelData = currentItem.modelData
+		dive_id = modelData.id
+		number = modelData.number
+		date = modelData.dateTime
+		location = modelData.location
+		locationIndex = manager.locationList.indexOf(modelData.location)
+		gps = modelData.gps
 		gpsCheckbox = false
-		duration = dive.duration
-		depth = dive.depth
-		airtemp = dive.airTemp
-		watertemp = dive.waterTemp
-		suitIndex = manager.suitList.indexOf(dive.suit)
-		if (dive.buddy.indexOf(",") > 0) {
-			buddyIndex = manager.buddyList.indexOf(dive.buddy.split(",", 1).toString())
+		duration = modelData.duration
+		depth = modelData.depth
+		airtemp = modelData.airTemp
+		watertemp = modelData.waterTemp
+		suitIndex = manager.suitList.indexOf(modelData.suit)
+		if (modelData.buddy.indexOf(",") > 0) {
+			buddyIndex = manager.buddyList.indexOf(modelData.buddy.split(",", 1).toString())
 		} else {
-			buddyIndex = manager.buddyList.indexOf(dive.buddy)
+			buddyIndex = manager.buddyList.indexOf(modelData.buddy)
 		}
-		buddyText = dive.buddy;
-		if (dive.divemaster.indexOf(",") > 0) {
-			divemasterIndex = manager.divemasterList.indexOf(dive.divemaster.split(",", 1).toString())
+		buddyText = modelData.buddy;
+		if (modelData.diveMaster.indexOf(",") > 0) {
+			divemasterIndex = manager.divemasterList.indexOf(modelData.diveMaster.split(",", 1).toString())
 		} else {
-			divemasterIndex = manager.divemasterList.indexOf(dive.divemaster)
+			divemasterIndex = manager.divemasterList.indexOf(modelData.diveMaster)
 		}
-		divemasterText = dive.divemaster
-		notes = dive.notes
-		if (dive.singleWeight) {
+		divemasterText = modelData.diveMaster
+		notes = modelData.notes
+		if (modelData.singleWeight) {
 			// we have only one weight, go ahead, have fun and edit it
-			weight = dive.sumWeight
+			weight = modelData.sumWeight
 		} else {
 			// careful when translating, this text is "magic" in DiveDetailsEdit.qml
 			weight = "cannot edit multiple weight systems"
@@ -292,8 +293,8 @@ Kirigami.Page {
 		cylinderIndex2 = dive.cylinderList.indexOf(usedCyl[2])
 		cylinderIndex3 = dive.cylinderList.indexOf(usedCyl[3])
 		cylinderIndex4 = dive.cylinderList.indexOf(usedCyl[4])
-		rating = dive.rating
-		visibility = dive.visibility
+		rating = modelData.rating
+		visibility = modelData.viz
 
 		diveDetailsPage.state = "edit"
 	}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -363,7 +363,7 @@ Item {
 				id: cylinderBox0
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}
@@ -420,7 +420,7 @@ Item {
 				id: cylinderBox1
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}
@@ -484,7 +484,7 @@ Item {
 				currentIndex: find(usedCyl[2])
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}
@@ -547,7 +547,7 @@ Item {
 				currentIndex: find(usedCyl[3])
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}
@@ -611,7 +611,7 @@ Item {
 				currentIndex: find(usedCyl[4])
 				flat: true
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.dive.cylinderList : null
+					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 			}

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -36,7 +36,7 @@ Item {
 		anchors.left: parent.left
 		Controls.Label {
 			id: locationText
-			text: dive.location
+			text: location
 			font.weight: Font.Bold
 			font.pointSize: subsurfaceTheme.titlePointSize
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -49,21 +49,21 @@ Item {
 			}
 			MouseArea {
 				anchors.fill: parent
-				enabled: dive.gps_decimal !== ""
+				enabled: gpsDecimal !== ""
 				onClicked: {
 					showMap()
-					mapPage.centerOnDiveSite(dive.dive_site)
+					mapPage.centerOnDiveSite(dive_site)
 				}
 			}
 		}
 		SsrfButton {
 			id: gpsButton
 			anchors.right: parent.right
-			enabled: dive.gps !== ""
+			enabled: gps !== ""
 			text: qsTr("Map it")
 			onClicked: {
 				showMap()
-				mapPage.centerOnDiveSite(dive.dive_site)
+				mapPage.centerOnDiveSite(dive_site)
 			}
 		}
 		Row {
@@ -77,14 +77,14 @@ Item {
 			}
 
 			Controls.Label {
-				text: dive.date + " " + dive.time
+				text: dateTime
 				width: Math.max(locationText.width * 0.45, paintedWidth)
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
 			// let's try to show the depth / duration very compact
 			Controls.Label {
-				text: dive.depth + ' / ' + dive.duration
+				text: depthDuration
 				width: Math.max(Kirigami.Units.gridUnit * 3, paintedWidth)
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
@@ -92,7 +92,7 @@ Item {
 		}
 		Controls.Label {
 			id: numberText
-			text: "#" + dive.number
+			text: "#" + number
 			font.pointSize: subsurfaceTheme.smallPointSize
 			color: subsurfaceTheme.textColor
 			anchors {
@@ -117,35 +117,35 @@ Item {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: ratingText.verticalCenter
-				source: (dive.rating >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (rating >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: ratingText.verticalCenter
-				source: (dive.rating >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (rating >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: ratingText.verticalCenter
-				source: (dive.rating >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (rating >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: ratingText.verticalCenter
-				source: (dive.rating >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (rating >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: ratingText.verticalCenter
-				source: (dive.rating === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (rating === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 		}
@@ -165,35 +165,35 @@ Item {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: visibilityText.verticalCenter
-				source: (dive.visibility >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (viz >= 1) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: visibilityText.verticalCenter
-				source: (dive.visibility >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (viz >= 2) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: visibilityText.verticalCenter
-				source: (dive.visibility >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (viz >= 3) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: visibilityText.verticalCenter
-				source: (dive.visibility >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (viz >= 4) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 			Kirigami.Icon {
 				width: height
 				height: subsurfaceTheme.regularPointSize
 				anchors.verticalCenter: visibilityText.verticalCenter
-				source: (dive.visibility === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
+				source: (viz === 5) ? ":/icons/ic_star.svg" : ":/icons/ic_star_border.svg"
 				color: subsurfaceTheme.textColor
 			}
 		}
@@ -214,7 +214,7 @@ Item {
 
 		QMLProfile {
 			id: qmlProfile
-			visible: !dive.noDive
+			visible: !noDive
 			Layout.fillWidth: true
 			Layout.preferredHeight: Layout.minimumHeight
 			Layout.minimumHeight: width * 0.75
@@ -230,7 +230,7 @@ Item {
 		}
 		Controls.Label {
 			id: noProfile
-			visible: dive.noDive
+			visible: noDive
 			Layout.fillWidth: true
 			Layout.columnSpan: 3
 			Layout.margins: Kirigami.Units.gridUnit
@@ -266,21 +266,21 @@ Item {
 		//------------
 		Controls.Label {
 			id: txtSuit
-			text: dive.suit
+			text: suit
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			color: subsurfaceTheme.textColor
 		}
 		Controls.Label {
 			id: txtAirTemp
-			text: dive.airTemp
+			text: airTemp
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 			color: subsurfaceTheme.textColor
 		}
 		Controls.Label {
 			id: txtWaterTemp
-			text: dive.waterTemp
+			text: waterTemp
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col3Width
 			color: subsurfaceTheme.textColor
@@ -325,21 +325,21 @@ Item {
 		//------------
 		Controls.Label {
 			id: txtCylinder
-			text: dive.getCylinder.join(', ')
+			text: cylinder
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			color: subsurfaceTheme.textColor
 		}
 		Controls.Label {
 			id: txtWeight
-			text: dive.sumWeight
+			text: sumWeight
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col2Width
 			color: subsurfaceTheme.textColor
 		}
 		Controls.Label {
 			id: txtSAC
-			text: dive.sac
+			text: sac
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col3Width
 			color: subsurfaceTheme.textColor
@@ -377,14 +377,14 @@ Item {
 		//-----------
 		Controls.Label {
 			id: txtDiveMaster
-			text: dive.divemaster
+			text: diveMaster
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			color: subsurfaceTheme.textColor
 		}
 		Controls.Label {
 			id: txtBuddy
-			text: dive.buddy
+			text: buddy
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.columnSpan: 2
 			Layout.maximumWidth: detailsView.col2Width + detailsView.col3Width
@@ -411,7 +411,7 @@ Item {
 
 		Controls.Label {
 			id: txtNotes
-			text: dive.notes
+			text: notes
 			focus: true
 			Layout.columnSpan: 3
 			Layout.fillWidth: true

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -241,7 +241,6 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	if (!d)
 		return QVariant();
 	switch(role) {
-	case DiveRole: return QVariant::fromValue(DiveObjectHelper(d));
 	case DiveDateRole: return (qlonglong)d->when;
 	// We have to return a QString as trip-id, because that will be used as section
 	// variable in the QtQuick list view. That has to be a string because it will try
@@ -276,6 +275,8 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	case NoDiveRole: return d->duration.seconds == 0 && d->dc.duration.seconds == 0;
 	case DiveSiteRole: return QVariant::fromValue(d->dive_site);
 	case CylinderRole: return formatGetCylinder(d).join(", ");
+	case GetCylinderRole: return formatGetCylinder(d);
+	case CylinderListRole: return getFullCylinderList();
 	case SingleWeightRole: return d->weightsystems.nr <= 1;
 	case StartPressureRole: return getStartPressure(d);
 	case EndPressureRole: return getEndPressure(d);
@@ -287,7 +288,6 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 QHash<int, QByteArray> DiveListModel::roleNames() const
 {
 	QHash<int, QByteArray> roles;
-	roles[DiveRole] = "dive";
 	roles[DiveDateRole] = "date";
 	roles[TripIdRole] = "tripId";
 	roles[TripNrDivesRole] = "tripNrDives";
@@ -313,6 +313,8 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[NoDiveRole] = "noDive";
 	roles[DiveSiteRole] = "diveSite";
 	roles[CylinderRole] = "cylinder";
+	roles[GetCylinderRole] = "getCylinder";
+	roles[CylinderListRole] = "cylinderList";
 	roles[SingleWeightRole] = "singleWeight";
 	roles[StartPressureRole] = "startPressure";
 	roles[EndPressureRole] = "endPressure";

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -36,15 +36,14 @@ QStringList formatGetCylinder(const dive *d);
 QStringList getStartPressure(const dive *d);
 QStringList getEndPressure(const dive *d);
 QStringList getFirstGas(const dive *d);
-
+QStringList getFullCylinderList();
 
 class DiveListModel : public QAbstractListModel
 {
 	Q_OBJECT
 public:
 	enum DiveListRoles {
-		DiveRole = Qt::UserRole + 1,
-		DiveDateRole,
+		DiveDateRole = Qt::UserRole + 1,
 		TripIdRole,
 		TripNrDivesRole,
 		DateTimeRole,
@@ -69,6 +68,8 @@ public:
 		NoDiveRole,
 		DiveSiteRole,
 		CylinderRole,
+		GetCylinderRole,
+		CylinderListRole,
 		SingleWeightRole,
 		StartPressureRole,
 		EndPressureRole,

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -29,6 +29,15 @@ private:
 	void updateFilterState();
 };
 
+QString formatSac(const dive *d);
+QString formatNotes(const dive *d);
+QString format_gps_decimal(const dive *d);
+QStringList formatGetCylinder(const dive *d);
+QStringList getStartPressure(const dive *d);
+QStringList getEndPressure(const dive *d);
+QStringList getFirstGas(const dive *d);
+
+
 class DiveListModel : public QAbstractListModel
 {
 	Q_OBJECT
@@ -42,7 +51,28 @@ public:
 		IdRole,
 		NumberRole,
 		LocationRole,
+		DepthRole,
+		DurationRole,
 		DepthDurationRole,
+		RatingRole,
+		VizRole,
+		SuitRole,
+		AirTempRole,
+		WaterTempRole,
+		SacRole,
+		SumWeightRole,
+		DiveMasterRole,
+		BuddyRole,
+		NotesRole,
+		GpsDecimalRole,
+		GpsRole,
+		NoDiveRole,
+		DiveSiteRole,
+		CylinderRole,
+		SingleWeightRole,
+		StartPressureRole,
+		EndPressureRole,
+		FirstGasRole,
 	};
 
 	static DiveListModel *instance();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an odd one. Not sure how to classify this.
It duplicates functionality from the DiveObjectHelper in the divelistmodel.
Instead of creating hundreds of DiveObjectHelpers with all the data of the dive, only to use one element of that and then discard it, return that one element directly from the model.
This adds a ton more roles and duplicates code, but wow does it reduce the number of DiveObjectHelpers that are being created. By seriously a factor of ten! ~130 per dive to 12 per dive.

Of course this raises the question... is the DiveObjectHelper maybe the wrong thing to use from QML, period?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger I'd love to hear what you think. And "this is totally bogus and stupid" is a valid response :-)