### PR TITLE
[RFC] Desktop: Improve speed of selecting multiple (or all) dives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 Mobile: (desktop only) new switch --testqml, allows to use qml files instead of resources.
+Desktop: increase speed of multi-trip selection
 Mobile: ensure that all BT/BLE flavors of the OSTC are recognized as dive computers [#2358]
 Desktop: allow copy&pasting of multiple cylinders [#2386]
 Desktop: don't output random SAC values for cylinders without data [#2376]

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -70,6 +70,9 @@ slots:
 	void filterFinished();
 	void tripChanged(dive_trip *trip, TripField);
 private:
+	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
+	void selectAll() override;
+	void selectionChangeDone();
 	bool mouseClickSelection;
 	QList<int> expandedRows;
 	DiveTripModelBase::Layout currentLayout;


### PR DESCRIPTION
When selecting all dives via CTRL-A or manually and the trips
were not expanded, the QSelectionModel sends a single
selectionChanged signal per trip. We are reloading the map
in every call, making this very slow.

I couldn't figure out how to make QSelectionModel behave more
nicely, therefore I chose the nuclear option: Remove the map
reloading from selectionChanged() and hook into all functions
that do selection changes. In these functions, first call the
original code and then do the selection-changed operations.

This will certainly need some tuning.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Willem reported slow selection of the whole divelog. The main cause was way too many map-reloads. I didn't find out how to solve this properly, therefore I propose this very dirty hack, which hooks into Qt's innards directly. Ideally a Qt-export would look into this, but I reckon that this is unrealistic.

This needs testing, as it will certainly break things.

Note: This doesn't fix the fundamental madness of the selection code.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Hook into selection changing functions.
2) Move map-reloading into kidnapped functions.
3) Remove dontEmitDiveChangedSignal, since the this is now solved differently, i.e. the code at the end of selection changes is called explicitly.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
no.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson: You complained about the selection problem, therefore I would appreciate your testing.