### PR TITLE
Implement proper(?) Qt model semantics for dive filtering

### DIFF
--- a/commands/CMakeLists.txt
+++ b/commands/CMakeLists.txt
@@ -14,8 +14,6 @@ set(SUBSURFACE_GENERIC_COMMANDS_SRCS
 	command_edit.h
 	command_edit_trip.cpp
 	command_edit_trip.h
-	command_private.cpp
-	command_private.h
 )
 if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DesktopExecutable")
 	add_library(subsurface_commands_desktop STATIC ${SUBSURFACE_GENERIC_COMMANDS_SRCS})

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "command_divelist.h"
-#include "command_private.h"
 #include "core/divelist.h"
 #include "core/display.h" // for amount_selected
 #include "core/qthelper.h"
+#include "core/selection.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "qt-models/filtermodels.h"
 #include "../profile-widget/profilewidget2.h"

--- a/commands/command_divesite.cpp
+++ b/commands/command_divesite.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "command_divesite.h"
-#include "command_private.h"
 #include "core/divesite.h"
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include "core/qthelper.h"

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "command_edit.h"
-#include "command_private.h"
 #include "core/divelist.h"
 #include "core/qthelper.h" // for copy_qstring
+#include "core/selection.h"
 #include "core/subsurface-string.h"
 #include "core/tag.h"
 

--- a/commands/command_edit_trip.cpp
+++ b/commands/command_edit_trip.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "command_edit_trip.h"
-#include "command_private.h"
 #include "core/qthelper.h"
+#include "core/selection.h"
 
 namespace Command {
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -139,6 +139,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	save-html.h
 	save-profiledata.c
 	save-xml.c
+	selection.cpp
+	selection.h
 	sha1.c
 	sha1.h
 	ssrf.h

--- a/core/display.h
+++ b/core/display.h
@@ -29,8 +29,6 @@ extern struct divecomputer *select_dc(struct dive *);
 
 extern unsigned int dc_number;
 
-extern unsigned int amount_selected;
-
 extern int is_default_dive_computer_device(const char *);
 extern int is_default_dive_computer(const char *, const char *);
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1,23 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
 /* divelist.c */
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <math.h>
-#include "gettext.h"
-#include <assert.h>
-#include <zip.h>
-#include <libxslt/transform.h>
 
 #include "subsurface-string.h"
 #include "deco.h"
 #include "divesite.h"
 #include "divelist.h"
-#include "display.h"
 #include "planner.h"
 #include "qthelper.h"
+#include "gettext.h"
 #include "git-access.h"
 #include "selection.h"
 #include "table.h"

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -41,12 +41,7 @@ extern void insert_dive(struct dive_table *table, struct dive *d);
 extern void get_dive_gas(const struct dive *dive, int *o2_p, int *he_p, int *o2low_p);
 extern int get_divenr(const struct dive *dive);
 extern int remove_dive(const struct dive *dive, struct dive_table *table);
-extern bool consecutive_selected();
-extern void select_dive(struct dive *dive);
-extern void deselect_dive(struct dive *dive);
 extern bool filter_dive(struct dive *d, bool shown); /* returns true if status changed */
-extern struct dive *first_selected_dive();
-extern struct dive *last_selected_dive();
 extern int get_dive_nr_at_idx(int idx);
 extern void set_dive_nr_for_current_dive();
 extern timestamp_t get_surface_interval(timestamp_t when);
@@ -62,10 +57,6 @@ int get_dive_id_closest_to(timestamp_t when);
 void clear_dive_file_data();
 void clear_dive_table(struct dive_table *table);
 void move_dive_table(struct dive_table *src, struct dive_table *dst);
-
-#ifdef DEBUG_TRIP
-extern void dump_selection(void);
-#endif
 
 #ifdef __cplusplus
 }

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 // Helper functions for the undo-commands
 
