### PR TITLE
Attempt at filter detangling

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -8,6 +8,7 @@
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "qt-models/filtermodels.h"
 #include "../profile-widget/profilewidget2.h"
+#include "core/divefilter.h"
 
 #include <array>
 
@@ -68,7 +69,7 @@ dive *DiveListBase::addDive(DiveToAdd &d)
 	dive *res = d.dive.release();		// Give up ownership of dive
 
 	// Set the filter flag according to current filter settings
-	bool show = MultiFilterSortModel::instance()->showDive(res);
+	bool show = DiveFilter::instance()->showDive(res);
 	res->hidden_by_filter = !show;
 	if (show)
 		++shown_dives;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -66,6 +66,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	dive.h
 	divecomputer.cpp
 	divecomputer.h
+	divefilter.cpp
+	divefilter.h
 	divelist.c
 	divelist.h
 	divelogexportlogic.cpp

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "divefilter.h"
+
+#ifdef SUBSURFACE_MOBILE
+
+DiveFilter::DiveFilter()
+{
+}
+
+bool DiveFilter::showDive(const struct dive *d) const
+{
+	// TODO: Do something useful
+	return true;
+}
+
+#else // SUBSURFACE_MOBILE
+
+#include "desktop-widgets/mapwidget.h"
+#include "desktop-widgets/mainwindow.h"
+#include "desktop-widgets/divelistview.h"
+#include "core/qthelper.h"
+#include "core/trip.h"
+#include "core/divesite.h"
+#include "qt-models/filtermodels.h"
+
+namespace {
+	// Check if a string-list contains at least one string containing the second argument.
+	// Comparison is non case sensitive and removes white space.
+	bool listContainsSuperstring(const QStringList &list, const QString &s)
+	{
+		return std::any_of(list.begin(), list.end(), [&s](const QString &s2)
+				   { return s2.trimmed().contains(s.trimmed(), Qt::CaseInsensitive); } );
+	}
+
+	// Check whether either all, any or none of the items of the first list is
+	// in the second list as a super string.
+	// The mode is controlled by the second argument
+	bool check(const QStringList &items, const QStringList &list, FilterData::Mode mode)
+	{
+		bool negate = mode == FilterData::Mode::NONE_OF;
+		bool any_of = mode == FilterData::Mode::ANY_OF;
+		auto fun = [&list, negate](const QString &item)
+			   { return listContainsSuperstring(list, item) != negate; };
+		return any_of ? std::any_of(items.begin(), items.end(), fun)
+			      : std::all_of(items.begin(), items.end(), fun);
+	}
+
+	bool hasTags(const QStringList &tags, const struct dive *d, FilterData::Mode mode)
+	{
+		if (tags.isEmpty())
+			return true;
+		QStringList dive_tags = get_taglist_string(d->tag_list).split(",");
+		dive_tags.append(gettextFromC::tr(divemode_text_ui[d->dc.divemode]));
+		return check(tags, dive_tags, mode);
+	}
+
+	bool hasPersons(const QStringList &people, const struct dive *d, FilterData::Mode mode)
+	{
+		if (people.isEmpty())
+			return true;
+		QStringList dive_people = QString(d->buddy).split(",", QString::SkipEmptyParts)
+			+ QString(d->divemaster).split(",", QString::SkipEmptyParts);
+		return check(people, dive_people, mode);
+	}
+
+	bool hasLocations(const QStringList &locations, const struct dive *d, FilterData::Mode mode)
+	{
+		if (locations.isEmpty())
+			return true;
+		QStringList diveLocations;
+		if (d->divetrip)
+			diveLocations.push_back(QString(d->divetrip->location));
+
+		if (d->dive_site)
+			diveLocations.push_back(QString(d->dive_site->name));
+
+		return check(locations, diveLocations, mode);
+	}
+
+	// TODO: Finish this implementation.
+	bool hasEquipment(const QStringList &, const struct dive *, FilterData::Mode)
+	{
+		return true;
+	}
+
+	bool hasSuits(const QStringList &suits, const struct dive *d, FilterData::Mode mode)
+	{
+		if (suits.isEmpty())
+			return true;
+		QStringList diveSuits;
+		if (d->suit)
+			diveSuits.push_back(QString(d->suit));
+		return check(suits, diveSuits, mode);
+	}
+
+	bool hasNotes(const QStringList &dnotes, const struct dive *d, FilterData::Mode mode)
+	{
+		if (dnotes.isEmpty())
+			return true;
+		QStringList diveNotes;
+		if (d->notes)
+			diveNotes.push_back(QString(d->notes));
+		return check(dnotes, diveNotes, mode);
+	}
+
+}
+
+DiveFilter *DiveFilter::instance()
+{
+	static DiveFilter self;
+	return &self;
+}
+
+DiveFilter::DiveFilter() : diveSiteRefCount(0)
+{
+}
+
+bool DiveFilter::showDive(const struct dive *d) const
+{
+	if (diveSiteMode())
+		return dive_sites.contains(d->dive_site);
+
+	if (!filterData.validFilter)
+		return true;
+
+	if (d->visibility < filterData.minVisibility || d->visibility > filterData.maxVisibility)
+		return false;
+
+	if (d->rating < filterData.minRating || d->rating > filterData.maxRating)
+		return false;
+
+	auto temp_comp = prefs.units.temperature == units::CELSIUS ? C_to_mkelvin : F_to_mkelvin;
+	if (d->watertemp.mkelvin &&
+	    (d->watertemp.mkelvin < (*temp_comp)(filterData.minWaterTemp) || d->watertemp.mkelvin > (*temp_comp)(filterData.maxWaterTemp)))
+		return false;
+
+	if (d->airtemp.mkelvin &&
+	    (d->airtemp.mkelvin < (*temp_comp)(filterData.minAirTemp) || d->airtemp.mkelvin > (*temp_comp)(filterData.maxAirTemp)))
+		return false;
+
+	QDateTime t = filterData.fromDate;
+	t.setTime(filterData.fromTime);
+	if (filterData.fromDate.isValid() && filterData.fromTime.isValid() &&
+	    d->when < t.toMSecsSinceEpoch()/1000 + t.offsetFromUtc())
+		return false;
+
+	t = filterData.toDate;
+	t.setTime(filterData.toTime);
+	if (filterData.toDate.isValid() && filterData.toTime.isValid() &&
+	    d->when > t.toMSecsSinceEpoch()/1000 + t.offsetFromUtc())
+		return false;
+
+	// tags.
+	if (!hasTags(filterData.tags, d, filterData.tagsMode))
+		return false;
+
+	// people
+	if (!hasPersons(filterData.people, d, filterData.peopleMode))
+		return false;
+
+	// Location
+	if (!hasLocations(filterData.location, d, filterData.locationMode))
+		return false;
+
+	// Suit
+	if (!hasSuits(filterData.suit, d, filterData.suitMode))
+		return false;
+
+	// Notes
+	if (!hasNotes(filterData.dnotes, d, filterData.dnotesMode))
+		return false;
+
+	if (!hasEquipment(filterData.equipment, d, filterData.equipmentMode))
+		return false;
+
+	// Planned/Logged
+	if (!filterData.logged && !has_planned(d, true))
+		return false;
+	if (!filterData.planned && !has_planned(d, false))
+		return false;
+
+	return true;
+}
+
+void DiveFilter::startFilterDiveSites(QVector<dive_site *> ds)
+{
+	if (++diveSiteRefCount > 1) {
+		setFilterDiveSite(ds);
+	} else {
+		std::sort(ds.begin(), ds.end());
+		dive_sites = ds;
+		// When switching into dive site mode, reload the dive sites.
+		// We won't do this in myInvalidate() once we are in dive site mode.
+		MapWidget::instance()->reload();
+		MultiFilterSortModel::instance()->myInvalidate();
+	}
+}
+
+void DiveFilter::stopFilterDiveSites()
+{
+	if (--diveSiteRefCount > 0)
+		return;
+	dive_sites.clear();
+	MultiFilterSortModel::instance()->myInvalidate();
+	MapWidget::instance()->reload();
+}
+
+void DiveFilter::setFilterDiveSite(QVector<dive_site *> ds)
+{
+	// If the filter didn't change, return early to avoid a full
+	// map reload. For a well-defined comparison, sort the vector first.
+	std::sort(ds.begin(), ds.end());
+	if (ds == dive_sites)
+		return;
+	dive_sites = ds;
+
+	MultiFilterSortModel::instance()->myInvalidate();
+	MapWidget::instance()->setSelected(dive_sites);
+	MainWindow::instance()->diveList->expandAll();
+}
+
+const QVector<dive_site *> &DiveFilter::filteredDiveSites() const
+{
+	return dive_sites;
+}
+
+bool DiveFilter::diveSiteMode() const
+{
+	return diveSiteRefCount > 0;
+}
+
+void DiveFilter::setFilter(const FilterData &data)
+{
+	filterData = data;
+	MultiFilterSortModel::instance()->myInvalidate();
+}
+#endif // SUBSURFACE_MOBILE

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -193,7 +193,7 @@ void DiveFilter::startFilterDiveSites(QVector<dive_site *> ds)
 		// When switching into dive site mode, reload the dive sites.
 		// We won't do this in myInvalidate() once we are in dive site mode.
 		MapWidget::instance()->reload();
