### PR TITLE
Reorganise the Information tab of the Info panel

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveInformation.h"
 #include "ui_TabDiveInformation.h"
+#include "desktop-widgets/mainwindow.h" // TODO: Only used temporarilly for edit mode changes
+#include "profile-widget/profilewidget2.h"
 #include "../tagwidget.h"
 #include "core/units.h"
 #include "core/dive.h"
@@ -12,6 +14,7 @@
 
 #define COMBO_CHANGED 0
 #define TEXT_EDITED 1
+#define CSS_SET_HEADING_BLUE "QLabel { color: mediumblue;} "
 
 TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveInformation())
 {
@@ -20,6 +23,28 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,"use dc"};
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
+	// This needs to be the same order as enum dive_comp_type in dive.h!
+	QStringList types;
+	for (int i = 0; i < NUM_DIVEMODE; i++)
+		types.append(gettextFromC::tr(divemode_text_ui[i]));
+	ui->diveType->insertItems(0, types);
+	connect(ui->diveType, SIGNAL(currentIndexChanged(int)), this, SLOT(diveModeChanged(int)));
+	QString CSSSetSmallLabel = "QLabel { color: mediumblue; font-size: " +                        /* // Using label height ... */
+		QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}"; // .. set CSS font size of star widget subscripts
+	ui->scrollAreaWidgetContents_3->setStyleSheet("QGroupBox::title { color: mediumblue;} ");
+	ui->diveModeBox->setStyleSheet("QGroupBox{ padding: 0;} ");
+	ui->diveHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);
+	ui->gasHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);
+	ui->environmentHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);
+	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
+	QAction *action = new QAction(tr("OK"), this);
+	connect(action, &QAction::triggered, this, &TabDiveInformation::closeWarning);
+	ui->multiDiveWarningMessage->addAction(action);
+	action = new QAction(tr("Undo"), this);
+	connect(action, &QAction::triggered, Command::undoAction(this), &QAction::trigger);
+	connect(action, &QAction::triggered, this, &TabDiveInformation::closeWarning);
+	ui->multiDiveWarningMessage->addAction(action);
+	ui->multiDiveWarningMessage->hide();
 }
 
 TabDiveInformation::~TabDiveInformation()
@@ -34,7 +59,6 @@ void TabDiveInformation::clear()
 	ui->maxcnsText->clear();
 	ui->oxygenHeliumText->clear();
 	ui->gasUsedText->clear();
-	ui->dateText->clear();
 	ui->diveTimeText->clear();
 	ui->surfaceIntervalText->clear();
 	ui->maximumDepthText->clear();
@@ -43,6 +67,22 @@ void TabDiveInformation::clear()
 	ui->airTemperatureText->clear();
 	ui->atmPressVal->clear();
 	ui->salinityText->clear();
+	ui->waterTypeText->clear();
+}
+
+void TabDiveInformation::divesEdited(int i)
+{
+	// No warning if only one dive was edited
+	if (i <= 1)
+		return;
+	ui->multiDiveWarningMessage->setCloseButtonVisible(false);
+	ui->multiDiveWarningMessage->setText(tr("Warning: edited %1 dives").arg(i));
+	ui->multiDiveWarningMessage->show();
+}
+
+void TabDiveInformation::closeWarning()
+{
+	ui->multiDiveWarningMessage->hide();
 }
 
 // Update fields that depend on the dive profile
