### PR TITLE
Attempt at fixing #2552

### DIFF
--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -115,7 +115,6 @@ slots: // Necessary to call from QAction's signals.
 	void removePictures(const QVector<QString> &fileUrls);
 	void setPlanState();
 	void setAddState();
-	void changeGas();
 	void addSetpointChange();
 	void splitDive();
 	void addBookmark();
@@ -162,6 +161,7 @@ protected:
 
 
 private: /*methods*/
+	void changeGas(int tank, int seconds);
 	void fixBackgroundPos();
 	void scrollViewTo(const QPoint &pos);
 	void setupSceneAndFlags();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -159,8 +159,7 @@ protected:
 	void dragEnterEvent(QDragEnterEvent *event) override;
 	void dragMoveEvent(QDragMoveEvent *event) override;
 
-
-private: /*methods*/
+private:
 	void changeGas(int tank, int seconds);
 	void fixBackgroundPos();
 	void scrollViewTo(const QPoint &pos);

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -134,6 +134,11 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 	if (!index.isValid() || index.row() >= rows)
 		return QVariant();
 
+	if (index.row() >= displayed_dive.cylinders.nr) {
+		qWarning("CylindersModel and displayed_dive are out of sync!");
+		return QVariant();
+	}
+
 	const cylinder_t *cyl = get_cylinder(&displayed_dive, index.row());
 
 	switch (role) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an attempt at fixing #2552. The core of the PR is populating the context menu from the current dive, not the model. I think this *should* work, because this part is not used in the planner?

Moreover, it replaces the crazy way in which the parameters were passed through the action by a lambda. Much simpler to grok and strongly typed. No casting through QVariant and (worse) a formatted string.

PS: The cylinder model appears to not be properly reset when switching dives. Will look into that.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't crash when CylindersModel and displayed_dive get out of sync.
2) Replace QAction payload by lamdba.
3) Populate context menu from current_dive.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2552.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure if problem exists in release.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @atdotde @djunkins 