### PR TITLE
Planner: Don't accumulate rounding errors in stop durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Planner: Improve rounding of stop durations in planner notes
 Desktop: register changes when clicking "done" on dive-site edit screen
 Mobile: re-enable GPS location service icon in global drawer
 Mobile: add support for editing the dive number of a dive

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -375,7 +375,8 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				}
 				put_string(&buf, "</tr>\n");
 				newdepth = dp->depth.mm;
-				lasttime = dp->time;
+				// Only add the time we actually displayed so rounding errors dont accumulate
+				lasttime += ((dp->time - lasttime + 30) / 60) * 60;
 			}
 		}
 		if (gaschange_after || gaschange_before) {


### PR DESCRIPTION
When displaying segment or stop times in the planner notes, we always
round to the next full minute. This can mean for example that we
round down more often than rounding up with the result that the sum
of the segment times does not match the total runtime and can for example
lead to stops that are shown with 0min duration.

With this patch, we increase the reference time of the last display only
by the duration time actually shown. This way, the rounding errors don't
accumulate but having rounded down previously makes rounding up the next
time more propable.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #2352 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
