### PR TITLE
Very minor table cleanups

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -128,10 +128,10 @@ struct divecomputer {
 	struct divecomputer *next;
 };
 
-typedef struct dive_table {
+struct dive_table {
 	int nr, allocated;
 	struct dive **dives;
-} dive_table_t;
+};
 
 struct picture;
 struct dive_site;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -692,7 +692,7 @@ int comp_dives(const struct dive *a, const struct dive *b)
 
 /* Dive table functions */
 static MAKE_GROW_TABLE(dive_table, struct dive *, dives)
-MAKE_GET_INSERTION_INDEX(dive_table, struct dive *, dives, dive_less_than)
+MAKE_GET_INSERTION_INDEX(dive_table, struct dive *, dives, comp_dives)
 MAKE_ADD_TO(dive_table, struct dive *, dives)
 static MAKE_REMOVE_FROM(dive_table, dives)
 static MAKE_GET_IDX(dive_table, struct dive *, dives)

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -118,13 +118,8 @@ static int compare_sites(const struct dive_site *a, const struct dive_site *b)
 	return a->uuid > b->uuid ? 1 : a->uuid == b->uuid ? 0 : -1;
 }
 
-static int site_less_than(const struct dive_site *a, const struct dive_site *b)
-{
-	return compare_sites(a, b) < 0;
-}
-
 static MAKE_GROW_TABLE(dive_site_table, struct dive_site *, dive_sites)
-static MAKE_GET_INSERTION_INDEX(dive_site_table, struct dive_site *, dive_sites, site_less_than)
+static MAKE_GET_INSERTION_INDEX(dive_site_table, struct dive_site *, dive_sites, compare_sites)
 static MAKE_ADD_TO(dive_site_table, struct dive_site *, dive_sites)
 static MAKE_REMOVE_FROM(dive_site_table, dive_sites)
 static MAKE_GET_IDX(dive_site_table, struct dive_site *, dive_sites)

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -45,7 +45,7 @@ void copy_weights(const struct weightsystem_table *s, struct weightsystem_table 
 /* weightsystem table functions */
 //static MAKE_GET_IDX(weightsystem_table, weightsystem_t, weightsystems)
 static MAKE_GROW_TABLE(weightsystem_table, weightsystem_t, weightsystems)
-//static MAKE_GET_INSERTION_INDEX(weightsystem_table, weightsystem_t, weightsystems, weightsystem_less_than)
+//static MAKE_GET_INSERTION_INDEX(weightsystem_table, weightsystem_t, weightsystems, comp_weightsystems)
 MAKE_ADD_TO(weightsystem_table, weightsystem_t, weightsystems)
 MAKE_REMOVE_FROM(weightsystem_table, weightsystems)
 //MAKE_SORT(weightsystem_table, weightsystem_t, weightsystems, comp_weightsystems)
@@ -55,7 +55,7 @@ MAKE_CLEAR_TABLE(weightsystem_table, weightsystems, weightsystem)
 /* cylinder table functions */
 //static MAKE_GET_IDX(cylinder_table, cylinder_t, cylinders)
 static MAKE_GROW_TABLE(cylinder_table, cylinder_t, cylinders)
-//static MAKE_GET_INSERTION_INDEX(cylinder_table, cylinder_t, cylinders, cylinder_less_than)
+//static MAKE_GET_INSERTION_INDEX(cylinder_table, cylinder_t, cylinders, comp_cylinders)
 MAKE_ADD_TO(cylinder_table, cylinder_t, cylinders)
 MAKE_REMOVE_FROM(cylinder_table, cylinders)
 //MAKE_SORT(cylinder_table, cylinder_t, cylinders, comp_cylinders)

--- a/core/table.h
+++ b/core/table.h
@@ -23,13 +23,13 @@
 	}
 
 /* get the index where we want to insert an object so that everything stays
- * ordered according to a comparison function() */
+ * ordered according to a comparison function() that returns <0, 0 or >0 (see qsort). */
 #define MAKE_GET_INSERTION_INDEX(table_type, item_type, array_name, fun)		\
 	int table_type##_get_insertion_index(struct table_type *table, item_type item)	\
 	{										\
 		/* we might want to use binary search here */				\
 		for (int i = 0; i < table->nr; i++) {					\
-			if (fun(item, table->array_name[i]))				\
+			if (fun(item, table->array_name[i]) < 0)			\
 				return i;						\
 		}									\
 		return table->nr;							\

--- a/core/trip.c
+++ b/core/trip.c
@@ -45,7 +45,7 @@ void free_trip(dive_trip_t *trip)
 /* Trip table functions */
 static MAKE_GET_IDX(trip_table, struct dive_trip *, trips)
 static MAKE_GROW_TABLE(trip_table, struct dive_trip *, trips)
-static MAKE_GET_INSERTION_INDEX(trip_table, struct dive_trip *, trips, trip_less_than)
+static MAKE_GET_INSERTION_INDEX(trip_table, struct dive_trip *, trips, comp_trips)
 static MAKE_ADD_TO(trip_table, struct dive_trip *, trips)
 static MAKE_REMOVE_FROM(trip_table, trips)
 MAKE_SORT(trip_table, struct dive_trip *, trips, comp_trips)
@@ -321,11 +321,6 @@ int comp_trips(const struct dive_trip *a, const struct dive_trip *b)
 	if (b->dives.nr <= 0)
 		return 1;
 	return comp_dives(a->dives.dives[0], b->dives.dives[0]);
-}
-
-bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b)
-{
-	return comp_trips(a, b) < 0;
 }
 
 static bool is_same_day(timestamp_t trip_when, timestamp_t dive_when)

--- a/core/trip.h
+++ b/core/trip.h
@@ -34,7 +34,6 @@ extern void free_trip(dive_trip_t *trip);
 extern timestamp_t trip_date(const struct dive_trip *trip);
 extern timestamp_t trip_enddate(const struct dive_trip *trip);
 
-extern bool trip_less_than(const struct dive_trip *a, const struct dive_trip *b);
 extern int comp_trips(const struct dive_trip *a, const struct dive_trip *b);
 extern void sort_trip_table(struct trip_table *table);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Originally, I wanted to refactor the table code:
1) Only have a single set of functions that takes the size of the object as parameter
2) Generate a number of inline-stubs that passes the correct size to these functions and casts the arguments/results

This turned out to be more tedious than expected owing to the need to pass sorting functions. Therefore I decided that it is not worth the hassle right now. Here is just two very minor cleanups.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unused typedef.
2) Use three-way comparison instead of less-than comparison, since the latter is trivially expressed in terms of the former. This allows removal of a few redundant stubs.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.