### PR TITLE
(1) last part of foundation (making qPrefUnit look "normal").

### DIFF
--- a/core/settings/qPref.cpp
+++ b/core/settings/qPref.cpp
@@ -49,6 +49,15 @@ void qPref::loadSync(bool doSync)
 Q_DECLARE_METATYPE(deco_mode);
 Q_DECLARE_METATYPE(def_file_behavior);
 Q_DECLARE_METATYPE(taxonomy_category);
+Q_DECLARE_METATYPE(units::DURATION);
+Q_DECLARE_METATYPE(units::LENGTH);
+Q_DECLARE_METATYPE(units::PRESSURE);
+Q_DECLARE_METATYPE(units::TEMPERATURE);
+Q_DECLARE_METATYPE(unit_system_values);
+Q_DECLARE_METATYPE(units::TIME);
+Q_DECLARE_METATYPE(units::VOLUME);
+Q_DECLARE_METATYPE(units::WEIGHT);
+
 void qPref::registerQML(QQmlEngine *engine)
 {
 	if (engine) {
@@ -77,4 +86,12 @@ void qPref::registerQML(QQmlEngine *engine)
 	qRegisterMetaType<deco_mode>();
 	qRegisterMetaType<def_file_behavior>();
 	qRegisterMetaType<taxonomy_category>();
+	qRegisterMetaType<units::DURATION>();
+	qRegisterMetaType<units::LENGTH>();
+	qRegisterMetaType<units::PRESSURE>();
+	qRegisterMetaType<units::TEMPERATURE>();
+	qRegisterMetaType<unit_system_values>();
+	qRegisterMetaType<units::TIME>();
+	qRegisterMetaType<units::VOLUME>();
+	qRegisterMetaType<units::WEIGHT>();
 }

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -28,19 +28,6 @@ void qPrefUnits::loadSync(bool doSync)
 
 HANDLE_PREFERENCE_BOOL(Units, "coordinates", coordinates_traditional);
 
-QString qPrefUnits::duration_units()
-{
-	return 	prefs.units.duration_units == units::DURATION::ALWAYS_HOURS ? QStringLiteral("hours") :
-									      prefs.units.duration_units == units::DURATION::MINUTES_ONLY ? QStringLiteral("minutes") :
-																	    QStringLiteral("mixed");
-}
-void qPrefUnits::set_duration_units(const QString& value)
-{
-	set_duration_units(value == QStringLiteral("hours") ?  units::DURATION::ALWAYS_HOURS :
-							       value == QStringLiteral("minutes")? units::DURATION::MINUTES_ONLY :
-												   units::DURATION::MIXED);
-	emit instance()->duration_unitsStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::DURATION, duration_units, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "duration_units", units::DURATION, duration_units, units.);
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -75,15 +75,6 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 }
 DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 
-QString qPrefUnits::vertical_speed_time()
-{
-	return 	prefs.units.vertical_speed_time == units::TIME::MINUTES ? QStringLiteral("minutes") : QStringLiteral("seconds");
-}
-void qPrefUnits::set_vertical_speed_time(const QString& value)
-{
-	set_vertical_speed_time(value == QStringLiteral("minutes") ? units::TIME::MINUTES : units::TIME::SECONDS);
-	emit instance()->vertical_speed_timeStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::TIME, vertical_speed_time, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "vertical_speed_time", units::TIME, vertical_speed_time, units.);
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -69,8 +69,6 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 		// because it sets all of prefs.units without calling the
 		// setters
 		prefs.units = IMPERIAL_units;
-	} else {
-		prefs.unit_system = PERSONALIZE;
 	}
 	disk_unit_system(true);
 	emit instance()->unit_systemChanged(value);

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -39,15 +39,6 @@ DISK_LOADSYNC_ENUM_EXT(Units, "pressure", units::PRESSURE, pressure, units.);
 
 HANDLE_PREFERENCE_BOOL_EXT(Units, "show_units_table", show_units_table, units.);
 
-QString qPrefUnits::temperature()
-{
-	return 	prefs.units.temperature == units::TEMPERATURE::CELSIUS ? QStringLiteral("celcius") : QStringLiteral("fahrenheit");
-}
-void qPrefUnits::set_temperature(const QString& value)
-{
-	set_temperature(value == QStringLiteral("celcius") ? units::TEMPERATURE::CELSIUS : units::TEMPERATURE::FAHRENHEIT);
-	emit instance()->temperatureStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, temperature, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "temperature", units::TEMPERATURE, temperature, units.);
 
@@ -81,10 +72,6 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 	emit instance()->volumeStringChanged(volume());
 	emit instance()->weightChanged(prefs.units.weight);
 	emit instance()->weightStringChanged(weight());
-	emit instance()->lengthChanged(prefs.units.length);
-	emit instance()->lengthStringChanged(length());
-	emit instance()->temperatureChanged(prefs.units.temperature);
-	emit instance()->temperatureStringChanged(temperature());
 }
 DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -68,36 +68,14 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 	}
 	disk_unit_system(true);
 	emit instance()->unit_systemChanged(value);
-	emit instance()->volumeChanged(prefs.units.volume);
-	emit instance()->volumeStringChanged(volume());
-	emit instance()->weightChanged(prefs.units.weight);
-	emit instance()->weightStringChanged(weight());
 }
 DISK_LOADSYNC_ENUM(Units, "unit_system", unit_system_values, unit_system);
 
 SET_PREFERENCE_ENUM_EXT(Units, units::TIME, vertical_speed_time, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "vertical_speed_time", units::TIME, vertical_speed_time, units.);
 
-QString qPrefUnits::volume()
-{
-	return 	prefs.units.volume == units::VOLUME::LITER ? QStringLiteral("liter") : QStringLiteral("cuft");
-}
-void qPrefUnits::set_volume(const QString& value)
-{
-	set_volume(value == QStringLiteral("liter") ? units::VOLUME::LITER : units::VOLUME::CUFT);
-	emit instance()->volumeStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::VOLUME, volume, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "volume", units::VOLUME, volume, units.);
 