-		MultiFilterSortModel::instance()->myInvalidate();
+		DiveTripModelBase::instance()->recalculateFilter();
 	}
 }
 
@@ -202,7 +202,7 @@ void DiveFilter::stopFilterDiveSites()
 	if (--diveSiteRefCount > 0)
 		return;
 	dive_sites.clear();
-	MultiFilterSortModel::instance()->myInvalidate();
+	DiveTripModelBase::instance()->recalculateFilter();
 	MapWidget::instance()->reload();
 }
 
@@ -215,7 +215,7 @@ void DiveFilter::setFilterDiveSite(QVector<dive_site *> ds)
 		return;
 	dive_sites = ds;
 
-	MultiFilterSortModel::instance()->myInvalidate();
+	DiveTripModelBase::instance()->recalculateFilter();
 	MapWidget::instance()->setSelected(dive_sites);
 	MainWindow::instance()->diveList->expandAll();
 }
@@ -233,6 +233,6 @@ bool DiveFilter::diveSiteMode() const
 void DiveFilter::setFilter(const FilterData &data)
 {
 	filterData = data;
-	MultiFilterSortModel::instance()->myInvalidate();
+	DiveTripModelBase::instance()->recalculateFilter();
 }
 #endif // SUBSURFACE_MOBILE

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0
+// A class that filters dives.
+#ifndef DIVE_FILTER_H
+#define DIVE_FILTER_H
+
+// The dive filter for mobile is currently much simpler than for desktop.
+// Therefore, for now we have two completely separate implementations.
+// This should be unified in the future.
+#ifdef SUBSURFACE_MOBILE
+
+class DiveFilter {
+public:
+	static DiveFilter *instance();
+
+	bool showDive(const struct dive *d) const;
+private:
+	DiveFilter();
+};
+
+#else
+
+#include <QDateTime>
+#include <QStringList>
+#include <QVector>
+
+struct dive;
+struct dive_trip;
+struct dive_site;
+
+struct FilterData {
+	// The mode ids are chosen such that they can be directly converted from / to combobox indices.
+	enum class Mode {
+		ALL_OF = 0,
+		ANY_OF = 1,
+		NONE_OF = 2
+	};
+
+	bool validFilter = false;
+	int minVisibility = 0;
+	int maxVisibility = 5;
+	int minRating = 0;
+	int maxRating = 5;
+	// The default minimum and maximum temperatures are set such that all
+	// physically reasonable dives are shown. Note that these values should
+	// work for both Celcius and Fahrenheit scales.
+	double minWaterTemp = -10;
+	double maxWaterTemp = 200;
+	double minAirTemp = -50;
+	double maxAirTemp = 200;
+	QDateTime fromDate = QDateTime(QDate(1980,1,1));
+	QTime fromTime = QTime(0,0);
+	QDateTime toDate = QDateTime::currentDateTime();
+	QTime toTime = QTime::currentTime();
+	QStringList tags;
+	QStringList people;
+	QStringList location;
+	QStringList suit;
+	QStringList dnotes;
+	QStringList equipment;
+	Mode tagsMode = Mode::ALL_OF;
+	Mode peopleMode = Mode::ALL_OF;
+	Mode locationMode = Mode::ANY_OF;
+	Mode dnotesMode = Mode::ALL_OF;
+	Mode suitMode = Mode::ANY_OF;
+	Mode equipmentMode = Mode::ALL_OF;
+	bool logged = true;
+	bool planned = true;
+};
+
+class DiveFilter {
+public:
+	static DiveFilter *instance();
+
+	bool showDive(const struct dive *d) const;
+	bool diveSiteMode() const; // returns true if we're filtering on dive site
+	const QVector<dive_site *> &filteredDiveSites() const;
+	void startFilterDiveSites(QVector<dive_site *> ds);
+	void setFilterDiveSite(QVector<dive_site *> ds);
+	void stopFilterDiveSites();
+	void setFilter(const FilterData &data);
+private:
+	DiveFilter();
+
+	QVector<dive_site *> dive_sites;
+	FilterData filterData;
+
+	// We use ref-counting for the dive site mode. The reason is that when switching
+	// between two tabs that both need dive site mode, the following course of
+	// events may happen:
+	//	1) The new tab appears -> enter dive site mode.
+	//	2) The old tab gets its hide() signal -> exit dive site mode.
+	// The filter is now not in dive site mode, even if it should
+	int diveSiteRefCount;
+};
+#endif // SUBSURFACE_MOBILE
+
+#endif

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -899,6 +899,7 @@ void deselect_dive(struct dive *dive)
 	}
 }
 