-#include "command_private.h"
-#include "core/divelist.h"
-#include "core/display.h" // for amount_selected
-#include "core/subsurface-qt/DiveListNotifier.h"
+#include "selection.h"
+#include "divelist.h"
+#include "display.h" // for amount_selected
+#include "subsurface-qt/DiveListNotifier.h"
 
-namespace Command {
+#include <QVector>
 
 // Set the current dive either from a list of selected dives,
 // or a newly selected dive. In both cases, try to select the
@@ -104,5 +104,3 @@ std::vector<dive *> getDiveSelection()
 	}
 	return res;
 }
-
-} // namespace Command

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -210,3 +210,16 @@ std::vector<dive *> getDiveSelection()
 	}
 	return res;
 }
+
+// Select the first dive that is visible
+extern "C" void select_newest_visible_dive()
+{
+	for (int i = dive_table.nr - 1; i >= 0; --i) {
+		dive *d = dive_table.dives[i];
+		if (!d->hidden_by_filter)
+			return setSelection({ d }, d);
+	}
+
+	// No visible dive -> deselect all
+	setSelection({}, nullptr);
+}

--- a/core/selection.h
+++ b/core/selection.h
@@ -4,12 +4,34 @@
 #ifndef SELECTION_H
 #define SELECTION_H
 
+struct dive;
+
+extern int amount_selected;
+
+/*** C and C++ functions ***/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void select_dive(struct dive *dive);
+extern void deselect_dive(struct dive *dive);
+extern struct dive *first_selected_dive(void);
+extern struct dive *last_selected_dive(void);
+extern bool consecutive_selected(void);
+
+#if DEBUG_SELECTION_TRACKING
+extern void dump_selection(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
 /*** C++-only functions ***/
 
 #ifdef __cplusplus
 #include <vector>
-
-struct dive;
 
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or

--- a/core/selection.h
+++ b/core/selection.h
@@ -1,25 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0
-// Private definitions for the command-objects
+// Selection related functions
 
-#ifndef COMMAND_PRIVATE_H
-#define COMMAND_PRIVATE_H
+#ifndef SELECTION_H
+#define SELECTION_H
 
-#include "core/dive.h"
+/*** C++-only functions ***/
 
+#ifdef __cplusplus
 #include <vector>
-#include <utility>
-#include <QVector>
 
-namespace Command {
+struct dive;
 
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
-// null if "seletion" is empty). Return true if the selection or current dive changed.
+// null if "seletion" is empty).
 void setSelection(const std::vector<dive *> &selection, dive *currentDive);
 
 // Get currently selectd dives
 std::vector<dive *> getDiveSelection();
 
-} // namespace Command
+#endif // __cplusplus
 
-#endif // COMMAND_PRIVATE_H
+#endif // SELECTION_H

--- a/core/selection.h
+++ b/core/selection.h
@@ -19,6 +19,7 @@ extern void deselect_dive(struct dive *dive);
 extern struct dive *first_selected_dive(void);
 extern struct dive *last_selected_dive(void);
 extern bool consecutive_selected(void);
+extern void select_newest_visible_dive();
 
 #if DEBUG_SELECTION_TRACKING
 extern void dump_selection(void);

--- a/core/trip.c
+++ b/core/trip.c
@@ -2,6 +2,7 @@
 
 #include "trip.h"
 #include "subsurface-string.h"
+#include "selection.h"
 #include "table.h"
 
 struct trip_table trip_table;

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -480,8 +480,6 @@ void DiveListView::sortIndicatorChanged(int i, Qt::SortOrder order)
 		sortByColumn(i, order);
 	} else {
 		// clear the model, repopulate with new indexes.
-		rememberSelection();
-		unselectDives();
 		if (currentLayout == DiveTripModelBase::TREE)
 			backupExpandedRows();
 		currentLayout = newLayout;
@@ -489,7 +487,6 @@ void DiveListView::sortIndicatorChanged(int i, Qt::SortOrder order)
 		sortByColumn(i, order);
 		if (newLayout == DiveTripModelBase::TREE)
 			restoreExpandedRows();
-		restoreSelection();
 	}
 }
 

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -9,7 +9,7 @@
 #include "desktop-widgets/modeldelegates.h"
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/divepicturewidget.h"
-#include "core/display.h"
+#include "core/selection.h"
 #include "core/divefilter.h"
 #include <unistd.h>
 #include <QSettings>

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -86,8 +86,11 @@ void DiveListView::resetModel()
 	MultiFilterSortModel::instance()->resetModel(currentLayout);
 	// If the model was reset, we have to reconnect the signals and tell
 	// the filter model to update its source model.
