### PR TITLE
Add Export divesites to mobile.

### DIFF
--- a/core/exportfuncs.cpp
+++ b/core/exportfuncs.cpp
@@ -8,6 +8,7 @@
 #include "core/file.h"
 #include "core/errorhelper.h"
 #include "core/divefilter.h"
+#include "core/divesite.h"
 #include "exportfuncs.h"
 
 
@@ -300,6 +301,12 @@ std::vector<const dive_site *> exportFuncs::getDiveSitesToExport(bool selectedOn
 			continue;
 		res.push_back(ds);
 	}
+#else
+	/* walk the dive site list */
+	int i;
+	const struct dive_site *ds;
+	for_each_dive_site (i, ds, &dive_site_table)
+		res.push_back(get_dive_site(i, &dive_site_table));
 #endif
 	return res;
 }

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -88,7 +88,6 @@ Kirigami.ScrollablePage {
 		}
 		RadioButton {
 			Layout.fillWidth: true
-			visible: false // TEMPORARY MEASURE, until DiveFilter is available
 			text: qsTr("Export Subsurface dive sites XML")
 			exclusiveGroup: radioGroup
 			onClicked: {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Found a way to bypass DiveFilter (which are not activated for mobile), using a C macro
for_each_dive_site

This PR extends the export functionality in #2396, with dive sites export.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
see commits

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
sits on top of #2396, and need to be rebased when (if) #2396 is accepted.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Mobile doc. should be extended with the Export facility, including dive site export.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
