### PR TITLE
(Theme 1) base to allow user selectable colours etc.

### DIFF
--- a/mobile-widgets/CMakeLists.txt
+++ b/mobile-widgets/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(SUBSURFACE_MOBILE_SRCS
 	qmlinterface.cpp
 	qmlmanager.cpp
+	themeinterface.cpp
 	qml/kirigami/src/columnview.cpp
 	qml/kirigami/src/delegaterecycler.cpp
 	qml/kirigami/src/enums.cpp

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -53,7 +53,7 @@ Kirigami.Page {
 	property alias cylinderModel4: detailsEdit.cylinderModel4
 
 	title: currentItem && currentItem.modelData && currentItem.modelData.location && "" !== currentItem.modelData.location ?
-		       currentItem.modelData.location : qsTr("Dive details")
+			   currentItem.modelData.location : qsTr("Dive details")
 	state: "view"
 	leftPadding: 0
 	topPadding: Kirigami.Units.gridUnit / 2
@@ -188,8 +188,8 @@ Kirigami.Page {
 
 	actions.main: Kirigami.Action {
 		icon {
-			name: state !== "view" ? ":/icons" + subsurfaceTheme.iconStyle + "/document-save.svg" :
-						 ":/icons" + subsurfaceTheme.iconStyle + "/document-edit.svg"
+			name: state !== "view" ? ThemeNew.iconStyle + "/document-save.svg" :
+						 ThemeNew.iconStyle + "/document-edit.svg"
 			color: subsurfaceTheme.primaryColor
 		}
 		text: state !== "view" ? qsTr("Save edits") : qsTr("Edit dive")

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -560,69 +560,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		] // end actions
 		Image {
 			fillMode: Image.PreserveAspectFit
-			source: "qrc:///icons/" + (subsurfaceTheme.currentTheme != "" ? subsurfaceTheme.currentTheme : "Blue") + "_gps.svg"
+			source: "qrc:///icons/" + (ThemeNew.currentTheme !== "" ? ThemeNew.currentTheme : "Blue") + "_gps.svg"
 			visible: locationServiceEnabled
 		}
-	}
-
-	function blueTheme() {
-		Material.theme = Material.Light
-		Material.accent = subsurfaceTheme.bluePrimaryColor
-		subsurfaceTheme.currentTheme = "Blue"
-		subsurfaceTheme.darkerPrimaryColor = subsurfaceTheme.blueDarkerPrimaryColor
-		subsurfaceTheme.darkerPrimaryTextColor= subsurfaceTheme.blueDarkerPrimaryTextColor
-		subsurfaceTheme.primaryColor = subsurfaceTheme.bluePrimaryColor
-		subsurfaceTheme.primaryTextColor = subsurfaceTheme.bluePrimaryTextColor
-		subsurfaceTheme.lightPrimaryColor = subsurfaceTheme.blueLightPrimaryColor
-		subsurfaceTheme.lightPrimaryTextColor = subsurfaceTheme.blueLightPrimaryTextColor
-		subsurfaceTheme.backgroundColor = subsurfaceTheme.blueBackgroundColor
-		subsurfaceTheme.textColor = subsurfaceTheme.blueTextColor
-		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.blueSecondaryTextColor
-		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
-		subsurfaceTheme.drawerColor = subsurfaceTheme.blueLightDrawerColor
-		subsurfaceTheme.contrastAccentColor = subsurfaceTheme.blueContrastAccentColor
-		subsurfaceTheme.lightDrawerColor = subsurfaceTheme.blueLightDrawerColor
-		subsurfaceTheme.iconStyle = "-dark"
-	}
-
-	function pinkTheme() {
-		Material.theme = Material.Light
-		Material.accent = subsurfaceTheme.pinkPrimaryColor
-		subsurfaceTheme.currentTheme = "Pink"
-		subsurfaceTheme.darkerPrimaryColor = subsurfaceTheme.pinkDarkerPrimaryColor
-		subsurfaceTheme.darkerPrimaryTextColor = subsurfaceTheme.pinkDarkerPrimaryTextColor
-		subsurfaceTheme.primaryColor = subsurfaceTheme.pinkPrimaryColor
-		subsurfaceTheme.primaryTextColor = subsurfaceTheme.pinkPrimaryTextColor
-		subsurfaceTheme.lightPrimaryColor = subsurfaceTheme.pinkLightPrimaryColor
-		subsurfaceTheme.lightPrimaryTextColor = subsurfaceTheme.pinkLightPrimaryTextColor
-		subsurfaceTheme.backgroundColor = subsurfaceTheme.pinkBackgroundColor
-		subsurfaceTheme.textColor = subsurfaceTheme.pinkTextColor
-		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.pinkSecondaryTextColor
-		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
-		subsurfaceTheme.drawerColor = subsurfaceTheme.pinkLightDrawerColor
-		subsurfaceTheme.contrastAccentColor = subsurfaceTheme.pinkContrastAccentColor
-		subsurfaceTheme.lightDrawerColor = subsurfaceTheme.pinkLightDrawerColor
-		subsurfaceTheme.iconStyle = ""
-	}
-
-	function darkTheme() {
-		Material.theme = Material.Dark
-		Material.accent = subsurfaceTheme.darkPrimaryColor
-		subsurfaceTheme.currentTheme = "Dark"
-		subsurfaceTheme.darkerPrimaryColor = subsurfaceTheme.darkDarkerPrimaryColor
-		subsurfaceTheme.darkerPrimaryTextColor= subsurfaceTheme.darkDarkerPrimaryTextColor
-		subsurfaceTheme.primaryColor = subsurfaceTheme.darkPrimaryColor
-		subsurfaceTheme.primaryTextColor = subsurfaceTheme.darkPrimaryTextColor
-		subsurfaceTheme.lightPrimaryColor = subsurfaceTheme.darkLightPrimaryColor
-		subsurfaceTheme.lightPrimaryTextColor = subsurfaceTheme.darkLightPrimaryTextColor
-		subsurfaceTheme.backgroundColor = subsurfaceTheme.darkBackgroundColor
-		subsurfaceTheme.textColor = subsurfaceTheme.darkTextColor
-		subsurfaceTheme.secondaryTextColor = subsurfaceTheme.darkSecondaryTextColor
-		manager.setStatusbarColor(subsurfaceTheme.darkerPrimaryColor)
-		subsurfaceTheme.drawerColor = subsurfaceTheme.darkDrawerColor
-		subsurfaceTheme.contrastAccentColor = subsurfaceTheme.darkContrastAccentColor
-		subsurfaceTheme.lightDrawerColor = subsurfaceTheme.darkLightDrawerColor
-		subsurfaceTheme.iconStyle = "-dark"
 	}
 
 	function setupUnits() {
@@ -667,65 +607,19 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		property double headingPointSize: regularPointSize * 1.2
 		property double smallPointSize: regularPointSize * 0.8
 
-		// icon Theme
-		property string iconStyle: ""
-
 		// colors currently in use
-		property string currentTheme
-		property color darkerPrimaryColor
-		property color darkerPrimaryTextColor
-		property color primaryColor
-		property color primaryTextColor
-		property color lightPrimaryColor
-		property color lightPrimaryTextColor
-		property color backgroundColor
-		property color textColor
-		property color secondaryTextColor
-		property color drawerColor
-		property color contrastAccentColor: "#FF5722" // used for delete button
-		property color lightDrawerColor: "#FFFFFF"
-
-		// colors for the blue theme
-		property color blueDarkerPrimaryColor: "#303F9f"
-		property color blueDarkerPrimaryTextColor: "#ECECEC"
-		property color bluePrimaryColor: "#3F51B5"
-		property color bluePrimaryTextColor: "#FFFFFF"
-		property color blueLightPrimaryColor: "#C5CAE9"
-		property color blueLightPrimaryTextColor: "#212121"
-		property color blueBackgroundColor: "#eff0f1"
-		property color blueTextColor: blueLightPrimaryTextColor
-		property color blueSecondaryTextColor: "#757575"
-		property color blueLightDrawerColor: "#FFFFFF"
-		property color blueDrawerColor: blueLightDrawerColor
-		property color blueContrastAccentColor: "#FF5722" // used for delete button
-
-		// colors for the pink theme
-		property color pinkDarkerPrimaryColor: "#C2185B"
-		property color pinkDarkerPrimaryTextColor: "#ECECEC"
-		property color pinkPrimaryColor: "#FF69B4"
-		property color pinkPrimaryTextColor: "#212121"
-		property color pinkLightPrimaryColor: "#FFDDF4"
-		property color pinkLightPrimaryTextColor: "#212121"
-		property color pinkBackgroundColor: "#eff0f1"
-		property color pinkTextColor: pinkLightPrimaryTextColor
-		property color pinkSecondaryTextColor: "#757575"
-		property color pinkLightDrawerColor: "#FFFFFF"
-		property color pinkDrawerColor: pinkLightDrawerColor
-		property color pinkContrastAccentColor: "#FF5722" // used for delete button
-
-		// colors for the dark theme
-		property color darkDarkerPrimaryColor: "#303F9f"
-		property color darkDarkerPrimaryTextColor: "#ECECEC"
-		property color darkPrimaryColor: "#3F51B5"
-		property color darkPrimaryTextColor: "#ECECEC"
-		property color darkLightPrimaryColor: "#C5CAE9"
-		property color darkLightPrimaryTextColor: "#ECECEC"
-		property color darkBackgroundColor: "#303030"
-		property color darkTextColor: darkPrimaryTextColor
-		property color darkSecondaryTextColor: "#757575"
-		property color darkDrawerColor: "#424242"
-		property color darkLightDrawerColor: "#FFFFFF"
-		property color darkContrastAccentColor: "#FF5722" // used for delete button
+		property color darkerPrimaryColor: ThemeNew.darkerPrimaryColor
+		property color darkerPrimaryTextColor: ThemeNew.darkerPrimaryTextColor
+		property color primaryColor: ThemeNew.primaryColor
+		property color primaryTextColor: ThemeNew.primaryTextColor
+		property color lightPrimaryColor: ThemeNew.lightPrimaryColor
+		property color lightPrimaryTextColor: ThemeNew.lightPrimaryTextColor
+		property color backgroundColor: ThemeNew.backgroundColor
+		property color textColor: ThemeNew.textColor
+		property color secondaryTextColor: ThemeNew.secondaryTextColor
+		property color drawerColor: ThemeNew.drawerColor
+		property color contrastAccentColor: ThemeNew.contrastAccentColor
+		property color lightDrawerColor: ThemeNew.lightDrawerColor
 
 		property int initialWidth: rootItem.width
 		property int initialHeight: rootItem.height
@@ -738,15 +632,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				setupUnits() // but don't count this as a change (after all, it's not)
 			else
 				manager.appendTextToLog("Already adjusted size, ignoring this")
-
-			// this needs to pick the theme from persistent preference settings
-			var theme = PrefDisplay.theme
-			if (theme === "Blue")
-				blueTheme()
-			else if (theme === "Pink")
-				pinkTheme()
-			else
-				darkTheme()
 		}
 	}
 

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -17,12 +17,57 @@ void themeInterface::setup()
 
 void themeInterface::set_currentTheme(const QString &theme)
 {
+	m_currentTheme = theme;
 	qPrefDisplay::set_theme(m_currentTheme);
+	update_theme();
 	emit currentThemeChanged(theme);
 }
 
 void themeInterface::update_theme()
 {
+	if (m_currentTheme == "Blue") {
+		m_backgroundColor = m_blueBackgroundColor;
+		m_contrastAccentColor = m_blueContrastAccentColor;
+		m_darkerPrimaryColor = m_blueDarkerPrimaryColor;
+		m_darkerPrimaryTextColor = m_blueDarkerPrimaryTextColor;
+		m_drawerColor = m_blueDrawerColor;
+		m_lightDrawerColor = m_blueDrawerColor;
+		m_lightPrimaryColor = m_blueLightPrimaryColor;
+		m_lightPrimaryTextColor = m_blueLightPrimaryTextColor;
+		m_primaryColor = m_bluePrimaryColor;
+		m_primaryTextColor = m_bluePrimaryTextColor;
+		m_secondaryTextColor = m_blueSecondaryTextColor;
+		m_textColor = m_blueTextColor;
+		m_iconStyle = ":/icons";
+	} else if (m_currentTheme == "Pink") {
+		m_backgroundColor = m_pinkBackgroundColor;
+		m_contrastAccentColor = m_pinkContrastAccentColor;
+		m_darkerPrimaryColor = m_pinkDarkerPrimaryColor;
+		m_darkerPrimaryTextColor = m_pinkDarkerPrimaryTextColor;
+		m_drawerColor = m_pinkDrawerColor;
+		m_lightDrawerColor = m_pinkDrawerColor;
+		m_lightPrimaryColor = m_pinkLightPrimaryColor;
+		m_lightPrimaryTextColor = m_pinkLightPrimaryTextColor;
+		m_primaryColor = m_pinkPrimaryColor;
+		m_primaryTextColor = m_pinkPrimaryTextColor;
+		m_secondaryTextColor = m_pinkSecondaryTextColor;
+		m_textColor = m_pinkTextColor;
+		m_iconStyle = ":/icons";
+	} else {
+		m_backgroundColor = m_darkBackgroundColor;
+		m_contrastAccentColor = m_darkContrastAccentColor;
+		m_darkerPrimaryColor = m_darkDarkerPrimaryColor;
+		m_darkerPrimaryTextColor = m_darkDarkerPrimaryTextColor;
+		m_drawerColor = m_darkDrawerColor;
+		m_lightDrawerColor = m_darkDrawerColor;
+		m_lightPrimaryColor = m_darkLightPrimaryColor;
+		m_lightPrimaryTextColor = m_darkLightPrimaryTextColor;
+		m_primaryColor = m_darkPrimaryColor;
+		m_primaryTextColor = m_darkPrimaryTextColor;
+		m_secondaryTextColor = m_darkSecondaryTextColor;
+		m_textColor = m_darkTextColor;
+		m_iconStyle = ":/icons-dark";
+	}
 }
 
 

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -23,8 +23,6 @@ void themeInterface::set_currentTheme(const QString &theme)
 
 void themeInterface::update_theme()
 {
-	m_contrastAccentColor = "#FF5722";
-	m_lightDrawerColor = "#FFFFFF";
 }
 
 

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "themeinterface.h"
+#include "core/settings/qPrefDisplay.h"
+
+themeInterface *themeInterface::instance()
+{
+	static themeInterface *self = new themeInterface;
+	return self;
+}
+
+void themeInterface::setup()
+{
+	// get current theme
+	m_currentTheme = qPrefDisplay::theme();
+	update_theme();
+}
+
+void themeInterface::set_currentTheme(const QString &theme)
+{
+	qPrefDisplay::set_theme(m_currentTheme);
+	emit currentThemeChanged(theme);
+}
+
+void themeInterface::update_theme()
+{
+	m_contrastAccentColor = "#FF5722";
+	m_lightDrawerColor = "#FFFFFF";
+}
+
+

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef THEMEINTERFACE_H
+#define THEMEINTERFACE_H
+#include <QObject>
+#include <QColor>
+#include <QSettings>
+
+class themeInterface : public QObject {
+	Q_OBJECT
+
+	// Color themes
+	Q_PROPERTY(QColor backgroundColor MEMBER m_backgroundColor NOTIFY backgroundColorChanged)
+	Q_PROPERTY(QColor contrastAccentColor MEMBER m_contrastAccentColor NOTIFY contrastAccentColorChanged)
+	Q_PROPERTY(QColor darkerPrimaryColor MEMBER m_darkerPrimaryColor NOTIFY darkerPrimaryColorChanged)
+	Q_PROPERTY(QColor darkerPrimaryTextColor MEMBER m_darkerPrimaryTextColor NOTIFY darkerPrimaryTextColorChanged)
+	Q_PROPERTY(QColor drawerColor MEMBER m_drawerColor NOTIFY drawerColorChanged)
+	Q_PROPERTY(QColor drawerTextColor MEMBER m_drawerTextColor NOTIFY drawerTextColorChanged)
+	Q_PROPERTY(QColor lightDrawerColor MEMBER m_lightDrawerColor NOTIFY lightDrawerColorChanged)
+	Q_PROPERTY(QColor lightPrimaryColor MEMBER m_lightPrimaryColor NOTIFY lightPrimaryColorChanged)
+	Q_PROPERTY(QColor lightPrimaryTextColor MEMBER m_lightPrimaryTextColor NOTIFY lightPrimaryTextColorChanged)
+	Q_PROPERTY(QColor primaryColor MEMBER m_primaryColor NOTIFY primaryColorChanged)
+	Q_PROPERTY(QColor primaryTextColor MEMBER m_primaryTextColor NOTIFY primaryTextColorChanged)
+	Q_PROPERTY(QColor secondaryColor MEMBER m_secondaryColor NOTIFY secondaryColorChanged)
+	Q_PROPERTY(QColor secondaryTextColor MEMBER m_secondaryTextColor NOTIFY secondaryTextColorChanged)
+	Q_PROPERTY(QColor textColor MEMBER m_textColor NOTIFY textColorChanged)
+
+	// Support
+	Q_PROPERTY(QString currentTheme MEMBER m_currentTheme WRITE set_currentTheme NOTIFY currentThemeChanged)
+
+	// Compatibility existing code
+	Q_PROPERTY(QColor blueBackgroundColor MEMBER m_blueBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor blueDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor blueDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor blueLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor blueLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor bluePrimaryColor MEMBER m_bluePrimaryColor CONSTANT)
+	Q_PROPERTY(QColor bluePrimaryTextColor MEMBER m_bluePrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor blueSecondaryTextColor MEMBER m_blueSecondaryTextColor CONSTANT)
+	Q_PROPERTY(QColor blueTextColor MEMBER m_blueTextColor CONSTANT)
+
+	Q_PROPERTY(QColor pinkBackgroundColor MEMBER m_pinkBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor pinkDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor pinkDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor pinkLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor pinkLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor pinkPrimaryColor MEMBER m_pinkPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor pinkPrimaryTextColor MEMBER m_pinkPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor pinkSecondaryTextColor MEMBER m_blueSecondaryTextColor CONSTANT)
+	Q_PROPERTY(QColor pinkTextColor MEMBER m_pinkTextColor CONSTANT)
+
+	Q_PROPERTY(QColor darkBackgroundColor MEMBER m_darkBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor darkDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor darkDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor darkDrawerColor MEMBER m_drawerColor CONSTANT)
+	Q_PROPERTY(QColor darkLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor darkLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor darkPrimaryColor MEMBER m_darkPrimaryColor CONSTANT)
+	Q_PROPERTY(QColor darkPrimaryTextColor MEMBER m_darkPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor darkSecondaryTextColor MEMBER m_blueSecondaryTextColor CONSTANT)
+	Q_PROPERTY(QColor darkTextColor MEMBER m_darkTextColor CONSTANT)
+
+public:
+	static themeInterface *instance();
+
+	void setup();
+
+public slots:
+	void set_currentTheme(const QString &theme);
+
+signals:
+	void backgroundColorChanged(QColor);
+	void contrastAccentColorChanged(QColor);
+	void darkerPrimaryColorChanged(QColor);
+	void darkerPrimaryTextColorChanged(QColor);
+	void drawerColorChanged(QColor);
+	void drawerTextColorChanged(QColor);
+	void lightDrawerColorChanged(QColor);
+	void lightPrimaryColorChanged(QColor);
+	void lightPrimaryTextColorChanged(QColor);
+	void primaryColorChanged(QColor);
+	void primaryTextColorChanged(QColor);
+	void secondaryColorChanged(QColor);
+	void secondaryTextColorChanged(QColor);
+	void textColorChanged(QColor);
+
+	void currentThemeChanged(const QString &);
+
+private:
+	themeInterface() {}
+	void update_theme();
+
+	QColor m_backgroundColor;
+	QColor m_contrastAccentColor;
+	QColor m_darkerPrimaryColor;
+	QColor m_darkerPrimaryTextColor;
+	QColor m_drawerColor;
+	QColor m_drawerTextColor;
+	QColor m_lightDrawerColor;
+	QColor m_lightPrimaryColor;
+	QColor m_lightPrimaryTextColor;
+	QColor m_primaryColor;
+	QColor m_primaryTextColor;
+	QColor m_secondaryColor;
+	QColor m_secondaryTextColor;
+	QColor m_textColor;
+
+	QString m_currentTheme;
+
+	// Compatibility existing code
+	const QColor m_blueBackgroundColor = "#eff0f1";
+	const QColor m_blueDarkerPrimaryColor = "#303F9f";
+	const QColor m_blueDarkerPrimaryTextColor = "#ECECEC";
+	const QColor m_blueLightPrimaryColor = "#C5CAE9";
+	const QColor m_blueLightPrimaryTextColor = "#212121";
+	const QColor m_bluePrimaryColor = "#3F51B5";
+	const QColor m_bluePrimaryTextColor = "#FFFFFF";
+	const QColor m_blueSecondaryTextColor = "#757575";
+	const QColor m_blueTextColor = "#212121";
+
+	const QColor m_pinkBackgroundColor = "#eff0f1";
+	const QColor m_pinkDarkerPrimaryColor = "#C2185B";
+	const QColor m_pinkDarkerPrimaryTextColor = "#ECECEC";
+	const QColor m_pinkLightPrimaryColor = "#FFDDF4";
+	const QColor m_pinkLightPrimaryTextColor = "#212121";
+	const QColor m_pinkPrimaryColor = "#FF69B4";
+	const QColor m_pinkPrimaryTextColor = "#212121";
+	const QColor m_pinkSecondaryTextColor = "#757575";
+	const QColor m_pinkTextColor = "#212121";
+
+	const QColor m_darkBackgroundColor = "#303030";
+	const QColor m_darkDarkerPrimaryColor = "#303F9f";
+	const QColor m_darkDarkerPrimaryTextColor = "#ECECEC";
+	const QColor m_darkDrawerColor = "#424242";
+	const QColor m_darkLightPrimaryColor = "#C5CAE9";
+	const QColor m_darkLightPrimaryTextColor = "#ECECEC";
+	const QColor m_darkPrimaryColor = "#3F51B5";
+	const QColor m_darkPrimaryTextColor = "#ECECEC";
+	const QColor m_darkSecondaryTextColor = "#757575";
+	const QColor m_darkTextColor = "#ECECEC";
+};
+#endif

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -14,13 +14,11 @@ class themeInterface : public QObject {
 	Q_PROPERTY(QColor darkerPrimaryColor MEMBER m_darkerPrimaryColor NOTIFY darkerPrimaryColorChanged)
 	Q_PROPERTY(QColor darkerPrimaryTextColor MEMBER m_darkerPrimaryTextColor NOTIFY darkerPrimaryTextColorChanged)
 	Q_PROPERTY(QColor drawerColor MEMBER m_drawerColor NOTIFY drawerColorChanged)
-	Q_PROPERTY(QColor drawerTextColor MEMBER m_drawerTextColor NOTIFY drawerTextColorChanged)
 	Q_PROPERTY(QColor lightDrawerColor MEMBER m_lightDrawerColor NOTIFY lightDrawerColorChanged)
 	Q_PROPERTY(QColor lightPrimaryColor MEMBER m_lightPrimaryColor NOTIFY lightPrimaryColorChanged)
 	Q_PROPERTY(QColor lightPrimaryTextColor MEMBER m_lightPrimaryTextColor NOTIFY lightPrimaryTextColorChanged)
 	Q_PROPERTY(QColor primaryColor MEMBER m_primaryColor NOTIFY primaryColorChanged)
 	Q_PROPERTY(QColor primaryTextColor MEMBER m_primaryTextColor NOTIFY primaryTextColorChanged)
-	Q_PROPERTY(QColor secondaryColor MEMBER m_secondaryColor NOTIFY secondaryColorChanged)
 	Q_PROPERTY(QColor secondaryTextColor MEMBER m_secondaryTextColor NOTIFY secondaryTextColorChanged)
 	Q_PROPERTY(QColor textColor MEMBER m_textColor NOTIFY textColorChanged)
 
@@ -29,8 +27,11 @@ class themeInterface : public QObject {
 
 	// Compatibility existing code
 	Q_PROPERTY(QColor blueBackgroundColor MEMBER m_blueBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor blueContrastAccentColor MEMBER m_blueTextColor CONSTANT)
 	Q_PROPERTY(QColor blueDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor blueDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor blueDrawerColor MEMBER m_blueDrawerColor CONSTANT)
+	Q_PROPERTY(QColor blueLightDrawerColor MEMBER m_blueLightDrawerColor CONSTANT)
 	Q_PROPERTY(QColor blueLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor blueLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
 	Q_PROPERTY(QColor bluePrimaryColor MEMBER m_bluePrimaryColor CONSTANT)
@@ -39,8 +40,11 @@ class themeInterface : public QObject {
 	Q_PROPERTY(QColor blueTextColor MEMBER m_blueTextColor CONSTANT)
 
 	Q_PROPERTY(QColor pinkBackgroundColor MEMBER m_pinkBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor pinkContrastAccentColor MEMBER m_pinkContrastAccentColor CONSTANT)
 	Q_PROPERTY(QColor pinkDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor pinkDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
+	Q_PROPERTY(QColor pinkDrawerColor MEMBER m_pinkDrawerColor CONSTANT)
+	Q_PROPERTY(QColor pinkLightDrawerColor MEMBER m_pinkLightDrawerColor CONSTANT)
 	Q_PROPERTY(QColor pinkLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor pinkLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
 	Q_PROPERTY(QColor pinkPrimaryColor MEMBER m_pinkPrimaryColor CONSTANT)
@@ -49,9 +53,11 @@ class themeInterface : public QObject {
 	Q_PROPERTY(QColor pinkTextColor MEMBER m_pinkTextColor CONSTANT)
 
 	Q_PROPERTY(QColor darkBackgroundColor MEMBER m_darkBackgroundColor CONSTANT)
+	Q_PROPERTY(QColor darkContrastAccentColor MEMBER m_darkContrastAccentColor CONSTANT)
 	Q_PROPERTY(QColor darkDarkerPrimaryColor MEMBER m_blueDarkerPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor darkDarkerPrimaryTextColor MEMBER m_blueDarkerPrimaryTextColor CONSTANT)
 	Q_PROPERTY(QColor darkDrawerColor MEMBER m_drawerColor CONSTANT)
+	Q_PROPERTY(QColor darkLightDrawerColor MEMBER m_darkLightDrawerColor CONSTANT)
 	Q_PROPERTY(QColor darkLightPrimaryColor MEMBER m_blueLightPrimaryColor CONSTANT)
 	Q_PROPERTY(QColor darkLightPrimaryTextColor MEMBER m_blueLightPrimaryTextColor CONSTANT)
 	Q_PROPERTY(QColor darkPrimaryColor MEMBER m_darkPrimaryColor CONSTANT)
@@ -73,13 +79,11 @@ signals:
 	void darkerPrimaryColorChanged(QColor);
 	void darkerPrimaryTextColorChanged(QColor);
 	void drawerColorChanged(QColor);
-	void drawerTextColorChanged(QColor);
 	void lightDrawerColorChanged(QColor);
 	void lightPrimaryColorChanged(QColor);
 	void lightPrimaryTextColorChanged(QColor);
 	void primaryColorChanged(QColor);
 	void primaryTextColorChanged(QColor);
-	void secondaryColorChanged(QColor);
 	void secondaryTextColorChanged(QColor);
 	void textColorChanged(QColor);
 
@@ -94,13 +98,11 @@ private:
 	QColor m_darkerPrimaryColor;
 	QColor m_darkerPrimaryTextColor;
 	QColor m_drawerColor;
-	QColor m_drawerTextColor;
 	QColor m_lightDrawerColor;
 	QColor m_lightPrimaryColor;
 	QColor m_lightPrimaryTextColor;
 	QColor m_primaryColor;
 	QColor m_primaryTextColor;
-	QColor m_secondaryColor;
 	QColor m_secondaryTextColor;
 	QColor m_textColor;
 
@@ -108,8 +110,11 @@ private:
 
 	// Compatibility existing code
 	const QColor m_blueBackgroundColor = "#eff0f1";
+	const QColor m_blueContrastAccentColor = "#FF5722";
 	const QColor m_blueDarkerPrimaryColor = "#303F9f";
 	const QColor m_blueDarkerPrimaryTextColor = "#ECECEC";
+	const QColor m_blueDrawerColor = "#FFFFFF";
+	const QColor m_blueLightDrawerColor = "#FFFFFF";
 	const QColor m_blueLightPrimaryColor = "#C5CAE9";
 	const QColor m_blueLightPrimaryTextColor = "#212121";
 	const QColor m_bluePrimaryColor = "#3F51B5";
@@ -118,8 +123,11 @@ private:
 	const QColor m_blueTextColor = "#212121";
 
 	const QColor m_pinkBackgroundColor = "#eff0f1";
+	const QColor m_pinkContrastAccentColor = "#FF5722";
 	const QColor m_pinkDarkerPrimaryColor = "#C2185B";
 	const QColor m_pinkDarkerPrimaryTextColor = "#ECECEC";
+	const QColor m_pinkDrawerColor = "#FFFFFF";
+	const QColor m_pinkLightDrawerColor = "#FFFFFF";
 	const QColor m_pinkLightPrimaryColor = "#FFDDF4";
 	const QColor m_pinkLightPrimaryTextColor = "#212121";
 	const QColor m_pinkPrimaryColor = "#FF69B4";
@@ -128,9 +136,11 @@ private:
 	const QColor m_pinkTextColor = "#212121";
 
 	const QColor m_darkBackgroundColor = "#303030";
+	const QColor m_darkContrastAccentColor = "#FF5722";
 	const QColor m_darkDarkerPrimaryColor = "#303F9f";
 	const QColor m_darkDarkerPrimaryTextColor = "#ECECEC";
 	const QColor m_darkDrawerColor = "#424242";
+	const QColor m_darkLightDrawerColor = "#FFFFFF";
 	const QColor m_darkLightPrimaryColor = "#C5CAE9";
 	const QColor m_darkLightPrimaryTextColor = "#ECECEC";
 	const QColor m_darkPrimaryColor = "#3F51B5";

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -24,6 +24,7 @@ class themeInterface : public QObject {
 
 	// Support
 	Q_PROPERTY(QString currentTheme MEMBER m_currentTheme WRITE set_currentTheme NOTIFY currentThemeChanged)
+	Q_PROPERTY(QString iconStyle MEMBER m_iconStyle CONSTANT)
 
 	// Compatibility existing code
 	Q_PROPERTY(QColor blueBackgroundColor MEMBER m_blueBackgroundColor CONSTANT)
@@ -107,6 +108,7 @@ private:
 	QColor m_textColor;
 
 	QString m_currentTheme;
+	QString m_iconStyle;
 
 	// Compatibility existing code
 	const QColor m_blueBackgroundColor = "#eff0f1";

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -112,6 +112,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../backend-shared/plannershared.cpp \
 	../../mobile-widgets/qmlinterface.cpp \
 	../../mobile-widgets/qmlmanager.cpp \
+	../../mobile-widgets/themeinterface.cpp \
 	../../qt-models/divelistmodel.cpp \
 	../../qt-models/diveplotdatamodel.cpp \
 	../../qt-models/gpslistmodel.cpp \
@@ -245,6 +246,7 @@ HEADERS += \
 	../../backend-shared/plannershared.h \
 	../../mobile-widgets/qmlinterface.h \
 	../../mobile-widgets/qmlmanager.h \
+	../../mobile-widgets/themeinterface.h \
 	../../map-widget/qmlmapwidgethelper.h \
 	../../qt-models/divelistmodel.h \
 	../../qt-models/diveplotdatamodel.h \

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -13,6 +13,7 @@
 #include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include "mobile-widgets/themeinterface.h"
 #include "mobile-widgets/qmlmanager.h"
 #include "mobile-widgets/qmlinterface.h"
 #include "qt-models/divelistmodel.h"
@@ -188,6 +189,9 @@ void register_qml_types(QQmlEngine *engine)
 
 		// Register qml interface class
 		QMLInterface::setup(ct);
+
+		themeInterface::instance()->setup();
+		ct->setContextProperty("ThemeNew", themeInterface::instance());
 	}
 
 	REGISTER_TYPE(QMLManager, "QMLManager");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The theme "thing" is moved to C++ for several reasons:
- let QML do UI and not a lot more
- Prepare for personalized themes (user can select colors freely)
- automatic day/night theme shift.

this PR moves theme colors to C++ in the least invasive manner. subsurfaceTheme still exist in 
main.qml, to cope with fonts, and skeleton color properties (to avoid doing a big search/replace).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
commit 1) remove columnWidth as it is undefined.
commit 2) add themeInterface  in C++
commit 3) register themeInterface, but with a temporary name
commit 4) add missing colors in the different themes
commit 5) add support for changing theme
commit 6) integrate ThemeNew in QML

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
What are the reasons to move something that works (main.qml - subsurfaceTheme) to C++, a good question that deserves a longer answer:

Arguments:
1) User should be able to select colours freely, and not just choose between themes. The idea is to keep the themes as "templates" for user selections.

<img width="304" alt="settingsColor" src="https://user-images.githubusercontent.com/6185391/73017741-994c2000-3e20-11ea-94cc-b1af63782c5d.png">

This can be done in QML, but the code will grow and QML is anything but a good environment for implementation code.

1a) day/night shift which is very popular among iOS applications.
Adding an alert in C++ was easy, it surely can be done in QML too but (I think) far less easy.

2) Use should be able to free select font sizes (not just small, normal, large):

<img width="302" alt="settingsFont" src="https://user-images.githubusercontent.com/6185391/73017926-e03a1580-3e20-11ea-87b5-e0b99bc8027d.png">

This can also be done in QML, but when the font size depend on the available real estate, it becomes complicated in QML.

3) Addon, do not need to be part of theme, it was just easy when developing it. The user should be able to choose language, time format and most importantly how to use '.' and ','. There seems to be a problem with number formatting in QML (it does not understand ES_en), so an added formatter helps doing that.

<img width="301" alt="settingsLanguage" src="https://user-images.githubusercontent.com/6185391/73018186-6191a800-3e21-11ea-8dbe-c78c24d6d6f5.png">

Side note (not relevant for this PR):
The screen shots are not the official subsurface-mobile, but our version. PageStack is long gone and replaced by a toolbar at the bottom, giving immediate access to the important pages, the rest are in globaldrawer. 

4) main.qml is overloaded with code, that would be logically in other places. All reductions of code, make main.qml more easy to understand, and thus maintain.

All of this and more are on my list to be integrated piece by piece (if wanted of course) in the official version.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