-	connect(DiveTripModelBase::instance(), &DiveTripModelBase::selectionChanged, this, &DiveListView::diveSelectionChanged);
-	connect(DiveTripModelBase::instance(), &DiveTripModelBase::currentDiveChanged, this, &DiveListView::currentDiveChanged);
+	DiveTripModelBase *m = DiveTripModelBase::instance();
+	connect(m, &DiveTripModelBase::selectionChanged, this, &DiveListView::diveSelectionChanged);
+	connect(m, &DiveTripModelBase::currentDiveChanged, this, &DiveListView::currentDiveChanged);
+	// Get the initial selection
+	m->initSelection();
 }
 
 void DiveListView::calculateInitialColumnWidth(int col)
@@ -519,10 +522,6 @@ void DiveListView::reload()
 {
 	resetModel();
 
-	if (amount_selected && current_dive != NULL)
-		selectDive(get_divenr(current_dive), true);
-	else
-		select_newest_visible_dive();
 	if (selectedIndexes().count()) {
 		QModelIndex curr = selectedIndexes().first();
 		curr = curr.parent().isValid() ? curr.parent() : curr;

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -30,7 +30,7 @@
 #include "desktop-widgets/simplewidgets.h"
 #include "desktop-widgets/mapwidget.h"
 
-DiveListView::DiveListView(QWidget *parent) : QTreeView(parent), mouseClickSelection(false),
+DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	currentLayout(DiveTripModelBase::TREE),
 	initialColumnWidths(DiveTripModelBase::COLUMNS, 50)	// Set up with default length 50
 {

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -474,28 +474,6 @@ void DiveListView::selectDives(const QList<int> &newDiveSelection)
 	selectionChangeDone();
 }
 
-// Get index of first dive. This assumes that trips without dives are never shown.
-// May return an invalid index if no dive is found.
-QModelIndex DiveListView::indexOfFirstDive()
-{
-	// Fetch the first top-level item. If this is a trip, it is supposed to have at least
-	// one child. In that case return the child. Otherwise return the top-level item, which
-	// should be a dive.
-	QAbstractItemModel *m = model();
-	QModelIndex firstDiveOrTrip = m->index(0, 0);
-	if (!firstDiveOrTrip.isValid())
-		return QModelIndex();
-	QModelIndex child = m->index(0, 0, firstDiveOrTrip);
-	return child.isValid() ? child : firstDiveOrTrip;
-}
-
-void DiveListView::selectFirstDive()
-{
-	QModelIndex first = indexOfFirstDive();
-	if (first.isValid())
-		setCurrentIndex(first);
-}
-
 bool DiveListView::eventFilter(QObject *, QEvent *event)
 {
 	if (event->type() != QEvent::KeyPress)
@@ -544,7 +522,7 @@ void DiveListView::reload()
 	if (amount_selected && current_dive != NULL)
 		selectDive(get_divenr(current_dive), true);
 	else
-		selectFirstDive();
+		select_newest_visible_dive();
 	if (selectedIndexes().count()) {
 		QModelIndex curr = selectedIndexes().first();
 		curr = curr.parent().isValid() ? curr.parent() : curr;
@@ -1114,7 +1092,7 @@ void DiveListView::filterFinished()
 
 	// If there are no more selected dives, select the first visible dive
 	if (!selectionModel()->hasSelection())
-		selectFirstDive();
+		select_newest_visible_dive();
 	emit divesSelected();
 }
 

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -322,13 +322,11 @@ QList<dive_trip_t *> DiveListView::selectedTrips()
 	return ret;
 }
 
-void DiveListView::selectDive(QModelIndex idx, bool scrollto, bool toggle)
+void DiveListView::selectDive(QModelIndex idx, bool scrollto)
 {
 	if (!idx.isValid())
 		return;
-	QItemSelectionModel::SelectionFlags flags = toggle ? QItemSelectionModel::Toggle : QItemSelectionModel::Select;
-	flags |= QItemSelectionModel::Rows;
-	selectionModel()->setCurrentIndex(idx, flags);
+	selectionModel()->setCurrentIndex(idx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
 	if (idx.parent().isValid()) {
 		setAnimated(false);
 		expand(idx.parent());
@@ -341,7 +339,7 @@ void DiveListView::selectDive(QModelIndex idx, bool scrollto, bool toggle)
 	selectionChangeDone();
 }
 
-void DiveListView::selectDive(int i, bool scrollto, bool toggle)
+void DiveListView::selectDive(int i, bool scrollto)
 {
 	if (i == -1)
 		return;
@@ -350,7 +348,7 @@ void DiveListView::selectDive(int i, bool scrollto, bool toggle)
 	if (match.isEmpty())
 		return;
 	QModelIndex idx = match.first();
-	selectDive(idx, scrollto, toggle);
+	selectDive(idx, scrollto);
 }
 
 void DiveListView::selectDives(const QList<int> &newDiveSelection)

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -87,7 +87,7 @@ void DiveListView::resetModel()
 	// If the model was reset, we have to reconnect the signals and tell
 	// the filter model to update its source model.
 	connect(DiveTripModelBase::instance(), &DiveTripModelBase::selectionChanged, this, &DiveListView::diveSelectionChanged);
-	connect(DiveTripModelBase::instance(), &DiveTripModelBase::newCurrentDive, this, &DiveListView::currentDiveChanged);
+	connect(DiveTripModelBase::instance(), &DiveTripModelBase::currentDiveChanged, this, &DiveListView::currentDiveChanged);
 }
 
 void DiveListView::calculateInitialColumnWidth(int col)

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -34,8 +34,6 @@ public:
 	void selectDive(QModelIndex index, bool scrollto = false, bool toggle = false);
 	void selectDive(int dive_table_idx, bool scrollto = false, bool toggle = false);
 	void selectDives(const QList<int> &newDiveSelection);
-	void selectFirstDive();
-	QModelIndex indexOfFirstDive();
 	void rememberSelection();
 	void restoreSelection();
 	void contextMenuEvent(QContextMenuEvent *event);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -34,8 +34,6 @@ public:
 	void selectDive(QModelIndex index, bool scrollto = false, bool toggle = false);
 	void selectDive(int dive_table_idx, bool scrollto = false, bool toggle = false);
 	void selectDives(const QList<int> &newDiveSelection);
-	void rememberSelection();
-	void restoreSelection();
 	void contextMenuEvent(QContextMenuEvent *event);
 	QList<dive_trip *> selectedTrips();
 	static QString lastUsedImageDir();
@@ -76,12 +74,9 @@ private:
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;
 	bool dontEmitDiveChangedSignal;
-	bool selectionSaved;
 	// Remember the initial column widths, to avoid writing unchanged widths to the settings
 	QVector<int> initialColumnWidths;
 
-	/* if dive_trip_t is null, there's no problem. */
-	QMultiHash<dive_trip *, int> selectedDives;
 	void resetModel();	// Call after model changed
 	void merge_trip(const QModelIndex &a, const int offset);
 	void setColumnWidths();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -31,8 +31,8 @@ public:
 	bool eventFilter(QObject *, QEvent *);
 	void unselectDives();
 	void clearTripSelection();
-	void selectDive(QModelIndex index, bool scrollto = false, bool toggle = false);
-	void selectDive(int dive_table_idx, bool scrollto = false, bool toggle = false);
+	void selectDive(QModelIndex index, bool scrollto = false);
+	void selectDive(int dive_table_idx, bool scrollto = false);
 	void selectDives(const QList<int> &newDiveSelection);
 	void contextMenuEvent(QContextMenuEvent *event);
 	QList<dive_trip *> selectedTrips();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -69,7 +69,6 @@ private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
 	void selectAll() override;
 	void selectionChangeDone();
-	bool mouseClickSelection;
 	QList<int> expandedRows;
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -69,7 +69,6 @@ private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
 	void selectAll() override;
 	void selectionChangeDone();
-	QList<int> expandedRows;
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;
 	bool dontEmitDiveChangedSignal;
@@ -80,8 +79,8 @@ private:
 	void merge_trip(const QModelIndex &a, const int offset);
 	void setColumnWidths();
 	void calculateInitialColumnWidth(int col);
-	void backupExpandedRows();
-	void restoreExpandedRows();
+	std::vector<int> backupExpandedRows();
+	void restoreExpandedRows(const std::vector<int> &);
 	int lastVisibleColumn();
 	void selectTrip(dive_trip *trip);
 	void updateLastImageTimeOffset(int offset);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -71,7 +71,6 @@ private:
 	void selectionChangeDone();
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;
-	bool dontEmitDiveChangedSignal;
 	// Remember the initial column widths, to avoid writing unchanged widths to the settings
 	QVector<int> initialColumnWidths;
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -149,7 +149,6 @@ void RenumberDialog::renumberOnlySelected(bool selected)
 void RenumberDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
-		MainWindow::instance()->diveList->rememberSelection();
 		// we remember a list from dive uuid to a new number
 		QVector<QPair<dive *, int>> renumberedDives;
 		int i;

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -18,7 +18,7 @@
 #include "core/qthelper.h"
 #include "libdivecomputer/parser.h"
 #include "desktop-widgets/divelistview.h"
-#include "core/display.h"
+#include "core/selection.h"
 #include "profile-widget/profilewidget2.h"
 #include "commands/command.h"
 #include "core/metadata.h"

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -11,7 +11,7 @@
 #include "core/file.h"
 #include "desktop-widgets/mapwidget.h"
 #include "desktop-widgets/tab-widgets/maintab.h"
-#include "core/display.h"
+#include "core/selection.h"
 #include "core/membuffer.h"
 #include "core/cloudstorage.h"
 #include "core/subsurface-string.h"

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -2,9 +2,9 @@
 #include "TabDiveStatistics.h"
 #include "ui_TabDiveStatistics.h"
 
-#include <core/qthelper.h>
-#include <core/selection.h>
-#include <core/statistics.h>
+#include "core/qthelper.h"
+#include "core/selection.h"
+#include "core/statistics.h"
 
 TabDiveStatistics::TabDiveStatistics(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveStatistics())
 {

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -3,7 +3,7 @@
 #include "ui_TabDiveStatistics.h"
 
 #include <core/qthelper.h>
-#include <core/display.h>
+#include <core/selection.h>
 #include <core/statistics.h>
 
 TabDiveStatistics::TabDiveStatistics(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveStatistics())

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -554,9 +554,7 @@ void MainTab::acceptChanges()
 		MainWindow::instance()->refreshDisplay();
 		MainWindow::instance()->graphics->replot();
 	} else {
-		MainWindow::instance()->diveList->rememberSelection();
 		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->diveList->restoreSelection();
 	}
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
 	MainWindow::instance()->diveList->verticalScrollBar()->setSliderPosition(scrolledBy);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -12,7 +12,7 @@
 #include "core/trip.h"
 #include "qt-models/diveplannermodel.h"
 #include "desktop-widgets/divelistview.h"
-#include "core/display.h"
+#include "core/selection.h"
 #include "profile-widget/profilewidget2.h"
 #include "desktop-widgets/diveplanner.h"
 #include "core/divesitehelpers.h"

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -4,7 +4,7 @@
 #include <list>
 
 #include "templatelayout.h"
-#include "core/display.h"
+#include "core/selection.h"
 
 QList<QString> grantlee_templates, grantlee_statistics_templates;
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -36,6 +36,7 @@
 #include "core/downloadfromdcthread.h"
 #include "core/subsurface-string.h"
 #include "core/pref.h"
+#include "core/selection.h"
 #include "core/ssrf.h"
 #include "core/save-profiledata.h"
 #include "core/settings/qPrefGeneral.h"

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -70,6 +70,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/equipment.c \
 	../../core/gas.c \
 	../../core/membuffer.c \
+	../../core/selection.cpp \
 	../../core/sha1.c \
 	../../core/strtod.c \
 	../../core/tag.c \
@@ -187,6 +188,8 @@ HEADERS += \
 	../../core/membuffer.h \
 	../../core/metrics.h \
 	../../core/qt-gui.h \
+	../../core/selection.h \
+	../../core/divecomputer.h \
 	../../core/sha1.h \
 	../../core/strndup.h \
 	../../core/subsurfacestartup.h \

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -691,6 +691,17 @@ dive *DiveTripModelTree::diveOrNull(const QModelIndex &index) const
 	return tripOrDive(index).dive;
 }
 
+static bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter)
+{
+	bool showTrip = false;
+	for (dive *d: dives) {
+		bool shown = filter->showDive(d);
+		filter_dive(d, shown);
+		showTrip |= shown;
+	}
+	return showTrip;
+}
+
 void DiveTripModelTree::recalculateFilter()
 {
 	{
@@ -710,17 +721,10 @@ void DiveTripModelTree::recalculateFilter()
 				filter_dive(d, item.shown);
 			} else {
 				// Trips are shown if any of the dives is shown
-				bool showTrip = false;
-				for (dive *d: item.dives) {
-					bool shown = filter->showDive(d);
-					filter_dive(d, shown);
-					showTrip |= shown;
-				}
-				item.shown = showTrip;
+				item.shown = calculateFilterForTrip(item.dives, filter);
 			}
 		}
 	}