@@ -87,7 +127,6 @@ void TabDiveInformation::updateProfile()
 	if (current_dive->surface_pressure.mbar == 0) {
 		ui->atmPressVal->clear();			// If no atm pressure for dive then clear text box
 	} else {
-
 		ui->atmPressVal->setEnabled(true);
 		QString pressStr;
 		pressStr.sprintf("%d",current_dive->surface_pressure.mbar);
@@ -98,7 +137,6 @@ void TabDiveInformation::updateProfile()
 // Update fields that depend on start of dive
 void TabDiveInformation::updateWhen()
 {
-	ui->dateText->setText(get_short_dive_date_string(current_dive->when));
 	timestamp_t surface_interval = get_surface_interval(current_dive->when);
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
@@ -108,10 +146,19 @@ void TabDiveInformation::updateWhen()
 
 void TabDiveInformation::updateSalinity()
 {
-	if (current_dive->salinity)
+	if (current_dive->salinity) {                 // Set up the salinity string:
 		ui->salinityText->setText(QString("%1g/ℓ").arg(current_dive->salinity / 10.0));
-	else
+		if (current_dive->salinity < 10050)   // Set water type indicator:
+			ui->waterTypeText->setText(tr("Fresh"));
+		else if (current_dive->salinity < 10190)
+			ui->waterTypeText->setText(tr("Salty"));
+		else if (current_dive->salinity < 10210) // (EN13319 = 1.019 - 1.021 g/l)
+			ui->waterTypeText->setText(tr("EN13319"));
+		else ui->waterTypeText->setText(tr("Salt"));
+	} else {
 		ui->salinityText->clear();
+		ui->waterTypeText->clear();
+	}
 }
 
 void TabDiveInformation::updateData()
@@ -125,12 +172,11 @@ void TabDiveInformation::updateData()
 	updateWhen();
 	ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
 	ui->airTemperatureText->setText(get_temperature_string(current_dive->airtemp, true));
-	updateSalinity();
-
-	ui->atmPressType->setEditable(true);
 	ui->atmPressType->setItemText(1, get_depth_unit());  // Check for changes in depth unit (imperial/metric)
-	ui->atmPressType->setEditable(false);
-	ui->atmPressType->setCurrentIndex(0);  // Set the atmospheric pressure combo box to mbar
+	ui->atmPressType->setCurrentIndex(0);                // Set the atmospheric pressure combo box to mbar
+	updateMode(current_dive);
+	updateSalinity();
+	ui->visibility->setCurrentStars(current_dive->visibility);
 }
 
 // This function gets called if a field gets updated by an undo command.
@@ -141,6 +187,10 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
+	if (field.visibility)
+		ui->visibility->setCurrentStars(current_dive->visibility);
+	if (field.mode)
+		updateMode(current_dive);
 	if (field.duration || field.depth || field.mode)
 		updateProfile();
 	if (field.air_temp)
@@ -149,10 +199,27 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		ui->waterTemperatureText->setText(get_temperature_string(current_dive->watertemp, true));
 	if (field.atm_press)
 		ui->atmPressVal->setText(ui->atmPressVal->text().sprintf("%d",current_dive->surface_pressure.mbar));
-	if (field.datetime)
-		updateWhen();
 	if (field.salinity)
 		updateSalinity();
+}
+
+
+void TabDiveInformation::on_visibility_valueChanged(int value)
+{
+	if (current_dive)
+		divesEdited(Command::editVisibility(value, false));
+}
+
+void TabDiveInformation::updateMode(struct dive *d)
+{
+	ui->diveType->setCurrentIndex(get_dive_dc(d, dc_number)->divemode);
+	MainWindow::instance()->graphics->recalcCeiling();
+}
+
+void TabDiveInformation::diveModeChanged(int index)
+{
+	if (current_dive)
+		divesEdited(Command::editMode(dc_number, (enum divemode_t)index, false));
 }
 
 void TabDiveInformation::on_atmPressType_currentIndexChanged(int index) { updateTextBox(COMBO_CHANGED); }
@@ -193,7 +260,7 @@ void TabDiveInformation::updateTextBox(int event) // Either the text box has bee
 			break;
 		}
 		if (atmpress.mbar)
-			Command::editAtmPress(atmpress.mbar, false);      // and save the pressure for undo
+			divesEdited(Command::editAtmPress(atmpress.mbar, false));      // and save the pressure for undo
 	}
 }
 

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -18,8 +18,10 @@ public:
 	void clear() override;
 private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void diveModeChanged(int index);
 	void on_atmPressVal_editingFinished();
 	void on_atmPressType_currentIndexChanged(int index);
