### PR TITLE
Profile: fix pressure scale

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -414,11 +414,12 @@ static void calculate_max_limits_new(struct dive *dive, struct divecomputer *giv
 
 	/* Get the per-cylinder maximum pressure if they are manual */
 	for (cyl = 0; cyl < dive->cylinders.nr; cyl++) {
-		int mbar = get_cylinder(dive, cyl)->start.mbar;
-		if (mbar > maxpressure)
-			maxpressure = mbar;
-		if (mbar < minpressure)
-			minpressure = mbar;
+		int mbar_start = get_cylinder(dive, cyl)->start.mbar;
+		int mbar_end = get_cylinder(dive, cyl)->end.mbar;
+		if (mbar_start > maxpressure)
+			maxpressure = mbar_start;
+		if (mbar_end < minpressure)
+			minpressure = mbar_end;
 	}
 
 	/* Then do all the samples from all the dive computers */


### PR DESCRIPTION
The determination of minimum pressure in calculate_max_limits_new()
in profile.c was wrong for a long time. Since the loop went over all
cylinders (even unused ones), the minimum pressure was always zero.

Since we loop only over used cylinders, the minimum pressure was
initialized to the lowest starting pressure of any cylinder.

If there were no events with pressure change, the minimum pressure
stayed unchanged, resulting in a funky scaling.

Instead, let's initialize the minimum pressure to the lowest ending
pressure.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Correctly calculate minimum pressure if there are no pressure event.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug was hidden by old cylinder code.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson @dirkhh @atdotde 
Please test / comment.