-
 
 	// Rerender all trip headers. TODO: be smarter about this and only rerender if the number
 	// of shown dives changed.

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -3,6 +3,7 @@
 #include "core/divefilter.h"
 #include "core/gettextfromc.h"
 #include "core/metrics.h"
+#include "core/selection.h"
 #include "core/trip.h"
 #include "core/qthelper.h"
 #include "core/divesite.h"
@@ -370,6 +371,19 @@ void DiveTripModelBase::resetModel(DiveTripModelBase::Layout layout)
 		currentModel.reset(new DiveTripModelTree);
 	else
 		currentModel.reset(new DiveTripModelList);
+}
+
+// After resetting the model, the higher up model or view may call this
+// function to get informed on the current selection.
+// TODO: Currently, this reads and resets the selection. Make this more
+//  efficient by maintaining a list of selected dives.
+void DiveTripModelBase::initSelection()
+{
+	std::vector<dive *> dives = getDiveSelection();
+	if (!dives.empty())
+		setSelection(dives, current_dive);
+	else
+		select_newest_visible_dive();
 }
 
 void DiveTripModelBase::clear()

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1320,6 +1320,12 @@ dive *DiveTripModelList::diveOrNull(const QModelIndex &index) const
 
 void DiveTripModelList::recalculateFilter()
 {
+	// Collect the changes in a vector used later to send signals.
+	// This could be solved more efficiently in one pass, but
+	// doing it in two passes allows us to use a common function without
+	// resorting to co-routines, lambdas or similar techniques.
+	std::vector<char> changed;
+	changed.reserve(items.size());
 	{
 		// This marker prevents the UI from getting notifications on selection changes.
 		// It is active until the end of the scope. See comment in DiveTripModelTree::recalculateFilter().
@@ -1331,6 +1337,9 @@ void DiveTripModelList::recalculateFilter()
 			filter_dive(d, shown);
 		}
 	}
