### PR TITLE
Undo of weightsystem editing

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -278,6 +278,11 @@ int removeWeight(int index, bool currentDiveOnly)
 	return execute_edit(new RemoveWeight(index, currentDiveOnly));
 }
 
+int editWeight(int index, weightsystem_t ws, bool currentDiveOnly)
+{
+	return execute_edit(new EditWeight(index, ws, currentDiveOnly));
+}
+
 // Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -273,6 +273,11 @@ int addWeight(bool currentDiveOnly)
 	return execute_edit(new AddWeight(currentDiveOnly));
 }
 
+int removeWeight(int index, bool currentDiveOnly)
+{
+	return execute_edit(new RemoveWeight(index, currentDiveOnly));
+}
+
 // Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -268,6 +268,11 @@ void editProfile(dive *d)
 	execute(new ReplanDive(d, true));
 }
 
+int addWeight(bool currentDiveOnly)
+{
+	return execute_edit(new AddWeight(currentDiveOnly));
+}
+
 // Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {

--- a/commands/command.h
+++ b/commands/command.h
@@ -83,6 +83,7 @@ void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
 void editProfile(dive *d); // dive computer(s) and cylinder(s) will be reset!
 int addWeight(bool currentDiveOnly);
 int removeWeight(int index, bool currentDiveOnly);
+int editWeight(int index, weightsystem_t ws, bool currentDiveOnly);
 
 // 5) Trip editing commands
 

--- a/commands/command.h
+++ b/commands/command.h
@@ -82,6 +82,7 @@ void pasteDives(const dive *d, dive_components what);
 void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
 void editProfile(dive *d); // dive computer(s) and cylinder(s) will be reset!
 int addWeight(bool currentDiveOnly);
+int removeWeight(int index, bool currentDiveOnly);
 
 // 5) Trip editing commands
 

--- a/commands/command.h
+++ b/commands/command.h
@@ -81,6 +81,7 @@ int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
 void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
 void editProfile(dive *d); // dive computer(s) and cylinder(s) will be reset!
+int addWeight(bool currentDiveOnly);
 
 // 5) Trip editing commands
 

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -953,4 +953,36 @@ void ReplanDive::redo()
 	undo();
 }
 
+// ***** Add Weight *****
+AddWeight::AddWeight(bool currentDiveOnly) :
+	EditDivesBase(currentDiveOnly)
+{
+	//: remove the part in parentheses for %n = 1
+	setText(tr("Add weight (%n dive(s))", "", dives.size()));
+}
+
+bool AddWeight::workToBeDone()
+{
+	return true;
+}
+
+void AddWeight::undo()
+{
+	for (dive *d: dives) {
+		if (d->weightsystems.nr <= 0)
+			continue;
+		remove_weightsystem(d, d->weightsystems.nr - 1);
+		emit diveListNotifier.weightRemoved(d, d->weightsystems.nr);
+	}
+}
+
+void AddWeight::redo()
+{
+	weightsystem_t ws { {0}, "" };
+	for (dive *d: dives) {
+		add_cloned_weightsystem(&d->weightsystems, ws);
+		emit diveListNotifier.weightAdded(d, d->weightsystems.nr - 1);
+	}
+}
+
 } // namespace Command

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1031,7 +1031,7 @@ RemoveWeight::RemoveWeight(int index, bool currentDiveOnly) :
 
 RemoveWeight::~RemoveWeight()
 {
-	free((void *)ws.description);
+	free_weightsystem(ws);
 }
 
 bool RemoveWeight::workToBeDone()

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -87,8 +87,9 @@ bool EditBase<T>::workToBeDone()
 
 	// Create a text for the menu entry. In the case of multiple dives add the number
 	size_t num_dives = dives.size();
-	if (num_dives > 0)
-		//: remove the part in parentheses for %n = 1
+	if (num_dives == 1)
+		setText(tr("Edit %1").arg(fieldName()));
+	else if (num_dives > 0)
 		setText(tr("Edit %1 (%n dive(s))", "", num_dives).arg(fieldName()));
 
 	return num_dives > 0;
@@ -626,8 +627,9 @@ bool EditTagsBase::workToBeDone()
 
 	// Create a text for the menu entry. In the case of multiple dives add the number
 	size_t num_dives = dives.size();
