### PR TITLE
[RFC] Remove plannerShared::instance()

### DIFF
--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -6,12 +6,6 @@
 #include "qt-models/diveplannermodel.h"
 #include "qt-models/cylindermodel.h"
 
-plannerShared *plannerShared::instance()
-{
-    static plannerShared *self = new plannerShared;
-    return self;
-}
-
 // Planning values
 deco_mode plannerShared::planner_deco_mode()
 {

--- a/backend-shared/plannershared.h
+++ b/backend-shared/plannershared.h
@@ -16,8 +16,6 @@ class plannerShared: public QObject {
 	Q_OBJECT
 
 public:
-	static plannerShared *instance();
-
 	// Planning data
 	static deco_mode planner_deco_mode();
 	static int reserve_gas();
@@ -53,9 +51,6 @@ public slots:
 	static void set_bottompo2(double value);
 	static void set_decopo2(double value);
 	static void set_bestmixend(int value);
-
-private:
-	plannerShared() {}
 };
 
 #endif // PLANNERSHARED_H

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -466,7 +466,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.display_runtime, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayRuntime);
 	connect(ui.display_transitions, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayTransitions);
 	connect(ui.safetystop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSafetyStop);
-	connect(ui.reserve_gas, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_reserve_gas);
+	connect(ui.reserve_gas, QOverload<int>::of(&QSpinBox::valueChanged), &plannerShared::set_reserve_gas);
 	connect(ui.ascRate75, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate75Display);
 	connect(ui.ascRate50, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate50Display);
 	connect(ui.ascRateStops, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscratestopsDisplay);
@@ -477,11 +477,11 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.gflow, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setGFLow);
 	connect(ui.vpmb_conservatism, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setVpmbConservatism);
 	connect(ui.backgasBreaks, &QAbstractButton::toggled, this, &PlannerSettingsWidget::setBackgasBreaks);
-	connect(ui.bailout, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_dobailout);
-	connect(ui.o2narcotic, &QAbstractButton::toggled, plannerShared::instance(), &plannerShared::set_o2narcotic);
+	connect(ui.bailout, &QAbstractButton::toggled, &plannerShared::set_dobailout);
+	connect(ui.o2narcotic, &QAbstractButton::toggled, &plannerShared::set_o2narcotic);
 	connect(ui.switch_at_req_stop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSwitchAtReqStop);
-	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_min_switch_duration);
-	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), plannerShared::set_surface_segment);
+	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), &plannerShared::set_min_switch_duration);
+	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), &plannerShared::set_surface_segment);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), plannerModel, &DivePlannerPointsModel::setRebreatherMode);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PlannerSettingsWidget::setBailoutVisibility);
 
@@ -489,13 +489,13 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [=] { disableDecoElements(BUEHLMANN); });
 	connect(ui.vpmb_deco, &QAbstractButton::clicked, [=] { disableDecoElements(VPMB); });
 
-	connect(ui.sacfactor, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_sacfactor);
+	connect(ui.sacfactor, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &plannerShared::set_sacfactor);
 	connect(ui.problemsolvingtime, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setProblemSolvingTime);
-	connect(ui.bottompo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_bottompo2);
-	connect(ui.decopo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_decopo2);
-	connect(ui.bestmixEND, QOverload<int>::of(&QSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_bestmixend);
-	connect(ui.bottomSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_bottomsac);
-	connect(ui.decoStopSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_decosac);
+	connect(ui.bottompo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &plannerShared::set_bottompo2);
+	connect(ui.decopo2, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &plannerShared::set_decopo2);
+	connect(ui.bestmixEND, QOverload<int>::of(&QSpinBox::valueChanged), &plannerShared::set_bestmixend);
+	connect(ui.bottomSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &plannerShared::set_bottomsac);
+	connect(ui.decoStopSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &plannerShared::set_decosac);
 
 	settingsChanged();
 	ui.gflow->setValue(prefs.gflow);

--- a/tests/testplannershared.cpp
+++ b/tests/testplannershared.cpp
@@ -12,7 +12,6 @@ void TestPlannerShared::initTestCase()
 	QCoreApplication::setOrganizationName("Subsurface");
 	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
 	QCoreApplication::setApplicationName("SubsurfaceTestPlannerShared");
-	plannerShared::instance();
 }
 
 


### PR DESCRIPTION
This class contains only static functions (i.e. it does not contain
any state). There does not seem to be a reason to have an instance
of that class. Therefore, remove the instance() function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The `plannerShared`[*] class has no state, but rather is a collection of static functions. Currently, there appears to be no reason to keep a global instance of this class. If QML needs it, it can generate its own instance.

Should the plan be to add state to this class, this needs some discussion. The planner state is already splattered over a number of classes, I'm not convinced that splitting this up more is the way to go.

[*] virtually all of our class-names are PascalCase, I see no reason to break this rule.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Remove `plannerShared::instance()`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
