### PR TITLE
AppImage: don't bundle our libdbus

### DIFF
--- a/.github/workflows/scripts/linux-in-container-build.sh
+++ b/.github/workflows/scripts/linux-in-container-build.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-# this gets executed by Travis when building an AppImage for Linux
+# this gets executed by the GitHub Action when building an AppImage for Linux
 # inside of the trusty-qt512 container
 
 export PATH=$QT_ROOT/bin:$PATH # Make sure correct qmake is found on the $PATH for linuxdeployqt
@@ -43,6 +43,10 @@ rm -rf appdir/usr/home/ appdir/usr/include/ appdir/usr/share/man/ # No need to s
 rm -rf appdir/usr/usr appdir/usr/lib/cmake appdir/usr/lib/pkgconfig
 cp /ssllibs/libssl.so appdir/usr/lib/libssl.so.1.1
 cp /ssllibs/libcrypto.so appdir/usr/lib/libcrypto.so.1.1
+
+# the dbus library appears to cause problems with Bluetooth. Let's not
+# bundle it in the AppImage
+rm appdir/usr/lib/libdbus-1.so.3
 
 # get the linuxdeployqt tool and run it to collect the libraries
 curl -L -O "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop/Linux: fix issue with Linux AppImage failing to communicate with Bluetooth dive computers [#2370]
 Desktop: allow copy&pasting of multiple cylinders [#2386]
 Desktop: don't output random SAC values for cylinders without data [#2376]
 Mobile: add menu entry to start a support email, using native email client


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
simply delete the offending library before bundling

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes: #2370

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
DONE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@glance- can you please check that the resulting AppImage works for you?
Since this is a PR, you'll need to go to the Action for Linux Qt5.12 and download it from the Artifacts drop down in the upper right area of the page