+
+	// Send the data-changed signals if some items changed visibility.
+	sendShownChangedSignals(changed, noParent);
 
 	emit diveListNotifier.numShownChanged();
 	emit diveListNotifier.filterReset();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1185,7 +1185,7 @@ void DiveTripModelTree::divesSelected(const QVector<dive *> &dives, dive *curren
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
 	if (!current) {
-		emit newCurrentDive(QModelIndex()); // No current dive -> tell view to clear current index with an invalid index
+		emit currentDiveChanged(QModelIndex()); // No current dive -> tell view to clear current index with an invalid index
 		return;
 	}
 
@@ -1196,26 +1196,26 @@ void DiveTripModelTree::divesSelected(const QVector<dive *> &dives, dive *curren
 		if (idx < 0) {
 			// We don't know this dive. Something is wrong. Warn and bail.
 			qWarning() << "DiveTripModelTree::diveSelected(): unknown top-level dive";
-			emit newCurrentDive(QModelIndex());
+			emit currentDiveChanged(QModelIndex());
 			return;
 		}
-		emit newCurrentDive(createIndex(idx, 0, noParent));
+		emit currentDiveChanged(createIndex(idx, 0, noParent));
 	} else {
 		int idx = findTripIdx(trip);
 		if (idx < 0) {
 			// We don't know the trip - this shouldn't happen. Warn and bail.
 			qWarning() << "DiveTripModelTree::diveSelected(): unknown trip";
-			emit newCurrentDive(QModelIndex());
+			emit currentDiveChanged(QModelIndex());
 			return;
 		}
 		int diveIdx = findDiveInTrip(idx, current);
 		if (diveIdx < 0) {
 			// We don't know this dive. Something is wrong. Warn and bail.
 			qWarning() << "DiveTripModelTree::diveSelected(): unknown dive";
-			emit newCurrentDive(QModelIndex());
+			emit currentDiveChanged(QModelIndex());
 			return;
 		}
-		emit newCurrentDive(createIndex(diveIdx, 0, idx));
+		emit currentDiveChanged(createIndex(diveIdx, 0, idx));
 	}
 }
 
