### PR TITLE
(1) mobile:  rewrap settings to use sections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: new layout for Settings page
 Desktop: add the ability to modify dive salinity
 Mobile: add menu item for cloud password reset
 Mobile: add DivePlanner setup, as first part of a mobile diveplanner

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -28,55 +28,49 @@ Kirigami.ScrollablePage {
 			title: qsTr("General settings")
 			isExpanded: true
 
-		}
+			GridLayout {
+				id: cloudSetting
+				visible: sectionGeneral.isExpanded
+				columns: 3
 
-		GridLayout {
-			id: cloudSetting
-			columns: 3
-
-			TemplateLabel {
-				text: qsTr("Cloud status")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 3
-			}
-			TemplateLabel {
-				text: qsTr("Email")
-				Layout.preferredWidth: gridWidth * 0.15
-			}
-			TemplateLabel {
-				text: Backend.cloud_verification_status === Enums.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
-				font.pointSize: subsurfaceTheme.regularPointSize
-				Layout.preferredWidth: gridWidth * 0.60
-			}
-			SsrfButton {
-				id: changeCloudSettings
-				text: qsTr("Change")
-				onClicked: {
-					Backend.cloud_verification_status = Enums.CS_UNKNOWN
-					manager.startPageText  = qsTr("Starting...");
+				TemplateLabel {
+					text: qsTr("Cloud status")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 3
+				}
+				TemplateLabel {
+					text: qsTr("Email")
+					Layout.preferredWidth: gridWidth * 0.15
+				}
+				TemplateLabel {
+					text: Backend.cloud_verification_status === Enums.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
+					Layout.preferredWidth: gridWidth * 0.60
+				}
+				SsrfButton {
+					id: changeCloudSettings
+					text: qsTr("Change")
+					onClicked: {
+						Backend.cloud_verification_status = Enums.CS_UNKNOWN
+						manager.startPageText  = qsTr("Starting...");
+					}
+				}
+				TemplateLabel {
+					text: qsTr("Status")
+					Layout.preferredWidth: gridWidth * 0.15
+					Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
+				}
+				TemplateLabel {
+					text: describe[Backend.cloud_verification_status]
+					Layout.preferredWidth: gridWidth * 0.60
+					Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
 				}
 			}
-			TemplateLabel {
-				text: qsTr("Status")
-				Layout.preferredWidth: gridWidth * 0.15
-				Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
-			}
-			TemplateLabel {
-				text: describe[Backend.cloud_verification_status]
-				Layout.preferredWidth: gridWidth * 0.60
-				Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
-			}
 		}
 
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
+
 		GridLayout {
 			id: themeSettings
 			columns: 3

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -380,164 +380,154 @@ Kirigami.ScrollablePage {
 			}
 		}
 
-		GridLayout {
-			id: gpsPrefs
-			columns: 2
+		TemplateSection {
+			id: sectionAdvanced
+			title: qsTr("Advanced")
 
-			TemplateLabel {
-				text: qsTr("GPS location service")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
-			}
+			GridLayout {
+				id: gpsPrefs
+				visible: sectionAdvanced.isExpanded
+				columns: 2
 
-			TemplateLabel {
-				text: qsTr("Distance threshold (meters)")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
+				TemplateLabel {
+					text: qsTr("GPS location service")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 2
+				}
 
-			TemplateTextField {
-				id: distanceThreshold
-				text: PrefLocationService.distance_threshold
-				Layout.preferredWidth: gridWidth * 0.25
-				onEditingFinished: {
-					PrefLocationService.distance_threshold = distanceThreshold.text
+				TemplateLabel {
+					text: qsTr("Distance threshold (meters)")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+
+				TemplateTextField {
+					id: distanceThreshold
+					text: PrefLocationService.distance_threshold
+					Layout.preferredWidth: gridWidth * 0.25
+					onEditingFinished: {
+						PrefLocationService.distance_threshold = distanceThreshold.text
+					}
+				}
+
+				TemplateLabel {
+					text: qsTr("Time threshold (minutes)")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+
+				TemplateTextField {
+					id: timeThreshold
+					text: PrefLocationService.time_threshold / 60
+					Layout.preferredWidth: gridWidth * 0.25
+					onEditingFinished: {
+						PrefLocationService.time_threshold = timeThreshold.text * 60
+					}
 				}
 			}
-
-			TemplateLabel {
-				text: qsTr("Time threshold (minutes)")
-				Layout.preferredWidth: gridWidth * 0.75
+			TemplateLine {
+				visible: sectionAdvanced.isExpanded
 			}
+			GridLayout {
+				id: filterPrefs
+				visible: sectionAdvanced.isExpanded
+				columns: 2
 
-			TemplateTextField {
-				id: timeThreshold
-				text: PrefLocationService.time_threshold / 60
-				Layout.preferredWidth: gridWidth * 0.25
-				onEditingFinished: {
-					PrefLocationService.time_threshold = timeThreshold.text * 60
+				TemplateLabel {
+					text: qsTr("Filter preferences")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 2
+				}
+				TemplateLabel {
+					text: qsTr("Include notes in full text filtering")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+
+				SsrfSwitch {
+					id: fullTextNotes
+					checked: PrefGeneral.filterFullTextNotes
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						PrefGeneral.filterFullTextNotes = checked
+					}
+				}
+
+				TemplateLabel {
+					text: qsTr("Match filter case sensitive")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+
+				SsrfSwitch {
+					id: filterCaseSensitive
+					checked: PrefGeneral.filterCaseSensitive
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						PrefGeneral.filterCaseSensitive = checked
+					}
 				}
 			}
-
-		}
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
-
-		GridLayout {
-			id: filterPrefs
-			columns: 2
-
-			TemplateLabel {
-				text: qsTr("Filter preferences")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
+			TemplateLine {
+				visible: sectionAdvanced.isExpanded
 			}
-			TemplateLabel {
-				text: qsTr("Include notes in full text filtering")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
+			GridLayout {
+				id: whichBluetoothDevices
+				visible: sectionAdvanced.isExpanded
+				columns: 2
+				TemplateLabel {
+					text: qsTr("Bluetooth")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 2
+				}
 
-			SsrfSwitch {
-				id: fullTextNotes
-				checked: PrefGeneral.filterFullTextNotes
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					PrefGeneral.filterFullTextNotes = checked
+				TemplateLabel {
+					text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+				SsrfSwitch {
+					id: nonDCButton
+					checked: manager.showNonDiveComputers
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						manager.showNonDiveComputers = checked
+					}
 				}
 			}
-
-			TemplateLabel {
-				text: qsTr("Match filter case sensitive")
-				Layout.preferredWidth: gridWidth * 0.75
+			TemplateLine {
+				visible: sectionAdvanced.isExpanded
 			}
+			GridLayout {
+				id: developer
+				visible: sectionAdvanced.isExpanded
+				columns: 2
+				TemplateLabel {
+					text: qsTr("Developer")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 2
+				}
 
-			SsrfSwitch {
-				id: filterCaseSensitive
-				checked: PrefGeneral.filterCaseSensitive
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					PrefGeneral.filterCaseSensitive = checked
+				TemplateLabel {
+					text: qsTr("Display Developer menu")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+				SsrfSwitch {
+					id: developerButton
+					checked: PrefDisplay.show_developer
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						PrefDisplay.show_developer = checked
+					}
 				}
 			}
-
-		}
-
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
-
-		GridLayout {
-			id: whichBluetoothDevices
-			columns: 2
-			TemplateLabel {
-				text: qsTr("Bluetooth")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
-			}
-
-			TemplateLabel {
-				text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
-			SsrfSwitch {
-				id: nonDCButton
-				checked: manager.showNonDiveComputers
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.showNonDiveComputers = checked
-				}
-			}
-		}
-
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
-
-		GridLayout {
-			id: developer
-			columns: 2
-			TemplateLabel {
-				text: qsTr("Developer")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
-			}
-
-			TemplateLabel {
-				text: qsTr("Display Developer menu")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
-			SsrfSwitch {
-				id: developerButton
-				checked: PrefDisplay.show_developer
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					PrefDisplay.show_developer = checked
-				}
-			}
-		}
-		Item {
-			height: Kirigami.Units.gridUnit * 6
 		}
 	}
 }

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -29,26 +29,22 @@ Kirigami.ScrollablePage {
 			id: cloudSetting
 			columns: 3
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Cloud status")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 3
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Email")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.15
-				color: subsurfaceTheme.textColor
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: Backend.cloud_verification_status === Enums.CS_NOCLOUD ? qsTr("Not applicable") : PrefCloudStorage.cloud_storage_email
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.60
-				color: subsurfaceTheme.textColor
 			}
 			SsrfButton {
 				id: changeCloudSettings
@@ -58,19 +54,15 @@ Kirigami.ScrollablePage {
 					manager.startPageText  = qsTr("Starting...");
 				}
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Status")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.15
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
-				color: subsurfaceTheme.textColor
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: describe[Backend.cloud_verification_status]
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.60
 				Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
-				color: subsurfaceTheme.textColor
 			}
 		}
 
@@ -84,19 +76,16 @@ Kirigami.ScrollablePage {
 			id: themeSettings
 			columns: 3
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Theme")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 3
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Blue")
-				font.pointSize: subsurfaceTheme.regularPointSize
-				color: subsurfaceTheme.textColor
 				rightPadding: Kirigami.Units.gridUnit
 				Layout.preferredWidth: gridWidth * 0.15
 			}
@@ -147,13 +136,11 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				id: pinkLabel
 				text: qsTr("Pink")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				rightPadding: Kirigami.Units.gridUnit
 				Layout.preferredWidth: gridWidth * 0.15
-				color: subsurfaceTheme.textColor
 			}
 			Row {
 				Layout.preferredWidth: gridWidth * 0.6
@@ -203,10 +190,8 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Dark")
-				font.pointSize: subsurfaceTheme.regularPointSize
-				color: subsurfaceTheme.textColor
 				rightPadding: Kirigami.Units.gridUnit
 				Layout.preferredWidth: gridWidth * 0.15
 			}
@@ -256,11 +241,10 @@ Kirigami.ScrollablePage {
 					PrefDisplay.theme = subsurfaceTheme.currentTheme
 				}
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Scaling")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 3
@@ -307,21 +291,18 @@ Kirigami.ScrollablePage {
 			id: gpsPrefs
 			columns: 2
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("GPS location service")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Distance threshold (meters)")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 
 			Controls.TextField {
@@ -335,11 +316,9 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Time threshold (minutes)")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 
 			Controls.TextField {
@@ -366,19 +345,16 @@ Kirigami.ScrollablePage {
 			columns: 2
 			Layout.rightMargin: Kirigami.Units.gridUnit * 1.5
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Default Cylinder")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Cylinder:")
-				font.pointSize: subsurfaceTheme.regularPointSize
-				color: subsurfaceTheme.textColor
 			}
 			Controls.ComboBox {
 				id: defaultCylinderBox
@@ -401,20 +377,17 @@ Kirigami.ScrollablePage {
 		GridLayout {
 			id: divecomputers
 			columns: 2
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Dive computers")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing
 				Layout.columnSpan: 2
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Forget remembered dive computers")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 			SsrfButton {
 				id: forgetDCButton
@@ -439,21 +412,18 @@ Kirigami.ScrollablePage {
 		GridLayout {
 			id: unit_system
 			columns: 2
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Units")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Use Imperial Units")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 			SsrfSwitch {
 				id: imperialButton
@@ -466,11 +436,9 @@ Kirigami.ScrollablePage {
 					manager.refreshDiveList()
 				}
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Use Metric Units")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 			SsrfSwitch {
 				id: metricButtton
@@ -495,20 +463,17 @@ Kirigami.ScrollablePage {
 			id: filterPrefs
 			columns: 2
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Filter preferences")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Include notes in full text filtering")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 
 			SsrfSwitch {
@@ -520,11 +485,9 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Match filter case sensitive")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 
 			SsrfSwitch {
@@ -548,21 +511,18 @@ Kirigami.ScrollablePage {
 		GridLayout {
 			id: whichBluetoothDevices
 			columns: 2
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Bluetooth")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 			SsrfSwitch {
 				id: nonDCButton
@@ -584,21 +544,18 @@ Kirigami.ScrollablePage {
 		GridLayout {
 			id: developer
 			columns: 2
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Developer")
 				font.pointSize: subsurfaceTheme.headingPointSize
 				font.weight: Font.Light
-				color: subsurfaceTheme.textColor
 				Layout.topMargin: Kirigami.Units.largeSpacing
 				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 				Layout.columnSpan: 2
 			}
 
-			Controls.Label {
+			TemplateLabel {
 				text: qsTr("Display Developer menu")
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
-				color: subsurfaceTheme.textColor
 			}
 			SsrfSwitch {
 				id: developerButton

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
-import QtQuick 2.6
-import QtQuick.Controls 2.2 as Controls
-import QtQuick.Window 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.2
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
 import org.kde.kirigami 2.4 as Kirigami
 import org.subsurfacedivelog.mobile 1.0
 

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -98,6 +98,38 @@ Kirigami.ScrollablePage {
 					}
 				}
 			}
+			TemplateLine {
+				visible: sectionGeneral.isExpanded
+			}
+			GridLayout {
+				id: divecomputers
+				visible: sectionGeneral.isExpanded
+				columns: 2
+				TemplateLabel {
+					text: qsTr("Dive computers")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing
+					Layout.columnSpan: 2
+				}
+				TemplateLabel {
+					text: qsTr("Forget remembered dive computers")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+				SsrfButton {
+					id: forgetDCButton
+					text: qsTr("Forget")
+					enabled: PrefDiveComputer.vendor1 !== ""
+					onClicked: {
+						PrefDiveComputer.vendor1 = PrefDiveComputer.product1 = PrefDiveComputer.device1 = ""
+						PrefDiveComputer.vendor2 = PrefDiveComputer.product2 = PrefDiveComputer.device2 = ""
+						PrefDiveComputer.vendor3 = PrefDiveComputer.product3 = PrefDiveComputer.device3 = ""
+						PrefDiveComputer.vendor4 = PrefDiveComputer.product4 = PrefDiveComputer.device4 = ""
+						PrefDiveComputer.vendor = PrefDiveComputer.product = PrefDiveComputer.device = ""
+					}
+				}
+			}
 		}
 
 
@@ -365,41 +397,6 @@ Kirigami.ScrollablePage {
 			Layout.fillWidth: true
 		}
 
-		GridLayout {
-			id: divecomputers
-			columns: 2
-			TemplateLabel {
-				text: qsTr("Dive computers")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing
-				Layout.columnSpan: 2
-			}
-			TemplateLabel {
-				text: qsTr("Forget remembered dive computers")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
-			SsrfButton {
-				id: forgetDCButton
-				text: qsTr("Forget")
-				enabled: PrefDiveComputer.vendor1 !== ""
-				onClicked: {
-					PrefDiveComputer.vendor1 = PrefDiveComputer.product1 = PrefDiveComputer.device1 = ""
-					PrefDiveComputer.vendor2 = PrefDiveComputer.product2 = PrefDiveComputer.device2 = ""
-					PrefDiveComputer.vendor3 = PrefDiveComputer.product3 = PrefDiveComputer.device3 = ""
-					PrefDiveComputer.vendor4 = PrefDiveComputer.product4 = PrefDiveComputer.device4 = ""
-					PrefDiveComputer.vendor = PrefDiveComputer.product = PrefDiveComputer.device = ""
-				}
-			}
-		}
-
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
 		GridLayout {
 			id: unit_system
 			columns: 2

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -356,9 +356,8 @@ Kirigami.ScrollablePage {
 			TemplateLabel {
 				text: qsTr("Cylinder:")
 			}
-			Controls.ComboBox {
+			TemplateComboBox {
 				id: defaultCylinderBox
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredHeight: fontMetrics.height * 2.5
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -338,12 +338,48 @@ Kirigami.ScrollablePage {
 			}
 		}
 
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
+		TemplateSection {
+			id: sectionUnits
+			title: qsTr("Units")
+
+			GridLayout {
+				id: unit_system
+				visible: sectionUnits.isExpanded
+				columns: 2
+
+				TemplateLabel {
+					text: qsTr("Use Imperial Units")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+				SsrfSwitch {
+					id: imperialButton
+					checked: PrefUnits.unit_system === "imperial"
+					enabled: PrefUnits.unit_system === "metric"
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						PrefUnits.unit_system = "imperial"
+						manager.changesNeedSaving()
+						manager.refreshDiveList()
+					}
+				}
+				TemplateLabel {
+					text: qsTr("Use Metric Units")
+					Layout.preferredWidth: gridWidth * 0.75
+				}
+				SsrfSwitch {
+					id: metricButtton
+					checked: PrefUnits.unit_system === "metric"
+					enabled: PrefUnits.unit_system === "imperial"
+					Layout.preferredWidth: gridWidth * 0.25
+					onClicked: {
+						PrefUnits.unit_system = "metric"
+						manager.changesNeedSaving()
+						manager.refreshDiveList()
+					}
+				}
+			}
 		}
+
 		GridLayout {
 			id: gpsPrefs
 			columns: 2
@@ -393,56 +429,6 @@ Kirigami.ScrollablePage {
 			Layout.fillWidth: true
 		}
 
-		GridLayout {
-			id: unit_system
-			columns: 2
-			TemplateLabel {
-				text: qsTr("Units")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
-			}
-
-			TemplateLabel {
-				text: qsTr("Use Imperial Units")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
-			SsrfSwitch {
-				id: imperialButton
-				checked: PrefUnits.unit_system === "imperial"
-				enabled: PrefUnits.unit_system === "metric"
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					PrefUnits.unit_system = "imperial"
-					manager.changesNeedSaving()
-					manager.refreshDiveList()
-				}
-			}
-			TemplateLabel {
-				text: qsTr("Use Metric Units")
-				Layout.preferredWidth: gridWidth * 0.75
-			}
-			SsrfSwitch {
-				id: metricButtton
-				checked: PrefUnits.unit_system === "metric"
-				enabled: PrefUnits.unit_system === "imperial"
-				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					PrefUnits.unit_system = "metric"
-					manager.changesNeedSaving()
-					manager.refreshDiveList()
-				}
-			}
-		}
-
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
 		GridLayout {
 			id: filterPrefs
 			columns: 2

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -132,214 +132,210 @@ Kirigami.ScrollablePage {
 			}
 		}
 
+		TemplateSection {
+			id: sectionTheme
+			title: qsTr("Theme")
 
-		GridLayout {
-			id: themeSettings
-			columns: 3
+			GridLayout {
+				id: themeSettings
+				visible: sectionTheme.isExpanded
+				columns: 3
 
-			TemplateLabel {
-				text: qsTr("Theme")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 3
-			}
-			TemplateLabel {
-				text: qsTr("Blue")
-				rightPadding: Kirigami.Units.gridUnit
-				Layout.preferredWidth: gridWidth * 0.15
-			}
-			Row {
-				Layout.preferredWidth: gridWidth * 0.6
-				Rectangle {
-					id: blueRect
-					color: subsurfaceTheme.blueBackgroundColor
-					border.color: "black"
-					width: sampleRegularBlue.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleRegularBlue
-						text: qsTr("regular text")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.blueTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
+				TemplateLabel {
+					text: qsTr("Blue")
+					rightPadding: Kirigami.Units.gridUnit
+					Layout.preferredWidth: gridWidth * 0.15
+				}
+				Row {
+					Layout.preferredWidth: gridWidth * 0.6
+					Rectangle {
+						id: blueRect
+						color: subsurfaceTheme.blueBackgroundColor
+						border.color: "black"
+						width: sampleRegularBlue.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleRegularBlue
+							text: qsTr("regular text")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.blueTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
+						}
+					}
+					Rectangle {
+						color: subsurfaceTheme.bluePrimaryColor
+						border.color: "black"
+						width: sampleHighlightBlue.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleHighlightBlue
+							text: qsTr("Highlight")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.bluePrimaryTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
 						}
 					}
 				}
-				Rectangle {
-					color: subsurfaceTheme.bluePrimaryColor
-					border.color: "black"
-					width: sampleHighlightBlue.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleHighlightBlue
-						text: qsTr("Highlight")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.bluePrimaryTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
-						}
-					}
-				}
-			}
-			SsrfSwitch {
-				id: blueButton
-				Layout.preferredWidth: gridWidth * 0.25
-				checked: subsurfaceTheme.currentTheme === "Blue"
-				enabled: subsurfaceTheme.currentTheme !== "Blue"
-				onClicked: {
-					blueTheme()
-					PrefDisplay.theme = subsurfaceTheme.currentTheme
-				}
-			}
-
-			TemplateLabel {
-				id: pinkLabel
-				text: qsTr("Pink")
-				rightPadding: Kirigami.Units.gridUnit
-				Layout.preferredWidth: gridWidth * 0.15
-			}
-			Row {
-				Layout.preferredWidth: gridWidth * 0.6
-				Rectangle {
-					id: pinkRect
-					color: subsurfaceTheme.pinkBackgroundColor
-					border.color: "black"
-					width: sampleRegularPink.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleRegularPink
-						text: qsTr("regular text")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.pinkTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
-						}
-					}
-				}
-				Rectangle {
-					color: subsurfaceTheme.pinkPrimaryColor
-					border.color: "black"
-					width: sampleHighlightPink.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleHighlightPink
-						text: qsTr("Highlight")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.pinkPrimaryTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
-						}
-					}
-				}
-			}
-
-			SsrfSwitch {
-				id: pinkButton
-				Layout.preferredWidth: gridWidth * 0.25
-				checked: subsurfaceTheme.currentTheme === "Pink"
-				enabled: subsurfaceTheme.currentTheme !== "Pink"
-				onClicked: {
-					pinkTheme()
-					PrefDisplay.theme = subsurfaceTheme.currentTheme
-				}
-			}
-
-			TemplateLabel {
-				text: qsTr("Dark")
-				rightPadding: Kirigami.Units.gridUnit
-				Layout.preferredWidth: gridWidth * 0.15
-			}
-			Row {
-				Layout.preferredWidth: gridWidth * 0.6
-				Rectangle {
-					id: blackRect
-					color: subsurfaceTheme.darkBackgroundColor
-					border.color: "black"
-					width: sampleRegularDark.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleRegularDark
-						text: qsTr("regular text")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.darkTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
-						}
-					}
-				}
-				Rectangle {
-					color: subsurfaceTheme.darkPrimaryColor
-					border.color: "black"
-					width: sampleHighlightDark.width + Kirigami.Units.gridUnit
-					height: Kirigami.Units.gridUnit * 2
-					Text {
-						id: sampleHighlightDark
-						text: qsTr("Highlight")
-						font.pointSize: subsurfaceTheme.regularPointSize
-						color: subsurfaceTheme.darkPrimaryTextColor
-						anchors {
-							horizontalCenter: parent.horizontalCenter
-							verticalCenter: parent.verticalCenter
-						}
-					}
-				}
-			}
-			SsrfSwitch {
-				id: darkButton
-				Layout.preferredWidth: gridWidth * 0.25
-				checked: subsurfaceTheme.currentTheme === "Dark"
-				enabled: subsurfaceTheme.currentTheme !== "Dark"
-				onClicked: {
-					darkTheme()
-					PrefDisplay.theme = subsurfaceTheme.currentTheme
-				}
-			}
-			TemplateLabel {
-				text: qsTr("Scaling")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 3
-			}
-			Row {
-				Layout.preferredWidth: gridWidth * 0.8
-				Layout.columnSpan: 3
-				spacing: Kirigami.Units.largeSpacing
-				SsrfButton {
-					text: qsTr("smaller")
-					enabled: PrefDisplay.mobile_scale !== 0.85
+				SsrfSwitch {
+					id: blueButton
+					Layout.preferredWidth: gridWidth * 0.25
+					checked: subsurfaceTheme.currentTheme === "Blue"
+					enabled: subsurfaceTheme.currentTheme !== "Blue"
 					onClicked: {
-						PrefDisplay.mobile_scale = 0.85
-						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+						blueTheme()
+						PrefDisplay.theme = subsurfaceTheme.currentTheme
 					}
 				}
-				SsrfButton {
-					text: qsTr("regular")
-					enabled: PrefDisplay.mobile_scale !== 1.0
-					onClicked: {
-						PrefDisplay.mobile_scale = 1.0
-						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+
+				TemplateLabel {
+					id: pinkLabel
+					text: qsTr("Pink")
+					rightPadding: Kirigami.Units.gridUnit
+					Layout.preferredWidth: gridWidth * 0.15
+				}
+				Row {
+					Layout.preferredWidth: gridWidth * 0.6
+					Rectangle {
+						id: pinkRect
+						color: subsurfaceTheme.pinkBackgroundColor
+						border.color: "black"
+						width: sampleRegularPink.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleRegularPink
+							text: qsTr("regular text")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.pinkTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
+						}
+					}
+					Rectangle {
+						color: subsurfaceTheme.pinkPrimaryColor
+						border.color: "black"
+						width: sampleHighlightPink.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleHighlightPink
+							text: qsTr("Highlight")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.pinkPrimaryTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
+						}
 					}
 				}
-				SsrfButton {
-					text: qsTr("larger")
-					enabled: PrefDisplay.mobile_scale !== 1.15
+
+				SsrfSwitch {
+					id: pinkButton
+					Layout.preferredWidth: gridWidth * 0.25
+					checked: subsurfaceTheme.currentTheme === "Pink"
+					enabled: subsurfaceTheme.currentTheme !== "Pink"
 					onClicked: {
-						PrefDisplay.mobile_scale = 1.15
-						fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+						pinkTheme()
+						PrefDisplay.theme = subsurfaceTheme.currentTheme
+					}
+				}
+
+				TemplateLabel {
+					text: qsTr("Dark")
+					rightPadding: Kirigami.Units.gridUnit
+					Layout.preferredWidth: gridWidth * 0.15
+				}
+				Row {
+					Layout.preferredWidth: gridWidth * 0.6
+					Rectangle {
+						id: blackRect
+						color: subsurfaceTheme.darkBackgroundColor
+						border.color: "black"
+						width: sampleRegularDark.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleRegularDark
+							text: qsTr("regular text")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.darkTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
+						}
+					}
+					Rectangle {
+						color: subsurfaceTheme.darkPrimaryColor
+						border.color: "black"
+						width: sampleHighlightDark.width + Kirigami.Units.gridUnit
+						height: Kirigami.Units.gridUnit * 2
+						Text {
+							id: sampleHighlightDark
+							text: qsTr("Highlight")
+							font.pointSize: subsurfaceTheme.regularPointSize
+							color: subsurfaceTheme.darkPrimaryTextColor
+							anchors {
+								horizontalCenter: parent.horizontalCenter
+								verticalCenter: parent.verticalCenter
+							}
+						}
+					}
+				}
+				SsrfSwitch {
+					id: darkButton
+					Layout.preferredWidth: gridWidth * 0.25
+					checked: subsurfaceTheme.currentTheme === "Dark"
+					enabled: subsurfaceTheme.currentTheme !== "Dark"
+					onClicked: {
+						darkTheme()
+						PrefDisplay.theme = subsurfaceTheme.currentTheme
+					}
+				}
+				TemplateLabel {
+					text: qsTr("Scaling")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 3
+				}
+				Row {
+					Layout.preferredWidth: gridWidth * 0.8
+					Layout.columnSpan: 3
+					spacing: Kirigami.Units.largeSpacing
+					SsrfButton {
+						text: qsTr("smaller")
+						enabled: subsurfaceTheme.currentScale !== 0.85
+						onClicked: {
+							PrefDisplay.mobile_scale = 0.85
+							fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+						}
+					}
+					SsrfButton {
+						text: qsTr("regular")
+						enabled: subsurfaceTheme.currentScale !== 1.0
+						onClicked: {
+							PrefDisplay.mobile_scale = 1.0
+							fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+						}
+					}
+					SsrfButton {
+						text: qsTr("larger")
+						enabled: subsurfaceTheme.currentScale !== 1.15
+						onClicked: {
+							PrefDisplay.mobile_scale = 1.15
+							fontMetrics.font.pointSize = subsurfaceTheme.basePointSize * PrefDisplay.mobile_scale;
+						}
 					}
 				}
 			}
-
 		}
 
 		Rectangle {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -68,6 +68,36 @@ Kirigami.ScrollablePage {
 					Layout.preferredHeight: Kirigami.Units.gridUnit * 1.5
 				}
 			}
+			TemplateLine {
+				visible: sectionGeneral.isExpanded
+			}
+			GridLayout {
+				id: defaultCylinder
+				visible: sectionGeneral.isExpanded
+				columns: 2
+				Layout.rightMargin: Kirigami.Units.gridUnit * 1.5
+
+				TemplateLabel {
+					text: qsTr("Default Cylinder")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
+					Layout.columnSpan: 2
+				}
+				TemplateLabel {
+					text: qsTr("Cylinder:")
+				}
+				TemplateComboBox {
+					id: defaultCylinderBox
+					Layout.preferredHeight: fontMetrics.height * 2.5
+					inputMethodHints: Qt.ImhNoPredictiveText
+					Layout.fillWidth: true
+					onActivated: {
+						PrefEquipment.default_cylinder = defaultCylinderBox.currentText
+					}
+				}
+			}
 		}
 
 
@@ -327,39 +357,6 @@ Kirigami.ScrollablePage {
 				}
 			}
 
-		}
-		Rectangle {
-			color: subsurfaceTheme.darkerPrimaryColor
-			height: 1
-			opacity: 0.5
-			Layout.fillWidth: true
-		}
-
-		GridLayout {
-			id: defaultCylinder
-			columns: 2
-			Layout.rightMargin: Kirigami.Units.gridUnit * 1.5
-
-			TemplateLabel {
-				text: qsTr("Default Cylinder")
-				font.pointSize: subsurfaceTheme.headingPointSize
-				font.weight: Font.Light
-				Layout.topMargin: Kirigami.Units.largeSpacing
-				Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-				Layout.columnSpan: 2
-			}
-			TemplateLabel {
-				text: qsTr("Cylinder:")
-			}
-			TemplateComboBox {
-				id: defaultCylinderBox
-				Layout.preferredHeight: fontMetrics.height * 2.5
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-				onActivated: {
-					PrefEquipment.default_cylinder = defaultCylinderBox.currentText
-				}
-			}
 		}
 		Rectangle {
 			color: subsurfaceTheme.darkerPrimaryColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -305,12 +305,10 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 
-			Controls.TextField {
+			TemplateTextField {
 				id: distanceThreshold
 				text: PrefLocationService.distance_threshold
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.25
-				color: subsurfaceTheme.textColor
 				onEditingFinished: {
 					PrefLocationService.distance_threshold = distanceThreshold.text
 				}
@@ -321,12 +319,10 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 
-			Controls.TextField {
+			TemplateTextField {
 				id: timeThreshold
 				text: PrefLocationService.time_threshold / 60
-				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.25
-				color: subsurfaceTheme.textColor
 				onEditingFinished: {
 					PrefLocationService.time_threshold = timeThreshold.text * 60
 				}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -20,8 +20,16 @@ Kirigami.ScrollablePage {
 		qsTr("Credentials verified"),
 		qsTr("No cloud mode")]
 
-	ColumnLayout {
+	Column {
 		width: gridWidth
+
+		TemplateSection {
+			id: sectionGeneral
+			title: qsTr("General settings")
+			isExpanded: true
+
+		}
+
 		GridLayout {
 			id: cloudSetting
 			columns: 3

--- a/mobile-widgets/qml/TemplateLine.qml
+++ b/mobile-widgets/qml/TemplateLine.qml
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+
+Rectangle {
+	color: "black"
+	height: 1
+	width: parent.width
+}

--- a/mobile-widgets/qml/TemplateTextField.qml
+++ b/mobile-widgets/qml/TemplateTextField.qml
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+
+TextField {
+	color: subsurfaceTheme.textColor
+	font.pointSize: subsurfaceTheme.regularPointSize
+}
+

--- a/mobile-widgets/qml/TemplateTitle.qml
+++ b/mobile-widgets/qml/TemplateTitle.qml
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+
+
+Item {
+	property alias title: myLabel.text
+	width: parent.width
+	height: myLabel.height + 1
+
+	Label {
+		id: myLabel
+		color: subsurfaceTheme.textColor
+		font.pointSize: subsurfaceTheme.titlePointSize
+		font.bold: true
+		anchors.horizontalCenter: parent.horizontalCenter
+		text: "using the TemplateTilte you need to set the title text"
+	}
+	TemplateLine {
+		anchors.top: myLabel.bottom
+		anchors.left: parent.left
+		anchors.right: parent.right
+	}
+}
+

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -4,6 +4,7 @@
 		<file>TemplateCheckBox.qml</file>
 		<file>TemplateComboBox.qml</file>
 		<file>TemplateLabel.qml</file>
+		<file>TemplateLine.qml</file>
 		<file>TemplateRadioButton.qml</file>
 		<file>TemplateSection.qml</file>
 		<file>TemplateSpinBox.qml</file>

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -7,6 +7,7 @@
 		<file>TemplateRadioButton.qml</file>
 		<file>TemplateSection.qml</file>
 		<file>TemplateSpinBox.qml</file>
+		<file>TemplateTextField.qml</file>
 
 		<!-- ********** qml ********** -->
 		<file>About.qml</file>

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -9,6 +9,7 @@
 		<file>TemplateSection.qml</file>
 		<file>TemplateSpinBox.qml</file>
 		<file>TemplateTextField.qml</file>
+		<file>TemplateTitle.qml</file>
 
 		<!-- ********** qml ********** -->
 		<file>About.qml</file>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR changes settings.qml to use sections, this allows much more real estate for each
part, and thus more information is possible.

See image of how settings look when first opened
<img width="411" alt="initialSettings" src="https://user-images.githubusercontent.com/6185391/72462537-91153480-37d1-11ea-964d-0bca115c6a39.png">

And when opening e.g. Theme:
<img width="411" alt="openTheme" src="https://user-images.githubusercontent.com/6185391/72462556-9bcfc980-37d1-11ea-8e9f-51e52b152782.png">

In one of the next PRs. Units will be expanded to allow "personalised" as in the desktop version.

In one of the next PRs. Theme will be expanded to allow user selected colours as well as day/night shift.

Which feature belong in which section is surely something, that can be talked about for a long time, and I have no problem moving features around.

The medium term plan is to make nearly all settings from the desktop available.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
commit 1: merge of planner 1-4 this needs to be removed
commit 2-4: new templates
commit 5: bump versions in settings to reflect qt5.12 in lower limit
remains: integrate TemplateSections


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
