### PR TITLE
bugfix: testqPrefDisplay

### DIFF
--- a/tests/testqPrefDisplay.cpp
+++ b/tests/testqPrefDisplay.cpp
@@ -86,6 +86,8 @@ void TestQPrefDisplay::test_set_load_struct()
 	display->set_display_invalid_dives(true);
 	display->set_divelist_font("doNotCareString");
 	display->set_font_size(15.0);
+	qDebug() << "--> got prefs. " << prefs.font_size << " and " << qPrefDisplay::font_size();
+
 	display->set_show_developer(true);
 	display->set_theme("myTheme2");
 	display->set_lastDir("test2");
@@ -106,10 +108,13 @@ void TestQPrefDisplay::test_set_load_struct()
 	prefs.show_developer = false;
 
 	display->load();
+#ifndef SUBSURFACE_MOBILE
+	// Font size is never stored on disk, but qPref grabs the system default
+	QCOMPARE(prefs.font_size, 15.0);
+#endif
 	QCOMPARE(prefs.animation_speed, 33);
 	QCOMPARE(prefs.display_invalid_dives, true);
 	QCOMPARE(prefs.divelist_font, "doNotCareString");
-	QCOMPARE(prefs.font_size, 15.0);
 	QCOMPARE(prefs.show_developer, true);
 	QCOMPARE(display->theme(), QString("myTheme2"));
 	QCOMPARE(display->lastDir(), QString("test2"));
@@ -147,7 +152,10 @@ void TestQPrefDisplay::test_struct_disk()
 	QCOMPARE(prefs.animation_speed, 27);
 	QCOMPARE(prefs.display_invalid_dives, true);
 	QCOMPARE(prefs.divelist_font, "doNotCareAtAll");
+#ifndef SUBSURFACE_MOBILE
+	// Font size is never stored on disk, but qPref grabs the system default
 	QCOMPARE(prefs.font_size, 17.0);
+#endif
 	QCOMPARE(prefs.show_developer, false);
 }
 


### PR DESCRIPTION
Font size are never stored on disk for the mobile version,
so testing load/save does not make sense.

add #ifndef SUBSURFACE_MOBILE

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
