### PR TITLE
[RFC]Sorting: use strcoll() instead of Qt-function

### DIFF
--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -198,18 +198,18 @@ bool DiveSiteSortedModel::lessThan(const QModelIndex &i1, const QModelIndex &i2)
 	switch (i1.column()) {
 	case LocationInformationModel::NAME:
 	default:
-		return QString::localeAwareCompare(QString(ds1->name), QString(ds2->name)) < 0; // TODO: avoid copy
+		return strcoll(ds1->name, ds2->name) < 0;
 	case LocationInformationModel::DESCRIPTION: {
-		int cmp = QString::localeAwareCompare(QString(ds1->description), QString(ds2->description)); // TODO: avoid copy
+		int cmp = strcoll(ds1->description, ds2->description);
 		return cmp != 0 ? cmp < 0 :
-		       QString::localeAwareCompare(QString(ds1->name), QString(ds2->name)) < 0; // TODO: avoid copy
+		       strcoll(ds1->name, ds2->name) < 0;
 	}
 	case LocationInformationModel::NUM_DIVES: {
 		int cmp = ds1->dives.nr - ds2->dives.nr;
 		// Since by default nr dives is descending, invert sort direction of names, such that
 		// the names are listed as ascending.
 		return cmp != 0 ? cmp < 0 :
-		       QString::localeAwareCompare(QString(ds1->name), QString(ds2->name)) < 0; // TODO: avoid copy
+		       strcoll(ds1->name, ds2->name) < 0;
 	}
 	}
 }

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1507,7 +1507,7 @@ static int strCmp(const char *s1, const char *s2)
 		return !s2 ? 0 : -1;
 	if (!s2)
 		return 1;
-	return QString::localeAwareCompare(QString(s1), QString(s2)); // TODO: avoid copy
+	return strcoll(s1, s2);
 }
 
 bool DiveTripModelList::lessThan(const QModelIndex &i1, const QModelIndex &i2) const


### PR DESCRIPTION
Instead of letting the QSortFilterProxyModel, which is placed
on top of our dive-list models, do the sorting we should keep
our dive list sorted in the core. This will make the code of
the new mobile-models much simpler, as we don't have to invert
the direction.

To do so, we shouldn't use Qt's QString::localeAwareCompare()
function, but rather libc's strcoll(). A further advantage is
that we don't have to transform C-strings into QStrings first.
Thus, this might even be a performance gain.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'd like to move the sorting of the dive-list models closer to the core. The main reason being that I'd like the lower models already be sorted in the correct direction to avoid complexities in potential rewrites mobile models.

As a first step, I'd like to replace Qt's locale-aware comparison by the libc strcoll(). The problem is that I'm not sure how well this works across different OSs and locales. I _feel_ that it should be reliable today, but who knows. Therefore, I'd appreciate comments from developers with different OS and locales (@neolit123 comes to mind).

An alternative would be the C++ stdlib `std::collate`, but the interface looks more involved than `strcoll()`.

This would avoid unnecessary creation of Qt UTF16 strings.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace `QString::localeAwareCompare` by `strcoll`.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 @dirkhh 