### PR TITLE
A few more model cleanups

### DIFF
--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -193,7 +193,7 @@ void DiveFilter::startFilterDiveSites(QVector<dive_site *> ds)
 		// When switching into dive site mode, reload the dive sites.
 		// We won't do this in myInvalidate() once we are in dive site mode.
 		MapWidget::instance()->reload();
-		DiveTripModelBase::instance()->recalculateFilter();
+		emit diveListNotifier.filterReset();
 	}
 }
 
@@ -202,7 +202,7 @@ void DiveFilter::stopFilterDiveSites()
 	if (--diveSiteRefCount > 0)
 		return;
 	dive_sites.clear();
-	DiveTripModelBase::instance()->recalculateFilter();
+	emit diveListNotifier.filterReset();
 	MapWidget::instance()->reload();
 }
 
@@ -215,7 +215,7 @@ void DiveFilter::setFilterDiveSite(QVector<dive_site *> ds)
 		return;
 	dive_sites = ds;
 
-	DiveTripModelBase::instance()->recalculateFilter();
+	emit diveListNotifier.filterReset();
 	MapWidget::instance()->setSelected(dive_sites);
 	MainWindow::instance()->diveList->expandAll();
 }
@@ -233,6 +233,6 @@ bool DiveFilter::diveSiteMode() const
 void DiveFilter::setFilter(const FilterData &data)
 {
 	filterData = data;
-	DiveTripModelBase::instance()->recalculateFilter();
+	emit diveListNotifier.filterReset();
 }
 #endif // SUBSURFACE_MOBILE

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -93,7 +93,7 @@ void DiveListView::calculateInitialColumnWidth(int col)
 	int em = metrics.width('m');
 	int zw = metrics.width('0');
 
-	QString header_txt = DiveTripModelBase::instance()->headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
+	QString header_txt = MultiFilterSortModel::instance()->headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
 	int width = metrics.width(header_txt);
 	int sw = 0;
 	switch (col) {

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -49,9 +49,6 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 
 	resetModel();
 
-	// Update selection if all selected dives were hidden by filter
-	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveListView::filterFinished);
-
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &DiveListView::tripChanged);
 
 	header()->setStretchLastSection(true);
@@ -271,26 +268,6 @@ void DiveListView::selectTrip(dive_trip_t *trip)
 	flags |= QItemSelectionModel::Rows;
 	selectionModel()->select(idx, flags);
 	expand(idx);
-}
-
-// this is an odd one - when filtering the dive list the selection status of the trips
-// is kept - but all other selections are lost. That's gets us into rather inconsistent state
-// we call this function which clears the selection state of the trips as well, but does so
-// without updating our internal "->selected" state. So once we called this function we can
-// go back and select those dives that are still visible under the filter and everything
-// works as expected
-void DiveListView::clearTripSelection()
-{
-	// This marks the selection change as being internal - ie. we don't process it further.
-	// TODO: This should probably be done differently.
-	auto marker = diveListNotifier.enterCommand();
-
-	// we want to make sure no trips are selected
-	Q_FOREACH (const QModelIndex &index, selectionModel()->selectedRows()) {
-		if (!index.data(DiveTripModelBase::IS_TRIP_ROLE).toBool())
-			continue;
-		selectionModel()->select(index, QItemSelectionModel::Deselect);
-	}
 }
 
 void DiveListView::unselectDives()
@@ -1017,19 +994,6 @@ void DiveListView::loadImageFromURL(QUrl url)
 			matchImagesToDives(QStringList(url.toString()));
 		}
 	}
-}
-
-void DiveListView::filterFinished()
-{
-	// first make sure the trips are no longer shown as selected
-	// (but without updating the selection state of the dives... this just cleans
-	// up an oddity in the filter handling)
-	clearTripSelection();
-
-	// If there are no more selected dives, select the first visible dive
-	if (!selectionModel()->hasSelection())
-		select_newest_visible_dive();
-	emit divesSelected();
 }
 
 QString DiveListView::lastUsedImageDir()

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -30,7 +30,6 @@ public:
 	void reload(); // Call to reload model data
 	bool eventFilter(QObject *, QEvent *);
 	void unselectDives();
