### PR TITLE
Help needed: Add CylindersModelFiltered

### DIFF
--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -126,7 +126,7 @@ void PlannerShared::set_o2narcotic(bool value)
 {
 	qPrefDivePlanner::set_o2narcotic(value);
 	DivePlannerPointsModel::instance()->emitDataChanged();
-	CylindersModelFiltered::instance()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
 }
 
 double PlannerShared::bottompo2()
@@ -136,7 +136,7 @@ double PlannerShared::bottompo2()
 void PlannerShared::set_bottompo2(double value)
 {
 	qPrefDivePlanner::set_bottompo2((int) (value * 1000.0));
-	CylindersModelFiltered::instance()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
 }
 
 double PlannerShared::decopo2()
@@ -148,8 +148,8 @@ void PlannerShared::set_decopo2(double value)
 	pressure_t olddecopo2;
 	olddecopo2.mbar = prefs.decopo2;
 	qPrefDivePlanner::instance()->set_decopo2((int) (value * 1000.0));
-	CylindersModelFiltered::instance()->model()->updateDecoDepths(olddecopo2);
-	CylindersModelFiltered::instance()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateDecoDepths(olddecopo2);
+	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
 }
 
 int PlannerShared::bestmixend()
@@ -159,5 +159,5 @@ int PlannerShared::bestmixend()
 void PlannerShared::set_bestmixend(int value)
 {
 	qPrefDivePlanner::set_bestmixend(units_to_depth(value).mm);
-	CylindersModelFiltered::instance()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
 }

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -126,7 +126,7 @@ void PlannerShared::set_o2narcotic(bool value)
 {
 	qPrefDivePlanner::set_o2narcotic(value);
 	DivePlannerPointsModel::instance()->emitDataChanged();
-	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->updateBestMixes();
 }
 
 double PlannerShared::bottompo2()
@@ -136,7 +136,7 @@ double PlannerShared::bottompo2()
 void PlannerShared::set_bottompo2(double value)
 {
 	qPrefDivePlanner::set_bottompo2((int) (value * 1000.0));
-	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->updateBestMixes();
 }
 
 double PlannerShared::decopo2()
@@ -148,8 +148,8 @@ void PlannerShared::set_decopo2(double value)
 	pressure_t olddecopo2;
 	olddecopo2.mbar = prefs.decopo2;
 	qPrefDivePlanner::instance()->set_decopo2((int) (value * 1000.0));
-	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateDecoDepths(olddecopo2);
-	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->updateDecoDepths(olddecopo2);
+	DivePlannerPointsModel::instance()->cylindersModel()->updateBestMixes();
 }
 
 int PlannerShared::bestmixend()
@@ -159,5 +159,5 @@ int PlannerShared::bestmixend()
 void PlannerShared::set_bestmixend(int value)
 {
 	qPrefDivePlanner::set_bestmixend(units_to_depth(value).mm);
-	DivePlannerPointsModel::instance()->cylindersModel()->model()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->updateBestMixes();
 }

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -126,7 +126,7 @@ void PlannerShared::set_o2narcotic(bool value)
 {
 	qPrefDivePlanner::set_o2narcotic(value);
 	DivePlannerPointsModel::instance()->emitDataChanged();
-	CylindersModel::instance()->updateBestMixes();
+	CylindersModelFiltered::instance()->model()->updateBestMixes();
 }
 
 double PlannerShared::bottompo2()
@@ -136,7 +136,7 @@ double PlannerShared::bottompo2()
 void PlannerShared::set_bottompo2(double value)
 {
 	qPrefDivePlanner::set_bottompo2((int) (value * 1000.0));
-	CylindersModel::instance()->updateBestMixes();
+	CylindersModelFiltered::instance()->model()->updateBestMixes();
 }
 
 double PlannerShared::decopo2()
@@ -148,8 +148,8 @@ void PlannerShared::set_decopo2(double value)
 	pressure_t olddecopo2;
 	olddecopo2.mbar = prefs.decopo2;
 	qPrefDivePlanner::instance()->set_decopo2((int) (value * 1000.0));
-	CylindersModel::instance()->updateDecoDepths(olddecopo2);
-	CylindersModel::instance()->updateBestMixes();
+	CylindersModelFiltered::instance()->model()->updateDecoDepths(olddecopo2);
+	CylindersModelFiltered::instance()->model()->updateBestMixes();
 }
 
 int PlannerShared::bestmixend()
