### PR TITLE
Cleanup: don't std::move() temporaries

### DIFF
--- a/desktop-widgets/command_divesite.cpp
+++ b/desktop-widgets/command_divesite.cpp
@@ -88,12 +88,12 @@ bool AddDiveSite::workToBeDone()
 
 void AddDiveSite::redo()
 {
-	sitesToRemove = std::move(addDiveSites(sitesToAdd));
+	sitesToRemove = addDiveSites(sitesToAdd);
 }
 
 void AddDiveSite::undo()
 {
-	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
+	sitesToAdd = removeDiveSites(sitesToRemove);
 }
 
 ImportDiveSites::ImportDiveSites(struct dive_site_table *sites, const QString &source)
@@ -124,12 +124,12 @@ bool ImportDiveSites::workToBeDone()
 
 void ImportDiveSites::redo()
 {
-	sitesToRemove = std::move(addDiveSites(sitesToAdd));
+	sitesToRemove = addDiveSites(sitesToAdd);
 }
 
 void ImportDiveSites::undo()
 {
-	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
+	sitesToAdd = removeDiveSites(sitesToRemove);
 }
 
 DeleteDiveSites::DeleteDiveSites(const QVector<dive_site *> &sites) : sitesToRemove(sites.toStdVector())
@@ -144,12 +144,12 @@ bool DeleteDiveSites::workToBeDone()
 
 void DeleteDiveSites::redo()
 {
-	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
+	sitesToAdd = removeDiveSites(sitesToRemove);
 }
 
 void DeleteDiveSites::undo()
 {
-	sitesToRemove = std::move(addDiveSites(sitesToAdd));
+	sitesToRemove = addDiveSites(sitesToAdd);
 }
 
 PurgeUnusedDiveSites::PurgeUnusedDiveSites()
@@ -169,12 +169,12 @@ bool PurgeUnusedDiveSites::workToBeDone()
 
 void PurgeUnusedDiveSites::redo()
 {
-	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
+	sitesToAdd = removeDiveSites(sitesToRemove);
 }
 
 void PurgeUnusedDiveSites::undo()
 {
-	sitesToRemove = std::move(addDiveSites(sitesToAdd));
+	sitesToRemove = addDiveSites(sitesToAdd);
 }
 
 // Helper function: swap C and Qt string
@@ -356,7 +356,7 @@ bool MergeDiveSites::workToBeDone()
 void MergeDiveSites::redo()
 {
 	// First, remove all dive sites
-	sitesToAdd = std::move(removeDiveSites(sitesToRemove));
+	sitesToAdd = removeDiveSites(sitesToRemove);
 
 	// Remember which dives changed so that we can send a single dives-edited signal
 	QVector<dive *> divesChanged;
@@ -387,7 +387,7 @@ void MergeDiveSites::undo()
 		}
 	}
 
-	sitesToRemove = std::move(addDiveSites(sitesToAdd));
+	sitesToRemove = addDiveSites(sitesToAdd);
 
 	emit diveListNotifier.divesChanged(divesChanged, DiveField::DIVESITE);
 }


### PR DESCRIPTION
clang correctly warns about std::move()ing objects returned from
functions. This is a pessimization, because the compiler can't
copy elide the object. Remove.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another trivial cleanup in the undo code. I have nothing to add to the commit message.