### PR TITLE
Cylinders: Fix crash when removing cylinders

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -486,7 +486,7 @@ Qt::ItemFlags CylindersModel::flags(const QModelIndex &index) const
 	return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
 }
 
-void CylindersModel::remove(const QModelIndex &index)
+void CylindersModel::remove(QModelIndex index)
 {
 
 	if (index.column() == USE) {

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -46,7 +46,7 @@ public:
 
 public
 slots:
-	void remove(const QModelIndex &index);
+	void remove(QModelIndex index);
 	void cylindersReset(const QVector<dive *> &dives);
 	bool updateBestMixes();
 

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -21,7 +21,7 @@ weightsystem_t *WeightModel::weightSystemAt(const QModelIndex &index)
 	return &displayed_dive.weightsystems.weightsystems[index.row()];
 }
 
-void WeightModel::remove(const QModelIndex &index)
+void WeightModel::remove(QModelIndex index)
 {
 	if (index.column() != REMOVE)
 		return;

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -31,7 +31,7 @@ public:
 
 public
 slots:
-	void remove(const QModelIndex &index);
+	void remove(QModelIndex index);
 	void weightsystemsReset(const QVector<dive *> &dives);
 
 private:


### PR DESCRIPTION
Change the remove() function of the cylinder and weight models
to take the index by value. The code used to take it by reference
and the reference would be invalidated when removing rows from
the model!

Reported-by: Gaetan Bisson <bisson@archlinux.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'm currently bedridden owing to a nasty cold. Therefore, no comments besides commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Pass model indexes by value instead of reference. References are evil.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@vesath