### PR TITLE
bugfixes: plannerShared and testPlannerShared

### DIFF
--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -236,7 +236,7 @@ void plannerShared::set_bottompo2(double value)
 
 double plannerShared::decopo2()
 {
-	return qPrefDivePlanner::decopo2() / 1000;
+	return qPrefDivePlanner::decopo2() / 1000.0;
 }
 void plannerShared::set_decopo2(double value)
 {

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -288,13 +288,13 @@ void TestPlannerShared::test_gas()
 	QCOMPARE(plannerShared::decopo2(), 1.0);
 
 	plannerShared::set_bestmixend(33);
-//Not implemented	QCOMPARE(qPrefDivePlanner::bestmixend(), 168);
+	QCOMPARE(qPrefDivePlanner::bestmixend(), 10058);
 	plannerShared::set_bestmixend(27);
-//Not implemented	QCOMPARE(qPrefDivePlanner::bestmixend(), 137);
-	qPrefDivePlanner::set_bestmixend(203);
-//Not implemented	QCOMPARE(plannerShared::bestmixend(), 40);
-	qPrefDivePlanner::set_bestmixend(178);
-//Not implemented	QCOMPARE(plannerShared::bestmixend(), 35);
+	QCOMPARE(qPrefDivePlanner::bestmixend(), 8230);
+	qPrefDivePlanner::set_bestmixend(11000);
+	QCOMPARE(plannerShared::bestmixend(), 36);
+	qPrefDivePlanner::set_bestmixend(7000);
+	QCOMPARE(plannerShared::bestmixend(), 23);
 
 	// Variables currently not tested
 	// o2narcotic

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -251,19 +251,23 @@ void TestPlannerShared::test_gas()
 	QCOMPARE(qPrefDivePlanner::bottomsac(), 25485);
 	plannerShared::set_bottomsac(0.01);
 	QCOMPARE(qPrefDivePlanner::bottomsac(), 283);
-	qPrefDivePlanner::set_bottomsac(11327);
-//Not implemented	QCOMPARE(plannerShared::bottomsac(), 0.4);
-	qPrefDivePlanner::set_bottomsac(19822);
-//Not implemented	QCOMPARE(plannerShared::bottomsac(), 0.7);
+
+	// Remark return will from qPref is in m / 1000.
+	qPrefDivePlanner::set_bottomsac(2830);
+	QCOMPARE(plannerShared::bottomsac(), 2.83);
+	qPrefDivePlanner::set_bottomsac(16000);
+	QCOMPARE(plannerShared::bottomsac(), 16);
 
 	plannerShared::set_decosac(0.9);
 	QCOMPARE(qPrefDivePlanner::decosac(), 25485);
 	plannerShared::set_decosac(0.01);
 	QCOMPARE(qPrefDivePlanner::decosac(), 283);
-	qPrefDivePlanner::set_decosac(11327);
-//Not implemented	QCOMPARE(plannerShared::decosac(), 0.4);
-	qPrefDivePlanner::set_decosac(19822);
-//Not implemented	QCOMPARE(plannerShared::decosac(), 0.7);
+
+	// Remark return will from qPref is in m / 1000.
+	qPrefDivePlanner::set_decosac(11500);
+	QCOMPARE(plannerShared::decosac(), 11.5);
+	qPrefDivePlanner::set_decosac(19800);
+	QCOMPARE(plannerShared::decosac(), 19.8);
 
 	// Remark bottompo2 is in BAR, even though unit system is
 	// Imperial, the desktop version is like that.

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -231,7 +231,7 @@ void TestPlannerShared::test_gas()
 	plannerShared::set_decopo2(1.6);
 	QCOMPARE(qPrefDivePlanner::decopo2(), 1600);
 	qPrefDivePlanner::set_decopo2(1100);
-//TEMP	QCOMPARE(plannerShared::decopo2(), 1.1);
+	QCOMPARE(plannerShared::decopo2(), 1.1);
 	qPrefDivePlanner::set_decopo2(1000);
 	QCOMPARE(plannerShared::decopo2(), 1.0);
 
@@ -265,6 +265,8 @@ void TestPlannerShared::test_gas()
 	qPrefDivePlanner::set_decosac(19822);
 //Not implemented	QCOMPARE(plannerShared::decosac(), 0.7);
 
+	// Remark bottompo2 is in BAR, even though unit system is
+	// Imperial, the desktop version is like that.
 	plannerShared::set_bottompo2(1.5);
 	QCOMPARE(qPrefDivePlanner::bottompo2(), 1500);
 	plannerShared::set_bottompo2(1.6);
@@ -274,6 +276,8 @@ void TestPlannerShared::test_gas()
 	qPrefDivePlanner::set_bottompo2(1000);
 	QCOMPARE(plannerShared::bottompo2(), 1.0);
 
+	// Remark decopo2 is in BAR, even though unit system is
+	// Imperial, the desktop version is like that.
 	plannerShared::set_decopo2(1.5);
 	QCOMPARE(qPrefDivePlanner::decopo2(), 1500);
 	plannerShared::set_decopo2(1.6);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a couple of fixes for both plannerShared (implementation) and testplannershared (testing),
based on more testing today.

I hope the rebase on top of the newly added commits works (did not compile every commit again, but only the whole PR).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
commit 1: correct deco2() problem in plannerShared
commit 2: reactivate decopo2 test case in testplannershared
commit 3: correct bestmixend test cases.
commit 4: correct test case decosac/bottomsac in imperial units 

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