@@ -1443,7 +1443,7 @@ void DiveTripModelList::divesSelected(const QVector<dive *> &dives, dive *curren
 
 	// Transform the current dive into an index and pass it on to the view.
 	if (!current) {
-		emit newCurrentDive(QModelIndex()); // No current dive -> tell view to clear current index with an invalid index
+		emit currentDiveChanged(QModelIndex()); // No current dive -> tell view to clear current index with an invalid index
 		return;
 	}
 
@@ -1451,10 +1451,10 @@ void DiveTripModelList::divesSelected(const QVector<dive *> &dives, dive *curren
 	if (it == items.end()) {
 		// We don't know this dive. Something is wrong. Warn and bail.
 		qWarning() << "DiveTripModelList::divesSelected(): unknown dive";
-		emit newCurrentDive(QModelIndex());
+		emit currentDiveChanged(QModelIndex());
 		return;
 	}
-	emit newCurrentDive(createIndex(it - items.begin(), 0));
+	emit currentDiveChanged(createIndex(it - items.begin(), 0));
 }
 
 // Simple sorting helper for sorting against a criterium and if

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -72,6 +72,9 @@ public:
 	// by instance().
 	static void resetModel(Layout layout);
 
+	// Call after having set the model to be informed of the current selection.
+	void initSelection();
+
 	// Clear all dives
 	void clear();
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -95,7 +95,7 @@ signals:
 	// indexes into local indexes according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
 	void selectionChanged(const QVector<QModelIndex> &indexes);
-	void newCurrentDive(QModelIndex index);
+	void currentDiveChanged(QModelIndex index);
 protected:
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -6,6 +6,8 @@
 #include "core/subsurface-qt/DiveListNotifier.h"
 #include <QAbstractItemModel>
 
+struct DiveFilter;
+
 // There are two different representations of the dive list:
 // 1) Tree view: two-level model where dives are grouped by trips
 // 2) List view: one-level model where dives are sorted by one out
@@ -98,6 +100,7 @@ protected:
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);
 	static QVariant tripData(const dive_trip *trip, int column, int role);
