### PR TITLE
 Notes tab: Use top RH for depth and duration fields

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -186,7 +186,6 @@ MainTab::~MainTab()
 void MainTab::hideMessage()
 {
 	ui.diveNotesMessage->animatedHide();
-	updateTextLabels(false);
 }
 
 void MainTab::closeMessage()
@@ -205,18 +204,6 @@ void MainTab::displayMessage(QString str)
 	ui.diveNotesMessage->setCloseButtonVisible(false);
 	ui.diveNotesMessage->setText(str);
 	ui.diveNotesMessage->animatedShow();
-	updateTextLabels();
-}
-
-void MainTab::updateTextLabels(bool showUnits)
-{
-	if (showUnits) {
-		ui.airTempLabel->setText(tr("Air temp. [%1]").arg(get_temp_unit()));
-		ui.waterTempLabel->setText(tr("Water temp. [%1]").arg(get_temp_unit()));
-	} else {
-		ui.airTempLabel->setText(tr("Air temp."));
-		ui.waterTempLabel->setText(tr("Water temp."));
-	}
 }
 
 void MainTab::enableEdition(EditMode newEditMode)
@@ -269,10 +256,6 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
 	if (field.depth)
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
-	if (field.air_temp)
-		ui.airtemp->setText(get_temperature_string(current_dive->airtemp, true));
-	if (field.water_temp)
-		ui.watertemp->setText(get_temperature_string(current_dive->watertemp, true));
 	if (field.rating)
 		ui.rating->setCurrentStars(current_dive->rating);
 	if (field.notes)
@@ -427,10 +410,6 @@ void MainTab::updateDiveInfo()
 			ui.RatingLabel->setVisible(false);
 			ui.tagWidget->setVisible(false);
 			ui.TagLabel->setVisible(false);
-			ui.airTempLabel->setVisible(false);
-			ui.airtemp->setVisible(false);
-			ui.waterTempLabel->setVisible(false);
-			ui.watertemp->setVisible(false);
 			ui.dateEdit->setReadOnly(true);
 			ui.timeLabel->setVisible(false);
 			ui.timeEdit->setVisible(false);
@@ -479,10 +458,6 @@ void MainTab::updateDiveInfo()
 			ui.DivemasterLabel->setVisible(true);
 			ui.TagLabel->setVisible(true);
 			ui.tagWidget->setVisible(true);
-			ui.airTempLabel->setVisible(true);
-			ui.airtemp->setVisible(true);
-			ui.waterTempLabel->setVisible(true);
-			ui.watertemp->setVisible(true);
 			ui.dateEdit->setReadOnly(false);
 			ui.timeLabel->setVisible(true);
 			ui.timeEdit->setVisible(true);
@@ -503,8 +478,6 @@ void MainTab::updateDiveInfo()
 			updateDateTime(current_dive);
 			ui.divemaster->setText(current_dive->divemaster);
 			ui.buddy->setText(current_dive->buddy);
-			ui.airtemp->setText(get_temperature_string(current_dive->airtemp, true));
-			ui.watertemp->setText(get_temperature_string(current_dive->watertemp, true));
 		}
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
@@ -524,8 +497,6 @@ void MainTab::updateDiveInfo()
 		ui.location->clear();
 		ui.divemaster->clear();
 		ui.buddy->clear();
-		ui.airtemp->clear();
-		ui.watertemp->clear();
 		ui.notes->clear();
 		/* set date and time to minimums which triggers showing the special value text */
 		ui.dateEdit->setSpecialValueText(QString("-"));
@@ -731,26 +702,6 @@ void MainTab::on_depth_editingFinished()
 
 	// Depth editing is special: we only edit the current dive.
 	divesEdited(Command::editDepth(parseLengthToMm(ui.depth->text()), true));
-}
-
-void MainTab::on_airtemp_editingFinished()
-{
-	// If the field wasn't modified by the user, don't post a new undo command.
-	// Owing to rounding errors, this might lead to undo commands that have
-	// no user visible effects. These can be very confusing.
-	if (editMode == IGNORE_MODE || !ui.airtemp->isModified() || !current_dive)
-		return;
-	divesEdited(Command::editAirTemp(parseTemperatureToMkelvin(ui.airtemp->text()), false));
-}
-
-void MainTab::on_watertemp_editingFinished()
-{
-	// If the field wasn't modified by the user, don't post a new undo command.
-	// Owing to rounding errors, this might lead to undo commands that have
-	// no user visible effects. These can be very confusing.
-	if (editMode == IGNORE_MODE || !ui.watertemp->isModified() || !current_dive)
-		return;
-	divesEdited(Command::editWaterTemp(parseTemperatureToMkelvin(ui.watertemp->text()), false));
 }
 
 // Editing of the dive time is different. If multiple dives are edited,

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -62,10 +62,8 @@ slots:
 	void on_buddy_editingFinished();
 	void on_diveTripLocation_editingFinished();
 	void on_notes_editingFinished();