-QString qPrefUnits::weight()
-{
-	return 	prefs.units.weight == units::WEIGHT::KG ? QStringLiteral("kg") : QStringLiteral("lbs");
-}
-void qPrefUnits::set_weight(const QString& value)
-{
-	set_weight(value == QStringLiteral("kg") ? units::WEIGHT::KG : units::WEIGHT::LBS);
-	emit instance()->weightStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::WEIGHT, weight, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "weight", units::WEIGHT, weight, units.);

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -46,23 +46,29 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 {
 	prefs.unit_system = value;
 	if (prefs.unit_system == METRIC) {
-		prefs.units = SI_units;
-
 		// make sure all types are updated when changing
 		set_volume(units::VOLUME::LITER);
 		set_weight(units::WEIGHT::KG);
 		set_length(units::LENGTH::METERS);
 		set_pressure(units::PRESSURE::BAR);
 		set_temperature(units::TEMPERATURE::CELSIUS);
-	} else if (prefs.unit_system == IMPERIAL) {
-		prefs.units = IMPERIAL_units;
 
+		// this statement need to be AFTER the setters are called
+		// because it sets all of prefs.units without calling the
+		// setters
+		prefs.units = SI_units;
+	} else if (prefs.unit_system == IMPERIAL) {
 		// make sure all types are updated when changing
 		set_volume(units::VOLUME::CUFT);
 		set_weight(units::WEIGHT::LBS);
 		set_length(units::LENGTH::FEET);
 		set_pressure(units::PRESSURE::PSI);
 		set_temperature(units::TEMPERATURE::FAHRENHEIT);
+
+		// this statement need to be AFTER the setters are called
+		// because it sets all of prefs.units without calling the
+		// setters
+		prefs.units = IMPERIAL_units;
 	} else {
 		prefs.unit_system = PERSONALIZE;
 	}

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -31,15 +31,6 @@ HANDLE_PREFERENCE_BOOL(Units, "coordinates", coordinates_traditional);
 SET_PREFERENCE_ENUM_EXT(Units, units::DURATION, duration_units, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "duration_units", units::DURATION, duration_units, units.);
 
-QString qPrefUnits::length()
-{
-	return 	prefs.units.length == units::LENGTH::METERS ? QStringLiteral("meters") : QStringLiteral("feet");
-}
-void qPrefUnits::set_length(const QString& value)
-{
-	set_length(value == QStringLiteral("meters") ? units::LENGTH::METERS : units::LENGTH::FEET);
-	emit instance()->lengthStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::LENGTH, length, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "length", units::LENGTH, length, units.);
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -34,15 +34,6 @@ DISK_LOADSYNC_ENUM_EXT(Units, "duration_units", units::DURATION, duration_units,
 SET_PREFERENCE_ENUM_EXT(Units, units::LENGTH, length, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "length", units::LENGTH, length, units.);
 
-QString qPrefUnits::pressure()
-{
-	return 	prefs.units.pressure == units::PRESSURE::BAR ? QStringLiteral("bar") : QStringLiteral("psi");
-}
-void qPrefUnits::set_pressure(const QString& value)
-{
-	set_pressure(value == QStringLiteral("bar") ? units::PRESSURE::BAR : units::PRESSURE::PSI);
-	emit instance()->pressureStringChanged(value);
-}
 SET_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, pressure, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "pressure", units::PRESSURE, pressure, units.);
 

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -82,21 +82,10 @@ void qPrefUnits::set_temperature(const QString& value)
 SET_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, temperature, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "temperature", units::TEMPERATURE, temperature, units.);
 
