### PR TITLE
Cleanup: Dive sites: select each dive site only once

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -555,10 +555,10 @@ void DiveListView::selectionChangeDone()
 	// by the selected dives.
 	if (!DiveFilter::instance()->diveSiteMode()) {
 		QVector<dive_site *> selectedSites;
-		for (QModelIndex index: selectionModel()->selection().indexes()) {
+		for (QModelIndex index: selectionModel()->selectedRows()) {
 			const QAbstractItemModel *model = index.model();
 			struct dive *dive = model->data(index, DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
-			if (dive && dive->dive_site)
+			if (dive && dive->dive_site && !selectedSites.contains(dive->dive_site))
 				selectedSites.push_back(dive->dive_site);
 		}
 		MapWidget::instance()->setSelected(selectedSites);


### PR DESCRIPTION
After selecting dives, the selected dive sites are collected.
This was done using the selectionModel()->selection().indexes(),
which is wrong, because it gives one index per row *and* column.
Accordingly, every dive site was added numerous times to the
array of dive sites to be selected. Change this to
selectionModel()->selectedRows(), which gives one entry per row.

Moreover, if multiple dives with the same site were selected,
this site was also added to the array multiple times. Therefore,
check the array before adding sites.

Note that all this should not change the user experience in
any way, it is only a code-hygiene thing.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is only a code-hygiene thing. Don't select the same dive site numerous times. Details in the commit description.
