### PR TITLE
Add current GF to infobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Profile: Add current GF to infobox
 Mobile: (desktop only) new switch --testqml, allows to use qml files instead of resources.
 Mobile: ensure that all BT/BLE flavors of the OSTC are recognized as dive computers [#2358]
 Desktop: allow copy&pasting of multiple cylinders [#2386]

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -2290,8 +2290,11 @@ TTS longer than 2 hours is not accurately calculated and Subsurface only indicat
 
 [icon="images/icons/GFLow.jpg"]
 [NOTE]
-Show *Deco information*. When enabled, the information box shows the surface GF and the momentary
-ceilings for the individual tissue compartments. The surface GF is an indication of to what degree
+Show *Deco information*. When enabled, the information box shows  the current gradient factor (GF),
+the surface GF and the momentary
+ceilings for the individual tissue compartments. The gradient factor is in indication of how
+much of the allowed pressure gradient between tissues (normalized with a 100/100 Bühlmann model)
+the diver is currently using. The surface GF is an indication of to what degree
 the partial pressure of nitrogen in the blood exceeds the partial pressure required for safely
 reaching the surface. Surface GF > 100% means that it is unsafe to surface.
 

--- a/core/profile.c
+++ b/core/profile.c
@@ -1126,13 +1126,17 @@ void calculate_deco_information(struct deco_state *ds, const struct deco_state *
 				}
 			}
 			entry->surface_gf = 0.0;
+			entry->current_gf = 0.0;
 			for (j = 0; j < 16; j++) {
 				double m_value = ds->buehlmann_inertgas_a[j] + entry->ambpressure / ds->buehlmann_inertgas_b[j];
 				double surface_m_value = ds->buehlmann_inertgas_a[j] + surface_pressure / ds->buehlmann_inertgas_b[j];
 				entry->ceilings[j] = deco_allowed_depth(ds->tolerated_by_tissue[j], surface_pressure, dive, 1);
+				double current_gf = (ds->tissue_inertgas_saturation[j] - entry->ambpressure) / (m_value - entry->ambpressure);
 				entry->percentages[j] = ds->tissue_inertgas_saturation[j] < entry->ambpressure ?
 					lrint(ds->tissue_inertgas_saturation[j] / entry->ambpressure * AMB_PERCENTAGE) :
-					lrint(AMB_PERCENTAGE + (ds->tissue_inertgas_saturation[j] - entry->ambpressure) / (m_value - entry->ambpressure) * (100.0 - AMB_PERCENTAGE));
+					lrint(AMB_PERCENTAGE + current_gf * (100.0 - AMB_PERCENTAGE));
+				if (current_gf > entry->current_gf)
+					entry->current_gf = current_gf;
 				double surface_gf = 100.0 * (ds->tissue_inertgas_saturation[j] - surface_pressure) / (surface_m_value - surface_pressure);
 				if (surface_gf > entry->surface_gf)
 					entry->surface_gf = surface_gf;
@@ -1552,7 +1556,9 @@ static void plot_string(struct plot_info *pi, int idx, struct membuffer *b)
 	if (entry->rbt)
 		put_format_loc(b, translate("gettextFromC", "RBT: %umin\n"), DIV_UP(entry->rbt, 60));
 	if (prefs.decoinfo) {
-		if (entry->surface_gf > 0)
+		if (entry->current_gf > 0.0)
+			put_format(b, translate("gettextFromC", "GF %d%%\n"), (int)(100.0 * entry->current_gf));
+		if (entry->surface_gf > 0.0)
 			put_format(b, translate("gettextFromC", "Surface GF %.0f%%\n"), entry->surface_gf);
 		if (entry->ceiling) {
 			depthvalue = get_depth_units(entry->ceiling, NULL, &depth_unit);

--- a/core/profile.h
+++ b/core/profile.h
@@ -75,6 +75,7 @@ struct plot_data {
 	double ambpressure;
 	double gfline;
 	double surface_gf;
+	double current_gf;
 	double density;
 	bool icd_warning;
 };


### PR DESCRIPTION
As per request from users on scubaforum.com, this adds
the current gradient factor to the deco information of
the infobox. Up to now, this information was only
graphically represented in the pressure bar graph
and the heatmap. This gives a numerical value.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
CHANGELOG and user manual updated.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
