### PR TITLE
(3) add design to planner setup and cleanup plannershared

### DIFF
--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -89,6 +89,9 @@ void plannerShared::set_bottomsac(double value)
 
 double plannerShared::decosac()
 {
+// Mobile and desktop use the same values when using units::LITER,
+// however when using units::CUFT desktop want 0.00 - 3.00 while
+// mobile wants 0 - 300, therefore multiply by 100 for mobile
 	return (qPrefUnits::volume() == units::LITER) ?
 				qPrefDivePlanner::decosac() / 1000.0 :
 				ml_to_cuft(qPrefDivePlanner::decosac()
@@ -105,6 +108,9 @@ void plannerShared::set_decosac(double value)
 
 double plannerShared::sacfactor()
 {
+// mobile want 0 - 100 which are shown with 1 decimal as 0.0 - 10.0
+// whereas desktop wants 0.0 - 10.0
+// as a consequence divide by 10 or 100
 	return qPrefDivePlanner::sacfactor() /
 #ifdef SUBSURFACE_MOBILE
 			10.0;

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -105,10 +105,18 @@ void plannerShared::set_decosac(double value)
 
 double plannerShared::sacfactor()
 {
-	return qPrefDivePlanner::sacfactor() / 100.0;
+	return qPrefDivePlanner::sacfactor() /
+#ifdef SUBSURFACE_MOBILE
+			10.0;
+#else
+			100.0;
+#endif
 }
 void plannerShared::set_sacfactor(double value)
 {
+#ifdef SUBSURFACE_MOBILE
+	value /= 10.0;
+#endif
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setSacFactor(value);
 }

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -61,6 +61,17 @@ void plannerShared::set_min_switch_duration(int value)
 	DivePlannerPointsModel::instance()->setMinSwitchDuration(value);
 }
 
+int plannerShared::surface_segment()
+{
+	return qPrefDivePlanner::surface_segment() / 60;
+}
+void plannerShared::set_surface_segment(int value)
+{
+	// NO conversion, this is done in the planner model.
+	DivePlannerPointsModel::instance()->setSurfaceSegment(value);
+	emit instance()->surface_segmentChanged(surface_segment());
+}
+
 double plannerShared::bottomsac()
 {
 	return (qPrefUnits::volume() == units::LITER) ?

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -83,11 +83,6 @@ double plannerShared::bottomsac()
 }
 void plannerShared::set_bottomsac(double value)
 {
-#ifdef SUBSURFACE_MOBILE
-	if (qPrefUnits::volume() == units::CUFT)
-		value /= 100; // cuft without decimals (0 - 300)
-#endif
-
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setBottomSac(value);
 }
@@ -104,11 +99,6 @@ double plannerShared::decosac()
 }
 void plannerShared::set_decosac(double value)
 {
-#ifdef SUBSURFACE_MOBILE
-	if (qPrefUnits::volume() == units::CUFT)
-		value /= 100; // cuft without decimals (0 - 300)
-#endif
-
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setDecoSac(value);
 }
@@ -124,9 +114,6 @@ double plannerShared::sacfactor()
 }
 void plannerShared::set_sacfactor(double value)
 {
-#ifdef SUBSURFACE_MOBILE
-	value /= 10.0;
-#endif
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setSacFactor(value);
 }

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -63,20 +63,42 @@ void plannerShared::set_min_switch_duration(int value)
 
 double plannerShared::bottomsac()
 {
-	return qPrefDivePlanner::bottomsac() / 1000.0;
+	return (qPrefUnits::volume() == units::LITER) ?
+				qPrefDivePlanner::bottomsac() / 1000.0 :
+				ml_to_cuft(qPrefDivePlanner::bottomsac()
+#ifdef SUBSURFACE_MOBILE
+					* 100 // cuft without decimals (0 - 300)
+#endif
+				);
 }
 void plannerShared::set_bottomsac(double value)
 {
+#ifdef SUBSURFACE_MOBILE
+	if (qPrefUnits::volume() == units::CUFT)
+		value /= 100; // cuft without decimals (0 - 300)
+#endif
+
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setBottomSac(value);
 }
 
 double plannerShared::decosac()
 {
-	return qPrefDivePlanner::decosac() / 1000.0;
+	return (qPrefUnits::volume() == units::LITER) ?
+				qPrefDivePlanner::decosac() / 1000.0 :
+				ml_to_cuft(qPrefDivePlanner::decosac()
+#ifdef SUBSURFACE_MOBILE
+					* 100 // cuft without decimals (0 - 300)
+#endif
+				);
 }
 void plannerShared::set_decosac(double value)
 {
+#ifdef SUBSURFACE_MOBILE
+	if (qPrefUnits::volume() == units::CUFT)
+		value /= 100; // cuft without decimals (0 - 300)
+#endif
+
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setDecoSac(value);
 }

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -31,42 +31,6 @@ void plannerShared::set_reserve_gas(int value)
 	DivePlannerPointsModel::instance()->setReserveGas(value);
 }
 
-bool plannerShared::safetystop()
-{
-	return qPrefDivePlanner::safetystop();
-}
-void plannerShared::set_safetystop(bool value)
-{
-	DivePlannerPointsModel::instance()->setSafetyStop(value);
-}
-
-int plannerShared::gflow()
-{
-	return qPrefTechnicalDetails::gflow();
-}
-void plannerShared::set_gflow(int value)
-{
-	DivePlannerPointsModel::instance()->setGFLow(value);
-}
-
-int plannerShared::gfhigh()
-{
-	return qPrefTechnicalDetails::gflow();
-}
-void plannerShared::set_gfhigh(int value)
-{
-	DivePlannerPointsModel::instance()->setGFHigh(value);
-}
-
-int plannerShared::vpmb_conservatism()
-{
-	return qPrefTechnicalDetails::vpmb_conservatism();
-}
-void plannerShared::set_vpmb_conservatism(int value)
-{
-	DivePlannerPointsModel::instance()->setVpmbConservatism(value);
-}
-
 bool plannerShared::dobailout()
 {
 	return qPrefDivePlanner::dobailout();
@@ -75,33 +39,6 @@ void plannerShared::set_dobailout(bool value)
 {
 	qPrefDivePlanner::set_dobailout(value);
 	DivePlannerPointsModel::instance()->emitDataChanged();
-}
-
-bool plannerShared::drop_stone_mode()
-{
-	return qPrefDivePlanner::drop_stone_mode();
-}
-void plannerShared::set_drop_stone_mode(bool value)
-{
-	DivePlannerPointsModel::instance()->setDropStoneMode(value);
-}
-
-bool plannerShared::last_stop()
-{
-	return qPrefDivePlanner::last_stop();
-}
-void plannerShared::set_last_stop(bool value)
-{
-	DivePlannerPointsModel::instance()->setLastStop6m(value);
-}
-
-bool plannerShared::switch_at_req_stop()
-{
-	return qPrefDivePlanner::switch_at_req_stop();
-}
-void plannerShared::set_switch_at_req_stop(bool value)
-{
-	DivePlannerPointsModel::instance()->setSwitchAtReqStop(value);
 }
 
 bool plannerShared::doo2breaks()
@@ -142,16 +79,6 @@ void plannerShared::set_decosac(double value)
 {
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setDecoSac(value);
-}
-
-int plannerShared::problemsolvingtime()
-{
-	return qPrefDivePlanner::problemsolvingtime();
-}
-void plannerShared::set_problemsolvingtime(int value)
-{
-	// NO conversion, this is done in the planner model.
-	DivePlannerPointsModel::instance()->setProblemSolvingTime(value);
 }
 
 double plannerShared::sacfactor()

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -69,7 +69,6 @@ void plannerShared::set_surface_segment(int value)
 {
 	// NO conversion, this is done in the planner model.
 	DivePlannerPointsModel::instance()->setSurfaceSegment(value);
-	emit instance()->surface_segmentChanged(surface_segment());
 }
 
 double plannerShared::bottomsac()

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -135,7 +135,6 @@ double plannerShared::bottompo2()
 }
 void plannerShared::set_bottompo2(double value)
 {
-	// NO conversion, this is done in the planner model.
 	qPrefDivePlanner::set_bottompo2((int) (value * 1000.0));
 	CylindersModel::instance()->updateBestMixes();
 }