-	if (num_dives > 0)
-		//: remove the part in parentheses for %n = 1
+	if (num_dives == 1)
+		setText(tr("Edit %1").arg(fieldName()));
+	else if (num_dives > 0)
 		setText(tr("Edit %1 (%n dive(s))", "", num_dives).arg(fieldName()));
 
 	return num_dives != 0;
@@ -958,8 +960,10 @@ void ReplanDive::redo()
 AddWeight::AddWeight(bool currentDiveOnly) :
 	EditDivesBase(currentDiveOnly)
 {
-	//: remove the part in parentheses for %n = 1
-	setText(tr("Add weight (%n dive(s))", "", dives.size()));
+	if (dives.size() == 1)
+		setText(tr("Add weight"));
+	else
+		setText(tr("Add weight (%n dive(s))", "", dives.size()));
 }
 
 bool AddWeight::workToBeDone()
@@ -1040,8 +1044,10 @@ bool EditWeightBase::workToBeDone()
 RemoveWeight::RemoveWeight(int index, bool currentDiveOnly) :
 	EditWeightBase(index, currentDiveOnly)
 {
-	//: remove the part in parentheses for %n = 1
-	setText(tr("Remove weight (%n dive(s))", "", dives.size()));
+	if (dives.size() == 1)
+		setText(tr("Remove weight"));
+	else
+		setText(tr("Remove weight (%n dive(s))", "", dives.size()));
 }
 
 void RemoveWeight::undo()
@@ -1067,8 +1073,10 @@ EditWeight::EditWeight(int index, weightsystem_t wsIn, bool currentDiveOnly) :
 	if (dives.empty())
 		return;
 
-	//: remove the part in parentheses for %n = 1
-	setText(tr("Edit weight (%n dive(s))", "", dives.size()));
+	if (dives.size() == 1)
+		setText(tr("Edit weight"));
+	else
+		setText(tr("Edit weight (%n dive(s))", "", dives.size()));
 
 	// Try to untranslate the weightsystem name
 	new_ws = clone_weightsystem(wsIn);

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -978,9 +978,8 @@ void AddWeight::undo()
 
 void AddWeight::redo()
 {
-	weightsystem_t ws { {0}, "" };
 	for (dive *d: dives) {
-		add_cloned_weightsystem(&d->weightsystems, ws);
+		add_cloned_weightsystem(&d->weightsystems, empty_weightsystem);
 		emit diveListNotifier.weightAdded(d, d->weightsystems.nr - 1);
 	}
 }
@@ -996,7 +995,7 @@ static int find_weightsystem_index(const struct dive *d, weightsystem_t ws)
 
 RemoveWeight::RemoveWeight(int index, bool currentDiveOnly) :
 	EditDivesBase(currentDiveOnly),
-	ws{ {0}, nullptr }
+	ws(empty_weightsystem)
 {
 	// Get the old weightsystem, bail if index is invalid
 	if (!current || index < 0 || index >= current->weightsystems.nr) {

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -339,6 +339,18 @@ private:
 	bool workToBeDone() override;
 };
 
+class RemoveWeight : public EditDivesBase {
+public:
+	RemoveWeight(int index, bool currentDiveOnly);
+	~RemoveWeight();
+private:
+	weightsystem_t ws;
+	std::vector<int> indexes; // An index for each dive in the dives vector.
+	void undo() override;
+	void redo() override;
+	bool workToBeDone() override;
+};
+
 } // namespace Command
 
 #endif

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -339,16 +339,32 @@ private:
 	bool workToBeDone() override;
 };
 
-class RemoveWeight : public EditDivesBase {
-public:
-	RemoveWeight(int index, bool currentDiveOnly);
-	~RemoveWeight();
-private:
+class EditWeightBase : public EditDivesBase {
+protected:
+	EditWeightBase(int index, bool currentDiveOnly);
+	~EditWeightBase();
+
 	weightsystem_t ws;
 	std::vector<int> indexes; // An index for each dive in the dives vector.
+	bool workToBeDone() override;
+};
+
+class RemoveWeight : public EditWeightBase {
+public:
+	RemoveWeight(int index, bool currentDiveOnly);
+private:
 	void undo() override;
 	void redo() override;
-	bool workToBeDone() override;
+};
+
+class EditWeight : public EditWeightBase {
+public:
+	EditWeight(int index, weightsystem_t ws, bool currentDiveOnly); // Clones ws
+	~EditWeight();
+private:
+	weightsystem_t new_ws;
+	void undo() override;
+	void redo() override;
 };
 
 } // namespace Command

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -330,6 +330,15 @@ private:
 	bool workToBeDone() override;
 };
 
