### PR TITLE
mobile: remove QMLPrefs::cloudUserName / cloudPassword (change of user experience!)

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -74,7 +74,7 @@ Item {
 
 		Controls.TextField {
 			id: password
-			text: prefs.cloudPassword
+			text: PrefCloudStorage.cloud_storage_password
 			visible: !rootItem.showPin
 			echoMode: TextInput.PasswordEchoOnEdit
 			inputMethodHints: Qt.ImhSensitiveData |

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -58,7 +58,7 @@ Item {
 
 		Controls.TextField {
 			id: login
-			text: prefs.cloudUserName
+			text: PrefCloudStorage.cloud_storage_email
 			visible: !prefs.showPin
 			Layout.fillWidth: true
 			inputMethodHints: Qt.ImhEmailCharactersOnly |
@@ -101,7 +101,7 @@ Item {
 			visible: prefs.showPin
 			SsrfButton {
 				id: registerpin
-				text: qsTr("Register") 
+				text: qsTr("Register")
 				onClicked: {
 					saveCredentials()
 				}

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -15,10 +15,8 @@ Item {
 	property string password: password.text;
 
 	function saveCredentials() {
-		prefs.cloudUserName = login.text
-		prefs.cloudPassword = password.text
 		prefs.cloudPin = pin.text
-		manager.saveCloudCredentials()
+		manager.saveCloudCredentials(login.text, password.text)
 	}
 
 	ColumnLayout {

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -50,7 +50,7 @@ Kirigami.ScrollablePage {
 				"If you do not receive an email from us within 15 minutes, please check " +
 				"the correct spelling of your email address and your spam box first.<br/><br/>" +
 				"In case of any problems regarding cloud account setup, please contact us " +
-				"at our user forum \(https://subsurface-divelog.org/user-forum/\).<br/><br/>").arg(prefs.cloudUserName)
+				"at our user forum \(https://subsurface-divelog.org/user-forum/\).<br/><br/>").arg(PrefCloudStorage.cloud_storage_email)
 			wrapMode: Text.WordWrap
 		}
 		Item { width: Kirigami.Units.gridUnit; height: 3 * Kirigami.Units.gridUnit}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -225,7 +225,7 @@ Kirigami.ApplicationWindow {
 						visible: text.length > 0
 						level: 3
 						color: "white"
-						text: prefs.cloudUserName
+						text: PrefCloudStorage.cloud_storage_email
 						wrapMode: Text.NoWrap
 						elide: Text.ElideRight
 						font.weight: Font.Normal

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -244,13 +244,6 @@ Kirigami.ApplicationWindow {
 				text: qsTr("Dive list")
 				onTriggered: {
 					manager.appendTextToLog("requested dive list with credential status " + prefs.credentialStatus)
-					if (prefs.credentialStatus == CloudStatus.CS_UNKNOWN) {
-						// the user has asked to change credentials - if the credentials before that
-						// were valid, go back to dive list
-						if (prefs.oldStatus == CloudStatus.CS_VERIFIED) {
-							prefs.credentialStatus = prefs.oldStatus
-						}
-					}
 					returnTopPage()
 					globalDrawer.close()
 				}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -50,8 +50,8 @@ Kirigami.ApplicationWindow {
 		id: fontMetrics
 		Component.onCompleted: {
 			manager.appendTextToLog("Using the following font: " + fontMetrics.font.family
-				    + " at " + subsurfaceTheme.basePointSize + "pt" +
-				    " with mobile_scale: " + PrefDisplay.mobile_scale)
+					+ " at " + subsurfaceTheme.basePointSize + "pt" +
+					" with mobile_scale: " + PrefDisplay.mobile_scale)
 		}
 	}
 	visible: false

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -458,7 +458,7 @@ void QMLManager::finishSetup()
 	} else if (!empty_string(existing_filename) &&
 				QMLPrefs::instance()->credentialStatus() != qPrefCloudStorage::CS_UNKNOWN) {
 		QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_NOCLOUD);
-		saveCloudCredentials();
+		saveCloudCredentials(qPrefCloudStorage::cloud_storage_email(), qPrefCloudStorage::cloud_storage_password());
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename, &dive_table, &trip_table, &dive_site_table);
 		if (error) {
@@ -494,10 +494,13 @@ QMLManager *QMLManager::instance()
 #define CLOUDURL QString(prefs.cloud_base_url)
 #define CLOUDREDIRECTURL CLOUDURL + "/cgi-bin/redirect.pl"
 
-void QMLManager::saveCloudCredentials()
+void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &newPassword)
 {
 	bool cloudCredentialsChanged = false;
 	bool noCloud = QMLPrefs::instance()->credentialStatus() == qPrefCloudStorage::CS_NOCLOUD;
+
+	QMLPrefs::instance()->setCloudUserName(newEmail);
+	QMLPrefs::instance()->setCloudPassword(newPassword);
 
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -167,7 +167,7 @@ public:
 public slots:
 	void appInitialized();
 	void applicationStateChanged(Qt::ApplicationState state);
-	void saveCloudCredentials();
+	void saveCloudCredentials(const QString &email, const QString &password);
 	bool verifyCredentials(QString email, QString password, QString pin);
 	void tryRetrieveDataFromBackend();
 	void handleError(QNetworkReply::NetworkError nError);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -132,8 +132,6 @@ void QMLPrefs::cancelCredentialsPinSetup()
 	 */
 	
 	setCredentialStatus(qPrefCloudStorage::CS_UNKNOWN);
-	qPrefCloudStorage::set_cloud_storage_email(m_cloudUserName);
-	qPrefCloudStorage::set_cloud_storage_password(m_cloudPassword);
 	qPrefCloudStorage::set_cloud_verification_status(m_credentialStatus);
 	QMLManager::instance()->setStartPageText(tr("Starting..."));
 	

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -33,17 +33,6 @@ QMLPrefs *QMLPrefs::instance()
 
 
 /*** public functions ***/
-const QString QMLPrefs::cloudPassword() const
-{
-	return m_cloudPassword;
-}
-
-void QMLPrefs::setCloudPassword(const QString &cloudPassword)
-{
-	m_cloudPassword = cloudPassword;
-	emit cloudPasswordChanged();
-}
-
 const QString QMLPrefs::cloudPin() const
 {
 	return m_cloudPin;
@@ -130,6 +119,6 @@ void QMLPrefs::cancelCredentialsPinSetup()
 void QMLPrefs::clearCredentials()
 {
 	qPrefCloudStorage::set_cloud_storage_email(NULL);
-	setCloudPassword(NULL);
+	qPrefCloudStorage::set_cloud_storage_password(NULL);
 	setCloudPin(NULL);
 }

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -55,17 +55,6 @@ void QMLPrefs::setCloudPin(const QString &cloudPin)
 	emit cloudPinChanged();
 }
 
-const QString QMLPrefs::cloudUserName() const
-{
-	return m_cloudUserName;
-}
-
-void QMLPrefs::setCloudUserName(const QString &cloudUserName)
-{
-	m_cloudUserName = cloudUserName.toLower();
-	emit cloudUserNameChanged();
-}
-
 qPrefCloudStorage::cloud_status QMLPrefs::credentialStatus() const
 {
 	return m_credentialStatus;
@@ -140,7 +129,7 @@ void QMLPrefs::cancelCredentialsPinSetup()
 
 void QMLPrefs::clearCredentials()
 {
-	setCloudUserName(NULL);
+	qPrefCloudStorage::set_cloud_storage_email(NULL);
 	setCloudPassword(NULL);
 	setCloudPin(NULL);
 }

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -17,10 +17,6 @@ class QMLPrefs : public QObject {
 				MEMBER m_cloudPin
 				WRITE setCloudPin
 				NOTIFY cloudPinChanged)
-	Q_PROPERTY(QString cloudUserName
-				MEMBER m_cloudUserName
-				WRITE setCloudUserName
-				NOTIFY cloudUserNameChanged)
 	Q_PROPERTY(qPrefCloudStorage::cloud_status credentialStatus
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
@@ -45,9 +41,6 @@ public:
 	const QString cloudPin() const;
 	void setCloudPin(const QString &cloudPin);
 
-	const QString cloudUserName() const;
-	void setCloudUserName(const QString &cloudUserName);
-
 	qPrefCloudStorage::cloud_status credentialStatus() const;
 	void setCredentialStatus(const qPrefCloudStorage::cloud_status value);
 
@@ -64,7 +57,6 @@ public slots:
 private:
 	QString m_cloudPassword;
 	QString m_cloudPin;
-	QString m_cloudUserName;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
 	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
@@ -73,7 +65,6 @@ private:
 signals:
 	void cloudPasswordChanged();
 	void cloudPinChanged();
-	void cloudUserNameChanged();
 	void credentialStatusChanged();
 	void oldStatusChanged();
 	void showPinChanged();

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -9,10 +9,6 @@
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(QString cloudPassword
-				MEMBER m_cloudPassword
-				WRITE setCloudPassword
-				NOTIFY cloudPasswordChanged)
 	Q_PROPERTY(QString cloudPin
 				MEMBER m_cloudPin
 				WRITE setCloudPin
@@ -35,9 +31,6 @@ public:
 
 	static QMLPrefs *instance();
 
-	const QString cloudPassword() const;
-	void setCloudPassword(const QString &cloudPassword);
-
 	const QString cloudPin() const;
 	void setCloudPin(const QString &cloudPin);
 
@@ -55,7 +48,6 @@ public slots:
 	void clearCredentials();
 
 private:
-	QString m_cloudPassword;
 	QString m_cloudPin;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
 	static QMLPrefs *m_instance;
@@ -63,7 +55,6 @@ private:
 	bool m_showPin;
 
 signals:
-	void cloudPasswordChanged();
 	void cloudPinChanged();
 	void credentialStatusChanged();
 	void oldStatusChanged();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
replaced cloudUserName and cloudPasword with qPrefCloudStorage::

Please note that the first commit "do not revert to old credentials." caused a change in the user experience in a special situation (when cancelling PIN setup).

This PR sits on top of #2450, and should not be merged before #2450 is merged

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
