### PR TITLE
Dive site: inform map of selection in DiveFilter::setFilterDiveSite

### DIFF
--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -217,6 +217,7 @@ void DiveFilter::setFilterDiveSite(QVector<dive_site *> ds)
 
 	emit diveListNotifier.filterReset();
 	MapWidget::instance()->setSelected(dive_sites);
+	MapWidget::instance()->selectionChanged();
 	MainWindow::instance()->diveList->expandAll();
 }
 


### PR DESCRIPTION
When starting / changing the dive-site filter, inform the map of
the changed dive site selection by calling
	MapWidget::instance()->selectionChanged();
This fixes a bug, where on clicking dive sites in the dive site
tab the dive sites from the *previous* click were highlighted.

Perhaps the selectionChanged() call should be put into the
setSelected() call. But the data flow between the different
parts of the dive-site and map code are so convoluted that I
don't want to risk anything!

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes an ugly UI bug, where clicking on dive-sites on the dive-site tab would highlight the dive-site from the *previous* click on the map. I'm not sure that the fix is correct - see commit message. But the whole interaction of filter / divesite / map is so complex that I don't dare to touch this for now. And yes, that's at least partially my fault.
