### PR TITLE
Implement dive-invalid flag. Needs some UI work and fine-tuning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: implement dive invalidation
 Mobile-android: remove libusb/FTDI support (largely non-functional)
 Mobile-android: Continue download after obtaining USB permission
 Mobile-android: Add usb-serial-for-android driver support

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -168,6 +168,11 @@ int editMode(int index, int newValue, bool currentDiveOnly)
 	return execute_edit(new EditMode(index, newValue, currentDiveOnly));
 }
 
+int editInvalid(int newValue, bool currentDiveOnly)
+{
+	return execute_edit(new EditInvalid(newValue, currentDiveOnly));
+}
+
 int editSuit(const QString &newValue, bool currentDiveOnly)
 {
 	return execute_edit(new EditSuit(newValue, currentDiveOnly));

--- a/commands/command.h
+++ b/commands/command.h
@@ -66,6 +66,7 @@ void purgeUnusedDiveSites();
 int editNotes(const QString &newValue, bool currentDiveOnly);
 int editSuit(const QString &newValue, bool currentDiveOnly);
 int editMode(int index, int newValue, bool currentDiveOnly);
+int editInvalid(int newValue, bool currentDiveOnly);
 int editRating(int newValue, bool currentDiveOnly);
 int editVisibility(int newValue, bool currentDiveOnly);
 int editWaveSize(int newValue, bool currentDiveOnly);

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -574,6 +574,27 @@ DiveField EditMode::fieldId() const
 	return DiveField::MODE;
 }
 
+// ***** Invalid *****
+void EditInvalid::set(struct dive *d, int invalid) const
+{
+	d->invalid = invalid;
+}
+
+int EditInvalid::data(struct dive *d) const
+{
+	return d->invalid;
+}
+
+QString EditInvalid::fieldName() const
+{
+	return tr("invalid");
+}
+
+DiveField EditInvalid::fieldId() const
+{
+	return DiveField::INVALID;
+}
+
 // ***** Tag based commands *****
 EditTagsBase::EditTagsBase(const QStringList &newListIn, bool currentDiveOnly) :
 	EditDivesBase(currentDiveOnly),

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -222,6 +222,15 @@ public:
 	DiveField fieldId() const override;
 };
 
+class EditInvalid : public EditBase<int> {
+public:
+	using EditBase<int>::EditBase;	// Use constructor of base class.
+	void set(struct dive *d, int number) const override;
+	int data(struct dive *d) const override;
+	QString fieldName() const override;
+	DiveField fieldId() const override;
+};
+
 // Fields that work with tag-lists (tags, buddies, divemasters) work differently and therefore
 // have their own base class. In this case, it's not a template, as all these lists are base
 // on strings.

--- a/core/dive.h
+++ b/core/dive.h
@@ -172,6 +172,7 @@ struct dive {
 	bool selected;
 	bool hidden_by_filter;
 	struct full_text_cache *full_text; /* word cache for full text search */
+	bool invalid;
 };
 
 /* For the top-level list: an entry is either a dive or a trip */

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -287,6 +287,9 @@ DiveFilter::DiveFilter() : diveSiteRefCount(0)
 
 bool DiveFilter::showDive(const struct dive *d) const
 {
+	if (d->invalid && !prefs.display_invalid_dives)
+		return false;
+
 	if (!filterData.validFilter)
 		return true;
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1268,6 +1268,16 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
 	}
 }
 
