### PR TITLE
(qmlpref 1) limit use of qmlprefs

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -109,8 +109,10 @@ Item {
 				id: cancelpin
 				text: qsTr("Cancel")
 				onClicked: {
-					prefs.cancelCredentialsPinSetup()
-					rootItem.returnTopPage()
+					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					prefs.cloudCredentials = CloudStatus.CS_UNKNOWN
+					manager.startPageText = qsTr("Check credentials...");
+					prefs.showPin = false;
 				}
 			}
 		}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -12,7 +12,6 @@ Kirigami.ScrollablePage {
 	objectName: "DiveList"
 	title: qsTr("Dive list")
 	verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
-	property int credentialStatus: prefs.credentialStatus
 	property int numDives: diveListView.count
 	property color textColor: subsurfaceTheme.textColor
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 				color: subsurfaceTheme.textColor
 			}
 			Controls.Label {
-				text: PrefCloudStorage.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
+				text: PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.60
 				color: subsurfaceTheme.textColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -54,8 +54,10 @@ Kirigami.ScrollablePage {
 				id: changeCloudSettings
 				text: qsTr("Change")
 				onClicked: {
-					prefs.cancelCredentialsPinSetup()
-					rootItem.returnTopPage()
+					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					prefs.credentialStatus = CloudStatus.CS_UNKNOWN
+					manager.startPageText  = qsTr("Starting...");
+					prefs.showPin = false;
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -56,7 +56,9 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 		if (value == qPrefCloudStorage::CS_NOCLOUD) {
 			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE);
-			clearCredentials();
+			qPrefCloudStorage::set_cloud_storage_email(NULL);
+			qPrefCloudStorage::set_cloud_storage_password(NULL);
+			setCloudPin(NULL);
 			if (qPrefUnits::unit_system() == "imperial")
 				prefs.units = IMPERIAL_units;
 			else if (qPrefUnits::unit_system() == "metric")
@@ -89,13 +91,4 @@ void QMLPrefs::setShowPin(bool enable)
 {
 	m_showPin = enable;
 	emit showPinChanged();
-}
-
-/*** public slot functions ***/
-
-void QMLPrefs::clearCredentials()
-{
-	qPrefCloudStorage::set_cloud_storage_email(NULL);
-	qPrefCloudStorage::set_cloud_storage_password(NULL);
-	setCloudPin(NULL);
 }

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -92,29 +92,6 @@ void QMLPrefs::setShowPin(bool enable)
 }
 
 /*** public slot functions ***/
-void QMLPrefs::cancelCredentialsPinSetup()
-{   
-	/* 
-	 * The user selected <cancel> on the final stage of the
-	 * cloud account generation (entering the emailed PIN).
-	 * 
-	 * Resets the cloud credential status to CS_UNKNOWN, resulting
-	 * in a return to the first crededentials page, with the
-	 * email and passwd still filled in. In case of a cancel
-	 * of registration (from the PIN page), the email address
-	 * was probably misspelled, so the user never received a PIN to
-	 * complete the process.
-	 * 
-	 * Notice that this function is also used to switch to a different
-	 * cloud account, so the name is not perfect.
-	 */
-	
-	setCredentialStatus(qPrefCloudStorage::CS_UNKNOWN);
-	qPrefCloudStorage::set_cloud_verification_status(m_credentialStatus);
-	QMLManager::instance()->setStartPageText(tr("Starting..."));
-	
-	setShowPin(false);
-}
 
 void QMLPrefs::clearCredentials()
 {

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -44,7 +44,6 @@ public:
 	void setShowPin(bool enable);
 
 public slots:
-	void cancelCredentialsPinSetup();
 	void clearCredentials();
 
 private:

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -43,9 +43,6 @@ public:
 	bool showPin() const;
 	void setShowPin(bool enable);
 
-public slots:
-	void clearCredentials();
-
 private:
 	QString m_cloudPin;
 	qPrefCloudStorage::cloud_status m_credentialStatus;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removed functions cancelCredentialsPinSetup() and clearCredentials() as part of the ongoing
effort to reduce (eliminate) the use of qmlprefs

The whole startup is very enveloped and seems to have been expanded piece by piece, at least 
it is hard to see the design. This series will focus on removing qmlprefs, but by doing so it is 
necessary to change some startup functions in qmlmanager.

Because the startup is complicated together with the many partly overlapping functions, removal will be done in small steps allowing a full test after each step.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
