### PR TITLE
Build container images in GitHub actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/android-builder:5.13.01
+      image: docker://docker.pkg.github.com/${{ github.repository }}/android-builder:5.13.01
 
     steps:
     - name: checkout sources

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,9 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${{ github.repository }}/android-builder:5.13.01
+      # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      #image: docker://docker.pkg.github.com/${{ github.repository }}/android-builder:5.13.01
+      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/android-builder:5.13.01
 
     steps:
     - name: checkout sources

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://dirkhh/android-builder:5.13.01
+      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/android-builder:5.13.01
 
     steps:
     - name: checkout sources

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      # and anonymus / actions access to github packages works.
       #image: docker://docker.pkg.github.com/${{ github.repository }}/android-builder:5.13.01
-      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/android-builder:5.13.01
+      image: docker://dirkhh/android-builder:5.13.01
 
     steps:
     - name: checkout sources

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -1,0 +1,72 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - scripts/docker/android-build-container/Dockerfile
+    - scripts/docker/mxe-build-container/Dockerfile
+    - scripts/docker/trusty-qt512/Dockerfile
+
+
+jobs:
+  android-build-container:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: 5.13.01
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Get our pre-reqs
+      run: |
+          cd scripts/docker/android-build-container
+          bash download.sh
+          sed -ie 's/^sudo/#sudo/' setup-docker.sh
+          bash setup-docker.sh
+
+    - name: Build the Docker image
+      run: docker build ./scripts/docker/android-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/android-build-container:${VERSION}
+
+    - name: Push the Docker image
+      run: |
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/android-build-container:${VERSION}
+
+  mxe-build-container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 720
+    env:
+      VERSION: 0.9
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: docker build ./scripts/docker/mxe-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:${VERSION}
+
+    - name: Push the Docker image
+      run: |
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:${VERSION}
+
+  trusty-qt512:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: 0.7
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Get our pre-reqs
+      run: |
+        cd scripts/docker/trusty-qt512
+        bash getpackages.sh
+
+    - name: Build the Docker image
+      run: docker build ./scripts/docker/trusty-qt512/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:${VERSION}
+
+    - name: Push the Docker image
+      run: |
+        docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:${VERSION}

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -27,12 +27,12 @@ jobs:
           bash setup-docker.sh
 
     - name: Build the Docker image
-      run: docker build ./scripts/docker/android-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/android-build-container:${VERSION}
+      run: docker build ./scripts/docker/android-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY,,}/android-build-container:${VERSION}
 
     - name: Push the Docker image
       run: |
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
-        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/android-build-container:${VERSION}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/android-build-container:${VERSION}
 
   mxe-build-container:
     runs-on: ubuntu-latest
@@ -43,12 +43,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build the Docker image
-      run: docker build ./scripts/docker/mxe-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:${VERSION}
+      run: docker build ./scripts/docker/mxe-build-container/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY,,}/mxe-build-container:${VERSION}
 
     - name: Push the Docker image
       run: |
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
-        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:${VERSION}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/mxe-build-container:${VERSION}
 
   trusty-qt512:
     runs-on: ubuntu-latest
@@ -64,9 +64,9 @@ jobs:
         bash getpackages.sh
 
     - name: Build the Docker image
