### PR TITLE
Mobile: simple message while storing downloaded dives

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -367,6 +367,12 @@ Kirigami.Page {
 			}
 		}
 
+		Controls.Label {
+			text: qsTr("Please wait while we record these dives...")
+			Layout.fillWidth: true
+			visible: !acceptButton.busy
+		}
+
 		RowLayout {
 			id: bottomButtons
 			Controls.Label {
@@ -375,10 +381,12 @@ Kirigami.Page {
 			}
 			SsrfButton {
 				id: acceptButton
+				property bool busy: false
 				enabled: divesDownloaded
 				text: qsTr("Accept")
 				bottomPadding: Kirigami.Units.gridUnit / 2
 				onClicked: {
+					busy = true
 					manager.appendTextToLog("Save downloaded dives that were selected")
 					importModel.recordDives()
 					manager.saveChangesLocal()
@@ -386,6 +394,7 @@ Kirigami.Page {
 					manager.refreshDiveList()
 					pageStack.pop();
 					download.text = qsTr("Download")
+					busy = false
 					divesDownloaded = false
 				}
 			}


### PR DESCRIPTION
Due to some recent changes processing the downloaded dives and
re-displaying the dive list can take quite a while. So show a small
message to warn the user.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Very simple, just display a line while things are processed