+int shown_dives = 0;
 void filter_dive(struct dive *d, bool shown)
 {
 	if (!d)

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -44,7 +44,7 @@ extern int remove_dive(const struct dive *dive, struct dive_table *table);
 extern bool consecutive_selected();
 extern void select_dive(struct dive *dive);
 extern void deselect_dive(struct dive *dive);
-extern void filter_dive(struct dive *d, bool shown);
+extern bool filter_dive(struct dive *d, bool shown); /* returns true if status changed */
 extern struct dive *first_selected_dive();
 extern struct dive *last_selected_dive();
 extern int get_dive_nr_at_idx(int idx);

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 struct deco_state;
+extern int shown_dives;
 
 /* this is used for both git and xml format */
 #define DATAFORMAT_VERSION 3

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -94,6 +94,7 @@ signals:
 
 	// Filter-related signals
 	void numShownChanged();
+	void filterReset();
 
 	// This signal is emited every time a command is executed.
 	// This is used to hide an old multi-dives-edited warning message.

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -82,6 +82,7 @@ signals:
 	// Trip edited signal
 	void tripChanged(dive_trip *trip, TripField field);
 
+	// Selection changes
 	void divesSelected(const QVector<dive *> &dives, dive *current);
 
 	// Dive site signals. Add and delete events are sent per dive site and

--- a/core/subsurface-qt/DiveListNotifier.h
+++ b/core/subsurface-qt/DiveListNotifier.h
@@ -92,6 +92,9 @@ signals:
 	void diveSiteChanged(dive_site *ds, int field); // field according to LocationInformationModel
 	void diveSiteDivesChanged(dive_site *ds); // The dives associated with that site changed
 
+	// Filter-related signals
+	void numShownChanged();
+
 	// This signal is emited every time a command is executed.
 	// This is used to hide an old multi-dives-edited warning message.
 	// This is necessary, so that the user can't click on the "undo" button and undo

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -10,6 +10,7 @@
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/divepicturewidget.h"
 #include "core/display.h"
+#include "core/divefilter.h"
 #include <unistd.h>
 #include <QSettings>
 #include <QKeyEvent>
@@ -463,7 +464,7 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 	// But don't do this if we are in divesite mode, because then
 	// the dive-site selection is controlled by the filter not
 	// by the selected dives.
-	if (!MultiFilterSortModel::instance()->diveSiteMode()) {
+	if (!DiveFilter::instance()->diveSiteMode()) {
 		QVector<dive_site *> selectedSites;
 		for (int idx: newDiveSelection) {
 			dive *d = get_dive(idx);
@@ -698,7 +699,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 		// But don't do this if we are in divesite mode, because then
 		// the dive-site selection is controlled by the filter not
 		// by the selected dives.
-		if (!MultiFilterSortModel::instance()->diveSiteMode()) {
+		if (!DiveFilter::instance()->diveSiteMode()) {
 			QVector<dive_site *> selectedSites;
 			for (QModelIndex index: selectionModel()->selection().indexes()) {
 				const QAbstractItemModel *model = index.model();

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -47,7 +47,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelec
 	resetModel();
 
 	// Update selection if all selected dives were hidden by filter
-	connect(MultiFilterSortModel::instance(), &MultiFilterSortModel::filterFinished, this, &DiveListView::filterFinished);
+	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveListView::filterFinished);
 
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &DiveListView::tripChanged);
 

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -11,6 +11,7 @@
 #include "core/save-html.h"
 #include "core/settings/qPrefDisplay.h"
 #include "core/save-profiledata.h"
+#include "core/divefilter.h"
 #include "core/divesite.h"
 #include "core/errorhelper.h"
 #include "core/file.h"
@@ -134,10 +135,10 @@ static std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly)
 {
 	std::vector<const dive_site *> res;
 
-	if (selectedOnly && MultiFilterSortModel::instance()->diveSiteMode()) {
+	if (selectedOnly && DiveFilter::instance()->diveSiteMode()) {
 		// Special case in dive site mode: export all selected dive sites,
 		// not the dive sites of selected dives.
-		QVector<dive_site *> sites = MultiFilterSortModel::instance()->filteredDiveSites();
+		QVector<dive_site *> sites = DiveFilter::instance()->filteredDiveSites();
 		res.reserve(sites.size());
 		for (const dive_site *ds: sites)
 			res.push_back(ds);

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -2,6 +2,7 @@
 #include "desktop-widgets/simplewidgets.h"
 #include "desktop-widgets/mainwindow.h"
 #include "core/qthelper.h"
+#include "core/divelist.h"
 #include "core/settings/qPrefUnit.h"
 
 #include <QDoubleSpinBox>
@@ -242,8 +243,7 @@ void FilterWidget2::filterDataChanged(const FilterData &data)
 QString FilterWidget2::shownText()
 {
 	if (isActive())
-		return tr("%L1/%L2 shown").arg(MultiFilterSortModel::instance()->divesDisplayed)
-				.arg(dive_table.nr);
+		return tr("%L1/%L2 shown").arg(shown_dives).arg(dive_table.nr);
 	else
 		return tr("%L1 dives").arg(dive_table.nr);
 }

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -237,7 +237,7 @@ void FilterWidget2::hideEvent(QHideEvent *event)
 
 void FilterWidget2::filterDataChanged(const FilterData &data)
 {
-	MultiFilterSortModel::instance()->filterDataChanged(data);
+	DiveFilter::instance()->setFilter(data);
 }
 
 QString FilterWidget2::shownText()

--- a/desktop-widgets/filterwidget2.h
+++ b/desktop-widgets/filterwidget2.h
@@ -8,7 +8,7 @@
 #include <memory>
 
 #include "ui_filterwidget2.h"
-#include "qt-models/filtermodels.h"
+#include "core/divefilter.h"
 
 namespace Ui {
 	class FilterWidget2;

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -5,7 +5,7 @@
 #include "desktop-widgets/divelistview.h"
 #include "core/qthelper.h"
 #include "desktop-widgets/mapwidget.h"
-#include "qt-models/filtermodels.h"
+#include "core/divefilter.h"
 #include "core/divesitehelpers.h"
 #include "desktop-widgets/modeldelegates.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
@@ -194,7 +194,7 @@ void LocationInformationWidget::acceptChanges()
 	MainWindow::instance()->diveList->setEnabled(true);
 	MainWindow::instance()->setEnabledToolbar(true);
 	MainWindow::instance()->setApplicationState(ApplicationState::Default);
-	MultiFilterSortModel::instance()->stopFilterDiveSites();
+	DiveFilter::instance()->stopFilterDiveSites();
 
 	// Subtlety alert: diveSite must be cleared *after* exiting the dive-site mode.
 	// Exiting dive-site mode removes the focus from the active widget and
@@ -211,7 +211,7 @@ void LocationInformationWidget::initFields(dive_site *ds)
 		filter_model.set(ds, ds->location);
 		updateLabels();
 		enableLocationButtons(dive_site_has_gps_location(ds));
-		MultiFilterSortModel::instance()->startFilterDiveSites(QVector<dive_site *>{ ds });
+		DiveFilter::instance()->startFilterDiveSites(QVector<dive_site *>{ ds });
 		filter_model.invalidate();
 	} else {
 		filter_model.set(0, location_t { degrees_t{ 0 }, degrees_t{ 0 } });

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -214,6 +214,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
 	connect(&windowTitleUpdate, &WindowTitleUpdate::updateTitle, this, &MainWindow::setAutomaticTitle);
+	connect(&diveListNotifier, &DiveListNotifier::numShownChanged, this, &MainWindow::setAutomaticTitle);
 #ifdef NO_PRINTING
 	plannerDetails->printPlan()->hide();
 	ui.menuFile->removeAction(ui.actionPrint);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -69,7 +69,6 @@
 #include "qt-models/cylindermodel.h"
 #include "qt-models/divepicturemodel.h"
 #include "qt-models/diveplannermodel.h"
-#include "qt-models/filtermodels.h"
 #include "qt-models/tankinfomodel.h"
 #include "qt-models/weightsysteminfomodel.h"
 #include "qt-models/yearlystatisticsmodel.h"
@@ -423,7 +422,6 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 void MainWindow::recreateDiveList()
 {
 	diveList->reload();
-	DiveTripModelBase::instance()->recalculateFilter();
 }
 
 void MainWindow::configureToolbar()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -320,7 +320,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(graphics, &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
 	connect(graphics, &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);
 	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
-	connect(graphics, &ProfileWidget2::refreshDisplay, this, &MainWindow::refreshDisplay);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
 	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab.get(), &MainTab::updateDiveInfo);
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -423,7 +423,7 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 void MainWindow::recreateDiveList()
 {
 	diveList->reload();
-	MultiFilterSortModel::instance()->myInvalidate();
+	DiveTripModelBase::instance()->recalculateFilter();
 }
 
 void MainWindow::configureToolbar()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -408,7 +408,7 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 	mainTab->reload();
 	TankInfoModel::instance()->update();
 	if (doRecreateDiveList)
-		recreateDiveList();
+		diveList->reload();
 
 	MapWidget::instance()->reload();
 	setApplicationState(ApplicationState::Default);
@@ -416,11 +416,6 @@ void MainWindow::refreshDisplay(bool doRecreateDiveList)
 	diveList->setFocus();
 	WSInfoModel::instance()->update();
 	ui.actionAutoGroup->setChecked(autogroup);
-}
-
-void MainWindow::recreateDiveList()
-{
-	diveList->reload();
 }
 
 void MainWindow::configureToolbar()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -691,7 +691,6 @@ void MainWindow::on_actionClose_triggered()
 		closeCurrentFile();
 		DivePictureModel::instance()->updateDivePictures();
 		setApplicationState(ApplicationState::Default);
-		recreateDiveList();
 	}
 }
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -163,7 +163,6 @@ slots:
 	void turnOffNdlTts();
 	void readSettings();
 	void refreshDisplay(bool doRecreateDiveList = true);
-	void recreateDiveList();
 	void showProfile();
 	void refreshProfile();
 	void editCurrentDive();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -21,6 +21,7 @@
 #include "desktop-widgets/filterwidget2.h"
 #include "core/applicationstate.h"
 #include "core/gpslocation.h"
+#include "core/dive.h"
 
 #define NUM_RECENT_FILES 4
 

--- a/desktop-widgets/tab-widgets/TabDiveSite.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveSite.cpp
@@ -2,8 +2,8 @@
 #include "TabDiveSite.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "core/divesite.h"
+#include "core/divefilter.h"
 #include "qt-models/divelocationmodel.h"
-#include "qt-models/filtermodels.h"
 #include "commands/command.h"
 
 #include <qt-models/divecomputerextradatamodel.h>
@@ -97,18 +97,18 @@ QVector<dive_site *> TabDiveSite::selectedDiveSites()
 
 void TabDiveSite::selectionChanged(const QItemSelection &, const QItemSelection &)
 {
-	MultiFilterSortModel::instance()->setFilterDiveSite(selectedDiveSites());
+	DiveFilter::instance()->setFilterDiveSite(selectedDiveSites());
 }
 
 void TabDiveSite::showEvent(QShowEvent *)
 {
 	// If the user switches to the dive site tab and there was already a selection,
 	// filter on that selection.
-	MultiFilterSortModel::instance()->startFilterDiveSites(selectedDiveSites());
+	DiveFilter::instance()->startFilterDiveSites(selectedDiveSites());
 }
 
 void TabDiveSite::hideEvent(QHideEvent *)
 {
 	// If the user switches to a different tab, stop the dive site filtering
-	MultiFilterSortModel::instance()->stopFilterDiveSites();
+	DiveFilter::instance()->stopFilterDiveSites();
 }

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -7,10 +7,10 @@
 #include "qmlmapwidgethelper.h"
 #include "core/divesite.h"
 #include "core/qthelper.h"
+#include "core/divefilter.h"
 #include "qt-models/maplocationmodel.h"
 #include "qt-models/divelocationmodel.h"
 #ifndef SUBSURFACE_MOBILE
-#include "qt-models/filtermodels.h"
 #include "desktop-widgets/mapwidget.h"
 #endif
 
@@ -106,7 +106,7 @@ void MapWidgetHelper::updateEditMode()
 	// The filter being set to dive site is the signal that we are in dive site edit mode.
 	// This is the case when either the dive site edit tab or the dive site list tab are active.
 	bool old = m_editMode;
-	m_editMode = MultiFilterSortModel::instance()->diveSiteMode();
+	m_editMode = DiveFilter::instance()->diveSiteMode();
 	if (old != m_editMode)
 		emit editModeChanged();
 #endif

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -97,7 +97,6 @@ signals:
 	void enableToolbar(bool enable);
 	void enableShortcuts();
 	void disableShortcuts(bool paste);
-	void refreshDisplay(bool recreateDivelist);
 	void updateDiveInfo();
 	void editCurrentDive();
 	void dateTimeChangedItems();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -376,6 +376,7 @@ void DiveTripModelBase::clear()
 {
 	beginResetModel();
 	clear_dive_file_data();
+	emit diveListNotifier.divesSelected({}, nullptr); // Inform profile, etc of changed selection
 	endResetModel();
 }
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1377,7 +1377,6 @@ void DiveTripModelList::filterFinished()
 	// In list mode, we don't have to change anything after filter finished.
 }
 
-
 // Simple sorting helper for sorting against a criterium and if
 // that is undefined against a different criterium.
 // Return true if diff1 < 0, false if diff1 > 0.

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -376,6 +376,7 @@ void DiveTripModelBase::clear()
 {
 	beginResetModel();
 	clear_dive_file_data();
+	clearData();
 	emit diveListNotifier.divesSelected({}, nullptr); // Inform profile, etc of changed selection
 	endResetModel();
 }
@@ -605,6 +606,11 @@ int DiveTripModelTree::rowCount(const QModelIndex &parent) const
 	// Only trips have items
 	const Item &entry =  items[parent.row()];
 	return entry.d_or_t.trip ? entry.dives.size() : 0;
+}
+
+void DiveTripModelList::clearData()
+{
+	items.clear();
 }
 
 static const quintptr noParent = ~(quintptr)0; // This is the "internalId" marker for top-level item
@@ -1236,6 +1242,11 @@ int DiveTripModelList::rowCount(const QModelIndex &parent) const
 	// In list-mode there is only one level, i.e only top-level
 	// (=invalid parent) has items.
 	return parent.isValid() ? 0 : items.size();
+}
+
+void DiveTripModelTree::clearData()
+{
+	items.clear();
 }
 
 QModelIndex DiveTripModelList::index(int row, int column, const QModelIndex &parent) const

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qt-models/divetripmodel.h"
 #include "qt-models/filtermodels.h"
+#include "core/divefilter.h"
 #include "core/gettextfromc.h"
 #include "core/metrics.h"
 #include "core/trip.h"

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -100,6 +100,7 @@ protected:
 	static QVariant tripData(const dive_trip *trip, int column, int role);
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
+	virtual void clearData() = 0;
 };
 
 class DiveTripModelTree : public DiveTripModelBase
@@ -119,6 +120,7 @@ public:
 	DiveTripModelTree(QObject *parent = nullptr);
 private:
 	int rowCount(const QModelIndex &parent) const override;
+	void clearData() override;
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
@@ -184,6 +186,7 @@ public:
 	DiveTripModelList(QObject *parent = nullptr);
 private:
 	int rowCount(const QModelIndex &parent) const override;
+	void clearData() override;
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -78,8 +78,7 @@ public:
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	DiveTripModelBase(QObject *parent = 0);
 	int columnCount(const QModelIndex&) const;
-	virtual void filterFinished() = 0;
-	virtual bool setShown(const QModelIndex &idx, bool shown) = 0;
+	virtual void recalculateFilter() = 0;
 
 	// Used for sorting. This is a bit of a layering violation, as sorting should be performed
 	// by the higher-up QSortFilterProxyModel, but it makes things so much easier!
@@ -123,11 +122,10 @@ private:
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
-	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	void divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &);
 	dive *diveOrNull(const QModelIndex &index) const override;