-      run: docker build ./scripts/docker/trusty-qt512/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:${VERSION}
+      run: docker build ./scripts/docker/trusty-qt512/ --tag docker.pkg.github.com/${GITHUB_REPOSITORY,,}/trusty-qt512:${VERSION}
 
     - name: Push the Docker image
       run: |
         docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY/\/*/} -p ${{ secrets.GITHUB_TOKEN }}
-        docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:${VERSION}
+        docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/trusty-qt512:${VERSION}

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://dirkhh/trusty-qt512:0.7
+      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:0.7
 
     steps:
     - name: checkout sources

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -11,7 +11,9 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${{ github.repository }}/trusty-qt512:0.7
+      # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      #image: docker://docker.pkg.github.com/${{ github.repository }}/trusty-qt512:0.7
+      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/trusty-qt512:0.7
 
     steps:
     - name: checkout sources

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/trusty-qt512:0.7
+      image: docker://docker.pkg.github.com/${{ github.repository }}/trusty-qt512:0.7
 
     steps:
     - name: checkout sources

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      # and anonymus / actions access to github packages works.
       #image: docker://docker.pkg.github.com/${{ github.repository }}/trusty-qt512:0.7
-      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/trusty-qt512:0.7
+      image: docker://dirkhh/trusty-qt512:0.7
 
     steps:
     - name: checkout sources

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://dirkhh/mxe-build-container:0.9
+      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:0.9
 
     steps:
     - name: checkout sources

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      # and anonymus / actions access to github packages works.
       #image: docker://docker.pkg.github.com/${{ github.repository }}/mxe-build-container:0.9
-      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/mxe-build-container:0.9
+      image: docker://dirkhh/mxe-build-container:0.9
 
     steps:
     - name: checkout sources

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${GITHUB_REPOSITORY}/mxe-build-container:0.9
+      image: docker://docker.pkg.github.com/${{ github.repository }}/mxe-build-container:0.9
 
     steps:
     - name: checkout sources

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,9 @@ jobs:
   buildInContainer:
     runs-on: ubuntu-latest
     container:
-      image: docker://docker.pkg.github.com/${{ github.repository }}/mxe-build-container:0.9
+      # FIXME: Use templating once we can mangle org/repo name into something that docker accepts.
+      #image: docker://docker.pkg.github.com/${{ github.repository }}/mxe-build-container:0.9
+      image: docker://docker.pkg.github.com/subsurface-divelog/subsurface/mxe-build-container:0.9
 
     steps:
     - name: checkout sources

--- a/scripts/windows-container/before_install.sh
+++ b/scripts/windows-container/before_install.sh
@@ -34,7 +34,7 @@ cd ${TRAVIS_BUILD_DIR}/..
 mkdir -p win32
 
 # start the container and keep it running
-docker run -v $PWD/win32:/win/win32 -v $PWD/subsurface:/win/subsurface --name=builder -w /win -d docker.pkg.github.com/subsurface-divelog/subsurface/mxe-build-container:0.9 /bin/sleep 60m
+docker run -v $PWD/win32:/win/win32 -v $PWD/subsurface:/win/subsurface --name=builder -w /win -d dirkhh/mxe-build-container:0.9 /bin/sleep 60m
 
 # for some reason this package was installed but still isn't there?
 # hmmmm. The container doesn't seem to have libtool installed

--- a/scripts/windows-container/before_install.sh
+++ b/scripts/windows-container/before_install.sh
@@ -34,7 +34,7 @@ cd ${TRAVIS_BUILD_DIR}/..
 mkdir -p win32
 
 # start the container and keep it running
-docker run -v $PWD/win32:/win/win32 -v $PWD/subsurface:/win/subsurface --name=builder -w /win -d dirkhh/mxe-build-container:0.9 /bin/sleep 60m
+docker run -v $PWD/win32:/win/win32 -v $PWD/subsurface:/win/subsurface --name=builder -w /win -d docker.pkg.github.com/subsurface-divelog/subsurface/mxe-build-container:0.9 /bin/sleep 60m
 
 # for some reason this package was installed but still isn't there?
 # hmmmm. The container doesn't seem to have libtool installed


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Build our ci containers in our ci system

### Changes made:
This moves the build tasks of manually building our containers for our ci system to building them on our ci, github actions.

### Related issues:
When we where working with #2394 for example, its quite clear that changes to our ci containers are painfull and hard to do, and can't be done by anyone else than @dirkhh , so this solves that by moving it to github actions, and that way opening up for others to help out.

### Additional information:
Because docker hates my github username because it contains a "-" in it, I can't really test this, so there might be bugs.

### Mentions:
@dirkhh 