--- a/backend-shared/plannershared.h
+++ b/backend-shared/plannershared.h
@@ -18,21 +18,13 @@ class plannerShared: public QObject {
 	// Planning data
 	Q_PROPERTY(deco_mode planner_deco_mode READ planner_deco_mode WRITE set_planner_deco_mode NOTIFY planner_deco_modeChanged);
 	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged);
-	Q_PROPERTY(bool safetystop READ safetystop WRITE set_safetystop NOTIFY safetystopChanged);
-	Q_PROPERTY(int gflow READ gflow WRITE set_gflow NOTIFY gflowChanged);
-	Q_PROPERTY(int gfhigh READ gfhigh WRITE set_gfhigh NOTIFY gfhighChanged);
-	Q_PROPERTY(int vpmb_conservatism READ vpmb_conservatism WRITE set_vpmb_conservatism NOTIFY vpmb_conservatismChanged);
 	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
-	Q_PROPERTY(bool drop_stone_mode READ drop_stone_mode WRITE set_drop_stone_mode NOTIFY drop_stone_modeChanged);
-	Q_PROPERTY(bool last_stop READ last_stop WRITE set_last_stop NOTIFY last_stopChanged);
-	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged);
 	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
 	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
 
 	// Gas data
 	Q_PROPERTY(double bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
 	Q_PROPERTY(double decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
-	Q_PROPERTY(int problemsolvingtime READ problemsolvingtime WRITE set_problemsolvingtime NOTIFY problemsolvingtimeChanged);
 	Q_PROPERTY(double sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged);
 	Q_PROPERTY(bool o2narcotic READ o2narcotic WRITE set_o2narcotic NOTIFY o2narcoticChanged);
 	Q_PROPERTY(double bottompo2 READ bottompo2 WRITE set_bottompo2 NOTIFY bottompo2Changed);
@@ -45,21 +37,13 @@ public:
 	// Planning data
 	static deco_mode planner_deco_mode();
 	static int reserve_gas();
-	static bool safetystop();
-	static int gflow();
-	static int gfhigh();
-	static int vpmb_conservatism();
 	static bool dobailout();
-	static bool drop_stone_mode();
-	static bool last_stop();
-	static bool switch_at_req_stop();
 	static bool doo2breaks();
 	static int min_switch_duration();
 
 	// Gas data
 	static double bottomsac();
 	static double decosac();
-	static int problemsolvingtime();
 	static double sacfactor();
 	static bool o2narcotic();
 	static double bottompo2();
@@ -71,21 +55,13 @@ public slots:
 	// Planning data
 	static void set_planner_deco_mode(deco_mode value);
 	static void set_reserve_gas(int value);
-	static void set_safetystop(bool value);
-	static void set_gflow(int value);
-	static void set_gfhigh(int value);
-	static void set_vpmb_conservatism(int value);
 	static void set_dobailout(bool value);
-	static void set_drop_stone_mode(bool value);
-	static void set_last_stop(bool value);
-	static void set_switch_at_req_stop(bool value);
 	static void set_doo2breaks(bool value);
 	static void set_min_switch_duration(int value);
 
 	// Gas data
 	static void set_bottomsac(double value);
 	static void set_decosac(double value);
-	static void set_problemsolvingtime(int value);
 	static void set_sacfactor(double value);
 	static void set_o2narcotic(bool value);
 	static void set_bottompo2(double value);
@@ -95,22 +71,14 @@ public slots:
 signals:
 	// Planning data
 	void planner_deco_modeChanged(deco_mode value);
-	void dobailoutChanged(bool value);
 	void reserve_gasChanged(int value);
-	void safetystopChanged(bool value);
-	void gflowChanged(int value);
-	void gfhighChanged(int value);
-	void vpmb_conservatismChanged(int value);
-	void drop_stone_modeChanged(bool value);
-	void last_stopChanged(bool value);
-	void switch_at_req_stopChanged(bool value);
+	void dobailoutChanged(bool value);
 	void doo2breaksChanged(bool value);
 	void min_switch_durationChanged(int value);
 
 	// Gas data
 	void bottomsacChanged(double value);
 	void decosacChanged(double value);
-	void problemsolvingtimeChanged(int value);
 	void sacfactorChanged(double value);
 	void o2narcoticChanged(bool value);
 	void bottompo2Changed(double value);

--- a/backend-shared/plannershared.h
+++ b/backend-shared/plannershared.h
@@ -21,6 +21,7 @@ class plannerShared: public QObject {
 	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
 	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
 	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
+	Q_PROPERTY(int surface_segment READ surface_segment WRITE set_surface_segment NOTIFY surface_segmentChanged);
 
 	// Gas data
 	Q_PROPERTY(double bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
@@ -40,6 +41,7 @@ public:
 	static bool dobailout();
 	static bool doo2breaks();
 	static int min_switch_duration();
+	static int surface_segment();
 
 	// Gas data
 	static double bottomsac();
@@ -58,6 +60,7 @@ public slots:
 	static void set_dobailout(bool value);
 	static void set_doo2breaks(bool value);
 	static void set_min_switch_duration(int value);
+	static void set_surface_segment(int value);
 
 	// Gas data
 	static void set_bottomsac(double value);
@@ -75,6 +78,7 @@ signals:
 	void dobailoutChanged(bool value);
 	void doo2breaksChanged(bool value);
 	void min_switch_durationChanged(int value);
+	void surface_segmentChanged(int value);
 
 	// Gas data
 	void bottomsacChanged(double value);

--- a/backend-shared/plannershared.h
+++ b/backend-shared/plannershared.h
@@ -15,23 +15,6 @@
 class plannerShared: public QObject {
 	Q_OBJECT
 
-	// Planning data
-	Q_PROPERTY(deco_mode planner_deco_mode READ planner_deco_mode WRITE set_planner_deco_mode NOTIFY planner_deco_modeChanged);
-	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged);
-	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
-	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
-	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
-	Q_PROPERTY(int surface_segment READ surface_segment WRITE set_surface_segment NOTIFY surface_segmentChanged);
-
-	// Gas data
-	Q_PROPERTY(double bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
-	Q_PROPERTY(double decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
-	Q_PROPERTY(double sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged);
-	Q_PROPERTY(bool o2narcotic READ o2narcotic WRITE set_o2narcotic NOTIFY o2narcoticChanged);
-	Q_PROPERTY(double bottompo2 READ bottompo2 WRITE set_bottompo2 NOTIFY bottompo2Changed);
-	Q_PROPERTY(double decopo2 READ decopo2 WRITE set_decopo2 NOTIFY decopo2Changed);
-	Q_PROPERTY(int bestmixend READ bestmixend WRITE set_bestmixend NOTIFY bestmixendChanged);
-
 public:
 	static plannerShared *instance();
 
@@ -70,24 +53,6 @@ public slots:
 	static void set_bottompo2(double value);
 	static void set_decopo2(double value);
 	static void set_bestmixend(int value);
-
-signals:
-	// Planning data
-	void planner_deco_modeChanged(deco_mode value);
-	void reserve_gasChanged(int value);
-	void dobailoutChanged(bool value);
-	void doo2breaksChanged(bool value);
-	void min_switch_durationChanged(int value);
-	void surface_segmentChanged(int value);
-
-	// Gas data
-	void bottomsacChanged(double value);
-	void decosacChanged(double value);
-	void sacfactorChanged(double value);
-	void o2narcoticChanged(bool value);
-	void bottompo2Changed(double value);
-	void decopo2Changed(double value);
-	void bestmixendChanged(int value);
 
 private:
 	plannerShared() {}

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -443,7 +443,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	ui.drop_stone_mode->setChecked(prefs.drop_stone_mode);
 	ui.switch_at_req_stop->setChecked(prefs.switch_at_req_stop);
 	ui.min_switch_duration->setValue(plannerShared::min_switch_duration());
-	ui.surface_segment->setValue(prefs.surface_segment / 60);
+	ui.surface_segment->setValue(plannerShared::surface_segment());
 	ui.recreational_deco->setChecked(prefs.planner_deco_mode == RECREATIONAL);
 	ui.buehlmann_deco->setChecked(prefs.planner_deco_mode == BUEHLMANN);
 	ui.vpmb_deco->setChecked(prefs.planner_deco_mode == VPMB);
@@ -481,7 +481,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.o2narcotic, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_o2narcotic);
 	connect(ui.switch_at_req_stop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSwitchAtReqStop);
 	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_min_switch_duration);
-	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setSurfaceSegment);
+	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), plannerShared::set_surface_segment);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), plannerModel, &DivePlannerPointsModel::setRebreatherMode);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PlannerSettingsWidget::setBailoutVisibility);
 

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -554,8 +554,8 @@ void PlannerSettingsWidget::settingsChanged()
 		ui.bottomSAC->setSingleStep(0.1);
 		ui.decoStopSAC->setDecimals(2);
 		ui.decoStopSAC->setSingleStep(0.1);