+	void on_visibility_valueChanged(int value);
 private:
 	Ui::TabDiveInformation *ui;
 	void updateProfile();
@@ -27,6 +29,9 @@ private:
 	void updateWhen();
 	int pressTypeIndex;
 	void updateTextBox(int event);
+	void updateMode(struct dive *d);
+	void divesEdited(int);
+	void closeWarning();
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -15,6 +15,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="KMessageWidget" name="multiDiveWarningMessage"/>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea_3">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -48,34 +51,64 @@
         <number>0</number>
        </property>
        <property name="horizontalSpacing">
-        <number>6</number>
+        <number>4</number>
        </property>
        <property name="verticalSpacing">
         <number>0</number>
        </property>
+
        <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Date</string>
+        <widget class="QLabel" name="diveHeadingLabel">
+         <property name="text">
+          <string>DIVE</string>
          </property>
-         <layout class="QHBoxLayout" name="diveInfoDateLayout">
+        </widget>
+       </item>
+
+       <item row="0" column="0">
+        <widget class="QLabel" name="diveHeadingLabel">
+         <property name="text">
+          <string>DIVE</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="diveModeBox">
+         <property name="title">
+          <string>Dive mode</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveModeLayout">
+         <property name="alignment">
+          <set>Qt::AlignBottom</set>
+         </property>
           <item>
-           <widget class="QLabel" name="dateText">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
+           <widget class="QComboBox" name="diveType">
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-       <item row="0" column="2">
+
+       <item row="1" column="1">
         <widget class="QGroupBox" name="groupBox_12">
          <property name="title">
           <string>Interval</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoSurfintervallLayout">
           <item>
@@ -84,17 +117,120 @@
              <string/>
             </property>
             <property name="alignment">
-             <set>Qt::AlignCenter</set>
+             <set>Qt::AlignHCenter</set>
             </property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="1" column="2">
+        <widget class="QGroupBox" name="groupBox_11">
+         <property name="title">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoDiveTimeLayout">
+          <item>
+           <widget class="QLabel" name="diveTimeText">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="title">
+          <string>Max. depth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoMaxDepthLayout">
+          <item>
+           <widget class="QLabel" name="maximumDepthText">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item row="1" column="4">
+        <widget class="QGroupBox" name="groupBox_7">
+         <property name="title">
+          <string>Avg. depth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoAvgDepthLayout">
+          <item>
+           <widget class="QLabel" name="averageDepthText">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item row="2" column="0">
+        <widget class="QLabel" name="gasHeadingLabel">
+         <property name="text">
+          <string>GAS</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="3" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
-          <string>Gases used</string>
+          <string> Gas name</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoGasesUsedLayout">
           <item>
@@ -110,10 +246,19 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="3" column="1">
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
           <string>Gas consumed</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoGasConsumedLayout">
           <item>
@@ -129,10 +274,19 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="2">
+       <item row="3" column="2">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>SAC</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoSacLayout">
           <item>
@@ -148,10 +302,19 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="3">
         <widget class="QGroupBox" name="groupBox_15">
          <property name="title">
           <string>CNS</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoCnsLayout">
           <item>
@@ -167,10 +330,19 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="4">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>OTU</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="diveInfoOtuLayout">
           <item>
@@ -178,44 +350,12 @@
             <property name="text">
              <string/>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QGroupBox" name="groupBox_6">
-         <property name="title">
-          <string>Max. depth</string>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <layout class="QHBoxLayout" name="diveInfoMaxDepthLayout">
-          <item>
-           <widget class="QLabel" name="maximumDepthText">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QGroupBox" name="groupBox_7">
-         <property name="title">
-          <string>Avg. depth</string>
-         </property>
-         <layout class="QHBoxLayout" name="diveInfoAvgDepthLayout">
-          <item>
-           <widget class="QLabel" name="averageDepthText">
-            <property name="text">
-             <string/>
-            </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
             </property>