+class AddWeight : public EditDivesBase {
+public:
+	AddWeight(bool currentDiveOnly);
+private:
+	void undo() override;
+	void redo() override;
+	bool workToBeDone() override;
+};
+
 } // namespace Command
 
 #endif

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -26,11 +26,13 @@
 void free_weightsystem(weightsystem_t ws)
 {
 	free((void *)ws.description);
+	ws.description = NULL;
 }
 
 static void free_cylinder(cylinder_t c)
 {
 	free((void *)c.type.description);
+	c.type.description = NULL;
 }
 
 void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d)

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -111,12 +111,24 @@ void add_weightsystem_description(const weightsystem_t *weightsystem)
 	}
 }
 
+weightsystem_t clone_weightsystem(weightsystem_t ws)
+{
+	weightsystem_t res = { ws.weight, copy_string(ws.description) };
+	return res;
+}
+
 /* Add a clone of a weightsystem to the end of a weightsystem table.
  * Cloned in means that the description-string is copied. */
 void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws)
 {
-	weightsystem_t w_clone = { ws.weight, copy_string(ws.description) };
-	add_to_weightsystem_table(t, t->nr, w_clone);
+	add_to_weightsystem_table(t, t->nr, clone_weightsystem(ws));
+}
+
+/* Add a clone of a weightsystem to the end of a weightsystem table.
+ * Cloned in means that the description-string is copied. */
+void add_cloned_weightsystem_at(struct weightsystem_table *t, weightsystem_t ws)
+{
+	add_to_weightsystem_table(t, t->nr, clone_weightsystem(ws));
 }
 
 /* Add a clone of a cylinder to the end of a cylinder table.

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -288,6 +288,15 @@ void remove_weightsystem(struct dive *dive, int idx)
 	remove_from_weightsystem_table(&dive->weightsystems, idx);
 }
 
+// ws is cloned.
+void set_weightsystem(struct dive *dive, int idx, weightsystem_t ws)
+{
+	if (idx < 0 || idx >= dive->weightsystems.nr)
+		return;
+	free_weightsystem(dive->weightsystems.weightsystems[idx]);
+	dive->weightsystems.weightsystems[idx] = clone_weightsystem(ws);
+}
+
 /* when planning a dive we need to make sure that all cylinders have a sane depth assigned
  * and if we are tracking gas consumption the pressures need to be reset to start = end = workingpressure */
 void reset_cylinders(struct dive *dive, bool track_gas)

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -19,9 +19,13 @@
 #include "subsurface-string.h"
 #include "table.h"
 
-static void free_weightsystem(weightsystem_t w)
+/* Warning: this has strange semantics for C-code! Not the weightsystem object
+ * is freed, but the data it references. The object itself is passed in by value.
+ * This is due to the fact how the table macros work.
+ */
+void free_weightsystem(weightsystem_t ws)
 {
-	free((void *)w.description);
+	free((void *)ws.description);
 }
 
 static void free_cylinder(cylinder_t c)

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -83,6 +83,7 @@ extern bool same_weightsystem(weightsystem_t w1, weightsystem_t w2);
 extern bool same_cylinder(cylinder_t cyl1, cylinder_t cyl2);
 extern void remove_cylinder(struct dive *dive, int idx);
 extern void remove_weightsystem(struct dive *dive, int idx);
+extern void set_weightsystem(struct dive *dive, int idx, weightsystem_t ws);
 extern void reset_cylinders(struct dive *dive, bool track_gas);
 extern int gas_volume(const cylinder_t *cyl, pressure_t p); /* Volume in mliter of a cylinder at pressure 'p' */
 extern int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table *cylinders);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -70,6 +70,7 @@ struct weightsystem_table {
 extern int cylinderuse_from_text(const char *text);
 extern void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d);
 extern weightsystem_t clone_weightsystem(weightsystem_t ws);