-		ui.bottomSAC->setValue(ml_to_cuft(prefs.bottomsac));
-		ui.decoStopSAC->setValue(ml_to_cuft(prefs.decosac));
+		ui.bottomSAC->setValue(plannerShared::bottomsac());
+		ui.decoStopSAC->setValue(plannerShared::decosac());
 	} else {
 		ui.bottomSAC->setSuffix(tr("ℓ/min"));
 		ui.decoStopSAC->setSuffix(tr("ℓ/min"));

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -459,27 +459,27 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [=] { plannerShared::set_planner_deco_mode(BUEHLMANN); });
 	connect(ui.vpmb_deco, &QAbstractButton::clicked, [=] { plannerShared::set_planner_deco_mode(VPMB); });
 
-	connect(ui.lastStop, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_last_stop);
+	connect(ui.lastStop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setLastStop6m);
 	connect(ui.lastStop, &QAbstractButton::toggled, this, &PlannerSettingsWidget::disableBackgasBreaks);
 	connect(ui.verbatim_plan, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setVerbatim);
 	connect(ui.display_duration, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayDuration);
 	connect(ui.display_runtime, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayRuntime);
 	connect(ui.display_transitions, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayTransitions);
-	connect(ui.safetystop, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_safetystop);
+	connect(ui.safetystop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSafetyStop);
 	connect(ui.reserve_gas, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_reserve_gas);
 	connect(ui.ascRate75, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate75Display);
 	connect(ui.ascRate50, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate50Display);
 	connect(ui.ascRateStops, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscratestopsDisplay);
 	connect(ui.ascRateLast6m, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscratelast6mDisplay);
 	connect(ui.descRate, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setDescrateDisplay);
-	connect(ui.drop_stone_mode, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_drop_stone_mode);
-	connect(ui.gfhigh, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_gfhigh);
-	connect(ui.gflow, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_gflow);
-	connect(ui.vpmb_conservatism, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_vpmb_conservatism);
+	connect(ui.drop_stone_mode, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDropStoneMode);
+	connect(ui.gfhigh, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setGFHigh);
+	connect(ui.gflow, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setGFLow);
+	connect(ui.vpmb_conservatism, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setVpmbConservatism);
 	connect(ui.backgasBreaks, &QAbstractButton::toggled, this, &PlannerSettingsWidget::setBackgasBreaks);
 	connect(ui.bailout, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_dobailout);
 	connect(ui.o2narcotic, &QAbstractButton::toggled, plannerShared::instance(), plannerShared::set_o2narcotic);
-	connect(ui.switch_at_req_stop, &QAbstractButton::toggled, plannerShared::instance(), plannerShared::set_switch_at_req_stop);
+	connect(ui.switch_at_req_stop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSwitchAtReqStop);
 	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_min_switch_duration);
 	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setSurfaceSegment);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), plannerModel, &DivePlannerPointsModel::setRebreatherMode);
@@ -490,7 +490,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.vpmb_deco, &QAbstractButton::clicked, [=] { disableDecoElements(VPMB); });
 
 	connect(ui.sacfactor, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_sacfactor);
-	connect(ui.problemsolvingtime, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_problemsolvingtime);
+	connect(ui.problemsolvingtime, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setProblemSolvingTime);
 	connect(ui.bottompo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_bottompo2);
 	connect(ui.decopo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_decopo2);
 	connect(ui.bestmixEND, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_bestmixend);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -478,7 +478,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.vpmb_conservatism, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setVpmbConservatism);
 	connect(ui.backgasBreaks, &QAbstractButton::toggled, this, &PlannerSettingsWidget::setBackgasBreaks);
 	connect(ui.bailout, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_dobailout);