-	bool setShown(const QModelIndex &idx, bool shown);
+	void recalculateFilter();
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 
@@ -189,10 +187,9 @@ private:
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
-	void filterFinished() override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	dive *diveOrNull(const QModelIndex &index) const override;
-	bool setShown(const QModelIndex &idx, bool shown);
+	void recalculateFilter();
 
 	std::vector<dive *> items;				// TODO: access core data directly
 };

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -199,14 +199,6 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 	return m->data(index0, DiveTripModelBase::SHOWN_ROLE).value<bool>();
 }
 
-void MultiFilterSortModel::filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles)
-{
-	// Only redo the filter if a checkbox changed. If the count of an entry changed,
-	// we do *not* want to recalculate the filters.
-	if (roles.contains(Qt::CheckStateRole))
-		myInvalidate();
-}
-
 void MultiFilterSortModel::myInvalidate()
 {
 	QAbstractItemModel *m = sourceModel();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -57,8 +57,6 @@ void MultiFilterSortModel::myInvalidate()
 		// as a consequence of the filterFinished signal right after the local scope.
 		auto marker = diveListNotifier.enterCommand();
 
-		shown_dives = 0;
-
 		DiveFilter *filter = DiveFilter::instance();
 		for (int i = 0; i < m->rowCount(QModelIndex()); ++i) {
 			QModelIndex idx = m->index(i, 0, QModelIndex());
@@ -75,18 +73,14 @@ void MultiFilterSortModel::myInvalidate()
 						continue;
 					}
 					bool show = filter->showDive(d);
-					if (show) {
-						shown_dives++;
+					if (show)
 						showTrip = true;
-					}
 					m->setData(idx2, show, DiveTripModelBase::SHOWN_ROLE);
 				}
 				m->setData(idx, showTrip, DiveTripModelBase::SHOWN_ROLE);
 			} else {
 				dive *d = m->data(idx, DiveTripModelBase::DIVE_ROLE).value<dive *>();
 				bool show = (d != NULL) && filter->showDive(d);
-				if (show)
-					shown_dives++;
 				m->setData(idx, show, DiveTripModelBase::SHOWN_ROLE);
 			}
 		}
