### PR TITLE
[TRIVIAL] Cleanup: use explicit capture clauses in lambdas

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -455,9 +455,9 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 		rebreather_modes.append(gettextFromC::tr(divemode_text_ui[i]));
 	ui.rebreathermode->insertItems(0, rebreather_modes);
 
-	connect(ui.recreational_deco, &QAbstractButton::clicked, [=] { plannerShared::set_planner_deco_mode(RECREATIONAL); });
-	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [=] { plannerShared::set_planner_deco_mode(BUEHLMANN); });
-	connect(ui.vpmb_deco, &QAbstractButton::clicked, [=] { plannerShared::set_planner_deco_mode(VPMB); });
+	connect(ui.recreational_deco, &QAbstractButton::clicked, [] { plannerShared::set_planner_deco_mode(RECREATIONAL); });
+	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [] { plannerShared::set_planner_deco_mode(BUEHLMANN); });
+	connect(ui.vpmb_deco, &QAbstractButton::clicked, [] { plannerShared::set_planner_deco_mode(VPMB); });
 
 	connect(ui.lastStop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setLastStop6m);
 	connect(ui.lastStop, &QAbstractButton::toggled, this, &PlannerSettingsWidget::disableBackgasBreaks);
@@ -485,9 +485,9 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent, Qt::WindowFlags f)
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), plannerModel, &DivePlannerPointsModel::setRebreatherMode);
 	connect(ui.rebreathermode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PlannerSettingsWidget::setBailoutVisibility);
 
-	connect(ui.recreational_deco, &QAbstractButton::clicked, [=] { disableDecoElements(RECREATIONAL); });
-	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [=] { disableDecoElements(BUEHLMANN); });
-	connect(ui.vpmb_deco, &QAbstractButton::clicked, [=] { disableDecoElements(VPMB); });
+	connect(ui.recreational_deco, &QAbstractButton::clicked, [this] { disableDecoElements(RECREATIONAL); });
+	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [this] { disableDecoElements(BUEHLMANN); });
+	connect(ui.vpmb_deco, &QAbstractButton::clicked, [this] { disableDecoElements(VPMB); });
 
 	connect(ui.sacfactor, QOverload<double>::of(&QDoubleSpinBox::valueChanged), plannerShared::instance(), &plannerShared::set_sacfactor);
 	connect(ui.problemsolvingtime, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setProblemSolvingTime);

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -18,23 +18,23 @@ void QMLInterface::setup(QQmlContext *ct)
 
 	// relink signals to QML
 	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
-		[=] (int value) { emit instance()->cloud_verification_statusChanged(CLOUD_STATUS(value)); });
+			[] (int value) { emit instance()->cloud_verification_statusChanged(CLOUD_STATUS(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
-			[=] (int value) { emit instance()->duration_unitsChanged(DURATION(value)); });
+			[] (int value) { emit instance()->duration_unitsChanged(DURATION(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
-			[=] (int value) { emit instance()->lengthChanged(LENGTH(value)); });
+			[] (int value) { emit instance()->lengthChanged(LENGTH(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::pressureChanged,
-			[=] (int value) { emit instance()->pressureChanged(PRESSURE(value)); });
+			[] (int value) { emit instance()->pressureChanged(PRESSURE(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
-			[=] (int value) { emit instance()->temperatureChanged(TEMPERATURE(value)); });
+			[] (int value) { emit instance()->temperatureChanged(TEMPERATURE(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
-			[=] (int value) { emit instance()->unit_systemChanged(UNIT_SYSTEM(value)); });
+			[] (int value) { emit instance()->unit_systemChanged(UNIT_SYSTEM(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::vertical_speed_timeChanged,
-			[=] (int value) { emit instance()->vertical_speed_timeChanged(TIME(value)); });
+			[] (int value) { emit instance()->vertical_speed_timeChanged(TIME(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::volumeChanged,
-			[=] (int value) { emit instance()->volumeChanged(VOLUME(value)); });
+			[] (int value) { emit instance()->volumeChanged(VOLUME(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::weightChanged,
-			[=] (int value) { emit instance()->weightChanged(WEIGHT(value)); });
+			[] (int value) { emit instance()->weightChanged(WEIGHT(value)); });
 
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratelast6mChanged,
 			instance(), &QMLInterface::ascratelast6mChanged);

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -106,7 +106,7 @@ void CollapsedDiveListSortModel::setActiveTrip(const QString &trip)
 	// to be destroyed before this function returns.
 	// Instead do this asynchronously
 	QtConcurrent::run(QThreadPool::globalInstance(),
-			  [=]{
+			  []{
 				CollapsedDiveListSortModel::instance()->updateFilterState();
 			  });
 }


### PR DESCRIPTION
There were a number of general [=] capture clauses for lambdas.
In a few cases nothing was captured - remove the clause.
In a few cases only "this" was captured - make these explicit.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is just a trivial code cleanup. Make things explicit if it is not too much of a burden (e.g. use auto only for very cumbersome types).