### PR TITLE
Cleanup: remove QMLInterface::instance()

### DIFF
--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -81,16 +81,11 @@ QMLInterface::QMLInterface()
 			this, &QMLInterface::display_variationsChanged);
 }
 
-QMLInterface *QMLInterface::instance()
-{
-	static QMLInterface *self = new QMLInterface;
-	return self;
-}
-
 void QMLInterface::setup(QQmlContext *ct)
 {
 	// Register interface class
-	ct->setContextProperty("Backend", QMLInterface::instance());
+	static QMLInterface self;
+	ct->setContextProperty("Backend", &self);
 
 	// Make enums available as types
 	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
@@ -99,7 +94,6 @@ void QMLInterface::setup(QQmlContext *ct)
 	// this is needed in order to load the divesummary page
 	diveSummary::summaryCalculation(0, 3);
 }
-
 
 void QMLInterface::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -2,6 +2,85 @@
 #include "qmlinterface.h"
 #include <QQmlEngine>
 
+QMLInterface::QMLInterface()
+{
+	// relink signals to QML
+	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
+		[this] (int value) { emit cloud_verification_statusChanged(CLOUD_STATUS(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
+			[this] (int value) { emit duration_unitsChanged(DURATION(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
+			[this] (int value) { emit lengthChanged(LENGTH(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::pressureChanged,
+			[this] (int value) { emit pressureChanged(PRESSURE(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
+			[this] (int value) { emit temperatureChanged(TEMPERATURE(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
+			[this] (int value) { emit unit_systemChanged(UNIT_SYSTEM(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::vertical_speed_timeChanged,
+			[this] (int value) { emit vertical_speed_timeChanged(TIME(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::volumeChanged,
+			[this] (int value) { emit volumeChanged(VOLUME(value)); });
+	connect(qPrefUnits::instance(), &qPrefUnits::weightChanged,
+			[this] (int value) { emit weightChanged(WEIGHT(value)); });
+
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratelast6mChanged,
+			this, &QMLInterface::ascratelast6mChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratestopsChanged,
+			this, &QMLInterface::ascratestopsChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascrate50Changed,
+			this, &QMLInterface::ascrate50Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascrate75Changed,
+			this, &QMLInterface::ascrate75Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::descrateChanged,
+			this, &QMLInterface::descrateChanged);
+
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::safetystopChanged,
+			this, &QMLInterface::safetystopChanged);
+	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::gflowChanged,
+			this, &QMLInterface::gflowChanged);
+	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::gfhighChanged,
+			this, &QMLInterface::gfhighChanged);
+	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::vpmb_conservatismChanged,
+			this, &QMLInterface::vpmb_conservatismChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::drop_stone_modeChanged,
+			this, &QMLInterface::drop_stone_modeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::last_stopChanged,
+			this, &QMLInterface::last_stop6mChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::switch_at_req_stopChanged,
+			this, &QMLInterface::switch_at_req_stopChanged);
+
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
+			this, &QMLInterface::problemsolvingtimeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottomsacChanged,
+			this, &QMLInterface::bottomsacChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decosacChanged,
+			this, &QMLInterface::decosacChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::sacfactorChanged,
+			this, &QMLInterface::sacfactorChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
+			this, &QMLInterface::problemsolvingtimeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::o2narcoticChanged,
+			this, &QMLInterface::o2narcoticChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottompo2Changed,
+			this, &QMLInterface::bottompo2Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decopo2Changed,
+			this, &QMLInterface::decopo2Changed);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bestmixendChanged,
+			this, &QMLInterface::bestmixendChanged);
+
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
+			this, &QMLInterface::display_runtimeChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_durationChanged,
+			this, &QMLInterface::display_durationChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_transitionsChanged,
+			this, &QMLInterface::display_transitionsChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::verbatim_planChanged,
+			this, &QMLInterface::verbatim_planChanged);
+	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_variationsChanged,
+			this, &QMLInterface::display_variationsChanged);
+}
+
 QMLInterface *QMLInterface::instance()
 {
 	static QMLInterface *self = new QMLInterface;
@@ -15,82 +94,6 @@ void QMLInterface::setup(QQmlContext *ct)
 
 	// Make enums available as types
 	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
-
-	// relink signals to QML
-	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
-		[=] (int value) { emit instance()->cloud_verification_statusChanged(CLOUD_STATUS(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
-			[=] (int value) { emit instance()->duration_unitsChanged(DURATION(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
-			[=] (int value) { emit instance()->lengthChanged(LENGTH(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::pressureChanged,
-			[=] (int value) { emit instance()->pressureChanged(PRESSURE(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
-			[=] (int value) { emit instance()->temperatureChanged(TEMPERATURE(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
-			[=] (int value) { emit instance()->unit_systemChanged(UNIT_SYSTEM(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::vertical_speed_timeChanged,
-			[=] (int value) { emit instance()->vertical_speed_timeChanged(TIME(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::volumeChanged,
-			[=] (int value) { emit instance()->volumeChanged(VOLUME(value)); });
-	connect(qPrefUnits::instance(), &qPrefUnits::weightChanged,
-			[=] (int value) { emit instance()->weightChanged(WEIGHT(value)); });
-
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratelast6mChanged,
-			instance(), &QMLInterface::ascratelast6mChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratestopsChanged,
-			instance(), &QMLInterface::ascratestopsChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascrate50Changed,
-			instance(), &QMLInterface::ascrate50Changed);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascrate75Changed,
-			instance(), &QMLInterface::ascrate75Changed);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::descrateChanged,
-			instance(), &QMLInterface::descrateChanged);
-
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::safetystopChanged,
-			instance(), &QMLInterface::safetystopChanged);
-	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::gflowChanged,
-			instance(), &QMLInterface::gflowChanged);
-	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::gfhighChanged,
-			instance(), &QMLInterface::gfhighChanged);
-	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::vpmb_conservatismChanged,
-			instance(), &QMLInterface::vpmb_conservatismChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::drop_stone_modeChanged,
-			instance(), &QMLInterface::drop_stone_modeChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::last_stopChanged,
-			instance(), &QMLInterface::last_stop6mChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::switch_at_req_stopChanged,
-			instance(), &QMLInterface::switch_at_req_stopChanged);
-
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
-			instance(), &QMLInterface::problemsolvingtimeChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottomsacChanged,
-			instance(), &QMLInterface::bottomsacChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decosacChanged,
-			instance(), &QMLInterface::decosacChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::sacfactorChanged,
-			instance(), &QMLInterface::sacfactorChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::problemsolvingtimeChanged,
-			instance(), &QMLInterface::problemsolvingtimeChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::o2narcoticChanged,
-			instance(), &QMLInterface::o2narcoticChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bottompo2Changed,
-			instance(), &QMLInterface::bottompo2Changed);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::decopo2Changed,
-			instance(), &QMLInterface::decopo2Changed);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::bestmixendChanged,
-			instance(), &QMLInterface::bestmixendChanged);
-
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_runtimeChanged,
-			instance(), &QMLInterface::display_runtimeChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_durationChanged,
-			instance(), &QMLInterface::display_durationChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_transitionsChanged,
-			instance(), &QMLInterface::display_transitionsChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::verbatim_planChanged,
-			instance(), &QMLInterface::verbatim_planChanged);
-	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_variationsChanged,
-			instance(), &QMLInterface::display_variationsChanged);
 
 	// calculate divesummary first time.
 	// this is needed in order to load the divesummary page

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -317,6 +317,6 @@ signals:
 
 	void diveSummaryTextChanged(QStringList);
 private:
-	QMLInterface() {}
+	QMLInterface();
 };
 #endif // QMLINTERFACE_H

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -81,9 +81,7 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(QStringList diveSummaryText READ diveSummaryText NOTIFY diveSummaryTextChanged);
 
 public:
-	static QMLInterface *instance();
-
-	// function to do the needed setup and do connect of signal/signal
+	// function to do the needed setup
 	static void setup(QQmlContext *ct);
 
 	// Duplicated enums, these enums are properly defined in the C/C++ structure


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
First of all, I must say that I think the QMLInterface class is quite horrible. Especially these enum things strike me as a remedy that is much worse than the disease.

Let's remove a few of the particularly illogical/inconsistent bits: an instance which is only used once; connecting in a helper function when you could just do in the constructor as we do nearly everywhere else.

This is only compile tested. Given how insane QML is, I wouldn't wonder if it can't handle non-heap allocated objects or the connects() have to be called in a certain way.

Let's see.