### PR TITLE
mobile: prevent crash adding dives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix potential crash when adding / editing dives
 Mobile: automatically scroll the dive edit screen so that the notes edit cursor stays visible
 Desktop: ignore dive sites without location in proximity search
 Mobile: add personalized option for units

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1122,14 +1122,19 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 			d->weightsystems.weightsystems[0].weight.grams = parseWeightToGrams(weight);
 		}
 	}
-	// start and end pressures for first cylinder only
+	// start and end pressures
+	// first, normalize the lists - QML gives us a list with just one empty string if nothing was entered
+	if (startpressure == QStringList(QString()))
+		startpressure = QStringList();
+	if (endpressure == QStringList(QString()))
+		endpressure = QStringList();
 	if (myDive.startPressure != startpressure || myDive.endPressure != endpressure) {
 		diveChanged = true;
 		for ( int i = 0, j = 0 ; j < startpressure.length() && j < endpressure.length() ; i++ ) {
 			if (state != "add" && !is_cylinder_used(d, i))
 				continue;
 
-			get_cylinder(d, i)->start.mbar = parsePressureToMbar(startpressure[j]);
+			get_or_create_cylinder(d, i)->start.mbar = parsePressureToMbar(startpressure[j]);
 			get_cylinder(d, i)->end.mbar = parsePressureToMbar(endpressure[j]);
 			if (get_cylinder(d, i)->end.mbar > get_cylinder(d, i)->start.mbar)
 				get_cylinder(d, i)->end.mbar = get_cylinder(d, i)->start.mbar;
@@ -1150,7 +1155,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 				he >= 0 && he <= 1000 &&
 				o2 + he <= 1000) {
 				diveChanged = true;
-				get_cylinder(d, i)->gasmix.o2.permille = o2;
+				get_or_create_cylinder(d, i)->gasmix.o2.permille = o2;
 				get_cylinder(d, i)->gasmix.he.permille = he;
 			}
 			j++;
@@ -1177,7 +1182,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 					break;
 				}
 			}
-			get_cylinder(d, j)->type.description = copy_qstring(usedCylinder[k]);
+			get_or_create_cylinder(d, j)->type.description = copy_qstring(usedCylinder[k]);
 			get_cylinder(d, j)->type.size.mliter = size;
 			get_cylinder(d, j)->type.workingpressure.mbar = wp;
 			k++;


### PR DESCRIPTION
When the cylinders became a dynamic data structure, a get_cylinder() call
suddenly could return a NULL pointer. So use get_or_create_cylinder() for the
first call when parsing the user's data.

Also, deal with an oddity where the string lists look different because an
empty list technically isn't the same as a list with one empty string.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) normalize (for some definition of that term) the `QStringList` we get from QML
2) first time we access a cylinder, make sure we create it if it doesn't exist

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I don't think we have a public version with that bug, but I added an entry, just in case

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
no

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 