### PR TITLE
(Trivial?) cleanup: Turn QMLProfile::diveId from QString to int

### DIFF
--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -80,17 +80,17 @@ void QMLProfile::setMargin(int margin)
 	m_margin = margin;
 }
 
-QString QMLProfile::diveId() const
+int QMLProfile::diveId() const
 {
 	return m_diveId;
 }
 
-void QMLProfile::setDiveId(const QString &diveId)
+void QMLProfile::setDiveId(int diveId)
 {
 	m_diveId = diveId;
-	struct dive *d = get_dive_by_uniq_id(m_diveId.toInt());
-	if (m_diveId.toInt() < 1)
+	if (m_diveId < 0)
 		return;
+	struct dive *d = get_dive_by_uniq_id(diveId);
 	if (!d)
 		return;
 	if (verbose)

--- a/profile-widget/qmlprofile.h
+++ b/profile-widget/qmlprofile.h
@@ -8,7 +8,7 @@
 class QMLProfile : public QQuickPaintedItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString diveId MEMBER m_diveId WRITE setDiveId)
+	Q_PROPERTY(int diveId MEMBER m_diveId WRITE setDiveId)
 	Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio NOTIFY devicePixelRatioChanged)
 
 public:
@@ -16,8 +16,8 @@ public:
 
 	void paint(QPainter *painter);
 
-	QString diveId() const;
-	void setDiveId(const QString &diveId);
+	int diveId() const;
+	void setDiveId(int diveId);
 	qreal devicePixelRatio() const;
 	void setDevicePixelRatio(qreal dpr);
 
@@ -25,7 +25,7 @@ public slots:
 	void setMargin(int margin);
 	void screenChanged(QScreen *screen);
 private:
-	QString m_diveId;
+	int m_diveId;
 	qreal m_devicePixelRatio;
 	int m_margin;
 	QScopedPointer<ProfileWidget2> m_profileWidget;


### PR DESCRIPTION
This property is used to render the profile of a given dive.
Weirdly, even though the diveId is an integer, it was stored
as a string. It is not clear why that is the case. Therefore,
turn into the more natural int and avoid unnecessary conversion.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is what appears to be an obvious tiny cleanup.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn a `QString` that represents an `int` into an `int`

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: Perhaps I'm missing something obvious? In a first test things still seemed to work.

[Side note: in the same test it became obvious that the current mobile-list in master does rather funky things when trips overlap - but this is not related to this PR].