+static struct dive *get_last_valid_dive()
+{
+	int i;
+	for (i = dive_table.nr - 1; i >= 0; i--) {
+		if (!dive_table.dives[i]->invalid)
+			return dive_table.dives[i];
+	}
+	return NULL;
+}
+
 /* return the number a dive gets when inserted at the given index.
  * this function is supposed to be called *before* a dive was added.
  * this returns:
@@ -1277,13 +1287,10 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
  */
 int get_dive_nr_at_idx(int idx)
 {
-	if (dive_table.nr == 0)
+	struct dive *last_dive = get_last_valid_dive(dive_table.nr - 1);
+	if (!last_dive)
 		return 1;
-	if (idx >= dive_table.nr) {
-		struct dive *last_dive = get_dive(dive_table.nr - 1);
-		return last_dive->number ? last_dive->number + 1 : 0;
-	}
-	return 0;
+	return last_dive->number ? last_dive->number + 1 : 0;
 }
 
 void set_dive_nr_for_current_dive()

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -283,6 +283,13 @@ static void parse_dive_notrip(char *line, struct membuffer *str, struct git_pars
 	state->active_dive->notrip = true;
 }
 
+static void parse_dive_invalid(char *line, struct membuffer *str, struct git_parser_state *state)
+{
+	UNUSED(str);
+	UNUSED(line);
+	state->active_dive->invalid = true;
+}
+
 static void parse_site_description(char *line, struct membuffer *str, struct git_parser_state *state)
 { UNUSED(line); state->active_site->description = detach_cstring(str); }
 
@@ -1039,7 +1046,7 @@ struct keyword_action dive_action[] = {
 #undef D
 #define D(x) { #x, parse_dive_ ## x }
 	D(airpressure), D(airtemp), D(buddy), D(chill), D(current), D(cylinder), D(divemaster), D(divesiteid), D(duration),
-	D(gps), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
+	D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
 	D(tags), D(visibility), D(watersalinity), D(watertemp), D(wavesize), D(weightsystem)
 };
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1381,6 +1381,8 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH_STATE("water.divetemperature", temperature, &dive->watertemp))
 		return;
+	if (MATCH("invalid", get_bool, &dive->invalid))
+		return;
 
 	nonmatch("dive", name, buf);
 }

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -442,6 +442,7 @@ static void create_dive_buffer(struct dive *dive, struct membuffer *b)
 	if (surface_pressure.mbar)
 		SAVE("airpressure", surface_pressure.mbar);
 	cond_put_format(dive->notrip, b, "notrip\n");
+	cond_put_format(dive->invalid, b, "invalid\n");
 	save_tags(b, dive->tag_list);
 	if (dive->dive_site)
 		put_format(b, "divesiteid %08x\n", dive->dive_site->uuid);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -498,6 +498,8 @@ void save_one_dive_to_mb(struct membuffer *b, struct dive *dive, bool anonymize)
 		put_format(b, " surge='%d'", dive->surge);
 	if (dive->chill)
 		put_format(b, " chill='%d'", dive->chill);
+	if (dive->invalid)
+		put_format(b, " invalid");
 	save_tags(b, dive->tag_list);
 	if (dive->dive_site)
 		put_format(b, " divesiteid='%8x'", dive->dive_site->uuid);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -499,7 +499,7 @@ void save_one_dive_to_mb(struct membuffer *b, struct dive *dive, bool anonymize)
 	if (dive->chill)
 		put_format(b, " chill='%d'", dive->chill);
 	if (dive->invalid)
-		put_format(b, " invalid");
+		put_format(b, " invalid='1'");
 	save_tags(b, dive->tag_list);
 	if (dive->dive_site)
 		put_format(b, " divesiteid='%8x'", dive->dive_site->uuid);

