### PR TITLE
GitHub Actions: switch back to the GitHub artifacts for PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,10 +39,15 @@ jobs:
         BIN1: ./Subsurface-mobile.apk
         BIN2: ./Subsurface-mobile.arm64.apk
 
-    - name: copy to transfer.sh
+    - name: prepare PR artifacts
       if: github.event_name == 'pull_request'
       run: |
-        apt-get update
-        apt-get install -y curl
-        curl --upload-file Subsurface-mobile.apk "https://transfer.sh/Subsurface-mobile.apk"
-        curl --upload-file Subsurface-mobile.arm64.apk "https://transfer.sh/Subsurface-mobile.arm64.apk"
+        mkdir -p Android-artifacts
+        mv Subsurface-mobile.apk Subsurface-mobile.arm64.apk Android-artifacts
+
+    - name: PR artifacts
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@master
+      with:
+        name: Android-artifacts
+        path: Android-artifacts

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -23,7 +23,7 @@ jobs:
         bash -x subsurface/.github/workflows/scripts/linux-in-container-build.sh
 
     - name: create CI release
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'push'
       uses: ./.github/actions/release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,9 +32,15 @@ jobs:
         COMMIT: ${{ github.sha }}
         BIN1: ./Subsurface.AppImage
 
-    - name: copy to transfer.sh
-      if: github.event_name == 'push'
+    - name: prepare PR artifacts
+      if: github.event_name == 'pull_request'
       run: |
-        apt-get update
-        apt-get install -y curl
-        curl --upload-file Subsurface.AppImage "https://transfer.sh/Subsurface.AppImage"
+        mkdir -p Linux-artifacts
+        mv Subsurface.AppImage Linux-artifacts
+
+    - name: PR artifacts
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@master
+      with:
+        name: Linux-artifacts
+        path: Linux-artifacts

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -111,7 +111,15 @@ jobs:
         COMMIT: ${{ github.sha }}
         BIN1: Subsurface.app.zip
 
-    - name: copy to transfer.sh
+    - name: prepare PR artifacts
       if: github.event_name == 'pull_request'
       run: |
-        curl --upload-file Subsurface.app.zip "https://transfer.sh/Subsurface.app.zip"
+        mkdir -p Mac-artifacts
+        mv Subsurface.app.zip Mac-artifacts
+
+    - name: PR artifacts
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@master
+      with:
+        name: Mac-artifacts
+        path: Mac-artifacts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,13 +53,15 @@ jobs:
         BIN4: ./smtk2ssrf-installer.exe
         BIN5: ./smtk2ssrf.exe
 
-    - name: copy to transfer.sh
+    - name: prepare PR artifacts
       if: github.event_name == 'pull_request'
       run: |
-        apt-get update
-        apt-get install -y curl
-        curl --upload-file subsurface-installer.exe "https://transfer.sh/subsurface-installer.exe"
-        curl --upload-file subsurface.exe "https://transfer.sh/subsurface.exe"
-        curl --upload-file subsurface.exe.debug "https://transfer.sh/subsurface.exe.debug"
-        curl --upload-file smtk2ssrf-installer.exe "https://transfer.sh/smtk2ssrf-installer.exe"
-        curl --upload-file smtk2ssrf.exe "https://transfer.sh/smtk2ssrf.exe"
+        mkdir -p Windows-artifacts
+        mv ./subsurface-installer.exe ./subsurface.exe ./subsurface.exe.debug ./smtk2ssrf-installer.exe ./smtk2ssrf.exe Windows-artifacts
+
+    - name: PR artifacts
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@master
+      with:
+        name: Windows-artifacts
+        path: Windows-artifacts


### PR DESCRIPTION
transfer.sh has suddenly started to time out. And for the rather
occasional need of having a binary to test from a PR, this should be
good enough.


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It was great while it lasted.
Facepalm
This is the official GitHub mechanism. It's not super convenient, but it should work well enough
