### PR TITLE
trying to solve broken master on macOS.

### DIFF
--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -298,13 +298,13 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 		NULL, /* get_lines */
 		NULL, /* get_received */
 		NULL, /* configure */
-		qt_ble_poll, /* poll */
+		qt_ble_poll, /* poll */    /* fails on mac 6 parm vs 2 */
 		qt_ble_read, /* read */
 		qt_ble_write, /* write */
-		qt_ble_ioctl, /* ioctl */
+		qt_ble_ioctl, /* ioctl */  /* fails on mac 1 parm vs 4 */
 		NULL, /* flush */
 		NULL, /* purge */
-		qt_custom_sleep, /* sleep */
+		qt_custom_sleep, /* sleep */ /* fails on mac 1 parm vs 2 */
 		qt_ble_close, /* close */
 	};
 


### PR DESCRIPTION
Signed-off-by: jan Iversen <jan@casacondor.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
After the latest update with libdivecomputer and new ble interface, my Mac produces the following errors:

/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:301:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *, unsigned int, unsigned int, dc_parity_t,
      dc_stopbits_t, dc_flowcontrol_t)' with an lvalue of type 'dc_status_t (void *, int)':
      different number of parameters (6 vs 2)
                qt_ble_poll, /* poll */
                ^~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:304:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *)' with an lvalue of type 'dc_status_t (void
      *, unsigned int, void *, size_t)' (aka 'dc_status_t (void *, unsigned int, void *, unsigned
      long)'): different number of parameters (1 vs 4)
                qt_ble_ioctl, /* ioctl */
                ^~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:307:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *)' with an lvalue of type 'dc_status_t
      (void *, unsigned int)': different number of parameters (1 vs 2)
                qt_custom_sleep, /* sleep */
                ^~~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:308:3: error: cannot initialize a
      member subobject of type 'const char *(*)(void *)' with an lvalue of type
      'dc_status_t (void *)': different return type ('const char *' vs 'dc_status_t')
                qt_ble_close, /* close */
                ^~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:333:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *, unsigned int *)' with an lvalue of type
      'dc_status_t (void *, size_t *)' (aka 'dc_status_t (void *, unsigned long *)'): type mismatch
      at 2nd parameter ('unsigned int *' vs 'size_t *' (aka 'unsigned long *'))
                qt_serial_get_available, /* get_received */
                ^~~~~~~~~~~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:335:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *, unsigned int, unsigned int, dc_parity_t,
      dc_stopbits_t, dc_flowcontrol_t)' with an lvalue of type 'dc_status_t (void *, int)':
      different number of parameters (6 vs 2)
                qt_serial_poll, /* poll */
                ^~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:338:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *)' with an lvalue of type 'dc_status_t (void
      *, unsigned int, void *, size_t)' (aka 'dc_status_t (void *, unsigned int, void *, unsigned
      long)'): different number of parameters (1 vs 4)
                qt_serial_ioctl, /* ioctl */
                ^~~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:340:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *, unsigned int)' with an lvalue of type
      'dc_status_t (void *, dc_direction_t)': type mismatch at 2nd parameter ('unsigned int' vs
      'dc_direction_t')
                qt_serial_purge, /* purge */
                ^~~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:341:3: error: cannot initialize a
      member subobject of type 'dc_status_t (*)(void *)' with an lvalue of type 'dc_status_t
      (void *, unsigned int)': different number of parameters (1 vs 2)
                qt_custom_sleep, /* sleep */
                ^~~~~~~~~~~~~~~
/Users/jani/develop/src/subsurface/core/qtserialbluetooth.cpp:342:3: error: cannot initialize a
      member subobject of type 'const char *(*)(void *)' with an lvalue of type
      'dc_status_t (void *)': different return type ('const char *' vs 'dc_status_t')
                qt_serial_close, /* close */

Remark this happens when compiling desktop as well as mobile.

the purpose of this PR is to see how it compiles centrally.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
