### PR TITLE
Fix get_divemode logic

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -246,9 +246,11 @@ void add_extra_data(struct divecomputer *dc, const char *key, const char *value)
 enum divemode_t get_current_divemode(const struct divecomputer *dc, int time, const struct event **evp, enum divemode_t *divemode)
 {
 	const struct event *ev = *evp;
-	if (*divemode == UNDEF_COMP_TYPE && dc) {
-		*divemode = dc->divemode;
-		ev = get_next_event(dc->events, "modechange");
+	if (dc) {
+		if (*divemode == UNDEF_COMP_TYPE) {
+			*divemode = dc->divemode;
+			ev = get_next_event(dc->events, "modechange");
+		}
 	} else {
 		ev = NULL;
 	}


### PR DESCRIPTION
Commit dbb504 tried to prevent an uninitialized dc pointer
from being dereferenced. But I screwed up the logic always
setting the event pointer to NULL. This fixes this error.

Reported-by: willemferguson@zoology.up.ac.za
Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported by @willemferguson 