### PR TITLE
Coding style: use std::equal_to instead of lambda

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1108,7 +1108,7 @@ void DiveTripModelTree::divesChangedTrip(dive_trip *trip, const QVector<dive *> 
 
 		// Change the dives in the trip. We do this range-wise.
 		processRangesZip(items[idx].dives, dives,
-				 [](const dive *d1, const dive *d2) { return d1 == d2; }, // Condition (std::equal_to only in C++14)
+				 std::equal_to<const dive *>(), // Condition: dive-pointers are equal
 				 [&](const std::vector<dive *> &, const QVector<dive *> &, int from, int to, int) -> int { // Action
 					// TODO: We might be smarter about which columns changed!
 					dataChanged(createIndex(from, 0, idx), createIndex(to - 1, COLUMNS - 1, idx));
@@ -1410,7 +1410,7 @@ void DiveTripModelList::divesDeleted(dive_trip *, bool, const QVector<dive *> &d
 	QVector<dive *> dives = divesIn;
 	std::sort(dives.begin(), dives.end(), dive_less_than);
 	processRangesZip(items, dives,
-			 [](const dive *d1, const dive *d2) { return d1 == d2; }, // Condition (std::equal_to only in C++14)
+			 std::equal_to<const dive *>(), // Condition: dive-pointers are equal
 			 [&](std::vector<dive *> &items, const QVector<dive *> &, int from, int to, int) -> int { // Action
 				beginRemoveRows(QModelIndex(), from, to - 1);
 				items.erase(items.begin() + from, items.begin() + to);
@@ -1437,7 +1437,7 @@ void DiveTripModelList::divesChanged(const QVector<dive *> &divesIn)
 	// in dives as this must be the first that we encounter. Once we find a range, increase the
 	// index accordingly.
 	processRangesZip(items, dives,
-			 [](const dive *d1, const dive *d2) { return d1 == d2; }, // Condition (std::equal_to only in C++14)
+			 std::equal_to<const dive *>(), // Condition: dive-pointers are equal
 			 [&](const std::vector<dive *> &, const QVector<dive *> &, int from, int to, int) -> int { // Action
 				// TODO: We might be smarter about which columns changed!
 				dataChanged(createIndex(from, 0, noParent), createIndex(to - 1, COLUMNS - 1, noParent));


### PR DESCRIPTION
Use std::equal_to instead of lambdas that compare two dive pointers.
One could argue over which version is more readable. For whatever
it's worth, std::equal_to is more compact and expressive.

This removes an old erroneous comment that stated that std::equal_to
is only available since C++14.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Random trivial cleanup. All information is in the commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use std::equal_to instead of lambda-expression.