### PR TITLE
Undo: make profile-editing undoable

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -240,7 +240,12 @@ void pasteDives(const dive *d, dive_components what)
 
 void replanDive(dive *d)
 {
-	execute(new ReplanDive(d));
+	execute(new ReplanDive(d, false));
+}
+
+void editProfile(dive *d)
+{
+	execute(new ReplanDive(d, true));
 }
 
 // Trip editing related commands

--- a/commands/command.h
+++ b/commands/command.h
@@ -76,6 +76,7 @@ int editBuddies(const QStringList &newList, bool currentDiveOnly);
 int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
 void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
+void editProfile(dive *d); // dive computer(s) and cylinder(s) will be reset!
 
 // 5) Trip editing commands
 

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -783,13 +783,17 @@ void PasteDives::redo()
 }
 
 // ***** Paste *****
-ReplanDive::ReplanDive(dive *source) : d(current_dive),
+ReplanDive::ReplanDive(dive *source, bool edit_profile) : d(current_dive),
 	dc({ 0 }),
 	notes(nullptr)
 {
 	memset(&cylinders, 0, sizeof(cylinders));
 	if (!d)
 		return;
+
+	// Fix source. Things might be inconsistent after modifying the profile.
+	source->maxdepth.mm = source->dc.maxdepth.mm = 0;
+	fixup_dive(source);
 
 	when = source->when;
 	maxdepth = source->maxdepth;
@@ -803,7 +807,7 @@ ReplanDive::ReplanDive(dive *source) : d(current_dive),
 	std::swap(source->cylinders, cylinders);
 	std::swap(source->dc, dc);
 
-	setText(tr("Replan dive"));
+	setText(edit_profile ? tr("Replan dive") : tr("Edit profile"));
 }
 
 ReplanDive::~ReplanDive()

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -279,7 +279,9 @@ class ReplanDive : public Base {
 	duration_t duration;
 	int salinity;
 public:
-	ReplanDive(dive *source); // Dive computer(s) and cylinders(s) of the source dive will be reset!
+	// Dive computer(s) and cylinders(s) of the source dive will be reset!
+	// If edit_profile is true, the text will be changed from "replan dive" to "edit profile".
+	ReplanDive(dive *source, bool edit_profile);
 	~ReplanDive();
 private:
 	void undo() override;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -529,8 +529,6 @@ void MainTab::refreshDisplayedDiveSite()
 
 void MainTab::acceptChanges()
 {
-	int addedId = -1;
-
 	if (ui.location->hasFocus())
 		stealFocus();
 
@@ -541,33 +539,18 @@ void MainTab::acceptChanges()
 	ui.dateEdit->setEnabled(true);
 	hideMessage();
 
-	if (lastMode == MANUALLY_ADDED_DIVE) {
-		// preserve any changes to the profile
-		free(current_dive->dc.sample);
-		copy_samples(&displayed_dive.dc, &current_dive->dc);
-		addedId = displayed_dive.id;
-	}
-
 	// TODO: This is a temporary hack until the equipment tab is included in the undo system:
 	// The equipment tab is hardcoded at the first place of the "extra widgets".
 	((TabDiveEquipment *)extraWidgets[0])->acceptChanges();
 
 	if (lastMode == MANUALLY_ADDED_DIVE) {
-		// we just added or edited the dive, let fixup_dive() make
-		// sure we get the max. depth right
-		current_dive->maxdepth.mm = current_dc->maxdepth.mm = 0;
-		fixup_dive(current_dive);
-		set_dive_nr_for_current_dive();
 		MainWindow::instance()->showProfile();
-		mark_divelist_changed(true);
 		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
+		Command::editProfile(&displayed_dive);
 	}
 	int scrolledBy = MainWindow::instance()->diveList->verticalScrollBar()->sliderPosition();
 	if (lastMode == MANUALLY_ADDED_DIVE) {
 		MainWindow::instance()->diveList->reload();
-		int newDiveNr = get_divenr(get_dive_by_uniq_id(addedId));
-		MainWindow::instance()->diveList->unselectDives();
-		MainWindow::instance()->diveList->selectDive(newDiveNr, true);
 		MainWindow::instance()->refreshDisplay();
 		MainWindow::instance()->graphics->replot();
 	} else {


### PR DESCRIPTION
Recently, undo of dive-replanning was introduced. Therefore,
it appears logical to do the same thing for editing of the
profile of manually added dives.

For now, use the same undo-command, just change the displayed
text from "replan dive" to "edit profile". Move the fixup dive
call into the undo-command.

Eventually, every action on the profile should be made undoable.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This implements a small oversight of making replanning undoable: profile editing is virtually the same and should likewise be undoable. This PR most certainly conflicts with the divelist and weightsystem undo PRs rhat are currently open.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not necessary, since undo of dive replanning is already mentioned.