@@ -103,14 +97,8 @@ void MultiFilterSortModel::myInvalidate()
 
 bool MultiFilterSortModel::updateDive(struct dive *d)
 {
-	bool oldStatus = !d->hidden_by_filter;
 	bool newStatus = DiveFilter::instance()->showDive(d);
-	bool changed = oldStatus != newStatus;
-	if (changed) {
-		filter_dive(d, newStatus);
-		shown_dives += newStatus - oldStatus;
-	}
-	return changed;
+	return filter_dive(d, newStatus);
 }
 
 bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -291,11 +291,6 @@ bool MultiFilterSortModel::updateDive(struct dive *d)
 	return changed;
 }
 
-void MultiFilterSortModel::clearFilter()
-{
-	myInvalidate();
-}
-
 void MultiFilterSortModel::startFilterDiveSites(QVector<dive_site *> ds)
 {
 	if (++diveSiteRefCount > 1) {

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -1,104 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qt-models/filtermodels.h"
-#include "qt-models/models.h"
 #include "core/display.h"
 #include "core/qthelper.h"
-#include "core/divesite.h"
 #include "core/trip.h"
 #include "core/subsurface-string.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "qt-models/divetripmodel.h"
 
 #if !defined(SUBSURFACE_MOBILE)
-#include "desktop-widgets/divelistview.h"
-#include "desktop-widgets/mainwindow.h"
-#include "desktop-widgets/mapwidget.h"
+#include "core/divefilter.h"
 #endif
 
 #include <QDebug>
 #include <algorithm>
-
-namespace {
-	// Check if a string-list contains at least one string containing the second argument.
-	// Comparison is non case sensitive and removes white space.
-	bool listContainsSuperstring(const QStringList &list, const QString &s)
-	{
-		return std::any_of(list.begin(), list.end(), [&s](const QString &s2)
-				   { return s2.trimmed().contains(s.trimmed(), Qt::CaseInsensitive); } );
-	}
-
-	// Check whether either all, any or none of the items of the first list is
-	// in the second list as a super string.
-	// The mode is controlled by the second argument
-	bool check(const QStringList &items, const QStringList &list, FilterData::Mode mode)
-	{
-		bool negate = mode == FilterData::Mode::NONE_OF;
-		bool any_of = mode == FilterData::Mode::ANY_OF;
-		auto fun = [&list, negate](const QString &item)
-			   { return listContainsSuperstring(list, item) != negate; };
-		return any_of ? std::any_of(items.begin(), items.end(), fun)
-			      : std::all_of(items.begin(), items.end(), fun);
-	}
-
-	bool hasTags(const QStringList &tags, const struct dive *d, FilterData::Mode mode)
-	{
-		if (tags.isEmpty())
-			return true;
-		QStringList dive_tags = get_taglist_string(d->tag_list).split(",");
-		dive_tags.append(gettextFromC::tr(divemode_text_ui[d->dc.divemode]));
-		return check(tags, dive_tags, mode);
-	}
-
-	bool hasPersons(const QStringList &people, const struct dive *d, FilterData::Mode mode)
-	{
-		if (people.isEmpty())
-			return true;
-		QStringList dive_people = QString(d->buddy).split(",", QString::SkipEmptyParts)
-			+ QString(d->divemaster).split(",", QString::SkipEmptyParts);
-		return check(people, dive_people, mode);
-	}
-
-	bool hasLocations(const QStringList &locations, const struct dive *d, FilterData::Mode mode)
-	{
-		if (locations.isEmpty())
-			return true;
-		QStringList diveLocations;
-		if (d->divetrip)
-			diveLocations.push_back(QString(d->divetrip->location));
-
-		if (d->dive_site)
-			diveLocations.push_back(QString(d->dive_site->name));
-
-		return check(locations, diveLocations, mode);
-	}
-
-	// TODO: Finish this implementation.
-	bool hasEquipment(const QStringList &, const struct dive *, FilterData::Mode)
-	{
-		return true;
-	}
-
-	bool hasSuits(const QStringList &suits, const struct dive *d, FilterData::Mode mode)
-	{
-		if (suits.isEmpty())
-			return true;
-		QStringList diveSuits;
-		if (d->suit)
-			diveSuits.push_back(QString(d->suit));
-		return check(suits, diveSuits, mode);
-	}
-
-	bool hasNotes(const QStringList &dnotes, const struct dive *d, FilterData::Mode mode)
-	{
-		if (dnotes.isEmpty())
-			return true;
-		QStringList diveNotes;
-		if (d->notes)
-			diveNotes.push_back(QString(d->notes));
-		return check(dnotes, diveNotes, mode);
-	}
-
-}
 
 MultiFilterSortModel *MultiFilterSortModel::instance()
 {
@@ -106,8 +20,7 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 	return &self;
 }
 
-MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent),
-	diveSiteRefCount(0)
+MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
@@ -119,73 +32,6 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 	// DiveTripModelBase::resetModel() generates a new instance.
 	// Thus, the source model must be reset.
 	setSourceModel(DiveTripModelBase::instance());
-}
-
-bool MultiFilterSortModel::showDive(const struct dive *d) const
-{
-	if (diveSiteMode())
-		return dive_sites.contains(d->dive_site);
-
-	if (!filterData.validFilter)
-		return true;
-
-	if (d->visibility < filterData.minVisibility || d->visibility > filterData.maxVisibility)
-		return false;
-
-	if (d->rating < filterData.minRating || d->rating > filterData.maxRating)
-		return false;
-
-	auto temp_comp = prefs.units.temperature == units::CELSIUS ? C_to_mkelvin : F_to_mkelvin;
-	if (d->watertemp.mkelvin &&
-	    (d->watertemp.mkelvin < (*temp_comp)(filterData.minWaterTemp) || d->watertemp.mkelvin > (*temp_comp)(filterData.maxWaterTemp)))
-		return false;
-
-	if (d->airtemp.mkelvin &&
-	    (d->airtemp.mkelvin < (*temp_comp)(filterData.minAirTemp) || d->airtemp.mkelvin > (*temp_comp)(filterData.maxAirTemp)))
-		return false;
-
-	QDateTime t = filterData.fromDate;
-	t.setTime(filterData.fromTime);
-	if (filterData.fromDate.isValid() && filterData.fromTime.isValid() &&
-	    d->when < t.toMSecsSinceEpoch()/1000 + t.offsetFromUtc())
-		return false;
-
-	t = filterData.toDate;
-	t.setTime(filterData.toTime);
-	if (filterData.toDate.isValid() && filterData.toTime.isValid() &&
-	    d->when > t.toMSecsSinceEpoch()/1000 + t.offsetFromUtc())
-		return false;
-
-	// tags.
-	if (!hasTags(filterData.tags, d, filterData.tagsMode))
-		return false;
-
-	// people
-	if (!hasPersons(filterData.people, d, filterData.peopleMode))
-		return false;
-
-	// Location
-	if (!hasLocations(filterData.location, d, filterData.locationMode))
-		return false;
-
-	// Suit
-	if (!hasSuits(filterData.suit, d, filterData.suitMode))
-		return false;
-
-	// Notes
-	if (!hasNotes(filterData.dnotes, d, filterData.dnotesMode))
-		return false;
-
-	if (!hasEquipment(filterData.equipment, d, filterData.equipmentMode))
-		return false;
-
-	// Planned/Logged
-	if (!filterData.logged && !has_planned(d, true))
-		return false;
-	if (!filterData.planned && !has_planned(d, false))
-		return false;
-
-	return true;
 }
 
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
@@ -213,6 +59,7 @@ void MultiFilterSortModel::myInvalidate()
 
 		shown_dives = 0;
 
