### PR TITLE
[RFC] Move sorting closer to the core

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1370,7 +1370,7 @@ static int comp_dive_to_trip(struct dive *a, struct dive_trip *b)
 	return comp_dives(a, b->dives.dives[0]);
 }
 
-static int comp_dive_or_trip(struct dive_or_trip a, struct dive_or_trip b)
+int comp_dive_or_trip(struct dive_or_trip a, struct dive_or_trip b)
 {
 	/* we should only be called with both a and b having exactly one of
 	 * dive or trip not NULL. But in an abundance of caution, make sure

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -49,6 +49,7 @@ extern void delete_dive_from_table(struct dive_table *table, int idx);
 extern struct dive *find_next_visible_dive(timestamp_t when);
 
 extern int comp_dives(const struct dive *a, const struct dive *b);
+extern int comp_dive_or_trip(struct dive_or_trip a, struct dive_or_trip b);
 
 int get_min_datafile_version();
 void reset_min_datafile_version();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -67,7 +67,8 @@ private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
 	void selectAll() override;
 	void selectionChangeDone();
-	DiveTripModelBase::Layout currentLayout;
+	DiveTripModelBase::Column sortRow;
+	Qt::SortOrder sortOrder;
 	QModelIndex contextMenuIndex;
 	// Remember the initial column widths, to avoid writing unchanged widths to the settings
 	QVector<int> initialColumnWidths;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1288,7 +1288,8 @@ bool DiveTripModelTree::lessThan(const QModelIndex &i1, const QModelIndex &i2) c
 
 // 3) ListModel functions
 
-DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent)
+DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent),
+	sort(dive_less_than)
 {
 	// Stay informed of changes to the divelist
 	connect(&diveListNotifier, &DiveListNotifier::divesAdded, this, &DiveTripModelList::divesAdded);
@@ -1397,9 +1398,9 @@ QVariant DiveTripModelList::data(const QModelIndex &index, int role) const
 void DiveTripModelList::divesAdded(dive_trip *, bool, const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = divesIn;
-	std::sort(dives.begin(), dives.end(), dive_less_than);
+	std::sort(dives.begin(), dives.end(), sort);
 	addInBatches(items, dives,
-		     &dive_less_than, // comp
+		     sort, // comp
 		     [&](std::vector<dive *> &items, const QVector<dive *> &dives, int idx, int from, int to) { // inserter
 			beginInsertRows(QModelIndex(), idx, idx + to - from - 1);
 			items.insert(items.begin() + idx, dives.begin() + from, dives.begin() + to);
@@ -1410,7 +1411,7 @@ void DiveTripModelList::divesAdded(dive_trip *, bool, const QVector<dive *> &div
 void DiveTripModelList::divesDeleted(dive_trip *, bool, const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = divesIn;
-	std::sort(dives.begin(), dives.end(), dive_less_than);
+	std::sort(dives.begin(), dives.end(), sort);
 	processRangesZip(items, dives,
 			 std::equal_to<const dive *>(), // Condition: dive-pointers are equal
 			 [&](std::vector<dive *> &items, const QVector<dive *> &, int from, int to, int) -> int { // Action
@@ -1431,7 +1432,7 @@ void DiveTripModelList::diveSiteChanged(dive_site *ds, int field)
 void DiveTripModelList::divesChanged(const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = divesIn;
-	std::sort(dives.begin(), dives.end(), dive_less_than);
+	std::sort(dives.begin(), dives.end(), sort);
 
 	updateShown(dives);
 
@@ -1450,7 +1451,7 @@ void DiveTripModelList::divesChanged(const QVector<dive *> &divesIn)
 void DiveTripModelList::divesTimeChanged(timestamp_t delta, const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = divesIn;
-	std::sort(dives.begin(), dives.end(), dive_less_than);
+	std::sort(dives.begin(), dives.end(), sort);
 
 	// See comment for DiveTripModelTree::divesTimeChanged above.
 	QVector<dive *> selectedDives = filterSelectedDives(dives);

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -190,6 +190,9 @@ public slots:
 public:
 	DiveTripModelList(QObject *parent = nullptr);
 private:
+	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
+	dive_less_than_t sort;
+
 	int rowCount(const QModelIndex &parent) const override;
 	void clearData() override;
 	void populate() override;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -161,6 +161,14 @@ private:
 	int findDiveInTrip(int tripIdx, const dive *d) const;	// Find dive inside trip. Second parameter is index of trip
 	int findInsertionIndex(const dive_trip *trip) const;	// Where to insert trip
 
+	// There are two sort functions: one for top-level items, one for dives inside trips
+public:
+	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
+	typedef bool(*dive_or_trip_less_than_t)(dive_or_trip a, dive_or_trip b);
+private:
+	dive_less_than_t sort;
+	dive_or_trip_less_than_t sortTopLevel;
+
 	// Comparison function between dive and arbitrary entry
 	static bool dive_before_entry(const dive *d, const Item &entry);
 };

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -72,10 +72,6 @@ public:
 	DiveTripModelBase(QObject *parent = 0);
 	int columnCount(const QModelIndex&) const;
 
-	// Used for sorting. This is a bit of a layering violation, as sorting should be performed
-	// by the higher-up QSortFilterProxyModel, but it makes things so much easier!
-	virtual bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const = 0;
-
 signals:
 	// The propagation of selection changes is complex.
 	// The control flow of dive-selection goes:
@@ -112,7 +108,7 @@ public slots:
 	void filterReset();
 
 public:
-	DiveTripModelTree(QObject *parent = nullptr);
+	DiveTripModelTree(bool ascending, QObject *parent = nullptr);
 
 	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
 	typedef bool(*dive_or_trip_less_than_t)(dive_or_trip a, dive_or_trip b);
@@ -123,7 +119,6 @@ private:
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
-	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	void divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &);
 	dive *diveOrNull(const QModelIndex &index) const override;
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
@@ -187,10 +182,11 @@ public slots:
 	void filterReset();
 
 public:
-	DiveTripModelList(QObject *parent = nullptr);
+	DiveTripModelList(DiveTripModelBase::Column row, bool ascending, QObject *parent = nullptr);
 private:
 	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
 	dive_less_than_t sort;
+	static dive_less_than_t get_dive_less_than_function(DiveTripModelBase::Column row, bool ascending);
 
 	int rowCount(const QModelIndex &parent) const override;
 	void clearData() override;
@@ -198,7 +194,6 @@ private:
 	QModelIndex index(int row, int column, const QModelIndex &parent) const override;
 	QModelIndex parent(const QModelIndex &index) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
-	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	dive *diveOrNull(const QModelIndex &index) const override;
 
 	std::vector<dive *> items;				// TODO: access core data directly

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -113,6 +113,9 @@ public slots:
 
 public:
 	DiveTripModelTree(QObject *parent = nullptr);
+
+	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
+	typedef bool(*dive_or_trip_less_than_t)(dive_or_trip a, dive_or_trip b);
 private:
 	int rowCount(const QModelIndex &parent) const override;
 	void clearData() override;
@@ -140,7 +143,7 @@ private:
 		std::vector<dive *>	dives;			// std::vector<> instead of QVector for insert() with three iterators
 		bool			shown;
 		Item(dive_trip *t, const QVector<dive *> &dives);
-		Item(dive_trip *t, dive *d);			// Initialize a trip with one dive
+		Item(dive_trip *t, dive_less_than_t sort);	// Initialize a trip with dives
 		Item(dive *d);					// Initialize a top-level dive
 		bool isDive(const dive *) const;		// Helper function: is this the give dive?
 		dive *getDive() const;				// Helper function: returns top-level-dive or null
@@ -161,10 +164,6 @@ private:
 	int findDiveInTrip(int tripIdx, const dive *d) const;	// Find dive inside trip. Second parameter is index of trip
 	int findInsertionIndex(const dive_trip *trip) const;	// Where to insert trip
 
-	// There are two sort functions: one for top-level items, one for dives inside trips
-public:
-	typedef bool(*dive_less_than_t)(const dive *a, const dive *b);
-	typedef bool(*dive_or_trip_less_than_t)(dive_or_trip a, dive_or_trip b);
 private:
 	dive_less_than_t sort;
 	dive_or_trip_less_than_t sortTopLevel;

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -15,18 +15,19 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
-	resetModel(DiveTripModelBase::TREE);
+	resetModel(DiveTripModelBase::NR, Qt::AscendingOrder);
 	setFilterKeyColumn(-1); // filter all columns
 	setFilterRole(DiveTripModelBase::SHOWN_ROLE); // Let the proxy-model known that is has to react to change events involving SHOWN_ROLE
 	setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
 
-void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
+void MultiFilterSortModel::resetModel(DiveTripModelBase::Column row, Qt::SortOrder direction)
 {
-	if (layout == DiveTripModelBase::TREE)
-		model.reset(new DiveTripModelTree);
+	bool ascending = direction == Qt::AscendingOrder;
+	if (row == DiveTripModelBase::NR)
+		model.reset(new DiveTripModelTree(ascending));
 	else
-		model.reset(new DiveTripModelList);
+		model.reset(new DiveTripModelList(row, ascending));
 
 	setSourceModel(model.get());
 	connect(model.get(), &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
@@ -67,8 +68,7 @@ bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &s
 	return m->data(index0, DiveTripModelBase::SHOWN_ROLE).value<bool>();
 }
 
-bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const
+void MultiFilterSortModel::sort(int column, Qt::SortOrder order = Qt::AscendingOrder)
 {
-	// Hand sorting down to the source model.
-	return model->lessThan(i1, i2);
+	resetModel(static_cast<DiveTripModelBase::Column>(column), order);
 }

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -14,9 +14,9 @@ class MultiFilterSortModel : public QSortFilterProxyModel {
 public:
 	static MultiFilterSortModel *instance();
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
-	bool lessThan(const QModelIndex &, const QModelIndex &) const override;
+	void sort(int column, Qt::SortOrder order) override;
 
-	void resetModel(DiveTripModelBase::Layout layout);
+	void resetModel(DiveTripModelBase::Column row, Qt::SortOrder direction);
 	void clear();
 signals:
 	void selectionChanged(const QVector<QModelIndex> &indexes);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] Refactoring of core logic

### Pull request long description:
<!-- Describe your pull request in detail. -->
Attempts to generate "flattened" versions of the tree model for mobile are complicated by the fact that the tree model is sorted in ascending order. To avoid these mental gymnastics, it would be nice to have the base model sorted in the "correct" way. However, we can't change the sort-order of the core dive list, because the planner needs to know the nitrogen loading incurred by previous dives and assumes ascending order. Therefore, this PR moves the sorting from down from the filter-model to the tree-model. That is of course pretty hairy so comments / testing are needed. Especially the interaction with the undo-commands that add / remove / modify dives needs testing.

Currently, when changing the sorting, the whole base model is reset. This sounds quite ineffective. However, on my run-of-the-mill laptop a full reload including sorting on buddies of a ~4000 dives test log takes less than 40 microseconds.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move the sorting of the dive model from filter-proxy model to base model

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.