### PR TITLE
[RFC] Summary cleanups

### DIFF
--- a/backend-shared/divesummary.cpp
+++ b/backend-shared/divesummary.cpp
@@ -1,11 +1,154 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "divesummary.h"
+#include "core/dive.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefUnit.h"
 
 #include <QDateTime>
+#include <array>
 
-QStringList diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
+struct Stats {
+	Stats();
+	int dives, divesEAN, divesDeep, diveplans;
+	long divetime, depth;
+	long divetimeMax, depthMax, sacMin, sacMax;
+	long divetimeAvg, depthAvg, sacAvg;
+	long totalSACTime, totalSacVolume;
+};
+
+Stats::Stats() :
+	dives(0), divesEAN(0), divesDeep(0), diveplans(0),
+	divetime(0), depth(0), divetimeMax(0), depthMax(0),
+	sacMin(99999), sacMax(0), totalSACTime(0), totalSacVolume(0)
+{
+}
+
+static void calculateDive(struct dive *dive, Stats &stats)
+{
+	if (is_dc_planner(&dive->dc)) {
+		stats.diveplans++;
+		return;
+	}
+
+	// one more real dive
+	stats.dives++;
+
+	// sum dive in minutes and check for new max.
+	stats.divetime += dive->duration.seconds;
+	if (dive->duration.seconds > stats.divetimeMax)
+		stats.divetimeMax = dive->duration.seconds;
+
+	// sum depth in meters, check for new max. and if dive is a deep dive
+	stats.depth += dive->maxdepth.mm;
+	if (dive->maxdepth.mm > stats.depthMax)
+		stats.depthMax = dive->maxdepth.mm;
+	if (dive->maxdepth.mm > 39000)
+		stats.divesDeep++;
+
+	// sum SAC, check for new min/max.
+	if (dive->sac) {
+		stats.totalSACTime += dive->duration.seconds;
+		stats.totalSacVolume += dive->sac * dive->duration.seconds;
+		if (dive->sac < stats.sacMin)
+			stats.sacMin = dive->sac;
+		if (dive->sac > stats.sacMax)
+			stats.sacMax = dive->sac;
+	}
+
+	// EAN dive ?
+	for (int j = 0; j < dive->cylinders.nr; ++j) {
+		if (dive->cylinders.cylinders[j].gasmix.o2.permille > 210) {
+			stats.divesEAN++;
+			break;
+		}
+	}
+}
+
+// Returns a (first_dive, last_dive) pair
+static std::array<timestamp_t, 2> loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1)
+{
+	struct dive *dive;
+	int i;
+	timestamp_t firstDive = 0, lastDive = 0;
+
+	for_each_dive (i, dive) {
+		// remember time of oldest and newest dive
+		if (i == 0)
+			firstDive = dive->when;
+		if (dive->when > lastDive)
+			lastDive = dive->when;
+
+		// check if dive is newer than primaryStart (add to first column)
+		if (dive->when > primaryStart)
+			calculateDive(dive, stats0);
+
+		// check if dive is newer than secondaryStart (add to second column)
+		if (dive->when > secondaryStart)
+			calculateDive(dive, stats1);
+	}
+	return { firstDive, lastDive };
+}
+
+static QString timeString(long duration)
+{
+	long hours = duration / 3600;
+	long minutes = (duration - hours * 3600) / 60;
+	if (hours >= 100)
+		return QStringLiteral("%1h").arg(hours);
+	else
+		return QStringLiteral("%1:%2").arg(hours).arg(minutes, 2, 10, QChar('0'));
+}
+
+static QString depthString(long depth)
+{
+	return QString("%1").arg((qPrefUnits::length() == units::METERS) ? depth / 1000 : lrint(mm_to_feet(depth)));
+}
+
+static QString volumeString(long volume)
+{
+	return QString("%1").arg((qPrefUnits::volume() == units::LITER) ? volume / 1000 : round(100.0 * ml_to_cuft(volume)) / 100.0);
+}
+
+static void buildStringList(int inx, const Stats &stats, QStringList &diveSummaryText)
+{
+	if (!stats.dives) {
+		diveSummaryText[2+inx] = QObject::tr("no dives in period");
+		return;
+	}
+
+	// dives
+	diveSummaryText[2+inx] = QStringLiteral("%1").arg(stats.dives);
+	diveSummaryText[4+inx] = QStringLiteral("%1").arg(stats.divesEAN);
+	diveSummaryText[6+inx] = QStringLiteral("%1").arg(stats.divesDeep);
+
+	// time
+	diveSummaryText[8+inx] = timeString(stats.divetime);
+	diveSummaryText[10+inx] = timeString(stats.divetimeMax);
+	diveSummaryText[12+inx] = timeString(stats.divetime / stats.dives);
+
+	// depth
+	QString unitText = (qPrefUnits::length() == units::METERS) ? " m" : " ft";
+	diveSummaryText[14+inx] = depthString(stats.depthMax) + unitText;
+	diveSummaryText[16+inx] = depthString(stats.depth / stats.dives) + unitText;
+
+	// SAC
+	unitText = (qPrefUnits::volume() == units::LITER) ? " l/min" : " cuft/min";
+	diveSummaryText[18+inx] = volumeString(stats.sacMin) + unitText;
+	diveSummaryText[20+inx] = volumeString(stats.sacMax) + unitText;
+
+	// finally the weighted average
+	if (stats.totalSACTime) {
+		long avgSac = stats.totalSacVolume / stats.totalSACTime;
+		diveSummaryText[22+inx] = volumeString(avgSac) + unitText;
+	} else {
+		diveSummaryText[22+inx] = QObject::tr("no dives");
+	}
+
+	// Diveplan(s)
+	diveSummaryText[24+inx] = QStringLiteral("%1").arg(stats.diveplans);
+}
+
+QStringList summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
 	QDateTime localTime;
 