@@ -159,5 +159,5 @@ int PlannerShared::bestmixend()
 void PlannerShared::set_bestmixend(int value)
 {
 	qPrefDivePlanner::set_bestmixend(units_to_depth(value).mm);
-	CylindersModel::instance()->updateBestMixes();
+	CylindersModelFiltered::instance()->model()->updateBestMixes();
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -110,7 +110,7 @@ void DiveHandler::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f)
 {
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	CylindersModelFiltered *cylinders = DivePlannerPointsModel::instance()->cylindersModel();
+	CylindersModel *cylinders = DivePlannerPointsModel::instance()->cylindersModel();
 
 	ui.setupUi(this);
 	ui.dateEdit->setDisplayFormat(prefs.date_format);
@@ -123,7 +123,7 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));
 	ui.cylinderTableWidget->setBtnToolTip(tr("Add cylinder"));
 	ui.cylinderTableWidget->setModel(cylinders);
-	connect(ui.cylinderTableWidget, &TableView::itemClicked, cylinders, &CylindersModelFiltered::remove);
+	connect(ui.cylinderTableWidget, &TableView::itemClicked, cylinders, &CylindersModel::remove);
 	ui.waterType->setItemData(0, FRESHWATER_SALINITY);
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);
@@ -141,13 +141,13 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	// Continue to use old syntax, to avoid problems.
 	connect(ui.tableWidget, SIGNAL(addButtonClicked()), plannerModel, SLOT(addStop()));
 