+	void sendShownChangedSignals(const std::vector<char> &changed, quintptr parentIndex);
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 	virtual void clearData() = 0;
@@ -130,6 +133,7 @@ private:
 	void recalculateFilter();
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
+	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, int parentIndex);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -133,7 +133,7 @@ private:
 	void recalculateFilter();
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
-	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, int parentIndex);
+	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, quintptr parentIndex);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -24,8 +24,33 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 {
 	DiveTripModelBase::resetModel(layout);
 	// DiveTripModelBase::resetModel() generates a new instance.
-	// Thus, the source model must be reset.
-	setSourceModel(DiveTripModelBase::instance());
+	// Thus, the source model must be reset and the connections must be reset.
+	DiveTripModelBase *m = DiveTripModelBase::instance();
+	setSourceModel(m);
+	connect(m, &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
+	connect(m, &DiveTripModelBase::currentDiveChanged, this, &MultiFilterSortModel::currentDiveChangedSlot);
+	m->initSelection();
+}
+
+// Translate selection into local indexes and re-emit signal
+void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indexes)
+{
+	QVector<QModelIndex> indexesLocal;
+	indexesLocal.reserve(indexes.size());
+	for (const QModelIndex &index: indexes) {
+		QModelIndex local = mapFromSource(index);
+		if (local.isValid())
+			indexesLocal.push_back(local);
+	}
+	emit selectionChanged(indexesLocal);
+}
+
+// Translate current dive into local indexes and re-emit signal
+void MultiFilterSortModel::currentDiveChangedSlot(QModelIndex index)
+{
+	QModelIndex local = mapFromSource(index);
+	if (local.isValid())
+		emit currentDiveChanged(mapFromSource(index));
 }
 
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -15,8 +15,8 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
-	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &MultiFilterSortModel::invalidateFilter);
 	setFilterKeyColumn(-1); // filter all columns
+	setFilterRole(DiveTripModelBase::SHOWN_ROLE); // Let the proxy-model known that is has to react to change events involving SHOWN_ROLE
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
 

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -14,6 +14,12 @@ public:
 	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
 
 	void resetModel(DiveTripModelBase::Layout layout);
+signals:
+	void selectionChanged(const QVector<QModelIndex> &indexes);
+	void currentDiveChanged(QModelIndex index);
+private slots:
+	void selectionChangedSlot(const QVector<QModelIndex> &indexes);
+	void currentDiveChangedSlot(QModelIndex index);
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is the "more controversial" PR I was hinting at in the recent model-unification PR. The ultimate goal is to use the same models on desktop and mobile as far as possible.

What this does is sending the proper changed-events if the shown status of a dive changed. Thus, when the filter-criteria change it is not necessary to fully invalidate the filter. This might be controversial, because the code is rather complex. Nevertheless, to my understanding(!), this is how qt-models are intended to be implemented. At least Qt's own model-source is full of these complications.

Next up: moving down selection changes from desktop's DiveListView, so that can be reused on mobile as well.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Send changed signals when show status changes.
2) Don't fully invalidate filter when filter-criteria change.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Continuation of #2389.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - should not be user visible.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: please comment.