+extern void free_weightsystem(weightsystem_t ws);
 extern void copy_cylinder_types(const struct dive *s, struct dive *d);
 extern void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws);
 extern cylinder_t *add_empty_cylinder(struct cylinder_table *t);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -67,6 +67,7 @@ struct weightsystem_table {
 
 extern int cylinderuse_from_text(const char *text);
 extern void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d);
+extern weightsystem_t clone_weightsystem(weightsystem_t ws);
 extern void copy_cylinder_types(const struct dive *s, struct dive *d);
 extern void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws);
 extern cylinder_t *add_empty_cylinder(struct cylinder_table *t);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -50,6 +50,8 @@ typedef struct
 	const char *description; /* "integrated", "belt", "ankle" */
 } weightsystem_t;
 
+static const weightsystem_t empty_weightsystem = { { 0 }, 0 };
+
 /* Table of weightsystems. Attention: this stores weightsystems,
  * *not* pointers * to weightsystems. This has two crucial
  * consequences:

--- a/core/parse.c
+++ b/core/parse.c
@@ -298,8 +298,7 @@ void cylinder_end(struct parser_state *state)
 
 void ws_start(struct parser_state *state)
 {
-	weightsystem_t w = { {0}, "" };
-	add_cloned_weightsystem(&state->cur_dive->weightsystems, w);
+	add_cloned_weightsystem(&state->cur_dive->weightsystems, empty_weightsystem);
 }
 
 void ws_end(struct parser_state *state)

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -88,6 +88,7 @@ signals:
 	void weightsystemsReset(const QVector<dive *> &dives);
 	void weightAdded(dive *d, int pos);
 	void weightRemoved(dive *d, int pos);
+	void weightEdited(dive *d, int pos);
 
 	// Trip edited signal
 	void tripChanged(dive_trip *trip, TripField field);

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -86,6 +86,8 @@ signals:
 
 	void cylindersReset(const QVector<dive *> &dives);
 	void weightsystemsReset(const QVector<dive *> &dives);
+	void weightAdded(dive *d, int pos);
+	void weightRemoved(dive *d, int pos);
 
 	// Trip edited signal
 	void tripChanged(dive_trip *trip, TripField field);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -114,12 +114,14 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	ui.dateEdit->setDisplayFormat(prefs.date_format);
 	ui.tableWidget->setTitle(tr("Dive planner points"));
 	ui.tableWidget->setModel(plannerModel);
+	connect(ui.tableWidget, &TableView::itemClicked, plannerModel, &DivePlannerPointsModel::remove);
 	plannerModel->setRecalc(true);
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::GAS, new AirTypesDelegate(this));
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(this));
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));
 	ui.cylinderTableWidget->setBtnToolTip(tr("Add cylinder"));
 	ui.cylinderTableWidget->setModel(CylindersModel::instance());
+	connect(ui.cylinderTableWidget, &TableView::itemClicked, CylindersModel::instance(), &CylindersModel::remove);
 	ui.waterType->setItemData(0, FRESHWATER_SALINITY);
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -371,9 +371,9 @@ QWidget *WSInfoDelegate::createEditor(QWidget *parent, const QStyleOptionViewIte
 	/* First, call the combobox-create editor, it will setup our globals. */
 	QWidget *editor = ComboBoxDelegate::createEditor(parent, option, index);
 	WeightModel *mymodel = qobject_cast<WeightModel *>(currCombo.model);
-	weightsystem_t *ws = mymodel->weightSystemAt(index);
-	currWeight.type = ws->description;
-	currWeight.weight = ws->weight.grams;
+	weightsystem_t ws = mymodel->weightSystemAt(index);
+	currWeight.type = ws.description;
+	currWeight.weight = ws.weight.grams;
 	return editor;
 }
 

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -45,7 +45,7 @@ slots:
 	//HACK: try to get rid of this in the future.
 	void fakeActivation();
 	void fixTabBehavior();
-	virtual void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) = 0;
+	virtual void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) = 0;
 private:
 	bool editable;
 protected:
@@ -60,7 +60,7 @@ public:
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 public
 slots:
