### PR TITLE
qPref constructor private (singleton) and all access functions static.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Documentation/docbook-xsl.css
 Documentation/user-manual*.html
 Documentation/user-manual*.pdf
 Documentation/user-manual*.text
+Documentation/mobile-images/mobile-images
 packaging/windows/subsurface.nsi
 packaging/macos/Info.plist
 *.kdev4
@@ -38,4 +39,5 @@ mobile-widgets/qml/kirigami
 packaging/ios/install-root
 packaging/ios/Info.plist
 packaging/ios/Qt
+packaging/ios/asset_catalog_compiler.Info.plist
 appdata/subsurface.appdata.xml

--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -50,10 +50,9 @@ void CloudStorageAuthenticate::uploadFinished()
 
 	QString cloudAuthReply(reply->readAll());
 	qDebug() << "Completed connection with cloud storage backend, response" << cloudAuthReply;
-	qPrefCloudStorage csSettings(parent());
 
 	if (cloudAuthReply == QLatin1String("[VERIFIED]") || cloudAuthReply == QLatin1String("[OK]")) {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
 		/* TODO: Move this to a correct place
 		NotificationWidget *nw = MainWindow::instance()->getNotificationWidget();
 		if (nw->getNotificationText() == myLastError)
@@ -62,15 +61,15 @@ void CloudStorageAuthenticate::uploadFinished()
 		myLastError.clear();
 	} else if (cloudAuthReply == QLatin1String("[VERIFY]") ||
 		   cloudAuthReply == QLatin1String("Invalid PIN")) {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_NEED_TO_VERIFY);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_NEED_TO_VERIFY);
 		report_error(qPrintable(tr("Cloud account verification required, enter PIN in preferences")));
 	} else if (cloudAuthReply == QLatin1String("[PASSWDCHANGED]")) {
-		csSettings.set_cloud_storage_password(cloudNewPassword);
+		qPrefCloudStorage::set_cloud_storage_password(cloudNewPassword);
 		cloudNewPassword.clear();
 		emit passwordChangeSuccessful();
 		return;
 	} else {
-		csSettings.set_cloud_verification_status(qPrefCloudStorage::CS_INCORRECT_USER_PASSWD);
+		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_INCORRECT_USER_PASSWD);
 		myLastError = cloudAuthReply;
 		report_error("%s", qPrintable(cloudAuthReply));
 	}

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("CloudStorage");
 
-qPrefCloudStorage::qPrefCloudStorage(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefCloudStorage *qPrefCloudStorage::instance()
 {
 	static qPrefCloudStorage *self = new qPrefCloudStorage;

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -7,16 +7,16 @@
 
 class qPrefCloudStorage : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool cloud_auto_sync READ cloud_auto_sync WRITE set_cloud_auto_sync NOTIFY cloud_auto_syncChanged);
-	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_urlChanged);
-	Q_PROPERTY(QString cloud_git_url READ cloud_git_url);
-	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_emailChanged);
-	Q_PROPERTY(QString cloud_storage_email_encoded READ cloud_storage_email_encoded WRITE set_cloud_storage_email_encoded NOTIFY cloud_storage_email_encodedChanged);
-	Q_PROPERTY(QString cloud_storage_password READ cloud_storage_password WRITE set_cloud_storage_password NOTIFY cloud_storage_passwordChanged);
-	Q_PROPERTY(QString cloud_storage_pin READ cloud_storage_pin WRITE set_cloud_storage_pin NOTIFY cloud_storage_pinChanged);
-	Q_PROPERTY(int cloud_verification_status READ cloud_verification_status WRITE set_cloud_verification_status NOTIFY cloud_verification_statusChanged);
-	Q_PROPERTY(int cloud_timeout READ cloud_timeout WRITE set_cloud_timeout NOTIFY cloud_timeoutChanged);
-	Q_PROPERTY(bool save_password_local READ save_password_local WRITE set_save_password_local NOTIFY save_password_localChanged);
+	Q_PROPERTY(bool cloud_auto_sync READ cloud_auto_sync WRITE set_cloud_auto_sync NOTIFY cloud_auto_syncChanged)
+	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_urlChanged)
+	Q_PROPERTY(QString cloud_git_url READ cloud_git_url)
+	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_emailChanged)
+	Q_PROPERTY(QString cloud_storage_email_encoded READ cloud_storage_email_encoded WRITE set_cloud_storage_email_encoded NOTIFY cloud_storage_email_encodedChanged)
+	Q_PROPERTY(QString cloud_storage_password READ cloud_storage_password WRITE set_cloud_storage_password NOTIFY cloud_storage_passwordChanged)
+	Q_PROPERTY(QString cloud_storage_pin READ cloud_storage_pin WRITE set_cloud_storage_pin NOTIFY cloud_storage_pinChanged)
+	Q_PROPERTY(int cloud_verification_status READ cloud_verification_status WRITE set_cloud_verification_status NOTIFY cloud_verification_statusChanged)
+	Q_PROPERTY(int cloud_timeout READ cloud_timeout WRITE set_cloud_timeout NOTIFY cloud_timeoutChanged)
+	Q_PROPERTY(bool save_password_local READ save_password_local WRITE set_save_password_local NOTIFY save_password_localChanged)
 
 public:
 	static qPrefCloudStorage *instance();

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -19,7 +19,6 @@ class qPrefCloudStorage : public QObject {
 	Q_PROPERTY(bool save_password_local READ save_password_local WRITE set_save_password_local NOTIFY save_password_localChanged);
 
 public:
-	qPrefCloudStorage(QObject *parent = NULL);
 	static qPrefCloudStorage *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -71,6 +70,8 @@ signals:
 	void save_password_localChanged(bool value);
 
 private:
+	qPrefCloudStorage() {}
+
 	// functions to load/sync variable with disk
 	static void disk_cloud_auto_sync(bool doSync);
 	static void disk_cloud_base_url(bool doSync);

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -41,10 +41,6 @@ static const QByteArray st_windowState_default;
 int qPrefDisplay::st_lastState;
 static int st_lastState_default = false;
 
-qPrefDisplay::qPrefDisplay(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDisplay *qPrefDisplay::instance()
 {
 	static qPrefDisplay *self = new qPrefDisplay;

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -27,7 +27,6 @@ class qPrefDisplay : public QObject {
 	Q_PROPERTY(int lastState READ lastState WRITE set_lastState NOTIFY lastStateChanged);
 
 public:
-	qPrefDisplay(QObject *parent = NULL);
 	static qPrefDisplay *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -93,6 +92,8 @@ signals:
 	void lastStateChanged(int value);
 
 private:
+	qPrefDisplay() {}
+
 	// functions to load/sync variable with disk
 	static void disk_animation_speed(bool doSync);
 	static void disk_divelist_font(bool doSync);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -8,23 +8,23 @@
 
 class qPrefDisplay : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(int animation_speed READ animation_speed WRITE set_animation_speed NOTIFY animation_speedChanged);
-	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_fontChanged);
-	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_sizeChanged);
-	Q_PROPERTY(double mobile_scale READ mobile_scale WRITE set_mobile_scale NOTIFY mobile_scaleChanged);
-	Q_PROPERTY(bool display_invalid_dives READ display_invalid_dives WRITE set_display_invalid_dives NOTIFY display_invalid_divesChanged);
-	Q_PROPERTY(QString lastDir READ lastDir WRITE set_lastDir NOTIFY lastDirChanged);
-	Q_PROPERTY(bool show_developer READ show_developer WRITE set_show_developer NOTIFY show_developerChanged);
-	Q_PROPERTY(QString theme READ theme WRITE set_theme NOTIFY themeChanged);
-	Q_PROPERTY(QPointF tooltip_position READ tooltip_position WRITE set_tooltip_position NOTIFY tooltip_positionChanged);
-	Q_PROPERTY(QString userSurvey READ userSurvey WRITE set_userSurvey NOTIFY userSurveyChanged);
-	Q_PROPERTY(QByteArray mainSplitter READ mainSplitter WRITE set_mainSplitter NOTIFY mainSplitterChanged);
-	Q_PROPERTY(QByteArray topSplitter READ topSplitter WRITE set_topSplitter NOTIFY topSplitterChanged);
-	Q_PROPERTY(QByteArray bottomSplitter READ bottomSplitter WRITE set_bottomSplitter NOTIFY bottomSplitterChanged);
-	Q_PROPERTY(bool maximized READ maximized WRITE set_maximized NOTIFY maximizedChanged);
-	Q_PROPERTY(QByteArray geometry READ geometry WRITE set_geometry NOTIFY geometryChanged);
-	Q_PROPERTY(QByteArray windowState READ windowState WRITE set_windowState NOTIFY windowStateChanged);
-	Q_PROPERTY(int lastState READ lastState WRITE set_lastState NOTIFY lastStateChanged);
+	Q_PROPERTY(int animation_speed READ animation_speed WRITE set_animation_speed NOTIFY animation_speedChanged)
+	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_fontChanged)
+	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_sizeChanged)
+	Q_PROPERTY(double mobile_scale READ mobile_scale WRITE set_mobile_scale NOTIFY mobile_scaleChanged)
+	Q_PROPERTY(bool display_invalid_dives READ display_invalid_dives WRITE set_display_invalid_dives NOTIFY display_invalid_divesChanged)
+	Q_PROPERTY(QString lastDir READ lastDir WRITE set_lastDir NOTIFY lastDirChanged)
+	Q_PROPERTY(bool show_developer READ show_developer WRITE set_show_developer NOTIFY show_developerChanged)
+	Q_PROPERTY(QString theme READ theme WRITE set_theme NOTIFY themeChanged)
+	Q_PROPERTY(QPointF tooltip_position READ tooltip_position WRITE set_tooltip_position NOTIFY tooltip_positionChanged)
+	Q_PROPERTY(QString userSurvey READ userSurvey WRITE set_userSurvey NOTIFY userSurveyChanged)
+	Q_PROPERTY(QByteArray mainSplitter READ mainSplitter WRITE set_mainSplitter NOTIFY mainSplitterChanged)
+	Q_PROPERTY(QByteArray topSplitter READ topSplitter WRITE set_topSplitter NOTIFY topSplitterChanged)
+	Q_PROPERTY(QByteArray bottomSplitter READ bottomSplitter WRITE set_bottomSplitter NOTIFY bottomSplitterChanged)
+	Q_PROPERTY(bool maximized READ maximized WRITE set_maximized NOTIFY maximizedChanged)
+	Q_PROPERTY(QByteArray geometry READ geometry WRITE set_geometry NOTIFY geometryChanged)
+	Q_PROPERTY(QByteArray windowState READ windowState WRITE set_windowState NOTIFY windowStateChanged)
+	Q_PROPERTY(int lastState READ lastState WRITE set_lastState NOTIFY lastStateChanged)
 
 public:
 	static qPrefDisplay *instance();

--- a/core/settings/qPrefDiveComputer.cpp
+++ b/core/settings/qPrefDiveComputer.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("DiveComputer");
 
-qPrefDiveComputer::qPrefDiveComputer(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDiveComputer *qPrefDiveComputer::instance()
 {
 	static qPrefDiveComputer *self = new qPrefDiveComputer;

--- a/core/settings/qPrefDiveComputer.h
+++ b/core/settings/qPrefDiveComputer.h
@@ -36,7 +36,6 @@ class qPrefDiveComputer : public QObject {
 	Q_PROPERTY(QString vendor4 READ vendor4 WRITE set_vendor4 NOTIFY vendor4Changed)
 
 public:
-	qPrefDiveComputer(QObject *parent = NULL);
 	static qPrefDiveComputer *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -101,6 +100,8 @@ signals:
 	void vendor4Changed(const QString &vendor);
 
 private:
+	qPrefDiveComputer() {}
+
 	// functions to load/sync variable with disk
 
 	static void disk_device(bool doSync);

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -5,10 +5,6 @@
 
 static const QString group = QStringLiteral("Planner");
 
-qPrefDivePlanner::qPrefDivePlanner(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefDivePlanner *qPrefDivePlanner::instance()
 {
 	static qPrefDivePlanner *self = new qPrefDivePlanner;

--- a/core/settings/qPrefDivePlanner.h
+++ b/core/settings/qPrefDivePlanner.h
@@ -7,33 +7,33 @@
 
 class qPrefDivePlanner : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(int ascratelast6m READ ascratelast6m WRITE set_ascratelast6m NOTIFY ascratelast6mChanged);
-	Q_PROPERTY(int ascratestops READ ascratestops WRITE set_ascratestops NOTIFY ascratestopsChanged);
-	Q_PROPERTY(int ascrate50 READ ascrate50 WRITE set_ascrate50 NOTIFY ascrate50Changed);
-	Q_PROPERTY(int ascrate75 READ ascrate75 WRITE set_ascrate75 NOTIFY ascrate75Changed);
-	Q_PROPERTY(int bestmixend READ bestmixend WRITE set_bestmixend NOTIFY bestmixendChanged);
-	Q_PROPERTY(int bottompo2 READ bottompo2 WRITE set_bottompo2 NOTIFY bottompo2Changed);
-	Q_PROPERTY(int bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
-	Q_PROPERTY(int decopo2 READ decopo2 WRITE set_decopo2 NOTIFY decopo2Changed);
-	Q_PROPERTY(int decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
-	Q_PROPERTY(int descrate READ descrate WRITE set_descrate NOTIFY descrateChanged);
-	Q_PROPERTY(bool display_duration READ display_duration WRITE set_display_duration NOTIFY display_durationChanged);
-	Q_PROPERTY(bool display_runtime READ display_runtime WRITE set_display_runtime NOTIFY display_runtimeChanged);
-	Q_PROPERTY(bool display_transitions READ display_transitions WRITE set_display_transitions NOTIFY      display_transitionsChanged);
-	Q_PROPERTY(bool display_variations READ display_variations WRITE set_display_variations NOTIFY display_variationsChanged);
-	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
-	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
+	Q_PROPERTY(int ascratelast6m READ ascratelast6m WRITE set_ascratelast6m NOTIFY ascratelast6mChanged)
+	Q_PROPERTY(int ascratestops READ ascratestops WRITE set_ascratestops NOTIFY ascratestopsChanged)
+	Q_PROPERTY(int ascrate50 READ ascrate50 WRITE set_ascrate50 NOTIFY ascrate50Changed)
+	Q_PROPERTY(int ascrate75 READ ascrate75 WRITE set_ascrate75 NOTIFY ascrate75Changed)
+	Q_PROPERTY(int bestmixend READ bestmixend WRITE set_bestmixend NOTIFY bestmixendChanged)
+	Q_PROPERTY(int bottompo2 READ bottompo2 WRITE set_bottompo2 NOTIFY bottompo2Changed)
+	Q_PROPERTY(int bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged)
+	Q_PROPERTY(int decopo2 READ decopo2 WRITE set_decopo2 NOTIFY decopo2Changed)
+	Q_PROPERTY(int decosac READ decosac WRITE set_decosac NOTIFY decosacChanged)
+	Q_PROPERTY(int descrate READ descrate WRITE set_descrate NOTIFY descrateChanged)
+	Q_PROPERTY(bool display_duration READ display_duration WRITE set_display_duration NOTIFY display_durationChanged)
+	Q_PROPERTY(bool display_runtime READ display_runtime WRITE set_display_runtime NOTIFY display_runtimeChanged)
+	Q_PROPERTY(bool display_transitions READ display_transitions WRITE set_display_transitions NOTIFY      display_transitionsChanged)
+	Q_PROPERTY(bool display_variations READ display_variations WRITE set_display_variations NOTIFY display_variationsChanged)
+	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged)
+	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged)
 	Q_PROPERTY(bool o2narcotic READ o2narcotic WRITE set_o2narcotic NOTIFY o2narcoticChanged)
-	Q_PROPERTY(bool drop_stone_mode READ drop_stone_mode WRITE set_drop_stone_mode NOTIFY drop_stone_modeChanged);
-	Q_PROPERTY(bool last_stop READ last_stop WRITE set_last_stop NOTIFY last_stopChanged);
-	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
-	Q_PROPERTY(deco_mode planner_deco_mode READ planner_deco_mode WRITE set_planner_deco_mode NOTIFY planner_deco_modeChanged);
-	Q_PROPERTY(int problemsolvingtime READ problemsolvingtime WRITE set_problemsolvingtime NOTIFY problemsolvingtimeChanged);
-	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged);
-	Q_PROPERTY(int sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged);
-	Q_PROPERTY(bool safetystop READ safetystop WRITE set_safetystop NOTIFY safetystopChanged);
-	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged);
-	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged);
+	Q_PROPERTY(bool drop_stone_mode READ drop_stone_mode WRITE set_drop_stone_mode NOTIFY drop_stone_modeChanged)
+	Q_PROPERTY(bool last_stop READ last_stop WRITE set_last_stop NOTIFY last_stopChanged)
+	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged)
+	Q_PROPERTY(deco_mode planner_deco_mode READ planner_deco_mode WRITE set_planner_deco_mode NOTIFY planner_deco_modeChanged)
+	Q_PROPERTY(int problemsolvingtime READ problemsolvingtime WRITE set_problemsolvingtime NOTIFY problemsolvingtimeChanged)
+	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged)
+	Q_PROPERTY(int sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged)
+	Q_PROPERTY(bool safetystop READ safetystop WRITE set_safetystop NOTIFY safetystopChanged)
+	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged)
+	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged)
 
 public:
 	static qPrefDivePlanner *instance();

--- a/core/settings/qPrefDivePlanner.h
+++ b/core/settings/qPrefDivePlanner.h
@@ -36,7 +36,6 @@ class qPrefDivePlanner : public QObject {
 	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged);
 
 public:
-	qPrefDivePlanner(QObject *parent = NULL);
 	static qPrefDivePlanner *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -135,6 +134,8 @@ signals:
 	void verbatim_planChanged(bool value);
 
 private:
+	qPrefDivePlanner() {}
+
 	static void disk_ascratelast6m(bool doSync);
 	static void disk_ascratestops(bool doSync);
 	static void disk_ascrate50(bool doSync);

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -11,10 +11,6 @@ static const QString st_diveshareExport_uid_default;
 bool qPrefGeneral::st_diveshareExport_private;
 static const bool st_diveshareExport_private_default = false;
 
-qPrefGeneral::qPrefGeneral(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefGeneral *qPrefGeneral::instance()
 {
 	static qPrefGeneral *self = new qPrefGeneral;

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -26,7 +26,6 @@ class qPrefGeneral : public QObject {
 
 
 public:
-	qPrefGeneral(QObject *parent = NULL);
 	static qPrefGeneral *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -90,6 +89,8 @@ signals:
 	void extraEnvironmentalDefaultChanged(bool value);
 
 private:
+	qPrefGeneral() {}
+
 	static void disk_auto_recalculate_thumbnails(bool doSync);
 	static void disk_default_cylinder(bool doSync);
 	static void disk_default_filename(bool doSync);

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -7,19 +7,19 @@
 
 class qPrefGeneral : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool auto_recalculate_thumbnails READ auto_recalculate_thumbnails WRITE set_auto_recalculate_thumbnails NOTIFY auto_recalculate_thumbnailsChanged);
-	Q_PROPERTY(QString default_cylinder READ default_cylinder WRITE set_default_cylinder NOTIFY default_cylinderChanged);
-	Q_PROPERTY(QString default_filename READ default_filename WRITE set_default_filename NOTIFY default_filenameChanged);
-	Q_PROPERTY(enum def_file_behavior default_file_behavior READ default_file_behavior WRITE set_default_file_behavior NOTIFY default_file_behaviorChanged);
-	Q_PROPERTY(int defaultsetpoint READ defaultsetpoint WRITE set_defaultsetpoint NOTIFY defaultsetpointChanged);
-	Q_PROPERTY(bool extract_video_thumbnails READ extract_video_thumbnails WRITE set_extract_video_thumbnails NOTIFY extract_video_thumbnailsChanged);
-	Q_PROPERTY(int extract_video_thumbnails_position READ extract_video_thumbnails_position WRITE set_extract_video_thumbnails_position NOTIFY extract_video_thumbnails_positionChanged);
-	Q_PROPERTY(QString ffmpeg_executable READ ffmpeg_executable WRITE set_ffmpeg_executable  NOTIFY ffmpeg_executableChanged);
-	Q_PROPERTY(int o2consumption READ o2consumption WRITE set_o2consumption NOTIFY o2consumptionChanged);
-	Q_PROPERTY(int pscr_ratio READ pscr_ratio WRITE set_pscr_ratio NOTIFY pscr_ratioChanged);
-	Q_PROPERTY(bool use_default_file READ use_default_file WRITE set_use_default_file NOTIFY use_default_fileChanged);
-	Q_PROPERTY(QString diveshareExport_uid READ diveshareExport_uid WRITE set_diveshareExport_uid NOTIFY diveshareExport_uidChanged);
-	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged);
+	Q_PROPERTY(bool auto_recalculate_thumbnails READ auto_recalculate_thumbnails WRITE set_auto_recalculate_thumbnails NOTIFY auto_recalculate_thumbnailsChanged)
+	Q_PROPERTY(QString default_cylinder READ default_cylinder WRITE set_default_cylinder NOTIFY default_cylinderChanged)
+	Q_PROPERTY(QString default_filename READ default_filename WRITE set_default_filename NOTIFY default_filenameChanged)
+	Q_PROPERTY(enum def_file_behavior default_file_behavior READ default_file_behavior WRITE set_default_file_behavior NOTIFY default_file_behaviorChanged)
+	Q_PROPERTY(int defaultsetpoint READ defaultsetpoint WRITE set_defaultsetpoint NOTIFY defaultsetpointChanged)
+	Q_PROPERTY(bool extract_video_thumbnails READ extract_video_thumbnails WRITE set_extract_video_thumbnails NOTIFY extract_video_thumbnailsChanged)
+	Q_PROPERTY(int extract_video_thumbnails_position READ extract_video_thumbnails_position WRITE set_extract_video_thumbnails_position NOTIFY extract_video_thumbnails_positionChanged)
+	Q_PROPERTY(QString ffmpeg_executable READ ffmpeg_executable WRITE set_ffmpeg_executable  NOTIFY ffmpeg_executableChanged)
+	Q_PROPERTY(int o2consumption READ o2consumption WRITE set_o2consumption NOTIFY o2consumptionChanged)
+	Q_PROPERTY(int pscr_ratio READ pscr_ratio WRITE set_pscr_ratio NOTIFY pscr_ratioChanged)
+	Q_PROPERTY(bool use_default_file READ use_default_file WRITE set_use_default_file NOTIFY use_default_fileChanged)
+	Q_PROPERTY(QString diveshareExport_uid READ diveshareExport_uid WRITE set_diveshareExport_uid NOTIFY diveshareExport_uidChanged)
+	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged)
 	Q_PROPERTY(bool filterFullTextNotes READ filterFullTextNotes WRITE set_filterFullTextNotes NOTIFY filterFullTextNotesChanged)
 	Q_PROPERTY(bool filterCaseSensitive READ filterCaseSensitive WRITE set_filterCaseSensitive NOTIFY filterCaseSensitiveChanged)
 	Q_PROPERTY(bool extraEnvironmentalDefault READ extraEnvironmentalDefault WRITE set_extraEnvironmentalDefault NOTIFY extraEnvironmentalDefaultChanged);

--- a/core/settings/qPrefGeocoding.cpp
+++ b/core/settings/qPrefGeocoding.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("geocoding");
 
-qPrefGeocoding::qPrefGeocoding(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefGeocoding *qPrefGeocoding::instance()
 {
 	static qPrefGeocoding *self = new qPrefGeocoding;

--- a/core/settings/qPrefGeocoding.h
+++ b/core/settings/qPrefGeocoding.h
@@ -13,7 +13,6 @@ class qPrefGeocoding : public QObject {
 	Q_PROPERTY(taxonomy_category third_taxonomy_category READ third_taxonomy_category WRITE set_third_taxonomy_category NOTIFY third_taxonomy_categoryChanged);
 
 public:
-	qPrefGeocoding(QObject *parent = NULL);
 	static qPrefGeocoding *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -37,6 +36,8 @@ signals:
 	void third_taxonomy_categoryChanged(taxonomy_category value);
 
 private:
+	qPrefGeocoding() {}
+
 	static void disk_first_taxonomy_category(bool doSync);
 	static void disk_second_taxonomy_category(bool doSync);
 	static void disk_third_taxonomy_category(bool doSync);

--- a/core/settings/qPrefGeocoding.h
+++ b/core/settings/qPrefGeocoding.h
@@ -22,9 +22,9 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
-	taxonomy_category first_taxonomy_category() { return prefs.geocoding.category[0]; }
-	taxonomy_category second_taxonomy_category() { return prefs.geocoding.category[1]; }
-	taxonomy_category third_taxonomy_category() { return prefs.geocoding.category[2]; }
+	static taxonomy_category first_taxonomy_category() { return prefs.geocoding.category[0]; }
+	static taxonomy_category second_taxonomy_category() { return prefs.geocoding.category[1]; }
+	static taxonomy_category third_taxonomy_category() { return prefs.geocoding.category[2]; }
 
 public slots:
 	static void set_first_taxonomy_category(taxonomy_category value);

--- a/core/settings/qPrefGeocoding.h
+++ b/core/settings/qPrefGeocoding.h
@@ -8,9 +8,9 @@
 
 class qPrefGeocoding : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(taxonomy_category first_taxonomy_category READ first_taxonomy_category WRITE set_first_taxonomy_category NOTIFY first_taxonomy_categoryChanged);
-	Q_PROPERTY(taxonomy_category second_taxonomy_category READ second_taxonomy_category WRITE set_second_taxonomy_category NOTIFY second_taxonomy_categoryChanged);
-	Q_PROPERTY(taxonomy_category third_taxonomy_category READ third_taxonomy_category WRITE set_third_taxonomy_category NOTIFY third_taxonomy_categoryChanged);
+	Q_PROPERTY(taxonomy_category first_taxonomy_category READ first_taxonomy_category WRITE set_first_taxonomy_category NOTIFY first_taxonomy_categoryChanged)
+	Q_PROPERTY(taxonomy_category second_taxonomy_category READ second_taxonomy_category WRITE set_second_taxonomy_category NOTIFY second_taxonomy_categoryChanged)
+	Q_PROPERTY(taxonomy_category third_taxonomy_category READ third_taxonomy_category WRITE set_third_taxonomy_category NOTIFY third_taxonomy_categoryChanged)
 
 public:
 	static qPrefGeocoding *instance();

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("Language");
 
-qPrefLanguage::qPrefLanguage(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefLanguage *qPrefLanguage::instance()
 {
 	static qPrefLanguage *self = new qPrefLanguage;

--- a/core/settings/qPrefLanguage.h
+++ b/core/settings/qPrefLanguage.h
@@ -17,7 +17,6 @@ class qPrefLanguage : public QObject {
 	Q_PROPERTY(bool use_system_language READ use_system_language WRITE set_use_system_language NOTIFY use_system_languageChanged);
 
 public:
-	qPrefLanguage(QObject *parent = NULL);
 	static qPrefLanguage *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -56,6 +55,8 @@ signals:
 	void use_system_languageChanged(bool value);
 
 private:
+	qPrefLanguage() {}
+
 	static void disk_date_format(bool doSync);
 	static void disk_date_format_override(bool doSync);
 	static void disk_date_format_short(bool doSync);

--- a/core/settings/qPrefLanguage.h
+++ b/core/settings/qPrefLanguage.h
@@ -7,14 +7,14 @@
 
 class qPrefLanguage : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(QString date_format READ date_format WRITE set_date_format NOTIFY date_formatChanged);
-	Q_PROPERTY(bool date_format_override READ date_format_override WRITE set_date_format_override NOTIFY date_format_overrideChanged);
-	Q_PROPERTY(QString date_format_short READ date_format_short WRITE set_date_format_short NOTIFY date_format_shortChanged);
-	Q_PROPERTY(QString language READ language WRITE set_language NOTIFY languageChanged);
-	Q_PROPERTY(QString lang_locale READ lang_locale WRITE set_lang_locale NOTIFY lang_localeChanged);
-	Q_PROPERTY(QString time_format READ time_format WRITE set_time_format NOTIFY time_formatChanged);
-	Q_PROPERTY(bool time_format_override READ time_format_override WRITE set_time_format_override NOTIFY time_format_overrideChanged);
-	Q_PROPERTY(bool use_system_language READ use_system_language WRITE set_use_system_language NOTIFY use_system_languageChanged);
+	Q_PROPERTY(QString date_format READ date_format WRITE set_date_format NOTIFY date_formatChanged)
+	Q_PROPERTY(bool date_format_override READ date_format_override WRITE set_date_format_override NOTIFY date_format_overrideChanged)
+	Q_PROPERTY(QString date_format_short READ date_format_short WRITE set_date_format_short NOTIFY date_format_shortChanged)
+	Q_PROPERTY(QString language READ language WRITE set_language NOTIFY languageChanged)
+	Q_PROPERTY(QString lang_locale READ lang_locale WRITE set_lang_locale NOTIFY lang_localeChanged)
+	Q_PROPERTY(QString time_format READ time_format WRITE set_time_format NOTIFY time_formatChanged)
+	Q_PROPERTY(bool time_format_override READ time_format_override WRITE set_time_format_override NOTIFY time_format_overrideChanged)
+	Q_PROPERTY(bool use_system_language READ use_system_language WRITE set_use_system_language NOTIFY use_system_languageChanged)
 
 public:
 	static qPrefLanguage *instance();

--- a/core/settings/qPrefLocationService.cpp
+++ b/core/settings/qPrefLocationService.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("LocationService");
 
-qPrefLocationService::qPrefLocationService(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefLocationService *qPrefLocationService::instance()
 {
 	static qPrefLocationService *self = new qPrefLocationService;

--- a/core/settings/qPrefLocationService.h
+++ b/core/settings/qPrefLocationService.h
@@ -12,7 +12,6 @@ class qPrefLocationService : public QObject {
 	Q_PROPERTY(int time_threshold READ time_threshold WRITE set_time_threshold NOTIFY time_thresholdChanged);
 
 public:
-	qPrefLocationService(QObject *parent = NULL);
 	static qPrefLocationService *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -34,6 +33,8 @@ signals:
 
 
 private:
+	qPrefLocationService() {}
+
 	static void disk_distance_threshold(bool doSync);
 	static void disk_time_threshold(bool doSync);
 };

--- a/core/settings/qPrefLocationService.h
+++ b/core/settings/qPrefLocationService.h
@@ -8,8 +8,8 @@
 
 class qPrefLocationService : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(int distance_threshold READ distance_threshold WRITE set_distance_threshold NOTIFY distance_thresholdChanged);
-	Q_PROPERTY(int time_threshold READ time_threshold WRITE set_time_threshold NOTIFY time_thresholdChanged);
+	Q_PROPERTY(int distance_threshold READ distance_threshold WRITE set_distance_threshold NOTIFY distance_thresholdChanged)
+	Q_PROPERTY(int time_threshold READ time_threshold WRITE set_time_threshold NOTIFY time_thresholdChanged)
 
 public:
 	static qPrefLocationService *instance();

--- a/core/settings/qPrefPartialPressureGas.cpp
+++ b/core/settings/qPrefPartialPressureGas.cpp
@@ -4,10 +4,6 @@
 
 static const QString group = QStringLiteral("TecDetails");
 
-qPrefPartialPressureGas::qPrefPartialPressureGas(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefPartialPressureGas *qPrefPartialPressureGas::instance()
 {
 	static qPrefPartialPressureGas *self = new qPrefPartialPressureGas;

--- a/core/settings/qPrefPartialPressureGas.h
+++ b/core/settings/qPrefPartialPressureGas.h
@@ -16,7 +16,6 @@ class qPrefPartialPressureGas : public QObject {
 	Q_PROPERTY(double po2_threshold_min READ po2_threshold_min WRITE set_po2_threshold_min NOTIFY po2_threshold_minChanged);
 
 public:
-	qPrefPartialPressureGas(QObject *parent = NULL);
 	static qPrefPartialPressureGas *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -52,6 +51,8 @@ signals:
 	void po2_threshold_minChanged(double value);
 
 private:
+	qPrefPartialPressureGas() {}
+
 	static void disk_phe(bool doSync);
 	static void disk_phe_threshold(bool doSync);
 	static void disk_pn2(bool doSync);

--- a/core/settings/qPrefPartialPressureGas.h
+++ b/core/settings/qPrefPartialPressureGas.h
@@ -7,13 +7,13 @@
 
 class qPrefPartialPressureGas : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool phe READ phe WRITE set_phe NOTIFY pheChanged);
-	Q_PROPERTY(double phe_threshold READ phe_threshold WRITE set_phe_threshold NOTIFY phe_thresholdChanged);
-	Q_PROPERTY(bool pn2 READ pn2 WRITE set_pn2 NOTIFY pn2Changed);
-	Q_PROPERTY(double pn2_threshold READ pn2_threshold WRITE set_pn2_threshold NOTIFY pn2_thresholdChanged);
-	Q_PROPERTY(bool po2 READ po2 WRITE set_po2 NOTIFY po2Changed);
-	Q_PROPERTY(double po2_threshold_max READ po2_threshold_max WRITE set_po2_threshold_max NOTIFY po2_threshold_maxChanged);
-	Q_PROPERTY(double po2_threshold_min READ po2_threshold_min WRITE set_po2_threshold_min NOTIFY po2_threshold_minChanged);
+	Q_PROPERTY(bool phe READ phe WRITE set_phe NOTIFY pheChanged)
+	Q_PROPERTY(double phe_threshold READ phe_threshold WRITE set_phe_threshold NOTIFY phe_thresholdChanged)
+	Q_PROPERTY(bool pn2 READ pn2 WRITE set_pn2 NOTIFY pn2Changed)
+	Q_PROPERTY(double pn2_threshold READ pn2_threshold WRITE set_pn2_threshold NOTIFY pn2_thresholdChanged)
+	Q_PROPERTY(bool po2 READ po2 WRITE set_po2 NOTIFY po2Changed)
+	Q_PROPERTY(double po2_threshold_max READ po2_threshold_max WRITE set_po2_threshold_max NOTIFY po2_threshold_maxChanged)
+	Q_PROPERTY(double po2_threshold_min READ po2_threshold_min WRITE set_po2_threshold_min NOTIFY po2_threshold_minChanged)
 
 public:
 	static qPrefPartialPressureGas *instance();

--- a/core/settings/qPrefProxy.cpp
+++ b/core/settings/qPrefProxy.cpp
@@ -6,10 +6,6 @@
 
 static const QString group = QStringLiteral("Network");
 
-qPrefProxy::qPrefProxy(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefProxy *qPrefProxy::instance()
 {
 	static qPrefProxy *self = new qPrefProxy;

--- a/core/settings/qPrefProxy.h
+++ b/core/settings/qPrefProxy.h
@@ -16,7 +16,6 @@ class qPrefProxy : public QObject {
 	Q_PROPERTY(QString proxy_user READ proxy_user WRITE set_proxy_user NOTIFY proxy_userChanged);
 
 public:
-	qPrefProxy(QObject *parent = NULL);
 	static qPrefProxy *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -49,6 +48,8 @@ signals:
 	void proxy_userChanged(const QString &value);
 
 private:
+	qPrefProxy() {}
+
 	static void disk_proxy_auth(bool doSync);
 	static void disk_proxy_host(bool doSync);
 	static void disk_proxy_pass(bool doSync);

--- a/core/settings/qPrefProxy.h
+++ b/core/settings/qPrefProxy.h
@@ -8,12 +8,12 @@
 
 class qPrefProxy : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool proxy_auth READ proxy_auth WRITE set_proxy_auth NOTIFY proxy_authChanged);
-	Q_PROPERTY(QString proxy_host READ proxy_host WRITE set_proxy_host NOTIFY proxy_hostChanged);
-	Q_PROPERTY(QString proxy_pass READ proxy_pass WRITE set_proxy_pass NOTIFY proxy_passChanged);
-	Q_PROPERTY(int proxy_port READ proxy_port WRITE set_proxy_port NOTIFY proxy_portChanged);
-	Q_PROPERTY(int proxy_type READ proxy_type WRITE set_proxy_type NOTIFY proxy_typeChanged);
-	Q_PROPERTY(QString proxy_user READ proxy_user WRITE set_proxy_user NOTIFY proxy_userChanged);
+	Q_PROPERTY(bool proxy_auth READ proxy_auth WRITE set_proxy_auth NOTIFY proxy_authChanged)
+	Q_PROPERTY(QString proxy_host READ proxy_host WRITE set_proxy_host NOTIFY proxy_hostChanged)
+	Q_PROPERTY(QString proxy_pass READ proxy_pass WRITE set_proxy_pass NOTIFY proxy_passChanged)
+	Q_PROPERTY(int proxy_port READ proxy_port WRITE set_proxy_port NOTIFY proxy_portChanged)
+	Q_PROPERTY(int proxy_type READ proxy_type WRITE set_proxy_type NOTIFY proxy_typeChanged)
+	Q_PROPERTY(QString proxy_user READ proxy_user WRITE set_proxy_user NOTIFY proxy_userChanged)
 
 public:
 	static qPrefProxy *instance();

--- a/core/settings/qPrefTechnicalDetails.cpp
+++ b/core/settings/qPrefTechnicalDetails.cpp
@@ -5,10 +5,6 @@
 
 static const QString group = QStringLiteral("TecDetails");
 
-qPrefTechnicalDetails::qPrefTechnicalDetails(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefTechnicalDetails *qPrefTechnicalDetails::instance()
 {
 	static qPrefTechnicalDetails *self = new qPrefTechnicalDetails;

--- a/core/settings/qPrefTechnicalDetails.h
+++ b/core/settings/qPrefTechnicalDetails.h
@@ -38,7 +38,6 @@ class qPrefTechnicalDetails : public QObject {
 	Q_PROPERTY(bool zoomed_plot READ zoomed_plot WRITE set_zoomed_plot NOTIFY zoomed_plotChanged);
 
 public:
-	qPrefTechnicalDetails(QObject *parent = NULL);
 	static qPrefTechnicalDetails *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -137,6 +136,8 @@ signals:
 	void zoomed_plotChanged(bool value);
 
 private:
+	qPrefTechnicalDetails() {}
+
 	static void disk_calcalltissues(bool doSync);
 	static void disk_calcceiling(bool doSync);
 	static void disk_calcceiling3m(bool doSync);

--- a/core/settings/qPrefTechnicalDetails.h
+++ b/core/settings/qPrefTechnicalDetails.h
@@ -8,34 +8,34 @@
 
 class qPrefTechnicalDetails : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool calcalltissues READ calcalltissues WRITE set_calcalltissues NOTIFY calcalltissuesChanged);
-	Q_PROPERTY(bool calcceiling READ calcceiling WRITE set_calcceiling NOTIFY calcceilingChanged);
-	Q_PROPERTY(bool calcceiling3m READ calcceiling3m WRITE set_calcceiling3m NOTIFY calcceiling3mChanged);
-	Q_PROPERTY(bool calcndltts READ calcndltts WRITE set_calcndltts NOTIFY calcndlttsChanged);
-	Q_PROPERTY(bool decoinfo READ decoinfo WRITE set_decoinfo NOTIFY decoinfoChanged);
-	Q_PROPERTY(bool dcceiling READ dcceiling WRITE set_dcceiling NOTIFY dcceilingChanged);
-	Q_PROPERTY(deco_mode display_deco_mode READ display_deco_mode WRITE set_display_deco_mode NOTIFY display_deco_modeChanged);
-	Q_PROPERTY(bool display_unused_tanks READ display_unused_tanks WRITE set_display_unused_tanks NOTIFY display_unused_tanksChanged);
-	Q_PROPERTY(bool ead READ ead WRITE set_ead NOTIFY eadChanged);
-	Q_PROPERTY(int gfhigh READ gfhigh WRITE set_gfhigh NOTIFY gfhighChanged);
-	Q_PROPERTY(int gflow READ gflow WRITE set_gflow NOTIFY gflowChanged);
-	Q_PROPERTY(bool gf_low_at_maxdepth READ gf_low_at_maxdepth WRITE set_gf_low_at_maxdepth NOTIFY gf_low_at_maxdepthChanged);
-	Q_PROPERTY(bool hrgraph READ hrgraph WRITE set_hrgraph NOTIFY hrgraphChanged);
-	Q_PROPERTY(bool mod READ mod WRITE set_mod NOTIFY modChanged);
-	Q_PROPERTY(double modpO2 READ modpO2 WRITE set_modpO2 NOTIFY modpO2Changed);
-	Q_PROPERTY(bool percentagegraph READ percentagegraph WRITE set_percentagegraph NOTIFY percentagegraphChanged);
-	Q_PROPERTY(bool redceiling READ redceiling WRITE set_redceiling NOTIFY redceilingChanged);
-	Q_PROPERTY(bool rulergraph READ rulergraph WRITE set_rulergraph NOTIFY rulergraphChanged);
-	Q_PROPERTY(bool show_average_depth READ show_average_depth WRITE set_show_average_depth NOTIFY show_average_depthChanged);
-	Q_PROPERTY(bool show_ccr_sensors READ show_ccr_sensors WRITE set_show_ccr_sensors NOTIFY show_ccr_sensorsChanged);
-	Q_PROPERTY(bool show_ccr_setpoint READ show_ccr_setpoint WRITE set_show_ccr_setpoint NOTIFY show_ccr_setpointChanged);
-	Q_PROPERTY(bool show_icd READ show_icd WRITE set_show_icd NOTIFY show_icdChanged);
-	Q_PROPERTY(bool show_pictures_in_profile READ show_pictures_in_profile WRITE set_show_pictures_in_profile NOTIFY show_pictures_in_profileChanged);
-	Q_PROPERTY(bool show_sac READ show_sac WRITE set_show_sac NOTIFY show_sacChanged);
-	Q_PROPERTY(bool show_scr_ocpo2 READ show_scr_ocpo2 WRITE set_show_scr_ocpo2 NOTIFY show_scr_ocpo2Changed);
-	Q_PROPERTY(bool tankbar READ tankbar WRITE set_tankbar NOTIFY tankbarChanged);
-	Q_PROPERTY(int vpmb_conservatism READ vpmb_conservatism WRITE set_vpmb_conservatism NOTIFY vpmb_conservatismChanged);
-	Q_PROPERTY(bool zoomed_plot READ zoomed_plot WRITE set_zoomed_plot NOTIFY zoomed_plotChanged);
+	Q_PROPERTY(bool calcalltissues READ calcalltissues WRITE set_calcalltissues NOTIFY calcalltissuesChanged)
+	Q_PROPERTY(bool calcceiling READ calcceiling WRITE set_calcceiling NOTIFY calcceilingChanged)
+	Q_PROPERTY(bool calcceiling3m READ calcceiling3m WRITE set_calcceiling3m NOTIFY calcceiling3mChanged)
+	Q_PROPERTY(bool calcndltts READ calcndltts WRITE set_calcndltts NOTIFY calcndlttsChanged)
+	Q_PROPERTY(bool decoinfo READ decoinfo WRITE set_decoinfo NOTIFY decoinfoChanged)
+	Q_PROPERTY(bool dcceiling READ dcceiling WRITE set_dcceiling NOTIFY dcceilingChanged)
+	Q_PROPERTY(deco_mode display_deco_mode READ display_deco_mode WRITE set_display_deco_mode NOTIFY display_deco_modeChanged)
+	Q_PROPERTY(bool display_unused_tanks READ display_unused_tanks WRITE set_display_unused_tanks NOTIFY display_unused_tanksChanged)
+	Q_PROPERTY(bool ead READ ead WRITE set_ead NOTIFY eadChanged)
+	Q_PROPERTY(int gfhigh READ gfhigh WRITE set_gfhigh NOTIFY gfhighChanged)
+	Q_PROPERTY(int gflow READ gflow WRITE set_gflow NOTIFY gflowChanged)
+	Q_PROPERTY(bool gf_low_at_maxdepth READ gf_low_at_maxdepth WRITE set_gf_low_at_maxdepth NOTIFY gf_low_at_maxdepthChanged)
+	Q_PROPERTY(bool hrgraph READ hrgraph WRITE set_hrgraph NOTIFY hrgraphChanged)
+	Q_PROPERTY(bool mod READ mod WRITE set_mod NOTIFY modChanged)
+	Q_PROPERTY(double modpO2 READ modpO2 WRITE set_modpO2 NOTIFY modpO2Changed)
+	Q_PROPERTY(bool percentagegraph READ percentagegraph WRITE set_percentagegraph NOTIFY percentagegraphChanged)
+	Q_PROPERTY(bool redceiling READ redceiling WRITE set_redceiling NOTIFY redceilingChanged)
+	Q_PROPERTY(bool rulergraph READ rulergraph WRITE set_rulergraph NOTIFY rulergraphChanged)
+	Q_PROPERTY(bool show_average_depth READ show_average_depth WRITE set_show_average_depth NOTIFY show_average_depthChanged)
+	Q_PROPERTY(bool show_ccr_sensors READ show_ccr_sensors WRITE set_show_ccr_sensors NOTIFY show_ccr_sensorsChanged)
+	Q_PROPERTY(bool show_ccr_setpoint READ show_ccr_setpoint WRITE set_show_ccr_setpoint NOTIFY show_ccr_setpointChanged)
+	Q_PROPERTY(bool show_icd READ show_icd WRITE set_show_icd NOTIFY show_icdChanged)
+	Q_PROPERTY(bool show_pictures_in_profile READ show_pictures_in_profile WRITE set_show_pictures_in_profile NOTIFY show_pictures_in_profileChanged)
+	Q_PROPERTY(bool show_sac READ show_sac WRITE set_show_sac NOTIFY show_sacChanged)
+	Q_PROPERTY(bool show_scr_ocpo2 READ show_scr_ocpo2 WRITE set_show_scr_ocpo2 NOTIFY show_scr_ocpo2Changed)
+	Q_PROPERTY(bool tankbar READ tankbar WRITE set_tankbar NOTIFY tankbarChanged)
+	Q_PROPERTY(int vpmb_conservatism READ vpmb_conservatism WRITE set_vpmb_conservatism NOTIFY vpmb_conservatismChanged)
+	Q_PROPERTY(bool zoomed_plot READ zoomed_plot WRITE set_zoomed_plot NOTIFY zoomed_plotChanged)
 
 public:
 	static qPrefTechnicalDetails *instance();

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -5,10 +5,6 @@
 
 static const QString group = QStringLiteral("Units");
 
-qPrefUnits::qPrefUnits(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefUnits *qPrefUnits::instance()
 {
 	static qPrefUnits *self = new qPrefUnits;

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -20,7 +20,6 @@ class qPrefUnits : public QObject {
 	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged);
 
 public:
-	qPrefUnits(QObject *parent = NULL);
 	static qPrefUnits *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -65,6 +64,8 @@ signals:
 	void weightChanged(int value);
 
 private:
+	qPrefUnits() {}
+
 	static void disk_coordinates_traditional(bool doSync);
 	static void disk_duration_units(bool doSync);
 	static void disk_length(bool doSync);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -8,16 +8,16 @@
 
 class qPrefUnits : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged);
-	Q_PROPERTY(units::DURATION duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsChanged);
-	Q_PROPERTY(units::LENGTH length READ length WRITE set_length NOTIFY lengthChanged);
-	Q_PROPERTY(units::PRESSURE pressure READ pressure WRITE set_pressure NOTIFY pressureChanged);
-	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged);
-	Q_PROPERTY(units::TEMPERATURE temperature READ temperature WRITE set_temperature NOTIFY temperatureChanged);
-	Q_PROPERTY(QString unit_system READ unit_system WRITE set_unit_system NOTIFY unit_systemChanged);
-	Q_PROPERTY(units::TIME vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeChanged);
-	Q_PROPERTY(units::VOLUME volume READ volume WRITE set_volume NOTIFY volumeChanged);
-	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged);
+	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
+	Q_PROPERTY(units::DURATION duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsChanged)
+	Q_PROPERTY(units::LENGTH length READ length WRITE set_length NOTIFY lengthChanged)
+	Q_PROPERTY(units::PRESSURE pressure READ pressure WRITE set_pressure NOTIFY pressureChanged)
+	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
+	Q_PROPERTY(units::TEMPERATURE temperature READ temperature WRITE set_temperature NOTIFY temperatureChanged)
+	Q_PROPERTY(QString unit_system READ unit_system WRITE set_unit_system NOTIFY unit_systemChanged)
+	Q_PROPERTY(units::TIME vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeChanged)
+	Q_PROPERTY(units::VOLUME volume READ volume WRITE set_volume NOTIFY volumeChanged)
+	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged)
 
 public:
 	static qPrefUnits *instance();

--- a/core/settings/qPrefUpdateManager.cpp
+++ b/core/settings/qPrefUpdateManager.cpp
@@ -8,10 +8,6 @@ static const QString group = QStringLiteral("UpdateManager");
 QString qPrefUpdateManager::st_uuidString;
 static const QString st_uuidString_default;
 
-qPrefUpdateManager::qPrefUpdateManager(QObject *parent) : QObject(parent)
-{
-}
-
 qPrefUpdateManager *qPrefUpdateManager::instance()
 {
 	static qPrefUpdateManager *self = new qPrefUpdateManager;

--- a/core/settings/qPrefUpdateManager.h
+++ b/core/settings/qPrefUpdateManager.h
@@ -15,7 +15,6 @@ class qPrefUpdateManager : public QObject {
 	Q_PROPERTY(const QString uuidString READ uuidString WRITE set_uuidString NOTIFY uuidStringChanged);
 
 public:
-	qPrefUpdateManager(QObject *parent = NULL);
 	static qPrefUpdateManager *instance();
 
 	// Load/Sync local settings (disk) and struct preference
@@ -45,6 +44,8 @@ signals:
 	void uuidStringChanged(const QString& value);
 
 private:
+	qPrefUpdateManager() {}
+
 	static void disk_dont_check_for_updates(bool doSync);
 	static void disk_last_version_used(bool doSync);
 	static void disk_next_check(bool doSync);

--- a/core/settings/qPrefUpdateManager.h
+++ b/core/settings/qPrefUpdateManager.h
@@ -8,11 +8,11 @@
 
 class qPrefUpdateManager : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(bool dont_check_for_updates READ dont_check_for_updates WRITE set_dont_check_for_updates NOTIFY dont_check_for_updatesChanged);
-	Q_PROPERTY(bool dont_check_exists READ dont_check_exists WRITE set_dont_check_exists NOTIFY dont_check_existsChanged);
-	Q_PROPERTY(const QString last_version_used READ last_version_used WRITE set_last_version_used NOTIFY last_version_usedChanged);
-	Q_PROPERTY(const QDate next_check READ next_check WRITE set_next_check NOTIFY next_checkChanged);
-	Q_PROPERTY(const QString uuidString READ uuidString WRITE set_uuidString NOTIFY uuidStringChanged);
+	Q_PROPERTY(bool dont_check_for_updates READ dont_check_for_updates WRITE set_dont_check_for_updates NOTIFY dont_check_for_updatesChanged)
+	Q_PROPERTY(bool dont_check_exists READ dont_check_exists WRITE set_dont_check_exists NOTIFY dont_check_existsChanged)
+	Q_PROPERTY(const QString last_version_used READ last_version_used WRITE set_last_version_used NOTIFY last_version_usedChanged)
+	Q_PROPERTY(const QDate next_check READ next_check WRITE set_next_check NOTIFY next_checkChanged)
+	Q_PROPERTY(const QString uuidString READ uuidString WRITE set_uuidString NOTIFY uuidStringChanged)
 
 public:
 	static qPrefUpdateManager *instance();

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -165,13 +165,11 @@ void TestQPrefCloudStorage::test_multiple()
 {
 	// test multiple instances have the same information
 
-	auto tst_direct = new qPrefCloudStorage;
-
 	prefs.cloud_timeout = 25;
 	auto tst = qPrefCloudStorage::instance();
 
-	QCOMPARE(tst->cloud_timeout(), tst_direct->cloud_timeout());
-	QCOMPARE(tst_direct->cloud_timeout(), 25);
+	QCOMPARE(tst->cloud_timeout(), qPrefCloudStorage::cloud_timeout());
+	QCOMPARE(qPrefCloudStorage::cloud_timeout(), 25);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefDisplay.cpp
+++ b/tests/testqPrefDisplay.cpp
@@ -154,15 +154,13 @@ void TestQPrefDisplay::test_struct_disk()
 void TestQPrefDisplay::test_multiple()
 {
 	// test multiple instances have the same information
-	auto display_direct = qPrefDisplay::instance();
 	prefs.divelist_font = copy_qstring("comic");
-
 	auto display = qPrefDisplay::instance();
 	prefs.font_size = 15.0;
 
-	QCOMPARE(display->divelist_font(), display_direct->divelist_font());
+	QCOMPARE(display->divelist_font(), qPrefDisplay::divelist_font());
 	QCOMPARE(display->divelist_font(), QString("comic"));
-	QCOMPARE(display->font_size(), display_direct->font_size());
+	QCOMPARE(display->font_size(), qPrefDisplay::font_size());
 	QCOMPARE(display->font_size(), 15.0);
 }
 

--- a/tests/testqPrefDiveComputer.cpp
+++ b/tests/testqPrefDiveComputer.cpp
@@ -101,12 +101,11 @@ void TestQPrefDiveComputer::test_struct_disk()
 void TestQPrefDiveComputer::test_multiple()
 {
 	// test multiple instances have the same information
-	auto tst_direct = new qPrefDiveComputer;
 
 	auto tst = qPrefDiveComputer::instance();
 	prefs.dive_computer.device = copy_qstring("mine");
 
-	QCOMPARE(tst->device(), tst_direct->device());
+	QCOMPARE(tst->device(), qPrefDiveComputer::device());
 	QCOMPARE(tst->device(), QString("mine"));
 }
 

--- a/tests/testqPrefDivePlanner.cpp
+++ b/tests/testqPrefDivePlanner.cpp
@@ -312,17 +312,14 @@ void TestQPrefDivePlanner::test_multiple()
 {
 	// test multiple instances have the same information
 
-	prefs.sacfactor = 22;
 	prefs.safetystop = true;
-	auto tst_direct = new qPrefDivePlanner;
-
 	prefs.sacfactor = 32;
 	auto tst = qPrefDivePlanner::instance();
 
-	QCOMPARE(tst->sacfactor(), tst_direct->sacfactor());
-	QCOMPARE(tst->safetystop(), tst_direct->safetystop());
-	QCOMPARE(tst_direct->sacfactor(), 32);
-	QCOMPARE(tst_direct->safetystop(), true);
+	QCOMPARE(tst->sacfactor(), qPrefDivePlanner::sacfactor());
+	QCOMPARE(tst->safetystop(), qPrefDivePlanner::safetystop());
+	QCOMPARE(qPrefDivePlanner::sacfactor(), 32);
+	QCOMPARE(qPrefDivePlanner::safetystop(), true);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefGeneral.cpp
+++ b/tests/testqPrefGeneral.cpp
@@ -181,15 +181,13 @@ void TestQPrefGeneral::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.o2consumption = 17;
-	auto tst_direct = new qPrefGeneral;
-
 	prefs.pscr_ratio = 18;
 	auto tst = qPrefGeneral::instance();
 
-	QCOMPARE(tst->o2consumption(), tst_direct->o2consumption());
-	QCOMPARE(tst->pscr_ratio(), tst_direct->pscr_ratio());
-	QCOMPARE(tst_direct->o2consumption(), 17);
-	QCOMPARE(tst_direct->pscr_ratio(), 18);
+	QCOMPARE(tst->o2consumption(), qPrefGeneral::o2consumption());
+	QCOMPARE(tst->pscr_ratio(), qPrefGeneral::pscr_ratio());
+	QCOMPARE(qPrefGeneral::o2consumption(), 17);
+	QCOMPARE(qPrefGeneral::pscr_ratio(), 18);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefGeocoding.cpp
+++ b/tests/testqPrefGeocoding.cpp
@@ -93,13 +93,11 @@ void TestQPrefGeocoding::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.geocoding.category[0] = TC_NONE;
-	auto tst_direct = new qPrefGeocoding;
-
 	prefs.geocoding.category[1] = TC_OCEAN;
 	auto tst = qPrefGeocoding::instance();
 
-	QCOMPARE(tst->first_taxonomy_category(), tst_direct->first_taxonomy_category());
-	QCOMPARE(tst->second_taxonomy_category(), tst_direct->second_taxonomy_category());
+	QCOMPARE(tst->first_taxonomy_category(), qPrefGeocoding::first_taxonomy_category());
+	QCOMPARE(tst->second_taxonomy_category(), qPrefGeocoding::second_taxonomy_category());
 	QCOMPARE(tst->first_taxonomy_category(), TC_NONE);
 	QCOMPARE(tst->second_taxonomy_category(), TC_OCEAN);
 }

--- a/tests/testqPrefLanguage.cpp
+++ b/tests/testqPrefLanguage.cpp
@@ -141,15 +141,14 @@ void TestQPrefLanguage::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.locale.use_system_language = false;
-	auto tst_direct = new qPrefLanguage;
 
 	prefs.time_format_override = true;
 	auto tst = qPrefLanguage::instance();
 
-	QCOMPARE(tst->use_system_language(), tst_direct->use_system_language());
-	QCOMPARE(tst->time_format_override(), tst_direct->time_format_override());
-	QCOMPARE(tst_direct->use_system_language(), false);
-	QCOMPARE(tst_direct->time_format_override(), true);
+	QCOMPARE(tst->use_system_language(), qPrefLanguage::use_system_language());
+	QCOMPARE(tst->time_format_override(), qPrefLanguage::time_format_override());
+	QCOMPARE(qPrefLanguage::use_system_language(), false);
+	QCOMPARE(qPrefLanguage::time_format_override(), true);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefLocationService.cpp
+++ b/tests/testqPrefLocationService.cpp
@@ -81,15 +81,13 @@ void TestQPrefLocationService::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.distance_threshold = 52;
-	auto tst_direct = new qPrefLocationService;
-
 	prefs.time_threshold = 62;
 	auto tst = qPrefLocationService::instance();
 
-	QCOMPARE(tst->distance_threshold(), tst_direct->distance_threshold());
-	QCOMPARE(tst->time_threshold(), tst_direct->time_threshold());
-	QCOMPARE(tst_direct->distance_threshold(), 52);
-	QCOMPARE(tst_direct->time_threshold(), 62);
+	QCOMPARE(tst->distance_threshold(), qPrefLocationService::distance_threshold());
+	QCOMPARE(tst->time_threshold(), qPrefLocationService::time_threshold());
+	QCOMPARE(qPrefLocationService::distance_threshold(), 52);
+	QCOMPARE(qPrefLocationService::time_threshold(), 62);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefPartialPressureGas.cpp
+++ b/tests/testqPrefPartialPressureGas.cpp
@@ -131,15 +131,13 @@ void TestQPrefPartialPressureGas::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.pp_graphs.phe_threshold = 2.2;
-	auto tst_direct = new qPrefPartialPressureGas;
-
 	prefs.pp_graphs.pn2_threshold = 2.3;
 	auto tst = qPrefPartialPressureGas::instance();
 
-	QCOMPARE(tst->phe_threshold(), tst_direct->phe_threshold());
-	QCOMPARE(tst->pn2_threshold(), tst_direct->pn2_threshold());
-	QCOMPARE(tst_direct->phe_threshold(), 2.2);
-	QCOMPARE(tst_direct->pn2_threshold(), 2.3);
+	QCOMPARE(tst->phe_threshold(), qPrefPartialPressureGas::phe_threshold());
+	QCOMPARE(tst->pn2_threshold(), qPrefPartialPressureGas::pn2_threshold());
+	QCOMPARE(qPrefPartialPressureGas::phe_threshold(), 2.2);
+	QCOMPARE(qPrefPartialPressureGas::pn2_threshold(), 2.3);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefProxy.cpp
+++ b/tests/testqPrefProxy.cpp
@@ -122,14 +122,12 @@ void TestQPrefProxy::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.proxy_port= 37;
-	auto tst_direct = new qPrefProxy;
-
 	prefs.proxy_type = 25;
 	auto tst = qPrefProxy::instance();
 
-	QCOMPARE(tst->proxy_port(), tst_direct->proxy_port());
+	QCOMPARE(tst->proxy_port(), qPrefProxy::proxy_port());
 	QCOMPARE(tst->proxy_port(), 37);
-	QCOMPARE(tst->proxy_type(), tst_direct->proxy_type());
+	QCOMPARE(tst->proxy_type(), qPrefProxy::proxy_type());
 	QCOMPARE(tst->proxy_type(), 25);
 }
 

--- a/tests/testqPrefTechnicalDetails.cpp
+++ b/tests/testqPrefTechnicalDetails.cpp
@@ -329,15 +329,13 @@ void TestQPrefTechnicalDetails::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.gfhigh = 27;
-	auto tst_direct = new qPrefTechnicalDetails;
-
 	prefs.gflow = 25;
 	auto tst = qPrefTechnicalDetails::instance();
 
-	QCOMPARE(tst->gfhigh(), tst_direct->gfhigh());
-	QCOMPARE(tst->gflow(), tst_direct->gflow());
-	QCOMPARE(tst_direct->gfhigh(), 27);
-	QCOMPARE(tst_direct->gflow(), 25);
+	QCOMPARE(tst->gfhigh(), qPrefTechnicalDetails::gfhigh());
+	QCOMPARE(tst->gflow(), qPrefTechnicalDetails::gflow());
+	QCOMPARE(qPrefTechnicalDetails::gfhigh(), 27);
+	QCOMPARE(qPrefTechnicalDetails::gflow(), 25);
 }
 
 #define TEST(METHOD, VALUE)      \

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -152,14 +152,13 @@ void TestQPrefUnits::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.units.length = units::METERS;
-	auto tst_direct = new qPrefUnits;
 
 	prefs.units.pressure = units::BAR;
 	auto tst = qPrefUnits::instance();
 
-	QCOMPARE(tst->length(), tst_direct->length());
+	QCOMPARE(tst->length(), qPrefUnits::length());
 	QCOMPARE(tst->length(), units::METERS);
-	QCOMPARE(tst->pressure(), tst_direct->pressure());
+	QCOMPARE(tst->pressure(), qPrefUnits::pressure());
 	QCOMPARE(tst->pressure(), units::BAR);
 }
 

--- a/tests/testqPrefUpdateManager.cpp
+++ b/tests/testqPrefUpdateManager.cpp
@@ -114,15 +114,14 @@ void TestQPrefUpdateManager::test_multiple()
 	// test multiple instances have the same information
 
 	prefs.update_manager.dont_check_for_updates = false;
-	auto tst_direct = new qPrefUpdateManager;
 
 	prefs.update_manager.dont_check_exists = false;
 	auto tst = qPrefUpdateManager::instance();
 
-	QCOMPARE(tst->dont_check_for_updates(), tst_direct->dont_check_for_updates());
+	QCOMPARE(tst->dont_check_for_updates(), qPrefUpdateManager::dont_check_for_updates());
 	QCOMPARE(tst->dont_check_for_updates(), false);
-	QCOMPARE(tst->dont_check_exists(), tst_direct->dont_check_exists());
-	QCOMPARE(tst_direct->dont_check_exists(), false);
+	QCOMPARE(tst->dont_check_exists(), qPrefUpdateManager::dont_check_exists());
+	QCOMPARE(qPrefUpdateManager::dont_check_exists(), false);
 }
 
 void TestQPrefUpdateManager::test_next_check()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Making all get/set functions static are slightly faster (since the functions are addressed without a vptr) but more importantly making the constructor private secures the object is a singleton.

This patch obsoletes #1672, and secures that both C++ and QML works efficiently.

This patch do not change functionality as such.

It also contains a single commit to update .gitignore with some untracked files, this strictly seen does not belong to this PR.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
see commits.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