+		DiveFilter *filter = DiveFilter::instance();
 		for (int i = 0; i < m->rowCount(QModelIndex()); ++i) {
 			QModelIndex idx = m->index(i, 0, QModelIndex());
 
@@ -227,7 +74,7 @@ void MultiFilterSortModel::myInvalidate()
 						qWarning("MultiFilterSortModel::myInvalidate(): subitem not a dive!?");
 						continue;
 					}
-					bool show = showDive(d);
+					bool show = filter->showDive(d);
 					if (show) {
 						shown_dives++;
 						showTrip = true;
@@ -237,7 +84,7 @@ void MultiFilterSortModel::myInvalidate()
 				m->setData(idx, showTrip, DiveTripModelBase::SHOWN_ROLE);
 			} else {
 				dive *d = m->data(idx, DiveTripModelBase::DIVE_ROLE).value<dive *>();
-				bool show = (d != NULL) && showDive(d);
+				bool show = (d != NULL) && filter->showDive(d);
 				if (show)
 					shown_dives++;
 				m->setData(idx, show, DiveTripModelBase::SHOWN_ROLE);
@@ -251,26 +98,13 @@ void MultiFilterSortModel::myInvalidate()
 		countsChanged();
 	}
 
-#if !defined(SUBSURFACE_MOBILE)
-	// The shown maps may have changed -> reload the map widget.
-	// But don't do this in dive site mode, because then we show all
-	// dive sites and only change the selected flag.
-	if (!diveSiteMode())
-		MapWidget::instance()->reload();
-#endif
-
 	emit filterFinished();
