### PR TITLE
Cleanup: un-classify export library

### DIFF
--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -12,7 +12,7 @@
 #include "core/divesite.h"
 #include "exportfuncs.h"
 
-void exportProfile(QString filename, const bool selected_only)
+void exportProfile(QString filename, bool selected_only)
 {
 	struct dive *dive;
 	int i;
@@ -33,7 +33,7 @@ void exportProfile(QString filename, const bool selected_only)
 }
 
 
-void export_TeX(const char *filename, const bool selected_only, bool plain)
+void export_TeX(const char *filename, bool selected_only, bool plain)
 {
 	FILE *f;
 	QDir texdir = QFileInfo(filename).dir();
@@ -233,7 +233,7 @@ void export_TeX(const char *filename, const bool selected_only, bool plain)
 
 }
 
-void export_depths(const char *filename, const bool selected_only)
+void export_depths(const char *filename, bool selected_only)
 {
 	FILE *f;
 	struct dive *dive;

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -311,8 +311,8 @@ std::vector<const dive_site *> exportFuncs::getDiveSitesToExport(bool selectedOn
 	return res;
 }
 
-void exportFuncs::exportUsingStyleSheet(QString filename, bool doExport, int units,
+QFuture<int> exportFuncs::exportUsingStyleSheet(QString filename, bool doExport, int units,
 	QString stylesheet, bool anonymize)
 {
-	future = QtConcurrent::run(export_dives_xslt, filename.toUtf8(), doExport, units, stylesheet.toUtf8(), anonymize);
+	return QtConcurrent::run(export_dives_xslt, filename.toUtf8(), doExport, units, stylesheet.toUtf8(), anonymize);
 }

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -4,6 +4,7 @@
 #include <QtConcurrent>
 #include "core/membuffer.h"
 #include "core/divesite.h"
+#include "core/gettextfromc.h"
 #include "core/tag.h"
 #include "core/file.h"
 #include "core/errorhelper.h"
@@ -11,14 +12,7 @@
 #include "core/divesite.h"
 #include "exportfuncs.h"
 
-
-exportFuncs *exportFuncs::instance()
-{
-    static exportFuncs *self = new exportFuncs;
-    return self;
-}
-
-void exportFuncs::exportProfile(QString filename, const bool selected_only)
+void exportProfile(QString filename, const bool selected_only)
 {
 	struct dive *dive;
 	int i;
@@ -31,15 +25,15 @@ void exportFuncs::exportProfile(QString filename, const bool selected_only)
 		if (selected_only && !dive->selected)
 			continue;
 		if (count)
-			saveProfile(dive, fi.path() + QDir::separator() + fi.completeBaseName().append(QString("-%1.").arg(count)) + fi.suffix());
+			exportProfile(dive, fi.path() + QDir::separator() + fi.completeBaseName().append(QString("-%1.").arg(count)) + fi.suffix());
 		else
-			saveProfile(dive, filename);
+			exportProfile(dive, filename);
 		++count;
 	}
 }
 
 
-void exportFuncs::export_TeX(const char *filename, const bool selected_only, bool plain)
+void export_TeX(const char *filename, const bool selected_only, bool plain)
 {
 	FILE *f;
 	QDir texdir = QFileInfo(filename).dir();
@@ -96,7 +90,7 @@ void exportFuncs::export_TeX(const char *filename, const bool selected_only, boo
 		if (selected_only && !dive->selected)
 			continue;
 
-		saveProfile(dive, texdir.filePath(QString("profile%1.png").arg(dive->number)));
+		exportProfile(dive, texdir.filePath(QString("profile%1.png").arg(dive->number)));
 		struct tm tm;
 		utc_mkdate(dive->when, &tm);
 
@@ -230,7 +224,7 @@ void exportFuncs::export_TeX(const char *filename, const bool selected_only, boo
 
 	f = subsurface_fopen(filename, "w+");
 	if (!f) {
-		report_error(qPrintable(tr("Can't open file %s")), filename);
+		report_error(qPrintable(gettextFromC::tr("Can't open file %s")), filename);
 	} else {
 		flush_buffer(&buf, f); /*check for writing errors? */
 		fclose(f);
@@ -239,7 +233,7 @@ void exportFuncs::export_TeX(const char *filename, const bool selected_only, boo
 
 }
 
-void exportFuncs::export_depths(const char *filename, const bool selected_only)
+void export_depths(const char *filename, const bool selected_only)
 {
 	FILE *f;
 	struct dive *dive;
@@ -268,7 +262,7 @@ void exportFuncs::export_depths(const char *filename, const bool selected_only)
 
 	f = subsurface_fopen(filename, "w+");
 	if (!f) {
-		report_error(qPrintable(tr("Can't open file %s")), filename);
+		report_error(qPrintable(gettextFromC::tr("Can't open file %s")), filename);
 	} else {
 		flush_buffer(&buf, f); /*check for writing errors? */
 		fclose(f);
@@ -276,7 +270,7 @@ void exportFuncs::export_depths(const char *filename, const bool selected_only)
 	free_buffer(&buf);
 }
 
-std::vector<const dive_site *> exportFuncs::getDiveSitesToExport(bool selectedOnly)
+std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly)
 {
 	std::vector<const dive_site *> res;
 #ifndef SUBSURFACE_MOBILE
@@ -311,7 +305,7 @@ std::vector<const dive_site *> exportFuncs::getDiveSitesToExport(bool selectedOn
 	return res;
 }
 
-QFuture<int> exportFuncs::exportUsingStyleSheet(QString filename, bool doExport, int units,
+QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units,
 	QString stylesheet, bool anonymize)
 {
 	return QtConcurrent::run(export_dives_xslt, filename.toUtf8(), doExport, units, stylesheet.toUtf8(), anonymize);

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -2,9 +2,10 @@
 #ifndef EXPORTFUNCS_H
 #define EXPORTFUNCS_H
 
-#include <QObject>
+#include <QString>
 #include <QFuture>
-#include "core/dive.h"
+
+struct dive_site;
 
 void exportProfile(QString filename, const bool selected_only);
 void export_TeX(const char *filename, const bool selected_only, bool plain);

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -16,9 +16,8 @@ public:
 	void export_TeX(const char *filename, const bool selected_only, bool plain);
 	void export_depths(const char *filename, const bool selected_only);
 	std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
-	void exportUsingStyleSheet(QString filename, bool doExport, int units,
+	QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units,
 		QString stylesheet, bool anonymize);
-	QFuture<int> future;
 
 	// prepareDivesForUploadDiveLog
 	// prepareDivesForUploadDiveShare

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -7,9 +7,9 @@
 
 struct dive_site;
 
-void exportProfile(QString filename, const bool selected_only);
-void export_TeX(const char *filename, const bool selected_only, bool plain);
-void export_depths(const char *filename, const bool selected_only);
+void exportProfile(QString filename, bool selected_only);
+void export_TeX(const char *filename, bool selected_only, bool plain);
+void export_depths(const char *filename, bool selected_only);
 std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
 QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units, QString stylesheet, bool anonymize);
 

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -6,33 +6,22 @@
 #include <QFuture>
 #include "core/dive.h"
 
-class exportFuncs: public QObject {
-	Q_OBJECT
+void exportProfile(QString filename, const bool selected_only);
+void export_TeX(const char *filename, const bool selected_only, bool plain);
+void export_depths(const char *filename, const bool selected_only);
+std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
+QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units, QString stylesheet, bool anonymize);
 
-public:
-	static exportFuncs *instance();
+// prepareDivesForUploadDiveLog
+// prepareDivesForUploadDiveShare
 
-	void exportProfile(QString filename, const bool selected_only);
-	void export_TeX(const char *filename, const bool selected_only, bool plain);
-	void export_depths(const char *filename, const bool selected_only);
-	std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
-	QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units,
-		QString stylesheet, bool anonymize);
-
-	// prepareDivesForUploadDiveLog
-	// prepareDivesForUploadDiveShare
-
-private:
-	exportFuncs() {}
-
-	// WARNING
-	// saveProfile uses the UI and are therefore different between
-	// Desktop (UI) and Mobile (QML)
-	// In order to solve this difference, the actual implementations
-	// are done in
-	// desktop-widgets/divelogexportdialog.cpp and
-	// mobile-widgets/qmlmanager.cpp
-	void saveProfile(const struct dive *dive, const QString filename);
-};
+// WARNING
+// exportProfile uses the UI and are therefore different between
+// Desktop (UI) and Mobile (QML)
+// In order to solve this difference, the actual implementations
+// are done in
+// desktop-widgets/divelogexportdialog.cpp and
+// mobile-widgets/qmlmanager.cpp
+void exportProfile(const struct dive *dive, const QString filename);
 
 #endif // EXPORT_FUNCS_H

--- a/commands/command.h
+++ b/commands/command.h
@@ -24,7 +24,7 @@ QAction *redoAction(QObject *parent);	// Create an redo action.
 // distance are added to a trip. dive d is consumed (the structure is reset)!
 // If newNumber is true, the dive is assigned a new number, depending on the
 // insertion position.
-void addDive(dive *d, const bool autogroup, bool newNumber);
+void addDive(dive *d, bool autogroup, bool newNumber);
 void importDives(struct dive_table *dives, struct trip_table *trips,
 		 struct dive_site_table *sites, int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);

--- a/core/dive.h
+++ b/core/dive.h
@@ -315,7 +315,7 @@ extern void set_filename(const char *filename);
 extern int save_dives(const char *filename);
 extern int save_dives_logic(const char *filename, bool select_only, bool anonymize);
 extern int save_dive(FILE *f, struct dive *dive, bool anonymize);
-extern int export_dives_xslt(const char *filename, const bool selected, const int units, const char *export_xslt, bool anonymize);
+extern int export_dives_xslt(const char *filename, bool selected, const int units, const char *export_xslt, bool anonymize);
 
 extern int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize);
 

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -344,7 +344,7 @@ void put_HTML_tags(struct membuffer *b, struct dive *dive, const char *pre, cons
 }
 
 /* if exporting list_only mode, we neglect exporting the samples, bookmarks and cylinders */
-void write_one_dive(struct membuffer *b, struct dive *dive, const char *photos_dir, int *dive_no, const bool list_only)
+void write_one_dive(struct membuffer *b, struct dive *dive, const char *photos_dir, int *dive_no, bool list_only)
 {
 	put_string(b, "{");
 	put_format(b, "\"number\":%d,", *dive_no);

--- a/core/save-profiledata.c
+++ b/core/save-profiledata.c
@@ -239,7 +239,7 @@ void save_subtitles_buffer(struct membuffer *b, struct dive *dive, int offset, i
 	free_plot_info_data(&pi);
 }
 
-int save_profiledata(const char *filename, const bool select_only)
+int save_profiledata(const char *filename, bool select_only)
 {
 	struct membuffer buf = { 0 };
 	FILE *f;

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -595,7 +595,7 @@ int save_dives(const char *filename)
 	return save_dives_logic(filename, false, false);
 }
 
-static void save_dives_buffer(struct membuffer *b, const bool select_only, bool anonymize)
+static void save_dives_buffer(struct membuffer *b, bool select_only, bool anonymize)
 {
 	int i;
 	struct dive *dive;

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -61,7 +61,7 @@ void uploadDiveLogsDE::doUpload(bool selected, const QString &userid, const QStr
 }
 
 
-bool uploadDiveLogsDE::prepareDives(const QString &tempfile, const bool selected)
+bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 {
 	static const char errPrefix[] = "divelog.de-upload:";
 #ifndef SUBSURFACE_MOBILE

--- a/core/uploadDiveLogsDE.h
+++ b/core/uploadDiveLogsDE.h
@@ -30,7 +30,7 @@ private:
 	void uploadDives(const QString &filename, const QString &userid, const QString &password);
 
 	// only to be used in desktop-widgets::subsurfacewebservices
-	bool prepareDives(const QString &tempfile, const bool selected);
+	bool prepareDives(const QString &tempfile, bool selected);
 
 	QNetworkReply *reply;
 	QHttpMultiPart *multipart;

--- a/core/worldmap-save.c
+++ b/core/worldmap-save.c
@@ -24,7 +24,7 @@ char *getGoogleApi()
 	return "https://maps.googleapis.com/maps/api/js?";
 }
 
-void writeMarkers(struct membuffer *b, const bool selected_only)
+void writeMarkers(struct membuffer *b, bool selected_only)
 {
 	int i, dive_no = 0;
 	struct dive *dive;

--- a/core/worldmap-save.h
+++ b/core/worldmap-save.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-extern void export_worldmap_HTML(const char *file_name, const bool selected_only);
+extern void export_worldmap_HTML(const char *file_name, bool selected_only);
 
 #ifdef __cplusplus
 }

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -214,9 +214,10 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		qPrefDisplay::set_lastDir(fileInfo.dir().path());
 		// the non XSLT exports are called directly above, the XSLT based ons are called here
 		if (!stylesheet.isEmpty()) {
-			exportFuncs::instance()->exportUsingStyleSheet(filename, ui->exportSelected->isChecked(), ui->CSVUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
-		MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
-		MainWindow::instance()->getNotificationWidget()->setFuture(exportFuncs::instance()->future);
+			QFuture<void> future = exportFuncs::instance()->exportUsingStyleSheet(filename, ui->exportSelected->isChecked(),
+					ui->CSVUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
+			MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
+			MainWindow::instance()->getNotificationWidget()->setFuture(future);
 		}
 	}
 }

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -179,21 +179,21 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 				if (!filename.contains('.'))
 					filename.append(".xml");
 				QByteArray bt = QFile::encodeName(filename);
-				std::vector<const dive_site *> sites = exportFuncs::instance()->getDiveSitesToExport(ui->exportSelected->isChecked());
+				std::vector<const dive_site *> sites = getDiveSitesToExport(ui->exportSelected->isChecked());
 				save_dive_sites_logic(bt.data(), &sites[0], (int)sites.size(), ui->anonymize->isChecked());
 			}
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
-				exportFuncs::instance()->export_depths(qPrintable(filename), ui->exportSelected->isChecked());
+				export_depths(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportTeX->isChecked() || ui->exportLaTeX->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export to TeX file"), lastDir, tr("TeX files") + " (*.tex)");
 			if (!filename.isNull() && !filename.isEmpty())
-				exportFuncs::instance()->export_TeX(qPrintable(filename), ui->exportSelected->isChecked(), ui->exportTeX->isChecked());
+				export_TeX(qPrintable(filename), ui->exportSelected->isChecked(), ui->exportTeX->isChecked());
 		} else if (ui->exportProfile->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile image"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
-				exportFuncs::instance()->exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
+				exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportProfileData->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile data"), lastDir);
 			if (!filename.isNull() && !filename.isEmpty())
@@ -214,7 +214,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		qPrefDisplay::set_lastDir(fileInfo.dir().path());
 		// the non XSLT exports are called directly above, the XSLT based ons are called here
 		if (!stylesheet.isEmpty()) {
-			QFuture<void> future = exportFuncs::instance()->exportUsingStyleSheet(filename, ui->exportSelected->isChecked(),
+			QFuture<void> future = exportUsingStyleSheet(filename, ui->exportSelected->isChecked(),
 					ui->CSVUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
 			MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
 			MainWindow::instance()->getNotificationWidget()->setFuture(future);
@@ -222,7 +222,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 	}
 }
 
-void exportFuncs::saveProfile(const struct dive *dive, const QString filename)
+void exportProfile(const struct dive *dive, const QString filename)
 {
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
 	profile->plotDive(dive, true, false, true);

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -637,7 +637,7 @@ QString TextHyperlinkEventFilter::tryToFormulateUrl(QTextCursor *cursor)
 	return stringMeetsOurUrlRequirements(maybeUrlStr) ? maybeUrlStr : QString();
 }
 
-QString TextHyperlinkEventFilter::fromCursorTilWhitespace(QTextCursor *cursor, const bool searchBackwards)
+QString TextHyperlinkEventFilter::fromCursorTilWhitespace(QTextCursor *cursor, bool searchBackwards)
 {
 	// fromCursorTilWhitespace calls cursor->movePosition repeatedly, while
 	// preserving the original 'anchor' (qt terminology) of the cursor.

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -156,7 +156,7 @@ private:
 	void handleUrlClick(const QString &urlStr);
 	void handleUrlTooltip(const QString &urlStr, const QPoint &pos);
 	bool stringMeetsOurUrlRequirements(const QString &maybeUrlStr);
-	QString fromCursorTilWhitespace(QTextCursor *cursor, const bool searchBackwards);
+	QString fromCursorTilWhitespace(QTextCursor *cursor, bool searchBackwards);
 	QString tryToFormulateUrl(QTextCursor *cursor);
 
 	QTextEdit const *const textEdit;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2137,36 +2137,36 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 			break;
 		case EX_DIVE_SITES_XML:
 			{
-				std::vector<const dive_site *> sites = exportFuncs::instance()->getDiveSitesToExport(false);
+				std::vector<const dive_site *> sites = getDiveSitesToExport(false);
 				save_dive_sites_logic(qPrintable(fileName + ".xml"), &sites[0], (int)sites.size(), anonymize);
 				break;
 			}
 		case EX_UDDF:
-			exportFuncs::instance()->exportUsingStyleSheet(fileName + ".uddf", true, 0, "uddf-export.xslt", anonymize);
+			exportUsingStyleSheet(fileName + ".uddf", true, 0, "uddf-export.xslt", anonymize);
 			break;
 		case EX_CSV_DIVE_PROFILE:
-			exportFuncs::instance()->exportUsingStyleSheet(fileName + ".uddf", true, 0, "xml2csv.xslt", anonymize);
+			exportUsingStyleSheet(fileName + ".uddf", true, 0, "xml2csv.xslt", anonymize);
 			break;
 		case EX_CSV_DETAILS:
-			exportFuncs::instance()->exportUsingStyleSheet(fileName + ".uddf", true, 0, "xml2manualcsv.xslt", anonymize);
+			exportUsingStyleSheet(fileName + ".uddf", true, 0, "xml2manualcsv.xslt", anonymize);
 			break;
 		case EX_CSV_PROFILE:
 			save_profiledata(qPrintable(fileName + ".csv"), true);
 			break;
 		case EX_PROFILE_PNG:
-			exportFuncs::instance()->exportProfile(qPrintable(fileName + ".png"), false);
+			exportProfile(qPrintable(fileName + ".png"), false);
 			break;
 		case EX_WORLD_MAP:
 			export_worldmap_HTML(qPrintable(fileName + ".html"), true);
 			break;
 		case EX_TEX:
-			exportFuncs::instance()->export_TeX(qPrintable(fileName + ".tex"), true, true);
+			export_TeX(qPrintable(fileName + ".tex"), true, true);
 			break;
 		case EX_LATEX:
-			exportFuncs::instance()->export_TeX(qPrintable(fileName + ".tex"), true, false);
+			export_TeX(qPrintable(fileName + ".tex"), true, false);
 			break;
 		case EX_IMAGE_DEPTHS:
-			exportFuncs::instance()->export_depths(qPrintable(fileName), false);
+			export_depths(qPrintable(fileName), false);
 			break;
 		default:
 			qDebug() << "export to unknown type " << type << " using " << dir << " remove names " << anonymize;
@@ -2174,7 +2174,7 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 	}
 }
 
-void exportFuncs::saveProfile(const struct dive *dive, const QString filename)
+void exportProfile(const struct dive *, const QString)
 {
 	// TBD
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is bike-shedding, but I see no reason for a class that is only composed of functions. The only state it had was a QFuture, but that seems to be better kept at the caller's site anyway. Reasoning: Why not allow multiple notifications that are closed automatically?

The one thing I have doubts is the namespace thing - we didn't have one before, so why would we need it now. On the other hand it doesn't seem to hurt. On the third hand, `Export::export_TeX` does feel a bit redundant - so one might keep the namespace and remove the prefix, etc. I really don't know.

I tested this on desktop and still could export files.

@neolit123 @dirkhh: You might have opinions on the namespace thing.