-	connect(cylinders, &CylindersModelFiltered::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(cylinders, &CylindersModelFiltered::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(cylinders, &CylindersModelFiltered::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(cylinders, &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
-	connect(cylinders, &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(cylinders, &CylindersModelFiltered::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(cylinders, &CylindersModelFiltered::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModel::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModel::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModel::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
+	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModel::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModel::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(plannerModel, &DivePlannerPointsModel::calculatedPlanNotes, MainWindow::instance(), &MainWindow::setPlanNotes);
 
 

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -110,6 +110,8 @@ void DiveHandler::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f)
 {
 	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
+	CylindersModelFiltered *cylinders = DivePlannerPointsModel::instance()->cylindersModel();
+
 	ui.setupUi(this);
 	ui.dateEdit->setDisplayFormat(prefs.date_format);
 	ui.tableWidget->setTitle(tr("Dive planner points"));
@@ -120,8 +122,8 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(this));
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));
 	ui.cylinderTableWidget->setBtnToolTip(tr("Add cylinder"));
-	ui.cylinderTableWidget->setModel(CylindersModelFiltered::instance());
-	connect(ui.cylinderTableWidget, &TableView::itemClicked, CylindersModelFiltered::instance(), &CylindersModelFiltered::remove);
+	ui.cylinderTableWidget->setModel(cylinders);
+	connect(ui.cylinderTableWidget, &TableView::itemClicked, cylinders, &CylindersModelFiltered::remove);
 	ui.waterType->setItemData(0, FRESHWATER_SALINITY);
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);
@@ -139,13 +141,13 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	// Continue to use old syntax, to avoid problems.
 	connect(ui.tableWidget, SIGNAL(addButtonClicked()), plannerModel, SLOT(addStop()));
 
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModelFiltered::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModelFiltered::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModelFiltered::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(cylinders, &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
+	connect(cylinders, &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModelFiltered::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(cylinders, &CylindersModelFiltered::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(plannerModel, &DivePlannerPointsModel::calculatedPlanNotes, MainWindow::instance(), &MainWindow::setPlanNotes);
 
 

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -120,8 +120,8 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(this));
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));
 	ui.cylinderTableWidget->setBtnToolTip(tr("Add cylinder"));
-	ui.cylinderTableWidget->setModel(CylindersModel::instance());
-	connect(ui.cylinderTableWidget, &TableView::itemClicked, CylindersModel::instance(), &CylindersModel::remove);
+	ui.cylinderTableWidget->setModel(CylindersModelFiltered::instance());
+	connect(ui.cylinderTableWidget, &TableView::itemClicked, CylindersModelFiltered::instance(), &CylindersModelFiltered::remove);
 	ui.waterType->setItemData(0, FRESHWATER_SALINITY);
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);
@@ -139,13 +139,13 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent, Qt::WindowFlags f) : QWidg
 	// Continue to use old syntax, to avoid problems.
 	connect(ui.tableWidget, SIGNAL(addButtonClicked()), plannerModel, SLOT(addStop()));
 
-	connect(CylindersModel::instance(), &CylindersModel::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModel::instance(), &CylindersModel::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModel::instance(), &CylindersModel::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
-	connect(CylindersModel::instance(), &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
-	connect(CylindersModel::instance(), &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(CylindersModel::instance(), &CylindersModel::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(CylindersModel::instance(), &CylindersModel::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
+	connect(CylindersModelFiltered::instance(), &CylindersModelFiltered::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(plannerModel, &DivePlannerPointsModel::calculatedPlanNotes, MainWindow::instance(), &MainWindow::setPlanNotes);
 
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -918,7 +918,7 @@ void MainWindow::on_actionReplanDive_triggered()
 		divePlannerWidget->setSalinity(current_dive->salinity);
 	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
 	reset_cylinders(&displayed_dive, true);
-	CylindersModelFiltered::instance()->updateDive();
+	DivePlannerPointsModel::instance()->cylindersModel()->updateDive();
 }
 
 void MainWindow::on_actionDivePlanner_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -918,7 +918,7 @@ void MainWindow::on_actionReplanDive_triggered()
 		divePlannerWidget->setSalinity(current_dive->salinity);
 	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
 	reset_cylinders(&displayed_dive, true);
-	CylindersModel::instance()->updateDive();
+	CylindersModelFiltered::instance()->updateDive();
 }
 
 void MainWindow::on_actionDivePlanner_triggered()

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -238,7 +238,7 @@ static struct RevertCylinderData {
 
 void TankInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelIndex&) const
 {
-	CylindersModel *mymodel = qobject_cast<CylindersModel *>(currCombo.model);
+	CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
 	TankInfoModel *tanks = TankInfoModel::instance();
 	QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, currCombo.activeText);
 	int row;
@@ -277,7 +277,7 @@ void TankInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint
 {
 	if (hint == QAbstractItemDelegate::NoHint ||
 	    hint == QAbstractItemDelegate::RevertModelCache) {
-		CylindersModel *mymodel = qobject_cast<CylindersModel *>(currCombo.model);
+		CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
 		mymodel->setData(IDX(CylindersModel::TYPE), currCylinderData.type, Qt::EditRole);
 		mymodel->passInData(IDX(CylindersModel::WORKINGPRESS), currCylinderData.pressure);
 		mymodel->passInData(IDX(CylindersModel::SIZE), currCylinderData.size);
@@ -289,7 +289,7 @@ QWidget *TankInfoDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	// ncreate editor needs to be called before because it will populate a few
 	// things in the currCombo global var.
 	QWidget *delegate = ComboBoxDelegate::createEditor(parent, option, index);
-	CylindersModel *mymodel = qobject_cast<CylindersModel *>(currCombo.model);
+	CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
 	cylinder_t *cyl = mymodel->cylinderAt(index);
 	currCylinderData.type = cyl->type.description;
 	currCylinderData.pressure = cyl->type.workingpressure.mbar;

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -17,7 +17,7 @@
 #include <QCompleter>
 
 TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
-	cylindersModel(new CylindersModel(this)),
+	cylindersModel(new CylindersModelFiltered(this)),
 	weightModel(new WeightModel(this))
 {
 	QCompleter *suitCompleter;
@@ -33,7 +33,7 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	ui.weights->setModel(weightModel);
 
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveEquipment::divesChanged);
-	connect(ui.cylinders, &TableView::itemClicked, cylindersModel, &CylindersModel::remove);
+	connect(ui.cylinders, &TableView::itemClicked, cylindersModel, &CylindersModelFiltered::remove);
 	connect(ui.cylinders, &TableView::itemClicked, this, &TabDiveEquipment::editCylinderWidget);
 	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
 
@@ -164,7 +164,7 @@ void TabDiveEquipment::addWeight_clicked()
 
 void TabDiveEquipment::editCylinderWidget(const QModelIndex &index)
 {
-	if (cylindersModel->changed && !MainWindow::instance()->mainTab->isEditing()) {
+	if (cylindersModel->model()->changed && !MainWindow::instance()->mainTab->isEditing()) {
 		MainWindow::instance()->mainTab->enableEdition();
 		return;
 	}
@@ -228,7 +228,7 @@ void TabDiveEquipment::acceptChanges()
 	// to the original value in current_dive like it should
 	QVector<dive *> selectedDives = getSelectedDivesCurrentLast();
 
-	if (cylindersModel->changed) {
+	if (cylindersModel->model()->changed) {
 		mark_divelist_changed(true);
 		MODIFY_DIVES(selectedDives,
 			// if we started out with the same cylinder description (for multi-edit) or if we do copt & paste
@@ -257,12 +257,12 @@ void TabDiveEquipment::acceptChanges()
 	if (do_replot)
 		MainWindow::instance()->graphics->replot();
 
-	cylindersModel->changed = false;
+	cylindersModel->model()->changed = false;
 }
 
 void TabDiveEquipment::rejectChanges()
 {
-	cylindersModel->changed = false;
+	cylindersModel->model()->changed = false;
 	cylindersModel->updateDive();
 	weightModel->updateDive(current_dive);
 }

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -12,7 +12,7 @@ namespace Ui {
 };
 
 class WeightModel;
-class CylindersModel;
+class CylindersModelFiltered;
 
 class TabDiveEquipment : public TabBase {
 	Q_OBJECT
@@ -38,7 +38,7 @@ private slots:
 private:
 	Ui::TabDiveEquipment ui;
 	SuitCompletionModel suitModel;
-	CylindersModel *cylindersModel;
+	CylindersModelFiltered *cylindersModel;
 	WeightModel *weightModel;
 };
 

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -611,12 +611,6 @@ void CylindersModel::cylindersReset(const QVector<dive *> &dives)
 	updateDive();
 }
 
-CylindersModelFiltered *CylindersModelFiltered::instance()
-{
-	static CylindersModelFiltered self;
-	return &self;
-}
-
 CylindersModelFiltered::CylindersModelFiltered(QObject *parent) : QSortFilterProxyModel(parent)
 {
 	setSourceModel(&source);

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -43,12 +43,12 @@ public:
 	cylinder_t *cylinderAt(const QModelIndex &index);
 	bool changed;
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+	bool updateBestMixes();
 
 public
 slots:
 	void remove(QModelIndex index);
 	void cylindersReset(const QVector<dive *> &dives);
-	bool updateBestMixes();
 
 private:
 	int rows;

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -61,7 +61,6 @@ class CylindersModelFiltered : public QSortFilterProxyModel {
 	Q_OBJECT
 public:
 	CylindersModelFiltered(QObject *parent = 0);
-	static CylindersModelFiltered *instance();
 	CylindersModel *model(); // Access to unfiltered base model
 
 	void clear();

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -2,6 +2,8 @@
 #ifndef CYLINDERMODEL_H
 #define CYLINDERMODEL_H
 
+#include <QSortFilterProxyModel>
+
 #include "cleanertablemodel.h"
 #include "core/dive.h"
 
@@ -27,7 +29,6 @@ public:
 	};
 
 	explicit CylindersModel(QObject *parent = 0);
-	static CylindersModel *instance();
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
@@ -44,6 +45,7 @@ public:
 	bool changed;
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 	bool updateBestMixes();
+	bool cylinderUsed(int i) const;
 
 public
 slots:
@@ -52,6 +54,27 @@ slots:
 
 private:
 	int rows;
+};
+
+// Cylinder model that hides unused cylinders if the pref.show_unused_cylinders flag is not set
+class CylindersModelFiltered : public QSortFilterProxyModel {
+	Q_OBJECT
+public:
+	CylindersModelFiltered(QObject *parent = 0);
+	static CylindersModelFiltered *instance();
+	CylindersModel *model(); // Access to unfiltered base model
+
+	void clear();
+	void add();
+	void updateDive();
+	cylinder_t *cylinderAt(const QModelIndex &index);
+	void passInData(const QModelIndex &index, const QVariant &value);
+public
+slots:
+	void remove(QModelIndex index);
+private:
+	CylindersModel source;
+	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
 };
 
 #endif

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -21,6 +21,11 @@
 
 #define UNIT_FACTOR ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
 
+CylindersModelFiltered *DivePlannerPointsModel::cylindersModel()
+{
+	return &cylinders;
+}
+
 /* TODO: Port this to CleanerTableModel to remove a bit of boilerplate and
  * use the signal warningMessage() to communicate errors to the MainWindow.
  */
@@ -37,7 +42,7 @@ void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 		divepoints.remove(v2[i]);
 	}
 	endRemoveRows();
-	CylindersModelFiltered::instance()->model()->updateTrashIcon();
+	cylinders.model()->updateTrashIcon();
 }
 
 void DivePlannerPointsModel::createSimpleDive()
@@ -89,7 +94,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	const struct event *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 	recalc = false;
-	CylindersModelFiltered::instance()->updateDive();
+	cylinders.updateDive();
 	duration_t lasttime = { 0 };
 	duration_t lastrecordedtime = {};
 	duration_t newtime = {};
@@ -162,7 +167,7 @@ void DivePlannerPointsModel::setupCylinders()
 		reset_cylinders(&displayed_dive, true);
 
 		if (displayed_dive.cylinders.nr > 0) {
-			CylindersModelFiltered::instance()->updateDive();
+			cylinders.updateDive();
 			return;		// We have at least one cylinder
 		}
 	}
@@ -180,7 +185,7 @@ void DivePlannerPointsModel::setupCylinders()
 		add_to_cylinder_table(&displayed_dive.cylinders, 0, cyl);
 	}
 	reset_cylinders(&displayed_dive, false);
-	CylindersModelFiltered::instance()->updateDive();
+	cylinders.updateDive();
 }
 
 // Update the dive's maximum depth.  Returns true if max. depth changed
@@ -209,10 +214,8 @@ void DivePlannerPointsModel::removeDeco()
 
 void DivePlannerPointsModel::addCylinder_clicked()
 {
-	CylindersModelFiltered::instance()->add();
+	cylinders.add();
 }
-
-
 
 void DivePlannerPointsModel::setPlanMode(Mode m)
 {
@@ -317,7 +320,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 			if (value.toInt() >= 0) {
 				p.depth = units_to_depth(value.toInt());
 				if (updateMaxDepth())
-					CylindersModelFiltered::instance()->model()->updateBestMixes();
+					cylinders.model()->updateBestMixes();
 			}
 			break;
 		case RUNTIME:
@@ -343,8 +346,8 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 				p.cylinderid = value.toInt();
 			/* Did we change the start (dp 0) cylinder to another cylinderid than 0? */
 			if (value.toInt() != 0 && index.row() == 0)
-				CylindersModelFiltered::instance()->model()->moveAtFirst(value.toInt());
-			CylindersModelFiltered::instance()->model()->updateTrashIcon();
+				cylinders.model()->moveAtFirst(value.toInt());
+			cylinders.model()->updateTrashIcon();
 			break;
 		case DIVEMODE:
 			if (value.toInt() < FREEDIVE) {
@@ -799,9 +802,9 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	divepoints[row] = newData;
 	std::sort(divepoints.begin(), divepoints.end(), divePointsLessThan);
 	if (updateMaxDepth())
-		CylindersModelFiltered::instance()->model()->updateBestMixes();
+		cylinders.model()->updateBestMixes();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		CylindersModelFiltered::instance()->model()->moveAtFirst(divepoints[0].cylinderid);
+		cylinders.model()->moveAtFirst(divepoints[0].cylinderid);
 	emitDataChanged();
 }
 
@@ -850,9 +853,9 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 		divepoints.remove(index.row());
 	}
 	endRemoveRows();
-	CylindersModelFiltered::instance()->model()->updateTrashIcon();
+	cylinders.model()->updateTrashIcon();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		CylindersModelFiltered::instance()->model()->moveAtFirst(divepoints[0].cylinderid);
+		cylinders.model()->moveAtFirst(divepoints[0].cylinderid);
 }
 
 struct diveplan &DivePlannerPointsModel::getDiveplan()
@@ -907,13 +910,13 @@ void DivePlannerPointsModel::clear()
 {
 	bool oldRecalc = setRecalc(false);
 
-	CylindersModelFiltered::instance()->updateDive();
+	cylinders.updateDive();
 	if (rowCount() > 0) {
 		beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
 		divepoints.clear();
 		endRemoveRows();
 	}
-	CylindersModelFiltered::instance()->clear();
+	cylinders.clear();
 	setRecalc(oldRecalc);
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -21,7 +21,7 @@
 
 #define UNIT_FACTOR ((prefs.units.length == units::METERS) ? 1000.0 / 60.0 : feet_to_mm(1.0) / 60.0)
 
-CylindersModelFiltered *DivePlannerPointsModel::cylindersModel()
+CylindersModel *DivePlannerPointsModel::cylindersModel()
 {
 	return &cylinders;
 }
@@ -42,7 +42,7 @@ void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 		divepoints.remove(v2[i]);
 	}
 	endRemoveRows();
-	cylinders.model()->updateTrashIcon();
+	cylinders.updateTrashIcon();
 }
 
 void DivePlannerPointsModel::createSimpleDive()
@@ -320,7 +320,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 			if (value.toInt() >= 0) {
 				p.depth = units_to_depth(value.toInt());
 				if (updateMaxDepth())
-					cylinders.model()->updateBestMixes();
+					cylinders.updateBestMixes();
 			}
 			break;
 		case RUNTIME:
@@ -346,8 +346,8 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 				p.cylinderid = value.toInt();
 			/* Did we change the start (dp 0) cylinder to another cylinderid than 0? */
 			if (value.toInt() != 0 && index.row() == 0)
-				cylinders.model()->moveAtFirst(value.toInt());
-			cylinders.model()->updateTrashIcon();
+				cylinders.moveAtFirst(value.toInt());
+			cylinders.updateTrashIcon();
 			break;
 		case DIVEMODE:
 			if (value.toInt() < FREEDIVE) {
@@ -802,9 +802,9 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	divepoints[row] = newData;
 	std::sort(divepoints.begin(), divepoints.end(), divePointsLessThan);
 	if (updateMaxDepth())
-		cylinders.model()->updateBestMixes();
+		cylinders.updateBestMixes();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		cylinders.model()->moveAtFirst(divepoints[0].cylinderid);
+		cylinders.moveAtFirst(divepoints[0].cylinderid);
 	emitDataChanged();
 }
 
@@ -853,9 +853,9 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 		divepoints.remove(index.row());
 	}
 	endRemoveRows();
-	cylinders.model()->updateTrashIcon();
+	cylinders.updateTrashIcon();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		cylinders.model()->moveAtFirst(divepoints[0].cylinderid);
+		cylinders.moveAtFirst(divepoints[0].cylinderid);
 }
 
 struct diveplan &DivePlannerPointsModel::getDiveplan()

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -37,7 +37,7 @@ void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 		divepoints.remove(v2[i]);
 	}
 	endRemoveRows();
