### PR TITLE
Partially revert 3025e0630de2b9ced3d0aadd1513cb0e1c93b159

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1446,6 +1446,7 @@ void clear_dive_file_data()
 {
 	while (dive_table.nr)
 		delete_single_dive(0);
+	current_dive = NULL;
 	while (dive_site_table.nr)
 		delete_dive_site(get_dive_site(0, &dive_site_table), &dive_site_table);
 	if (trip_table.nr != 0) {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -658,7 +658,6 @@ void MainWindow::closeCurrentFile()
 	/* free the dives and trips */
 	clear_git_id();
 	clear_dive_file_data();
-	current_dive = nullptr;
 	setCurrentFile(nullptr);
 	graphics->setEmptyState();
 	mainTab->clearTabs();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -657,12 +657,8 @@ void MainWindow::closeCurrentFile()
 {
 	/* free the dives and trips */
 	clear_git_id();
-	clear_dive_file_data();
+	DiveTripModelBase::instance()->clear();
 	setCurrentFile(nullptr);
-	graphics->setEmptyState();
-	mainTab->clearTabs();
-	mainTab->updateDiveInfo();
-	diveList->reload();
 	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
 	MapWidget::instance()->reload();
 	LocationInformationModel::instance()->update();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -634,21 +634,6 @@ void MainWindow::on_actionCloudOnline_triggered()
 	updateCloudOnlineStatus();
 }
 
-void MainWindow::cleanUpEmpty()
-{
-	current_dive = nullptr;
-	mainTab->clearTabs();
-	mainTab->updateDiveInfo();
-	graphics->setEmptyState();
-	diveList->reload();
-	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
-	MapWidget::instance()->reload();
-	LocationInformationModel::instance()->update();
-	if (!existing_filename)
-		setTitle();
-	disableShortcuts();
-}
-
 bool MainWindow::okToClose(QString message)
 {
 	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING ||
@@ -670,12 +655,21 @@ void MainWindow::setFileClean()
 
 void MainWindow::closeCurrentFile()
 {
-	graphics->setEmptyState();
 	/* free the dives and trips */
 	clear_git_id();
 	clear_dive_file_data();
+	current_dive = nullptr;
 	setCurrentFile(nullptr);
-	cleanUpEmpty();
+	graphics->setEmptyState();
+	mainTab->clearTabs();
+	mainTab->updateDiveInfo();
+	diveList->reload();
+	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
+	MapWidget::instance()->reload();
+	LocationInformationModel::instance()->update();
+	if (!existing_filename)
+		setTitle();
+	disableShortcuts();
 	setFileClean();
 
 	clear_events();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -71,7 +71,6 @@ public:
 
 	void loadFiles(const QStringList files);
 	void importFiles(const QStringList importFiles);
-	void cleanUpEmpty();
 	void setToolButtonsEnabled(bool enabled);
 	void printPlan();
 	void checkSurvey();

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -139,7 +139,7 @@ ToolTipItem::ToolTipItem(QGraphicsItem *parent) : QGraphicsRectItem(parent),
 	timeAxis(0),
 	lastTime(-1)
 {
-	memset(&pInfo, 0, sizeof(pInfo));
+	clearPlotInfo();
 	entryToolTip.first = NULL;
 	entryToolTip.second = NULL;
 	setFlags(ItemIgnoresTransformations | ItemIsMovable | ItemClipsChildrenToShape);
@@ -221,6 +221,11 @@ void ToolTipItem::readPos()
 void ToolTipItem::setPlotInfo(const plot_info &plot)
 {
 	pInfo = plot;
+}
+
+void ToolTipItem::clearPlotInfo()
+{
+	memset(&pInfo, 0, sizeof(pInfo));
 }
 
 void ToolTipItem::setTimeAxis(DiveCartesianAxis *axis)

--- a/profile-widget/divetooltipitem.h
+++ b/profile-widget/divetooltipitem.h
@@ -44,6 +44,7 @@ public:
 	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
 	void setTimeAxis(DiveCartesianAxis *axis);
 	void setPlotInfo(const plot_info &plot);
+	void clearPlotInfo();
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
 public
 slots:

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1134,6 +1134,7 @@ void ProfileWidget2::setEmptyState()
 	ccrsensor3GasItem->setVisible(false);
 	ocpo2GasItem->setVisible(false);
 #ifndef SUBSURFACE_MOBILE
+	toolTipItem->clearPlotInfo();
 	toolTipItem->setVisible(false);
 	diveCeiling->setVisible(false);
 	decoModelParameters->setVisible(false);

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -169,15 +169,17 @@ QVariant DivePlotDataModel::headerData(int section, Qt::Orientation orientation,
 
 void DivePlotDataModel::clear()
 {
-	beginResetModel();
-	pInfo.nr = 0;
-	free(pInfo.entry);
-	free(pInfo.pressures);
-	pInfo.entry = nullptr;
-	pInfo.pressures = nullptr;
-	diveId = -1;
-	dcNr = -1;
-	endResetModel();
+	if (rowCount() != 0) {
+		beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
+		pInfo.nr = 0;
+		free(pInfo.entry);
+		free(pInfo.pressures);
+		pInfo.entry = nullptr;
+		pInfo.pressures = nullptr;
+		diveId = -1;
+		dcNr = -1;
+		endRemoveRows();
+	}
 }
 
 void DivePlotDataModel::setDive(dive *d, const plot_info &info)

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -372,6 +372,13 @@ void DiveTripModelBase::resetModel(DiveTripModelBase::Layout layout)
 		currentModel.reset(new DiveTripModelList);
 }
 
+void DiveTripModelBase::clear()
+{
+	beginResetModel();
+	clear_dive_file_data();
+	endResetModel();
+}
+
 DiveTripModelBase::DiveTripModelBase(QObject *parent) : QAbstractItemModel(parent)
 {
 }

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -70,6 +70,9 @@ public:
 	// by instance().
 	static void resetModel(Layout layout);
 
+	// Clear all dives
+	void clear();
+
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;


### PR DESCRIPTION
This commit did the "right" thing by implementing Qt mode semantics
as intended, but for unknown reasons the profile is not properly
cleared on close-file anymore. This code is so convoluted that there
is not point in fighting it at the moment. Revert to remove-rows
instead of reset-model.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a recently introduced bug by doing a semi-revert. The code is too convoluted to find out what is actually happening.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.