-
-#if !defined(SUBSURFACE_MOBILE)
-	if (diveSiteMode())
-		MainWindow::instance()->diveList->expandAll();
-#endif
 }
 
 bool MultiFilterSortModel::updateDive(struct dive *d)
 {
 	bool oldStatus = !d->hidden_by_filter;
-	bool newStatus = showDive(d);
+	bool newStatus = DiveFilter::instance()->showDive(d);
 	bool changed = oldStatus != newStatus;
 	if (changed) {
 		filter_dive(d, newStatus);
@@ -279,65 +113,10 @@ bool MultiFilterSortModel::updateDive(struct dive *d)
 	return changed;
 }
 
-void MultiFilterSortModel::startFilterDiveSites(QVector<dive_site *> ds)
-{
-	if (++diveSiteRefCount > 1) {
-		setFilterDiveSite(ds);
-	} else {
-		std::sort(ds.begin(), ds.end());
-		dive_sites = ds;
-#if !defined(SUBSURFACE_MOBILE)
-		// When switching into dive site mode, reload the dive sites.
-		// We won't do this in myInvalidate() once we are in dive site mode.
-		MapWidget::instance()->reload();
-#endif
-		myInvalidate();
-	}
-}
-
-void MultiFilterSortModel::stopFilterDiveSites()
-{
-	if (--diveSiteRefCount > 0)
-		return;
-	dive_sites.clear();
-	myInvalidate();
-}
-
-void MultiFilterSortModel::setFilterDiveSite(QVector<dive_site *> ds)
-{
-	// If the filter didn't change, return early to avoid a full
-	// map reload. For a well-defined comparison, sort the vector first.
-	std::sort(ds.begin(), ds.end());
-	if (ds == dive_sites)
-		return;
-	dive_sites = ds;
-
-#if !defined(SUBSURFACE_MOBILE)
-	MapWidget::instance()->setSelected(dive_sites);
-#endif
-	myInvalidate();
-}
-
-const QVector<dive_site *> &MultiFilterSortModel::filteredDiveSites() const
-{
-	return dive_sites;
-}
-
-bool MultiFilterSortModel::diveSiteMode() const
-{
-	return diveSiteRefCount > 0;
-}
-
 bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
 {
 	// Hand sorting down to the source model.
 	return DiveTripModelBase::instance()->lessThan(i1, i2);
-}
-
-void MultiFilterSortModel::filterDataChanged(const FilterData &data)
-{
-	filterData = data;
-	myInvalidate();
 }
 
 void MultiFilterSortModel::countsChanged()

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -107,7 +107,6 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 }
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent),
-	divesDisplayed(0),
 	diveSiteRefCount(0)
 {
 	setFilterKeyColumn(-1); // filter all columns
@@ -215,7 +214,7 @@ void MultiFilterSortModel::myInvalidate()
 		// as a consequence of the filterFinished signal right after the local scope.
 		auto marker = diveListNotifier.enterCommand();
 
-		divesDisplayed = 0;
+		shown_dives = 0;
 
 		for (int i = 0; i < m->rowCount(QModelIndex()); ++i) {
 			QModelIndex idx = m->index(i, 0, QModelIndex());
@@ -233,7 +232,7 @@ void MultiFilterSortModel::myInvalidate()
 					}
 					bool show = showDive(d);
 					if (show) {
-						divesDisplayed++;
+						shown_dives++;
 						showTrip = true;
 					}
 					m->setData(idx2, show, DiveTripModelBase::SHOWN_ROLE);
@@ -243,7 +242,7 @@ void MultiFilterSortModel::myInvalidate()
 				dive *d = m->data(idx, DiveTripModelBase::DIVE_ROLE).value<dive *>();
 				bool show = (d != NULL) && showDive(d);
 				if (show)
-					divesDisplayed++;
+					shown_dives++;
 				m->setData(idx, show, DiveTripModelBase::SHOWN_ROLE);
 			}
 		}
@@ -278,7 +277,7 @@ bool MultiFilterSortModel::updateDive(struct dive *d)
 	bool changed = oldStatus != newStatus;
 	if (changed) {
 		filter_dive(d, newStatus);
-		divesDisplayed += newStatus - oldStatus;
+		shown_dives += newStatus - oldStatus;
 	}
 	return changed;
 }
@@ -348,7 +347,7 @@ void MultiFilterSortModel::divesAdded(dive_trip *, bool, const QVector<dive *> &
 {
 	for (dive *d: dives) {
 		if (!d->hidden_by_filter)
-			++divesDisplayed;
+			++shown_dives;
 	}
 	countsChanged();
 }
@@ -357,7 +356,7 @@ void MultiFilterSortModel::divesDeleted(dive_trip *, bool, const QVector<dive *>
 {
 	for (dive *d: dives) {
 		if (!d->hidden_by_filter)
-			--divesDisplayed;
+			--shown_dives;
 	}
 	countsChanged();
 }

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -111,9 +111,6 @@ MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyMo
 {
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
-
-	connect(&diveListNotifier, &DiveListNotifier::divesAdded, this, &MultiFilterSortModel::divesAdded);
-	connect(&diveListNotifier, &DiveListNotifier::divesDeleted, this, &MultiFilterSortModel::divesDeleted);
 }
 
 void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
@@ -341,24 +338,6 @@ void MultiFilterSortModel::filterDataChanged(const FilterData &data)
 {
 	filterData = data;
 	myInvalidate();
-}
-
-void MultiFilterSortModel::divesAdded(dive_trip *, bool, const QVector<dive *> &dives)
-{
-	for (dive *d: dives) {
-		if (!d->hidden_by_filter)
-			++shown_dives;
-	}
-	countsChanged();
-}
-
-void MultiFilterSortModel::divesDeleted(dive_trip *, bool, const QVector<dive *> &dives)
-{
-	for (dive *d: dives) {
-		if (!d->hidden_by_filter)
-			--shown_dives;
-	}
-	countsChanged();
 }
 
 void MultiFilterSortModel::countsChanged()

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -7,13 +7,6 @@
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "qt-models/divetripmodel.h"
 
-#if !defined(SUBSURFACE_MOBILE)
-#include "core/divefilter.h"
-#endif
-
-#include <QDebug>
-#include <algorithm>
-
 MultiFilterSortModel *MultiFilterSortModel::instance()
 {
 	static MultiFilterSortModel self;
@@ -22,6 +15,7 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
+	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &MultiFilterSortModel::invalidateFilter);
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
@@ -41,73 +35,8 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 	return m->data(index0, DiveTripModelBase::SHOWN_ROLE).value<bool>();
 }
 
-void MultiFilterSortModel::myInvalidate()
-{
-	QAbstractItemModel *m = sourceModel();
-	if (!m)
-		return;
-
-	{
-		// This marker prevents the UI from getting notifications on selection changes.
-		// It is active until the end of the scope.
-		// This is actually meant for the undo-commands, so that they can do their work
-		// without having the UI updated.
-		// Here, it is used because invalidating the filter can generate numerous
-		// selection changes, which do full ui reloads. Instead, do that all at once
-		// as a consequence of the filterFinished signal right after the local scope.
-		auto marker = diveListNotifier.enterCommand();
-
-		DiveFilter *filter = DiveFilter::instance();
-		for (int i = 0; i < m->rowCount(QModelIndex()); ++i) {
-			QModelIndex idx = m->index(i, 0, QModelIndex());
-
-			if (m->data(idx, DiveTripModelBase::IS_TRIP_ROLE).toBool()) {
-				// This is a trip -> loop over all dives and see if any is selected
-
-				bool showTrip = false;
-				for (int j = 0; j < m->rowCount(idx); ++j) {
-					QModelIndex idx2 = m->index(j, 0, idx);
-					dive *d = m->data(idx2, DiveTripModelBase::DIVE_ROLE).value<dive *>();
-					if (!d) {
-						qWarning("MultiFilterSortModel::myInvalidate(): subitem not a dive!?");
-						continue;
-					}
-					bool show = filter->showDive(d);
-					if (show)
-						showTrip = true;
-					m->setData(idx2, show, DiveTripModelBase::SHOWN_ROLE);
-				}
-				m->setData(idx, showTrip, DiveTripModelBase::SHOWN_ROLE);
-			} else {
-				dive *d = m->data(idx, DiveTripModelBase::DIVE_ROLE).value<dive *>();
-				bool show = (d != NULL) && filter->showDive(d);
-				m->setData(idx, show, DiveTripModelBase::SHOWN_ROLE);
-			}
-		}
-
-		invalidateFilter();
-
-		// Tell the dive trip model to update the displayed-counts
-		DiveTripModelBase::instance()->filterFinished();
-		countsChanged();
-	}
-
-	emit filterFinished();
-}
-
-bool MultiFilterSortModel::updateDive(struct dive *d)
-{
-	bool newStatus = DiveFilter::instance()->showDive(d);
-	return filter_dive(d, newStatus);
-}
-
 bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
 {
 	// Hand sorting down to the source model.
 	return DiveTripModelBase::instance()->lessThan(i1, i2);
-}
-
-void MultiFilterSortModel::countsChanged()
-{
-	updateWindowTitle();
 }

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -11,67 +11,16 @@
 #include <stdint.h>
 #include <vector>
 
-struct dive;
-struct dive_trip;
-
-struct FilterData {
-	// The mode ids are chosen such that they can be directly converted from / to combobox indices.
-	enum class Mode {
-		ALL_OF = 0,
-		ANY_OF = 1,
-		NONE_OF = 2
-	};
-
-	bool validFilter = false;
-	int minVisibility = 0;
-	int maxVisibility = 5;
-	int minRating = 0;
-	int maxRating = 5;
-	// The default minimum and maximum temperatures are set such that all
-	// physically reasonable dives are shown. Note that these values should
-	// work for both Celcius and Fahrenheit scales.
-	double minWaterTemp = -10;
-	double maxWaterTemp = 200;
-	double minAirTemp = -50;
-	double maxAirTemp = 200;
-	QDateTime fromDate = QDateTime(QDate(1980,1,1));
-	QTime fromTime = QTime(0,0);
-	QDateTime toDate = QDateTime::currentDateTime();
-	QTime toTime = QTime::currentTime();
-	QStringList tags;
-	QStringList people;
-	QStringList location;
-	QStringList suit;
-	QStringList dnotes;
-	QStringList equipment;
-	Mode tagsMode = Mode::ALL_OF;
-	Mode peopleMode = Mode::ALL_OF;
-	Mode locationMode = Mode::ANY_OF;
-	Mode dnotesMode = Mode::ALL_OF;
-	Mode suitMode = Mode::ANY_OF;
-	Mode equipmentMode = Mode::ALL_OF;
-	bool logged = true;
-	bool planned = true;
-};
-
 class MultiFilterSortModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	static MultiFilterSortModel *instance();
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
-	bool showDive(const struct dive *d) const;
 	bool updateDive(struct dive *d); // returns true if visibility status changed
 	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
-	bool diveSiteMode() const; // returns true if we're filtering on dive site
-	const QVector<dive_site *> &filteredDiveSites() const;
-public
-slots:
-	void myInvalidate();
-	void startFilterDiveSites(QVector<dive_site *> ds);
-	void setFilterDiveSite(QVector<dive_site *> ds);
-	void stopFilterDiveSites();
+
 	void resetModel(DiveTripModelBase::Layout layout);
-	void filterDataChanged(const FilterData &data);
+	void myInvalidate();
 
 signals:
 	void filterFinished();
@@ -79,17 +28,7 @@ signals:
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 	// Dive site filtering has priority over other filters
-	QVector<dive_site *> dive_sites;
 	void countsChanged();
-	FilterData filterData;
-
-	// We use ref-counting for the dive site mode. The reason is that when switching
-	// between two tabs that both need dive site mode, the following course of
-	// events may happen:
-	//	1) The new tab appears -> enter dive site mode.
-	//	2) The old tab gets its hide() signal -> exit dive site mode.
-	// The filter is now not in dive site mode, even if it should
-	int diveSiteRefCount;
 };
 
 #endif

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -71,7 +71,6 @@ slots:
 	void startFilterDiveSites(QVector<dive_site *> ds);
 	void setFilterDiveSite(QVector<dive_site *> ds);
 	void stopFilterDiveSites();