-	CylindersModel::instance()->updateTrashIcon();
+	CylindersModelFiltered::instance()->model()->updateTrashIcon();
 }
 
 void DivePlannerPointsModel::createSimpleDive()
@@ -89,7 +89,7 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	const struct event *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
 	recalc = false;
-	CylindersModel::instance()->updateDive();
+	CylindersModelFiltered::instance()->updateDive();
 	duration_t lasttime = { 0 };
 	duration_t lastrecordedtime = {};
 	duration_t newtime = {};
@@ -162,7 +162,7 @@ void DivePlannerPointsModel::setupCylinders()
 		reset_cylinders(&displayed_dive, true);
 
 		if (displayed_dive.cylinders.nr > 0) {
-			CylindersModel::instance()->updateDive();
+			CylindersModelFiltered::instance()->updateDive();
 			return;		// We have at least one cylinder
 		}
 	}
@@ -180,7 +180,7 @@ void DivePlannerPointsModel::setupCylinders()
 		add_to_cylinder_table(&displayed_dive.cylinders, 0, cyl);
 	}
 	reset_cylinders(&displayed_dive, false);
-	CylindersModel::instance()->updateDive();
+	CylindersModelFiltered::instance()->updateDive();
 }
 
 // Update the dive's maximum depth.  Returns true if max. depth changed
@@ -209,7 +209,7 @@ void DivePlannerPointsModel::removeDeco()
 
 void DivePlannerPointsModel::addCylinder_clicked()
 {
-	CylindersModel::instance()->add();
+	CylindersModelFiltered::instance()->add();
 }
 
 
@@ -317,7 +317,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 			if (value.toInt() >= 0) {
 				p.depth = units_to_depth(value.toInt());
 				if (updateMaxDepth())
-					CylindersModel::instance()->updateBestMixes();
+					CylindersModelFiltered::instance()->model()->updateBestMixes();
 			}
 			break;
 		case RUNTIME:
@@ -343,8 +343,8 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 				p.cylinderid = value.toInt();
 			/* Did we change the start (dp 0) cylinder to another cylinderid than 0? */
 			if (value.toInt() != 0 && index.row() == 0)
-				CylindersModel::instance()->moveAtFirst(value.toInt());
-			CylindersModel::instance()->updateTrashIcon();
+				CylindersModelFiltered::instance()->model()->moveAtFirst(value.toInt());
+			CylindersModelFiltered::instance()->model()->updateTrashIcon();
 			break;
 		case DIVEMODE:
 			if (value.toInt() < FREEDIVE) {
@@ -799,9 +799,9 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	divepoints[row] = newData;
 	std::sort(divepoints.begin(), divepoints.end(), divePointsLessThan);
 	if (updateMaxDepth())
-		CylindersModel::instance()->updateBestMixes();
+		CylindersModelFiltered::instance()->model()->updateBestMixes();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		CylindersModel::instance()->moveAtFirst(divepoints[0].cylinderid);
+		CylindersModelFiltered::instance()->model()->moveAtFirst(divepoints[0].cylinderid);
 	emitDataChanged();
 }
 
@@ -850,9 +850,9 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 		divepoints.remove(index.row());
 	}
 	endRemoveRows();
-	CylindersModel::instance()->updateTrashIcon();
+	CylindersModelFiltered::instance()->model()->updateTrashIcon();
 	if (divepoints[0].cylinderid != old_first_cylid)
-		CylindersModel::instance()->moveAtFirst(divepoints[0].cylinderid);
+		CylindersModelFiltered::instance()->model()->moveAtFirst(divepoints[0].cylinderid);
 }
 
 struct diveplan &DivePlannerPointsModel::getDiveplan()
@@ -907,13 +907,13 @@ void DivePlannerPointsModel::clear()
 {
 	bool oldRecalc = setRecalc(false);
 
-	CylindersModel::instance()->updateDive();
+	CylindersModelFiltered::instance()->updateDive();
 	if (rowCount() > 0) {
 		beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
 		divepoints.clear();
 		endRemoveRows();
 	}
-	CylindersModel::instance()->clear();
+	CylindersModelFiltered::instance()->clear();
 	setRecalc(oldRecalc);
 }
 

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -48,7 +48,7 @@ public:
 	bool tankInUse(int cylinderid);
 	void setupCylinders();
 	bool updateMaxDepth();
-	CylindersModelFiltered *cylindersModel();
+	CylindersModel *cylindersModel();
 
 	int ascrate75Display();
 	int ascrate50Display();
@@ -129,7 +129,7 @@ private:
 	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
-	CylindersModelFiltered cylinders;
+	CylindersModel cylinders;
 	Mode mode;
 	bool recalc;
 	QVector<divedatapoint> divepoints;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -7,6 +7,7 @@
 
 #include "core/deco.h"
 #include "core/planner.h"
+#include "qt-models/cylindermodel.h"
 
 class DivePlannerPointsModel : public QAbstractTableModel {
 	Q_OBJECT
@@ -47,6 +48,7 @@ public:
 	bool tankInUse(int cylinderid);
 	void setupCylinders();
 	bool updateMaxDepth();
+	CylindersModelFiltered *cylindersModel();
 
 	int ascrate75Display();
 	int ascrate50Display();
@@ -127,6 +129,7 @@ private:
 	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
+	CylindersModelFiltered cylinders;
 	Mode mode;
 	bool recalc;
 	QVector<divedatapoint> divepoints;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Currently, the handling of unused cylinders is completely broken: In `CylindersModel` the right number of cylinders are shown, but the code doesn't account for the fact that the unused cylinders might not be the last cylinders.

As a comment suggests, this should be solved by placing a proxy-model on top of the CylindersModel. This PR does just that. It is a bit inconsistent in how some calls are routed through (those taking indexes as parameter must be of course - the index has to be mapped). For other functions the caller has to access the base model. This is up for debate.

I suspect that this completely breaks the planner, as the planner probably supposes that the indexes are with respect to the list in the core...? Therefore, I need help with testing this.

Moreover, we should discuss if this feature is even worth the complexities. Perhaps we should add a "delete unused cylinders" button (with undo functionality, so no risk) and an "import unused cylinders" flag on import instead?

One advantage of the proxy model as realized here is that we can easily implement sorting of the cylinder list if something like that is even useful?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Implement CylindersModelFiltered
2) Replace CylindersModel by CylindersModelFiltered


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Perhaps?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @dirkhh 