@@ -225,17 +365,125 @@
         </widget>
        </item>
 
-       <item row="2" column="2" colspan="1">
+       <item row="4" column="0">
+        <widget class="QLabel" name="environmentHeadingLabel">
+         <property name="text">
+          <string>ENVIRONMENT</string>
+         </property>
+        </widget>
+       </item>
+
+       <item row="5" column="0">
+        <widget class="QGroupBox" name="groupBox_9">
+         <property name="title">
+          <string>Air temp.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoAirTempLayout">
+          <item>
+           <widget class="QLabel" name="airTemperatureText">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item row="5" column="1">
+        <widget class="QGroupBox" name="groupBox_8">
+         <property name="title">
+          <string>Water temp.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoWaterTempLayout">
+          <item>
+           <widget class="QLabel" name="waterTemperatureText">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item row="5" column="2" colspan="3">
+        <layout class="QGridLayout" name="envGroupLayout">
+         <property name="horizontalSpacing">
+          <number>4</number>
+         </property>
+
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox_1">
+         <property name="title">
+          <string>Water type/Density</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="diveInfoWaterDensityLayout">
+
+          <item>
+        <widget class="QLabel" name="waterTypeText">
+         <property name="text">
+          <string>EN13319</string>
+         </property>
+        </widget>
+          </item>
+
+          <item>
+           <widget class="QLabel" name="salinityText">
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+
+         </layout>
+        </widget>
+       </item>
+
+       <item row="0" column="1">
         <widget class="QGroupBox" name="groupBox_10">
          <property name="title">
-          <string>Atm. pressure</string>
+          <string>Atm. pressure/Altitude</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignHCenter</set>
          </property>
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
+            <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+             <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
@@ -255,86 +503,71 @@
         </widget>
        </item>
 
-       <item row="3" column="2">
-        <widget class="QGroupBox" name="groupBox_9">
+       </layout>
+       </item>
+
+       <item row="6" column="1" alignment="Qt::AlignVCenter">
+        <widget class="QGroupBox" name="groupBox_visibility">
          <property name="title">
-          <string>Air temp.</string>
+          <string>Visibility</string>
          </property>
-         <layout class="QHBoxLayout" name="diveInfoAirTempLayout">
-          <item>
-           <widget class="QLabel" name="airTemperatureText">
+         <property name="alignment">
+          <set>Qt::AlignHCenter</set>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QGridLayout" name="visibilityLayout">
+          <property name="verticalSpacing">
+           <number>0</number>
+          </property>
+          <item row="0" column="0" colspan="2" alignment="Qt::AlignHCenter">
+           <widget class="StarWidget" name="visibility" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" alignment="Qt::AlignLeft">
+           <widget class="QLabel" name="visLabel1">
             <property name="text">
-             <string/>
+             <string>Bad</string>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
+           </widget>
+           </item>
+           <item row="1" column="1" alignment="Qt::AlignRight">
+            <widget class="QLabel" name="visLabel2">
+             <property name="text">
+              <string>Good</string>
+             </property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QGroupBox" name="groupBox_8">
-         <property name="title">
-          <string>Water temp.</string>
-         </property>
-         <layout class="QHBoxLayout" name="diveInfoWaterTempLayout">
-          <item>
-           <widget class="QLabel" name="waterTemperatureText">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QGroupBox" name="groupBox_11">
-         <property name="title">
-          <string>Dive time</string>
-         </property>
-         <layout class="QHBoxLayout" name="diveInfoDiveTimeLayout">
-          <item>
-           <widget class="QLabel" name="diveTimeText">
-            <property name="text">
-             <string/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QGroupBox" name="groupBox_1">
-         <property name="title">
-          <string>Water type</string>
-         </property>
-         <layout class="QHBoxLayout" name="diveInfoSalinityLayout">
-          <item>
-           <widget class="QLabel" name="salinityText">
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0">
+
+       <item row="7" column="0">
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -51,7 +51,6 @@ slots:
 	void tripChanged(dive_trip *trip, TripField field);
 	void updateDiveInfo();
 	void updateNotes(const struct dive *d);
