### PR TITLE
Dive list: implement DiveTripModelBase::reset()

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -379,6 +379,15 @@ void DiveTripModelBase::clear()
 	endResetModel();
 }
 
+void DiveTripModelBase::reset()
+{
+	beginResetModel();
+	clearData();
+	populate();
+	endResetModel();
+	initSelection();
+}
+
 DiveTripModelBase::DiveTripModelBase(QObject *parent) : QAbstractItemModel(parent)
 {
 }
@@ -561,7 +570,11 @@ DiveTripModelTree::DiveTripModelTree(QObject *parent) : DiveTripModelBase(parent
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &DiveTripModelTree::tripChanged);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelTree::filterReset);
 
-	// Fill model
+	populate();
+}
+
+void DiveTripModelTree::populate()
+{
 	for (int i = 0; i < dive_table.nr ; ++i) {
 		dive *d = get_dive(i);
 		update_cylinder_related_info(d);
@@ -1286,6 +1299,11 @@ DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent
 	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelList::divesSelected);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelList::filterReset);
 
+	populate();
+}
+
+void DiveTripModelList::populate()
+{
 	// Fill model
 	items.reserve(dive_table.nr);
 	for (int i = 0; i < dive_table.nr ; ++i)

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -63,6 +63,9 @@ public:
 	// Clear all dives
 	void clear();
 
+	// Reload data
+	void reset();
+
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
@@ -91,6 +94,7 @@ protected:
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 	virtual void clearData() = 0;
+	virtual void populate() = 0;
 };
 
 class DiveTripModelTree : public DiveTripModelBase
@@ -112,6 +116,7 @@ public:
 private:
 	int rowCount(const QModelIndex &parent) const override;
 	void clearData() override;
+	void populate() override;
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
@@ -179,6 +184,7 @@ public:
 private:
 	int rowCount(const QModelIndex &parent) const override;
 	void clearData() override;
+	void populate() override;
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;


### PR DESCRIPTION
On desktop, resetting the model is realized by generating a new
model object. This is due to the fact that we have two different
models (tree and list) and for switching between those, we have
to create a new object.

On mobile, currently there are no plans to support the list-mode.
Therefore, there is no reason the recreate the object. Instead,
implement a reset() function that reloads the core data.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is another (tiny) preparation for mobile and desktop unification. On desktop, we reset the models by doing a full regeneration of the model-object. Since we don't support list-mode on mobile (yet?) add a function to reset the model.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh