### PR TITLE
Dive site: ignore dive sites without location in proximity search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: ignore dive sites without location in proximity search
 Mobile: add personalized option for units
 Mobile: add Dive Summary page
 Mobile: option to reset default cylinder

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -285,8 +285,11 @@ GeoReferencingOptionsModel::GeoReferencingOptionsModel(QObject *parent) : QStrin
 
 bool GPSLocationInformationModel::filterAcceptsRow(int sourceRow, const QModelIndex &parent) const
 {
+	if (!has_location(&location))
+		return false;
+
 	struct dive_site *ds = sourceModel()->index(sourceRow, LocationInformationModel::DIVESITE, parent).data().value<dive_site *>();
-	if (!ds || ds == ignoreDs || ds == RECENTLY_ADDED_DIVESITE)
+	if (!ds || ds == ignoreDs || ds == RECENTLY_ADDED_DIVESITE || !has_location(&ds->location))
 		return false;
 
 	return distance <= 0 ? same_location(&ds->location, &location)


### PR DESCRIPTION
When editing a dive site, the user can search for close dive sites
to merge duplicates. Dive sites without location are treated as
being located at 0N0E. This makes no sense, because:

When selecting a dive site without location, we shouldn't list
dive sites close to 0N0E.

Likewise when having a dive site close to 0N0E, we shouldn't list
dive sites that have no location.

Therefore, ignore these cases.

This also means that now dive sites without location are not
considered as close to other dive sites without location. That
might be a debatable point.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes what IMHO is a bug: dive sites without location are considered as located at 0N0E and treated as such. By ignoring dive sites without location this changes the semantics of the close-dive site search: dive sites without location are now not considered as being at the same place. Not sure about that.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Ignore dive sites without location
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