-	void updateMode(struct dive *d);
 	void updateDateTime(const struct dive *d);
 	void updateTripDate(const struct dive_trip *t);
 	void updateDiveSite(struct dive *d);
@@ -66,12 +65,10 @@ slots:
 	void on_airtemp_editingFinished();
 	void on_duration_editingFinished();
 	void on_depth_editingFinished();
-	void divetype_Changed(int);
 	void on_watertemp_editingFinished();
 	void on_dateEdit_dateChanged(const QDate &date);
 	void on_timeEdit_timeChanged(const QTime & time);
 	void on_rating_valueChanged(int value);
-	void on_visibility_valueChanged(int value);
 	void on_tagWidget_editingFinished();
 	void hideMessage();
 	void closeMessage();

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -298,114 +298,19 @@
             </layout>
            </item>
            <item>
-            <layout class="QGridLayout" name="gridLayout_8" columnstretch="0,0,1">
-             <property name="leftMargin">
+            <layout class="QHBoxLayout" name="gridLayout_9">
+             <property name="Spacing">
               <number>5</number>
              </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="horizontalSpacing">
-              <number>5</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="RatingLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Rating</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="visibilityLabel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Visibility</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" alignment="Qt::AlignVCenter">
-              <widget class="StarWidget" name="rating" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="focusPolicy">
-                <enum>Qt::StrongFocus</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1" alignment="Qt::AlignVCenter">
-              <widget class="StarWidget" name="visibility" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="focusPolicy">
-                <enum>Qt::StrongFocus</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <spacer>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                 <enum>QSizePolicy::Expanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
            <item>
-            <layout class="QGridLayout" name="gridLayout_9">
-             <property name="horizontalSpacing">
+            <layout class="QVBoxLayout" name="gridLayout_tags">
+             <property name="Spacing">
               <number>5</number>
              </property>
-             <property name="verticalSpacing">
-              <number>0</number>
-             </property>
-             <item row="1" column="1">
-              <widget class="QComboBox" name="DiveType"/>
-             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="TagLabel">
                <property name="text">
                 <string>Tags</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="TypeLabel">
-               <property name="text">
-                <string>Dive mode</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -439,6 +344,41 @@
              </item>
             </layout>
            </item>
+           <item>
+            <layout class="QVBoxLayout" name="gridLayout_rating">
+             <property name="Spacing">
+              <number>5</number>
+             </property>
+             <item row="0" column="1">
+              <widget class="QLabel" name="RatingLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Rating</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1" alignment="Qt::AlignVCenter">
+              <widget class="StarWidget" name="rating" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::StrongFocus</enum>
+               </property>
+              </widget>
+             </item>
+          </layout>
+          </item>
+          </layout>
+         </item>
            <item>
             <layout class="QVBoxLayout" name="verticalLayout_7">
              <property name="spacing">


### PR DESCRIPTION
1)  Reorganise the existing widgets in the Information tab
2)  Move divemode widget and visibility widget from Notes tab to
    Information tab
3)  Add 4 additional star widgets to cater for additional environmental
    data (wavesize, current, surge, chill). They are not connected to
    the underlying code yet.
4)  Translate water density to a word indicating water type
5)  Reorganise the Notes tab to compensate for the moving the
    divemode and visibility widgets to the Information tab
6)  Add corrections suggested by Dirk and Berthold
    Colour hex codes to colour names
    Calculate font size for star widget subscripts
    Change sone strings to tr("string")
    Remove instructions that have been commented out
    C++ stylistic changes
7)  Remove the problems in showing a QGroupBox in Qt Windows. I do
    this by removing the CSS specifying border characteristics

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. --> This implies changes to the user manual.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkh @bstoeger @sfuchs79 