### PR TITLE
make qPrefUnit accesable from QML

### DIFF
--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -28,15 +28,63 @@ void qPrefUnits::loadSync(bool doSync)
 
 HANDLE_PREFERENCE_BOOL(Units, "coordinates", coordinates_traditional);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::DURATION, "duration_units", duration_units, units.);
+QString qPrefUnits::duration_units()
+{
+	return 	prefs.units.duration_units == units::DURATION::ALWAYS_HOURS ? QStringLiteral("hours") :
+			prefs.units.duration_units == units::DURATION::MINUTES_ONLY ? QStringLiteral("minutes") :
+											QStringLiteral("mixed");
+}
+void qPrefUnits::set_duration_units(const QString& value)
+{
+	prefs.units.duration_units = value == QStringLiteral("hours") ? units::DURATION::ALWAYS_HOURS :
+								 value == QStringLiteral("minutes")? units::DURATION::MINUTES_ONLY :
+																	 units::DURATION::MIXED;
+	disk_duration_units(true);
+	emit instance()->duration_unitsStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::DURATION, duration_units, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "duration_units", units::DURATION, duration_units, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::LENGTH, "length", length, units.);
+QString qPrefUnits::length()
+{
+	return 	prefs.units.length == units::LENGTH::METERS ? QStringLiteral("meters") : QStringLiteral("feet");
+}
+void qPrefUnits::set_length(const QString& value)
+{
+	prefs.units.length = value == QStringLiteral("meters") ? units::LENGTH::METERS : units::LENGTH::FEET;
+	disk_length(true);
+	emit instance()->lengthStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::LENGTH, length, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "length", units::LENGTH, length, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, "pressure", pressure, units.);
+QString qPrefUnits::pressure()
+{
+	return 	prefs.units.pressure == units::PRESSURE::BAR ? QStringLiteral("bar") : QStringLiteral("psi");
+}
+void qPrefUnits::set_pressure(const QString& value)
+{
+	prefs.units.pressure = value == QStringLiteral("bar") ? units::PRESSURE::BAR : units::PRESSURE::PSI;
+	disk_pressure(true);
+	emit instance()->pressureStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, pressure, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "pressure", units::PRESSURE, pressure, units.);
 
 HANDLE_PREFERENCE_BOOL_EXT(Units, "show_units_table", show_units_table, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, "temperature", temperature, units.);
+QString qPrefUnits::temperature()
+{
+	return 	prefs.units.temperature == units::TEMPERATURE::CELSIUS ? QStringLiteral("celcius") : QStringLiteral("fahrenheit");
+}
+void qPrefUnits::set_temperature(const QString& value)
+{
+	prefs.units.temperature = value == QStringLiteral("celcius") ? units::TEMPERATURE::CELSIUS : units::TEMPERATURE::FAHRENHEIT;
+	disk_temperature(true);
+	emit instance()->temperatureStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, temperature, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "temperature", units::TEMPERATURE, temperature, units.);
 
 QString qPrefUnits::unit_system()
 {
@@ -63,8 +111,41 @@ void qPrefUnits::set_unit_system(const QString& value)
 }
 DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::TIME, "vertical_speed_time", vertical_speed_time, units.);
+QString qPrefUnits::vertical_speed_time()
+{
+	return 	prefs.units.vertical_speed_time == units::TIME::MINUTES ? QStringLiteral("minutes") : QStringLiteral("seconds");
+}
+void qPrefUnits::set_vertical_speed_time(const QString& value)
+{
+	prefs.units.vertical_speed_time = value == QStringLiteral("minutes") ? units::TIME::MINUTES : units::TIME::SECONDS;
+	disk_vertical_speed_time(true);
+	emit instance()->vertical_speed_timeStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::TIME, vertical_speed_time, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "vertical_speed_time", units::TIME, vertical_speed_time, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::VOLUME, "volume", volume, units.);
+QString qPrefUnits::volume()
+{
+	return 	prefs.units.volume == units::VOLUME::LITER ? QStringLiteral("liter") : QStringLiteral("cuft");
+}
+void qPrefUnits::set_volume(const QString& value)
+{
+	prefs.units.volume = value == QStringLiteral("liter") ? units::VOLUME::LITER : units::VOLUME::CUFT;
+	disk_volume(true);
+	emit instance()->volumeStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::VOLUME, volume, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "volume", units::VOLUME, volume, units.);
 
-HANDLE_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, "weight", weight, units.);
+QString qPrefUnits::weight()
+{
+	return 	prefs.units.weight == units::WEIGHT::KG ? QStringLiteral("kg") : QStringLiteral("lbs");
+}
+void qPrefUnits::set_weight(const QString& value)
+{
+	prefs.units.weight = value == QStringLiteral("kg") ? units::WEIGHT::KG : units::WEIGHT::LBS;
+	disk_weight(true);
+	emit instance()->weightStringChanged(value);
+}
+SET_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, weight, units.);
+DISK_LOADSYNC_ENUM_EXT(Units, "weight", units::WEIGHT, weight, units.);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -9,15 +9,15 @@
 class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
-	Q_PROPERTY(units::DURATION duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsChanged)
-	Q_PROPERTY(units::LENGTH length READ length WRITE set_length NOTIFY lengthChanged)
-	Q_PROPERTY(units::PRESSURE pressure READ pressure WRITE set_pressure NOTIFY pressureChanged)
+	Q_PROPERTY(QString duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsStringChanged)
+	Q_PROPERTY(QString length READ length WRITE set_length NOTIFY lengthStringChanged)
+	Q_PROPERTY(QString pressure READ pressure WRITE set_pressure NOTIFY pressureStringChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
-	Q_PROPERTY(units::TEMPERATURE temperature READ temperature WRITE set_temperature NOTIFY temperatureChanged)
+	Q_PROPERTY(QString temperature READ temperature WRITE set_temperature NOTIFY temperatureStringChanged)
 	Q_PROPERTY(QString unit_system READ unit_system WRITE set_unit_system NOTIFY unit_systemChanged)
-	Q_PROPERTY(units::TIME vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeChanged)
-	Q_PROPERTY(units::VOLUME volume READ volume WRITE set_volume NOTIFY volumeChanged)
-	Q_PROPERTY(units::WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged)
+	Q_PROPERTY(QString vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeStringChanged)
+	Q_PROPERTY(QString volume READ volume WRITE set_volume NOTIFY volumeStringChanged)
+	Q_PROPERTY(QString weight READ weight WRITE set_weight NOTIFY weightStringChanged)
 
 public:
 	static qPrefUnits *instance();
@@ -29,40 +29,61 @@ public:
 
 public:
 	static bool coordinates_traditional() { return prefs.coordinates_traditional; }
-	static units::DURATION duration_units() { return prefs.units.duration_units; }
-	static units::LENGTH length() { return prefs.units.length; }
-	static units::PRESSURE pressure() { return prefs.units.pressure; }
+	static QString duration_units();
+	static QString length();
+	static QString pressure();
 	static bool show_units_table() { return prefs.units.show_units_table; }
-	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
+	static QString temperature();
 	static QString unit_system();
-	static units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
-	static units::VOLUME volume() { return prefs.units.volume; }
-	static units::WEIGHT weight() { return prefs.units.weight; }
+	static QString vertical_speed_time();
+	static QString volume();
+	static QString weight();
 
 public slots:
 	static void set_coordinates_traditional(bool value);
 	static void set_duration_units(units::DURATION value);
+	static void set_duration_units(const QString& value);
 	static void set_length(units::LENGTH value);
+	static void set_length(const QString& value);
 	static void set_pressure(units::PRESSURE value);
+	static void set_pressure(const QString& value);
 	static void set_show_units_table(bool value);
 	static void set_temperature(units::TEMPERATURE value);
+	static void set_temperature(const QString& value);
 	static void set_unit_system(const QString& value);
 	static void set_vertical_speed_time(units::TIME value);
+	static void set_vertical_speed_time(const QString& value);
 	static void set_volume(units::VOLUME value);
+	static void set_volume(const QString& value);
 	static void set_weight(units::WEIGHT value);
+	static void set_weight(const QString& value);
 
 signals:
+	// Normally the same signal name are used with different parameters:
+	// void weightChanged(int value);
+	// void weightChanged(const QString& value);
+	// This works perfect, however connect() cannot automatically determine
+	// which signal to catch, for that purpose SIGNAL() / SLOT() macros are used,
+	// since they include the parameter type.
+	// However there is a design decision, not to use the macros, so
+	// signal must have unique names.
 	void coordinates_traditionalChanged(bool value);
 	void duration_unitsChanged(int value);
+	void duration_unitsStringChanged(const QString& value);
 	void lengthChanged(int value);
+	void lengthStringChanged(const QString& value);
 	void pressureChanged(int value);
+	void pressureStringChanged(const QString& value);
 	void show_units_tableChanged(bool value);
 	void temperatureChanged(int value);
+	void temperatureStringChanged(const QString& value);
 	void unit_systemChanged(const QString& value);
 	void vertical_speed_timeChanged(int value);
+	void vertical_speed_timeStringChanged(const QString& value);
 	void volumeChanged(int value);
+	void volumeStringChanged(const QString& value);
 	void weightChanged(int value);
-
+	void weightStringChanged(const QString& value);
 private:
 	qPrefUnits() {}
 

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -32,14 +32,14 @@ void TestQPrefUnits::test_struct_get()
 	prefs.units.weight = units::KG;
 
 	QCOMPARE(tst->coordinates_traditional(), true);
-	QCOMPARE(tst->duration_units(), units::MIXED);
-	QCOMPARE(tst->length(), units::METERS);
-	QCOMPARE(tst->pressure(), units::BAR);
+	QCOMPARE(tst->duration_units(), QStringLiteral("mixed"));
+	QCOMPARE(tst->length(), QStringLiteral("meters"));
+	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
 	QCOMPARE(tst->show_units_table(), true);
-	QCOMPARE(tst->temperature(), units::CELSIUS);
-	QCOMPARE(tst->vertical_speed_time(), units::SECONDS);
-	QCOMPARE(tst->volume(), units::LITER);
-	QCOMPARE(tst->weight(), units::KG);
+	QCOMPARE(tst->temperature(), QStringLiteral("celcius"));
+	QCOMPARE(tst->vertical_speed_time(), QStringLiteral("seconds"));
+	QCOMPARE(tst->volume(), QStringLiteral("liter"));
+	QCOMPARE(tst->weight(), QStringLiteral("kg"));
 }
 
 void TestQPrefUnits::test_set_struct()
@@ -157,9 +157,9 @@ void TestQPrefUnits::test_multiple()
 	auto tst = qPrefUnits::instance();
 
 	QCOMPARE(tst->length(), qPrefUnits::length());
-	QCOMPARE(tst->length(), units::METERS);
+	QCOMPARE(tst->length(), QStringLiteral("meters"));
 	QCOMPARE(tst->pressure(), qPrefUnits::pressure());
-	QCOMPARE(tst->pressure(), units::BAR);
+	QCOMPARE(tst->pressure(), QStringLiteral("meters"));
 }
 
 void TestQPrefUnits::test_unit_system()
@@ -170,20 +170,20 @@ void TestQPrefUnits::test_unit_system()
 
 	tst->set_unit_system("metric");
 	QCOMPARE(prefs.unit_system, METRIC);
-	QCOMPARE(tst->unit_system(), QString("metric"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("metric"));
 	tst->set_unit_system("imperial");
 	QCOMPARE(prefs.unit_system, IMPERIAL);
-	QCOMPARE(tst->unit_system(), QString("imperial"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("imperial"));
 	tst->set_unit_system("personalized");
 	QCOMPARE(prefs.unit_system, PERSONALIZE);
-	QCOMPARE(tst->unit_system(), QString("personalized"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("personalized"));
 
 	prefs.unit_system = METRIC;
-	QCOMPARE(tst->unit_system(), QString("metric"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("metric"));
 	prefs.unit_system = IMPERIAL;
-	QCOMPARE(tst->unit_system(), QString("imperial"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("imperial"));
 	prefs.unit_system = PERSONALIZE;
-	QCOMPARE(tst->unit_system(), QString("personalized"));
+	QCOMPARE(tst->unit_system(), QStringLiteral("personalized"));
 }
 
 #define TEST(METHOD, VALUE)      \
@@ -205,12 +205,12 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_coordinates_traditional(false);
 	units->set_vertical_speed_time(units::SECONDS);
 
-	TEST(units->length(), units::METERS);
-	TEST(units->pressure(), units::BAR);
-	TEST(units->volume(), units::LITER);
-	TEST(units->temperature(), units::CELSIUS);
-	TEST(units->weight(), units::KG);
-	TEST(units->vertical_speed_time(), units::SECONDS);
+	TEST(units->length(), QStringLiteral("meters"));
+	TEST(units->pressure(), QStringLiteral("bar"));
+	TEST(units->volume(), QStringLiteral("liter"));
+	TEST(units->temperature(), QStringLiteral("celcius"));
+	TEST(units->weight(), QStringLiteral("kg"));
+	TEST(units->vertical_speed_time(), QStringLiteral("seconds"));
 	TEST(units->unit_system(), QStringLiteral("metric"));
 	TEST(units->coordinates_traditional(), false);
 
@@ -223,12 +223,12 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_unit_system(QStringLiteral("fake-metric-system"));
 	units->set_coordinates_traditional(true);
 
-	TEST(units->length(), units::FEET);
-	TEST(units->pressure(), units::PSI);
-	TEST(units->volume(), units::CUFT);
-	TEST(units->temperature(), units::FAHRENHEIT);
-	TEST(units->weight(), units::LBS);
-	TEST(units->vertical_speed_time(), units::MINUTES);
+	TEST(units->length(), QStringLiteral("feet"));
+	TEST(units->pressure(), QStringLiteral("psi"));
+	TEST(units->volume(), QStringLiteral("cuft"));
+	TEST(units->temperature(), QStringLiteral("fahrenheit"));
+	TEST(units->weight(), QStringLiteral("lbs"));
+	TEST(units->vertical_speed_time(), QStringLiteral("minutes"));
 	TEST(units->unit_system(), QStringLiteral("personalized"));
 	TEST(units->coordinates_traditional(), true);
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use string literals to communicate with QML.

Instead of passing arounds enum/int value, it seems easier to pass string literals to QML and have that code respond to those

Remark the signal names are somewhat special, due to a design restriction (causing an earlier PR to be closed, because changing the connect() was incorrect).

Qt allows (like C++) multiple signals with the same name but different parameters. This fails, because the connect() that uses the signals are made without the SIGNAL macro and the type of parameter (design decision), meaning connect() would need to automatically guess which signal to use something it does not do.

To solve the problem the signal have different names:
temperatureChanged(int)
temperatureStringChanged(const QString &)
and the connect() stays untouched.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