-	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 	void reenableReplot(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 };
 
@@ -78,10 +78,9 @@ class WSInfoDelegate : public ComboBoxDelegate {
 public:
 	explicit WSInfoDelegate(QObject *parent = 0);
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 public
 slots:
-	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 };
 
 class AirTypesDelegate : public ComboBoxDelegate {
@@ -91,7 +90,7 @@ public:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 public
 slots:
-	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 };
 
 class DiveTypesDelegate : public ComboBoxDelegate {
@@ -101,7 +100,7 @@ public:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 public
 slots:
-	void revertModelData(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
 };
 
 class SpinBoxDelegate : public QStyledItemDelegate {

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -158,8 +158,7 @@ void TabDiveEquipment::addCylinder_clicked()
 
 void TabDiveEquipment::addWeight_clicked()
 {
-	MainWindow::instance()->mainTab->enableEdition();
-	weightModel->add();
+	divesEdited(Command::addWeight(false));
 }
 
 void TabDiveEquipment::editCylinderWidget(const QModelIndex &index)

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -35,7 +35,6 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveEquipment::divesChanged);
 	connect(ui.cylinders, &TableView::itemClicked, cylindersModel, &CylindersModel::remove);
 	connect(ui.cylinders, &TableView::itemClicked, this, &TabDiveEquipment::editCylinderWidget);
-	connect(ui.weights, &TableView::itemClicked, weightModel, &WeightModel::remove);
 	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
 
 	// Current display of things on Gnome3 looks like shit, so
@@ -177,10 +176,15 @@ void TabDiveEquipment::editCylinderWidget(const QModelIndex &index)
 
 void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
 {
-	MainWindow::instance()->mainTab->enableEdition();
+	if (!index.isValid())
+		return;
 
-	if (index.isValid() && index.column() != WeightModel::REMOVE)
+	if (index.column() == WeightModel::REMOVE) {
+		divesEdited(Command::removeWeight(index.row(), false));
+	} else {
+		MainWindow::instance()->mainTab->enableEdition();
 		ui.weights->edit(index);
+	}
 }
 
 // tricky little macro to edit all the selected dives

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -179,12 +179,10 @@ void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
 	if (!index.isValid())
 		return;
 
-	if (index.column() == WeightModel::REMOVE) {
+	if (index.column() == WeightModel::REMOVE)
 		divesEdited(Command::removeWeight(index.row(), false));
-	} else {
-		MainWindow::instance()->mainTab->enableEdition();
+	else
 		ui.weights->edit(index);
-	}
 }
 
 // tricky little macro to edit all the selected dives
@@ -254,15 +252,6 @@ void TabDiveEquipment::acceptChanges()
 			sdc = sdc->next;
 		}
 		do_replot = true;
-	}
-
-	if (weightModel->changed) {
-		mark_divelist_changed(true);
-		MODIFY_DIVES(selectedDives,
-			if (weightsystems_equal(mydive, cd))
-				copy_weights(&displayed_dive.weightsystems, &mydive->weightsystems);
-		);
-		copy_weights(&displayed_dive.weightsystems, &cd->weightsystems);
 	}
 
 	if (do_replot)

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -33,8 +33,10 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	ui.weights->setModel(weightModel);
 
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveEquipment::divesChanged);
-	connect(ui.cylinders->view(), &QTableView::clicked, this, &TabDiveEquipment::editCylinderWidget);
-	connect(ui.weights->view(), &QTableView::clicked, this, &TabDiveEquipment::editWeightWidget);
+	connect(ui.cylinders, &TableView::itemClicked, cylindersModel, &CylindersModel::remove);
+	connect(ui.cylinders, &TableView::itemClicked, this, &TabDiveEquipment::editCylinderWidget);
+	connect(ui.weights, &TableView::itemClicked, weightModel, &WeightModel::remove);
+	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
 
 	// Current display of things on Gnome3 looks like shit, so
 	// let's fix that.

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -129,7 +129,7 @@ void TabDiveEquipment::toggleTriggeredColumn()
 void TabDiveEquipment::updateData()
 {
 	cylindersModel->updateDive();
-	weightModel->updateDive();
+	weightModel->updateDive(current_dive);
 	suitModel.updateModel();
 
 	ui.cylinders->view()->hideColumn(CylindersModel::DEPTH);
@@ -272,7 +272,7 @@ void TabDiveEquipment::rejectChanges()
 	cylindersModel->changed = false;
 	weightModel->changed = false;
 	cylindersModel->updateDive();
-	weightModel->updateDive();
+	weightModel->updateDive(current_dive);
 }
 
 void TabDiveEquipment::divesEdited(int i)

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -258,13 +258,11 @@ void TabDiveEquipment::acceptChanges()
 		MainWindow::instance()->graphics->replot();
 
 	cylindersModel->changed = false;
