### PR TITLE
Make it harder to fat-finger our action button

### DIFF
--- a/scripts/kirigami.diff
+++ b/scripts/kirigami.diff
@@ -201,3 +201,15 @@ diff -rwu ../kirigami/src/kirigamiplugin.cpp ./src/kirigamiplugin.cpp
  #endif
  
  QUrl KirigamiPlugin::componentUrl(const QString &fileName) const
+diff -rwu ../kirigami/src/controls/private/ActionButton.qml ./src/controls/private/ActionButton.qml
+--- ../kirigami/src/controls/private/ActionButton.qml	2019-10-11 14:00:51.783839545 -0400
++++ ./src/controls/private/ActionButton.qml	2019-10-27 17:12:04.339302719 -0400
+@@ -70,7 +70,7 @@
+ 
+         anchors.bottom: edgeMouseArea.bottom
+ 
+-        implicitWidth: implicitHeight + Units.iconSizes.smallMedium*2 + Units.gridUnit
++	implicitWidth: implicitHeight + Units.iconSizes.smallMedium*4 + Units.gridUnit
+         implicitHeight: Units.iconSizes.medium + Units.largeSpacing * 2
+ 
+ 

--- a/scripts/kirigami.diff
+++ b/scripts/kirigami.diff
@@ -213,3 +213,48 @@ diff -rwu ../kirigami/src/controls/private/ActionButton.qml ./src/controls/priva
          implicitHeight: Units.iconSizes.medium + Units.largeSpacing * 2
  
  
+@@ -291,7 +291,7 @@
+                         bottomMargin: Units.smallSpacing
+                     }
+                     enabled: root.leftAction && root.leftAction.enabled
+-                    radius: Units.devicePixelRatio*2
++		    radius: Units.devicePixelRatio*4
+                     height: Units.iconSizes.smallMedium + Units.smallSpacing * 2
+                     width: height + (root.action ? Units.gridUnit*2 : 0)
+                     visible: root.leftAction
+@@ -326,6 +326,17 @@
+                             margins: Units.smallSpacing * 2
+                         }
+                     }
++		    Rectangle {
++			anchors.left: parent.left
++			anchors.leftMargin: Units.smallSpacing
++			anchors.verticalCenter: parent.verticalCenter
++			width: Units.iconSizes.smallMedium + Units.smallSpacing * 2
++			height: width
++			radius: width / 2
++			color: "transparent"
++			border.color: Qt.lighter(buttonGraphics.baseColor, 1.1)
++			border.width: 0.5
++		    }
+                 }
+                 //right button
+                 Rectangle {
+@@ -372,6 +383,17 @@
+                             margins: Units.smallSpacing * 2
+                         }
+                     }
++		    Rectangle {
++			anchors.right: parent.right
++			anchors.rightMargin: Units.smallSpacing
++			anchors.verticalCenter: parent.verticalCenter
++			width: Units.iconSizes.smallMedium + Units.smallSpacing * 2
++			height: width
++			radius: width / 2
++			color: "transparent"
++			border.color: Qt.lighter(buttonGraphics.baseColor, 1.1)
++			border.width: 0.5
++		    }
+                 }
+             }
+ 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I had a few comments, not only from older Subsurface-mobile users (but several of them pointed out that they were older) that it's very easy to hit one of the "side buttons" by mistake and delete a dive or cancel an edit when you didn't want to do that.
The easy fix is of course to move those side buttons further away.
That's once again a Kirigami hack.
Oh, and then Linus pointed out that this looks ugly and maybe we should turn it into three buttons, so I made a lame attempt of UI design and added these cute rings around the side button icons.
I really would like to get feedback on how this looks and if this is useful enough to deal with any more Kirigami hacks

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
I'll tag @janmulder again, just in case you have the time. Or maybe @atdotde ? Or @glance- ?