### PR TITLE
Bugfix: several Pref* registration was registered to wrong object.

### DIFF
--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -67,10 +67,10 @@ void qPref::registerQML(QQmlEngine *engine)
 		ct->setContextProperty("PrefTechnicalDetails", qPrefTechnicalDetails::instance());
 		ct->setContextProperty("PrefUnits", qPrefUnits::instance());
 		ct->setContextProperty("PrefUpdateManager", qPrefUpdateManager::instance());
-		ct->setContextProperty("PrefEquipment", qPrefUpdateManager::instance());
-		ct->setContextProperty("PrefMedia", qPrefUpdateManager::instance());
+		ct->setContextProperty("PrefEquipment", qPrefEquipment::instance());
+		ct->setContextProperty("PrefMedia", qPrefMedia::instance());
 		ct->setContextProperty("PrefClearDc", qPrefUpdateManager::instance());
-		ct->setContextProperty("PrefLog", qPrefUpdateManager::instance());
+		ct->setContextProperty("PrefLog", qPrefLog::instance());
 	}
 
 	// Register special types

--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -69,7 +69,6 @@ void qPref::registerQML(QQmlEngine *engine)
 		ct->setContextProperty("PrefUpdateManager", qPrefUpdateManager::instance());
 		ct->setContextProperty("PrefEquipment", qPrefEquipment::instance());
 		ct->setContextProperty("PrefMedia", qPrefMedia::instance());
-		ct->setContextProperty("PrefClearDc", qPrefUpdateManager::instance());
 		ct->setContextProperty("PrefLog", qPrefLog::instance());
 	}
 

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -387,7 +387,7 @@ Kirigami.ScrollablePage {
 				inputMethodHints: Qt.ImhNoPredictiveText
 				Layout.fillWidth: true
 				onActivated: {
-					PrefGeneral.default_cylinder = defaultCylinderBox.currentText
+					PrefEquipment.default_cylinder = defaultCylinderBox.currentText
 				}
 			}
 		}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -150,7 +150,7 @@ Kirigami.ApplicationWindow {
 		detailsWindow.cylinderModel2 = manager.cylinderInit
 		detailsWindow.cylinderModel3 = manager.cylinderInit
 		detailsWindow.cylinderModel4 = manager.cylinderInit
-		detailsWindow.cylinderIndex0 = PrefGeneral.default_cylinder == "" ? -1 : detailsWindow.cylinderModel0.indexOf(PrefGeneral.default_cylinder)
+		detailsWindow.cylinderIndex0 = PrefEquipment.default_cylinder == "" ? -1 : detailsWindow.cylinderModel0.indexOf(PrefEquipment.default_cylinder)
 		detailsWindow.usedCyl = ["",]
 		detailsWindow.weight = ""
 		detailsWindow.usedGas = []
@@ -412,7 +412,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				onTriggered: {
 					globalDrawer.close()
 					settingsWindow.defaultCylinderModel = manager.cylinderInit
-					PrefGeneral.default_cylinder === "" ? defaultCylinderIndex = "-1" : defaultCylinderIndex = settingsWindow.defaultCylinderModel.indexOf(PrefGeneral.default_cylinder)
+					PrefEquipment.default_cylinder === "" ? defaultCylinderIndex = "-1" : defaultCylinderIndex = settingsWindow.defaultCylinderModel.indexOf(PrefEquipment.default_cylinder)
 					pageStack.push(settingsWindow)
 					detailsWindow.endEditMode()
 				}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
qPref::registerQML contained, what posible is a paste error:
PrefEquipment, PrefMedia, PrefLog
was all registered to the object qPrefUpdateManager, which surely is wrong.

PrefClearDc was also registered to qPrefUpdateManager but unused.

Settings.qml and main.qml also referenced PrefGeneral.default_cylinder, changed to
PrefEquipment.default_cylinder.

I hope this change is correct (at least the functions work better), because it seems strange not to have been catched in testing or review.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
