### PR TITLE
(1b) Fix Kirigami error.

### DIFF
--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -11,23 +11,6 @@ Kirigami.ScrollablePage {
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 	title: qsTr("Dive summary")
 
-	ListModel {
-		id: monthModel
-		ListElement {text: qsTr("Total")}
-		ListElement {text: qsTr(" 1 month [ 30 days]")}
-		ListElement {text: qsTr(" 2 month [ 60 days]")}
-		ListElement {text: qsTr(" 3 month [ 90 days]")}
-		ListElement {text: qsTr(" 4 month [120 days]")}
-		ListElement {text: qsTr(" 5 month [150 days]")}
-		ListElement {text: qsTr(" 6 month [180 days]")}
-		ListElement {text: qsTr(" 7 month [210 days]")}
-		ListElement {text: qsTr(" 8 month [240 days]")}
-		ListElement {text: qsTr(" 9 month [270 days]")}
-		ListElement {text: qsTr("10 month [300 days]")}
-		ListElement {text: qsTr("11 month [330 days]")}
-		ListElement {text: qsTr("12 month [360 days]")}
-	}
-
 	onVisibleChanged: {
 		if (visible)
 			Backend.summaryCalculation(selectionPrimary.currentIndex, selectionSecondary.currentIndex)
@@ -38,6 +21,23 @@ Kirigami.ScrollablePage {
 		width: parent.width
 		columnSpacing: Kirigami.Units.smallSpacing
 		rowSpacing: Kirigami.Units.smallSpacing
+
+		ListModel {
+			id: monthModel
+			ListElement {text: qsTr("Total")}
+			ListElement {text: qsTr(" 1 month [ 30 days]")}
+			ListElement {text: qsTr(" 2 month [ 60 days]")}
+			ListElement {text: qsTr(" 3 month [ 90 days]")}
+			ListElement {text: qsTr(" 4 month [120 days]")}
+			ListElement {text: qsTr(" 5 month [150 days]")}
+			ListElement {text: qsTr(" 6 month [180 days]")}
+			ListElement {text: qsTr(" 7 month [210 days]")}
+			ListElement {text: qsTr(" 8 month [240 days]")}
+			ListElement {text: qsTr(" 9 month [270 days]")}
+			ListElement {text: qsTr("10 month [300 days]")}
+			ListElement {text: qsTr("11 month [330 days]")}
+			ListElement {text: qsTr("12 month [360 days]")}
+		}
 
 		TemplateLabel {
 			text: qsTr("oldest/newest dive")


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
For a short while this error have been reported:
INFO: qrc:/org/kde/kirigami/ScrollablePage.qml:187: TypeError: Cannot assign to read-only property "parent".

It boiled down to a ListModel that was defined directly at page level, something which is very normal and allowed in QtQuick 2. Kirigami.scrollPage does not allow non graphical elements to be defined directly.

Kirigami did an excellent job, with QtQuick 1, but with QtQuick 2 in reality offers very little and poses limitations compared to using QtQuick 2 directly. I believe strongly it is a good idea to isolate Kirigami in Template*, but not in a "Big Bang" commit, but as we slowly update the pages.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