-	void filterChanged(const QModelIndex &from, const QModelIndex &to, const QVector<int> &roles);
 	void resetModel(DiveTripModelBase::Layout layout);
 	void filterDataChanged(const FilterData &data);
 	void divesAdded(struct dive_trip *, bool, const QVector<dive *> &dives);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -68,7 +68,6 @@ public:
 public
 slots:
 	void myInvalidate();
-	void clearFilter();
 	void startFilterDiveSites(QVector<dive_site *> ds);
 	void setFilterDiveSite(QVector<dive_site *> ds);
 	void stopFilterDiveSites();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -4,31 +4,18 @@
 
 #include "divetripmodel.h"
 
-#include <QStringListModel>
 #include <QSortFilterProxyModel>
-#include <QDateTime>
-
-#include <stdint.h>
-#include <vector>
 
 class MultiFilterSortModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	static MultiFilterSortModel *instance();
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
-	bool updateDive(struct dive *d); // returns true if visibility status changed
 	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
 
 	void resetModel(DiveTripModelBase::Layout layout);
-	void myInvalidate();
-
-signals:
-	void filterFinished();
-
 private:
 	MultiFilterSortModel(QObject *parent = 0);
-	// Dive site filtering has priority over other filters
-	void countsChanged();
 };
 
 #endif

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -72,8 +72,6 @@ slots:
 	void stopFilterDiveSites();
 	void resetModel(DiveTripModelBase::Layout layout);
 	void filterDataChanged(const FilterData &data);
-	void divesAdded(struct dive_trip *, bool, const QVector<dive *> &dives);
-	void divesDeleted(struct dive_trip *, bool, const QVector<dive *> &dives);
 
 signals:
 	void filterFinished();

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -61,7 +61,6 @@ public:
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 	bool showDive(const struct dive *d) const;
 	bool updateDive(struct dive *d); // returns true if visibility status changed
-	int divesDisplayed;
 	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
 	bool diveSiteMode() const; // returns true if we're filtering on dive site
 	const QVector<dive_site *> &filteredDiveSites() const;

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -2,6 +2,7 @@
 #include "maplocationmodel.h"
 #include "divelocationmodel.h"
 #include "core/divesite.h"
+#include "core/divefilter.h"
 #ifndef SUBSURFACE_MOBILE
 #include "qt-models/filtermodels.h"
 #include "desktop-widgets/mapwidget.h"
@@ -133,9 +134,9 @@ void MapLocationModel::reload(QObject *map)
 	// the dive site tab), we want to show all dive sites, not only those
 	// of the non-hidden dives. Moreover, the selected dive sites are those
 	// that we filter for.
-	bool diveSiteMode = MultiFilterSortModel::instance()->diveSiteMode();
+	bool diveSiteMode = DiveFilter::instance()->diveSiteMode();
 	if (diveSiteMode)
-		m_selectedDs = MultiFilterSortModel::instance()->filteredDiveSites();
+		m_selectedDs = DiveFilter::instance()->filteredDiveSites();
 #endif
 	for (int i = 0; i < dive_site_table.nr; ++i) {
 		struct dive_site *ds = dive_site_table.dive_sites[i];


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at making the filter code
1) somewhat more clear
2) unified for mobile and desktop

I'm not yet very happy about the results. I'm sure that this can be done in a more controlled way. Data flow is still a complete mess. But I hope that it is a step in the right direction.

What this basically does:
1) Create a class that is only responsible for filtering.
2) Move the logic to set the hidden_by_filter flag closer to the core. Still, this is spread out over DiveTripModel, undo-commands and core in a rather nasty way.

@dirkhh: If you agree with the general direction I will try if I can make the new mobile code run with this. But I will only be able to do so tomorrow evening.