-	weightModel->changed = false;
 }
 
 void TabDiveEquipment::rejectChanges()
 {
 	cylindersModel->changed = false;
-	weightModel->changed = false;
 	cylindersModel->updateDive();
 	weightModel->updateDive(current_dive);
 }
@@ -290,5 +288,3 @@ void TabDiveEquipment::closeWarning()
 {
 	ui.multiDiveWarningMessage->hide();
 }
-
-

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveExtraInfo.h"
 #include "ui_TabDiveExtraInfo.h"
-
-#include <qt-models/divecomputerextradatamodel.h>
+#include "qt-models/divecomputerextradatamodel.h"
 
 TabDiveExtraInfo::TabDiveExtraInfo(QWidget *parent) :
 	TabBase(parent),

--- a/desktop-widgets/tab-widgets/TabDiveSite.h
+++ b/desktop-widgets/tab-widgets/TabDiveSite.h
@@ -16,6 +16,7 @@ private slots:
 	void add();
 	void diveSiteAdded(struct dive_site *, int idx);
 	void diveSiteChanged(struct dive_site *ds, int field);
+	void diveSiteClicked(const QModelIndex &);
 	void on_purgeUnused_clicked();
 	void on_filterText_textChanged(const QString &text);
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);

--- a/desktop-widgets/tableview.cpp
+++ b/desktop-widgets/tableview.cpp
@@ -10,6 +10,8 @@ TableView::TableView(QWidget *parent) : QGroupBox(parent)
 	ui.setupUi(this);
 	ui.tableView->setItemDelegate(new DiveListDelegate(this));
 
+	connect(ui.tableView, &QTableView::clicked, this, &TableView::itemClicked);
+
 	QFontMetrics fm(defaultModelFont());
 	int text_ht = fm.height();
 
@@ -93,7 +95,6 @@ void TableView::setBtnToolTip(const QString &tooltip)
 void TableView::setModel(QAbstractItemModel *model)
 {
 	ui.tableView->setModel(model);
-	connect(ui.tableView, SIGNAL(clicked(QModelIndex)), model, SLOT(remove(QModelIndex)));
 
 	QSettings s;
 	s.beginGroup(objectName());

--- a/desktop-widgets/tableview.h
+++ b/desktop-widgets/tableview.h
@@ -28,10 +28,6 @@ class TableView : public QGroupBox {
 public:
 	TableView(QWidget *parent = 0);
 	~TableView();
-	/* The model is expected to have a 'remove' slot, that takes a QModelIndex as parameter.
-	 * It's also expected to have the column '1' as a trash icon. I most probably should create a
-	 * proxy model and add that column, will mark that as TODO. see? marked.
-	 */
 	void setModel(QAbstractItemModel *model);
 	void setBtnToolTip(const QString &tooltip);
 	void fixPlusPosition();
@@ -45,6 +41,7 @@ protected:
 
 signals:
 	void addButtonClicked();
+	void itemClicked(const QModelIndex &);
 
 private:
 	Ui::TableView ui;

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -7,9 +7,7 @@
 #include "core/metrics.h"
 #ifndef SUBSURFACE_MOBILE
 #include "cleanertablemodel.h" // for trashIcon() and editIcon()
-#include "desktop-widgets/mainwindow.h" // to place message box
 #include "commands/command.h"
-#include <QMessageBox>
 #endif
 #include <QLineEdit>
 #include <QIcon>
@@ -262,27 +260,6 @@ bool DiveSiteSortedModel::setData(const QModelIndex &index, const QVariant &valu
 	}
 }
 
-// TODO: Remove or edit. It doesn't make sense to call the model here, which calls the undo command,
-// which in turn calls the model.
-void DiveSiteSortedModel::remove(const QModelIndex &index)
-{
-	struct dive_site *ds = getDiveSite(index);
-	if (!ds)
-		return;
-	switch (index.column()) {
-	case LocationInformationModel::EDIT:
-		MainWindow::instance()->editDiveSite(ds);
-		break;
-	case LocationInformationModel::REMOVE:
-		if (ds->dives.nr > 0 &&
-		    QMessageBox::warning(MainWindow::instance(), tr("Delete dive site?"),
-					 tr("This dive site has %n dive(s). Do you really want to delete it?\n", "", ds->dives.nr),
-					 QMessageBox::Yes|QMessageBox::No) == QMessageBox::No)
-				return;
-		Command::deleteDiveSites(QVector<dive_site *>{ds});
-		break;
-	}
-}
 #endif // SUBSURFACE_MOBILE
 
 void DiveSiteSortedModel::setFilter(const QString &text)

--- a/qt-models/divelocationmodel.h
+++ b/qt-models/divelocationmodel.h
@@ -46,8 +46,6 @@ private:
 	QString fullText;
 #ifndef SUBSURFACE_MOBILE
 	bool setData(const QModelIndex &index, const QVariant &value, int role) override;
-public slots:
-	void remove(const QModelIndex &index);
 #endif // SUBSURFACE_MOBILE
 public:
 	DiveSiteSortedModel();

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -29,17 +29,6 @@ weightsystem_t *WeightModel::weightSystemAt(const QModelIndex &index)
 	return &d->weightsystems.weightsystems[index.row()];
 }
 
