### PR TITLE
make robust and simple interface for using enums in QML

### DIFF
--- a/backend-shared/CMakeLists.txt
+++ b/backend-shared/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BACKEND_SRCS
 	exportfuncs.h
 	plannershared.cpp
 	plannershared.h
+	typeenum.h
 )
 
 add_library(subsurface_backend_shared STATIC ${BACKEND_SRCS})

--- a/backend-shared/typeenum.h
+++ b/backend-shared/typeenum.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TYPEENUM_H
+#define TYPEENUM_H
+
+// *** REMARK ***
+// This feature is currently not used
+// but is left to allow for future use.
+
+//FUTURE This header file can be included twice
+//FUTURE 1 time as enum only (TYPEENUM_COMPILE_AS_ENUM defined)
+//FUTURE 1 time as class (TYPEENUM_COMPILE_AS_ENUM not defined)
+//FUTURE #if !defined(TYPEENUM_ALLOW_ENUM) || !defined(TYPEENUM_ALLOW_CLASS)
+//FUTURE #if defined(TYPEENUM_COMPILE_AS_ENUM)
+//FUTURE #define TYPEENUM_ALLOW_ENUM
+//FUTURE #else
+//FUTURE #define TYPEENUM_ALLOW_CLASS
+//FUTURE #endif
+
+//FUTURE This header is shared between the C/C++ part of subsurface and
+//FUTURE indirectly with QML.
+//FUTURE it secures that shared enums are defined identical for QML
+//FUTURE and C++ by having the shared enums defined only once in this
+//FUTURE header.
+//
+//FUTURE TYPEENUM_COMPILE_AS_ENUM is set where it is included, to NOT
+//FUTURE generate the class (which is only needed for the QML interface)
+//FUTURE that can be registred to make the enums available in QML
+
+//FUTURE #ifndef TYPEENUM_COMPILE_AS_ENUM
+//FUTURE  This part is only relevant when generating the QML accessible
+//FUTURE  class.
+#include <QObject>
+
+class typeEnum : public QObject {
+	Q_OBJECT
+
+public:
+
+private:
+	typeEnum() {}
+
+public:
+//FUTURE #endif // TYPEENUM_COMPILE_AS_ENUM
+
+	// Shared enums
+	//FUTURE accessed in C/C++ just with the name.value
+	// accessed in QML with TypeEnum.name.value
+	enum CLOUD_STATUS {
+		CS_UNKNOWN,
+		CS_INCORRECT_USER_PASSWD,
+		CS_NEED_TO_VERIFY,
+		CS_VERIFIED,
+		CS_NOCLOUD
+	};
+
+	// Do not activate these enums until code is changed
+	enum LENGTH {
+		METERS,
+		FEET
+	};
+	enum VOLUME {
+		LITER,
+		CUFT
+	};
+	enum PRESSURE {
+		BAR,
+		PSI,
+		PASCALS
+	};
+	enum TEMPERATURE {
+		CELSIUS,
+		FAHRENHEIT,
+		KELVIN
+	};
+	enum WEIGHT {
+		KG,
+		LBS
+	};
+	enum TIME {
+		SECONDS,
+		MINUTES
+	};
+	enum DURATION {
+		MIXED,
+		MINUTES_ONLY,
+		ALWAYS_HOURS
+	};
+
+//FUTURE #ifndef TYPEENUM_COMPILE_AS_ENUM
+	Q_ENUM(CLOUD_STATUS);
+	Q_ENUM(LENGTH);
+	Q_ENUM(VOLUME);
+	Q_ENUM(PRESSURE);
+	Q_ENUM(TEMPERATURE);
+	Q_ENUM(WEIGHT);
+	Q_ENUM(TIME);
+	Q_ENUM(DURATION);
+//FUTURE #endif
+};
+//FUTURE #endif // TYPEENUM_COMPILE_AS_ENUM
+
+//FUTURE  Clear TYPEENUM_COMPILE_AS_ENUM to allow multple includes
+//FUTURE #undef TYPEENUM_COMPILE_AS_ENUM
+#endif

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -74,7 +74,6 @@ void qPref::registerQML(QQmlEngine *engine)
 	}
 
 	// Register special types
