### PR TITLE
Mobile: make the GPS service icon work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: re-enable GPS location service icon in global drawer
 Mobile: add support for editing the dive number of a dive
 Desktop: make dive replanning undoable
 Desktop: update statistics tab on undo or redo

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -461,12 +461,11 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			}
 		] // end actions
-		Kirigami.Icon {
-			source: ":/icons/" + (subsurfaceTheme.currentTheme != "" ? subsurfaceTheme.currentTheme : "Blue") + "_gps.svg"
-			enabled: false
+		Image {
+			fillMode: Image.PreserveAspectFit
+			source: "qrc:///icons/" + (subsurfaceTheme.currentTheme != "" ? subsurfaceTheme.currentTheme : "Blue") + "_gps.svg"
 			visible: locationServiceEnabled
 		}
-
 	}
 
 	function blueTheme() {


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When testing the GPS service I noticed that the icon at the bottom of the GlobalDrawer was no longer shown. This fixes that.