-void WeightModel::remove(QModelIndex index)
-{
-	if (index.column() != REMOVE || !d)
-		return;
-	beginRemoveRows(QModelIndex(), index.row(), index.row());
-	rows--;
-	remove_weightsystem(d, index.row());
-	changed = true;
-	endRemoveRows();
-}
-
 void WeightModel::clear()
 {
 	updateDive(nullptr);
@@ -95,7 +84,6 @@ void WeightModel::passInData(const QModelIndex &index, const QVariant &value)
 		}
 	}
 }
-
 
 bool WeightModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -11,7 +11,6 @@
 #endif
 
 WeightModel::WeightModel(QObject *parent) : CleanerTableModel(parent),
-	changed(false),
 	d(nullptr),
 	tempRow(-1),
 	tempWS(empty_weightsystem)

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -23,7 +23,7 @@ weightsystem_t WeightModel::weightSystemAt(const QModelIndex &index) const
 	int row = index.row();
 	if (row < 0 || row >= d->weightsystems.nr) {
 		qWarning("WeightModel: Accessing invalid weightsystem %d (of %d)", row, d->weightsystems.nr);
-		return { { 0 }, nullptr };
+		return empty_weightsystem;
 	}
 	return d->weightsystems.weightsystems[index.row()];
 }

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -19,14 +19,14 @@ WeightModel::WeightModel(QObject *parent) : CleanerTableModel(parent),
 	connect(&diveListNotifier, &DiveListNotifier::weightRemoved, this, &WeightModel::weightRemoved);
 }
 
-weightsystem_t *WeightModel::weightSystemAt(const QModelIndex &index)
+weightsystem_t WeightModel::weightSystemAt(const QModelIndex &index)
 {
 	int row = index.row();
 	if (row < 0 || row >= d->weightsystems.nr) {
 		qWarning("WeightModel: Accessing invalid weightsystem %d (of %d)", row, d->weightsystems.nr);
-		return nullptr;
+		return { { 0 }, nullptr };
 	}
-	return &d->weightsystems.weightsystems[index.row()];
+	return d->weightsystems.weightsystems[index.row()];
 }
 
 void WeightModel::clear()

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -82,14 +82,12 @@ void WeightModel::setTempWS(int row, weightsystem_t ws)
 		return;
 
 	clearTempWS(); // Shouldn't be necessary, just in case: Reset old temporary row.
