### PR TITLE
[RFC] build-system: allow shared source across multiple hosts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,22 +9,40 @@
 #
 # it installs the libraries and subsurface in the install-root subdirectory
 # of the current directory (except on Mac where the Subsurface.app ends up
-# in subsurface/build
+# in subsurface/build)
+#
+# by default it puts the build folders in
+# ./subsurface/llibdivecomputer/build (libdivecomputer build)
+# ./subsurface/build                  (desktop build)
+# ./subsurface/build-mobile           (mobile build)
 #
 # there is basic support for building from a shared directory, e.g., with
 # one subsurface source tree on a host computer, accessed from multiple
 # VMs as well as the host to build without stepping on each other - the
 # one exceptioin is running autotools for libdiveconputer which has to
 # happen in the shared libdivecomputer folder
-
-# create a log file of the build
+# one way to achieve this is to have ./subsurface be a symlink; in that
+# case the build directories are libdivecomputer/build, build, build-mobile
+# alternatively a build prefix can be explicitly given with -build-prefix
+# that build prefix is directly pre-pended to the destinations mentioned
+# above - if this is a directory, it needs to end with '/'
 
 # don't keep going if we run into an error
 set -e
 
+# create a log file of the build
+
 exec 1> >(tee build.log) 2>&1
 
 SRC=$(pwd)
+
+if [[ -L subsurface && -d subsurface ]] ; then
+	# ./subsurface is a symbolic link to the source directory, so let's
+	# set up a prefix that puts the build directories in the current directory
+	# but this can be overwritten via the command line
+	BUILD_PREFIX="${SRC}/"
+fi
+
 PLATFORM=$(uname)
 
 BTSUPPORT="ON"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -174,8 +174,12 @@ if [[ ! -d "subsurface" ]] ; then
 	exit 1
 fi
 
-mkdir -p install-root
-INSTALL_ROOT=$SRC/install-root
+if [ -z "$BUILD_PREFIX" ] ; then
+	INSTALL_ROOT=$SRC/install-root
+else
+	INSTALL_ROOT="$BUILD_PREFIX"install-root
+fi
+mkdir -p "$INSTALL_ROOT"
 export INSTALL_ROOT
 
 # make sure we find our own packages first (e.g., libgit2 only uses pkg_config to find libssh2)


### PR DESCRIPTION
This attempts to allow sharing a host directory across multiple builds, target
use case is to have a shared source directory on a VM host and be able to build
from that in a number of VMs without those builds stepping on top of each
other.

Instead of subsurface/build, subsurface/mobile-build,
subsurface/libdivecomputer/build, use a prefix path to allow having true out of
tree builds.

The one shortcoming is that the autotools need to be run in the libdivecomputer
directory - that means this will be run on the first system that starts a
build. But that seems to cause no harm in my testing.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It's fairly straight forward, trying hard not to break things for people who aren't using the prefix (i.e. 99% of the users), while giving this extra flexibility to people like me who build on several different platforms on the same system.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
not sure if any of you would use this. but I'd love critical eyes on this to make sure I didn't break anything. @glance- you tend to be good at these things...