### PR TITLE
Don't expose 'detach_buffer()' to membuffer users

### DIFF
--- a/core/errorhelper.c
+++ b/core/errorhelper.c
@@ -22,8 +22,7 @@ int report_error(const char *fmt, ...)
 		return -1;
 
 	VA_BUF(&buf, fmt);
-	mb_cstring(&buf);
-	error_cb(detach_buffer(&buf));
+	error_cb(detach_cstring(&buf));
 
 	return -1;
 }

--- a/core/membuffer.c
+++ b/core/membuffer.c
@@ -12,13 +12,20 @@
 #include "dive.h"
 #include "membuffer.h"
 
-char *detach_buffer(struct membuffer *b)
+/* Only for internal use */
+static char *detach_buffer(struct membuffer *b)
 {
 	char *result = b->buffer;
 	b->buffer = NULL;
 	b->len = 0;
 	b->alloc = 0;
 	return result;
+}
+
+char *detach_cstring(struct membuffer *b)
+{
+	mb_cstring(b);
+	return detach_buffer(b);
 }
 
 void free_buffer(struct membuffer *b)
@@ -117,8 +124,7 @@ char *vformat_string(const char *fmt, va_list args)
 {
 	struct membuffer mb = { 0 };
 	put_vformat(&mb, fmt, args);
-	mb_cstring(&mb);
-	return detach_buffer(&mb);
+	return detach_cstring(&mb);
 }
 
 char *format_string(const char *fmt, ...)

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -23,17 +23,13 @@
  *
  *     "something, something else"
  *
- * Unless ownership to the buffer is given away say to a caller
+ * Unless ownership to the buffer is given away by using "detach_cstring()":
  *
- *     mb_cstring(&mb);
- *     return detach_buffer(&mb);
+ *	ptr = detach_cstring();
  *
- * or via a callback
+ * where the caller now has a C string and is supposed to free it.
  *
- *     mb_cstring(&mb);
- *     cb(detach_buffer(&mb));
- *
- * otherwise allocated memory should be freed
+ * Otherwise allocated memory should be freed
  *
  *     free_buffer(&mb);
  */
@@ -60,7 +56,7 @@ struct membuffer {
 #define __printf(x, y)
 #endif
 
-extern char *detach_buffer(struct membuffer *b);
+extern char *detach_cstring(struct membuffer *b);
 extern void free_buffer(struct membuffer *);
 extern void make_room(struct membuffer *b, unsigned int size);
 extern void flush_buffer(struct membuffer *, FILE *);

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -89,7 +89,7 @@ char *get_planner_disclaimer_formatted()
 	const char *deco = decoMode() == VPMB ? translate("gettextFromC", "VPM-B")
 					      : translate("gettextFromC", "BUHLMANN");
 	put_format(&buf, get_planner_disclaimer(), deco);
-	return detach_buffer(&buf);
+	return detach_cstring(&buf);
 }
 
 void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_disclaimer, int error)
@@ -618,9 +618,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 	if (o2warning_exist)
 		put_string(&buf, "</div>\n");
 finished:
-	mb_cstring(&buf);
 	free(dive->notes);
-	dive->notes = detach_buffer(&buf);
+	dive->notes = detach_cstring(&buf);
 #ifdef DEBUG_PLANNER_NOTES
 	printf("<!DOCTYPE html>\n<html>\n\t<head><title>plannernotes</title><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/></head>\n\t<body>\n%s\t</body>\n</html>\n", dive->notes);
 #endif

--- a/core/tag.c
+++ b/core/tag.c
@@ -72,8 +72,7 @@ char *taglist_get_tagstring(struct tag_entry *tag_list)
 	 *  - empty tag list
 	 *  - tag list with empty tag only
 	 */
-	mb_cstring(&b);
-	return detach_buffer(&b);
+	return detach_cstring(&b);
 }
 
 static inline void taglist_free_divetag(struct divetag *tag)

--- a/core/unix.c
+++ b/core/unix.c
@@ -60,8 +60,7 @@ void subsurface_user_info(struct user_info *user)
 		struct membuffer mb = {};
 		gethostname(hostname, sizeof(hostname));
 		put_format(&mb, "%s@%s", username, hostname);
-		mb_cstring(&mb);
-		user->email = detach_buffer(&mb);
+		user->email = detach_cstring(&mb);
 	}
 }
 

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -132,7 +132,7 @@ void TabDivePhotos::saveSubtitles()
 					continue;
 				struct membuffer b = { 0 };
 				save_subtitles_buffer(&b, &displayed_dive, offset, duration);
-				char *data = detach_buffer(&b);
+				char *data = detach_cstring(&b);
 				subtitlefile.open(QIODevice::WriteOnly);
 				subtitlefile.write(data, strlen(data));
 				subtitlefile.close();


### PR DESCRIPTION
The native buffer of a membuffer is not NUL-terminated, so when you want
to detach it and use it as a C string, you had to first do
'mb_cstring()' that adds the proper termination/

This was all documented in the header files, and all but two users did
it correctly.

But there were those two users, and the exported interface was
unnecessarily hard to use.  We do want the "just detach the raw buffer"
internally in the membuffer code, but let's not make the exported
interface be that hard to use.

So this switches the exported interface to be 'detach_cstring()', which
does that 'mb_cstring()' for you, and avoids the possibility that you'd
use a non-terminated memory buffer as a C string.

The old 'detach_buffer()' is now purely the internal membuffer
implementation, and not used by others.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