@@ -47,135 +190,4 @@ QStringList diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeri
 	buildStringList(0, stats0, res);
 	buildStringList(1, stats1, res);
 	return res;
-}
-
-diveSummary::Stats::Stats() :
-	dives(0), divesEAN(0), divesDeep(0), diveplans(0),
-	divetime(0), depth(0), divetimeMax(0), depthMax(0),
-	sacMin(99999), sacMax(0), totalSACTime(0), totalSacVolume(0)
-{
-}
-
-std::array<timestamp_t, 2> diveSummary::loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1)
-{
-	struct dive *dive;
-	int i;
-	timestamp_t firstDive = 0, lastDive = 0;
-
-	for_each_dive (i, dive) {
-		// remember time of oldest and newest dive
-		if (i == 0)
-			firstDive = dive->when;
-		if (dive->when > lastDive)
-			lastDive = dive->when;
-
-		// check if dive is newer than primaryStart (add to first column)
-		if (dive->when > primaryStart)
-			calculateDive(dive, stats0);
-
-		// check if dive is newer than secondaryStart (add to second column)
-		if (dive->when > secondaryStart)
-			calculateDive(dive, stats1);
-	}
-	return { firstDive, lastDive };
-}
-
-void diveSummary::calculateDive(struct dive *dive, Stats &stats)
-{
-	if (is_dc_planner(&dive->dc)) {
-		stats.diveplans++;
-		return;
-	}
-
-	// one more real dive
-	stats.dives++;
-
-	// sum dive in minutes and check for new max.
-	stats.divetime += dive->duration.seconds;
-	if (dive->duration.seconds > stats.divetimeMax)
-		stats.divetimeMax = dive->duration.seconds;
-
-	// sum depth in meters, check for new max. and if dive is a deep dive
-	stats.depth += dive->maxdepth.mm;
-	if (dive->maxdepth.mm > stats.depthMax)
-		stats.depthMax = dive->maxdepth.mm;
-	if (dive->maxdepth.mm > 39000)
-		stats.divesDeep++;
-
-	// sum SAC, check for new min/max.
-	if (dive->sac) {
-		stats.totalSACTime += dive->duration.seconds;
-		stats.totalSacVolume += dive->sac * dive->duration.seconds;
-		if (dive->sac < stats.sacMin)
-			stats.sacMin = dive->sac;
-		if (dive->sac > stats.sacMax)
-			stats.sacMax = dive->sac;
-	}
-
-	// EAN dive ?
-	for (int j = 0; j < dive->cylinders.nr; ++j) {
-		if (dive->cylinders.cylinders[j].gasmix.o2.permille > 210) {
-			stats.divesEAN++;
-			break;
-		}
-	}
-}
-
-static QString timeString(long duration)
-{
-	long hours = duration / 3600;
-	long minutes = (duration - hours * 3600) / 60;
-	if (hours >= 100)
-		return QStringLiteral("%1h").arg(hours);
-	else
-		return QStringLiteral("%1:%2").arg(hours).arg(minutes, 2, 10, QChar('0'));
-}
-
-static QString depthString(long depth)
-{
-	return QString("%1").arg((qPrefUnits::length() == units::METERS) ? depth / 1000 : lrint(mm_to_feet(depth)));
-}
-
-static QString volumeString(long volume)
-{
-	return QString("%1").arg((qPrefUnits::volume() == units::LITER) ? volume / 1000 : round(100.0 * ml_to_cuft(volume)) / 100.0);
-}
-
-void diveSummary::buildStringList(int inx, const Stats &stats, QStringList &diveSummaryText)
-{
-	if (!stats.dives) {
-		diveSummaryText[2+inx] = QObject::tr("no dives in period");
-		return;
-	}
-
-	// dives
-	diveSummaryText[2+inx] = QStringLiteral("%1").arg(stats.dives);
-	diveSummaryText[4+inx] = QStringLiteral("%1").arg(stats.divesEAN);
-	diveSummaryText[6+inx] = QStringLiteral("%1").arg(stats.divesDeep);
-
-	// time
-	diveSummaryText[8+inx] = timeString(stats.divetime);
-	diveSummaryText[10+inx] = timeString(stats.divetimeMax);
-	diveSummaryText[12+inx] = timeString(stats.divetime / stats.dives);
-
-	// depth
-	QString unitText = (qPrefUnits::length() == units::METERS) ? " m" : " ft";
-	diveSummaryText[14+inx] = depthString(stats.depthMax) + unitText;
-	diveSummaryText[16+inx] = depthString(stats.depth / stats.dives) + unitText;
-
-	// SAC
-	unitText = (qPrefUnits::volume() == units::LITER) ? " l/min" : " cuft/min";
-	diveSummaryText[18+inx] = volumeString(stats.sacMin) + unitText;
-	diveSummaryText[20+inx] = volumeString(stats.sacMax) + unitText;
-
-	// finally the weighted average
-	if (stats.totalSACTime) {
-		long avgSac = stats.totalSacVolume / stats.totalSACTime;
-		diveSummaryText[22+inx] = volumeString(avgSac) + unitText;
-	} else {
-		diveSummaryText[22+inx] = QObject::tr("no dives");
-	}
-
-	// Diveplan(s)
-	diveSummaryText[24+inx] = QStringLiteral("%1").arg(stats.diveplans);
 }

