### PR TITLE
Dive list: signal correct trip in DiveTripModelTree::topLevelChanged

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -759,6 +759,11 @@ void DiveTripModelTree::topLevelChanged(int idx)
 		endMoveRows();
 	}
 
+	// If we moved the object backwards in the array, we have to
+	// subtract one from the index to account for the removed object.
+	if (newIdx > idx)
+		--newIdx;
+
 	// Finally, inform UI of changed trip header
 	QModelIndex tripIdx = createIndex(newIdx, 0, noParent);
 	dataChanged(tripIdx, tripIdx);


### PR DESCRIPTION
DiveTripModelTree::topLevelChanged() has pretty complex code, as
it has to handle the fact that when adding/removing a dive from
a trip, the trip can change it's position.

It got the common case (trip stays where it is) wrong: it sent
a signal to redraw the next trip. Catch that special case.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a bug fix for a bug detected when adapting the model code for mobile. Weirdly enough, desktop works even with this bug.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Signal correct trip, not the trip after the correct trip.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - for some reason not visible on desktop. Apparently, the header is updated automatically if a child is updated.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh