### PR TITLE
qmlinterface: make setup non-static

### DIFF
--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -11,30 +11,30 @@ QMLInterface *QMLInterface::instance()
 void QMLInterface::setup(QQmlContext *ct)
 {
 	// Register interface class
-	ct->setContextProperty("Backend", QMLInterface::instance());
+	ct->setContextProperty("Backend", this);
 
 	// Make enums available as types
 	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
 
 	// relink signals to QML
 	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
-		[=] (int value) { emit instance()->cloud_verification_statusChanged(CLOUD_STATUS(value)); });
+		[this] (int value) { emit cloud_verification_statusChanged(CLOUD_STATUS(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
-			[=] (int value) { emit instance()->duration_unitsChanged(DURATION(value)); });
+			[this] (int value) { emit duration_unitsChanged(DURATION(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
-			[=] (int value) { emit instance()->lengthChanged(LENGTH(value)); });
+			[this] (int value) { emit lengthChanged(LENGTH(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::pressureChanged,
-			[=] (int value) { emit instance()->pressureChanged(PRESSURE(value)); });
+			[this] (int value) { emit pressureChanged(PRESSURE(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::temperatureChanged,
-			[=] (int value) { emit instance()->temperatureChanged(TEMPERATURE(value)); });
+			[this] (int value) { emit temperatureChanged(TEMPERATURE(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::unit_systemChanged,
-			[=] (int value) { emit instance()->unit_systemChanged(UNIT_SYSTEM(value)); });
+			[this] (int value) { emit unit_systemChanged(UNIT_SYSTEM(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::vertical_speed_timeChanged,
-			[=] (int value) { emit instance()->vertical_speed_timeChanged(TIME(value)); });
+			[this] (int value) { emit vertical_speed_timeChanged(TIME(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::volumeChanged,
-			[=] (int value) { emit instance()->volumeChanged(VOLUME(value)); });
+			[this] (int value) { emit volumeChanged(VOLUME(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::weightChanged,
-			[=] (int value) { emit instance()->weightChanged(WEIGHT(value)); });
+			[this] (int value) { emit weightChanged(WEIGHT(value)); });
 
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::ascratelast6mChanged,
 			instance(), &QMLInterface::ascratelast6mChanged);

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -84,7 +84,7 @@ public:
 	static QMLInterface *instance();
 
 	// function to do the needed setup and do connect of signal/signal
-	static void setup(QQmlContext *ct);
+	void setup(QQmlContext *ct);
 
 	// Duplicated enums, these enums are properly defined in the C/C++ structure
 	// but duplicated here to make them available to QML.

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -188,7 +188,7 @@ void register_qml_types(QQmlEngine *engine)
 		QQmlContext *ct = engine->rootContext();
 
 		// Register qml interface classes
-		QMLInterface::setup(ct);
+		QMLInterface::instance()->setup(ct);
 		themeInterface::setup(ct);
 	}
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
NOTE: this PR competes with #2574, but with 2 major differences
- it is actually tested
- it updates the Lambda (Very good idea in #2574), while keeping setup()

Basically it consist of 2 changes:
1) make qmlinterface::setup() non-static
2) change lambda [=] to [this], thanks to suggestion from bstoeger in #2574

I am aware,  that submitting a "competing" PR is not a recommended or even polite way, and this is one of the very few times I have actually done that.

But considering the way #2474 talks about qmlinterface quote
"I think the QMLInterface class is quite horrible. Especially these enum things strike me as a remedy that is much worse than the disease."
it seems easier to make a PR that is tested and I am comfortable with, instead of discussing.

VERY Important: This PR should be closed without merging, if #2474 is changed!

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