-	void on_airtemp_editingFinished();
 	void on_duration_editingFinished();
 	void on_depth_editingFinished();
-	void on_watertemp_editingFinished();
 	void on_dateEdit_dateChanged(const QDate &date);
 	void on_timeEdit_timeChanged(const QTime & time);
 	void on_rating_valueChanged(int value);
@@ -75,7 +73,6 @@ slots:
 	void closeWarning();
 	void displayMessage(QString str);
 	void enableEdition(EditMode newEditMode = NONE);
-	void updateTextLabels(bool showUnits = true);
 	void escDetected(void);
 private:
 	Ui::MainTab ui;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -77,20 +77,19 @@
              <property name="verticalSpacing">
               <number>0</number>
              </property>
-             <item row="2" column="3">
-              <widget class="QLabel" name="durationLabel">
-               <property name="text">
-                <string>Duration</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="dateLabel">
-               <property name="text">
+            <item row="0" column="0">
+             <widget class="QLabel" name="dateLabel">
+              <property name="text">
                 <string>Date</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+              </property>
+              <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+              </property>
+                <property name="alignment">
+                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
                </property>
               </widget>
              </item>
@@ -99,28 +98,53 @@
                <property name="text">
                 <string>Time</string>
                </property>
+               <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                  <horstretch>1</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+               </property>
                <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2" colspan="2">
+              <widget class="QLabel" name="depthLabely">
+               <property name="text">
+                <string> </string>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                 <horstretch>2</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
               </widget>
              </item>
              <item row="0" column="2">
-              <widget class="QLabel" name="airTempLabel">
-               <property name="text">
-                <string>Air temp.</string>
+              <widget class="QLabel" name="depthLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+               <property name="text">
+                <string>Depth</string>
                </property>
               </widget>
              </item>
              <item row="0" column="3">
-              <widget class="QLabel" name="waterTempLabel">
-               <property name="text">
-                <string>Water temp.</string>
+              <widget class="QLabel" name="durationLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-               <property name="alignment">
-                <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+               <property name="text">
+                <string>Duration (h:mm)</string>
                </property>
               </widget>
              </item>
@@ -132,49 +156,61 @@
                <property name="timeSpec">
                 <enum>Qt::UTC</enum>
                </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QTimeEdit" name="timeEdit">
+               <widget class="QTimeEdit" name="timeEdit">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
                <property name="timeSpec">
                 <enum>Qt::UTC</enum>
                </property>
+               </widget>
+             </item>
+             <item row="1" column="2" colspan="2">
+              <widget class="QLabel" name="depthLabelx">
+               <property name="text">
+                <string> </string>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                 <horstretch>2</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
               </widget>
              </item>
              <item row="1" column="2">
-              <widget class="QLineEdit" name="airtemp">
-               <property name="readOnly">
-                <bool>false</bool>
+              <widget class="QLineEdit" name="depth">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
               </widget>
              </item>
              <item row="1" column="3">
-              <widget class="QLineEdit" name="watertemp">
-               <property name="readOnly">
-                <bool>false</bool>
+              <widget class="QLineEdit" name="duration">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
               </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QLabel" name="depthLabel">
-               <property name="text">
-                <string>Depth</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
-              <widget class="QLineEdit" name="depth"/>
-             </item>
-             <item row="3" column="3">
-              <widget class="QLineEdit" name="duration"/>
-             </item>
-            </layout>
+              </item>
+             </layout>
            </item>
            <item>
             <layout class="QVBoxLayout" name="verticalLayout_6">


### PR DESCRIPTION
    Currently the top righthand part of the notes tab is used for
    showing and editing air temperature and water temperature. But
    these fields were moved over to the Information tab and are not
    required in the Notes tab any more. Rather use this space for the
    depth and duration data for manually-entered dives. Currently
    extra vertical space is created in the Notes tab for showing this
    field, resulting in inefficient use of screen space and
    inelegant layout. This code moves the Duration and Depth fields
    into the top righthand of the Notes tab.

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @bstoeger @glance @sfuchs79 