### PR TITLE
[TRIVIAL] Cleanup: remove erroneous comments

### DIFF
--- a/core/settings/qPrefPrivate.cpp
+++ b/core/settings/qPrefPrivate.cpp
@@ -18,10 +18,6 @@ QString keyFromGroupAndName(QString group, QString name)
 
 void qPrefPrivate::propSetValue(const QString &key, const QVariant &value, const QVariant &defaultValue)
 {
-	// REMARK: making s static (which would be logical) does NOT work
-	// because it gets initialized too early.
-	// Having it as a local variable is light weight, because it is an
-	// interface class.
 	QSettings s;
 	bool isDefault = false;
 	if (value.isValid() && value.type() == QVariant::Double)
@@ -37,10 +33,6 @@ void qPrefPrivate::propSetValue(const QString &key, const QVariant &value, const
 
 QVariant qPrefPrivate::propValue(const QString &key, const QVariant &defaultValue)
 {
-	// REMARK: making s static (which would be logical) does NOT work
-	// because it gets initialized too early.
-	// Having it as a local variable is light weight, because it is an
-	// interface class.
 	QSettings s;
 	return  s.value(key, defaultValue);
 }


### PR DESCRIPTION
Remove two erroneous comments stating that a function-local
QSettings variable should not be static because it is initialized
too early. Scoped static variables are initialized when execution
first hits the statement.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an idle removal of an erroneous comment, which I stumbled upon when git grep-ing for some qPref stuff.
In case someone doesn't believe me and is too lazy to test, here's the corresponding part of a working draft of the ISO standard:
https://timsong-cpp.github.io/cppwp/n3337/stmt.dcl
On "block-scope variables": "Otherwise [when it can't be statically initialized, rem.] such a variable is initialized the first time control passes through its declaration; such a variable is considered initialized upon the completion of its initialization."

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove comments.