### PR TITLE
scripts: update get-deps to allow clean build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -237,6 +237,17 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	make install
 	popd
 
+	./subsurface/scripts/get-dep-lib.sh single . openssl
+	pushd openssl
+	mkdir -p build
+	cd build
+	../Configure --prefix=$INSTALL_ROOT --openssldir=$INSTALL_ROOT $OLDER_MAC darwin64-x86_64-cc
+	make depend
+	# all the tests fail because the assume that openssl is already installed. Odd? Still thinks work
+	make -j4 -k
+	make -k install
+	popd
+
 	./subsurface/scripts/get-dep-lib.sh single . libssh2
 	pushd libssh2
 	mkdir -p build
@@ -314,17 +325,6 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	CFLAGS="$OLDER_MAC" ../configure --prefix=$INSTALL_ROOT --disable-examples
 	make -j4
 	make install
-	popd
-
-	./subsurface/scripts/get-dep-lib.sh single . openssl
-	pushd openssl
-	mkdir -p build
-	cd build
-	../Configure --prefix=$INSTALL_ROOT --openssldir=$INSTALL_ROOT $OLDER_MAC darwin64-x86_64-cc
-	make depend
-	# all the tests fail because the assume that openssl is already installed. Odd? Still thinks work
-	make -j4 -k
-	make -k install
 	popd
 fi
 


### PR DESCRIPTION
libssh2 depends on openssl, therefore it is important that openssl is
build before libssh2.

The old get-deps would cause errors in 2 situations:
1) In a clean build, make of libssh2 would fail
2) In a normal build, where openssl changed version, make of libssh2 would
depend on old build.

Signed-off-by: Jan Iversen <jan@casacondor.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
