### PR TITLE
Added export functionality to subsurface-mobile (only file export)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,8 +29,10 @@ Willem Ferguson <willemferguson@zoology.up.ac.za>
 <willemferguson@zoology.up.ac.za> <willem@localhost.localdomain>
 <willemferguson@zoology.up.ac.za> <willem@willem-Precision-M4700.(none)>
 <willemferguson@zoology.up.ac.za> <fergusonwillem@gmail.com>
-<jani@apache.org> <jani@libreoffice.org>
-jan Iversen <jani@apache.org> jan iversen <jani@apache.org>
+<jan@casacondor.com> <jani@libreoffice.org>
+<jan@casacondor.com> <jani@apache.org>
+<jan@casacondor.com> <jancasacondor@gmail.com>
+jan Iversen <jan@casacondor.com> jan iversen <jani@apache.org>
 Gehad Elrobey <gehadelrobey@gmail.com> <gehadelrobey@gmail.com>
 Joseph W. Joshua <joejoshw@gmail.com> <joejoshw@gmail.com>
 Joseph W. Joshua <joejoshw@gmail.com> <joshua@megvel.me.ke>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Profile: Add current GF to infobox
 Mobile: (desktop only) new switch --testqml, allows to use qml files instead of resources.
 Desktop: increase speed of multi-trip selection
 Mobile: ensure that all BT/BLE flavors of the OSTC are recognized as dive computers [#2358]
+mobile-widgets: Add export function
 Desktop: allow copy&pasting of multiple cylinders [#2386]
 Desktop: don't output random SAC values for cylinders without data [#2376]
 Mobile: add menu entry to start a support email, using native email client

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -84,6 +84,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	errorhelper.c
 	exif.cpp
 	exif.h
+	exportfuncs.cpp
+	exportfuncs.h
 	file.c
 	file.h
 	format.cpp

--- a/core/exportfuncs.cpp
+++ b/core/exportfuncs.cpp
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <QFileInfo>
+#include <QDir>
+#include <QtConcurrent>
+#include "core/membuffer.h"
+#include "core/divesite.h"
+#include "core/tag.h"
+#include "core/file.h"
+#include "core/errorhelper.h"
+#include "core/divefilter.h"
+#include "exportfuncs.h"
+
+
+exportFuncs *exportFuncs::instance()
+{
+    static exportFuncs *self = new exportFuncs;
+    return self;
+}
+
+void exportFuncs::exportProfile(QString filename, const bool selected_only)
+{
+	struct dive *dive;
+	int i;
+	int count = 0;
+	if (!filename.endsWith(".png", Qt::CaseInsensitive))
+		filename = filename.append(".png");
+	QFileInfo fi(filename);
+
+	for_each_dive (i, dive) {
+		if (selected_only && !dive->selected)
+			continue;
+		if (count)
+			saveProfile(dive, fi.path() + QDir::separator() + fi.completeBaseName().append(QString("-%1.").arg(count)) + fi.suffix());
+		else
+			saveProfile(dive, filename);
+		++count;
+	}
+}
+
+
+void exportFuncs::export_TeX(const char *filename, const bool selected_only, bool plain)
+{
+	FILE *f;
+	QDir texdir = QFileInfo(filename).dir();
+	struct dive *dive;
+	const struct units *units = get_units();
+	const char *unit;
+	const char *ssrf;
+	int i;
+	bool need_pagebreak = false;
+
+	struct membuffer buf = {};
+
+	if (plain) {
+		ssrf = "";
+		put_format(&buf, "\\input subsurfacetemplate\n");
+		put_format(&buf, "%% This is a plain TeX file. Compile with pdftex, not pdflatex!\n");
+		put_format(&buf, "%% You will also need a subsurfacetemplate.tex in the current directory.\n");
+	} else {
+		ssrf = "ssrf";
+		put_format(&buf, "\\input subsurfacelatextemplate\n");
+		put_format(&buf, "%% This is a plain LaTeX file. Compile with pdflatex, not pdftex!\n");
+		put_format(&buf, "%% You will also need a subsurfacelatextemplate.tex in the current directory.\n");
+	}
+	put_format(&buf, "%% You can download an example from http://www.atdotde.de/~robert/subsurfacetemplate\n%%\n");
+	put_format(&buf, "%%\n");
+	put_format(&buf, "%% Notes: TeX/LaTex will not render the degree symbol correctly by default. In LaTeX, you may\n");
+	put_format(&buf, "%% add the following line to the end of the preamble of your template to ensure correct output:\n");
+	put_format(&buf, "%% \\usepackage[utf8]{inputenc}\n");
+	put_format(&buf, "%% \\usepackage{gensymb}\n");
+	put_format(&buf, "%% \\DeclareUnicodeCharacter{00B0}{\\degree}\n"); //replaces ° with \degree
+	put_format(&buf, "%%\n");
+
+	/* Define text fields with the units used for export.  These values are set in the Subsurface Preferences
+	 * and the text fields created here are included in the data fields below.
+	 */
+	put_format(&buf, "\n%% These fields contain the units used in other fields below. They may be\n");
+	put_format(&buf, "%% referenced as needed in TeX templates.\n");
+	put_format(&buf, "%% \n");
+	put_format(&buf, "%% By default, Subsurface exports units of volume as \"ℓ\" and \"cuft\", which do\n");
+	put_format(&buf, "%% not render well in TeX/LaTeX.  The code below substitutes \"L\" and \"ft$^{3}$\",\n");
+	put_format(&buf, "%% respectively.  If you wish to display the original values, you may edit this\n");
+	put_format(&buf, "%% list and all calls to those units will be updated in your document.\n");
+
+	put_format(&buf, "\\def\\%sdepthunit{\\%sunit%s}", ssrf, ssrf, units->length == units::METERS ? "meter" : "ft");
+	put_format(&buf, "\\def\\%sweightunit{\\%sunit%s}",ssrf, ssrf, units->weight == units::KG ? "kg" : "lb");
+	put_format(&buf, "\\def\\%spressureunit{\\%sunit%s}", ssrf, ssrf, units->pressure == units::BAR ? "bar" : "psi");
+	put_format(&buf, "\\def\\%stemperatureunit{\\%sunit%s}", ssrf, ssrf, units->temperature == units::CELSIUS ? "centigrade" : "fahrenheit");
+	put_format(&buf, "\\def\\%svolumeunit{\\%sunit%s}", ssrf, ssrf, units->volume == units::LITER ? "liter" : "cuft");
+	put_format(&buf, "\\def\\%sverticalspeedunit{\\%sunit%s}", ssrf, ssrf, units->length == units::METERS ? "meterpermin" : "ftpermin");
+
+	put_format(&buf, "\n%%%%%%%%%% Begin Dive Data: %%%%%%%%%%\n");
+
+	for_each_dive (i, dive) {
+		if (selected_only && !dive->selected)
+			continue;
+
+		saveProfile(dive, texdir.filePath(QString("profile%1.png").arg(dive->number)));
+		struct tm tm;
+		utc_mkdate(dive->when, &tm);
+
+		dive_site *site = dive->dive_site;
+		QRegExp ct("countrytag: (\\w+)");
+		QString country;
+		if (site && ct.indexIn(site->notes) >= 0)
+			country = ct.cap(1);
+		else
+			country = "";
+
+		pressure_t delta_p = {.mbar = 0};
+
+		QString star = "*";
+		QString viz = star.repeated(dive->visibility);
+		QString rating = star.repeated(dive->rating);
+
+		int i;
+		int qty_cyl;
+		int qty_weight;
+		double total_weight;
+
+		if (need_pagebreak) {
+			if (plain)
+				put_format(&buf, "\\vfill\\eject\n");
+
+			else
+				put_format(&buf, "\\newpage\n");
+		}
+		need_pagebreak = true;
+		put_format(&buf, "\n%% Time, Date, and location:\n");
+		put_format(&buf, "\\def\\%sdate{%04u-%02u-%02u}\n", ssrf,
+		      tm.tm_year, tm.tm_mon+1, tm.tm_mday);
+		put_format(&buf, "\\def\\%shour{%02u}\n", ssrf, tm.tm_hour);
+		put_format(&buf, "\\def\\%sminute{%02u}\n", ssrf, tm.tm_min);
+		put_format(&buf, "\\def\\%snumber{%d}\n", ssrf, dive->number);
+		put_format(&buf, "\\def\\%splace{%s}\n", ssrf, site ? site->name : "");
+		put_format(&buf, "\\def\\%sspot{}\n", ssrf);
+		put_format(&buf, "\\def\\%ssitename{%s}\n", ssrf, site ? site->name : "");
+		site ? put_format(&buf, "\\def\\%sgpslat{%f}\n", ssrf, site->location.lat.udeg / 1000000.0) : put_format(&buf, "\\def\\%sgpslat{}\n", ssrf);
+		site ? put_format(&buf, "\\def\\%sgpslon{%f}\n", ssrf, site->location.lon.udeg / 1000000.0) : put_format(&buf, "\\def\\gpslon{}\n");
+		put_format(&buf, "\\def\\%scomputer{%s}\n", ssrf, dive->dc.model);
+		put_format(&buf, "\\def\\%scountry{%s}\n", ssrf, qPrintable(country));
+		put_format(&buf, "\\def\\%stime{%u:%02u}\n", ssrf, FRACTION(dive->duration.seconds, 60));
+
+		put_format(&buf, "\n%% Dive Profile Details:\n");
+		dive->maxtemp.mkelvin ? put_format(&buf, "\\def\\%smaxtemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->maxtemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%smaxtemp{}\n", ssrf);
+		dive->mintemp.mkelvin ? put_format(&buf, "\\def\\%smintemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->mintemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%ssrfmintemp{}\n", ssrf);
+		dive->watertemp.mkelvin ? put_format(&buf, "\\def\\%swatertemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->watertemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%swatertemp{}\n", ssrf);
+		dive->airtemp.mkelvin ? put_format(&buf, "\\def\\%sairtemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->airtemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%sairtemp{}\n", ssrf);
+		dive->maxdepth.mm ? put_format(&buf, "\\def\\%smaximumdepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->maxdepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%smaximumdepth{}\n", ssrf);
+		dive->meandepth.mm ? put_format(&buf, "\\def\\%smeandepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->meandepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%smeandepth{}\n", ssrf);
+
+		struct tag_entry *tag = dive->tag_list;
+		QString tags;
+		if (tag) {
+			tags = tag->tag->name;
+			while ((tag = tag->next))
+				tags += QString(", ") + QString(tag->tag->name);
+		}
+		put_format(&buf, "\\def\\%stype{%s}\n", ssrf, qPrintable(tags));
+		put_format(&buf, "\\def\\%sviz{%s}\n", ssrf, qPrintable(viz));
+		put_format(&buf, "\\def\\%srating{%s}\n", ssrf, qPrintable(rating));
+		put_format(&buf, "\\def\\%splot{\\includegraphics[width=9cm,height=4cm]{profile%d}}\n", ssrf, dive->number);
+		put_format(&buf, "\\def\\%sprofilename{profile%d}\n", ssrf, dive->number);
+		put_format(&buf, "\\def\\%scomment{%s}\n", ssrf, dive->notes ? dive->notes : "");
+		put_format(&buf, "\\def\\%sbuddy{%s}\n", ssrf, dive->buddy ? dive->buddy : "");
+		put_format(&buf, "\\def\\%sdivemaster{%s}\n", ssrf, dive->divemaster ? dive->divemaster : "");
+		put_format(&buf, "\\def\\%ssuit{%s}\n", ssrf, dive->suit ? dive->suit : "");
+
+		// Print cylinder data
+		put_format(&buf, "\n%% Gas use information:\n");
+		qty_cyl = 0;
+		for (i = 0; i < dive->cylinders.nr; i++){
+			const cylinder_t &cyl = *get_cylinder(dive, i);
+			if (is_cylinder_used(dive, i) || (prefs.display_unused_tanks && cyl.type.description)){
+				put_format(&buf, "\\def\\%scyl%cdescription{%s}\n", ssrf, 'a' + i, cyl.type.description);
+				put_format(&buf, "\\def\\%scyl%cgasname{%s}\n", ssrf, 'a' + i, gasname(cyl.gasmix));
+				put_format(&buf, "\\def\\%scyl%cmixO2{%.1f\\%%}\n", ssrf, 'a' + i, get_o2(cyl.gasmix)/10.0);
+				put_format(&buf, "\\def\\%scyl%cmixHe{%.1f\\%%}\n", ssrf, 'a' + i, get_he(cyl.gasmix)/10.0);
+				put_format(&buf, "\\def\\%scyl%cmixN2{%.1f\\%%}\n", ssrf, 'a' + i, (100.0 - (get_o2(cyl.gasmix)/10.0) - (get_he(cyl.gasmix)/10.0)));
+				delta_p.mbar += cyl.start.mbar - cyl.end.mbar;
+				put_format(&buf, "\\def\\%scyl%cstartpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.start.mbar, &unit)/1.0, ssrf);
+				put_format(&buf, "\\def\\%scyl%cendpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.end.mbar, &unit)/1.0, ssrf);
+				qty_cyl += 1;
+			} else {
+				put_format(&buf, "\\def\\%scyl%cdescription{}\n", ssrf, 'a' + i);
+				put_format(&buf, "\\def\\%scyl%cgasname{}\n", ssrf, 'a' + i);
+				put_format(&buf, "\\def\\%scyl%cmixO2{}\n", ssrf, 'a' + i);
+				put_format(&buf, "\\def\\%scyl%cmixHe{}\n", ssrf, 'a' + i);
+				put_format(&buf, "\\def\\%scyl%cmixN2{}\n", ssrf, 'a' + i);
+				delta_p.mbar += cyl.start.mbar - cyl.end.mbar;
+				put_format(&buf, "\\def\\%scyl%cstartpress{}\n", ssrf, 'a' + i);
+				put_format(&buf, "\\def\\%scyl%cendpress{}\n", ssrf, 'a' + i);
+				qty_cyl += 1;
+			}
+		}
+		put_format(&buf, "\\def\\%sqtycyl{%d}\n", ssrf, qty_cyl);
+		put_format(&buf, "\\def\\%sgasuse{%.1f\\%spressureunit}\n", ssrf, get_pressure_units(delta_p.mbar, &unit)/1.0, ssrf);
+		put_format(&buf, "\\def\\%ssac{%.2f\\%svolumeunit/min}\n", ssrf, get_volume_units(dive->sac, NULL, &unit), ssrf);
+
+		//Code block prints all weights listed in dive.
+		put_format(&buf, "\n%% Weighting information:\n");
+		qty_weight = 0;
+		total_weight = 0;
+		for (i = 0; i < dive->weightsystems.nr; i++) {
+			weightsystem_t w = dive->weightsystems.weightsystems[i];
+			put_format(&buf, "\\def\\%sweight%ctype{%s}\n", ssrf, 'a' + i, w.description);
+			put_format(&buf, "\\def\\%sweight%camt{%.3f\\%sweightunit}\n", ssrf, 'a' + i, get_weight_units(w.weight.grams, NULL, &unit), ssrf);
+			qty_weight += 1;
+			total_weight += get_weight_units(w.weight.grams, NULL, &unit);
+		}
+		put_format(&buf, "\\def\\%sqtyweights{%d}\n", ssrf, qty_weight);
+		put_format(&buf, "\\def\\%stotalweight{%.2f\\%sweightunit}\n", ssrf, total_weight, ssrf);
+		unit = "";
+
+		// Legacy fields
+		put_format(&buf, "\\def\\%sspot{}\n", ssrf);
+		put_format(&buf, "\\def\\%sentrance{}\n", ssrf);
+		put_format(&buf, "\\def\\%splace{%s}\n", ssrf, site ? site->name : "");
+		dive->maxdepth.mm ? put_format(&buf, "\\def\\%sdepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->maxdepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%sdepth{}\n", ssrf);
+
+		put_format(&buf, "\\%spage\n", ssrf);
+
+	}
+
+	if (plain)
+		put_format(&buf, "\\bye\n");
+	else
+		put_format(&buf, "\\end{document}\n");
+
+	f = subsurface_fopen(filename, "w+");
+	if (!f) {
+		report_error(qPrintable(tr("Can't open file %s")), filename);
+	} else {
+		flush_buffer(&buf, f); /*check for writing errors? */
+		fclose(f);
+	}
+	free_buffer(&buf);
+
+}
+
+void exportFuncs::export_depths(const char *filename, const bool selected_only)
+{
+	FILE *f;
+	struct dive *dive;
+	depth_t depth;
+	int i;
+	const char *unit = NULL;
+
+	struct membuffer buf = {};
+
+	for_each_dive (i, dive) {
+		if (selected_only && !dive->selected)
+			continue;
+
+		FOR_EACH_PICTURE (dive) {
+			int n = dive->dc.samples;
+			struct sample *s = dive->dc.sample;
+			depth.mm = 0;
+			while (--n >= 0 && (int32_t)s->time.seconds <= picture->offset.seconds) {
+				depth.mm = s->depth.mm;
+				s++;
+			}
+			put_format(&buf, "%s\t%.1f", picture->filename, get_depth_units(depth.mm, NULL, &unit));
+			put_format(&buf, "%s\n", unit);
+		}
+	}
+
+	f = subsurface_fopen(filename, "w+");
+	if (!f) {
+		report_error(qPrintable(tr("Can't open file %s")), filename);
+	} else {
+		flush_buffer(&buf, f); /*check for writing errors? */
+		fclose(f);
+	}
+	free_buffer(&buf);
+}
+
+std::vector<const dive_site *> exportFuncs::getDiveSitesToExport(bool selectedOnly)
+{
+	std::vector<const dive_site *> res;
+#ifndef SUBSURFACE_MOBILE
+	// Waiting for DiveFilter to be combined for both mobile and desktop
+
+	if (selectedOnly && DiveFilter::instance()->diveSiteMode()) {
+		// Special case in dive site mode: export all selected dive sites,
+		// not the dive sites of selected dives.
+		QVector<dive_site *> sites = DiveFilter::instance()->filteredDiveSites();
+		res.reserve(sites.size());
+		for (const dive_site *ds: sites)
+			res.push_back(ds);
+		return res;
+	}
+
+	res.reserve(dive_site_table.nr);
+	for (int i = 0; i < dive_site_table.nr; i++) {
+		struct dive_site *ds = get_dive_site(i, &dive_site_table);
+		if (dive_site_is_empty(ds))
+			continue;
+		if (selectedOnly && !is_dive_site_selected(ds))
+			continue;
+		res.push_back(ds);
+	}
+#endif
+	return res;
+}
+
+void exportFuncs::exportUsingStyleSheet(QString filename, bool doExport, int units,
+	QString stylesheet, bool anonymize)
+{
+	future = QtConcurrent::run(export_dives_xslt, filename.toUtf8(), doExport, units, stylesheet.toUtf8(), anonymize);
+}

--- a/core/exportfuncs.h
+++ b/core/exportfuncs.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef EXPORTFUNCS_H
+#define EXPORTFUNCS_H
+
+#include <QObject>
+#include <QFuture>
+#include "dive.h"
+
+class exportFuncs: public QObject {
+	Q_OBJECT
+
+public:
+	static exportFuncs *instance();
+
+	void exportProfile(QString filename, const bool selected_only);
+	void export_TeX(const char *filename, const bool selected_only, bool plain);
+	void export_depths(const char *filename, const bool selected_only);
+	std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
+	void exportUsingStyleSheet(QString filename, bool doExport, int units,
+		QString stylesheet, bool anonymize);
+	QFuture<int> future;
+
+	// prepareDivesForUploadDiveLog
+	// prepareDivesForUploadDiveShare
+
+private:
+	exportFuncs() {}
+
+	// WARNING
+	// saveProfile uses the UI and are therefore different between
+	// Desktop (UI) and Mobile (QML)
+	// In order to solve this difference, the actual implementations
+	// are done in
+	// desktop-widgets/divelogexportdialog.cpp and
+	// mobile-widgets/qmlmanager.cpp
+	void saveProfile(const struct dive *dive, const QString filename);
+};
+
+#endif // EXPORT_FUNCS_H

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -2,7 +2,6 @@
 #include <QFileDialog>
 #include <QShortcut>
 #include <QSettings>
-#include <QtConcurrent>
 #include <string.h> // Allows string comparisons and substitutions in TeX export
 
 #include "ui_divelogexportdialog.h"
@@ -16,6 +15,7 @@
 #include "core/errorhelper.h"
 #include "core/file.h"
 #include "core/tag.h"
+#include "core/exportfuncs.h"
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/divelogexportdialog.h"
 #include "desktop-widgets/diveshareexportdialog.h"
@@ -131,32 +131,6 @@ void DiveLogExportDialog::on_exportGroup_buttonClicked(QAbstractButton*)
 	showExplanation();
 }
 
-static std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly)
-{
-	std::vector<const dive_site *> res;
-
-	if (selectedOnly && DiveFilter::instance()->diveSiteMode()) {
-		// Special case in dive site mode: export all selected dive sites,
-		// not the dive sites of selected dives.
-		QVector<dive_site *> sites = DiveFilter::instance()->filteredDiveSites();
-		res.reserve(sites.size());
-		for (const dive_site *ds: sites)
-			res.push_back(ds);
-		return res;
-	}
-
-	res.reserve(dive_site_table.nr);
-	for (int i = 0; i < dive_site_table.nr; i++) {
-		struct dive_site *ds = get_dive_site(i, &dive_site_table);
-		if (dive_site_is_empty(ds))
-			continue;
-		if (selectedOnly && !is_dive_site_selected(ds))
-			continue;
-		res.push_back(ds);
-	}
-	return res;
-}
-
 void DiveLogExportDialog::on_buttonBox_accepted()
 {
 	QString filename;
@@ -205,21 +179,21 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 				if (!filename.contains('.'))
 					filename.append(".xml");
 				QByteArray bt = QFile::encodeName(filename);
-				std::vector<const dive_site *> sites = getDiveSitesToExport(ui->exportSelected->isChecked());
+				std::vector<const dive_site *> sites = exportFuncs::instance()->getDiveSitesToExport(ui->exportSelected->isChecked());
 				save_dive_sites_logic(bt.data(), &sites[0], (int)sites.size(), ui->anonymize->isChecked());
 			}
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
-				export_depths(qPrintable(filename), ui->exportSelected->isChecked());
+				exportFuncs::instance()->export_depths(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportTeX->isChecked() || ui->exportLaTeX->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export to TeX file"), lastDir, tr("TeX files") + " (*.tex)");
 			if (!filename.isNull() && !filename.isEmpty())
-				export_TeX(qPrintable(filename), ui->exportSelected->isChecked(), ui->exportTeX->isChecked());
+				exportFuncs::instance()->export_TeX(qPrintable(filename), ui->exportSelected->isChecked(), ui->exportTeX->isChecked());
 		} else if (ui->exportProfile->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile image"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
-				exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
+				exportFuncs::instance()->exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportProfileData->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile data"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
@@ -240,71 +214,14 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		qPrefDisplay::set_lastDir(fileInfo.dir().path());
 		// the non XSLT exports are called directly above, the XSLT based ons are called here
 		if (!stylesheet.isEmpty()) {
-			future = QtConcurrent::run(export_dives_xslt, filename.toUtf8(), ui->exportSelected->isChecked(), ui->CSVUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
-			MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
-			MainWindow::instance()->getNotificationWidget()->setFuture(future);
+			exportFuncs::instance()->exportUsingStyleSheet(filename, ui->exportSelected->isChecked(), ui->CSVUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
+		MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
+		MainWindow::instance()->getNotificationWidget()->setFuture(exportFuncs::instance()->future);
 		}
 	}
 }
 
-void DiveLogExportDialog::export_depths(const char *filename, const bool selected_only)
-{
-	FILE *f;
-	struct dive *dive;
-	depth_t depth;
-	int i;
-	const char *unit = NULL;
-
-	struct membuffer buf = {};
-
-	for_each_dive (i, dive) {
-		if (selected_only && !dive->selected)
-			continue;
-
-		FOR_EACH_PICTURE (dive) {
-			int n = dive->dc.samples;
-			struct sample *s = dive->dc.sample;
-			depth.mm = 0;
-			while (--n >= 0 && (int32_t)s->time.seconds <= picture->offset.seconds) {
-				depth.mm = s->depth.mm;
-				s++;
-			}
-			put_format(&buf, "%s\t%.1f", picture->filename, get_depth_units(depth.mm, NULL, &unit));
-			put_format(&buf, "%s\n", unit);
-		}
-	}
-
-	f = subsurface_fopen(filename, "w+");
-	if (!f) {
-		report_error(qPrintable(tr("Can't open file %s")), filename);
-	} else {
-		flush_buffer(&buf, f); /*check for writing errors? */
-		fclose(f);
-	}
-	free_buffer(&buf);
-}
-
-void DiveLogExportDialog::exportProfile(QString filename, const bool selected_only)
-{
-	struct dive *dive;
-	int i;
-	int count = 0;
-	if (!filename.endsWith(".png", Qt::CaseInsensitive))
-		filename = filename.append(".png");
-	QFileInfo fi(filename);
-
-	for_each_dive (i, dive) {
-		if (selected_only && !dive->selected)
-			continue;
-		if (count)
-			saveProfile(dive, fi.path() + QDir::separator() + fi.completeBaseName().append(QString("-%1.").arg(count)) + fi.suffix());
-		else
-			saveProfile(dive, filename);
-		++count;
-	}
-}
-
-void DiveLogExportDialog::saveProfile(const struct dive *dive, const QString filename)
+void exportFuncs::saveProfile(const struct dive *dive, const QString filename)
 {
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
 	profile->plotDive(dive, true, false, true);
@@ -312,203 +229,4 @@ void DiveLogExportDialog::saveProfile(const struct dive *dive, const QString fil
 	QPixmap pix = profile->grab();
 	profile->setToolTipVisibile(true);
 	pix.save(filename);
-}
-
-void DiveLogExportDialog::export_TeX(const char *filename, const bool selected_only, bool plain)
-{
-	FILE *f;
-	QDir texdir = QFileInfo(filename).dir();
-	struct dive *dive;
-	const struct units *units = get_units();
-	const char *unit;
-	const char *ssrf;
-	int i;
-	bool need_pagebreak = false;
-
-	struct membuffer buf = {};
-
-	if (plain) {
-		ssrf = "";
-		put_format(&buf, "\\input subsurfacetemplate\n");
-		put_format(&buf, "%% This is a plain TeX file. Compile with pdftex, not pdflatex!\n");
-		put_format(&buf, "%% You will also need a subsurfacetemplate.tex in the current directory.\n");
-	} else {
-		ssrf = "ssrf";
-		put_format(&buf, "\\input subsurfacelatextemplate\n");
-		put_format(&buf, "%% This is a plain LaTeX file. Compile with pdflatex, not pdftex!\n");
-		put_format(&buf, "%% You will also need a subsurfacelatextemplate.tex in the current directory.\n");
-	}
-	put_format(&buf, "%% You can download an example from http://www.atdotde.de/~robert/subsurfacetemplate\n%%\n");
-	put_format(&buf, "%%\n");
-	put_format(&buf, "%% Notes: TeX/LaTex will not render the degree symbol correctly by default. In LaTeX, you may\n");
-	put_format(&buf, "%% add the following line to the end of the preamble of your template to ensure correct output:\n");
-	put_format(&buf, "%% \\usepackage[utf8]{inputenc}\n");
-	put_format(&buf, "%% \\usepackage{gensymb}\n");
-	put_format(&buf, "%% \\DeclareUnicodeCharacter{00B0}{\\degree}\n"); //replaces ° with \degree
-	put_format(&buf, "%%\n");
-
-	/* Define text fields with the units used for export.  These values are set in the Subsurface Preferences
-	 * and the text fields created here are included in the data fields below.
-	 */
-	put_format(&buf, "\n%% These fields contain the units used in other fields below. They may be\n");
-	put_format(&buf, "%% referenced as needed in TeX templates.\n");
-	put_format(&buf, "%% \n");
-	put_format(&buf, "%% By default, Subsurface exports units of volume as \"ℓ\" and \"cuft\", which do\n");
-	put_format(&buf, "%% not render well in TeX/LaTeX.  The code below substitutes \"L\" and \"ft$^{3}$\",\n");
-	put_format(&buf, "%% respectively.  If you wish to display the original values, you may edit this\n");
-	put_format(&buf, "%% list and all calls to those units will be updated in your document.\n");
-
-	put_format(&buf, "\\def\\%sdepthunit{\\%sunit%s}", ssrf, ssrf, units->length == units::METERS ? "meter" : "ft");
-	put_format(&buf, "\\def\\%sweightunit{\\%sunit%s}",ssrf, ssrf, units->weight == units::KG ? "kg" : "lb");
-	put_format(&buf, "\\def\\%spressureunit{\\%sunit%s}", ssrf, ssrf, units->pressure == units::BAR ? "bar" : "psi");
-	put_format(&buf, "\\def\\%stemperatureunit{\\%sunit%s}", ssrf, ssrf, units->temperature == units::CELSIUS ? "centigrade" : "fahrenheit");
-	put_format(&buf, "\\def\\%svolumeunit{\\%sunit%s}", ssrf, ssrf, units->volume == units::LITER ? "liter" : "cuft");
-	put_format(&buf, "\\def\\%sverticalspeedunit{\\%sunit%s}", ssrf, ssrf, units->length == units::METERS ? "meterpermin" : "ftpermin");
-
-	put_format(&buf, "\n%%%%%%%%%% Begin Dive Data: %%%%%%%%%%\n");
-
-	for_each_dive (i, dive) {
-		if (selected_only && !dive->selected)
-			continue;
-
-		saveProfile(dive, texdir.filePath(QString("profile%1.png").arg(dive->number)));
-		struct tm tm;
-		utc_mkdate(dive->when, &tm);
-
-		dive_site *site = dive->dive_site;
-		QRegExp ct("countrytag: (\\w+)");
-		QString country;
-		if (site && ct.indexIn(site->notes) >= 0)
-			country = ct.cap(1);
-		else
-			country = "";
-
-		pressure_t delta_p = {.mbar = 0};
-
-		QString star = "*";
-		QString viz = star.repeated(dive->visibility);
-		QString rating = star.repeated(dive->rating);
-
-		int i;
-		int qty_cyl;
-		int qty_weight;
-		double total_weight;
-
-		if (need_pagebreak) {
-			if (plain)
-				put_format(&buf, "\\vfill\\eject\n");
-
-			else
-				put_format(&buf, "\\newpage\n");
-		}
-		need_pagebreak = true;
-		put_format(&buf, "\n%% Time, Date, and location:\n");
-		put_format(&buf, "\\def\\%sdate{%04u-%02u-%02u}\n", ssrf,
-		      tm.tm_year, tm.tm_mon+1, tm.tm_mday);
-		put_format(&buf, "\\def\\%shour{%02u}\n", ssrf, tm.tm_hour);
-		put_format(&buf, "\\def\\%sminute{%02u}\n", ssrf, tm.tm_min);
-		put_format(&buf, "\\def\\%snumber{%d}\n", ssrf, dive->number);
-		put_format(&buf, "\\def\\%splace{%s}\n", ssrf, site ? site->name : "");
-		put_format(&buf, "\\def\\%sspot{}\n", ssrf);
-		put_format(&buf, "\\def\\%ssitename{%s}\n", ssrf, site ? site->name : "");
-		site ? put_format(&buf, "\\def\\%sgpslat{%f}\n", ssrf, site->location.lat.udeg / 1000000.0) : put_format(&buf, "\\def\\%sgpslat{}\n", ssrf);
-		site ? put_format(&buf, "\\def\\%sgpslon{%f}\n", ssrf, site->location.lon.udeg / 1000000.0) : put_format(&buf, "\\def\\gpslon{}\n");
-		put_format(&buf, "\\def\\%scomputer{%s}\n", ssrf, dive->dc.model);
-		put_format(&buf, "\\def\\%scountry{%s}\n", ssrf, qPrintable(country));
-		put_format(&buf, "\\def\\%stime{%u:%02u}\n", ssrf, FRACTION(dive->duration.seconds, 60));
-
-		put_format(&buf, "\n%% Dive Profile Details:\n");
-		dive->maxtemp.mkelvin ? put_format(&buf, "\\def\\%smaxtemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->maxtemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%smaxtemp{}\n", ssrf);
-		dive->mintemp.mkelvin ? put_format(&buf, "\\def\\%smintemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->mintemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%ssrfmintemp{}\n", ssrf);
-		dive->watertemp.mkelvin ? put_format(&buf, "\\def\\%swatertemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->watertemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%swatertemp{}\n", ssrf);
-		dive->airtemp.mkelvin ? put_format(&buf, "\\def\\%sairtemp{%.1f\\%stemperatureunit}\n", ssrf, get_temp_units(dive->airtemp.mkelvin, &unit), ssrf) : put_format(&buf, "\\def\\%sairtemp{}\n", ssrf);
-		dive->maxdepth.mm ? put_format(&buf, "\\def\\%smaximumdepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->maxdepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%smaximumdepth{}\n", ssrf);
-		dive->meandepth.mm ? put_format(&buf, "\\def\\%smeandepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->meandepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%smeandepth{}\n", ssrf);
-
-		struct tag_entry *tag = dive->tag_list;
-		QString tags;
-		if (tag) {
-			tags = tag->tag->name;
-			while ((tag = tag->next))
-				tags += QString(", ") + QString(tag->tag->name);
-		}
-		put_format(&buf, "\\def\\%stype{%s}\n", ssrf, qPrintable(tags));
-		put_format(&buf, "\\def\\%sviz{%s}\n", ssrf, qPrintable(viz));
-		put_format(&buf, "\\def\\%srating{%s}\n", ssrf, qPrintable(rating));
-		put_format(&buf, "\\def\\%splot{\\includegraphics[width=9cm,height=4cm]{profile%d}}\n", ssrf, dive->number);
-		put_format(&buf, "\\def\\%sprofilename{profile%d}\n", ssrf, dive->number);
-		put_format(&buf, "\\def\\%scomment{%s}\n", ssrf, dive->notes ? dive->notes : "");
-		put_format(&buf, "\\def\\%sbuddy{%s}\n", ssrf, dive->buddy ? dive->buddy : "");
-		put_format(&buf, "\\def\\%sdivemaster{%s}\n", ssrf, dive->divemaster ? dive->divemaster : "");
-		put_format(&buf, "\\def\\%ssuit{%s}\n", ssrf, dive->suit ? dive->suit : "");
-
-		// Print cylinder data
-		put_format(&buf, "\n%% Gas use information:\n");
-		qty_cyl = 0;
-		for (i = 0; i < dive->cylinders.nr; i++){
-			const cylinder_t &cyl = *get_cylinder(dive, i);
-			if (is_cylinder_used(dive, i) || (prefs.display_unused_tanks && cyl.type.description)){
-				put_format(&buf, "\\def\\%scyl%cdescription{%s}\n", ssrf, 'a' + i, cyl.type.description);
-				put_format(&buf, "\\def\\%scyl%cgasname{%s}\n", ssrf, 'a' + i, gasname(cyl.gasmix));
-				put_format(&buf, "\\def\\%scyl%cmixO2{%.1f\\%%}\n", ssrf, 'a' + i, get_o2(cyl.gasmix)/10.0);
-				put_format(&buf, "\\def\\%scyl%cmixHe{%.1f\\%%}\n", ssrf, 'a' + i, get_he(cyl.gasmix)/10.0);
-				put_format(&buf, "\\def\\%scyl%cmixN2{%.1f\\%%}\n", ssrf, 'a' + i, (100.0 - (get_o2(cyl.gasmix)/10.0) - (get_he(cyl.gasmix)/10.0)));
-				delta_p.mbar += cyl.start.mbar - cyl.end.mbar;
-				put_format(&buf, "\\def\\%scyl%cstartpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.start.mbar, &unit)/1.0, ssrf);
-				put_format(&buf, "\\def\\%scyl%cendpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.end.mbar, &unit)/1.0, ssrf);
-				qty_cyl += 1;
-			} else {
-				put_format(&buf, "\\def\\%scyl%cdescription{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%scyl%cgasname{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%scyl%cmixO2{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%scyl%cmixHe{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%scyl%cmixN2{}\n", ssrf, 'a' + i);
-				delta_p.mbar += cyl.start.mbar - cyl.end.mbar;
-				put_format(&buf, "\\def\\%scyl%cstartpress{}\n", ssrf, 'a' + i);
-				put_format(&buf, "\\def\\%scyl%cendpress{}\n", ssrf, 'a' + i);
-				qty_cyl += 1;
-			}
-		}
-		put_format(&buf, "\\def\\%sqtycyl{%d}\n", ssrf, qty_cyl);
-		put_format(&buf, "\\def\\%sgasuse{%.1f\\%spressureunit}\n", ssrf, get_pressure_units(delta_p.mbar, &unit)/1.0, ssrf);
-		put_format(&buf, "\\def\\%ssac{%.2f\\%svolumeunit/min}\n", ssrf, get_volume_units(dive->sac, NULL, &unit), ssrf);
-
-		//Code block prints all weights listed in dive.
-		put_format(&buf, "\n%% Weighting information:\n");
-		qty_weight = 0;
-		total_weight = 0;
-		for (i = 0; i < dive->weightsystems.nr; i++) {
-			weightsystem_t w = dive->weightsystems.weightsystems[i];
-			put_format(&buf, "\\def\\%sweight%ctype{%s}\n", ssrf, 'a' + i, w.description);
-			put_format(&buf, "\\def\\%sweight%camt{%.3f\\%sweightunit}\n", ssrf, 'a' + i, get_weight_units(w.weight.grams, NULL, &unit), ssrf);
-			qty_weight += 1;
-			total_weight += get_weight_units(w.weight.grams, NULL, &unit);
-		}
-		put_format(&buf, "\\def\\%sqtyweights{%d}\n", ssrf, qty_weight);
-		put_format(&buf, "\\def\\%stotalweight{%.2f\\%sweightunit}\n", ssrf, total_weight, ssrf);
-		unit = "";
-
-		// Legacy fields
-		put_format(&buf, "\\def\\%sspot{}\n", ssrf);
-		put_format(&buf, "\\def\\%sentrance{}\n", ssrf);
-		put_format(&buf, "\\def\\%splace{%s}\n", ssrf, site ? site->name : "");
-		dive->maxdepth.mm ? put_format(&buf, "\\def\\%sdepth{%.1f\\%sdepthunit}\n", ssrf, get_depth_units(dive->maxdepth.mm, NULL, &unit), ssrf) : put_format(&buf, "\\def\\%sdepth{}\n", ssrf);
-
-		put_format(&buf, "\\%spage\n", ssrf);
-
-	}
-
-	if (plain)
-		put_format(&buf, "\\bye\n");
-	else
-		put_format(&buf, "\\end{document}\n");
-
-	f = subsurface_fopen(filename, "w+");
-	if (!f) {
-		report_error(qPrintable(tr("Can't open file %s")), filename);
-	} else {
-		flush_buffer(&buf, f); /*check for writing errors? */
-		fclose(f);
-	}
-	free_buffer(&buf);
 }

--- a/desktop-widgets/divelogexportdialog.h
+++ b/desktop-widgets/divelogexportdialog.h
@@ -4,7 +4,6 @@
 
 #include <QDialog>
 #include <QTextStream>
-#include <QFuture>
 #include "core/statistics.h"
 
 class QAbstractButton;
@@ -28,14 +27,9 @@ slots:
 	void on_exportGroup_buttonClicked(QAbstractButton *);
 
 private:
-	QFuture<int> future;
 	Ui::DiveLogExportDialog *ui;
 	void showExplanation();
 	void exportHtmlInit(const QString &filename);
-	void export_depths(const char *filename, const bool selected_only);
-	void export_TeX(const char *filename, const bool selected_only, bool plain);
-	void exportProfile(QString filename, const bool selected_only);
-	void saveProfile(const struct dive *dive, const QString filename);
 
 };
 

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -107,6 +107,7 @@ Kirigami.ScrollablePage {
 		}
 		RadioButton {
 			Layout.fillWidth: true
+			visible: false // TEMPORARY MEASURE, until non UI related WEB service is ready
 			text: qsTr("Upload divelogs.de")
 			exclusiveGroup: radioGroup
 			onClicked: {
@@ -116,6 +117,7 @@ Kirigami.ScrollablePage {
 		}
 		RadioButton {
 			Layout.fillWidth: true
+			visible: false // TEMPORARY MEASURE, until non UI related WEB service is ready
 			text: qsTr("Upload DiveShare")
 			exclusiveGroup: radioGroup
 			onClicked: {

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -88,6 +88,7 @@ Kirigami.ScrollablePage {
 		}
 		RadioButton {
 			Layout.fillWidth: true
+			visible: false // TEMPORARY MEASURE, until DiveFilter is available
 			text: qsTr("Export Subsurface dive sites XML")
 			exclusiveGroup: radioGroup
 			onClicked: {

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -12,6 +12,20 @@ Kirigami.ScrollablePage {
 
 	property int selectedExport: ExportType.EX_DIVE_XML
 
+	FileDialog {
+		id: saveAsDialog
+		folder: shortcuts.documents
+		selectFolder: true
+		title: radioGroup.current.text
+		onAccepted: {
+			manager.exportToFile(selectedExport, fileUrls, anonymize.checked)
+			close()
+		}
+		onRejected: {
+			close()
+		}
+	}
+
 	ColumnLayout {
 		width: parent.width
 		spacing: 1
@@ -149,6 +163,12 @@ Kirigami.ScrollablePage {
 		SsrfButton {
 			text: qsTr("Next")
 			onClicked: {
+				if (selectedExport === ExportType.EX_DIVELOGS_DE ||
+					selectedExport === ExportType.EX_DIVESHARE) {
+					console.log("Upload TO BE DONE, You chose: " + selectedExport)
+				} else {
+					saveAsDialog.open()
+				}
 			}
 		}
 	}

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -154,6 +154,7 @@ Kirigami.ScrollablePage {
 		}
 		RadioButton {
 			Layout.fillWidth: true
+			visible: false // TEMPORARY MEASURE, until a non UI PNG generation is ready
 			text: qsTr("Export Dive profile")
 			exclusiveGroup: radioGroup
 			onClicked: {

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -26,6 +26,50 @@ Kirigami.ScrollablePage {
 		}
 	}
 
+	Dialog {
+		id: uploadDialog
+		title: radioGroup.current.text
+		standardButtons: StandardButton.Apply | StandardButton.Cancel
+
+		GridLayout {
+			rowSpacing: 10
+			columnSpacing: 10
+			columns: 2
+
+			Text {
+				text: qsTr("User ID")
+			}
+			TextField {
+				id: fieldUserID
+				Layout.fillWidth: true
+				inputMethodHints: Qt.ImhNoAutoUppercase
+			}
+			Text {
+				text: qsTr("Password:")
+			}
+			TextField {
+				id: fieldPassword
+				Layout.fillWidth: true
+				inputMethodHints: Qt.ImhSensitiveData |
+								  Qt.ImhHiddenText |
+								  Qt.ImhNoAutoUppercase
+				echoMode: TextInput.PasswordEchoOnEdit
+			}
+			ProgressBar {
+				indeterminate: true
+			}
+		}
+
+		onApply: {
+			manager.exportToWEB(selectedExport, fieldUserID.text, fieldPassword.text, anonymize.checked)
+			close()
+		}
+		onRejected: {
+			close()
+		}
+
+	}
+
 	ColumnLayout {
 		width: parent.width
 		spacing: 1
@@ -165,7 +209,7 @@ Kirigami.ScrollablePage {
 			onClicked: {
 				if (selectedExport === ExportType.EX_DIVELOGS_DE ||
 					selectedExport === ExportType.EX_DIVESHARE) {
-					console.log("Upload TO BE DONE, You chose: " + selectedExport)
+					uploadDialog.open()
 				} else {
 					saveAsDialog.open()
 				}

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls 1.4
+import QtQuick.Layouts 1.12
+import QtQuick.Dialogs 1.3
+import org.subsurfacedivelog.mobile 1.0
+import org.kde.kirigami 2.4 as Kirigami
+
+Kirigami.ScrollablePage {
+	title: qsTr("Export Divelog information")
+
+	property int selectedExport: ExportType.EX_DIVE_XML
+
+	ColumnLayout {
+		width: parent.width
+		spacing: 1
+		Layout.margins: 10
+
+		ExclusiveGroup { id: radioGroup }
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export Subsurface XML")
+			checked: true
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_DIVES_XML
+				explain.text = qsTr("Subsurface native XML format.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export Subsurface dive sites XML")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_DIVE_SITES_XML
+				explain.text = qsTr("Subsurface dive sites native XML format.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export UDDF")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_UDDF
+				explain.text = qsTr("Generic format that is used for data exchange between a variety of diving related programs.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Upload divelogs.de")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_DIVELOGS_DE
+				explain.text = qsTr("Send the dive data to divelogs.de website.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Upload DiveShare")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_DIVESHARE
+				explain.text = qsTr("Send the dive data to dive-share.appspot.com website.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export CSV dive profile")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_CSV_DIVE_PROFILE
+				explain.text = qsTr("Comma separated values describing the dive profile.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export CSV dive details")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_CSV_DETAILS
+				explain.text = qsTr("Comma separated values of the dive information. This includes most of the dive details but no profile information.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export CSV profile data")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_CSV_PROFILE
+				explain.text = qsTr("Write profile data to a CSV file.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export Dive profile")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_PROFILE_PNG
+				explain.text = qsTr("Write the profile image as PNG file.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export Worldmap")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_WORLD_MAP
+				explain.text = qsTr("HTML export of the dive locations, visualized on a world map.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export TeX")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_TEX
+				explain.text = qsTr("Write dive as TeX macros to file.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export LaTeX")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_LATEX
+				explain.text = qsTr("Write dive as LaTeX macros to file.")
+			}
+		}
+		RadioButton {
+			Layout.fillWidth: true
+			text: qsTr("Export Image depths")
+			exclusiveGroup: radioGroup
+			onClicked: {
+				selectedExport = ExportType.EX_IMAGE_DEPTHS
+				explain.text = qsTr("Write depths of images to file.")
+			}
+		}
+		Text {
+			id: explain
+			Layout.fillWidth: true
+			wrapMode: Text.Wrap
+		}
+		CheckBox {
+			id: anonymize
+			Layout.fillWidth: true
+			text: qsTr("Anonymize")
+		}
+		SsrfButton {
+			text: qsTr("Next")
+			onClicked: {
+			}
+		}
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -436,6 +436,17 @@ if you have network connectivity and want to sync your data to cloud storage."),
 			},
 			Kirigami.Action {
 				icon {
+					name: ":/icons/ic_cloud_upload.svg"
+				}
+				text: qsTr("Export")
+				onTriggered: {
+					globalDrawer.close()
+					pageStack.push(exportWindow)
+					detailsWindow.endEditMode()
+				}
+			},
+			Kirigami.Action {
+				icon {
 					name: ":/icons/ic_help_outline.svg"
 				}
 				text: qsTr("Help")
@@ -791,6 +802,11 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 	About {
 		id: aboutWindow
+		visible: false
+	}
+
+	Export {
+		id: exportWindow
 		visible: false
 	}
 

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -9,6 +9,7 @@
 		<file>DiveList.qml</file>
 		<file>DownloadFromDiveComputer.qml</file>
 		<file>DownloadedDiveDelegate.qml</file>
+		<file>Export.qml</file>
 		<file>GpsList.qml</file>
 		<file>HintsTextEdit.qml</file>
 		<file>Log.qml</file>

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -91,4 +91,13 @@
 		<file alias="go-next-symbolic">kirigami/icons/go-next.svg</file>
 		<file alias="go-previous-symbolic">kirigami/icons/go-previous.svg</file>
 	</qresource>
+
+
+	<qresource prefix="/qml">
+		<!-- ********** xslt ********** -->
+		<file alias="xslt/commonTemplates.xsl">../../xslt/commonTemplates.xsl</file>
+		<file alias="xslt/uddf-export.xslt">../../xslt/uddf-export.xslt</file>
+		<file alias="xslt/xml2csv.xslt">../../xslt/xml2csv.xslt</file>
+		<file alias="xslt/xml2manualcsv.xslt">../../xslt/xml2manualcsv.xslt</file>
+	</qresource>
 </RCC>

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -53,6 +53,26 @@ public:
 	QMLManager();
 	~QMLManager();
 
+	enum export_types {
+		EX_DIVES_XML,
+		EX_DIVE_SITES_XML,
+		EX_UDDF,
+		EX_DIVELOGS_DE,
+		EX_DIVESHARE,
+		EX_CSV_DIVE_PROFILE,
+		EX_CSV_DETAILS,
+		EX_CSV_PROFILE,
+		EX_PROFILE_PNG,
+		EX_WORLD_MAP,
+		EX_TEX,
+		EX_LATEX,
+		EX_IMAGE_DEPTHS
+	};
+	Q_ENUM(export_types)
+	Q_INVOKABLE void exportToFile(export_types type, QString directory, bool anonymize);
+	Q_INVOKABLE void exportToWEB(export_types type, QString userId, QString password, bool anonymize);
+
+
 	QString DC_vendor() const;
 	void DC_setVendor(const QString& vendor);
 

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -28,6 +28,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/divesitehelpers.cpp \
 	../../core/errorhelper.c \
 	../../core/exif.cpp \
+	../../core/exportfuncs.cpp \
 	../../core/format.cpp \
 	../../core/gettextfromc.cpp \
 	../../core/metrics.cpp \
@@ -80,6 +81,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/btdiscovery.cpp \
 	../../core/connectionlistmodel.cpp \
 	../../core/qt-ble.cpp \
+	../../core/save-profiledata.c \
 	../../core/settings/qPref.cpp \
 	../../core/settings/qPrefCloudStorage.cpp \
 	../../core/settings/qPrefDisplay.cpp \
@@ -177,6 +179,7 @@ HEADERS += \
 	../../core/divelogexportlogic.h \
 	../../core/divesitehelpers.h \
 	../../core/exif.h \
+	../../core/exportfuncs.h \
 	../../core/file.h \
 	../../core/gaspressures.h \
 	../../core/gettext.h \
@@ -198,6 +201,7 @@ HEADERS += \
 	../../core/btdiscovery.h \
 	../../core/connectionlistmodel.h \
 	../../core/qt-ble.h \
+	../../core/save-profiledata.h \
 	../../core/settings/qPref.h \
 	../../core/settings/qPrefCloudStorage.h \
 	../../core/settings/qPrefDisplay.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -111,6 +111,8 @@ void run_ui()
 	ctxt->setContextProperty("connectionListModel", &connectionListModel);
 	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
 
+	qmlRegisterUncreatableType<QMLManager>("org.subsurfacedivelog.mobile",1,0,"ExportType","Enum is not a type");
+
 #ifdef SUBSURFACE_MOBILE_DESKTOP
 	if (testqml) {
 		QString fileLoad(testqml);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Add the possibility to do export directly in Subsurface-mobile.

The dialogs are kept close to the desktop version, with needed differences
(f.x. Subsurface-mobile to not have "selected dives" so all dives are exported).

The functionality is in principle the same as the desktop, and the "old" export 
functions have been moved from desktop-widgets to core in order to be shared.

There were a couple of problems found during implementation:

1) generating a PNG file (export profile) is intertwined with the UI and needs to 
be done completely different in mobile. Provisions are made to have 2 different
implementations, but the mobile implementation is open.

2) DiveFilter have 2 different implementations, and the mobile one is very limited, therefore
"exporting dive sites" would have needed a completely different implementation. The better
solution is to make the full functionality of DiveFilter available to Subsurface-mobile, but
that is outside the scope of this PR.

3) Upload to DiveShare and DiveLogs.de, the current web service implementation is 
intertwined with the UI and need to be detangled.

4) The design could use improvements.

These will be addressed later by me, or others.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
See Commits, which each are small, and considered documented.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Allowed myself to include a commit (first one) even though it is not related to the patch, but
administrative important.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Added change to CHANGELOG.md

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
GlobalDrawer contains a new entry "Export"
New Export page
New File dialog (standard QT version)

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
