### PR TITLE
Notes edit visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: automatically scroll the dive edit screen so that the notes edit cursor stays visible
 Desktop: ignore dive sites without location in proximity search
 Mobile: add personalized option for units
 Mobile: add Dive Summary page

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -716,11 +716,22 @@ Item {
 				selectByMouse: true
 				wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 				property bool firstTime: true
+				property int visibleTop: detailsEditFlickable.contentY
+				property int visibleBottom: visibleTop + detailsEditFlickable.height - 4 * Kirigami.Units.gridUnit
 				onPressed: waitForKeyboard.start()
+				onCursorRectangleChanged: {
+					ensureVisible(y + cursorRectangle.y)
+				}
+				onContentHeightChanged: {
+					console.log("content height changed")
+				}
 
-				// we repeat the Timer / Function from the SsrfTextField here (no point really in creating a matching customized TextArea)
+				// ensure that the y coordinate is inside the visible part of the detailsEditFlickable (our flickable)
 				function ensureVisible(yDest) {
-					detailsEditFlickable.contentY = yDest
+					if (yDest > visibleBottom)
+						detailsEditFlickable.contentY += yDest - visibleBottom
+					if (yDest < visibleTop)
+						detailsEditFlickable.contentY -= visibleTop - yDest
 				}
 
 				// give the OS enough time to actually resize the flickable
@@ -729,15 +740,14 @@ Item {
 					interval: 300 // 300ms seems like FOREVER
 					onTriggered: {
 						if (!Qt.inputMethod.visible) {
-							if (firstTime) {
-								firstTime = false
+							if (txtNotes.firstTime) {
+								txtNotes.firstTime = false
 								restart()
 							}
 							return
 						}
 						// make sure at least half the Notes field is visible
-						if (txtNotes.y + txtNotes.height / 2 > detailsEditFlickable.contentY + detailsEditFlickable.height - 3 * Kirigami.Units.gridUnit || txtNotes.y < detailsEditFlickable.contentY)
-							txtNotes.ensureVisible(Math.max(0, 3 * Kirigami.Units.gridUnit + txtNotes.y + txtNotes.height / 2 - detailsEditFlickable.height))
+						txtNotes.ensureVisible(txtNotes.y + txtNotes.cursorRectangle.y)
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I figured out a better way to ensure that the cursor in the notes field stays visible on a mobile device (especially when using a virtual keyboard). I have done _some_ testing (on three different devices) and this seems to work extremely well :-)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Re-assess the visibility of the cursor after every cursor move. And scroll if it's below the useful lower bottom (the action button) or above the top.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2579 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
my guess is this won't get a lot of testing until I make a beta available :-(

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
included

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
don't think that's necessary. This just fixes an unfortunate issue we have today

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
