### PR TITLE
Update libdivecomputer and make Windows use qtbluetooth

### DIFF
--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -23,7 +23,13 @@ public:
 	inline void set_timeout(int value) { timeout = value; }
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
-	inline const char *get_name() { return device->btname; }
+	inline dc_status_t get_name(char *res, size_t size)
+	{
+		if (!device->btname) return DC_STATUS_UNSUPPORTED;
+		strncpy(res, device->btname, size);
+		return DC_STATUS_SUCCESS;
+	}
+	dc_status_t poll(int timeout);
 
 	inline QLowEnergyService *preferredService() { return preferred; }
 	inline int descriptorWritten() { return desc_written; }
@@ -61,10 +67,11 @@ private:
 extern "C" {
 dc_status_t qt_ble_open(void **io, dc_context_t *context, const char *devaddr, dc_user_device_t *user_device);
 dc_status_t qt_ble_set_timeout(void *io, int timeout);
+dc_status_t qt_ble_poll(void *io, int timeout);
 dc_status_t qt_ble_read(void *io, void* data, size_t size, size_t *actual);
 dc_status_t qt_ble_write(void *io, const void* data, size_t size, size_t *actual);
+dc_status_t qt_ble_ioctl(void *io, unsigned int request, void *data, size_t size);
 dc_status_t qt_ble_close(void *io);
-const char *qt_ble_get_name(void *io);
 }
 
 #endif

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -212,7 +212,16 @@ static dc_status_t qt_serial_poll(void *io, int timeout)
 
 	if (!device->socket)
 		return DC_STATUS_INVALIDARGS;
-	if (device->socket->waitForReadyRead(timeout))
+
+	QEventLoop loop;
+	QTimer timer;
+	timer.setSingleShot(true);
+	loop.connect(&timer, SIGNAL(timeout()), SLOT(quit()));
+	loop.connect(device->socket, SIGNAL(readyRead()), SLOT(quit()));
+	timer.start(timeout);
+	loop.exec();
+
+	if (!timer.isActive())
 		return DC_STATUS_SUCCESS;
 	return DC_STATUS_TIMEOUT;
 }


### PR DESCRIPTION
This is the same old "update to new libdivecomputer version", with the added twist that it also has a commit to make the Windows rfcomm code use QtBluetooth like all other platforms.

That's a nice cleanup, but I don't know if modern Qt is good enough on Windows these days..

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