-	void clearTripSelection();
 	void selectDive(QModelIndex index, bool scrollto = false);
 	void selectDive(int dive_table_idx, bool scrollto = false);
 	void selectDives(const QList<int> &newDiveSelection);
@@ -63,7 +62,6 @@ slots:
 	void loadWebImages();
 	void diveSelectionChanged(const QVector<QModelIndex> &indexes);
 	void currentDiveChanged(QModelIndex index);
-	void filterFinished();
 	void tripChanged(dive_trip *trip, TripField);
 private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -69,6 +69,7 @@
 #include "qt-models/cylindermodel.h"
 #include "qt-models/divepicturemodel.h"
 #include "qt-models/diveplannermodel.h"
+#include "qt-models/filtermodels.h"
 #include "qt-models/tankinfomodel.h"
 #include "qt-models/weightsysteminfomodel.h"
 #include "qt-models/yearlystatisticsmodel.h"
@@ -650,7 +651,7 @@ void MainWindow::closeCurrentFile()
 {
 	/* free the dives and trips */
 	clear_git_id();
-	DiveTripModelBase::instance()->clear();
+	MultiFilterSortModel::instance()->clear();
 	setCurrentFile(nullptr);
 	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
 	MapWidget::instance()->reload();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -357,22 +357,6 @@ QVariant DiveTripModelBase::headerData(int section, Qt::Orientation orientation,
 	return QVariant();
 }
 
-static std::unique_ptr<DiveTripModelBase> currentModel;
-DiveTripModelBase *DiveTripModelBase::instance()
-{
-	if (!currentModel)
-		resetModel(TREE);
-	return currentModel.get();
-}
-
-void DiveTripModelBase::resetModel(DiveTripModelBase::Layout layout)
-{
-	if (layout == TREE)
-		currentModel.reset(new DiveTripModelTree);
-	else
-		currentModel.reset(new DiveTripModelList);
-}
-
 // After resetting the model, the higher up model or view may call this
 // function to get informed on the current selection.
 // TODO: Currently, this reads and resets the selection. Make this more

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1347,7 +1347,7 @@ void DiveTripModelList::filterReset()
 
 		for (dive *d: items) {
 			bool shown = filter->showDive(d);
-			filter_dive(d, shown);
+			changed.push_back(filter_dive(d, shown));
 		}
 	}
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -742,7 +742,7 @@ void DiveTripModelTree::filterReset()
 	// resorting to co-routines, lambdas or similar techniques.
 	std::vector<char> changed;
 	changed.reserve(items.size());
-
+	dive *old_current = current_dive;
 	{
 		// This marker prevents the UI from getting notifications on selection changes.
 		// It is active until the end of the scope.
@@ -780,6 +780,11 @@ void DiveTripModelTree::filterReset()
 	}
 
 	emit diveListNotifier.numShownChanged();
+
+	// If the current dive changed, instruct the UI of the changed selection
+	// TODO: This is way to heavy, as it reloads the whole selection!
+	if (old_current != current_dive)
+		initSelection();
 }
 
 
@@ -1333,6 +1338,7 @@ void DiveTripModelList::filterReset()
 	// resorting to co-routines, lambdas or similar techniques.
 	std::vector<char> changed;
 	changed.reserve(items.size());
+	dive *old_current = current_dive;
 	{
 		// This marker prevents the UI from getting notifications on selection changes.
 		// It is active until the end of the scope. See comment in DiveTripModelTree::filterReset().
@@ -1349,6 +1355,11 @@ void DiveTripModelList::filterReset()
 	sendShownChangedSignals(changed, noParent);
 
 	emit diveListNotifier.numShownChanged();
+
+	// If the current dive changed, instruct the UI of the changed selection
+	// TODO: This is way to heavy, as it reloads the whole selection!
+	if (old_current != current_dive)
+		initSelection();
 }
 
 QVariant DiveTripModelList::data(const QModelIndex &index, int role) const

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -83,7 +83,6 @@ public:
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	DiveTripModelBase(QObject *parent = 0);
 	int columnCount(const QModelIndex&) const;
