### PR TITLE
mobile UI: add ability to unset the default cylinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: option to reset default cylinder
 Mobile: new layout for Settings page
 Desktop: add the ability to modify dive salinity
 Mobile: add menu item for cloud password reset

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -94,7 +94,12 @@ Kirigami.ScrollablePage {
 					inputMethodHints: Qt.ImhNoPredictiveText
 					Layout.fillWidth: true
 					onActivated: {
-						PrefEquipment.default_cylinder = defaultCylinderBox.currentText
+						// the entry for 'no default cylinder' is known to be the top, but its text
+						// is possibly translated so check against the index
+						if (currentIndex === 0)
+							PrefEquipment.default_cylinder = ""
+						else
+							PrefEquipment.default_cylinder = defaultCylinderBox.currentText
 					}
 				}
 			}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1810,6 +1810,8 @@ QStringList QMLManager::cylinderInit() const
 
 	cylinders.removeDuplicates();
 	cylinders.sort();
+	// now add fist one that indicates that the user wants no default cylinder
+	cylinders.prepend(tr("no default cylinder"));
 	return cylinders;
 }
 


### PR DESCRIPTION
This was requested in a 'bug report' by a user.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
prepend an option to not have a default cylinder in the list of cylinders and reset the default cylinder if that one is chosen

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
this came in as in app support bug report

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
added

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
maybe -- not sure

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
