### PR TITLE
bug fix: make PIN page work as expected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: secure user selects operational mode, before leaving login
 Mobile: use of qml compiler, smaller footprint and faster UI
 Mobile: support for "upload to divelogs.de"
 mobile: add support for upload to dive-share.com

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -144,7 +144,7 @@ Item {
 					manager.setGitLocalOnly(true)
 					PrefCloudStorage.cloud_auto_sync = false
 					prefs.credentialStatus = CloudStatus.CS_NOCLOUD
-					manager.saveCloudCredentials()
+					manager.saveCloudCredentials("", "")
 					manager.openNoCloudRepo()
 				}
 			}

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -15,7 +15,6 @@ Item {
 	property string password: password.text;
 
 	function saveCredentials() {
-		prefs.cloudPin = pin.text
 		manager.saveCloudCredentials(login.text, password.text)
 	}
 
@@ -103,7 +102,7 @@ Item {
 				id: registerpin
 				text: qsTr("Register")
 				onClicked: {
-					saveCredentials()
+					verifyCredentials(login.text, password.text, pin.text)
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -14,10 +14,6 @@ Item {
 	property string username: login.text;
 	property string password: password.text;
 
-	function saveCredentials() {
-		manager.saveCloudCredentials(login.text, password.text)
-	}
-
 	ColumnLayout {
 		id: outerLayout
 		width: loginWindow.width - Kirigami.Units.gridUnit // to ensure the full input fields are visible
@@ -129,7 +125,7 @@ Item {
 				id: signin_register_normal
 				text: qsTr("Sign-in or Register")
 				onClicked: {
-					saveCredentials()
+					manager.saveCloudCredentials(login.text, password.text)
 				}
 			}
 			Controls.Label {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When pressing "register" in the pin page, it did not switch to divelog page
- wrong function called in onClick event
When pressing "no cloud" in the credential page qml reported an error
- missing parameters in function call.

Cleanup: qml function saveCredentials() just called manager.saveCredentials()
- call manager.saveCredentials() direct
prefs.showPin = pin.text removed since it was wrong.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