--- a/backend-shared/divesummary.cpp
+++ b/backend-shared/divesummary.cpp
@@ -7,12 +7,6 @@
 
 QStringList diveSummary::diveSummaryText;
 
-timestamp_t diveSummary::firstDive, diveSummary::lastDive;
-int diveSummary::dives[2], diveSummary::divesEAN[2], diveSummary::divesDeep[2], diveSummary::diveplans[2];
-long diveSummary::divetime[2], diveSummary::depth[2];
-long diveSummary::divetimeMax[2], diveSummary::depthMax[2], diveSummary::sacMin[2], diveSummary::sacMax[2];
-long diveSummary::totalSACTime[2], diveSummary::totalSacVolume[2];
-
 void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
 	QDateTime localTime;
@@ -24,7 +18,10 @@ void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 	secondaryStart = (secondaryPeriod == 0) ? 0 : now - secondaryPeriod * 30 * 24 * 60 * 60;
 
 	// Loop over all dives and sum up data
-	loopDives(primaryStart, secondaryStart);
+	Stats stats0, stats1;
+	std::array<timestamp_t, 2> firstLast = loopDives(primaryStart, secondaryStart, stats0, stats1);
+	timestamp_t firstDive = firstLast[0]; // One day we will be able to use C++17 structured bindings
+	timestamp_t lastDive = firstLast[1];
 
 	// prepare stringlist
 	diveSummaryText.clear();
@@ -48,25 +45,22 @@ void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 	}
 
 	// and add data
-	buildStringList(0);
-	buildStringList(1);
+	buildStringList(0, stats0);
+	buildStringList(1, stats1);
 }
 
-void diveSummary::loopDives(timestamp_t primaryStart, timestamp_t secondaryStart)
+diveSummary::Stats::Stats() :
+	dives(0), divesEAN(0), divesDeep(0), diveplans(0),
+	divetime(0), depth(0), divetimeMax(0), depthMax(0),
+	sacMin(99999), sacMax(0), totalSACTime(0), totalSacVolume(0)
+{
+}
+
+std::array<timestamp_t, 2> diveSummary::loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1)
 {
 	struct dive *dive;
 	int i;
-
-	// Clear summary data
-	firstDive = lastDive = 0;
-	dives[0] = dives[1] = divesEAN[0] = divesEAN[1] = 0;
-	divesDeep[0] = divesDeep[1] = diveplans[0] = diveplans[1] = 0;
-	divetime[0] = divetime[1] = depth[0] = depth[1] = 0;
-	divetimeMax[0] = divetimeMax[1] = depthMax[0] = depthMax[1] = 0;
-	sacMin[0] = sacMin[1] = 99999;
-	sacMax[0] = sacMax[1] = 0;
-	totalSACTime[0] = totalSACTime[1] = 0;
-	totalSacVolume[0] = totalSacVolume[1] = 0;
+	timestamp_t firstDive = 0, lastDive = 0;
 
 	for_each_dive (i, dive) {
 		// remember time of oldest and newest dive
@@ -78,52 +72,53 @@ void diveSummary::loopDives(timestamp_t primaryStart, timestamp_t secondaryStart
 		// check if dive is newer than primaryStart (add to first column)
 		if (dive->when > primaryStart) {
 			if (is_dc_planner(&dive->dc))
-				diveplans[0]++;
+				stats0.diveplans++;
 			else
-				calculateDive(0, dive);
+				calculateDive(dive, stats0);
 		}
 
 		// check if dive is newer than secondaryStart (add to second column)
 		if (dive->when > secondaryStart) {
 			if (is_dc_planner(&dive->dc))
-				diveplans[1]++;
+				stats1.diveplans++;
 			else
-				calculateDive(1, dive);
+				calculateDive(dive, stats1);
 		}
 	}
+	return { firstDive, lastDive };
 }
 
-void diveSummary::calculateDive(int inx, struct dive *dive)
+void diveSummary::calculateDive(struct dive *dive, Stats &stats)
 {
 	// one more real dive
-	dives[inx]++;
+	stats.dives++;
 
 	// sum dive in minutes and check for new max.
-	divetime[inx] += dive->duration.seconds;
-	if (dive->duration.seconds > divetimeMax[inx])
-		divetimeMax[inx] = dive->duration.seconds;
+	stats.divetime += dive->duration.seconds;
+	if (dive->duration.seconds > stats.divetimeMax)
+		stats.divetimeMax = dive->duration.seconds;
 
 	// sum depth in meters, check for new max. and if dive is a deep dive
-	depth[inx] += dive->maxdepth.mm;
-	if (dive->maxdepth.mm > depthMax[inx])
-		depthMax[inx] = dive->maxdepth.mm;
+	stats.depth += dive->maxdepth.mm;
+	if (dive->maxdepth.mm > stats.depthMax)
+		stats.depthMax = dive->maxdepth.mm;
 	if (dive->maxdepth.mm > 39000)
-		divesDeep[inx]++;
+		stats.divesDeep++;
 
 	// sum SAC, check for new min/max.
 	if (dive->sac) {
-		totalSACTime[inx] += dive->duration.seconds;
-		totalSacVolume[inx] += dive->sac * dive->duration.seconds;
-		if (dive->sac < sacMin[inx])
-			sacMin[inx] = dive->sac;
-		if (dive->sac > sacMax[inx])
-			sacMax[inx] = dive->sac;
+		stats.totalSACTime += dive->duration.seconds;
+		stats.totalSacVolume += dive->sac * dive->duration.seconds;
+		if (dive->sac < stats.sacMin)
+			stats.sacMin = dive->sac;
+		if (dive->sac > stats.sacMax)
+			stats.sacMax = dive->sac;
 	}
 
 	// EAN dive ?
 	for (int j = 0; j < dive->cylinders.nr; ++j) {
 		if (dive->cylinders.cylinders[j].gasmix.o2.permille > 210) {
-			divesEAN[inx]++;
+			stats.divesEAN++;
 			break;
 		}
 	}
@@ -149,41 +144,41 @@ static QString volumeString(long volume)
 	return QString("%1").arg((qPrefUnits::volume() == units::LITER) ? volume / 1000 : round(100.0 * ml_to_cuft(volume)) / 100.0);
 }
 
-void diveSummary::buildStringList(int inx)
+void diveSummary::buildStringList(int inx, const Stats &stats)
 {
-	if (!dives[inx]) {
+	if (!stats.dives) {
 		diveSummaryText[2+inx] = QObject::tr("no dives in period");
 		return;
 	}
 
 	// dives
-	diveSummaryText[2+inx] = QStringLiteral("%1").arg(dives[inx]);
-	diveSummaryText[4+inx] = QStringLiteral("%1").arg(divesEAN[inx]);
-	diveSummaryText[6+inx] = QStringLiteral("%1").arg(divesDeep[inx]);
+	diveSummaryText[2+inx] = QStringLiteral("%1").arg(stats.dives);
+	diveSummaryText[4+inx] = QStringLiteral("%1").arg(stats.divesEAN);
+	diveSummaryText[6+inx] = QStringLiteral("%1").arg(stats.divesDeep);
 
 	// time
-	diveSummaryText[8+inx] = timeString(divetime[inx]);
-	diveSummaryText[10+inx] = timeString(divetimeMax[inx]);
-	diveSummaryText[12+inx] = timeString(divetime[inx] / dives[inx]);
+	diveSummaryText[8+inx] = timeString(stats.divetime);
+	diveSummaryText[10+inx] = timeString(stats.divetimeMax);
+	diveSummaryText[12+inx] = timeString(stats.divetime / stats.dives);
 
 	// depth
 	QString unitText = (qPrefUnits::length() == units::METERS) ? " m" : " ft";
-	diveSummaryText[14+inx] = depthString(depthMax[inx]) + unitText;
-	diveSummaryText[16+inx] = depthString(depth[inx] / dives[inx]) + unitText;
+	diveSummaryText[14+inx] = depthString(stats.depthMax) + unitText;
+	diveSummaryText[16+inx] = depthString(stats.depth / stats.dives) + unitText;
 
 	// SAC
 	unitText = (qPrefUnits::volume() == units::LITER) ? " l/min" : " cuft/min";
-	diveSummaryText[18+inx] = volumeString(sacMin[inx]) + unitText;
-	diveSummaryText[20+inx] = volumeString(sacMax[inx]) + unitText;
+	diveSummaryText[18+inx] = volumeString(stats.sacMin) + unitText;
+	diveSummaryText[20+inx] = volumeString(stats.sacMax) + unitText;
 
 	// finally the weighted average
-	if (totalSACTime[inx]) {
-		long avgSac = totalSacVolume[inx] / totalSACTime[inx];
+	if (stats.totalSACTime) {
+		long avgSac = stats.totalSacVolume / stats.totalSACTime;
 		diveSummaryText[22+inx] = volumeString(avgSac) + unitText;
 	} else {
 		diveSummaryText[22+inx] = QObject::tr("no dives");
 	}
 
 	// Diveplan(s)
-	diveSummaryText[24+inx] = QStringLiteral("%1").arg(diveplans[inx]);
+	diveSummaryText[24+inx] = QStringLiteral("%1").arg(stats.diveplans);
 }

--- a/backend-shared/divesummary.cpp
+++ b/backend-shared/divesummary.cpp
@@ -5,9 +5,7 @@
 
 #include <QDateTime>
 
-QStringList diveSummary::diveSummaryText;
-
-void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
+QStringList diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
 	QDateTime localTime;
 
@@ -24,29 +22,31 @@ void diveSummary::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 	timestamp_t lastDive = firstLast[1];
 
 	// prepare stringlist
-	diveSummaryText.clear();
-	diveSummaryText << "??" << "??" << QObject::tr("no dives in period") << QObject::tr("no divies in period")  << "??" <<
-						 "??" << "??" << "??" <<
-						 "?:??" << "?:??" << "?:??" <<
-						 "?:??" << "?:??" << "?:??" <<
-						 "??" << "??" << "??" << "??" << "??" <<
-						 "??" << "??" << "??" << "??" << "??" << "??" << "??";
+	QStringList res = {
+		"??", "??", QObject::tr("no dives in period"), QObject::tr("no dives in period"), "??",
+		"??", "??", "??",
+		"?:??", "?:??", "?:??",
+		"?:??", "?:??", "?:??",
+		"??", "??", "??", "??", "??",
+		"??", "??", "??", "??", "??", "??", "??"
+	};
 
 	// set oldest/newest date
 	if (firstDive) {
 		localTime = QDateTime::fromMSecsSinceEpoch(1000 * firstDive, Qt::UTC);
 		localTime.setTimeSpec(Qt::UTC);
-		diveSummaryText[0] = QStringLiteral("%1").arg(localTime.date().toString(prefs.date_format_short));
+		res[0] = QStringLiteral("%1").arg(localTime.date().toString(prefs.date_format_short));
 	}
 	if (lastDive) {
 		localTime = QDateTime::fromMSecsSinceEpoch(1000 * lastDive, Qt::UTC);
 		localTime.setTimeSpec(Qt::UTC);
-		diveSummaryText[1] = QStringLiteral("%1").arg(localTime.date().toString(prefs.date_format_short));
+		res[1] = QStringLiteral("%1").arg(localTime.date().toString(prefs.date_format_short));
 	}
 
 	// and add data
-	buildStringList(0, stats0);
-	buildStringList(1, stats1);
+	buildStringList(0, stats0, res);
+	buildStringList(1, stats1, res);
+	return res;
 }
 
 diveSummary::Stats::Stats() :
@@ -141,7 +141,7 @@ static QString volumeString(long volume)
 	return QString("%1").arg((qPrefUnits::volume() == units::LITER) ? volume / 1000 : round(100.0 * ml_to_cuft(volume)) / 100.0);
 }
 
-void diveSummary::buildStringList(int inx, const Stats &stats)
+void diveSummary::buildStringList(int inx, const Stats &stats, QStringList &diveSummaryText)
 {
 	if (!stats.dives) {
 		diveSummaryText[2+inx] = QObject::tr("no dives in period");

--- a/backend-shared/divesummary.cpp
+++ b/backend-shared/divesummary.cpp
@@ -70,26 +70,23 @@ std::array<timestamp_t, 2> diveSummary::loopDives(timestamp_t primaryStart, time
 			lastDive = dive->when;
 
 		// check if dive is newer than primaryStart (add to first column)
-		if (dive->when > primaryStart) {
-			if (is_dc_planner(&dive->dc))
-				stats0.diveplans++;
-			else
-				calculateDive(dive, stats0);
-		}
+		if (dive->when > primaryStart)
+			calculateDive(dive, stats0);
 
 		// check if dive is newer than secondaryStart (add to second column)
-		if (dive->when > secondaryStart) {
-			if (is_dc_planner(&dive->dc))
-				stats1.diveplans++;
-			else
-				calculateDive(dive, stats1);
-		}
+		if (dive->when > secondaryStart)
+			calculateDive(dive, stats1);
 	}
 	return { firstDive, lastDive };
 }
 
 void diveSummary::calculateDive(struct dive *dive, Stats &stats)
 {
+	if (is_dc_planner(&dive->dc)) {
+		stats.diveplans++;
+		return;
+	}
+
 	// one more real dive
 	stats.dives++;
 

--- a/backend-shared/divesummary.h
+++ b/backend-shared/divesummary.h
@@ -8,9 +8,7 @@
 class diveSummary {
 
 public:
-	static void summaryCalculation(int primaryPeriod, int secondaryPeriod);
-
-	static QStringList diveSummaryText;
+	static QStringList summaryCalculation(int primaryPeriod, int secondaryPeriod);
 
 private:
 	diveSummary() {}
@@ -27,6 +25,6 @@ private:
 	// Returns a (first_dive, last_dive) pair
 	static std::array<timestamp_t, 2> loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1);
 	static void calculateDive(struct dive *dive, Stats &stats);
-	static void buildStringList(int inx, const Stats &stats);
+	static void buildStringList(int inx, const Stats &stats, QStringList &diveSummaryText);
 };
 #endif // DIVESUMMARY_H

--- a/backend-shared/divesummary.h
+++ b/backend-shared/divesummary.h
@@ -2,29 +2,7 @@
 #ifndef DIVESUMMARY_H
 #define DIVESUMMARY_H
 #include <QStringList>
-#include <array>
-#include "core/dive.h"
 
-class diveSummary {
+QStringList summaryCalculation(int primaryPeriod, int secondaryPeriod);
 
-public:
-	static QStringList summaryCalculation(int primaryPeriod, int secondaryPeriod);
-
-private:
-	diveSummary() {}
-
-	struct Stats {
-		Stats();
-		int dives, divesEAN, divesDeep, diveplans;
-		long divetime, depth;
-		long divetimeMax, depthMax, sacMin, sacMax;
-		long divetimeAvg, depthAvg, sacAvg;
-		long totalSACTime, totalSacVolume;
-	};
-
-	// Returns a (first_dive, last_dive) pair
-	static std::array<timestamp_t, 2> loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1);
-	static void calculateDive(struct dive *dive, Stats &stats);
-	static void buildStringList(int inx, const Stats &stats, QStringList &diveSummaryText);
-};
 #endif // DIVESUMMARY_H

--- a/backend-shared/divesummary.h
+++ b/backend-shared/divesummary.h
@@ -2,8 +2,8 @@
 #ifndef DIVESUMMARY_H
 #define DIVESUMMARY_H
 #include <QStringList>
+#include <array>
 #include "core/dive.h"
-
 
 class diveSummary {
 
@@ -15,15 +15,18 @@ public:
 private:
 	diveSummary() {}
 
-	static void loopDives(timestamp_t primaryStart, timestamp_t secondaryStart);
-	static void calculateDive(int inx, struct dive *dive);
-	static void buildStringList(int inx);
+	struct Stats {
+		Stats();
+		int dives, divesEAN, divesDeep, diveplans;
+		long divetime, depth;
+		long divetimeMax, depthMax, sacMin, sacMax;
+		long divetimeAvg, depthAvg, sacAvg;
+		long totalSACTime, totalSacVolume;
+	};
 
-	static timestamp_t firstDive, lastDive;
-	static int dives[2], divesEAN[2], divesDeep[2], diveplans[2];
-	static long divetime[2], depth[2];
-	static long divetimeMax[2], depthMax[2], sacMin[2], sacMax[2];
-	static long divetimeAvg[2], depthAvg[2], sacAvg[2];
-	static long totalSACTime[2], totalSacVolume[2];
+	// Returns a (first_dive, last_dive) pair
+	static std::array<timestamp_t, 2> loopDives(timestamp_t primaryStart, timestamp_t secondaryStart, Stats &stats0, Stats &stats1);
+	static void calculateDive(struct dive *dive, Stats &stats);
+	static void buildStringList(int inx, const Stats &stats);
 };
 #endif // DIVESUMMARY_H

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -95,8 +95,15 @@ void QMLInterface::setup(QQmlContext *ct)
 	diveSummary::summaryCalculation(0, 3);
 }
 
+static QStringList diveSummaryTextCached;
+
 void QMLInterface::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
-	diveSummary::summaryCalculation(primaryPeriod, secondaryPeriod);
-	emit diveSummaryTextChanged(diveSummary::diveSummaryText);
+	diveSummaryTextCached = diveSummary::summaryCalculation(primaryPeriod, secondaryPeriod);
+	emit diveSummaryTextChanged(diveSummaryTextCached);
+}
+
+const QStringList QMLInterface::diveSummaryText()
+{
+	return diveSummaryTextCached;
 }

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -92,14 +92,14 @@ void QMLInterface::setup(QQmlContext *ct)
 
 	// calculate divesummary first time.
 	// this is needed in order to load the divesummary page
-	diveSummary::summaryCalculation(0, 3);
+	self.summaryCalculation(0, 3);
 }
 
 static QStringList diveSummaryTextCached;
 
 void QMLInterface::summaryCalculation(int primaryPeriod, int secondaryPeriod)
 {
-	diveSummaryTextCached = diveSummary::summaryCalculation(primaryPeriod, secondaryPeriod);
+	diveSummaryTextCached = ::summaryCalculation(primaryPeriod, secondaryPeriod);
 	emit diveSummaryTextChanged(diveSummaryTextCached);
 }
 

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -217,7 +217,7 @@ public:
 	bool verbatim_plan() { return prefs.verbatim_plan; }
 	bool display_variations() { return prefs.display_variations; }
 
-	const QStringList &diveSummaryText() { return diveSummary::diveSummaryText; }
+	const QStringList diveSummaryText();
 
 public slots:
 	void set_cloud_verification_status(CLOUD_STATUS value) {  qPrefCloudStorage::set_cloud_verification_status(value); }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
To be honest, I'm not very happy about how the summary code uses a completely unstructured QStringList to display structured data. I understand that it's annoying but writing this in model-form would seem to be more appropriate and also much more flexible, as you could have an arbitrary number of rows / columns. The way the code looks right now it doesn't seem very appealing to use it on desktop.

Even though this PR doesn't address my fundamental problem with the code - it makes it at least a bit more palatable, because it removes a lot of global state (why are we still adding these?). The only global state left is a cache of the summary in the QML interface. I'm not going to touch that, as DiveSummary.qml gives me vertigo.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Remove global state; attempt to make the code more logical.
