### PR TITLE
(qmlpref 3) remove cloudPin.

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -98,7 +98,7 @@ Item {
 				id: registerpin
 				text: qsTr("Register")
 				onClicked: {
-					verifyCredentials(login.text, password.text, pin.text)
+					manager.saveCloudCredentials(login.text, password.text, pin.text)
 				}
 			}
 			Controls.Label {
@@ -127,7 +127,7 @@ Item {
 				id: signin_register_normal
 				text: qsTr("Sign-in or Register")
 				onClicked: {
-					manager.saveCloudCredentials(login.text, password.text)
+					manager.saveCloudCredentials(login.text, password.text, "")
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -109,8 +109,10 @@ Item {
 				id: cancelpin
 				text: qsTr("Cancel")
 				onClicked: {
-					prefs.cancelCredentialsPinSetup()
-					rootItem.returnTopPage()
+					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					prefs.cloudCredentials = CloudStatus.CS_UNKNOWN
+					manager.startPageText = qsTr("Check credentials...");
+					prefs.showPin = false;
 				}
 			}
 		}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -12,7 +12,6 @@ Kirigami.ScrollablePage {
 	objectName: "DiveList"
 	title: qsTr("Dive list")
 	verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
-	property int credentialStatus: prefs.credentialStatus
 	property int numDives: diveListView.count
 	property color textColor: subsurfaceTheme.textColor
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 				color: subsurfaceTheme.textColor
 			}
 			Controls.Label {
-				text: PrefCloudStorage.credentialStatus === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
+				text: PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.60
 				color: subsurfaceTheme.textColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -54,8 +54,10 @@ Kirigami.ScrollablePage {
 				id: changeCloudSettings
 				text: qsTr("Change")
 				onClicked: {
-					prefs.cancelCredentialsPinSetup()
-					rootItem.returnTopPage()
+					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					prefs.credentialStatus = CloudStatus.CS_UNKNOWN
+					manager.startPageText  = qsTr("Starting...");
+					prefs.showPin = false;
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -457,7 +457,7 @@ void QMLManager::finishSetup()
 	} else if (!empty_string(existing_filename) &&
 				QMLPrefs::instance()->credentialStatus() != qPrefCloudStorage::CS_UNKNOWN) {
 		QMLPrefs::instance()->setCredentialStatus(qPrefCloudStorage::CS_NOCLOUD);
-		saveCloudCredentials(qPrefCloudStorage::cloud_storage_email(), qPrefCloudStorage::cloud_storage_password());
+		saveCloudCredentials(qPrefCloudStorage::cloud_storage_email(), qPrefCloudStorage::cloud_storage_password(), qPrefCloudStorage::cloud_storage_pin());
 		appendTextToLog(tr("working in no-cloud mode"));
 		int error = parse_file(existing_filename, &dive_table, &trip_table, &dive_site_table);
 		if (error) {
@@ -493,7 +493,7 @@ QMLManager *QMLManager::instance()
 #define CLOUDURL QString(prefs.cloud_base_url)
 #define CLOUDREDIRECTURL CLOUDURL + "/cgi-bin/redirect.pl"
 
-void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &newPassword)
+void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &newPassword, const QString &pin)
 {
 	bool cloudCredentialsChanged = false;
 	bool noCloud = QMLPrefs::instance()->credentialStatus() == qPrefCloudStorage::CS_NOCLOUD;
@@ -530,7 +530,7 @@ void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &ne
 	}
 
 	if (!noCloud &&
-		!verifyCredentials(newEmail, newPassword, QMLPrefs::instance()->cloudPin()))
+		!verifyCredentials(newEmail, newPassword, pin))
 		return;
 
 	qPrefCloudStorage::set_cloud_storage_email(newEmail);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -565,10 +565,6 @@ void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &ne
 		currentGitLocalOnly = git_local_only;
 		git_local_only = false;
 		openLocalThenRemote(url);
-	} else if (prefs.cloud_verification_status == qPrefCloudStorage::CS_NEED_TO_VERIFY &&
-				!QMLPrefs::instance()->cloudPin().isEmpty()) {
-		// the user entered a PIN?
-		tryRetrieveDataFromBackend();
 	}
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -621,8 +621,8 @@ void QMLManager::tryRetrieveDataFromBackend()
 		setStartPageText(tr("Testing cloud credentials"));
 		appendTextToLog("Have credentials, let's see if they are valid");
 		CloudStorageAuthenticate *csa = new CloudStorageAuthenticate(this);
-		csa->backend(prefs.cloud_storage_email, prefs.cloud_storage_password,
-						QMLPrefs::instance()->cloudPin());
+		csa->backend(prefs.cloud_storage_email, prefs.cloud_storage_password, "");
+
 		// let's wait here for the signal to avoid too many more nested functions
 		QTimer myTimer;
 		myTimer.setSingleShot(true);
@@ -638,7 +638,6 @@ void QMLManager::tryRetrieveDataFromBackend()
 			return;
 		}
 		myTimer.stop();
-		QMLPrefs::instance()->setCloudPin("");
 		if (prefs.cloud_verification_status == qPrefCloudStorage::CS_INCORRECT_USER_PASSWD) {
 			appendTextToLog(QStringLiteral("Incorrect cloud credentials"));
 			setStartPageText(RED_FONT + tr("Incorrect cloud credentials") + END_FONT);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -168,7 +168,6 @@ public slots:
 	void appInitialized();
 	void applicationStateChanged(Qt::ApplicationState state);
 	void saveCloudCredentials(const QString &email, const QString &password, const QString &pin);
-	bool verifyCredentials(QString email, QString password, QString pin);
 	void tryRetrieveDataFromBackend();
 	void handleError(QNetworkReply::NetworkError nError);
 	void handleSslErrors(const QList<QSslError> &errors);
@@ -266,6 +265,8 @@ private:
 	bool m_showNonDiveComputers;
 	struct dive *m_copyPasteDive = NULL;
 	struct dive_components what;
+
+	bool verifyCredentials(QString email, QString password, QString pin);
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	QString appLogFileName;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -167,7 +167,7 @@ public:
 public slots:
 	void appInitialized();
 	void applicationStateChanged(Qt::ApplicationState state);
-	void saveCloudCredentials(const QString &email, const QString &password);
+	void saveCloudCredentials(const QString &email, const QString &password, const QString &pin);
 	bool verifyCredentials(QString email, QString password, QString pin);
 	void tryRetrieveDataFromBackend();
 	void handleError(QNetworkReply::NetworkError nError);

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -33,16 +33,6 @@ QMLPrefs *QMLPrefs::instance()
 
 
 /*** public functions ***/
-const QString QMLPrefs::cloudPin() const
-{
-	return m_cloudPin;
-}
-
-void QMLPrefs::setCloudPin(const QString &cloudPin)
-{
-	m_cloudPin = cloudPin;
-	emit cloudPinChanged();
-}
 
 qPrefCloudStorage::cloud_status QMLPrefs::credentialStatus() const
 {
@@ -58,7 +48,6 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 			set_filename(NOCLOUD_LOCALSTORAGE);
 			qPrefCloudStorage::set_cloud_storage_email(NULL);
 			qPrefCloudStorage::set_cloud_storage_password(NULL);
-			setCloudPin(NULL);
 			if (qPrefUnits::unit_system() == "imperial")
 				prefs.units = IMPERIAL_units;
 			else if (qPrefUnits::unit_system() == "metric")

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -56,7 +56,9 @@ void QMLPrefs::setCredentialStatus(const qPrefCloudStorage::cloud_status value)
 		if (value == qPrefCloudStorage::CS_NOCLOUD) {
 			QMLManager::instance()->appendTextToLog("Switching to no cloud mode");
 			set_filename(NOCLOUD_LOCALSTORAGE);
-			clearCredentials();
+			qPrefCloudStorage::set_cloud_storage_email(NULL);
+			qPrefCloudStorage::set_cloud_storage_password(NULL);
+			setCloudPin(NULL);
 			if (qPrefUnits::unit_system() == "imperial")
 				prefs.units = IMPERIAL_units;
 			else if (qPrefUnits::unit_system() == "metric")
@@ -89,13 +91,4 @@ void QMLPrefs::setShowPin(bool enable)
 {
 	m_showPin = enable;
 	emit showPinChanged();
-}
-
-/*** public slot functions ***/
-
-void QMLPrefs::clearCredentials()
-{
-	qPrefCloudStorage::set_cloud_storage_email(NULL);
-	qPrefCloudStorage::set_cloud_storage_password(NULL);
-	setCloudPin(NULL);
 }

--- a/mobile-widgets/qmlprefs.cpp
+++ b/mobile-widgets/qmlprefs.cpp
@@ -92,29 +92,6 @@ void QMLPrefs::setShowPin(bool enable)
 }
 
 /*** public slot functions ***/
-void QMLPrefs::cancelCredentialsPinSetup()
-{   
-	/* 
-	 * The user selected <cancel> on the final stage of the
-	 * cloud account generation (entering the emailed PIN).
-	 * 
-	 * Resets the cloud credential status to CS_UNKNOWN, resulting
-	 * in a return to the first crededentials page, with the
-	 * email and passwd still filled in. In case of a cancel
-	 * of registration (from the PIN page), the email address
-	 * was probably misspelled, so the user never received a PIN to
-	 * complete the process.
-	 * 
-	 * Notice that this function is also used to switch to a different
-	 * cloud account, so the name is not perfect.
-	 */
-	
-	setCredentialStatus(qPrefCloudStorage::CS_UNKNOWN);
-	qPrefCloudStorage::set_cloud_verification_status(m_credentialStatus);
-	QMLManager::instance()->setStartPageText(tr("Starting..."));
-	
-	setShowPin(false);
-}
 
 void QMLPrefs::clearCredentials()
 {

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -44,7 +44,6 @@ public:
 	void setShowPin(bool enable);
 
 public slots:
-	void cancelCredentialsPinSetup();
 	void clearCredentials();
 
 private:

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -9,10 +9,6 @@
 
 class QMLPrefs : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(QString cloudPin
-				MEMBER m_cloudPin
-				WRITE setCloudPin
-				NOTIFY cloudPinChanged)
 	Q_PROPERTY(qPrefCloudStorage::cloud_status credentialStatus
 				MEMBER m_credentialStatus
 				WRITE setCredentialStatus
@@ -31,9 +27,6 @@ public:
 
 	static QMLPrefs *instance();
 
-	const QString cloudPin() const;
-	void setCloudPin(const QString &cloudPin);
-
 	qPrefCloudStorage::cloud_status credentialStatus() const;
 	void setCredentialStatus(const qPrefCloudStorage::cloud_status value);
 
@@ -44,14 +37,12 @@ public:
 	void setShowPin(bool enable);
 
 private:
-	QString m_cloudPin;
 	qPrefCloudStorage::cloud_status m_credentialStatus;
 	static QMLPrefs *m_instance;
 	qPrefCloudStorage::cloud_status m_oldStatus;
 	bool m_showPin;
 
 signals:
-	void cloudPinChanged();
 	void credentialStatusChanged();
 	void oldStatusChanged();
 	void showPinChanged();

--- a/mobile-widgets/qmlprefs.h
+++ b/mobile-widgets/qmlprefs.h
@@ -43,9 +43,6 @@ public:
 	bool showPin() const;
 	void setShowPin(bool enable);
 
-public slots:
-	void clearCredentials();
-
 private:
 	QString m_cloudPin;
 	qPrefCloudStorage::cloud_status m_credentialStatus;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
qmlprefs::cloudPin was only ever set to "" and NULL (both in qmlmanager), it was never set to
the real pin value.

Desktop uses qPrefCloudStorage::cloud_storage_pin, and it is stored in the plist, but that does not seem necessary. This is however a potential PR for somebody else.

Remove qmlprefs::cloudPin from all sources.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
