### PR TITLE
Dive list: be more careful on when updating the UI after selection

### DIFF
--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -65,6 +65,7 @@ slots:
 	void tripChanged(dive_trip *trip, TripField);
 private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
 	void selectAll() override;
 	void selectionChangeDone();
 	DiveTripModelBase::Layout currentLayout;


### PR DESCRIPTION
Fix two issues:

1) When narrowing the selection, we didn't get setSelection()
   calls. Only, when the user released the mouse button was
   the selection updated. Therefore, hook into the mouse-release-
   event and update the UI if the selection changed.

2) We updated the ui in setSelection(). However, this was called
   on mouse-move even if the actual selection didn't change.
   Therefore, compare selection before and after processing of
   the event and only refresh the UI if there are changes.

Clearly, this can only be a quick stopgap solution and we
should find out how to properly hook into the selection change
machinery. Though see commit 4928c4ae0421193bbd371cb0924091a970489611
for the reason why we do things as we do them.

Fixes #2595

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the selection bug reported in #2595. The code is a catastrophe, but is the only way I found to fix the problem reported in commit 4928c4ae0421193bbd371cb0924091a970489611. Sigh - I'm not getting the selection problems under control. :-/

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Hook into selection changes in mouseReleaseEvent
2) Only update UI when selection actually changes

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2595.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not needed - bug not in release.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Not needed - only bug fix.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson @dirkhh 