### PR TITLE
mobile-widget/qml: correct syntax error in main.qml introduced in e63257f0e

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -66,8 +66,8 @@ Kirigami.ApplicationWindow {
 		anchors.centerIn: parent
 	}
 
-	function showBusy(msg = "") {
-		if (msg !== "")
+	function showBusy(msg) {
+		if (msg !== undefined)
 			showPassiveNotification(msg, 15000) // show for 15 seconds
 		busy.running = true
 	}


### PR DESCRIPTION
default parameter values is not supported as this syntax was introduced
in ECMA-262 6th edition while QML only implements the fifth edition
(as of Qt 5.11).

remove default parameter and check for undefined instead.

Signed-off-by: Jan Iversen <jan@casacondor.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
