### PR TITLE
Cleanup: Fix order of initialization in MainTab::MainTab()

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -50,11 +50,11 @@ struct Completers {
 
 MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	editMode(NONE),
+	modified(false),
 	lastSelectedDive(true),
 	lastTabSelectedDive(0),
 	lastTabSelectedDiveTrip(0),
-	currentTrip(0),
-	modified(false)
+	currentTrip(0)
 {
 	ui.setupUi(this);
 


### PR DESCRIPTION
For deterministic construction/destruction (i.e. objects are
destructed in reverse order of construction) it is crucial that
constructor initializer lists follow the order of the class
definition.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial cleanup / fix.