-	free_weightsystem(tempWS);
 
 	// It is really hard to get the editor-close-hints and setModelData calls under
 	// control. Therefore, if the row is set to the already existing entry, don't
 	// enter temporary mode.
 	if (same_string(d->weightsystems.weightsystems[row].description, ws.description)) {
 		free_weightsystem(ws);
-		tempWS.description = nullptr;
 	} else {
 		tempRow = row;
 		tempWS = ws;
@@ -103,6 +101,7 @@ void WeightModel::clearTempWS()
 		return;
 	int oldRow = tempRow;
 	tempRow = -1;
+	free_weightsystem(tempWS);
 	dataChanged(index(oldRow, TYPE), index(oldRow, WEIGHT));
 }
 

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -28,7 +28,6 @@ public:
 	void clear();
 	void updateDive(dive *d);
 	weightsystem_t weightSystemAt(const QModelIndex &index) const;
-	bool changed;
 
 public
 slots:

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -25,7 +25,7 @@ public:
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void clear();
 	void updateDive(dive *d);
-	weightsystem_t weightSystemAt(const QModelIndex &index);
+	weightsystem_t weightSystemAt(const QModelIndex &index) const;
 	bool changed;
 
 public
@@ -36,7 +36,6 @@ slots:
 
 private:
 	dive *d;
-	int rows;
 };
 
 #endif

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -25,7 +25,7 @@ public:
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();
 	void clear();
-	void updateDive();
+	void updateDive(dive *d);
 	weightsystem_t *weightSystemAt(const QModelIndex &index);
 	bool changed;
 
@@ -35,6 +35,7 @@ slots:
 	void weightsystemsReset(const QVector<dive *> &dives);
 
 private:
+	dive *d;
 	int rows;
 };
 

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -30,7 +30,6 @@ public:
 
 public
 slots:
-	void remove(QModelIndex index);
 	void weightsystemsReset(const QVector<dive *> &dives);
 	void weightAdded(dive *d, int pos);
 	void weightRemoved(dive *d, int pos);

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -21,8 +21,10 @@ public:
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+	void setTempWS(int row, weightsystem_t ws);
+	void clearTempWS();
+	void commitTempWS();
 
-	void passInData(const QModelIndex &index, const QVariant &value);
 	void clear();
 	void updateDive(dive *d);
 	weightsystem_t weightSystemAt(const QModelIndex &index) const;
@@ -36,6 +38,9 @@ slots:
 
 private:
 	dive *d;
+	// If we temporarily change a line because the user is selecting a weight type
+	int tempRow;
+	weightsystem_t tempWS;
 };
 
 #endif

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -35,6 +35,7 @@ slots:
 	void weightsystemsReset(const QVector<dive *> &dives);
 	void weightAdded(dive *d, int pos);
 	void weightRemoved(dive *d, int pos);
+	void weightEdited(dive *d, int pos);
 
 private:
 	dive *d;

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -25,7 +25,7 @@ public:
 	void passInData(const QModelIndex &index, const QVariant &value);
 	void clear();
 	void updateDive(dive *d);
-	weightsystem_t *weightSystemAt(const QModelIndex &index);
+	weightsystem_t weightSystemAt(const QModelIndex &index);
 	bool changed;
 
 public

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -23,7 +23,6 @@ public:
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
 	void passInData(const QModelIndex &index, const QVariant &value);
-	void add();
 	void clear();
 	void updateDive(dive *d);
 	weightsystem_t *weightSystemAt(const QModelIndex &index);
@@ -33,6 +32,8 @@ public
 slots:
 	void remove(QModelIndex index);
 	void weightsystemsReset(const QVector<dive *> &dives);
+	void weightAdded(dive *d, int pos);
+	void weightRemoved(dive *d, int pos);
 
 private:
 	dive *d;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We have to progress on that front - this implements undo of the weight system actions (add, delete, edit). That's the easy part of the equipment tab, but it gave me some ideas on how to handle the much harder part: cylinders. The problem with cylinders is that they are used in two places: normal editing and planner. That will be fun.

Overall, this was a bit harder than expected, because when hovering over the weightsystem-types, the old code would overwrite the displayed dive. The logic was changed so that the model now has a "temporary" weightsystem line that it can display. This can be set, committed or reset.

I don't like how the model calls the undo-command, but that's the easiest way for now.

This is only lightly tested.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Unsure.
