### PR TITLE
Update to new libdivecomputer version

### DIFF
--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -23,7 +23,13 @@ public:
 	inline void set_timeout(int value) { timeout = value; }
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
-	inline const char *get_name() { return device->btname; }
+	inline dc_status_t get_name(char *res, size_t size)
+	{
+		if (!device->btname) return DC_STATUS_UNSUPPORTED;
+		strncpy(res, device->btname, size);
+		return DC_STATUS_SUCCESS;
+	}
+	dc_status_t poll(int timeout);
 
 	inline QLowEnergyService *preferredService() { return preferred; }
 	inline int descriptorWritten() { return desc_written; }
@@ -61,10 +67,11 @@ private:
 extern "C" {
 dc_status_t qt_ble_open(void **io, dc_context_t *context, const char *devaddr, dc_user_device_t *user_device);
 dc_status_t qt_ble_set_timeout(void *io, int timeout);
+dc_status_t qt_ble_poll(void *io, int timeout);
 dc_status_t qt_ble_read(void *io, void* data, size_t size, size_t *actual);
 dc_status_t qt_ble_write(void *io, const void* data, size_t size, size_t *actual);
+dc_status_t qt_ble_ioctl(void *io, unsigned int request, void *data, size_t size);
 dc_status_t qt_ble_close(void *io);
-const char *qt_ble_get_name(void *io);
 }
 
 #endif


### PR DESCRIPTION
Jef has changed the libdivecomputer iostream layer and extended it in
two different ways:

 - iostram's now have a 'poll()' method, which does what the name
   implies: waits for data to be available with a timeout.

 - iostreams now have a 'ioctl()' method, which can be used to implement
   miscellaneous operations. Right now the two ones that you can do are
   "set latency" (this replaces the old 'set_latency()' method) and "get
   BLE name" (this replaces our 'get_name()' method that was never part
   of the upstream libdivecomputer interfaces)

Neither of these is all that complicated, and the transition is fairly
obvious.

HOWEVER.

I have absolutely no idea how to do 'poll()' on Windows sockets, and I
have no intention of figuring it out.  We use a direct socket interface
to implement the (non-BLE) RFCOMM bluetooth serial protocol, and I'm not
sure why Windows is so special here.  I suspect - but cannot test - that
we should just switch the Windows RFCOMM implementation over to the use
the same QtBluetooth code that we use on other platforms.

I assume that the Windows Bluetooth support was originally not
sufficiently good for that, but these days we depend on Qt doing BLE for
us even on Windows, so presumably FRCOMM works too.

That would be a nice cleanup, and would make 'poll()' work on RFCOMM
under Windows too.  However, since I can't test it, I've not done that,
but instead just made the Windows RFCOMM 'poll()' method always return
success.  That may or may not get the thing limping along.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
