### PR TITLE
first version of live values in mobile diveplanner setup.

### DIFF
--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -299,6 +299,10 @@ Kirigami.ScrollablePage {
 				}
 				TemplateCheckBox {
 					text: qsTr("O2 narcotic")
+					checked: Planner.o2narcotic
+					onClicked: {
+						Planner.o2narcotic = checked
+					}
 				}
 			}
 		}
@@ -311,18 +315,38 @@ Kirigami.ScrollablePage {
 
 				TemplateCheckBox {
 					text: qsTr("Display runtime")
+					checked: Planner.display_runtime
+					onClicked: {
+						Planner.display_runtime = checked
+					}
 				}
 				TemplateCheckBox {
 					text: qsTr("Display segment duration")
+					checked: Planner.display_duration
+					onClicked: {
+						Planner.display_duration = checked
+					}
 				}
 				TemplateCheckBox {
 					text: qsTr("Display transitions in deco")
+					checked: Planner.display_transitions
+					onClicked: {
+						Planner.display_transitions = checked
+					}
 				}
 				TemplateCheckBox {
 					text: qsTr("Verbatim dive plan")
+					checked: Planner.verbatim_plan
+					onClicked: {
+						Planner.verbatim_plan = checked
+					}
 				}
 				TemplateCheckBox {
 					text: qsTr("Display plan variations")
+					checked: Planner.display_variations
+					onClicked: {
+						Planner.display_variations = checked
+					}
 				}
 			}
 		}

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -37,12 +37,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 15
+					value: Planner.ascrate75
 					textFromValue: function (value, locale) {
 						return value + qsTr("m/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.ascrate75 = value
 					}
 				}
 				TemplateLabel {
@@ -52,12 +52,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 15
+					value: Planner.ascrate50
 					textFromValue: function (value, locale) {
 						return value + qsTr("m/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.ascrate50 = value
 					}
 				}
 				TemplateLabel {
@@ -67,12 +67,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 15
+					value: Planner.ascratestops
 					textFromValue: function (value, locale) {
 						return value + qsTr("m/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.ascratestops = value
 					}
 				}
 				TemplateLabel {
@@ -82,12 +82,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 15
+					value: Planner.ascratelast6m
 					textFromValue: function (value, locale) {
 						return value + qsTr("m/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.ascratelast6m = value
 					}
 				}
 				TemplateLabel {
@@ -102,12 +102,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 15
+					value: Planner.descrate
 					textFromValue: function (value, locale) {
 						return value + qsTr("m/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.descrate = value
 					}
 				}
 			}
@@ -199,12 +199,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 20
+					value: Planner.bottomsac
 					textFromValue: function (value, locale) {
 						return value + qsTr("l/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.bottomsac = value
 					}
 				}
 				TemplateLabel {
@@ -214,12 +214,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 17
+					value: Planner.decosac
 					textFromValue: function (value, locale) {
 						return value + qsTr("l/min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.decosac = value
 					}
 				}
 				TemplateLabel {
@@ -229,12 +229,12 @@ Kirigami.ScrollablePage {
 					from: 20
 					to: 99
 					stepSize: 1
-					value: 20
+					value: Planner.sacfactor
 					textFromValue: function (value, locale) {
 						return (value / 10).toFixed(1)
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.sacfactor = value
 					}
 				}
 				TemplateLabel {
@@ -244,12 +244,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 9
 					stepSize: 1
-					value: 4
+					value: Planner.problemsolvingtime
 					textFromValue: function (value, locale) {
 						return value + qsTr("min")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.problemsolvingtime = value
 					}
 				}
 				TemplateLabel {
@@ -259,12 +259,12 @@ Kirigami.ScrollablePage {
 					from: 0
 					to: 200
 					stepSize: 1
-					value: 120
+					value: Planner.bottompo2
 					textFromValue: function (value, locale) {
 						return (value / 100).toFixed(2) + "bar"
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.bottompo2 = value
 					}
 				}
 				TemplateLabel {
@@ -274,12 +274,12 @@ Kirigami.ScrollablePage {
 					from: 0
 					to: 200
 					stepSize: 1
-					value: 160
+					value: Planner.decopo2
 					textFromValue: function (value, locale) {
 						return (value / 100).toFixed(2) + "bar"
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.decopo2 = value
 					}
 				}
 				TemplateLabel {
@@ -289,12 +289,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 20
+					value: Planner.bestmixend
 					textFromValue: function (value, locale) {
 						return value + qsTr("m")
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Planner.bestmixend = value
 					}
 				}
 				TemplateCheckBox {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a rather small, but very important step, it allows to compare desktop and mobile diveplanner setup (apart from planning). 

This will be the last mobile planner update in 2019.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Connected plannerShared with DivePlannerSetup.qml to view and update qPref values.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