-	virtual void recalculateFilter() = 0;
 
 	// Used for sorting. This is a bit of a layering violation, as sorting should be performed
 	// by the higher-up QSortFilterProxyModel, but it makes things so much easier!
@@ -121,6 +120,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives, dive *current);
 	void tripChanged(dive_trip *trip, TripField);
+	void filterReset();
 
 public:
 	DiveTripModelTree(QObject *parent = nullptr);
@@ -133,7 +133,6 @@ private:
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	void divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &);
 	dive *diveOrNull(const QModelIndex &index) const override;
-	void recalculateFilter();
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, quintptr parentIndex);
@@ -188,6 +187,7 @@ public slots:
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives, dive *current);
+	void filterReset();
 
 public:
 	DiveTripModelList(QObject *parent = nullptr);
@@ -199,7 +199,6 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	dive *diveOrNull(const QModelIndex &index) const override;
-	void recalculateFilter();
 
 	std::vector<dive *> items;				// TODO: access core data directly
 };

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -18,12 +18,6 @@ struct DiveFilter;
 // from DiveTripModelBase, which implements common features (e.g.
 // definition of the column types, access of data from the core
 // structures) and a common interface.
-//
-// The currently active model is set via DiveTripModelBase::resetModel().
-// This will create a new model. The model can be accessed with
-// DiveTripModelBase::instance(). A pointer obtained by instance()
-// is invalidated by a call to resetModel()! Yes, this is surprising
-// behavior, so care must be taken.
 class DiveTripModelBase : public QAbstractItemModel {
 	Q_OBJECT
 public:
@@ -62,15 +56,6 @@ public:
 		TREE,
 		LIST,
 	};
-
-	// Functions implemented by base class
-	static DiveTripModelBase *instance();
-
-	// Reset the model using the given layout. After this call instance() will return
-	// a newly allocated object and the old model will have been destroyed! Thus, the
-	// caller is responsible for removing all references to any previous model obtained
-	// by instance().
-	static void resetModel(Layout layout);
 
 	// Call after having set the model to be informed of the current selection.
 	void initSelection();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -32,6 +32,11 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 	m->initSelection();
 }
 
+void MultiFilterSortModel::clear()
+{
+	DiveTripModelBase::instance()->clear();
+}
+
 // Translate selection into local indexes and re-emit signal
 void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indexes)
 {

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -5,7 +5,10 @@
 #include "divetripmodel.h"
 
 #include <QSortFilterProxyModel>
+#include <memory>
 
+// This proxy model sits on top of either a DiveTripList or DiveTripTree model
+// and does filtering and/or sorting.
 class MultiFilterSortModel : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
@@ -23,6 +26,7 @@ private slots:
 	void currentDiveChangedSlot(QModelIndex index);
 private:
 	MultiFilterSortModel(QObject *parent = 0);
+	std::unique_ptr<DiveTripModelBase> model;
 };
 
 #endif

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -14,6 +14,7 @@ public:
 	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
 
 	void resetModel(DiveTripModelBase::Layout layout);
+	void clear();
 signals:
 	void selectionChanged(const QVector<QModelIndex> &indexes);
 	void currentDiveChanged(QModelIndex index);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We had that absolutely horrible way that the pointer returned from `DiveTripModel::instance()` was invalidated if the model was reset, because a new model object was generated.

Make this logic local to the MultiFilterSortModel. This straightens up data and control flow, because now all interactions of the UI are via the MultiFilterSortModel.

The main reason for this PR is that on mobile we want two different proxy-models translating the DiveTripModel and that didn't work out with the old method.

Finally, this PR fixes a few bugs concerning selection and signals.

PS: This still doesn't make it possible to have a DiveTripList and a DiveTripTree model at the same time. The reason being that on filter-reset the model directly modifies the hidden_by_filter flag of the core. The reason for that is that the model sends signals for all dives where hidden_by_filter changed. To move the filter-recalculation to the core, the model would have to remember the old filter-status and I didn't want to do that for now.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 