### PR TITLE
Profile: remove ProfileWidget2::recalcCeiling()

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -355,7 +355,7 @@ void MainTab::updateNotes(const struct dive *d)
 void MainTab::updateMode(struct dive *d)
 {
 	ui.DiveType->setCurrentIndex(get_dive_dc(d, dc_number)->divemode);
-	MainWindow::instance()->graphics->recalcCeiling();
+	MainWindow::instance()->graphics->replot();
 }
 
 static QDateTime timestampToDateTime(timestamp_t when)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -839,13 +839,6 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 #endif
 }
 
-void ProfileWidget2::recalcCeiling()
-{
-#ifndef SUBSURFACE_MOBILE
-	diveCeiling->recalc();
-#endif
-}
-
 void ProfileWidget2::dateTimeChanged()
 {
 	emit dateTimeChangedItems();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -87,7 +87,6 @@ public:
 	bool eventFilter(QObject *, QEvent *) override;
 	void clearHandlers();
 #endif
-	void recalcCeiling();
 	void setToolTipVisibile(bool visible);
 	State currentState;
 	int animSpeed;


### PR DESCRIPTION
The ProfileWidget2::recalcCeiling() function is used in one place,
namely when an undo-command changes the mode. It recalculates
decompression data and repaints the ceilings and thus avoids a
full profile-redraw.

This is smart, but it becomes problematic when the dive is changed
and the ceiling is recalculated before the profile is redrawn.
The DivePlotDataModel then still has data from the previous dive
but cylinders of the new dive are accessed.

This kind of situation may arise if multiple dive fields are
updated, as for example when replanning a dive.

Currently, this only causes a temporary mis-calculation. When
removing MAX_CYLINDERS this will lead to crashes.

One might attempt to fix the whole data-dependency mess. This
commit goes the cheap route and simply redraws the profile when
the mode is changed. Yes, it is in a way ineffective, but we
do worse things. The ProfileWidget2::recalcCeiling() thus becomes
unused and is removed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

I'm not sure what to classify this as - it is not a cleanup, nor does it change behavior, nor fix a current bug. It fixes a future bug: #2208 may crash on undo of dive-replanning without this. Details are in the commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Do a full profile reload when dive mode changes - not only a recalculation of the ceilings. This prevents out-of-sync data.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Needed for #2208

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Nope.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde: Please comment.