### PR TITLE
bugfix: solve spurious loss of signal/slots.

### DIFF
--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -2,6 +2,12 @@
 #include "qmlinterface.h"
 #include <QQmlEngine>
 
+QMLInterface *QMLInterface::instance()
+{
+	static QMLInterface *self = new QMLInterface;
+	return self;
+}
+
 QMLInterface::QMLInterface()
 {
 	// relink signals to QML
@@ -84,8 +90,7 @@ QMLInterface::QMLInterface()
 void QMLInterface::setup(QQmlContext *ct)
 {
 	// Register interface class
-	static QMLInterface self;
-	ct->setContextProperty("Backend", &self);
+	ct->setContextProperty("Backend", instance());
 
 	// Make enums available as types
 	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -8,11 +8,21 @@ QMLInterface *QMLInterface::instance()
 	return self;
 }
 
-QMLInterface::QMLInterface()
+void QMLInterface::setup(QQmlContext *ct)
 {
+	// Register interface class
+	ct->setContextProperty("Backend", instance());
+
+	// Make enums available as types
+	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
+
+	// calculate divesummary first time.
+	// this is needed in order to load the divesummary page
+	diveSummary::summaryCalculation(0, 3);
+
 	// relink signals to QML
 	connect(qPrefCloudStorage::instance(), &qPrefCloudStorage::cloud_verification_statusChanged,
-		[this] (int value) { emit cloud_verification_statusChanged(CLOUD_STATUS(value)); });
+			[this] (int value) { emit cloud_verification_statusChanged(CLOUD_STATUS(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::duration_unitsChanged,
 			[this] (int value) { emit duration_unitsChanged(DURATION(value)); });
 	connect(qPrefUnits::instance(), &qPrefUnits::lengthChanged,
@@ -85,19 +95,6 @@ QMLInterface::QMLInterface()
 			this, &QMLInterface::verbatim_planChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_variationsChanged,
 			this, &QMLInterface::display_variationsChanged);
-}
-
-void QMLInterface::setup(QQmlContext *ct)
-{
-	// Register interface class
-	ct->setContextProperty("Backend", instance());
-
-	// Make enums available as types
-	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
-
-	// calculate divesummary first time.
-	// this is needed in order to load the divesummary page
-	diveSummary::summaryCalculation(0, 3);
 }
 
 void QMLInterface::summaryCalculation(int primaryPeriod, int secondaryPeriod)

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -86,7 +86,7 @@ public:
 	static QMLInterface *instance();
 	
 	// function to do the needed setup
-	static void setup(QQmlContext *ct);
+	void setup(QQmlContext *ct);
 
 	// Duplicated enums, these enums are properly defined in the C/C++ structure
 	// but duplicated here to make them available to QML.
@@ -319,6 +319,6 @@ signals:
 
 	void diveSummaryTextChanged(QStringList);
 private:
-	QMLInterface();
+	QMLInterface() {}
 };
 #endif // QMLINTERFACE_H

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -81,6 +81,10 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(QStringList diveSummaryText READ diveSummaryText NOTIFY diveSummaryTextChanged);
 
 public:
+	// function to address the object, which is not needed in production code,
+	// but highly needed when testing signal/slot.
+	static QMLInterface *instance();
+	
 	// function to do the needed setup
 	static void setup(QQmlContext *ct);
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -188,7 +188,7 @@ void register_qml_types(QQmlEngine *engine)
 		QQmlContext *ct = engine->rootContext();
 
 		// Register qml interface classes
-		QMLInterface::setup(ct);
+		QMLInterface::instance()->setup(ct);
 		themeInterface::setup(ct);
 	}
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This PR solves a problem of missing signal/slots from QMLInterface. With the connect() being in the constructor that constructs a global object, there are no guarantee that the referenced objects are constructed, and thus sometimes leads to the connect not being successful. Unfortunate Qt does not report an error when this happens.

Solution was to move the connect() back into setup(), while keeping the nice lambda changes.

In contrary to what I wrote earlier, we (a student who writes a paper on clang and myself) have, out of scientific interest, examined the clang compiler (Xcode 11.3.1) compiling for iOS, other compilers might behave differently.

We found that the global space is created in 3 steps:
1) all public const (we are still debating if a class const is added at this step, it seems to depend on compiler switches). These are created in a special const segment, and are created by the linker.
2) all public global variables, including classes. The sequence seems very random, changing the compile order is no guarantee of changing the sequence of constructor calls. Linker allocates the global space needed, and the constructors are called as part of the startup code.
3) all private static variables, including those hidden in e.g. instance(). Because instance()
does:
       static <class> *self = new <class>;
       return self;

self is a hidden (compiler scope is local) global object, and it is constructed before instance() is called. We have seen hints that some optimization switches might cause a delayed construct, but for debug it is constructed as part of the global space creation.
4) main is called

Based on these finding, it seems like a good idea, never to reference parallel global objects in a global constructor (actually this is also taught here in the C++ class).

Some of the reasons why this has not been detected before can be:
1) most of the connects relate to the UI, and a missing change in a single graphical element is easily overlooked
2) There are very little formal testing of the signal/slot (apart from qPref)
3) Bulk of the connects are in desktop-widget, that connect a library (like e.g. core or backend-shared) to the UI, while QMLInterface interconnect signals.

remark, this was a practical study using Xcode 11.3.1 and IPadOS 13.1 simulator. I am sure reading the C++ specs contains some descriptions as well, but theory and practice are often two different pair of shoes.

Any positive comment and/or suggestions are mostly welcome.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