-QString qPrefUnits::unit_system()
-{
-	return 	prefs.unit_system == METRIC ? QStringLiteral("metric") :
-					      prefs.unit_system == IMPERIAL ? QStringLiteral("imperial") :
-									      QStringLiteral("personalized");
-}
-void qPrefUnits::set_unit_system(const QString& value)
-{
-	set_unit_system(value == QStringLiteral("metric") ? METRIC : value == QStringLiteral("imperial")? IMPERIAL : PERSONALIZE);
-	emit instance()->unit_systemStringChanged(value);
-}
 void qPrefUnits::set_unit_system(unit_system_values value)
 {
-	if (value == METRIC) {
-		prefs.unit_system = METRIC;
+	prefs.unit_system = value;
+	if (prefs.unit_system == METRIC) {
 		prefs.units = SI_units;
 
 		// make sure all types are updated when changing
@@ -105,8 +94,7 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 		set_length(units::LENGTH::METERS);
 		set_pressure(units::PRESSURE::BAR);
 		set_temperature(units::TEMPERATURE::CELSIUS);
-	} else if (value == IMPERIAL) {
-		prefs.unit_system = IMPERIAL;
+	} else if (prefs.unit_system == IMPERIAL) {
 		prefs.units = IMPERIAL_units;
 
 		// make sure all types are updated when changing
@@ -120,7 +108,6 @@ void qPrefUnits::set_unit_system(unit_system_values value)
 	}
 	disk_unit_system(true);
 	emit instance()->unit_systemChanged(value);
-	emit instance()->unit_systemStringChanged(unit_system());
 	emit instance()->volumeChanged(prefs.units.volume);
 	emit instance()->volumeStringChanged(volume());
 	emit instance()->weightChanged(prefs.units.weight);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -10,8 +10,6 @@ class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
-	Q_PROPERTY(QString volume READ volume WRITE set_volume NOTIFY volumeStringChanged)
-	Q_PROPERTY(QString weight READ weight WRITE set_weight NOTIFY weightStringChanged)
 
 public:
 	static qPrefUnits *instance();
@@ -30,8 +28,8 @@ public:
 	static unit_system_values unit_system() { return prefs.unit_system; }
 	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
 	static units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
-	static QString volume();
-	static QString weight();
+	static units::VOLUME volume() { return prefs.units.volume; }
+	static units::WEIGHT weight() { return prefs.units.weight; }
 
 public slots:
 	static void set_coordinates_traditional(bool value);
@@ -43,9 +41,7 @@ public slots:
 	static void set_unit_system(unit_system_values value);
 	static void set_vertical_speed_time(units::TIME value);
 	static void set_volume(units::VOLUME value);
-	static void set_volume(const QString& value);
 	static void set_weight(units::WEIGHT value);
-	static void set_weight(const QString& value);
 
 signals:
 	void coordinates_traditionalChanged(bool value);
@@ -56,10 +52,9 @@ signals:
 	void temperatureChanged(units::TEMPERATURE value);
 	void unit_systemChanged(unit_system_values value);
 	void vertical_speed_timeChanged(units::TIME value);
-	void volumeChanged(int value);
-	void volumeStringChanged(const QString& value);
-	void weightChanged(int value);
-	void weightStringChanged(const QString& value);
+	void volumeChanged(units::VOLUME value);
+	void weightChanged(units::WEIGHT value);
+
 private:
 	qPrefUnits() {}
 

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -10,7 +10,6 @@ class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
-	Q_PROPERTY(QString temperature READ temperature WRITE set_temperature NOTIFY temperatureStringChanged)
 	Q_PROPERTY(QString vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeStringChanged)
 	Q_PROPERTY(QString volume READ volume WRITE set_volume NOTIFY volumeStringChanged)
 	Q_PROPERTY(QString weight READ weight WRITE set_weight NOTIFY weightStringChanged)
@@ -29,8 +28,8 @@ public:
 	static units::LENGTH length() { return prefs.units.length; }
 	static units::PRESSURE pressure() { return prefs.units.pressure; }
 	static bool show_units_table() { return prefs.units.show_units_table; }
-	static QString temperature();
 	static unit_system_values unit_system() { return prefs.unit_system; }
+	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
 	static QString vertical_speed_time();
 	static QString volume();
 	static QString weight();
@@ -42,7 +41,6 @@ public slots:
 	static void set_pressure(units::PRESSURE value);
 	static void set_show_units_table(bool value);
 	static void set_temperature(units::TEMPERATURE value);
-	static void set_temperature(const QString& value);
 	static void set_unit_system(unit_system_values value);
 	static void set_vertical_speed_time(units::TIME value);
 	static void set_vertical_speed_time(const QString& value);
@@ -57,8 +55,7 @@ signals:
 	void lengthChanged(units::LENGTH value);
 	void pressureChanged(units::PRESSURE value);
 	void show_units_tableChanged(bool value);
-	void temperatureChanged(int value);
-	void temperatureStringChanged(const QString& value);
+	void temperatureChanged(units::TEMPERATURE value);
 	void unit_systemChanged(unit_system_values value);
 	void vertical_speed_timeChanged(int value);
 	void vertical_speed_timeStringChanged(const QString& value);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -9,7 +9,6 @@
 class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
-	Q_PROPERTY(QString length READ length WRITE set_length NOTIFY lengthStringChanged)
 	Q_PROPERTY(QString pressure READ pressure WRITE set_pressure NOTIFY pressureStringChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
 	Q_PROPERTY(QString temperature READ temperature WRITE set_temperature NOTIFY temperatureStringChanged)
@@ -28,7 +27,7 @@ public:
 public:
 	static bool coordinates_traditional() { return prefs.coordinates_traditional; }
 	static units::DURATION duration_units() { return prefs.units.duration_units; }
-	static QString length();
+	static units::LENGTH length() { return prefs.units.length; }
 	static QString pressure();
 	static bool show_units_table() { return prefs.units.show_units_table; }
 	static QString temperature();
@@ -41,7 +40,6 @@ public slots:
 	static void set_coordinates_traditional(bool value);
 	static void set_duration_units(units::DURATION value);
 	static void set_length(units::LENGTH value);
-	static void set_length(const QString& value);
 	static void set_pressure(units::PRESSURE value);
 	static void set_pressure(const QString& value);
 	static void set_show_units_table(bool value);
@@ -58,8 +56,7 @@ public slots:
 signals:
 	void coordinates_traditionalChanged(bool value);
 	void duration_unitsChanged(units::DURATION value);
-	void lengthChanged(int value);
-	void lengthStringChanged(const QString& value);
+	void lengthChanged(units::LENGTH value);
 	void pressureChanged(int value);
 	void pressureStringChanged(const QString& value);
 	void show_units_tableChanged(bool value);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -10,7 +10,6 @@ class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
-	Q_PROPERTY(QString vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeStringChanged)
 	Q_PROPERTY(QString volume READ volume WRITE set_volume NOTIFY volumeStringChanged)
 	Q_PROPERTY(QString weight READ weight WRITE set_weight NOTIFY weightStringChanged)
 
@@ -30,7 +29,7 @@ public:
 	static bool show_units_table() { return prefs.units.show_units_table; }
 	static unit_system_values unit_system() { return prefs.unit_system; }
 	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
-	static QString vertical_speed_time();
+	static units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
 	static QString volume();
 	static QString weight();
 
@@ -43,7 +42,6 @@ public slots:
 	static void set_temperature(units::TEMPERATURE value);
 	static void set_unit_system(unit_system_values value);
 	static void set_vertical_speed_time(units::TIME value);
-	static void set_vertical_speed_time(const QString& value);
 	static void set_volume(units::VOLUME value);
 	static void set_volume(const QString& value);
 	static void set_weight(units::WEIGHT value);
@@ -57,8 +55,7 @@ signals:
 	void show_units_tableChanged(bool value);
 	void temperatureChanged(units::TEMPERATURE value);
 	void unit_systemChanged(unit_system_values value);
-	void vertical_speed_timeChanged(int value);
-	void vertical_speed_timeStringChanged(const QString& value);
+	void vertical_speed_timeChanged(units::TIME value);
 	void volumeChanged(int value);
 	void volumeStringChanged(const QString& value);
 	void weightChanged(int value);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -9,7 +9,6 @@
 class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
-	Q_PROPERTY(QString pressure READ pressure WRITE set_pressure NOTIFY pressureStringChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
 	Q_PROPERTY(QString temperature READ temperature WRITE set_temperature NOTIFY temperatureStringChanged)
 	Q_PROPERTY(QString vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeStringChanged)
@@ -28,7 +27,7 @@ public:
 	static bool coordinates_traditional() { return prefs.coordinates_traditional; }
 	static units::DURATION duration_units() { return prefs.units.duration_units; }
 	static units::LENGTH length() { return prefs.units.length; }
-	static QString pressure();
+	static units::PRESSURE pressure() { return prefs.units.pressure; }
 	static bool show_units_table() { return prefs.units.show_units_table; }
 	static QString temperature();
 	static unit_system_values unit_system() { return prefs.unit_system; }
@@ -41,7 +40,6 @@ public slots:
 	static void set_duration_units(units::DURATION value);
 	static void set_length(units::LENGTH value);
 	static void set_pressure(units::PRESSURE value);
-	static void set_pressure(const QString& value);
 	static void set_show_units_table(bool value);
 	static void set_temperature(units::TEMPERATURE value);
 	static void set_temperature(const QString& value);
@@ -57,8 +55,7 @@ signals:
 	void coordinates_traditionalChanged(bool value);
 	void duration_unitsChanged(units::DURATION value);
 	void lengthChanged(units::LENGTH value);
-	void pressureChanged(int value);
-	void pressureStringChanged(const QString& value);
+	void pressureChanged(units::PRESSURE value);
 	void show_units_tableChanged(bool value);
 	void temperatureChanged(int value);
 	void temperatureStringChanged(const QString& value);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -14,7 +14,6 @@ class qPrefUnits : public QObject {
 	Q_PROPERTY(QString pressure READ pressure WRITE set_pressure NOTIFY pressureStringChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
 	Q_PROPERTY(QString temperature READ temperature WRITE set_temperature NOTIFY temperatureStringChanged)
-	Q_PROPERTY(QString unit_system READ unit_system WRITE set_unit_system NOTIFY unit_systemStringChanged)
 	Q_PROPERTY(QString vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeStringChanged)
 	Q_PROPERTY(QString volume READ volume WRITE set_volume NOTIFY volumeStringChanged)
 	Q_PROPERTY(QString weight READ weight WRITE set_weight NOTIFY weightStringChanged)
@@ -34,7 +33,7 @@ public:
 	static QString pressure();
 	static bool show_units_table() { return prefs.units.show_units_table; }
 	static QString temperature();
-	static QString unit_system();
+	static unit_system_values unit_system() { return prefs.unit_system; }
 	static QString vertical_speed_time();
 	static QString volume();
 	static QString weight();
@@ -51,7 +50,6 @@ public slots:
 	static void set_temperature(units::TEMPERATURE value);
 	static void set_temperature(const QString& value);
 	static void set_unit_system(unit_system_values value);
-	static void set_unit_system(const QString& value);
 	static void set_vertical_speed_time(units::TIME value);
 	static void set_vertical_speed_time(const QString& value);
 	static void set_volume(units::VOLUME value);
@@ -60,14 +58,6 @@ public slots:
 	static void set_weight(const QString& value);
 
 signals:
-	// Normally the same signal name are used with different parameters:
-	// void weightChanged(int value);
-	// void weightChanged(const QString& value);
-	// This works perfect, however connect() cannot automatically determine
-	// which signal to catch, for that purpose SIGNAL() / SLOT() macros are used,
-	// since they include the parameter type.
-	// However there is a design decision, not to use the macros, so
-	// signal must have unique names.
 	void coordinates_traditionalChanged(bool value);
 	void duration_unitsChanged(int value);
 	void duration_unitsStringChanged(const QString& value);
@@ -78,8 +68,7 @@ signals:
 	void show_units_tableChanged(bool value);
 	void temperatureChanged(int value);
 	void temperatureStringChanged(const QString& value);
-	void unit_systemChanged(int value);
-	void unit_systemStringChanged(const QString& value);
+	void unit_systemChanged(unit_system_values value);
 	void vertical_speed_timeChanged(int value);
 	void vertical_speed_timeStringChanged(const QString& value);
 	void volumeChanged(int value);
@@ -100,5 +89,4 @@ private:
 	static void disk_volume(bool doSync);
 	static void disk_weight(bool doSync);
 };
-
 #endif

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -9,7 +9,6 @@
 class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
-	Q_PROPERTY(QString duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsStringChanged)
 	Q_PROPERTY(QString length READ length WRITE set_length NOTIFY lengthStringChanged)
 	Q_PROPERTY(QString pressure READ pressure WRITE set_pressure NOTIFY pressureStringChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
@@ -28,7 +27,7 @@ public:
 
 public:
 	static bool coordinates_traditional() { return prefs.coordinates_traditional; }
-	static QString duration_units();
+	static units::DURATION duration_units() { return prefs.units.duration_units; }
 	static QString length();
 	static QString pressure();
 	static bool show_units_table() { return prefs.units.show_units_table; }
@@ -41,7 +40,6 @@ public:
 public slots:
 	static void set_coordinates_traditional(bool value);
 	static void set_duration_units(units::DURATION value);
-	static void set_duration_units(const QString& value);
 	static void set_length(units::LENGTH value);
 	static void set_length(const QString& value);
 	static void set_pressure(units::PRESSURE value);
@@ -59,8 +57,7 @@ public slots:
 
 signals:
 	void coordinates_traditionalChanged(bool value);
-	void duration_unitsChanged(int value);
-	void duration_unitsStringChanged(const QString& value);
+	void duration_unitsChanged(units::DURATION value);
 	void lengthChanged(int value);
 	void lengthStringChanged(const QString& value);
 	void pressureChanged(int value);

--- a/desktop-widgets/preferences/preferences_units.cpp
+++ b/desktop-widgets/preferences/preferences_units.cpp
@@ -50,7 +50,7 @@ void PreferencesUnits::syncSettings()
 	QString unitSystem[] = {"metric", "imperial", "personal"};
 	short unitValue = ui->metric->isChecked() ? METRIC : (ui->imperial->isChecked() ? IMPERIAL : PERSONALIZE);
 
-	qPrefUnits::set_unit_system(unitSystem[unitValue]);
+	qPrefUnits::set_unit_system((unit_system_values)unitValue);
 	qPrefUnits::set_temperature(ui->fahrenheit->isChecked() ? units::FAHRENHEIT : units::CELSIUS);
 	qPrefUnits::set_length(ui->feet->isChecked() ? units::FEET : units::METERS);
 	qPrefUnits::set_pressure(ui->psi->isChecked() ? units::PSI : units::BAR);

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -10,9 +10,9 @@ import org.kde.kirigami 2.4 as Kirigami
 Kirigami.ScrollablePage {
 	title: qsTr("Dive planner setup")
 
-	property string speedUnit: (PrefUnits.length === "meters") ? qsTr("m/min") : qsTr("ft/min")
+	property string speedUnit: (Backend.length === Enums.METERS) ? qsTr("m/min") : qsTr("ft/min")
 	Connections {
-		target: PrefUnits
+		target: Backend
 		onLengthChanged: {
 			spinAscrate75.value = Planner.ascrate75
 			spinAscrate50.value = Planner.ascrate50

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -353,11 +353,11 @@ Kirigami.ScrollablePage {
 				}
 				SsrfSwitch {
 					id: imperialButton
-					checked: PrefUnits.unit_system === "imperial"
-					enabled: PrefUnits.unit_system === "metric"
+					checked: Backend.unit_system === Enums.IMPERIAL
+					enabled: Backend.unit_system === Enums.METRIC
 					Layout.preferredWidth: gridWidth * 0.25
 					onClicked: {
-						PrefUnits.unit_system = "imperial"
+						Backend.unit_system = Enums.IMPERIAL
 						manager.changesNeedSaving()
 						manager.refreshDiveList()
 					}
@@ -368,11 +368,11 @@ Kirigami.ScrollablePage {
 				}
 				SsrfSwitch {
 					id: metricButtton
-					checked: PrefUnits.unit_system === "metric"
-					enabled: PrefUnits.unit_system === "imperial"
+					checked: Backend.unit_system === Enums.METRIC
+					enabled: Backend.unit_system === Enums.IMPERIAL
 					Layout.preferredWidth: gridWidth * 0.25
 					onClicked: {
-						PrefUnits.unit_system = "metric"
+						Backend.unit_system = Enums.METRIC
 						manager.changesNeedSaving()
 						manager.refreshDiveList()
 					}

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -20,4 +20,20 @@ void QMLInterface::setup(QQmlContext *ct)
 	// relink signals to QML
 	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
 		[=] (int value) { emit instance()->cloud_verification_statusChanged(CLOUD_STATUS(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
+			[=] (int value) { emit instance()->duration_unitsChanged(DURATION(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
+			[=] (int value) { emit instance()->lengthChanged(LENGTH(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::pressureChanged,
+			[=] (int value) { emit instance()->pressureChanged(PRESSURE(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
+			[=] (int value) { emit instance()->temperatureChanged(TEMPERATURE(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
+			[=] (int value) { emit instance()->unit_systemChanged(UNIT_SYSTEM(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::vertical_speed_timeChanged,
+			[=] (int value) { emit instance()->vertical_speed_timeChanged(TIME(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::volumeChanged,
+			[=] (int value) { emit instance()->volumeChanged(VOLUME(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::weightChanged,
+			[=] (int value) { emit instance()->weightChanged(WEIGHT(value)); });
 }

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -2,6 +2,7 @@
 #ifndef QMLINTERFACE_H
 #define QMLINTERFACE_H
 #include "core/settings/qPrefCloudStorage.h"
+#include "core/settings/qPrefUnit.h"
 
 #include <QObject>
 #include <QQmlContext>
@@ -25,6 +26,14 @@ class QMLInterface : public QObject {
 
 	// Q_PROPERTY used in QML
 	Q_PROPERTY(CLOUD_STATUS cloud_verification_status READ cloud_verification_status WRITE set_cloud_verification_status NOTIFY cloud_verification_statusChanged)
+	Q_PROPERTY(DURATION duration_units READ duration_units WRITE set_duration_units NOTIFY duration_unitsChanged)
+	Q_PROPERTY(LENGTH length READ length WRITE set_length NOTIFY lengthChanged)
+	Q_PROPERTY(PRESSURE pressure READ pressure WRITE set_pressure NOTIFY pressureChanged)
+	Q_PROPERTY(TEMPERATURE temperature READ temperature WRITE set_temperature NOTIFY temperatureChanged)
+	Q_PROPERTY(UNIT_SYSTEM unit_system READ unit_system WRITE set_unit_system NOTIFY unit_systemChanged)
+	Q_PROPERTY(TIME vertical_speed_time READ vertical_speed_time WRITE set_vertical_speed_time NOTIFY vertical_speed_timeChanged)
+	Q_PROPERTY(VOLUME volume READ volume WRITE set_volume NOTIFY volumeChanged)
+	Q_PROPERTY(WEIGHT weight READ weight WRITE set_weight NOTIFY weightChanged)
 
 public:
 	static QMLInterface *instance();
@@ -102,12 +111,36 @@ public:
 
 public:
 	CLOUD_STATUS cloud_verification_status() { return (CLOUD_STATUS)prefs.cloud_verification_status; }
+	DURATION duration_units() { return (DURATION)prefs.units.duration_units; }
+	LENGTH length() { return (LENGTH)prefs.units.length; }
+	PRESSURE pressure() { return (PRESSURE)prefs.units.pressure; }
+	TEMPERATURE temperature() { return (TEMPERATURE)prefs.units.temperature; }
+	UNIT_SYSTEM unit_system() { return (UNIT_SYSTEM)prefs.unit_system; }
+	TIME vertical_speed_time() { return (TIME)prefs.units.vertical_speed_time; }
+	VOLUME volume() { return (VOLUME)prefs.units.volume; }
+	WEIGHT weight() { return (WEIGHT)prefs.units.weight; }
 
 public slots:
 	void set_cloud_verification_status(CLOUD_STATUS value) {  qPrefCloudStorage::set_cloud_verification_status(value); }
+	void set_duration_units(DURATION value) { qPrefUnits::set_duration_units((units::DURATION)value); }
+	void set_length(LENGTH value) { qPrefUnits::set_length((units::LENGTH)value); }
+	void set_pressure(PRESSURE value) { qPrefUnits::set_pressure((units::PRESSURE)value); }
+	void set_temperature(TEMPERATURE value) { qPrefUnits::set_temperature((units::TEMPERATURE)value); }
+	void set_unit_system(UNIT_SYSTEM value) { qPrefUnits::set_unit_system((unit_system_values)value); }
+	void set_vertical_speed_time(TIME value) { qPrefUnits::set_vertical_speed_time((units::TIME)value); }
+	void set_volume(VOLUME value) { qPrefUnits::set_volume((units::VOLUME)value); }
+	void set_weight(WEIGHT value) { qPrefUnits::set_weight((units::WEIGHT)value); }
 
 signals:
 	void cloud_verification_statusChanged(CLOUD_STATUS);
+	void duration_unitsChanged(DURATION);
+	void lengthChanged(LENGTH);
+	void pressureChanged(PRESSURE);
+	void temperatureChanged(TEMPERATURE);
+	void unit_systemChanged(UNIT_SYSTEM);
+	void vertical_speed_timeChanged(TIME);
+	void volumeChanged(VOLUME);
+	void weightChanged(WEIGHT);
 
 private:
 	QMLInterface() {}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -323,10 +323,7 @@ void QMLManager::openLocalThenRemote(QString url)
 		setLoadFromCloud(true);
 		if (qPrefCloudStorage::cloud_verification_status() == qPrefCloudStorage::CS_UNKNOWN)
 			qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_VERIFIED);
-		if (git_prefs.unit_system == IMPERIAL)
-			qPrefUnits::set_unit_system("imperial");
-		else if (git_prefs.unit_system == METRIC)
-			qPrefUnits::set_unit_system("metric");
+		qPrefUnits::set_unit_system(git_prefs.unit_system);
 		qPrefTechnicalDetails::set_tankbar(git_prefs.tankbar);
 		qPrefTechnicalDetails::set_dcceiling(git_prefs.dcceiling);
 		qPrefTechnicalDetails::set_show_ccr_setpoint(git_prefs.show_ccr_setpoint);

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -61,7 +61,7 @@ void TestPlannerShared::test_rates()
 
 {
 	// Set system to use meters
-	qPrefUnits::set_unit_system(QStringLiteral("metric"));
+	qPrefUnits::set_unit_system(METRIC);
 
 	plannerShared::set_ascratelast6m(16);
 	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 267);
@@ -109,7 +109,7 @@ void TestPlannerShared::test_rates()
 	QCOMPARE(plannerShared::descrate(), 10);
 
 	// Set system to use feet
-	qPrefUnits::set_unit_system(QStringLiteral("imperial"));
+	qPrefUnits::set_unit_system(IMPERIAL);
 
 	plannerShared::set_ascratelast6m(33);
 	QCOMPARE(qPrefDivePlanner::ascratelast6m(), 168);
@@ -197,7 +197,7 @@ void TestPlannerShared::test_gas()
 	QCOMPARE(plannerShared::problemsolvingtime(), 6);
 
 	// Set system to use meters
-	qPrefUnits::set_unit_system(QStringLiteral("metric"));
+	qPrefUnits::set_unit_system(METRIC);
 
 	plannerShared::set_bottomsac(30);
 	QCOMPARE(qPrefDivePlanner::bottomsac(), 30000);
@@ -245,7 +245,7 @@ void TestPlannerShared::test_gas()
 	QCOMPARE(plannerShared::bestmixend(), 10);
 
 	// Set system to use feet
-	qPrefUnits::set_unit_system(QStringLiteral("imperial"));
+	qPrefUnits::set_unit_system(IMPERIAL);
 
 	plannerShared::set_bottomsac(0.9);
 	QCOMPARE(qPrefDivePlanner::bottomsac(), 25485);

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -36,7 +36,7 @@ void TestQPrefUnits::test_struct_get()
 	QCOMPARE(tst->coordinates_traditional(), true);
 	QCOMPARE(tst->duration_units(), units::MIXED);
 	QCOMPARE(tst->length(), units::METERS);
-	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
+	QCOMPARE(tst->pressure(), units::BAR);
 	QCOMPARE(tst->show_units_table(), true);
 	QCOMPARE(tst->temperature(), QStringLiteral("celcius"));
 	QCOMPARE(tst->vertical_speed_time(), QStringLiteral("seconds"));
@@ -161,7 +161,7 @@ void TestQPrefUnits::test_multiple()
 	QCOMPARE(tst->length(), qPrefUnits::length());
 	QCOMPARE(tst->length(), units::METERS);
 	QCOMPARE(tst->pressure(), qPrefUnits::pressure());
-	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
+	QCOMPARE(tst->pressure(), units::BAR);
 }
 
 void TestQPrefUnits::test_unit_system()
@@ -208,7 +208,7 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_vertical_speed_time(units::SECONDS);
 
 	TEST(units->length(), units::METERS);
-	TEST(units->pressure(), QStringLiteral("bar"));
+	TEST(units->pressure(), units::BAR);
 	TEST(units->volume(), QStringLiteral("liter"));
 	TEST(units->temperature(), QStringLiteral("celcius"));
 	TEST(units->weight(), QStringLiteral("kg"));
@@ -225,7 +225,7 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_coordinates_traditional(true);
 
 	TEST(units->length(), units::FEET);
-	TEST(units->pressure(), QStringLiteral("psi"));
+	TEST(units->pressure(), units::PSI);
 	TEST(units->volume(), QStringLiteral("cuft"));
 	TEST(units->temperature(), QStringLiteral("fahrenheit"));
 	TEST(units->weight(), QStringLiteral("lbs"));

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -34,7 +34,7 @@ void TestQPrefUnits::test_struct_get()
 	prefs.units.weight = units::KG;
 
 	QCOMPARE(tst->coordinates_traditional(), true);
-	QCOMPARE(tst->duration_units(), QStringLiteral("mixed"));
+	QCOMPARE(tst->duration_units(), units::MIXED);
 	QCOMPARE(tst->length(), QStringLiteral("meters"));
 	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
 	QCOMPARE(tst->show_units_table(), true);

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -39,7 +39,7 @@ void TestQPrefUnits::test_struct_get()
 	QCOMPARE(tst->pressure(), units::BAR);
 	QCOMPARE(tst->show_units_table(), true);
 	QCOMPARE(tst->temperature(), units::CELSIUS);
-	QCOMPARE(tst->vertical_speed_time(), QStringLiteral("seconds"));
+	QCOMPARE(tst->vertical_speed_time(), units::SECONDS);
 	QCOMPARE(tst->volume(), QStringLiteral("liter"));
 	QCOMPARE(tst->weight(), QStringLiteral("kg"));
 }
@@ -212,7 +212,7 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->volume(), QStringLiteral("liter"));
 	TEST(units->temperature(), units::CELSIUS);
 	TEST(units->weight(), QStringLiteral("kg"));
-	TEST(units->vertical_speed_time(), QStringLiteral("seconds"));
+	TEST(units->vertical_speed_time(), units::SECONDS);
 	TEST(units->unit_system(), METRIC);
 	TEST(units->coordinates_traditional(), false);
 
@@ -229,7 +229,7 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->volume(), QStringLiteral("cuft"));
 	TEST(units->temperature(), units::FAHRENHEIT);
 	TEST(units->weight(), QStringLiteral("lbs"));
-	TEST(units->vertical_speed_time(), QStringLiteral("minutes"));
+	TEST(units->vertical_speed_time(), units::MINUTES);
 	TEST(units->coordinates_traditional(), true);
 }
 

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -38,7 +38,7 @@ void TestQPrefUnits::test_struct_get()
 	QCOMPARE(tst->length(), units::METERS);
 	QCOMPARE(tst->pressure(), units::BAR);
 	QCOMPARE(tst->show_units_table(), true);
-	QCOMPARE(tst->temperature(), QStringLiteral("celcius"));
+	QCOMPARE(tst->temperature(), units::CELSIUS);
 	QCOMPARE(tst->vertical_speed_time(), QStringLiteral("seconds"));
 	QCOMPARE(tst->volume(), QStringLiteral("liter"));
 	QCOMPARE(tst->weight(), QStringLiteral("kg"));
@@ -210,7 +210,7 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->length(), units::METERS);
 	TEST(units->pressure(), units::BAR);
 	TEST(units->volume(), QStringLiteral("liter"));
-	TEST(units->temperature(), QStringLiteral("celcius"));
+	TEST(units->temperature(), units::CELSIUS);
 	TEST(units->weight(), QStringLiteral("kg"));
 	TEST(units->vertical_speed_time(), QStringLiteral("seconds"));
 	TEST(units->unit_system(), METRIC);
@@ -227,7 +227,7 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->length(), units::FEET);
 	TEST(units->pressure(), units::PSI);
 	TEST(units->volume(), QStringLiteral("cuft"));
-	TEST(units->temperature(), QStringLiteral("fahrenheit"));
+	TEST(units->temperature(), units::FAHRENHEIT);
 	TEST(units->weight(), QStringLiteral("lbs"));
 	TEST(units->vertical_speed_time(), QStringLiteral("minutes"));
 	TEST(units->coordinates_traditional(), true);

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -40,8 +40,8 @@ void TestQPrefUnits::test_struct_get()
 	QCOMPARE(tst->show_units_table(), true);
 	QCOMPARE(tst->temperature(), units::CELSIUS);
 	QCOMPARE(tst->vertical_speed_time(), units::SECONDS);
-	QCOMPARE(tst->volume(), QStringLiteral("liter"));
-	QCOMPARE(tst->weight(), QStringLiteral("kg"));
+	QCOMPARE(tst->volume(), units::LITER);
+	QCOMPARE(tst->weight(), units::KG);
 }
 
 void TestQPrefUnits::test_set_struct()
@@ -209,9 +209,11 @@ void TestQPrefUnits::test_oldPreferences()
 
 	TEST(units->length(), units::METERS);
 	TEST(units->pressure(), units::BAR);
-	TEST(units->volume(), QStringLiteral("liter"));
+	TEST(units->volume(), units::LITER);
 	TEST(units->temperature(), units::CELSIUS);
-	TEST(units->weight(), QStringLiteral("kg"));
+	TEST(units->weight(), units::KG);
+	TEST(units->vertical_speed_time(), units::SECONDS);
+	TEST(units->unit_system(), METRIC);
 	TEST(units->vertical_speed_time(), units::SECONDS);
 	TEST(units->unit_system(), METRIC);
 	TEST(units->coordinates_traditional(), false);
@@ -226,9 +228,9 @@ void TestQPrefUnits::test_oldPreferences()
 
 	TEST(units->length(), units::FEET);
 	TEST(units->pressure(), units::PSI);
-	TEST(units->volume(), QStringLiteral("cuft"));
+	TEST(units->volume(), units::CUFT);
 	TEST(units->temperature(), units::FAHRENHEIT);
-	TEST(units->weight(), QStringLiteral("lbs"));
+	TEST(units->weight(), units::LBS);
 	TEST(units->vertical_speed_time(), units::MINUTES);
 	TEST(units->coordinates_traditional(), true);
 }

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -35,7 +35,7 @@ void TestQPrefUnits::test_struct_get()
 
 	QCOMPARE(tst->coordinates_traditional(), true);
 	QCOMPARE(tst->duration_units(), units::MIXED);
-	QCOMPARE(tst->length(), QStringLiteral("meters"));
+	QCOMPARE(tst->length(), units::METERS);
 	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
 	QCOMPARE(tst->show_units_table(), true);
 	QCOMPARE(tst->temperature(), QStringLiteral("celcius"));
@@ -159,7 +159,7 @@ void TestQPrefUnits::test_multiple()
 	auto tst = qPrefUnits::instance();
 
 	QCOMPARE(tst->length(), qPrefUnits::length());
-	QCOMPARE(tst->length(), QStringLiteral("meters"));
+	QCOMPARE(tst->length(), units::METERS);
 	QCOMPARE(tst->pressure(), qPrefUnits::pressure());
 	QCOMPARE(tst->pressure(), QStringLiteral("bar"));
 }
@@ -207,7 +207,7 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_coordinates_traditional(false);
 	units->set_vertical_speed_time(units::SECONDS);
 
-	TEST(units->length(), QStringLiteral("meters"));
+	TEST(units->length(), units::METERS);
 	TEST(units->pressure(), QStringLiteral("bar"));
 	TEST(units->volume(), QStringLiteral("liter"));
 	TEST(units->temperature(), QStringLiteral("celcius"));
@@ -224,7 +224,7 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_vertical_speed_time(units::MINUTES);
 	units->set_coordinates_traditional(true);
 
-	TEST(units->length(), QStringLiteral("feet"));
+	TEST(units->length(), units::FEET);
 	TEST(units->pressure(), QStringLiteral("psi"));
 	TEST(units->volume(), QStringLiteral("cuft"));
 	TEST(units->temperature(), QStringLiteral("fahrenheit"));

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -3,6 +3,7 @@
 
 #include "core/pref.h"
 #include "core/qthelper.h"
+#include "core/settings/qPref.h"
 #include "core/settings/qPrefUnit.h"
 
 #include <QTest>
@@ -13,6 +14,7 @@ void TestQPrefUnits::initTestCase()
 	QCoreApplication::setOrganizationName("Subsurface");
 	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
 	QCoreApplication::setApplicationName("SubsurfaceTestQPrefUnits");
+	qPref::registerQML(NULL);
 }
 
 void TestQPrefUnits::test_struct_get()

--- a/tests/testqPrefUnits.cpp
+++ b/tests/testqPrefUnits.cpp
@@ -170,22 +170,22 @@ void TestQPrefUnits::test_unit_system()
 
 	auto tst = qPrefUnits::instance();
 
-	tst->set_unit_system("metric");
+	tst->set_unit_system(METRIC);
 	QCOMPARE(prefs.unit_system, METRIC);
-	QCOMPARE(tst->unit_system(), QStringLiteral("metric"));
-	tst->set_unit_system("imperial");
+	QCOMPARE(tst->unit_system(), METRIC);
+	tst->set_unit_system(IMPERIAL);
 	QCOMPARE(prefs.unit_system, IMPERIAL);
-	QCOMPARE(tst->unit_system(), QStringLiteral("imperial"));
-	tst->set_unit_system("personalized");
+	QCOMPARE(tst->unit_system(), IMPERIAL);
+	tst->set_unit_system(PERSONALIZE);
 	QCOMPARE(prefs.unit_system, PERSONALIZE);
-	QCOMPARE(tst->unit_system(), QStringLiteral("personalized"));
+	QCOMPARE(tst->unit_system(), PERSONALIZE);
 
 	prefs.unit_system = METRIC;
-	QCOMPARE(tst->unit_system(), QStringLiteral("metric"));
+	QCOMPARE(tst->unit_system(), METRIC);
 	prefs.unit_system = IMPERIAL;
-	QCOMPARE(tst->unit_system(), QStringLiteral("imperial"));
+	QCOMPARE(tst->unit_system(), IMPERIAL);
 	prefs.unit_system = PERSONALIZE;
-	QCOMPARE(tst->unit_system(), QStringLiteral("personalized"));
+	QCOMPARE(tst->unit_system(), PERSONALIZE);
 }
 
 #define TEST(METHOD, VALUE)      \
@@ -203,7 +203,7 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_volume(units::LITER);
 	units->set_temperature(units::CELSIUS);
 	units->set_weight(units::KG);
-	units->set_unit_system(QStringLiteral("metric"));
+	units->set_unit_system(METRIC);
 	units->set_coordinates_traditional(false);
 	units->set_vertical_speed_time(units::SECONDS);
 
@@ -213,7 +213,7 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->temperature(), QStringLiteral("celcius"));
 	TEST(units->weight(), QStringLiteral("kg"));
 	TEST(units->vertical_speed_time(), QStringLiteral("seconds"));
-	TEST(units->unit_system(), QStringLiteral("metric"));
+	TEST(units->unit_system(), METRIC);
 	TEST(units->coordinates_traditional(), false);
 
 	units->set_length(units::FEET);
@@ -222,7 +222,6 @@ void TestQPrefUnits::test_oldPreferences()
 	units->set_temperature(units::FAHRENHEIT);
 	units->set_weight(units::LBS);
 	units->set_vertical_speed_time(units::MINUTES);
-	units->set_unit_system(QStringLiteral("fake-metric-system"));
 	units->set_coordinates_traditional(true);
 
 	TEST(units->length(), QStringLiteral("feet"));
@@ -231,7 +230,6 @@ void TestQPrefUnits::test_oldPreferences()
 	TEST(units->temperature(), QStringLiteral("fahrenheit"));
 	TEST(units->weight(), QStringLiteral("lbs"));
 	TEST(units->vertical_speed_time(), QStringLiteral("minutes"));
-	TEST(units->unit_system(), QStringLiteral("personalized"));
 	TEST(units->coordinates_traditional(), true);
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add qPrefUnit to the new pure interface, and then remove string functions.

I am sorry, that I did it in small steps (commits), but the small differences in each change, made me not only build but also run "make check". The commits can be squashed, if you want, but for bisecting have them separate makes kind of sense.

Next up, before rebasing the lot of WIP, is to change names in plannerShared as you suggested. Now that have a pure interface for QML, I will also start using that.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
commit 1: allow qPrefUnit strongly typed in QML
commit 2: use strongly typed units in QML
commit 3: allow signals to be strongly typed in C++
- Remark, this is something new, not only cleanup, the old (including very old) used int !
commit 4: change qPrefUnits::unit_system() to strongly typed and no strings
commit 5: remove string func. for duration_units
commit 6: remove string func. for length
commit 7: remove string func. for pressure
commit 8: remove string func. for temperature
commit 9: remove string func. for vertical_speed_time
commit 10: remove string func. for volume
commit 11: correct signal error.
- this surely must have caused spurious errors at least in the mobile.
commit 12: removed not needed if.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
