### PR TITLE
Core: set gas use to zero if no values are given

### DIFF
--- a/core/statistics.c
+++ b/core/statistics.c
@@ -376,6 +376,8 @@ volume_t *get_gas_used(struct dive *dive)
 		end = cyl->end.mbar ? cyl->end : cyl->sample_end;
 		if (end.mbar && start.mbar > end.mbar)
 			gases[idx].mliter = gas_volume(cyl, start) - gas_volume(cyl, end);
+		else
+			gases[idx].mliter = 0;
 	}
 
 	return gases;


### PR DESCRIPTION
In get_gas_used() the use was left uninitialized if there are neither
user- nor computer-supplied values. This gives random SACs in the UI.
Initialize to 0.

Fixes #2376.

Reported-by: Stefan Fuchs <sfuchs@gmx.de>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is supposed to fix #2376. All info in the commit message.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sfuchs79 @willemferguson 