### PR TITLE
Diveplanner for mobile, first PR of a larger number of PR´s

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -72,6 +72,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	divelist.h
 	divelogexportlogic.cpp
 	divelogexportlogic.h
+	plannershared.cpp
+	plannershared.h
 	divesite-helper.cpp
 	divesite.c
 	divesite.h

--- a/core/plannershared.cpp
+++ b/core/plannershared.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "plannershared.h"
+
+
+plannerShared *plannerShared::instance()
+{
+    static plannerShared *self = new plannerShared;
+    return self;
+}

--- a/core/plannershared.cpp
+++ b/core/plannershared.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "plannershared.h"
+#include "core/pref.h"
+#include "core/settings/qPrefDivePlanner.h"
 
 
 plannerShared *plannerShared::instance()
@@ -7,3 +9,53 @@ plannerShared *plannerShared::instance()
     static plannerShared *self = new plannerShared;
     return self;
 }
+
+// Used to convert between meter/feet and keep the qPref variables independent
+#define TO_MM_BY_SEC ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
+
+// Converted meter/feet qPrefDivePlanner values
+int plannerShared::ascratelast6m()
+{
+	return lrint(prefs.ascratelast6m / TO_MM_BY_SEC);
+}
+void plannerShared::set_ascratelast6m(int value)
+{
+	qPrefDivePlanner::set_ascratelast6m(value * TO_MM_BY_SEC);
+}
+
+int plannerShared::ascratestops()
+{
+	return lrint(prefs.ascratestops / TO_MM_BY_SEC);
+}
+void plannerShared::set_ascratestops(int value)
+{
+	qPrefDivePlanner::set_ascratestops(value * TO_MM_BY_SEC);
+}
+
+int plannerShared::ascrate50()
+{
+	return lrint(prefs.ascrate50 / TO_MM_BY_SEC);
+}
+void plannerShared::set_ascrate50(int value)
+{
+	qPrefDivePlanner::set_ascrate50(value * TO_MM_BY_SEC);
+}
+
+int plannerShared::ascrate75()
+{
+	return lrint(prefs.ascrate75 / TO_MM_BY_SEC);
+}
+void plannerShared::set_ascrate75(int value)
+{
+	qPrefDivePlanner::set_ascrate75(value * TO_MM_BY_SEC);
+}
+
+int plannerShared::descrate()
+{
+	return lrint(prefs.descrate / TO_MM_BY_SEC);
+}
+void plannerShared::set_descrate(int value)
+{
+	qPrefDivePlanner::set_descrate(value * TO_MM_BY_SEC);
+}
+

--- a/core/plannershared.h
+++ b/core/plannershared.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef PLANNERSHARED_H
+#define PLANNERSHARED_H
+#include <QObject>
+
+// This is a shared class (mobile/desktop), and contains the core of the diveplanner
+// without UI entanglement.
+// It make variables and functions available to QML, these are referenced directly
+// in the desktop version
+//
+// The mobile diveplanner shows all diveplans, but the editing functionality is
+// limited to keep the UI simpler.
+
+class plannerShared: public QObject {
+	Q_OBJECT
+
+public:
+	static plannerShared *instance();
+
+private:
+	plannerShared() {}
+};
+
+#endif // PLANNERSHARED_H

--- a/core/plannershared.h
+++ b/core/plannershared.h
@@ -14,8 +14,39 @@
 class plannerShared: public QObject {
 	Q_OBJECT
 
+	// Ascend/Descend data, converted to meter/feet depending on user selection
+	// Settings these will automatically update the corresponding qPrefDivePlanner
+	// Variables
+	Q_PROPERTY(int ascratelast6m READ ascratelast6m WRITE set_ascratelast6m NOTIFY ascratelast6mChanged);
+	Q_PROPERTY(int ascratestops READ ascratestops WRITE set_ascratestops NOTIFY ascratestopsChanged);
+	Q_PROPERTY(int ascrate50 READ ascrate50 WRITE set_ascrate50 NOTIFY ascrate50Changed);
+	Q_PROPERTY(int ascrate75 READ ascrate75 WRITE set_ascrate75 NOTIFY ascrate75Changed);
+	Q_PROPERTY(int descrate READ descrate WRITE set_descrate NOTIFY descrateChanged);
 public:
 	static plannerShared *instance();
+
+	// Ascend/Descend data, converted to meter/feet depending on user selection
+	static int ascratelast6m();
+	static int ascratestops();
+	static int ascrate50();
+	static int ascrate75();
+	static int descrate();
+
+public slots:
+	// Ascend/Descend data, converted to meter/feet depending on user selection
+	static void set_ascratelast6m(int value);
+	static void set_ascratestops(int value);
+	static void set_ascrate50(int value);
+	static void set_ascrate75(int value);
+	static void set_descrate(int value);
+
+signals:
+	// Ascend/Descend data, converted to meter/feet depending on user selection
+	void ascratelast6mChanged(int value);
+	void ascratestopsChanged(int value);
+	void ascrate50Changed(int value);
+	void ascrate75Changed(int value);
+	void descrateChanged(int value);
 
 private:
 	plannerShared() {}

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -510,11 +510,11 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.o2narcotic, SIGNAL(toggled(bool)), CylindersModel::instance(), SLOT(updateBestMixes()));
 
 	connect(modeMapper, SIGNAL(mapped(int)), this, SLOT(disableDecoElements(int)));
-	connect(ui.ascRate75, SIGNAL(valueChanged(int)), this, SLOT(setAscrate75(int)));
-	connect(ui.ascRate50, SIGNAL(valueChanged(int)), this, SLOT(setAscrate50(int)));
-	connect(ui.descRate, SIGNAL(valueChanged(int)), this, SLOT(setDescrate(int)));
-	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), this, SLOT(setAscratestops(int)));
-	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), this, SLOT(setAscratelast6m(int)));
+	connect(ui.ascRate75, SIGNAL(valueChanged(int)), plannerShared::instance(), SLOT(set_ascrate75(int)));
+	connect(ui.ascRate50, SIGNAL(valueChanged(int)), plannerShared::instance(), SLOT(set_ascrate50(int)));
+	connect(ui.descRate, SIGNAL(valueChanged(int)), plannerShared::instance(), SLOT(set_descrate(int)));
+	connect(ui.ascRateStops, SIGNAL(valueChanged(int)), plannerShared::instance(), SLOT(set_ascratestops(int)));
+	connect(ui.ascRateLast6m, SIGNAL(valueChanged(int)), plannerShared::instance(), SLOT(set_ascratelast6m(int)));
 	connect(ui.sacfactor, SIGNAL(valueChanged(double)), this, SLOT(sacFactorChanged(double)));
 	connect(ui.problemsolvingtime, SIGNAL(valueChanged(int)), this, SLOT(problemSolvingTimeChanged(int)));
 	connect(ui.bottompo2, SIGNAL(valueChanged(double)), this, SLOT(setBottomPo2(double)));

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -7,6 +7,7 @@
 #include "core/units.h"
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/gettextfromc.h"
+#include "core/plannershared.h"
 
 #include "qt-models/cylindermodel.h"
 #include "qt-models/models.h"
@@ -22,8 +23,6 @@
 
 #define MAX_DEPTH M_OR_FT(150, 450)
 #define MIN_DEPTH M_OR_FT(20, 60)
-
-#define UNIT_FACTOR ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
 
 static DivePlannerPointsModel* plannerModel = DivePlannerPointsModel::instance();
 
@@ -543,11 +542,11 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 
 void PlannerSettingsWidget::updateUnitsUI()
 {
-	ui.ascRate75->setValue(lrint(prefs.ascrate75 / UNIT_FACTOR));
-	ui.ascRate50->setValue(lrint(prefs.ascrate50 / UNIT_FACTOR));
-	ui.ascRateStops->setValue(lrint(prefs.ascratestops / UNIT_FACTOR));
-	ui.ascRateLast6m->setValue(lrint(prefs.ascratelast6m / UNIT_FACTOR));
-	ui.descRate->setValue(lrint(prefs.descrate / UNIT_FACTOR));
+	ui.ascRate75->setValue(plannerShared::ascrate75());
+	ui.ascRate50->setValue(plannerShared::ascrate50());
+	ui.ascRateStops->setValue(plannerShared::ascratestops());
+	ui.ascRateLast6m->setValue(plannerShared::ascratelast6m());
+	ui.descRate->setValue(lrint(plannerShared::descrate()));
 	ui.bestmixEND->setValue(lrint(get_depth_units(prefs.bestmixend.mm, NULL, NULL)));
 }
 
@@ -621,27 +620,27 @@ void PlannerSettingsWidget::printDecoPlan()
 
 void PlannerSettingsWidget::setAscrate75(int rate)
 {
-	qPrefDivePlanner::instance()->set_ascrate75(lrint(rate * UNIT_FACTOR));
+	plannerShared::set_ascrate75(rate);
 }
 
 void PlannerSettingsWidget::setAscrate50(int rate)
 {
-	qPrefDivePlanner::instance()->set_ascrate50(lrint(rate * UNIT_FACTOR));
+	plannerShared::set_ascrate50(rate);
 }
 
 void PlannerSettingsWidget::setAscratestops(int rate)
 {
-	qPrefDivePlanner::instance()->set_ascratestops(lrint(rate * UNIT_FACTOR));
+	plannerShared::set_ascratestops(rate);
 }
 
 void PlannerSettingsWidget::setAscratelast6m(int rate)
 {
-	qPrefDivePlanner::instance()->set_ascratelast6m(lrint(rate * UNIT_FACTOR));
+	plannerShared::set_ascratelast6m(rate);
 }
 
 void PlannerSettingsWidget::setDescrate(int rate)
 {
-	qPrefDivePlanner::instance()->set_descrate(lrint(rate * UNIT_FACTOR));
+	plannerShared::set_descrate(rate);
 }
 
 void PlannerSettingsWidget::sacFactorChanged(const double factor)

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -618,31 +618,6 @@ void PlannerSettingsWidget::printDecoPlan()
 {
 }
 
-void PlannerSettingsWidget::setAscrate75(int rate)
-{
-	plannerShared::set_ascrate75(rate);
-}
-
-void PlannerSettingsWidget::setAscrate50(int rate)
-{
-	plannerShared::set_ascrate50(rate);
-}
-
-void PlannerSettingsWidget::setAscratestops(int rate)
-{
-	plannerShared::set_ascratestops(rate);
-}
-
-void PlannerSettingsWidget::setAscratelast6m(int rate)
-{
-	plannerShared::set_ascratelast6m(rate);
-}
-
-void PlannerSettingsWidget::setDescrate(int rate)
-{
-	plannerShared::set_descrate(rate);
-}
-
 void PlannerSettingsWidget::sacFactorChanged(const double factor)
 {
 	plannerModel->setSacFactor(factor);

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -74,11 +74,6 @@ slots:
 	void bottomSacChanged(const double bottomSac);
 	void decoSacChanged(const double decosac);
 	void printDecoPlan();
-	void setAscrate75(int rate);
-	void setAscrate50(int rate);
-	void setAscratestops(int rate);
-	void setAscratelast6m(int rate);
-	void setDescrate(int rate);
 	void sacFactorChanged(const double factor);
 	void problemSolvingTimeChanged(const int min);
 	void setBottomPo2(double po2);

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -88,6 +88,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/uploadDiveShare.cpp \
 	../../core/uploadDiveLogsDE.cpp \
 	../../core/save-profiledata.c \
+	../../core/plannershared.cpp \
 	../../core/settings/qPref.cpp \
 	../../core/settings/qPrefCloudStorage.cpp \
 	../../core/settings/qPrefDisplay.cpp \
@@ -212,6 +213,7 @@ HEADERS += \
 	../../core/save-profiledata.h \
 	../../core/uploadDiveShare.h \
 	../../core/uploadDiveLogsDE.h \
+	../../core/plannershared.h \
 	../../core/settings/qPref.h \
 	../../core/settings/qPrefCloudStorage.h \
 	../../core/settings/qPrefDisplay.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -20,6 +20,7 @@
 #include "qt-models/messagehandlermodel.h"
 #include "profile-widget/qmlprofile.h"
 #include "core/downloadfromdcthread.h"
+#include "core/plannershared.h"
 #include "qt-models/diveimportedmodel.h"
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 #else
@@ -183,6 +184,13 @@ void register_qml_types(QQmlEngine *engine)
 	int rc;
 
 #ifdef SUBSURFACE_MOBILE
+	// register shared diveplanner class
+	if (engine != NULL) {
+		QQmlContext *ct = engine->rootContext();
+
+		ct->setContextProperty("Planner", plannerShared::instance());
+	}
+
 	REGISTER_TYPE(QMLManager, "QMLManager");
 	REGISTER_TYPE(QMLPrefs, "QMLPrefs");
 	REGISTER_TYPE(QMLProfile, "QMLProfile");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Diveplanner is probably the most wanted feature in mobile, this PR is the first of a longer series to make this happen.

The work to make planner available in a fashion compatible with the desktop version will be made in phases:
- Remove functional code from UI and move to a plannerShared (to avoid duplicated code)
- Planner Setting UI
- Planner Edit UI
- Planner Edit from dive UI
- Planner View UI
- Planner manage dive plans UI

The biggest challenge is to integrate the planner in a non-intrusive mode, and for each step secure that the desktop functionality is unchanged.

Focus is on not breaking the desktop, which is the cause for smaller commits and tests after each commit. 

The review comments from the "export in mobile" PR´s have been incorporated.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Move conversion of ascent/descend settings to shared code.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
This PR is really pure code move, but it would be nice if one of dive planner developers keep an eye on this and comming PR´s, at least review comments are more than welcome.