-	qmlRegisterUncreatableType<qPrefCloudStorage>("org.subsurfacedivelog.mobile",1,0,"CloudStatus","Enum is not a type");
 	qRegisterMetaType<deco_mode>();
 	qRegisterMetaType<def_file_behavior>();
 	qRegisterMetaType<taxonomy_category>();

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -38,7 +38,6 @@ public:
 		CS_VERIFIED,
 		CS_NOCLOUD
 	};
-	Q_ENUM(cloud_status);
 
 	static bool cloud_auto_sync() { return prefs.cloud_auto_sync; }
 	static QString cloud_base_url() { return prefs.cloud_base_url; }

--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -13,7 +13,7 @@ Item {
 
 	property string username: login.text;
 	property string password: password.text;
-	property bool showPin: (PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NEED_TO_VERIFY)
+	property bool showPin: (PrefCloudStorage.cloud_verification_status === TypeEnum.CS_NEED_TO_VERIFY)
 
 	ColumnLayout {
 		id: outerLayout
@@ -110,7 +110,7 @@ Item {
 				id: cancelpin
 				text: qsTr("Cancel")
 				onClicked: {
-					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					PrefCloudStorage.cloud_verification_status = TypeEnum.CS_UNKNOWN
 					manager.startPageText = qsTr("Check credentials...");
 				}
 			}
@@ -140,7 +140,7 @@ Item {
 					manager.setGitLocalOnly(true)
 					PrefCloudStorage.cloud_auto_sync = false
 					manager.oldStatus = PrefCloudStorage.cloud_verification_status
-					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_NOCLOUD
+					PrefCloudStorage.cloud_verification_status = TypeEnum.CS_NOCLOUD
 					manager.saveCloudCredentials("", "", "")
 					manager.openNoCloudRepo()
 				}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -30,7 +30,7 @@ Kirigami.ScrollablePage {
 	supportsRefreshing: true
 	onRefreshingChanged: {
 		if (refreshing) {
-			if (PrefCloudStorage.cloud_verification_status === CloudStatus.CS_VERIFIED) {
+			if (PrefCloudStorage.cloud_verification_status === Enums.CS_VERIFIED) {
 				detailsWindow.endEditMode()
 				manager.saveChangesCloud(true)
 				refreshing = false

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 				color: subsurfaceTheme.textColor
 			}
 			Controls.Label {
-				text: PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
+				text: PrefCloudStorage.cloud_verification_status === Enums.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.60
 				color: subsurfaceTheme.textColor
@@ -54,7 +54,7 @@ Kirigami.ScrollablePage {
 				id: changeCloudSettings
 				text: qsTr("Change")
 				onClicked: {
-					PrefCloudStorage.cloud_verification_status = CloudStatus.CS_UNKNOWN
+					PrefCloudStorage.cloud_verification_status = Enums.CS_UNKNOWN
 					manager.startPageText  = qsTr("Starting...");
 				}
 			}

--- a/mobile-widgets/qml/StartPage.qml
+++ b/mobile-widgets/qml/StartPage.qml
@@ -27,7 +27,7 @@ Kirigami.ScrollablePage {
 		}
 		Controls.Label {
 			id: explanationTextBasic
-			visible: PrefCloudStorage.cloud_verification_status !== CloudStatus.CS_NEED_TO_VERIFY
+			visible: PrefCloudStorage.cloud_verification_status !== Enums.CS_NEED_TO_VERIFY
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3
@@ -40,7 +40,7 @@ Kirigami.ScrollablePage {
 		}
 		Controls.Label {
 			id: explanationTextPin
-			visible: PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NEED_TO_VERIFY
+			visible: PrefCloudStorage.cloud_verification_status === Enums.CS_NEED_TO_VERIFY
 			Layout.fillWidth: true
 			Layout.margins: Kirigami.Units.gridUnit
 			Layout.topMargin: Kirigami.Units.gridUnit * 3

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -164,8 +164,8 @@ Kirigami.ApplicationWindow {
 		id: globalDrawer
 		height: rootItem.height
 		rightPadding: 0
-		enabled: (PrefCloudStorage.cloud_verification_status === CloudStatus.CS_NOCLOUD ||
-				  PrefCloudStorage.cloud_verification_status === CloudStatus.CS_VERIFIED)
+		enabled: (PrefCloudStorage.cloud_verification_status === Enums.CS_NOCLOUD ||
+				  PrefCloudStorage.cloud_verification_status === Enums.CS_VERIFIED)
 		topContent: Image {
 			source: "qrc:/qml/icons/dive.jpg"
 			Layout.fillWidth: true
@@ -319,7 +319,7 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/cloud_sync.svg"
 					}
 					text: qsTr("Manual sync with cloud")
-					enabled: PrefCloudStorage.cloud_verification_status === CloudStatus.CS_VERIFIED
+					enabled: PrefCloudStorage.cloud_verification_status === Enums.CS_VERIFIED
 					onTriggered: {
 						globalDrawer.close()
 						detailsWindow.endEditMode()
@@ -332,7 +332,7 @@ Kirigami.ApplicationWindow {
 					name: PrefCloudStorage.cloud_auto_sync ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
 				text: PrefCloudStorage.cloud_auto_sync ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
-					visible: PrefCloudStorage.cloud_verification_status !== CloudStatus.CS_NOCLOUD
+					visible: PrefCloudStorage.cloud_verification_status !== Enums.CS_NOCLOUD
 					onTriggered: {
 						PrefCloudStorage.cloud_auto_sync = !PrefCloudStorage.cloud_auto_sync
 						manager.setGitLocalOnly(PrefCloudStorage.cloud_auto_sync)
@@ -825,8 +825,8 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	StartPage {
 		id: startPage
 		anchors.fill: parent
-		visible: PrefCloudStorage.cloud_verification_status !== CloudStatus.CS_NOCLOUD &&
-			 PrefCloudStorage.cloud_verification_status !== CloudStatus.CS_VERIFIED
+		visible: PrefCloudStorage.cloud_verification_status !== Enums.CS_NOCLOUD &&
+			 PrefCloudStorage.cloud_verification_status !== Enums.CS_VERIFIED
 		Behavior on opacity { NumberAnimation { duration: Kirigami.Units.shortDuration } }
 
 		onVisibleChanged: {

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -242,6 +242,7 @@ HEADERS += \
 	../../core/subsurface-qt/DiveListNotifier.h \
 	../../backend-shared/exportfuncs.h \
 	../../backend-shared/plannershared.h \
+	../../backend-shared/typeenum.h \
 	../../mobile-widgets/qmlmanager.h \
 	../../map-widget/qmlmapwidgethelper.h \
 	../../qt-models/divelistmodel.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -8,6 +8,7 @@
 #include "core/qt-gui.h"
 #include "core/settings/qPref.h"
 #include "core/ssrf.h"
+#include "backend-shared/typeenum.h"
 
 #ifdef SUBSURFACE_MOBILE
 #include <QApplication>
@@ -181,6 +182,9 @@ void register_qml_types(QQmlEngine *engine)
 
 #ifndef SUBSURFACE_TEST_DATA
 	int rc;
+
+	// Register shared enum
+	qmlRegisterUncreatableType<typeEnum>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
 
 #ifdef SUBSURFACE_MOBILE
 	// register shared diveplanner class


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add a header file with a class that contains the enums used both in C/C++ and QML. These
enums are in effect duplicated and needs to be updated when the C/C++ variant changes.

Use of 1 class for making enums available to QML, makes problem searching a lot easier, and
the interface becomes simpler.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

