### PR TITLE
Selection: provide convenience function for single-dive selection

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -574,10 +574,7 @@ void DeleteDive::redoit()
 		timestamp_t when = divesToAdd.dives[0].dive->when;
 		newCurrent = find_next_visible_dive(when);
 	}
-	if (newCurrent)
-		setSelection(std::vector<dive *>{ newCurrent }, newCurrent);
-	else
-		setSelection(std::vector<dive *>(), nullptr);
+	select_single_dive(newCurrent);
 }
 
 

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -195,6 +195,14 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive)
 	emit diveListNotifier.divesSelected(divesToSelect, current_dive);
 }
 
+extern "C" void select_single_dive(dive *d)
+{
+	if (d)
+		setSelection(std::vector<dive *>{ d }, d);
+	else
+		setSelection(std::vector<dive *>(), nullptr);
+}
+
 // Turn current selection into a vector.
 // TODO: This could be made much more efficient if we kept a sorted list of selected dives!
 std::vector<dive *> getDiveSelection()
@@ -217,9 +225,9 @@ extern "C" void select_newest_visible_dive()
 	for (int i = dive_table.nr - 1; i >= 0; --i) {
 		dive *d = dive_table.dives[i];
 		if (!d->hidden_by_filter)
-			return setSelection({ d }, d);
+			return select_single_dive(d);
 	}
 
 	// No visible dive -> deselect all
-	setSelection({}, nullptr);
+	select_single_dive(nullptr);
 }

--- a/core/selection.h
+++ b/core/selection.h
@@ -20,6 +20,7 @@ extern struct dive *first_selected_dive(void);
 extern struct dive *last_selected_dive(void);
 extern bool consecutive_selected(void);
 extern void select_newest_visible_dive();
+extern void select_single_dive(struct dive *d); // wrapper for setSelection() with a single dive. NULL clears the selection.
 
 #if DEBUG_SELECTION_TRACKING
 extern void dump_selection(void);


### PR DESCRIPTION
Currently, selecting a single dive or deselecting all dives was
quite awkward: One had to pass in a single-dive vector and the
dive itself (as current dive). Provide a convenience function
that selects a single dive or deselects all dives if null is
passed in.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Provide a small helper function to select single dives. The plan is to use this for mobile, but it appears to be useful as-is. Untested.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh