### PR TITLE
[do not merge, need rebase] (planner 1a) prepare to test plannerShared

### DIFF
--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -120,6 +120,11 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../qt-models/maplocationmodel.cpp \
 	../../qt-models/diveimportedmodel.cpp \
 	../../qt-models/messagehandlermodel.cpp \
+	../../qt-models/diveplannermodel.cpp \
+	../../qt-models/cylindermodel.cpp \
+	../../qt-models/cleanertablemodel.cpp \
+	../../qt-models/tankinfomodel.cpp \
+	../../qt-models/models.cpp \
 	../../profile-widget/qmlprofile.cpp \
 	../../profile-widget/divecartesianaxis.cpp \
 	../../profile-widget/diveeventitem.cpp \
@@ -250,6 +255,11 @@ HEADERS += \
 	../../qt-models/maplocationmodel.h \
 	../../qt-models/diveimportedmodel.h \
 	../../qt-models/messagehandlermodel.h \
+	../../qt-models/diveplannermodel.h \
+	../../qt-models/cylindermodel.h \
+	../../qt-models/cleanertablemodel.h \
+	../../qt-models/tankinfomodel.h \
+	../../qt-models/models.h \
 	../../profile-widget/qmlprofile.h \
 	../../profile-widget/diveprofileitem.h \
 	../../profile-widget/profilewidget2.h \

--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -3,42 +3,42 @@
 
 # models used both mobile and desktop builds
 set(SUBSURFACE_GENERIC_MODELS_LIB_SRCS
+	cleanertablemodel.cpp
+	cleanertablemodel.h
 	completionmodels.cpp
 	completionmodels.h
+	cylindermodel.cpp
+	cylindermodel.h
 	diveimportedmodel.cpp
 	diveimportedmodel.h
 	divelocationmodel.cpp
 	divelocationmodel.h
+	diveplannermodel.cpp
+	diveplannermodel.h
 	diveplotdatamodel.cpp
 	diveplotdatamodel.h
 	maplocationmodel.cpp
 	maplocationmodel.h
+	models.cpp
+	models.h
+	tankinfomodel.cpp
+	tankinfomodel.h
 )
 
 # models exclusively used in desktop builds
 set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
-	cleanertablemodel.cpp
-	cleanertablemodel.h
-	cylindermodel.cpp
-	cylindermodel.h
 	divecomputerextradatamodel.cpp
 	divecomputerextradatamodel.h
 	divecomputermodel.cpp
 	divecomputermodel.h
 	divepicturemodel.cpp
 	divepicturemodel.h
-	diveplannermodel.cpp
-	diveplannermodel.h
 	divesiteimportmodel.cpp
 	divesiteimportmodel.h
 	divetripmodel.cpp
 	divetripmodel.h
 	filtermodels.cpp
 	filtermodels.h
-	models.cpp
-	models.h
-	tankinfomodel.cpp
-	tankinfomodel.h
 	treemodel.cpp
 	treemodel.h
 	weightmodel.cpp

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -7,9 +7,9 @@
 #include "core/device.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefDivePlanner.h"
-#ifndef SUBSURFACE_MOBILE
+#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
 #include "commands/command.h"
-#endif // SUBSURFACE_MOBILE
+#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
 #include "core/gettextfromc.h"
 #include "core/deco.h"
 #include <QApplication>
@@ -1171,20 +1171,20 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing one
 		displayed_dive.divetrip = nullptr; // Should not be necessary, just in case!
-#ifndef SUBSURFACE_MOBILE
+#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
 		Command::addDive(&displayed_dive, autogroup, true);
-#endif // SUBSURFACE_MOBILE
+#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
 	} else if (replanCopy) {
 		// we were planning an old dive and save as a new dive
 		displayed_dive.id = dive_getUniqID(); // Things will break horribly if we create dives with the same id.
-#ifndef SUBSURFACE_MOBILE
+#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
 		Command::addDive(&displayed_dive, false, false);
-#endif // SUBSURFACE_MOBILE
+#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
 	} else {
 		// we were planning an old dive and rewrite the plan
-#ifndef SUBSURFACE_MOBILE
+#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
 		Command::replanDive(&displayed_dive);
-#endif // SUBSURFACE_MOBILE
+#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
 	}
 
 	// Remove and clean the diveplan, so we don't delete

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -7,7 +7,9 @@
 #include "core/device.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefDivePlanner.h"
+#ifndef SUBSURFACE_MOBILE
 #include "commands/command.h"
+#endif // SUBSURFACE_MOBILE
 #include "core/gettextfromc.h"
 #include "core/deco.h"
 #include <QApplication>
@@ -1169,14 +1171,20 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing one
 		displayed_dive.divetrip = nullptr; // Should not be necessary, just in case!
+#ifndef SUBSURFACE_MOBILE
 		Command::addDive(&displayed_dive, autogroup, true);
+#endif // SUBSURFACE_MOBILE
 	} else if (replanCopy) {
 		// we were planning an old dive and save as a new dive
 		displayed_dive.id = dive_getUniqID(); // Things will break horribly if we create dives with the same id.
+#ifndef SUBSURFACE_MOBILE
 		Command::addDive(&displayed_dive, false, false);
+#endif // SUBSURFACE_MOBILE
 	} else {
 		// we were planning an old dive and rewrite the plan
+#ifndef SUBSURFACE_MOBILE
 		Command::replanDive(&displayed_dive);
+#endif // SUBSURFACE_MOBILE
 	}
 
 	// Remove and clean the diveplan, so we don't delete

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,10 @@ TEST(TestPicture testpicture.cpp)
 TEST(TestMerge testmerge.cpp)
 TEST(TestTagList testtaglist.cpp)
 
+if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
+TEST(TestPlannerShared testplannershared.cpp)
+endif()
+
 TEST(TestQPrefCloudStorage testqPrefCloudStorage.cpp)
 TEST(TestQPrefDisplay testqPrefDisplay.cpp)
 TEST(TestQPrefDiveComputer testqPrefDiveComputer.cpp)
@@ -149,6 +153,10 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestPicture
 	TestMerge
 	TestTagList
+
+if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
+	TestPlannerShared
+endif()
 
 	TestQPrefCloudStorage
 	TestQPrefDisplay

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,12 +39,23 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	endif()
 endif()
 
+# define libraries to use, due to the fact that some library names are different between mobile and desktop
+# extra settings are needed
+# even though the targets are test executable the overall target is the same
+if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DesktopExecutable")
+	set(TEST_SPECIFIC_LIBRARIES subsurface_models_desktop)
+else()
+	set(TEST_SPECIFIC_LIBRARIES subsurface_models_mobile )
+endif()
+
 # Helper function TEST used to created rules to build, link, install and run tests
 function(TEST NAME FILE)
 	get_filename_component(HDR "${FILE}" NAME_WE)
 	add_executable(${NAME} ${FILE} ${HDR}.h)
 	target_link_libraries(
 		${NAME}
+		subsurface_backend_shared
+		${TEST_SPECIFIC_LIBRARIES}
 		subsurface_corelib
 		RESOURCE_LIBRARY
 		${QT_TEST_LIBRARIES}

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testplannershared.h"
 #include "backend-shared/plannershared.h"
+#include "core/settings/qPrefDivePlanner.h"
+#include "core/settings/qPrefUnit.h"
 
 #include <QTest>
 #include <QSignalSpy>
@@ -25,12 +27,101 @@ void TestPlannerShared::test_rates()
 	//     8m      -    133               40f    -     203
 	//    10m      -    167               35f    -     178
 
-	// Variables to test
-	// ascratelast6m
-	// ascratestops
-	// ascrate50
-	// ascrate75
-	// descrate
+	// Set system to use meters
+	qPrefUnits::set_unit_system(QStringLiteral("metric"));
+
+	plannerShared::set_ascratelast6m(16);
+	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 267);
+	plannerShared::set_ascratelast6m(7);
+	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 117);
+	qPrefDivePlanner::set_ascratelast6m(133);
+	QCOMPARE(plannerShared::ascratelast6m(), 8);
+	qPrefDivePlanner::set_ascratelast6m(167);
+	QCOMPARE(plannerShared::ascratelast6m(), 10);
+
+	plannerShared::set_ascratestops(16);
+	QCOMPARE(qPrefDivePlanner::ascratestops(), 267);
+	plannerShared::set_ascratestops(7);
+	QCOMPARE(qPrefDivePlanner::ascratestops(), 117);
+	qPrefDivePlanner::set_ascratestops(133);
+	QCOMPARE(plannerShared::ascratestops(), 8);
+	qPrefDivePlanner::set_ascratestops(167);
+	QCOMPARE(plannerShared::ascratestops(), 10);
+
+	plannerShared::set_ascrate50(16);
+	QCOMPARE(qPrefDivePlanner::ascrate50(), 267);
+	plannerShared::set_ascrate50(7);
+	QCOMPARE(qPrefDivePlanner::ascrate50(), 117);
+	qPrefDivePlanner::set_ascrate50(133);
+	QCOMPARE(plannerShared::ascrate50(), 8);
+	qPrefDivePlanner::set_ascrate50(167);
+	QCOMPARE(plannerShared::ascrate50(), 10);
+
+	plannerShared::set_ascrate75(16);
+	QCOMPARE(qPrefDivePlanner::ascrate75(), 267);
+	plannerShared::set_ascrate75(7);
+	QCOMPARE(qPrefDivePlanner::ascrate75(), 117);
+	qPrefDivePlanner::set_ascrate75(133);
+	QCOMPARE(plannerShared::ascrate75(), 8);
+	qPrefDivePlanner::set_ascrate75(167);
+	QCOMPARE(plannerShared::ascrate75(), 10);
+
+	plannerShared::set_descrate(16);
+	QCOMPARE(qPrefDivePlanner::descrate(), 267);
+	plannerShared::set_descrate(7);
+	QCOMPARE(qPrefDivePlanner::descrate(), 117);
+	qPrefDivePlanner::set_descrate(133);
+	QCOMPARE(plannerShared::descrate(), 8);
+	qPrefDivePlanner::set_descrate(167);
+	QCOMPARE(plannerShared::descrate(), 10);
+
+	// Set system to use feet
+	qPrefUnits::set_unit_system(QStringLiteral("imperial"));
+
+	plannerShared::set_ascratelast6m(33);
+	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 168);
+	plannerShared::set_ascratelast6m(27);
+	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 137);
+	qPrefDivePlanner::set_ascratelast6m(203);
+	QCOMPARE(plannerShared::ascratelast6m(), 40);
+	qPrefDivePlanner::set_ascratelast6m(178);
+	QCOMPARE(plannerShared::ascratelast6m(), 35);
+
+	plannerShared::set_ascratestops(33);
+	QCOMPARE(qPrefDivePlanner::ascratestops(), 168);
+	plannerShared::set_ascratestops(27);
+	QCOMPARE(qPrefDivePlanner::ascratestops(), 137);
+	qPrefDivePlanner::set_ascratestops(203);
+	QCOMPARE(plannerShared::ascratestops(), 40);
+	qPrefDivePlanner::set_ascratestops(178);
+	QCOMPARE(plannerShared::ascratestops(), 35);
+
+	plannerShared::set_ascrate50(33);
+	QCOMPARE(qPrefDivePlanner::ascrate50(), 168);
+	plannerShared::set_ascrate50(27);
+	QCOMPARE(qPrefDivePlanner::ascrate50(), 137);
+	qPrefDivePlanner::set_ascrate50(203);
+	QCOMPARE(plannerShared::ascrate50(), 40);
+	qPrefDivePlanner::set_ascrate50(178);
+	QCOMPARE(plannerShared::ascrate50(), 35);
+
+	plannerShared::set_ascrate75(33);
+	QCOMPARE(qPrefDivePlanner::ascrate75(), 168);
+	plannerShared::set_ascrate75(27);
+	QCOMPARE(qPrefDivePlanner::ascrate75(), 137);
+	qPrefDivePlanner::set_ascrate75(203);
+	QCOMPARE(plannerShared::ascrate75(), 40);
+	qPrefDivePlanner::set_ascrate75(178);
+	QCOMPARE(plannerShared::ascrate75(), 35);
+
+	plannerShared::set_descrate(33);
+	QCOMPARE(qPrefDivePlanner::descrate(), 168);
+	plannerShared::set_descrate(27);
+	QCOMPARE(qPrefDivePlanner::descrate(), 137);
+	qPrefDivePlanner::set_descrate(203);
+	QCOMPARE(plannerShared::descrate(), 40);
+	qPrefDivePlanner::set_descrate(178);
+	QCOMPARE(plannerShared::descrate(), 35);
 }
 
 void TestPlannerShared::test_planning()

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testplannershared.h"
+#include "backend-shared/plannershared.h"
+
+#include <QTest>
+#include <QSignalSpy>
+
+void TestPlannerShared::initTestCase()
+{
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("SubsurfaceTestPlannerShared");
+	plannerShared::instance();
+}
+
+void TestPlannerShared::test_rates()
+
+{
+	// Rates all use meters pr time unit
+	// test values have been researched with official subsurface 4.9.3
+
+	// UI (meters) - plist value       UI (feet) - plist value
+	//    16m      -    267               33f    -     168
+	//     7m      -    117               27f    -     137
+	//     8m      -    133               40f    -     203
+	//    10m      -    167               35f    -     178
+
+	// Variables to test
+	// ascratelast6m
+	// ascratestops
+	// ascrate50
+	// ascrate75
+	// descrate
+}
+
+void TestPlannerShared::test_planning()
+{
+	// Variables to test
+	// dive_mode
+	//OC, CCR, PSCR, FREEDIVE, NUM_DIVEMODE, UNDEF_COMP_TYPE
+
+	// planner_deco_mode
+	// dobailout
+	// reserve_gas
+	// safetystop
+	// gflow
+	// gfhigh
+	// vpmb_conservatism
+	// drop_stone_mode
+	// last_stop
+	// switch_at_req_stop
+	// doo2breaks
+	// min_switch_duration
+}
+
+void TestPlannerShared::test_gas()
+{
+	// Variables to test
+	// bottomsac
+	// decosac
+	// problemsolvingtime
+	// sacfactor
+	// o2narcotic
+	// bottompo2
+	// decopo2
+	// bestmixend
+}
+
+void TestPlannerShared::test_notes()
+{
+	// Variables to test
+	// display_runtime
+	// display_duration
+	// display_transitions
+	// verbatim_plan
+	// display_variations
+}
+
+QTEST_MAIN(TestPlannerShared)

--- a/tests/testplannershared.h
+++ b/tests/testplannershared.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTPLANNERSHARED_H
+#define TESTPLANNERSHARED_H
+#include <QObject>
+
+class TestPlannerShared : public QObject {
+	Q_OBJECT
+
+private slots:
+	void initTestCase();
+
+	// test case grouping correspond to panels diveplanner window
+	void test_rates();
+	void test_planning();
+	void test_gas();
+	void test_notes();
+};
+
+#endif // TESTPLANNERSHARED_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It is very important that the introduction of plannerShared do not change the behavior of the diveplanner, especially the variables (meters, liters etc) are important since they can cause 
severe problems (if the deco is not calculated correctly).

Create framework in tests to allow testing of backend-shared classes:
- add qt-models etc. to link
- secure it works for building desktop as well as mobile

Create framework for testing plannerShared
- add add class and integrate into test framework

Currently this test is only available for mobile builds (build-mobile/tests), due to commands
currently included e.g. mainWindow::instance().

This PR will fails in tests if merged before #2476 (which are made, due to errors found with help of these test cases).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
