### PR TITLE
GitHub Actions: change passwords to be hard coded

### DIFF
--- a/.github/workflows/linux-bionic-5.9.yml
+++ b/.github/workflows/linux-bionic-5.9.yml
@@ -37,7 +37,7 @@ jobs:
     - name: test desktop build
       env:
         SSRF_USER_EMAIL: ssrftest-u18@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudu18 }}
+        SSRF_USER_PASSWORD: geheim-u18
       run: |
         # and now run the tests - with Qt 5.9 we can only run the desktop flavor
         echo "------------------------------------"

--- a/.github/workflows/linux-eoan-5.12.yml
+++ b/.github/workflows/linux-eoan-5.12.yml
@@ -18,9 +18,6 @@ jobs:
       uses: actions/checkout@v1
 
     - name: get container ready for build
-      env:
-        SSRF_USER_EMAIL: ssrftest-u19@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudu19 }}
       run: |
         echo "--------------------------------------------------------------"
         echo "update distro and install dependencies"
@@ -49,7 +46,7 @@ jobs:
     - name: test mobile build
       env:
         SSRF_USER_EMAIL: ssrftest-u19@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudu19 }}
+        SSRF_USER_PASSWORD: geheim-u19
       run: |
         echo "--------------------------------------------------------------"
         echo "running tests for mobile"
@@ -69,7 +66,7 @@ jobs:
     - name: test desktop build
       env:
         SSRF_USER_EMAIL: ssrftest-u19@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudu19 }}
+        SSRF_USER_PASSWORD: geheim-u19
       run: |
         echo "--------------------------------------------------------------"
         echo "running tests for desktop"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -35,7 +35,7 @@ jobs:
     - name: test mobile build
       env:
         SSRF_USER_EMAIL: ssrftest-mac@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudmac }}
+        SSRF_USER_PASSWORD: geheim-mac
       run: |
         echo "------------------------------------"
         echo "run tests for mobile build"
@@ -64,7 +64,7 @@ jobs:
     - name: test desktop build
       env:
         SSRF_USER_EMAIL: ssrftest-mac@hohndel.org
-        SSRF_USER_PASSWORD: ${{ secrets.cloudmac }}
+        SSRF_USER_PASSWORD: geheim-mac
       run: |
         echo "------------------------------------"
         echo "run tests for desktop build"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,7 +111,7 @@ TEST(TestParsePerformance testparseperformance.cpp)
 TEST(TestPlan testplan.cpp)
 TEST(TestDiveSiteDuplication testdivesiteduplication.cpp)
 TEST(TestRenumber testrenumber.cpp)
-# right now this causes random test failures... TEST(TestGitStorage testgitstorage.cpp)
+TEST(TestGitStorage testgitstorage.cpp)
 TEST(TestPicture testpicture.cpp)
 TEST(TestMerge testmerge.cpp)
 TEST(TestTagList testtaglist.cpp)
@@ -148,7 +148,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestProfile
 	TestGpsCoords
 	TestParse
-	# TestGitStorage
+	TestGitStorage
 	TestPlan
 	TestAirPressure
 	TestDiveSiteDuplication


### PR DESCRIPTION
As much as I hate having passwords exposed through the source code,
since GitHub wisely prevents reading secrets in pull requests, there
isn't really a sane way to have this use confidential credentials.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