--- a/core/statistics.c
+++ b/core/statistics.c
@@ -165,6 +165,8 @@ void calculate_stats_summary(struct stats_summary *out, bool selected_only)
 	for_each_dive (idx, dp) {
 		if (selected_only && !dp->selected)
 			continue;
+		if (dp->invalid)
+			continue;
 		process_dive(dp, &stats);
 
 		/* yearly statistics */
@@ -296,7 +298,7 @@ void calculate_stats_selected(stats_t *stats_selection)
 
 	nr = 0;
 	for_each_dive(i, dive) {
-		if (dive->selected) {
+		if (dive->selected && !dive->invalid) {
 			process_dive(dive, stats_selection);
 			nr++;
 		}
@@ -404,7 +406,7 @@ void selected_dives_gas_parts(volume_t *o2_tot, volume_t *he_tot)
 	int i, j;
 	struct dive *d;
 	for_each_dive (i, d) {
-		if (!d->selected)
+		if (!d->selected || d->invalid)
 			continue;
 		volume_t *diveGases = get_gas_used(d);
 		for (j = 0; j < d->cylinders.nr; j++) {

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -35,6 +35,7 @@ struct DiveField {
 	unsigned int mode : 1;
 	unsigned int notes : 1;
 	unsigned int salinity : 1;
+	unsigned int invalid : 1;
 	enum Flags {
 		NONE = 0,
 		NR = 1 << 0,
@@ -57,7 +58,8 @@ struct DiveField {
 		TAGS = 1 << 17,
 		MODE = 1 << 18,
 		NOTES = 1 << 19,
-		SALINITY = 1 << 20
+		SALINITY = 1 << 20,
+		INVALID = 1 << 21
 	};
 	DiveField(int flags);
 };

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -838,22 +838,7 @@ void DiveListView::addToTrip(int delta)
 
 void DiveListView::markDiveInvalid()
 {
-	int i;
-	struct dive *d = contextMenuIndex.data(DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
-	if (!d)
-		return;
-	for_each_dive (i, d) {
-		if (!d->selected)
-			continue;
-		//TODO: this should be done in the future
-		// now mark the dive invalid... how do we do THAT?
-		// d->invalid = true;
-	}
-	mark_divelist_changed(true);
-	MainWindow::instance()->refreshDisplay();
-	if (prefs.display_invalid_dives == false) {
-		clearSelection();
-	}
+	Command::editInvalid(true, false);
 }
 
 void DiveListView::deleteDive()
@@ -935,9 +920,7 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 	}
 	if (d) {
 		popup.addAction(tr("Delete dive(s)"), this, &DiveListView::deleteDive);
-#if 0
-		popup.addAction(tr("Mark dive(s) invalid", this, &DiveListView::markDiveInvalid);
-#endif
+		popup.addAction(tr("Mark dive(s) invalid"), this, &DiveListView::markDiveInvalid);
 	}
 	if (amount_selected > 1 && consecutive_selected())
 		popup.addAction(tr("Merge selected dives"), this, &DiveListView::mergeDives);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -841,6 +841,11 @@ void DiveListView::markDiveInvalid()
 	Command::editInvalid(true, false);
 }
 
+void DiveListView::markDiveValid()
+{
+	Command::editInvalid(false, false);
+}
+
 void DiveListView::deleteDive()
 {
 	struct dive *d = contextMenuIndex.data(DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
@@ -920,7 +925,10 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 	}
 	if (d) {
 		popup.addAction(tr("Delete dive(s)"), this, &DiveListView::deleteDive);
-		popup.addAction(tr("Mark dive(s) invalid"), this, &DiveListView::markDiveInvalid);
+		if (d->invalid)
+			popup.addAction(tr("Mark dive(s) valid"), this, &DiveListView::markDiveValid);
+		else
+			popup.addAction(tr("Mark dive(s) invalid"), this, &DiveListView::markDiveInvalid);
 	}
 	if (amount_selected > 1 && consecutive_selected())
 		popup.addAction(tr("Merge selected dives"), this, &DiveListView::mergeDives);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -47,6 +47,7 @@ slots:
 	void removeFromTrip();
 	void deleteDive();
 	void markDiveInvalid();
+	void markDiveValid();
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;
 	void reset() override;
 	void mergeTripAbove();

--- a/desktop-widgets/preferences/preferences_log.cpp
+++ b/desktop-widgets/preferences/preferences_log.cpp
@@ -6,6 +6,7 @@
 #include "core/settings/qPrefDisplay.h"
 #include "core/settings/qPrefCloudStorage.h"
 #include "core/settings/qPrefDiveComputer.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 
 #include <QFileDialog>
 #include <QProcess>
@@ -85,8 +86,14 @@ void PreferencesLog::syncSettings()
 	else if (ui->cloudDefaultFile->isChecked())
 		log->set_default_file_behavior(CLOUD_DEFAULT_FILE);
 
+	bool displayinvalid_changed = ui->displayinvalid->isChecked() != prefs.display_invalid_dives;
+
 	qPrefLog::set_show_average_depth(ui->show_average_depth->isChecked());
 	qPrefDisplay::set_display_invalid_dives(ui->displayinvalid->isChecked());
 	qPrefLog::set_extraEnvironmentalDefault(ui->extraEnvironmentalDefault->isChecked());
 	qPrefLog::set_salinityEditDefault(ui->salinityEditDefault->isChecked());
+
+	// TODO: Move to preferences code?
+	if (displayinvalid_changed)
+		emit diveListNotifier.filterReset();
 }

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -107,6 +107,9 @@ QVariant DiveTripModelBase::tripData(const dive_trip *trip, int column, int role
 	case MobileListModel::TripNotesRole: return QString(trip->notes);
 	}
 #endif
+	// Set the font for all trips alike
+	if (role == Qt::FontRole)
+		return defaultModelFont();
 
 	if (role == TRIP_ROLE)
 		return QVariant::fromValue(const_cast<dive_trip *>(trip)); // Not nice: casting away a const
@@ -187,6 +190,15 @@ static QString displayWeight(const struct dive *d, bool units)
 		return s + gettextFromC::tr("lbs");
 }
 
+static QFont struckOutFont()
+{
+	QFont font;
+	font.setStrikeOut(true);
+	return font;
+}
+static QBrush invalidForeground(Qt::gray);
+static QFont invalidFont = struckOutFont();
+
 QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 {
 #ifdef SUBSURFACE_MOBILE
@@ -235,6 +247,10 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	}
 #endif
 	switch (role) {
+	case Qt::FontRole:
+		return d->invalid ? invalidFont : defaultModelFont();
+	case Qt::ForegroundRole:
+		return d->invalid ? invalidForeground : QVariant();
 	case Qt::TextAlignmentRole:
 		return dive_table_alignment(column);
 	case Qt::DisplayRole:
@@ -920,10 +936,6 @@ void DiveTripModelTree::divesHidden(dive_trip *trip, const QVector<dive *> &dive
 
 QVariant DiveTripModelTree::data(const QModelIndex &index, int role) const
 {
-	// Set the font for all items alike
-	if (role == Qt::FontRole)
-		return defaultModelFont();
-
 	dive_or_trip entry = tripOrDive(index);
 	if (!entry.trip && !entry.dive)
 		return QVariant();			// That's an invalid index!
@@ -1522,10 +1534,6 @@ void DiveTripModelList::filterReset()
 
 QVariant DiveTripModelList::data(const QModelIndex &index, int role) const
 {
-	// Set the font for all items alike
-	if (role == Qt::FontRole)
-		return defaultModelFont();
-
 	dive *d = diveOrNull(index);
 	return d ? diveData(d, index.column(), role) : QVariant();
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This implements the "mark dive invalid" feature that has been requested a few times.

This implements the core code. However, the UI code is only a proof of concept: Invalid dives, if shown, are marked by a gray background. This is unfortunate as this is not visible when selected. I'd ask someone else to do the UI part, if there is interest.

The invalid flag is considered for the statistics and when calculating a new dive number. This probably needs some fine-tuning. For example, what about residual N2 in the planner?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement invalid-flag
2) Save/load invalid-flag
3) Implement undo-command to set/reset the invalid-flag
4) Update filter when changing the show-invalid-dives preferences
5) Ignore invalid dives in statistics / when calculating new dive numbers

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This feature was suggested as a potential solution for #2154.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Let's wait for approval / refinement.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Should be done, yes.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @willemferguson @atdotde