### PR TITLE
Desktop: fix dive site editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: register changes when clicking "done" on dive-site edit screen
 Mobile: re-enable GPS location service icon in global drawer
 Mobile: add support for editing the dive number of a dive
 Desktop: make dive replanning undoable

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -189,13 +189,19 @@ void LocationInformationWidget::diveSiteDeleted(struct dive_site *ds, int)
 
 void LocationInformationWidget::acceptChanges()
 {
-	diveSite = nullptr;
 	closeDistance = 0;
 
 	MainWindow::instance()->diveList->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
 	MainWindow::instance()->setApplicationState(ApplicationState::Default);
 	MultiFilterSortModel::instance()->stopFilterDiveSites();
+
+	// Subtlety alert: diveSite must be cleared *after* exiting the dive-site mode.
+	// Exiting dive-site mode removes the focus from the active widget and
+	// thus fires the corresponding editingFinished signal, which in turn creates
+	// an undo-command. To set an undo-command, the widget has to know the
+	// currently edited dive-site.
+	diveSite = nullptr;
 }
 
 void LocationInformationWidget::initFields(dive_site *ds)


### PR DESCRIPTION
When clicking "done" on the dive site edit screen, the diveSite
member variable was reset to nullptr in acceptChanges() at the
beginning of the function. This prevented posting an undo-command
as a consequence of the active widget losing focus.

Reset the diveSite variable after exiting dive-site mode, which
causes the active widget to lose focus.

Reported-by: Linus Torvalds <torvalds@linux-foundation.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This fixes the "Done" button on the dive-site edit screen. Which, by the way, should perhaps be renamed to "OK" to make it clear that this is not a modal dialog.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Reset `diveSite` variable after exiting dive-site mode.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @torvalds