-	connect(ui.o2narcotic, &QAbstractButton::toggled, plannerShared::instance(), plannerShared::set_o2narcotic);
+	connect(ui.o2narcotic, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_o2narcotic);
 	connect(ui.switch_at_req_stop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSwitchAtReqStop);
 	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_min_switch_duration);
 	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setSurfaceSegment);

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -38,12 +38,14 @@ Kirigami.ScrollablePage {
 		TemplateSection {
 			id: rates
 			title: qsTr("Rates")
+			width: parent.width
 
 			GridLayout {
 				columns: 2
 				rowSpacing: Kirigami.Units.smallSpacing * 2
 				columnSpacing: Kirigami.Units.smallSpacing
 				visible: rates.isExpanded
+				width: parent.width
 
 				TemplateLabel {
 					Layout.columnSpan: 2

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -12,6 +12,7 @@ Kirigami.ScrollablePage {
 
 	property string speedUnit: (Backend.length === Enums.METERS) ? qsTr(" m/min") : qsTr(" ft/min")
 	property string volumeUnit: (Backend.volume === Enums.LITER) ? qsTr(" l/min") : qsTr(" cuft/min")
+	property string pressureUnit: (Backend.pressure === Enums.BAR) ? qsTr(" BAR") : qsTr(" PSI")
 	Connections {
 		target: Backend
 		onLengthChanged: {
@@ -25,6 +26,8 @@ Kirigami.ScrollablePage {
 		onVolumeChanged: {
 			spinBottomsac.value = Backend.bottomsac
 			spinDecosac.value = Backend.decosac
+		}
+		onPressureChanged: {
 		}
 	}
 	Column {
@@ -157,37 +160,46 @@ Kirigami.ScrollablePage {
 				}
 				TemplateComboBox {
 					editable: false
+					currentIndex: Backend.dive_mode
 					model: ListModel {
 						ListElement {text: qsTr("Open circuit")}
 						ListElement {text: qsTr("CCR")}
 						ListElement {text: qsTr("pSCR")}
 					}
 					onActivated:  {
+						Backend.dive_mode = currentIndex
 					}
 				}
 				TemplateCheckBox {
 					text: qsTr("Bailout: Deco on OC")
 					Layout.columnSpan: 2
+					checked: Backend.dobailout
 				}
 
 				TemplateRadioButton {
 					text: qsTr("Recreational mode")
 					Layout.columnSpan: 2
+					checked: Backend.planner_deco_mode === Enums.RECREATIONAL
+					onClicked: {
+						Backend.planner_deco_mode = Enums.RECREATIONAL
+					}
 				}
 
 				TemplateLabel {
 					text: qsTr("Reserve gas")
 					leftPadding: Kirigami.Units.smallSpacing * 2
+					enabled: Backend.planner_deco_mode === Enums.RECREATIONAL
 				}
 				TemplateSpinBox {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 50
+					value: Backend.reserve_gas
 					textFromValue: function (value, locale) {
 						return value + volumeUnit
 					}
 					onValueModified: {
+						Backend.reserve_gas = value
 					}
 				}
 
@@ -195,11 +207,19 @@ Kirigami.ScrollablePage {
 					text: qsTr("Safety stop")
 					Layout.columnSpan: 2
 					leftPadding: Kirigami.Units.smallSpacing * 6
+					checked: Backend.safetystop
+					onClicked: {
+						Backend.safetystop = checked
+					}
 				}
 
 				TemplateRadioButton {
 					text: qsTr("Bühlmannh deco")
 					Layout.columnSpan: 2
+					checked: Backend.planner_deco_mode === Enums.BUEHLMANN
+					onClicked: {
+						Backend.planner_deco_mode = Enums.BUEHLMANN
+					}
 				}
 
 				TemplateLabel {
@@ -210,11 +230,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 50
+					value: Backend.gflow
 					textFromValue: function (value, locale) {
 						return value + volumeUnit
 					}
 					onValueModified: {
+						Backend.gflow = value
 					}
 				}
 
@@ -226,17 +247,22 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 99
 					stepSize: 1
-					value: 50
+					value: Backend.gfhigh
 					textFromValue: function (value, locale) {
 						return value + volumeUnit
 					}
 					onValueModified: {
+						Backend.gfhigh = value
 					}
 				}
 
 				TemplateRadioButton {
 					text: qsTr("VPM-B deco")
 					Layout.columnSpan: 2
+					checked: Backend.planner_deco_mode === Enums.VPMB
+					onClicked: {
+						Backend.planner_deco_mode = Enums.VPMB
+					}
 				}
 
 				TemplateLabel {
@@ -247,12 +273,12 @@ Kirigami.ScrollablePage {
 					from: 0
 					to: 4
 					stepSize: 1
-					value: 2
+					value: Backend.vpmb_conservatism
 					textFromValue: function (value, locale) {
 						return qsTr("+") + value
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Backend.vpmb_conservatism = value
 					}
 				}
 
@@ -264,11 +290,19 @@ Kirigami.ScrollablePage {
 				TemplateCheckBox {
 					text: qsTr("Plan backgas breaks")
 					Layout.columnSpan: 2
+					checked: Backend.last_stop6m
+					onClicked: {
+						Backend.last_stop6m = checked
+					}
 				}
 
 				TemplateCheckBox {
 					text: qsTr("Only switch at required stops")
 					Layout.columnSpan: 2
+					checked: Backend.switch_at_req_stop
+					onClicked: {
+						Backend.switch_at_req_stop = checked
+					}
 				}
 
 				TemplateLabel {
@@ -278,12 +312,12 @@ Kirigami.ScrollablePage {
 					from: 0
 					to: 4
 					stepSize: 1
-					value: 2
+					value: Backend.min_switch_duration
 					textFromValue: function (value, locale) {
 						return qsTr("+") + value
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Backend.min_switch_duration = value
 					}
 				}
 
@@ -294,12 +328,12 @@ Kirigami.ScrollablePage {
 					from: 0
 					to: 4
 					stepSize: 1
-					value: 2
+					value: Backend.surface_segment
 					textFromValue: function (value, locale) {
 						return qsTr("+") + value
 					}
 					onValueModified: {
-						console.log("got value: " + value)
+						Backend.surface_segment = value
 					}
 				}
 			}

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -22,8 +22,8 @@ Kirigami.ScrollablePage {
 			spinDescrate.value = Backend.descrate
 		}
 		onVolumeChanged: {
-			spinBottomsac.value = Planner.bottomsac
-			spinDecosac.value = Planner.decosac
+			spinBottomsac.value = Backend.bottomsac
+			spinDecosac.value = Backend.decosac
 		}
 	}
 	Column {
@@ -227,14 +227,16 @@ Kirigami.ScrollablePage {
 				TemplateSpinBox {
 					id: spinBottomsac
 					from: 1
-					to: 99
+					to:  (Backend.volume === Enums.LITER) ? 85 : 300
 					stepSize: 1
-					value: Planner.bottomsac
+					value: Backend.bottomsac
 					textFromValue: function (value, locale) {
-						return value + volumeUnit
+						return (Backend.volume === Enums.LITER) ?
+									value + volumeUnit :
+									(value / 100).toFixed(2) + volumeUnit
 					}
 					onValueModified: {
-						Planner.bottomsac = value
+						Backend.bottomsac = value
 					}
 				}
 				TemplateLabel {
@@ -243,14 +245,16 @@ Kirigami.ScrollablePage {
 				TemplateSpinBox {
 					id: spinDecosac
 					from: 1
-					to: 99
+					to: (Backend.volume === Enums.LITER) ? 85 : 300
 					stepSize: 1
-					value: Planner.decosac
+					value: Backend.decosac
 					textFromValue: function (value, locale) {
-						return value + volumeUnit
+						return (Backend.volume === Enums.LITER) ?
+									value + volumeUnit :
+									(value / 100).toFixed(2) + volumeUnit
 					}
 					onValueModified: {
-						Planner.decosac = value
+						Backend.decosac = value
 					}
 				}
 				TemplateLabel {

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -261,15 +261,15 @@ Kirigami.ScrollablePage {
 					text: qsTr("SAC factor")
 				}
 				TemplateSpinBox {
-					from: 20
+					from: 10
 					to: 99
 					stepSize: 1
-					value: Planner.sacfactor
+					value: Backend.sacfactor
 					textFromValue: function (value, locale) {
 						return (value / 10).toFixed(1)
 					}
 					onValueModified: {
-						Planner.sacfactor = value
+						Backend.sacfactor = value
 					}
 				}
 				TemplateLabel {

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -152,51 +152,143 @@ Kirigami.ScrollablePage {
 				columnSpacing: Kirigami.Units.smallSpacing
 				visible: planning.isExpanded
 
-				// Only support "Open circuit"
 				TemplateLabel {
-					text: "WORK in progress"
+					text: qsTr("Dive mode")
 				}
-
-				TemplateRadioButton {
-					text: qsTr("Recreational NO deco")
+				TemplateComboBox {
+					editable: false
+					model: ListModel {
+						ListElement {text: qsTr("Open circuit")}
+						ListElement {text: qsTr("CCR")}
+						ListElement {text: qsTr("pSCR")}
+					}
+					onActivated:  {
+					}
+				}
+				TemplateCheckBox {
+					text: qsTr("Bailout: Deco on OC")
 					Layout.columnSpan: 2
 				}
-				// Reserve gas is 50bar (PADI/SSI rules)
-				TemplateRadioButton {
-					text: qsTr("Bühlmann, GFLow/GFHigh:")
-				}
-				Row {
-					spacing: 0
 
-					TemplateSpinBox {
-						width: planning.width / 2 -30
-						from: 1
-						to: 99
-						stepSize: 1
-						value: 15
-						textFromValue: function (value, locale) {
-							return value + qsTr(" %")
-						}
-						onValueModified: {
-							console.log("got value: " + value)
-						}
+				TemplateRadioButton {
+					text: qsTr("Recreational mode")
+					Layout.columnSpan: 2
+				}
+
+				TemplateLabel {
+					text: qsTr("Reserve gas")
+					leftPadding: Kirigami.Units.smallSpacing * 2
+				}
+				TemplateSpinBox {
+					from: 1
+					to: 99
+					stepSize: 1
+					value: 50
+					textFromValue: function (value, locale) {
+						return value + volumeUnit
 					}
-					TemplateSpinBox {
-						width: planning.width / 2 -30
-						from: 1
-						to: 99
-						stepSize: 1
-						value: 15
-						textFromValue: function (value, locale) {
-							return value + qsTr(" %")
-						}
-						onValueModified: {
-							console.log("got value: " + value)
-						}
+					onValueModified: {
 					}
 				}
+
+				TemplateCheckBox {
+					text: qsTr("Safety stop")
+					Layout.columnSpan: 2
+					leftPadding: Kirigami.Units.smallSpacing * 6
+				}
+
 				TemplateRadioButton {
-					text: qsTr("VPM-B, Conservatism:")
+					text: qsTr("Bühlmannh deco")
+					Layout.columnSpan: 2
+				}
+
+				TemplateLabel {
+					text: qsTr("GFLow")
+					leftPadding: Kirigami.Units.smallSpacing * 2
+				}
+				TemplateSpinBox {
+					from: 1
+					to: 99
+					stepSize: 1
+					value: 50
+					textFromValue: function (value, locale) {
+						return value + volumeUnit
+					}
+					onValueModified: {
+					}
+				}
+
+				TemplateLabel {
+					text: qsTr("GFHigh")
+					leftPadding: Kirigami.Units.smallSpacing * 2
+				}
+				TemplateSpinBox {
+					from: 1
+					to: 99
+					stepSize: 1
+					value: 50
+					textFromValue: function (value, locale) {
+						return value + volumeUnit
+					}
+					onValueModified: {
+					}
+				}
+
+				TemplateRadioButton {
+					text: qsTr("VPM-B deco")
+					Layout.columnSpan: 2
+				}
+
+				TemplateLabel {
+					text: qsTr("Conservatism level")
+					leftPadding: 20
+				}
+				TemplateSpinBox {
+					from: 0
+					to: 4
+					stepSize: 1
+					value: 2
+					textFromValue: function (value, locale) {
+						return qsTr("+") + value
+					}
+					onValueModified: {
+						console.log("got value: " + value)
+					}
+				}
+
+				TemplateCheckBox {
+					text: qsTr("Last stop at ??")
+					Layout.columnSpan: 2
+				}
+
+				TemplateCheckBox {
+					text: qsTr("Plan backgas breaks")
+					Layout.columnSpan: 2
+				}
+
+				TemplateCheckBox {
+					text: qsTr("Only switch at required stops")
+					Layout.columnSpan: 2
+				}
+
+				TemplateLabel {
+					text: qsTr("Min switch time")
+				}
+				TemplateSpinBox {
+					from: 0
+					to: 4
+					stepSize: 1
+					value: 2
+					textFromValue: function (value, locale) {
+						return qsTr("+") + value
+					}
+					onValueModified: {
+						console.log("got value: " + value)
+					}
+				}
+
+				TemplateLabel {
+					text: qsTr("Surface segment")
 				}
 				TemplateSpinBox {
 					from: 0

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -20,6 +20,7 @@ Kirigami.ScrollablePage {
 			spinAscratestops.value = Backend.ascratestops
 			spinAscratelast6m.value = Backend.ascratelast6m
 			spinDescrate.value = Backend.descrate
+			spinBestmixend.value = Backend.bestmixend
 		}
 		onVolumeChanged: {
 			spinBottomsac.value = Backend.bottomsac
@@ -292,14 +293,14 @@ Kirigami.ScrollablePage {
 				}
 				TemplateSpinBox {
 					from: 0
-					to: 200
+					to: 250
 					stepSize: 1
-					value: Planner.bottompo2
+					value: Backend.bottompo2
 					textFromValue: function (value, locale) {
 						return (value / 100).toFixed(2) + "bar"
 					}
 					onValueModified: {
-						Planner.bottompo2 = value
+						Backend.bottompo2 = value
 					}
 				}
 				TemplateLabel {
@@ -307,36 +308,37 @@ Kirigami.ScrollablePage {
 				}
 				TemplateSpinBox {
 					from: 0
-					to: 200
+					to: 250
 					stepSize: 1
-					value: Planner.decopo2
+					value: Backend.decopo2
 					textFromValue: function (value, locale) {
 						return (value / 100).toFixed(2) + "bar"
 					}
 					onValueModified: {
-						Planner.decopo2 = value
+						Backend.decopo2 = value
 					}
 				}
 				TemplateLabel {
 					text: qsTr("Best mix END")
 				}
 				TemplateSpinBox {
+					id: spinBestmixend
 					from: 1
 					to: 99
 					stepSize: 1
-					value: Planner.bestmixend
+					value: Backend.bestmixend
 					textFromValue: function (value, locale) {
 						return value + speedUnit
 					}
 					onValueModified: {
-						Planner.bestmixend = value
+						Backend.bestmixend = value
 					}
 				}
 				TemplateCheckBox {
 					text: qsTr("O2 narcotic")
-					checked: Planner.o2narcotic
+					checked: Backend.o2narcotic
 					onClicked: {
-						Planner.o2narcotic = checked
+						Backend.o2narcotic = checked
 					}
 				}
 			}

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -9,6 +9,7 @@ import org.kde.kirigami 2.4 as Kirigami
 
 Kirigami.ScrollablePage {
 	title: qsTr("Dive planner setup")
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 
 	property string speedUnit: (Backend.length === Enums.METERS) ? qsTr(" m/min") : qsTr(" ft/min")
 	property string volumeUnit: (Backend.volume === Enums.LITER) ? qsTr(" l/min") : qsTr(" cuft/min")

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -275,12 +275,12 @@ Kirigami.ScrollablePage {
 					from: 1
 					to: 9
 					stepSize: 1
-					value: Planner.problemsolvingtime
+					value: Backend.problemsolvingtime
 					textFromValue: function (value, locale) {
-						return value + qsTr("min")
+						return value + qsTr(" min")
 					}
 					onValueModified: {
-						Planner.problemsolvingtime = value
+						Backend.problemsolvingtime = value
 					}
 				}
 				TemplateLabel {

--- a/mobile-widgets/qml/TemplateComboBox.qml
+++ b/mobile-widgets/qml/TemplateComboBox.qml
@@ -5,5 +5,5 @@ import QtQuick.Layouts 1.11
 
 ComboBox {
 	Layout.fillWidth: true
-	font.pointSize: theme.regularPointSize
+	font.pointSize: subsurfaceTheme.regularPointSize
 }

--- a/mobile-widgets/qml/TemplateSection.qml
+++ b/mobile-widgets/qml/TemplateSection.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.11
 
 Column {
-	width: parent.width -20
+	width: parent.width
 	property string title: "no title"
 	property bool isExpanded: false
 

--- a/mobile-widgets/qml/TemplateSpinBox.qml
+++ b/mobile-widgets/qml/TemplateSpinBox.qml
@@ -4,5 +4,65 @@ import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.11
 
 SpinBox {
-	font.pointSize: subsurfaceTheme.regularPointSize;
+	id: control
+	editable: true
+	font.pointSize: subsurfaceTheme.regularPointSize
+
+	contentItem: TextInput {
+		z: 2
+		text: control.textFromValue(control.value, control.locale)
+
+		font: control.font
+		color: control.enabled ? "black" : "lightgrey"
+		horizontalAlignment: Qt.AlignHCenter
+		verticalAlignment: Qt.AlignVCenter
+
+		readOnly: !control.editable
+		validator: control.validator
+		inputMethodHints: Qt.ImhFormattedNumbersOnly
+	}
+
+	up.indicator: Rectangle {
+		x: control.mirrored ? 0 : parent.width - width
+		height: control.height
+		implicitWidth: 30
+		implicitHeight: 30
+		color: control.enabled ? "grey" : "lightgrey"
+		border.color: control.enabled ? "grey" : "lightgrey"
+
+		Text {
+			text: "+"
+			font.pixelSize: control.font.pixelSize * 2
+			color: control.enabled ? "black" : "lightgrey"
+			anchors.fill: parent
+			fontSizeMode: Text.Fit
+			horizontalAlignment: Text.AlignHCenter
+			verticalAlignment: Text.AlignVCenter
+		}
+	}
+
+	down.indicator: Rectangle {
+		x: control.mirrored ? parent.width - width : 0
+		height: control.height
+		implicitWidth: 30
+		implicitHeight: 30
+		color: control.enabled ? "grey" : "lightgrey"
+		border.color: control.enabled ? "grey" : "lightgrey"
+
+		Text {
+			text: "-"
+			font.pixelSize: control.font.pixelSize * 2
+			color: control.enabled ? "black" : "lightgrey"
+			anchors.fill: parent
+			fontSizeMode: Text.Fit
+			horizontalAlignment: Text.AlignHCenter
+			verticalAlignment: Text.AlignVCenter
+		}
+	}
+
+	background: Rectangle {
+		implicitWidth: 140
+		color: subsurfaceTheme.backgroundColor
+		border.color: subsurfaceTheme.backgroundColor
+	}
 }

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -63,6 +63,8 @@ void QMLInterface::setup(QQmlContext *ct)
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::switch_at_req_stopChanged,
 			instance(), &QMLInterface::switch_at_req_stopChanged);
 
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
+			instance(), &QMLInterface::problemsolvingtimeChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
 			instance(), &QMLInterface::display_runtimeChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_durationChanged,

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -65,6 +65,10 @@ void QMLInterface::setup(QQmlContext *ct)
 
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
 			instance(), &QMLInterface::problemsolvingtimeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottomsacChanged,
+			instance(), &QMLInterface::bottomsacChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decosacChanged,
+			instance(), &QMLInterface::decosacChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
 			instance(), &QMLInterface::display_runtimeChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_durationChanged,

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -69,6 +69,9 @@ void QMLInterface::setup(QQmlContext *ct)
 			instance(), &QMLInterface::bottomsacChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decosacChanged,
 			instance(), &QMLInterface::decosacChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::sacfactorChanged,
+			instance(), &QMLInterface::sacfactorChanged);
+
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
 			instance(), &QMLInterface::display_runtimeChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_durationChanged,

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -71,6 +71,16 @@ void QMLInterface::setup(QQmlContext *ct)
 			instance(), &QMLInterface::decosacChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::sacfactorChanged,
 			instance(), &QMLInterface::sacfactorChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
+			instance(), &QMLInterface::problemsolvingtimeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::o2narcoticChanged,
+			instance(), &QMLInterface::o2narcoticChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottompo2Changed,
+			instance(), &QMLInterface::bottompo2Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decopo2Changed,
+			instance(), &QMLInterface::decopo2Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bestmixendChanged,
+			instance(), &QMLInterface::bestmixendChanged);
 
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
 			instance(), &QMLInterface::display_runtimeChanged);

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -45,13 +45,18 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(int ascrate75 READ ascrate75 WRITE set_ascrate75 NOTIFY ascrate75Changed);
 	Q_PROPERTY(int descrate READ descrate WRITE set_descrate NOTIFY descrateChanged);
 
+	Q_PROPERTY(DECO_MODE planner_deco_mode READ planner_deco_mode WRITE set_planner_deco_mode NOTIFY planner_deco_modeChanged);
+	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged);
 	Q_PROPERTY(bool safetystop READ safetystop WRITE set_safetystop NOTIFY safetystopChanged);
 	Q_PROPERTY(int gflow READ gflow WRITE set_gflow NOTIFY gflowChanged);
 	Q_PROPERTY(int gfhigh READ gfhigh WRITE set_gfhigh NOTIFY gfhighChanged);
 	Q_PROPERTY(int vpmb_conservatism READ vpmb_conservatism WRITE set_vpmb_conservatism NOTIFY vpmb_conservatismChanged);
+	Q_PROPERTY(bool dobailout READ dobailout WRITE set_dobailout NOTIFY dobailoutChanged);
 	Q_PROPERTY(bool drop_stone_mode READ drop_stone_mode WRITE set_drop_stone_mode NOTIFY drop_stone_modeChanged);
 	Q_PROPERTY(bool last_stop6m READ last_stop6m WRITE set_last_stop6m NOTIFY last_stop6mChanged);
 	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged);
+	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
+	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
 
 	Q_PROPERTY(int bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
 	Q_PROPERTY(int decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
@@ -174,13 +179,18 @@ public:
 	int ascrate75() { return DivePlannerPointsModel::instance()->ascrate75Display(); }
 	int descrate() { return DivePlannerPointsModel::instance()->descrateDisplay(); }
 
+	DECO_MODE planner_deco_mode() { return (DECO_MODE)plannerShared::planner_deco_mode(); }
+	int reserve_gas() { return plannerShared::reserve_gas(); }
 	bool safetystop() { return prefs.safetystop; }
 	int gflow() { return prefs.gflow; }
 	int gfhigh() { return prefs.gfhigh; }
 	int vpmb_conservatism() { return prefs.vpmb_conservatism; }
+	bool dobailout() { return plannerShared::dobailout(); }
 	bool drop_stone_mode() { return prefs.drop_stone_mode; }
 	bool last_stop6m() { return prefs.last_stop; }
 	bool switch_at_req_stop() { return prefs.switch_at_req_stop; }
+	bool doo2breaks() { return plannerShared::doo2breaks(); }
+	int min_switch_duration() { return plannerShared::min_switch_duration(); }
 
 	int bottomsac() { return (int)plannerShared::bottomsac(); }
 	int decosac() { return (int)plannerShared::decosac(); }
@@ -214,13 +224,18 @@ public slots:
 	void set_ascrate75(int value) { DivePlannerPointsModel::instance()->setAscrate75Display(value); }
 	void set_descrate(int value) { DivePlannerPointsModel::instance()->setDescrateDisplay(value); }
 
+	void set_planner_deco_mode(DECO_MODE value) { plannerShared::set_planner_deco_mode((deco_mode)value); }
+	void set_reserve_gas(int value) { plannerShared::set_reserve_gas(value); }
 	void set_safetystop(bool value) { DivePlannerPointsModel::instance()->setSafetyStop(value); }
 	void set_gflow(int value) { DivePlannerPointsModel::instance()->setGFLow(value); }
 	void set_gfhigh(int value) { DivePlannerPointsModel::instance()->setGFHigh(value); }
 	void set_vpmb_conservatism(int value) { DivePlannerPointsModel::instance()->setVpmbConservatism(value); }
+	void set_dobailout(bool value) { plannerShared::set_dobailout(value); }
 	void set_drop_stone_mode(bool value) { DivePlannerPointsModel::instance()->setDropStoneMode(value); }
 	void set_last_stop6m(bool value) { DivePlannerPointsModel::instance()->setLastStop6m(value); }
 	void set_switch_at_req_stop(bool value) { DivePlannerPointsModel::instance()->setSwitchAtReqStop(value); }
+	void set_doo2breaks(bool value) { plannerShared::set_doo2breaks(value); }
+	void set_min_switch_duration(int value) { plannerShared::set_min_switch_duration(value); }
 
 	void set_bottomsac(int value) { plannerShared::set_bottomsac((double)value); }
 	void set_decosac(int value) { plannerShared::set_decosac((double)value); }
@@ -254,13 +269,18 @@ signals:
 	void ascrate75Changed(int);
 	void descrateChanged(int);
 
+	void planner_deco_modeChanged(DECO_MODE value);
+	void reserve_gasChanged(int value);
 	void safetystopChanged(bool value);
 	void gflowChanged(int value);
 	void gfhighChanged(int value);
 	void vpmb_conservatismChanged(int value);
+	void dobailoutChanged(bool value);
 	void drop_stone_modeChanged(bool value);
 	void last_stop6mChanged(bool value);
 	void switch_at_req_stopChanged(bool value);
+	void doo2breaksChanged(bool value);
+	void min_switch_durationChanged(int value);
 
 	void bottomsacChanged(int value);
 	void decosacChanged(int value);

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -53,6 +53,15 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(bool last_stop6m READ last_stop6m WRITE set_last_stop6m NOTIFY last_stop6mChanged);
 	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged);
 
+	Q_PROPERTY(int bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
+	Q_PROPERTY(int decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
+	Q_PROPERTY(int problemsolvingtime READ problemsolvingtime WRITE set_problemsolvingtime NOTIFY problemsolvingtimeChanged);
+	Q_PROPERTY(int sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged);
+	Q_PROPERTY(bool o2narcotic READ o2narcotic WRITE set_o2narcotic NOTIFY o2narcoticChanged);
+	Q_PROPERTY(int bottompo2 READ bottompo2 WRITE set_bottompo2 NOTIFY bottompo2Changed);
+	Q_PROPERTY(int decopo2 READ decopo2 WRITE set_decopo2 NOTIFY decopo2Changed);
+	Q_PROPERTY(int bestmixend READ bestmixend WRITE set_bestmixend NOTIFY bestmixendChanged);
+
 	Q_PROPERTY(bool display_runtime READ display_runtime WRITE set_display_runtime NOTIFY display_runtimeChanged);
 	Q_PROPERTY(bool display_duration READ display_duration WRITE set_display_duration NOTIFY display_durationChanged);
 	Q_PROPERTY(bool display_transitions READ display_transitions WRITE set_display_transitions NOTIFY display_transitionsChanged);
@@ -158,6 +167,15 @@ public:
 	bool last_stop6m() { return prefs.last_stop; }
 	bool switch_at_req_stop() { return prefs.switch_at_req_stop; }
 
+	int bottomsac() { return (int)plannerShared::bottomsac(); }
+	int decosac() { return (int)plannerShared::decosac(); }
+	int problemsolvingtime() { return prefs.problemsolvingtime; }
+	int sacfactor() { return (int)plannerShared::sacfactor(); }
+	bool o2narcotic() { return (int)plannerShared::o2narcotic(); }
+	int bottompo2() { return (int)plannerShared::bottompo2(); }
+	int decopo2() { return (int)plannerShared::decopo2(); }
+	int bestmixend() { return plannerShared::bestmixend(); }
+
 	bool display_runtime() { return prefs.display_runtime; }
 	bool display_duration() { return prefs.display_duration; }
 	bool display_transitions() { return prefs.display_transitions; }
@@ -189,6 +207,15 @@ public slots:
 	void set_last_stop6m(bool value) { DivePlannerPointsModel::instance()->setLastStop6m(value); }
 	void set_switch_at_req_stop(bool value) { DivePlannerPointsModel::instance()->setSwitchAtReqStop(value); }
 
+	void set_bottomsac(int value) { plannerShared::set_bottomsac((double)value); }
+	void set_decosac(int value) { plannerShared::set_decosac((double)value); }
+	void set_problemsolvingtime(int value) { DivePlannerPointsModel::instance()->setProblemSolvingTime(value); }
+	void set_sacfactor(int value) { plannerShared::set_sacfactor((double)value); }
+	void set_o2narcotic(bool value) { plannerShared::set_o2narcotic(value); }
+	void set_bottompo2(int value) { plannerShared::set_bottompo2((double)value); }
+	void set_decopo2(int value) { plannerShared::set_decopo2((double)value); }
+	void set_bestmixend(int value) { plannerShared::set_bestmixend(value); }
+
 	void set_display_runtime(bool value) { DivePlannerPointsModel::instance()->setDisplayRuntime(value); }
 	void set_display_duration(bool value) { DivePlannerPointsModel::instance()->setDisplayDuration(value); }
 	void set_display_transitions(bool value) { DivePlannerPointsModel::instance()->setDisplayTransitions(value); }
@@ -219,6 +246,15 @@ signals:
 	void drop_stone_modeChanged(bool value);
 	void last_stop6mChanged(bool value);
 	void switch_at_req_stopChanged(bool value);
+
+	void bottomsacChanged(int value);
+	void decosacChanged(int value);
+	void sacfactorChanged(int value);
+	void problemsolvingtimeChanged(int value);
+	void o2narcoticChanged(bool value);
+	void bottompo2Changed(int value);
+	void decopo2Changed(int value);
+	void bestmixendChanged(int value);
 
 	void display_runtimeChanged(bool value);
 	void display_durationChanged(bool value);

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -57,6 +57,7 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged);
 	Q_PROPERTY(bool doo2breaks READ doo2breaks WRITE set_doo2breaks NOTIFY doo2breaksChanged);
 	Q_PROPERTY(int min_switch_duration READ min_switch_duration WRITE set_min_switch_duration NOTIFY min_switch_durationChanged);
+	Q_PROPERTY(int surface_segment READ surface_segment WRITE set_surface_segment NOTIFY surface_segmentChanged);
 
 	Q_PROPERTY(int bottomsac READ bottomsac WRITE set_bottomsac NOTIFY bottomsacChanged);
 	Q_PROPERTY(int decosac READ decosac WRITE set_decosac NOTIFY decosacChanged);
@@ -191,6 +192,7 @@ public:
 	bool switch_at_req_stop() { return prefs.switch_at_req_stop; }
 	bool doo2breaks() { return plannerShared::doo2breaks(); }
 	int min_switch_duration() { return plannerShared::min_switch_duration(); }
+	int surface_segment() { return plannerShared::surface_segment(); }
 
 	int bottomsac() { return (int)plannerShared::bottomsac(); }
 	int decosac() { return (int)plannerShared::decosac(); }
@@ -236,6 +238,7 @@ public slots:
 	void set_switch_at_req_stop(bool value) { DivePlannerPointsModel::instance()->setSwitchAtReqStop(value); }
 	void set_doo2breaks(bool value) { plannerShared::set_doo2breaks(value); }
 	void set_min_switch_duration(int value) { plannerShared::set_min_switch_duration(value); }
+	void set_surface_segment(int value) { plannerShared::set_surface_segment(value); }
 
 	void set_bottomsac(int value) { plannerShared::set_bottomsac((double)value); }
 	void set_decosac(int value) { plannerShared::set_decosac((double)value); }
@@ -281,6 +284,7 @@ signals:
 	void switch_at_req_stopChanged(bool value);
 	void doo2breaksChanged(bool value);
 	void min_switch_durationChanged(int value);
+	void surface_segmentChanged(int value);
 
 	void bottomsacChanged(int value);
 	void decosacChanged(int value);

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -6,6 +6,7 @@
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "qt-models/diveplannermodel.h"
+#include "backend-shared/plannershared.h"
 
 #include <QObject>
 #include <QQmlContext>

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -142,6 +142,21 @@ public:
 	};
 	Q_ENUM(CLOUD_STATUS);
 
+	enum DECO_MODE {
+		BUEHLMANN,
+		RECREATIONAL,
+		VPMB
+	};
+	Q_ENUM(DECO_MODE);
+
+	enum DIVE_MODE {
+		OC,
+		CCR,
+		PSCR,
+		FREEDIVE
+	};
+	Q_ENUM(DIVE_MODE);
+
 public:
 	CLOUD_STATUS cloud_verification_status() { return (CLOUD_STATUS)prefs.cloud_verification_status; }
 	DURATION duration_units() { return (DURATION)prefs.units.duration_units; }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -434,6 +434,10 @@ void DivePlannerPointsModel::emitDataChanged()
 
 void DivePlannerPointsModel::setBottomSac(double sac)
 {
+// mobile delivers the same value as desktop when using
+// units:METERS
+// however when using units:CUFT mobile deliver 0-300 which
+// are really 0.00 - 3.00 so start be correcting that
 #ifdef SUBSURFACE_MOBILE
 	if (qPrefUnits::volume() == units::CUFT)
 		sac /= 100; // cuft without decimals (0 - 300)
@@ -445,6 +449,10 @@ void DivePlannerPointsModel::setBottomSac(double sac)
 
 void DivePlannerPointsModel::setDecoSac(double sac)
 {
+// mobile delivers the same value as desktop when using
+// units:METERS
+// however when using units:CUFT mobile deliver 0-300 which
+// are really 0.00 - 3.00 so start be correcting that
 #ifdef SUBSURFACE_MOBILE
 	if (qPrefUnits::volume() == units::CUFT)
 		sac /= 100; // cuft without decimals (0 - 300)
@@ -456,6 +464,9 @@ void DivePlannerPointsModel::setDecoSac(double sac)
 
 void DivePlannerPointsModel::setSacFactor(double factor)
 {
+// sacfactor is normal x.y (one decimal), however mobile
+// delivers 0 - 100 so adjust that to 0.0 - 10.0, to have
+// the same value as desktop
 #ifdef SUBSURFACE_MOBILE
 	factor /= 10.0;
 #endif

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -7,6 +7,7 @@
 #include "core/device.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefDivePlanner.h"
+#include "core/settings/qPrefUnit.h"
 #if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
 #include "commands/command.h"
 #endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
@@ -433,6 +434,10 @@ void DivePlannerPointsModel::emitDataChanged()
 
 void DivePlannerPointsModel::setBottomSac(double sac)
 {
+#ifdef SUBSURFACE_MOBILE
+	if (qPrefUnits::volume() == units::CUFT)
+		sac /= 100; // cuft without decimals (0 - 300)
+#endif
 	diveplan.bottomsac = units_to_sac(sac);
 	qPrefDivePlanner::set_bottomsac(diveplan.bottomsac);
 	emitDataChanged();
@@ -440,6 +445,10 @@ void DivePlannerPointsModel::setBottomSac(double sac)
 
 void DivePlannerPointsModel::setDecoSac(double sac)
 {
+#ifdef SUBSURFACE_MOBILE
+	if (qPrefUnits::volume() == units::CUFT)
+		sac /= 100; // cuft without decimals (0 - 300)
+#endif
 	diveplan.decosac = units_to_sac(sac);
 	qPrefDivePlanner::set_decosac(diveplan.decosac);
 	emitDataChanged();
@@ -447,6 +456,9 @@ void DivePlannerPointsModel::setDecoSac(double sac)
 
 void DivePlannerPointsModel::setSacFactor(double factor)
 {
+#ifdef SUBSURFACE_MOBILE
+	factor /= 10.0;
+#endif
 	qPrefDivePlanner::set_sacfactor((int) round(factor * 100));
 	emitDataChanged();
 }

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -20,7 +20,6 @@
 #include "qt-models/messagehandlermodel.h"
 #include "profile-widget/qmlprofile.h"
 #include "core/downloadfromdcthread.h"
-#include "backend-shared/plannershared.h"
 #include "qt-models/diveimportedmodel.h"
 #include "mobile-widgets/qml/kirigami/src/kirigamiplugin.h"
 #else
@@ -184,11 +183,8 @@ void register_qml_types(QQmlEngine *engine)
 	int rc;
 
 #ifdef SUBSURFACE_MOBILE
-	// register shared diveplanner class
 	if (engine != NULL) {
 		QQmlContext *ct = engine->rootContext();
-
-		ct->setContextProperty("Planner", plannerShared::instance());
 
 		// Register qml interface class
 		QMLInterface::setup(ct);

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -79,13 +79,13 @@ void TestPlannerShared::test_gas()
 {
 	// test independent of metric/imperial
 	plannerShared::set_sacfactor(4.2);
-	QCOMPARE(qPrefDivePlanner::sacfactor(), 420);
+	QCOMPARE(qPrefDivePlanner::sacfactor(), 42);
 	plannerShared::set_sacfactor(3.5);
-	QCOMPARE(qPrefDivePlanner::sacfactor(), 350);
+	QCOMPARE(qPrefDivePlanner::sacfactor(), 35);
 	qPrefDivePlanner::set_sacfactor(280);
-	QCOMPARE(plannerShared::sacfactor(), 2.8);
+	QCOMPARE(plannerShared::sacfactor(), 28);
 	qPrefDivePlanner::set_sacfactor(200);
-	QCOMPARE(plannerShared::sacfactor(), 2.0);
+	QCOMPARE(plannerShared::sacfactor(), 20);
 
 	// Set system to use meters
 	qPrefUnits::set_unit_system(METRIC);
@@ -139,26 +139,26 @@ void TestPlannerShared::test_gas()
 	qPrefUnits::set_unit_system(IMPERIAL);
 
 	plannerShared::set_bottomsac(0.9);
-	QCOMPARE(qPrefDivePlanner::bottomsac(), 25485);
+	QCOMPARE(qPrefDivePlanner::bottomsac(), 255);
 	plannerShared::set_bottomsac(0.01);
-	QCOMPARE(qPrefDivePlanner::bottomsac(), 283);
+	QCOMPARE(qPrefDivePlanner::bottomsac(), 3);
 
 	// Remark return will from qPref is in m / 1000.
 	qPrefDivePlanner::set_bottomsac(2830);
-	QCOMPARE(int(plannerShared::bottomsac() * 1000), 99);
+	QCOMPARE(int(plannerShared::bottomsac()), 9);
 	qPrefDivePlanner::set_bottomsac(16000);
-	QCOMPARE(int(plannerShared::bottomsac() * 1000), 565);
+	QCOMPARE(int(plannerShared::bottomsac()), 56);
 
 	plannerShared::set_decosac(0.9);
-	QCOMPARE(qPrefDivePlanner::decosac(), 25485);
+	QCOMPARE(qPrefDivePlanner::decosac(), 255);
 	plannerShared::set_decosac(0.01);
-	QCOMPARE(qPrefDivePlanner::decosac(), 283);
+	QCOMPARE(qPrefDivePlanner::decosac(), 3);
 
 	// Remark return will from qPref is in m / 1000.
 	qPrefDivePlanner::set_decosac(11500);
-	QCOMPARE(int(plannerShared::decosac() * 1000), 406);
+	QCOMPARE(int(plannerShared::decosac()), 40);
 	qPrefDivePlanner::set_decosac(19800);
-	QCOMPARE(int(plannerShared::decosac() * 1000), 699);
+	QCOMPARE(int(plannerShared::decosac()), 69);
 
 	// Remark bottompo2 is in BAR, even though unit system is
 	// Imperial, the desktop version is like that.

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -145,9 +145,9 @@ void TestPlannerShared::test_gas()
 
 	// Remark return will from qPref is in m / 1000.
 	qPrefDivePlanner::set_bottomsac(2830);
-	QCOMPARE(plannerShared::bottomsac(), 2.83);
+	QCOMPARE(int(plannerShared::bottomsac() * 1000), 99);
 	qPrefDivePlanner::set_bottomsac(16000);
-	QCOMPARE(plannerShared::bottomsac(), 16);
+	QCOMPARE(int(plannerShared::bottomsac() * 1000), 565);
 
 	plannerShared::set_decosac(0.9);
 	QCOMPARE(qPrefDivePlanner::decosac(), 25485);
@@ -156,9 +156,9 @@ void TestPlannerShared::test_gas()
 
 	// Remark return will from qPref is in m / 1000.
 	qPrefDivePlanner::set_decosac(11500);
-	QCOMPARE(plannerShared::decosac(), 11.5);
+	QCOMPARE(int(plannerShared::decosac() * 1000), 406);
 	qPrefDivePlanner::set_decosac(19800);
-	QCOMPARE(plannerShared::decosac(), 19.8);
+	QCOMPARE(int(plannerShared::decosac() * 1000), 699);
 
 	// Remark bottompo2 is in BAR, even though unit system is
 	// Imperial, the desktop version is like that.

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -87,15 +87,6 @@ void TestPlannerShared::test_gas()
 	qPrefDivePlanner::set_sacfactor(200);
 	QCOMPARE(plannerShared::sacfactor(), 2.0);
 
-	plannerShared::set_problemsolvingtime(4);
-	QCOMPARE(qPrefDivePlanner::problemsolvingtime(), 4);
-	plannerShared::set_problemsolvingtime(5);
-	QCOMPARE(qPrefDivePlanner::problemsolvingtime(), 5);
-	qPrefDivePlanner::set_problemsolvingtime(2);
-	QCOMPARE(plannerShared::problemsolvingtime(), 2);
-	qPrefDivePlanner::set_problemsolvingtime(6);
-	QCOMPARE(plannerShared::problemsolvingtime(), 6);
-
 	// Set system to use meters
 	qPrefUnits::set_unit_system(METRIC);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Change some of the templates to look better (and be smaller) in order to better fit on the
real estate of a mobile, without considering but also not blocking different sizes on different
devices.

Before image (look at section and spin box):

<img width="431" alt="before" src="https://user-images.githubusercontent.com/6185391/72995327-ffbd4800-3df8-11ea-9a87-a114d3390490.png">

after image

<img width="446" alt="after" src="https://user-images.githubusercontent.com/6185391/72995380-1794cc00-3df9-11ea-8256-9ebfe9c3e757.png">

The changes are within the limitations of the current subsurfaceTheme (and especially the font
handling). In a later PR subsurfaceTheme will be replaced by one that adjust depending on the
size of the real estate (as well as day/night).

Remark the changes are far more than just colouring, especially the spin box have a tendency to stretch across all the space it thinks are available, which leads to part of the box being off-screen.

Moved some calculations from plannershared to diveplannermodel in order to not split calculations over 2 functions (and files).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Commit 1-4: Design updates
Commit 5 -: plannershared cleanup

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
