### PR TITLE
small adjustments to Divesummary

### DIFF
--- a/backend-shared/divesummary.cpp
+++ b/backend-shared/divesummary.cpp
@@ -12,6 +12,7 @@ int diveSummary::dives[2], diveSummary::divesEAN[2], diveSummary::divesDeep[2], 
 long diveSummary::divetime[2], diveSummary::depth[2];
 long diveSummary::divetimeMax[2], diveSummary::depthMax[2], diveSummary::sacMin[2], diveSummary::sacMax[2];
 long diveSummary::totalSACTime[2], diveSummary::totalSacVolume[2];
+bool diveSummary::diveSummaryLimit;
 
 void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
@@ -98,8 +99,8 @@ void diveSummary::calculateDive(int inx, struct dive *dive)
 	// Check for dive validity
 	// Swimmingpool dives (4 meters) are not counted, nor
 	// are very short dives (5 minutes)
-	if (dive->maxdepth.mm < 4000 ||
-		dive->duration.seconds < 5 * 60)
+	if (!diveSummaryLimit && (dive->maxdepth.mm < 4000 ||
+		dive->duration.seconds < 5 * 60))
 		return;
 
 	// one more real dive
@@ -120,7 +121,7 @@ void diveSummary::calculateDive(int inx, struct dive *dive)
 	// sum SAC, check for new min/max.
 	// Do not include dives with SAC > 40 l/min (probably a free flow regulator)
 	// and SAC < 4 l/min (probably a faulty transmittor)
-	if (dive->sac <= 40000 && dive->sac >= 4000) {
+	if (!diveSummaryLimit && dive->sac <= 40000 && dive->sac >= 4000) {
 		totalSACTime[inx] += dive->duration.seconds;
 		totalSacVolume[inx] += dive->sac * dive->duration.seconds;
 		if (dive->sac < sacMin[inx])

--- a/backend-shared/divesummary.h
+++ b/backend-shared/divesummary.h
@@ -11,6 +11,8 @@ public:
 	static void summaryCalculation(int primaryPeriod, int secondaryPeriod);
 
 	static QStringList diveSummaryText;
+	static bool diveSummaryLimit;
+	static void set_diveSummaryLimit(bool value) { diveSummaryLimit = value; }
 
 private:
 	diveSummary() {}

--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -15,6 +15,16 @@ Kirigami.ScrollablePage {
 		if (visible)
 			Backend.summaryCalculation(selectionPrimary.currentIndex, selectionSecondary.currentIndex)
 	}
+	Connections {
+		target: Backend
+		onLengthChanged: {
+			Backend.summaryCalculation(selectionPrimary.currentIndex, selectionSecondary.currentIndex)
+		}
+		onVolumeChanged: {
+			Backend.summaryCalculation(selectionPrimary.currentIndex, selectionSecondary.currentIndex)
+		}
+	}
+
 
 	GridLayout {
 		columns: 3

--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -226,5 +226,26 @@ Kirigami.ScrollablePage {
 			text: Backend.diveSummaryText[25]
 		}
 
+
+		TemplateLabel {
+			Layout.columnSpan: 3
+		}
+
+		TemplateLabel {
+			font.bold: true
+			Layout.columnSpan: 3
+			text: qsTr("Note on calculation")
+		}
+		TemplateLabel {
+			Layout.columnSpan: 3
+			Layout.maximumWidth: parent.width
+			wrapMode: Text.WordWrap
+			property string depthLimit: (Backend.length === Enums.METERS) ? qsTr("4 meters") : qsTr("13 feet")
+			property string sacLimitMax: (Backend.volume === Enums.LITER) ? qsTr("40 l/min") : qsTr("1.41 cuft/min")
+			property string sacLimitMin: (Backend.volume === Enums.LITER) ? qsTr("4 l/min") : qsTr("0.14 cuft/min")
+
+			text: "Dives shorter than 5 minutes or shallower than " + depthLimit + " are excluded." +
+				  " SAC higher than " + sacLimitMax + " or lower than " + sacLimitMin + " are excluded from the SAC calculation."
+		}
 	}
 }

--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -247,5 +247,14 @@ Kirigami.ScrollablePage {
 			text: "Dives shorter than 5 minutes or shallower than " + depthLimit + " are excluded." +
 				  " SAC higher than " + sacLimitMax + " or lower than " + sacLimitMin + " are excluded from the SAC calculation."
 		}
+		TemplateCheckBox {
+			Layout.columnSpan: 3
+			text: "bypass limitations"
+			checked: Backend.diveSummaryLimit
+			onClicked: {
+				Backend.diveSummaryLimit = checked
+				Backend.summaryCalculation(selectionPrimary.currentIndex, selectionSecondary.currentIndex)
+			}
+		}
 	}
 }

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -79,6 +79,7 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(bool display_variations READ display_variations WRITE set_display_variations NOTIFY display_variationsChanged);
 
 	Q_PROPERTY(QStringList diveSummaryText READ diveSummaryText NOTIFY diveSummaryTextChanged);
+	Q_PROPERTY(bool diveSummaryLimit READ diveSummaryLimit WRITE set_diveSummaryLimit NOTIFY diveSummaryLimitChanged);
 
 public:
 	static QMLInterface *instance();
@@ -220,6 +221,7 @@ public:
 	bool display_variations() { return prefs.display_variations; }
 
 	const QStringList &diveSummaryText() { return diveSummary::diveSummaryText; }
+	bool diveSummaryLimit() { return diveSummary::diveSummaryLimit; }
 
 public slots:
 	void set_cloud_verification_status(CLOUD_STATUS value) {  qPrefCloudStorage::set_cloud_verification_status(value); }
@@ -267,6 +269,8 @@ public slots:
 	void set_display_transitions(bool value) { DivePlannerPointsModel::instance()->setDisplayTransitions(value); }
 	void set_verbatim_plan(bool value) { DivePlannerPointsModel::instance()->setVerbatim(value); }
 	void set_display_variations(bool value) { DivePlannerPointsModel::instance()->setDisplayVariations(value); }
+
+	void set_diveSummaryLimit(bool value) { return diveSummary::set_diveSummaryLimit(value); }
 
 signals:
 	void cloud_verification_statusChanged(CLOUD_STATUS);
@@ -316,6 +320,7 @@ signals:
 	void display_variationsChanged(bool value);
 
 	void diveSummaryTextChanged(QStringList);
+	void diveSummaryLimitChanged(bool);
 private:
 	QMLInterface() {}
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Commit 1:
Secures page is updated when user changes units (length or volume)

Commit 2:
introduces limit to what is calculated.

1) Add a note telling how the calculation is done
2) Exclude dives shorter than 5 minutes and shallower than 4 meters (swimming pool)
Remark: the page is intended to be shown in dive centres, and a dive center will not consider
these dives as real dives
3) Exclude SAC < 4 l/min from SAC calculation
thinking of your 30 1 l/min dives
4) Exclude SAC > 40 l/min from SAC calculation
Any diver breathing more than 40 l/min have a serious problem :-)
And this excludes my real life experience with 2 regulators stuck in free flow at 30m when returning on a deco dive (luckily my O2 tank worked at 6m)

Having digested your changes of the calculation, I agree they make a lot sense, including the SAC average.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
