### PR TITLE
[RFC] Mobile dive list refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix subtle potential new data loss bug in first session connecting to a cloud account
 Planner: Add checkbox on considering oxygen narcotic
 Planner: Improve rounding of stop durations in planner notes
 Desktop: register changes when clicking "done" on dive-site edit screen

--- a/core/dive.h
+++ b/core/dive.h
@@ -144,6 +144,9 @@ struct dive {
 	struct dive_trip *divetrip;
 	bool selected;
 	bool hidden_by_filter;
+#if defined(SUBSURFACE_MOBILE)
+	uint8_t collapsed; /* four values: 0 = don't show, 1 = show as dive, 2 = show corresponding trip, 3 = show dive and trip */
+#endif
 	timestamp_t when;
 	struct dive_site *dive_site;
 	char *notes;

--- a/core/dive.h
+++ b/core/dive.h
@@ -139,23 +139,17 @@ struct dive_site_table;
 struct dive_trip;
 struct trip_table;
 struct dive {
-	int number;
-	bool notrip; /* Don't autogroup this dive to a trip */
 	struct dive_trip *divetrip;
-	bool selected;
-	bool hidden_by_filter;
-#if defined(SUBSURFACE_MOBILE)
-	uint8_t collapsed; /* four values: 0 = don't show, 1 = show as dive, 2 = show corresponding trip, 3 = show dive and trip */
-#endif
 	timestamp_t when;
 	struct dive_site *dive_site;
 	char *notes;
 	char *divemaster, *buddy;
-	int rating;
-	int visibility; /* 0 - 5 star rating */
 	cylinder_t cylinder[MAX_CYLINDERS];
 	struct weightsystem_table weightsystems;
 	char *suit;
+	int number;
+	int rating;
+	int visibility; /* 0 - 5 star rating */
 	int sac, otu, cns, maxcns;
 
 	/* Calculated based on dive computer data */
@@ -170,6 +164,12 @@ struct dive {
 	int id; // unique ID for this dive
 	struct picture *picture_list;
 	unsigned char git_id[20];
+	bool notrip; /* Don't autogroup this dive to a trip */
+	bool selected;
+	bool hidden_by_filter;
+#if defined(SUBSURFACE_MOBILE)
+	uint8_t collapsed; /* four values: 0 = don't show, 1 = show as dive, 2 = show corresponding trip, 3 = show dive and trip */
+#endif
 };
 
 /* For the top-level list: an entry is either a dive or a trip */

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -229,9 +229,9 @@ Kirigami.Page {
 		}
 	}
 
-	function showDiveIndex(index) {
-		currentIndex = index;
-		diveDetailsListView.positionViewAtIndex(index, ListView.End);
+	function showDiveIndex(id) {
+		currentIndex = diveModel.getIdxForId(id);
+		diveDetailsListView.positionViewAtIndex(currentIndex, ListView.End);
 	}
 
 	function endEditMode() {

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -82,6 +82,11 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
+			// spacer, just in case
+			Controls.Label {
+				text: " "
+				width: Kirigami.Units.largeSpacing
+			}
 			// let's try to show the depth / duration very compact
 			Controls.Label {
 				text: depthDuration

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -148,6 +148,11 @@ Kirigami.ScrollablePage {
 							font.pointSize: subsurfaceTheme.smallPointSize
 							color: innerListItem.checked ? subsurfaceTheme.darkerPrimaryTextColor : secondaryTextColor
 						}
+						// spacer, just in case
+						Controls.Label {
+							text: " "
+							width: Kirigami.Units.largeSpacing
+						}
 						// let's try to show the depth / duration very compact
 						Controls.Label {
 							text: (undefined !== depthDuration) ? depthDuration : ""

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -557,7 +557,7 @@ Kirigami.ScrollablePage {
 		text: qsTr("Filter dives")
 		onTriggered: {
 			rootItem.filterToggle = !rootItem.filterToggle
-			diveModel.resetFilter()
+			manager.setFilter("")
 			numShownText = diveModel.shown()
 		}
 	}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -330,7 +330,7 @@ Kirigami.ScrollablePage {
 					}
 					Controls.Label {
 						text: {
-							diveListView.model ? diveListView.model.tripShortDate(section) : "no data model"
+							diveListModel ? diveListModel.tripShortDate(section) : "no data model"
 						}
 						color: subsurfaceTheme.primaryTextColor
 						font.pointSize: subsurfaceTheme.smallPointSize
@@ -346,16 +346,18 @@ Kirigami.ScrollablePage {
 				MouseArea {
 					anchors.fill: headingBackground
 					onClicked: {
-						if (diveTripModel.activeTrip()  === section)
-							diveTripModel.setActiveTrip("")
-						else
-							diveTripModel.setActiveTrip(section)
+						if (diveListModel) {
+							if (diveListModel.activeTrip()  === section)
+								diveListModel.setActiveTrip("")
+							else
+								diveListModel.setActiveTrip(section)
+						}
 					}
 				}
 				Controls.Label {
 					id: sectionText
 					text: {
-						diveListView.model ? diveListView.model.tripTitle(section) : "no data model"
+						diveListModel ? diveListModel.tripTitle(section) : "no data model"
 					}
 					wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 					visible: text !== ""
@@ -491,7 +493,7 @@ Kirigami.ScrollablePage {
 		anchors.fill: parent
 		opacity: 1.0 - startPage.opacity
 		visible: opacity > 0
-		model: page.diveListModel
+		model: diveListModel
 		currentIndex: -1
 		delegate: diveDelegate
 		header: filterHeader
@@ -578,7 +580,8 @@ Kirigami.ScrollablePage {
 	function setCurrentDiveListIndex(idx, noScroll) {
 		// pick the dive in the dive list and make sure its trip is expanded
 		diveListView.currentIndex = idx
-		diveTripModel.setActiveTrip(diveListView.currentItem.myData.tripId)
+		if (diveListModel)
+			diveListModel.setActiveTrip(diveListView.currentItem.myData.tripId)
 
 		// update the diveDetails page to also show that dive
 		detailsWindow.showDiveIndex(idx)

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -387,7 +387,7 @@ Kirigami.Page {
 				onClicked: {
 					manager.appendTextToLog("Save downloaded dives that were selected")
 					busy = true
-					rootItem.showBusy()
+					rootItem.showBusy("Save selected dives")
 					manager.appendTextToLog("temporary disconnecting dive list model")
 					diveList.diveListModel = null
 					manager.appendTextToLog("Record dives")

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -84,7 +84,7 @@ Kirigami.ApplicationWindow {
 
 	function hideBusyAndConnectModel() { // this is used by QMLManager when done filtering
 		busy.running = false
-		diveList.diveListModel = diveModel
+		diveList.diveListModel = diveTripModel
 	}
 
 	function returnTopPage() {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -66,7 +66,9 @@ Kirigami.ApplicationWindow {
 		anchors.centerIn: parent
 	}
 
-	function showBusy() {
+	function showBusy(msg = "") {
+		if (msg !== "")
+			showPassiveNotification(msg, 15000) // show for 15 seconds
 		busy.running = true
 	}
 
@@ -77,6 +79,7 @@ Kirigami.ApplicationWindow {
 
 	function hideBusy() {
 		busy.running = false
+		showPassiveNotification("", 10) // this hides a notification messssage that's still shown
 	}
 
 	function hideBusyAndConnectModel() { // this is used by QMLManager when done filtering

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -451,7 +451,22 @@ if you have network connectivity and want to sync your data to cloud storage."),
 						pageStack.push(logWindow)
 					}
 				}
-
+				Kirigami.Action {
+					text: qsTr("Test busy indicator (toggle)")
+					onTriggered: {
+						if (busy.running) {
+							hideBusy()
+						} else {
+							showBusy()
+						}
+					}
+				}
+				Kirigami.Action {
+					text: qsTr("Test notification text")
+					onTriggered: {
+						showPassiveNotification(qsTr("Test notification text"), 5000)
+					}
+				}
 				Kirigami.Action {
 					text: qsTr("Theme information")
 					onTriggered: {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -302,6 +302,9 @@ void QMLManager::openLocalThenRemote(QString url)
 			QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_NEED_TO_VERIFY);
 	} else {
 		// if we can load from the cache, we know that we have a valid cloud account
+		// and we know that there was at least one successful sync with the cloud when
+		// that local cache was created - so there is a common ancestor
+		setLoadFromCloud(true);
 		if (QMLPrefs::instance()->credentialStatus() == qPrefCloudStorage::CS_UNKNOWN)
 			QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_VERIFIED);
 		if (git_prefs.unit_system == IMPERIAL)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -280,10 +280,10 @@ void QMLManager::openLocalThenRemote(QString url)
 	DiveListModel::instance()->clear();
 	setNotificationText(tr("Open local dive data file"));
 	QByteArray fileNamePrt = QFile::encodeName(url);
-	bool glo = git_local_only;
-	git_local_only = true;
+	/* if this is a cloud storage repo and we have no local cache (i.e., it's the first time
+	 * we try to open this), parse_file will ALWAYS connect to the remote and populate the cache.
+	 * Otherwise parse_file will respect the git_local_only flag and only update if that isn't set */
 	int error = parse_file(fileNamePrt.data(), &dive_table, &trip_table, &dive_site_table);
-	git_local_only = glo;
 	if (error) {
 		appendTextToLog(QStringLiteral("loading dives from cache failed %1").arg(error));
 		setNotificationText(tr("Opening local data file failed"));

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2090,6 +2090,7 @@ void QMLManager::setFilter(const QString filterText)
 	QtConcurrent::run(QThreadPool::globalInstance(),
 			  [=]{
 				DiveListSortModel::instance()->setFilter(filterText);
+				CollapsedDiveListSortModel::instance()->updateFilterState();
 				QMetaObject::invokeMethod(qmlWindow, "hideBusyAndConnectModel");
 			  });
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -277,6 +277,7 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 
 void QMLManager::openLocalThenRemote(QString url)
 {
+	CollapsedDiveListSortModel::instance()->setSourceModel(nullptr);
 	DiveListModel::instance()->clear();
 	setNotificationText(tr("Open local dive data file"));
 	QByteArray fileNamePrt = QFile::encodeName(url);
@@ -318,6 +319,8 @@ void QMLManager::openLocalThenRemote(QString url)
 		qPrefPartialPressureGas::set_po2(git_prefs.pp_graphs.po2);
 		process_loaded_dives();
 		DiveListModel::instance()->reload();
+		CollapsedDiveListSortModel::instance()->setSourceModel(DiveListModel::instance());
+		CollapsedDiveListSortModel::instance()->updateFilterState();
 		appendTextToLog(QStringLiteral("%1 dives loaded from cache").arg(dive_table.nr));
 		setNotificationText(tr("%1 dives loaded from local dive data file").arg(dive_table.nr));
 	}
@@ -1397,6 +1400,8 @@ void QMLManager::selectDive(int id)
 	}
 	if (amount_selected == 0)
 		qWarning("QManager::selectDive() called with unknown id");
+	else
+		CollapsedDiveListSortModel::instance()->updateSelectionState();
 }
 
 void QMLManager::deleteDive(int id)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -555,7 +555,7 @@ bool QMLManager::verifyCredentials(QString email, QString password, QString pin)
 {
 	setStartPageText(tr("Testing cloud credentials"));
 	if (pin.isEmpty())
-		appendTextToLog(QStringLiteral("verify credentials for email %1 (no PIN)").arg(email, pin));
+		appendTextToLog(QStringLiteral("verify credentials for email %1 (no PIN)").arg(email));
 	else
 		appendTextToLog(QStringLiteral("verify credentials for email %1 PIN %2").arg(email, pin));
 	CloudStorageAuthenticate *csa = new CloudStorageAuthenticate(this);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1349,6 +1349,7 @@ void QMLManager::saveChangesCloud(bool forceRemoteSync)
 		return;
 
 	if (!m_loadFromCloud) {
+		setNotificationText(tr("Fatal error: cannot save data file. Please copy log file and report."));
 		appendTextToLog("Don't save dives without loading from the cloud, first.");
 		return;
 	}

--- a/packaging/ios/Info.plist.in
+++ b/packaging/ios/Info.plist.in
@@ -25,9 +25,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NOTE</key>
-	<string>Subsurface is a open source software released under the GPLv2 -- and it is based on many pieces of open source software.</string>
+	<string>Subsurface is open source software released under the GPLv2 -- and includes many other open source components like Qt, Kirigami, libdivecomputer, and others.</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2011-2018 Linus Torvalds, Dirk Hohndel, Tomaz Canabrava and the Subsurface developer team</string>
+	<string>Copyright © 2011-2019 Linus Torvalds, Dirk Hohndel, Tomaz Canabrava and the Subsurface developer team</string>
 	<key>NSMainNibFile</key>
 	<string>SubsurfaceMobileLaunch</string>
 	<key>UILaunchStoryboardName</key>
@@ -44,6 +44,8 @@
 		<string>bluetooth-central</string>
 		<string>location</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Subsurface-mobile can download dive information directly from some Bluetooth LE enabled dive computers; for this it needs access to your Bluetooth peripherals.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Subsurface-mobile can download dive information directly from some Bluetooth LE enabled dive computers; for this it needs access to your Bluetooth peripherals.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/packaging/ios/README
+++ b/packaging/ios/README
@@ -4,7 +4,7 @@ Tool repo to crosscompile subsurface for iOS
 Dependencies:
 
 - This only works on a Mac
-- XCode with iOS SDK and Qt5.9 or later
+- XCode with iOS SDK and Qt5.13 or later
 - cmake
 
 Follow the instruction in:
@@ -19,7 +19,7 @@ note: this builds all dependencies and is only needed first time
       it currently build for armv7 arm64 and x86_64 (simulator)
 
 1) cd <repo>/..
-2) Launch QtCreator and open subsurface/packaging/ios/Subsurface-mobile/Subsurface-mobile.pro
+2) Launch QtCreator and open subsurface/packaging/ios/Subsurface-mobile.pro
 3) Build Subsurface-mobile in QtCreator - you can build for the simulator and for
 a device and even deploy to a connected device.
 
@@ -44,6 +44,6 @@ number, even though the sources have been recompiled which can be very
 confusing.
 
 Do a simply version update by running:
-build.sh version
-and then rebuilding in Qt Creator
+build.sh -version
+and then rebuilding in Qt Creator (or Xcode)
 

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -160,6 +160,8 @@ for ARCH in $ARCHS; do
 			-DCMAKE_INSTALL_PREFIX=${PREFIX} \
 			-DCMAKE_PREFIX_PATH=${PREFIX} \
 			-DCMAKE_DISABLE_FIND_PACKAGE_BZip2=TRUE \
+			-DENABLE_OPENSSL=FALSE \
+			-DENABLE_GNUTLS=FALSE \
 			${SSRF_CLONE}/libzip
 		# quiet the super noise warnings
 		sed -i.bak 's/C_FLAGS = /C_FLAGS = -Wno-nullability-completeness -Wno-expansion-to-defined /' lib/CMakeFiles/zip.dir/flags.make

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -234,6 +234,11 @@ mkdir -p build-ios/googlemaps-build
 pushd build-ios/googlemaps-build
 ${IOS_QT}/${QT_VERSION}/ios/bin/qmake ${SSRF_CLONE}/googlemaps/googlemaps.pro CONFIG+=release
 make
+if [ "$DEBUGRELEASE" != "Release" ] ; then
+	${IOS_QT}/${QT_VERSION}/ios/bin/qmake ${SSRF_CLONE}/googlemaps/googlemaps.pro CONFIG+=debug
+	make clean
+	make
+fi
 popd
 
 # now combine the libraries into fat libraries

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -4,7 +4,6 @@
 set -x
 set -e
 
-doVersion=$1
 DEBUGRELEASE="Release"
 ARCHS="armv7 arm64 x86_64"
 TARGET="iphoneos"
@@ -13,6 +12,11 @@ TARGET2="Device"
 while [[ $# -gt 0 ]] ; do
 	arg="$1"
 	case $arg in
+		-version)
+			# only update the version info without rebuilding
+			# this is useful when working with Xcode
+			versionOnly="1"
+			;;
 		-debug)
 			# build for debugging
 			DEBUGRELEASE="Debug"
@@ -68,7 +72,7 @@ fi
 # create Info.plist with the correct versions
 cat Info.plist.in | sed "s/@MOBILE_VERSION@/$MOBILEVERSION/;s/@CANONICAL_VERSION@/$CANONICALVERSION/;s/@PRODUCT_BUNDLE_IDENTIFIER@/$BUNDLE/" > Info.plist
 
-if [ "$doVersion" = "version" ] ; then
+if [ "$versionOnly" = "1" ] ; then
 	exit 0
 fi
 

--- a/packaging/ios/storeIcon.xcassets/AppIcon.appiconset/Contents.json
+++ b/packaging/ios/storeIcon.xcassets/AppIcon.appiconset/Contents.json
@@ -85,6 +85,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
       "size" : "76x76",
       "idiom" : "ipad",
       "filename" : "AppIcon-76@2x.png",

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -17,8 +17,6 @@
 CollapsedDiveListSortModel::CollapsedDiveListSortModel()
 {
 	setSourceModel(DiveListSortModel::instance());
-	setDynamicSortFilter(true);
-	updateFilterState();
 	// make sure that we after changes to the underlying model (and therefore the dive list
 	// we update the filter state
 	connect(DiveListModel::instance(), &DiveListModel::rowsInserted, this, &CollapsedDiveListSortModel::updateFilterState);
@@ -35,6 +33,10 @@ CollapsedDiveListSortModel *CollapsedDiveListSortModel::instance()
 void CollapsedDiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
 	QSortFilterProxyModel::setSourceModel(sourceModel);
+	// make sure we sort descending and have the filters correct
+	setDynamicSortFilter(true);
+	setSortRole(DiveListModel::DiveDateRole);
+	sort(0, Qt::DescendingOrder);
 	updateFilterState();
 }
 
@@ -175,10 +177,6 @@ bool CollapsedDiveListSortModel::filterAcceptsRow(int source_row, const QModelIn
 DiveListSortModel::DiveListSortModel()
 {
 	setSourceModel(DiveListModel::instance());
-	setDynamicSortFilter(true);
-	setSortRole(DiveListModel::DiveDateRole);
-	sort(0, Qt::DescendingOrder);
-	updateFilterState();
 	LOG_STP("run_ui diveListModel sorted");
 }
 
@@ -212,6 +210,11 @@ void DiveListSortModel::updateFilterState()
 void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
 	QSortFilterProxyModel::setSourceModel(sourceModel);
+	// make sure we sort descending and have the filters correct
+	setDynamicSortFilter(true);
+	setSortRole(DiveListModel::DiveDateRole);
+	sort(0, Qt::DescendingOrder);
+	updateFilterState();
 }
 
 void DiveListSortModel::setFilter(QString f)

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -5,7 +5,172 @@
 #include "core/trip.h"
 #include "core/settings/qPrefGeneral.h"
 #include "core/ssrf.h" // for LOG_STP
+#include "core/errorhelper.h" // for verbose
 #include <QDateTime>
+#include <QDebug>
+
+// the DiveListSortModel creates the sorted, filtered list of dives that the user
+// can flip through horizontally
+// the CollapsedDiveListSortModel creates the vertical dive list which is a second
+// filter on top of the one applied to the DiveListSortModel
+
+CollapsedDiveListSortModel::CollapsedDiveListSortModel()
+{
+	setSourceModel(DiveListSortModel::instance());
+	setDynamicSortFilter(true);
+	updateFilterState();
+	// make sure that we after changes to the underlying model (and therefore the dive list
+	// we update the filter state
+	connect(DiveListModel::instance(), &DiveListModel::rowsInserted, this, &CollapsedDiveListSortModel::updateFilterState);
+	connect(DiveListModel::instance(), &DiveListModel::rowsMoved, this, &CollapsedDiveListSortModel::updateFilterState);
+	connect(DiveListModel::instance(), &DiveListModel::rowsRemoved, this, &CollapsedDiveListSortModel::updateFilterState);
+}
+
+CollapsedDiveListSortModel *CollapsedDiveListSortModel::instance()
+{
+	static CollapsedDiveListSortModel self;
+	return &self;
+}
+
+void CollapsedDiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
+{
+	QSortFilterProxyModel::setSourceModel(sourceModel);
+	updateFilterState();
+}
+
+// In QtQuick ListView, section headings can only be strings. To identify dives
+// that belong to the same trip, a string containing the trip-id is passed in.
+// To format the trip heading, the string is then converted back with this function.
+static dive_trip *tripIdToObject(const QString &s)
+{
+	if (s.isEmpty())
+		return nullptr;
+	int id = s.toInt();
+	dive_trip **trip = std::find_if(&trip_table.trips[0], &trip_table.trips[trip_table.nr],
+					[id] (const dive_trip *t) { return t->id == id; });
+	if (trip == &trip_table.trips[trip_table.nr]) {
+		fprintf(stderr, "Warning: unknown trip id passed through QML: %d\n", id);
+		return nullptr;
+	}
+	return *trip;
+}
+
+// the trip title is designed to be location (# dives)
+// or, if there is no location name date range (# dives)
+// where the date range is given as "month year" or "month-month year" or "month year - month year"
+QString CollapsedDiveListSortModel::tripTitle(const QString &section)
+{
+	const dive_trip *dt = tripIdToObject(section);
+	if (!dt)
+		return QString();
+	QString numDives = tr("(%n dive(s))", "", dt->dives.nr);
+	int shown = trip_shown_dives(dt);
+	QString shownDives = shown != dt->dives.nr ? QStringLiteral(" ") + tr("(%L1 shown)").arg(shown) : QString();
+	QString title(dt->location);
+
+	if (title.isEmpty()) {
+		// so use the date range
+		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
+		QString firstMonth = firstTime.toString("MMM");
+		QString firstYear = firstTime.toString("yyyy");
+		QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*dt->dives.dives[0]->when, Qt::UTC);
+		QString lastMonth = lastTime.toString("MMM");
+		QString lastYear = lastTime.toString("yyyy");
+		if (lastMonth == firstMonth && lastYear == firstYear)
+			title = firstMonth + " " + firstYear;
+		else if (lastMonth != firstMonth && lastYear == firstYear)
+			title = firstMonth + "-" + lastMonth + " " + firstYear;
+		else
+			title = firstMonth + " " + firstYear + " - " + lastMonth + " " + lastYear;
+	}
+	return QStringLiteral("%1 %2%3").arg(title, numDives, shownDives);
+}
+
+QString CollapsedDiveListSortModel::tripShortDate(const QString &section)
+{
+	const dive_trip *dt = tripIdToObject(section);
+	if (!dt)
+		return QString();
+	QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
+	QString firstMonth = firstTime.toString("MMM");
+	return QStringLiteral("%1\n'%2").arg(firstMonth,firstTime.toString("yy"));
+}
+
+void CollapsedDiveListSortModel::setActiveTrip(const QString &trip)
+{
+	m_activeTrip = trip;
+	updateFilterState();
+	invalidateFilter();
+}
+
+QString CollapsedDiveListSortModel::activeTrip() const
+{
+	return m_activeTrip;
+}
+
+// tell us if this dive is the first dive in a trip that has at least one
+// dive that isn't hidden (even if this dive is hidden)
+static bool isFirstInNotCompletelyHiddenTrip(struct dive *d)
+{
+	struct dive_trip *dt = d->divetrip;
+	if (dt->dives.nr > 0 && dt->dives.dives[0] == d) {
+		// ok, this is the first dive in its trip
+		int i = -1;
+		while (++i < dt->dives.nr)
+			if (!dt->dives.dives[i]->hidden_by_filter)
+				return true;
+	}
+	return false;
+}
+
+// the mobile app allows only one selected dive
+// that means there are either zero or exactly one expanded trip -
+bool CollapsedDiveListSortModel::isExpanded(struct dive_trip *dt) const
+{
+	return !m_activeTrip.isEmpty() && dt == tripIdToObject(m_activeTrip);
+}
+
+void CollapsedDiveListSortModel::updateFilterState()
+{
+	// now do something clever to show the right dives
+	// first make sure that the underlying filtering is taken care of
+	DiveListSortModel::instance()->updateFilterState();
+	int i;
+	struct dive *d;
+	for_each_dive(i, d) {
+		CollapsedState state = DontShow;
+		struct dive_trip *dt = d->divetrip;
+
+		// we show the dives that are outside of a trip or inside of the one expanded trip
+		if (!d->hidden_by_filter && (dt == nullptr || isExpanded(dt)))
+			state = ShowDive;
+		// we mark the first dive of a trip that contains any unfiltered dives as ShowTrip  or ShowDiveAndTrip (if this is the one expanded trip)
+		if (dt != nullptr && isFirstInNotCompletelyHiddenTrip(d))
+			state = (state == ShowDive) ? ShowDiveAndTrip : ShowTrip;
+		d->collapsed = state;
+	}
+	// everything up to here can be done even if we don't have a source model
+	if (sourceModel() != nullptr) {
+		QVector<int> changedRoles = { DiveListModel::CollapsedRole };
+		dataChanged(index(0,0), index(rowCount() - 1, 0), changedRoles);
+	}
+}
+
+void CollapsedDiveListSortModel::updateSelectionState()
+{
+	QVector<int> changedRoles = { DiveListModel::SelectedRole };
+	dataChanged(index(0,0), index(rowCount() - 1, 0), changedRoles);
+}
+
+bool CollapsedDiveListSortModel::filterAcceptsRow(int source_row, const QModelIndex &) const
+{
+	// get the corresponding dive from the DiveListModel and check if we should show it
+	const dive *d = DiveListModel::instance()->getDive(source_row);
+	if (verbose > 1)
+		qDebug() << "FAR source row" << source_row << "dive" << (d ? QString::number(d->number) : "NULL") << "is" << (d != nullptr && d->collapsed != DontShow) <<
+			    (d != nullptr ? QString::number(d->collapsed) : "");
+	return d != nullptr && d->collapsed != DontShow;
+}
 
 DiveListSortModel::DiveListSortModel()
 {
@@ -21,6 +186,11 @@ DiveListSortModel *DiveListSortModel::instance()
 {
 	static DiveListSortModel self;
 	return &self;
+}
+
+QString DiveListSortModel::getFilterString() const
+{
+	return filterString;
 }
 
 void DiveListSortModel::updateFilterState()
@@ -87,64 +257,6 @@ void DiveListSortModel::reload()
 {
 	DiveListModel *mySourceModel = qobject_cast<DiveListModel *>(sourceModel());
 	mySourceModel->resetInternalData();
-}
-
-// In QtQuick ListView, section headings can only be strings. To identify dives
-// that belong to the same trip, a string containing the trip-id is passed in.
-// To format the trip heading, the string is then converted back with this function.
-static dive_trip *tripIdToObject(const QString &s)
-{
-	if (s.isEmpty())
-		return nullptr;
-	int id = s.toInt();
-	dive_trip **trip = std::find_if(&trip_table.trips[0], &trip_table.trips[trip_table.nr],
-					[id] (const dive_trip *t) { return t->id == id; });
-	if (trip == &trip_table.trips[trip_table.nr]) {
-		fprintf(stderr, "Warning: unknown trip id passed through QML: %d\n", id);
-		return nullptr;
-	}
-	return *trip;
-}
-
-// the trip title is designed to be location (# dives)
-// or, if there is no location name date range (# dives)
-// where the date range is given as "month year" or "month-month year" or "month year - month year"
-QString DiveListSortModel::tripTitle(const QString &section)
-{
-	const dive_trip *dt = tripIdToObject(section);
-	if (!dt)
-		return QString();
-	QString numDives = tr("(%n dive(s))", "", dt->dives.nr);
-	int shown = trip_shown_dives(dt);
-	QString shownDives = shown != dt->dives.nr ? QStringLiteral(" ") + tr("(%L1 shown)").arg(shown) : QString();
-	QString title(dt->location);
-
-	if (title.isEmpty()) {
-		// so use the date range
-		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
-		QString firstMonth = firstTime.toString("MMM");
-		QString firstYear = firstTime.toString("yyyy");
-		QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*dt->dives.dives[0]->when, Qt::UTC);
-		QString lastMonth = lastTime.toString("MMM");
-		QString lastYear = lastTime.toString("yyyy");
-		if (lastMonth == firstMonth && lastYear == firstYear)
-			title = firstMonth + " " + firstYear;
-		else if (lastMonth != firstMonth && lastYear == firstYear)
-			title = firstMonth + "-" + lastMonth + " " + firstYear;
-		else
-			title = firstMonth + " " + firstYear + " - " + lastMonth + " " + lastYear;
-	}
-	return QStringLiteral("%1 %2%3").arg(title, numDives, shownDives);
-}
-
-QString DiveListSortModel::tripShortDate(const QString &section)
-{
-	const dive_trip *dt = tripIdToObject(section);
-	if (!dt)
-		return QString();
-	QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
-	QString firstMonth = firstTime.toString("MMM");
-	return QStringLiteral("%1\n'%2").arg(firstMonth,firstTime.toString("yy"));
 }
 
 DiveListModel::DiveListModel()
@@ -281,6 +393,8 @@ QVariant DiveListModel::data(const QModelIndex &index, int role) const
 	case StartPressureRole: return getStartPressure(d);
 	case EndPressureRole: return getEndPressure(d);
 	case FirstGasRole: return getFirstGas(d);
+	case CollapsedRole: return d->collapsed;
+	case SelectedRole: return d->selected;
 	}
 	return QVariant();
 }
@@ -319,6 +433,8 @@ QHash<int, QByteArray> DiveListModel::roleNames() const
 	roles[StartPressureRole] = "startPressure";
 	roles[EndPressureRole] = "endPressure";
 	roles[FirstGasRole] = "firstGas";
+	roles[CollapsedRole] = "collapsed";
+	roles[SelectedRole] = "selected";
 	return roles;
 }
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -102,6 +102,7 @@ void run_ui()
 	gpsSortModel->sort(0, Qt::DescendingOrder);
 	QQmlContext *ctxt = engine.rootContext();
 	ctxt->setContextProperty("diveModel", DiveListSortModel::instance());
+	ctxt->setContextProperty("diveTripModel", CollapsedDiveListSortModel::instance());
 	ctxt->setContextProperty("gpsModel", gpsSortModel);
 	ctxt->setContextProperty("vendorList", vendorList);
 	set_non_bt_addresses();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a first working draft of what I want to do with the dive list on mobile.
Having two nested filter proxy models seems fragile, but it seems to work well with excellent performance, both mobile-on-desktop and more importantly when testing on a fairly old iPhone 6.
I need to go through the code a couple more time to see if we still need all the hacks and if the models can be simplified.
Right now I just flat out removed the animation of expanding/collapsing trips - that should be easy to add back.
Having said all this, in my "modest" testing (three different types of dive lists that hopefully cover all the various combinations of trips, dives, notrip dives, mobile-on-desktop and on device) this seems to work as designed with a significant performance improvement.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add second `QSortFilterProxyModel` for the vertical dive list that hides all but the first dive in any non-expanded trip
2) use that model and simplify the visibility decision by implementing that in C++ code
3) ensure that the filters get updated when things change
4) change the way we pick which dive is marked as selected in the vertical dive list (going back to the core data structures instead of assuming that indices between the models align)
5) connect that new model to the horizontal dive list (the dive details you can flip through) by translating dive id into the corresponding index

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
many, many performance complaints

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
need to add to CHANGELOG

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
This should be user transparent (except for the better performance)

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger I'd love your comments on the model implementation. I hope I didn't do anything too terrible
@atdotde please test on your iDevice (and also look at the code)
@janmulder if you have the time... I'm interested in your comments about my QML code