### PR TITLE
Bt updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: ensure that all BT/BLE flavors of the OSTC are recognized as dive computers [#2358]
 Desktop: allow copy&pasting of multiple cylinders [#2386]
 Desktop: don't output random SAC values for cylinders without data [#2376]
 Mobile: add menu entry to start a support email, using native email client

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -30,9 +30,10 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		else if (btName.mid(4,2) == "4-") product = "OSTC 4";
 		else if (btName.mid(4,2) == "2-") product = "OSTC 2N";
 		else if (btName.mid(4,2) == "+ ") product = "OSTC 2";
-		// all OSTCs are HW_FAMILY_OSTC_3, so when we do not know,
-		// just try this
-		else product = "OSTC 3"; // all OSTCs are HW_FAMILY_OSTC_3
+		// all BT/BLE enabled OSTCs are HW_FAMILY_OSTC_3, so when we do not know,
+		// just use a default product that allows the codoe to download from the
+		// user's dive computer
+		else product = "OSTC 2";
 	}
 
 	if (btName.startsWith("Predator") ||

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -559,7 +559,7 @@ Kirigami.ScrollablePage {
 			}
 
 			Controls.Label {
-				text: qsTr("Show all bluetooth devices \neven if not recognized as dive computers")
+				text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
 				color: subsurfaceTheme.textColor


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
two small fixes.
One subtle update to the detection code for the OSTC family of computers - picking OSTC 3 ended up causing us to not recognize certain BLE versions of the OSTC on iOS as dive computers.
And a change to the language on the settings page that clarifies that the "show all BT devices" settings is not persistent.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2358 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

