### PR TITLE
GitHub Actions: deal with case sensitive file system

### DIFF
--- a/scripts/docker/mxe-build-container/Dockerfile-stage2
+++ b/scripts/docker/mxe-build-container/Dockerfile-stage2
@@ -13,7 +13,8 @@ RUN cd /win/mxe ; \
 
 # manually build the Win BLE version of QtConnectivity (we can drop this with Qt 5.14)
 RUN cd /win/mxe ; \
-    mkdir -p neolit ; cd neolit ; git clone -b wip/win git://github.com/qt/qtconnectivity
+    mkdir -p neolit ; cd neolit ; git clone -b wip/win git://github.com/qt/qtconnectivity ; \
+    sed -i 's/SetupAPI.h/setupapi.h/' qtconnectivity/src/bluetooth/qlowenergycontroller_win.cpp
 RUN cd /win/mxe/neolit/qtconnectivity ; \
     PATH=/win/mxe/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /win/mxe/usr/i686-w64-mingw32.shared/qt5/bin/qmake qtconnectivity.pro ; \
     PATH=/win/mxe/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make -j 6 ; \


### PR DESCRIPTION
Sadly, there's an explicit change in the sources to of QtConnectivity
that requires this workaround when running the build on a case sensitive
file system.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Things like this waste so much time - and I remember running into this before.
Windows developer changes something that works into something that looks neat, but fails on a case sensitive filesystem.
https://github.com/qt/qtconnectivity/commit/8b7b52d66f2616040ca4aaae3f2732be96e19ab8#r36318531

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
force the include file name to be all lower case

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
build failures of our stage 2 build for MXE

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 