### PR TITLE
Move filtering closer to the core

### DIFF
--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -8,10 +8,12 @@ DiveFilter::DiveFilter()
 {
 }
 
-bool DiveFilter::showDive(const struct dive *d) const
+ShownChange DiveFilter::update(const QVector<dive *> &) const
 {
-	// TODO: Do something useful
-	return true;
+}
+
+ShownChange DiveFilter::updateAll() const
+{
 }
 
 #else // SUBSURFACE_MOBILE
@@ -23,6 +25,37 @@ bool DiveFilter::showDive(const struct dive *d) const
 #include "core/trip.h"
 #include "core/divesite.h"
 #include "qt-models/filtermodels.h"
+
+void DiveFilter::updateDiveStatus(dive *d, ShownChange &change) const
+{
+	bool newStatus = showDive(d);
+	if (filter_dive(d, newStatus)) {
+		if (newStatus)
+			change.newShown.push_back(d);
+		else
+			change.newHidden.push_back(d);
+	}
+}
+
+ShownChange DiveFilter::update(const QVector<dive *> &dives) const
+{
+	dive *old_current = current_dive;
+	ShownChange res;
+	for (dive *d: dives)
+		updateDiveStatus(d, res);
+	res.currentChanged = old_current != current_dive;
+	return res;
+}
+
+ShownChange DiveFilter::updateAll() const
+{
+	dive *old_current = current_dive;
+	ShownChange res;
+	for (int i = 0; i < dive_table.nr; ++i)
+		updateDiveStatus(get_dive(i), res);
+	res.currentChanged = old_current != current_dive;
+	return res;
+}
 
 namespace {
 	// Pointer to function that takes two strings and returns whether

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -3,6 +3,16 @@
 #ifndef DIVE_FILTER_H
 #define DIVE_FILTER_H
 
+#include <QVector>
+struct dive;
+
+// Structure describing changes of shown status upon applying the filter
+struct ShownChange {
+	QVector<dive *> newShown;
+	QVector<dive *> newHidden;
+	bool currentChanged;
+};
+
 // The dive filter for mobile is currently much simpler than for desktop.
 // Therefore, for now we have two completely separate implementations.
 // This should be unified in the future.
@@ -12,7 +22,8 @@ class DiveFilter {
 public:
 	static DiveFilter *instance();
 
-	bool showDive(const struct dive *d) const;
+	ShownChange update(const QVector<dive *> &dives) const; // Update filter status of given dives and return dives whose status changed
+	ShownChange updateAll() const; // Update filter status of all dives and return dives whose status changed
 private:
 	DiveFilter();
 };
@@ -21,9 +32,7 @@ private:
 
 #include <QDateTime>
 #include <QStringList>
-#include <QVector>
 
-struct dive;
 struct dive_trip;
 struct dive_site;
 
@@ -82,15 +91,18 @@ class DiveFilter {
 public:
 	static DiveFilter *instance();
 
-	bool showDive(const struct dive *d) const;
 	bool diveSiteMode() const; // returns true if we're filtering on dive site
 	const QVector<dive_site *> &filteredDiveSites() const;
 	void startFilterDiveSites(QVector<dive_site *> ds);
 	void setFilterDiveSite(QVector<dive_site *> ds);
 	void stopFilterDiveSites();
 	void setFilter(const FilterData &data);
+	ShownChange update(const QVector<dive *> &dives) const; // Update filter status of given dives and return dives whose status changed
+	ShownChange updateAll() const; // Update filter status of all dives and return dives whose status changed
 private:
 	DiveFilter();
+	void updateDiveStatus(dive *d, ShownChange &change) const;
+	bool showDive(const struct dive *d) const; // Should that dive be shown?
 
 	QVector<dive_site *> dive_sites;
 	FilterData filterData;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -752,46 +752,6 @@ dive *DiveTripModelTree::diveOrNull(const QModelIndex &index) const
 	return tripOrDive(index).dive;
 }
 
-// Send data changed signals blockwise. Which entries are changed is collected
-// in the first parameter "changed".
-void DiveTripModelBase::sendShownChangedSignals(const std::vector<char> &changed, quintptr parentIndex)
-{
-	static const QVector<int> roles { SHOWN_ROLE };
-	for (size_t i = 0; i < changed.size(); ++i) {
-		// Find first and last block of changed items
-		if (!changed[i])
-			continue;
-		size_t j;
-		for (j = i + 1; j < changed.size() && changed[j]; ++j)
-			; // Pass
-		dataChanged(createIndex(i, 0, parentIndex), createIndex(j - 1, 0, parentIndex), roles);
-		i = j - 1;
-	}
-}
-
-// Applying the filter to trip-items is a bit tricky:
-// We only want to send changed-signals if one of the dives remains visible.
-// Because if no dive remains visible, we'll simply send a signal on the parent trip,
-// which will then be hidden and all the dives will be hidden implicitly as well.
-// Thus, do this in two passes: collect changed dives and only if any dive is visible,
-// send the signals.
-bool DiveTripModelTree::calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, quintptr parentIndex)
-{
-	bool showTrip = false;
-	std::vector<char> changed;
-	changed.reserve(dives.size());
-	for (dive *d: dives) {
-		bool shown = filter->showDive(d);
-		changed.push_back(filter_dive(d, shown));
-		showTrip |= shown;
-	}
-
-	// If any dive is shown, send changed-signals
-	if (showTrip)
-		sendShownChangedSignals(changed, parentIndex);
-	return showTrip;
-}
-
 // The tree-version of the model wants to process the dives per trip.
 // This template takes a vector of dives and calls a function batchwise for each trip.
 template<typename Function>

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -841,14 +841,6 @@ void DiveTripModelTree::divesHidden(dive_trip *trip, const QVector<dive *> &dive
 
 QVariant DiveTripModelTree::data(const QModelIndex &index, int role) const
 {
-	if (role == SHOWN_ROLE) {
-		QModelIndex parent = index.parent();
-		// An invalid parent means that we're at the top-level
-		if (!parent.isValid())
-			return items[index.row()].shown;
-		return !items[parent.row()].dives[index.row()]->hidden_by_filter;
-	}
-
 	// Set the font for all items alike
 	if (role == Qt::FontRole)
 		return defaultModelFont();
@@ -1409,8 +1401,6 @@ QVariant DiveTripModelList::data(const QModelIndex &index, int role) const
 		return defaultModelFont();
 
 	dive *d = diveOrNull(index);
-	if (role == SHOWN_ROLE)
-		return d && !d->hidden_by_filter;
 	return d ? diveData(d, index.column(), role) : QVariant();
 }
 

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -702,19 +702,15 @@ QModelIndex DiveTripModelTree::parent(const QModelIndex &index) const
 }
 
 DiveTripModelTree::Item::Item(dive_trip *t, const QVector<dive *> &divesIn) : d_or_t{nullptr, t},
-	dives(std::vector<dive *>(divesIn.begin(), divesIn.end())),
-	shown(std::any_of(dives.begin(), dives.end(), [](dive *d){ return !d->hidden_by_filter; }))
+	dives(std::vector<dive *>(divesIn.begin(), divesIn.end()))
 {
 }
 
-DiveTripModelTree::Item::Item(dive_trip *t, dive *d) : d_or_t{nullptr, t},
-	dives({ d }),
-	shown(!d->hidden_by_filter)
+DiveTripModelTree::Item::Item(dive_trip *t, dive *d) : d_or_t{nullptr, t}, dives({ d })
 {
 }
 
-DiveTripModelTree::Item::Item(dive *d) : d_or_t{d, nullptr},
-	shown(!d->hidden_by_filter)
+DiveTripModelTree::Item::Item(dive *d) : d_or_t{d, nullptr}
 {
 }
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -124,6 +124,8 @@ private:
 	void divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &);
 	dive *diveOrNull(const QModelIndex &index) const override;
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
+	void divesShown(dive_trip *trip, const QVector<dive *> &dives);
+	void divesHidden(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, quintptr parentIndex);
 
@@ -151,8 +153,13 @@ private:
 	dive_or_trip tripOrDive(const QModelIndex &index) const;
 								// Returns either a pointer to a trip or a dive, or twice null of index is invalid
 								// null, something is really wrong
-	// Addition and deletion of dives
+	// Addition and deletion of dives and trips
+	void addTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void addDivesToTrip(int idx, const QVector<dive *> &dives);
+	void addDivesTopLevel(const QVector<dive *> &dives);
+	void removeDivesFromTrip(int idx, const QVector<dive *> &dives);
+	void removeDivesTopLevel(const QVector<dive *> &dives);
+	void removeTrip(int idx);
 	void topLevelChanged(int idx);
 
 	// Access trips and dives
@@ -190,6 +197,8 @@ private:
 	QVariant data(const QModelIndex &index, int role) const override;
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	dive *diveOrNull(const QModelIndex &index) const override;
+	void addDives(QVector<dive *> &dives);
+	void removeDives(QVector<dive *> &dives);
 
 	std::vector<dive *> items;				// TODO: access core data directly
 };

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -90,7 +90,6 @@ protected:
 	// Access trip and dive data
 	static QVariant diveData(const struct dive *d, int column, int role);
 	static QVariant tripData(const dive_trip *trip, int column, int role);
-	void sendShownChangedSignals(const std::vector<char> &changed, quintptr parentIndex);
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 	virtual void clearData() = 0;
@@ -127,7 +126,6 @@ private:
 	void divesShown(dive_trip *trip, const QVector<dive *> &dives);
 	void divesHidden(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
-	bool calculateFilterForTrip(const std::vector<dive *> &dives, const DiveFilter *filter, quintptr parentIndex);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -137,7 +137,6 @@ private:
 	struct Item {
 		dive_or_trip		d_or_t;
 		std::vector<dive *>	dives;			// std::vector<> instead of QVector for insert() with three iterators
-		bool			shown;
 		Item(dive_trip *t, const QVector<dive *> &dives);
 		Item(dive_trip *t, dive *d);			// Initialize a trip with one dive
 		Item(dive *d);					// Initialize a top-level dive

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -49,7 +49,6 @@ public:
 		DIVE_ROLE,
 		TRIP_ROLE,
 		DIVE_IDX,
-		SHOWN_ROLE,
 		SELECTED_ROLE
 	};
 	enum Layout {

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -16,9 +16,6 @@ MultiFilterSortModel *MultiFilterSortModel::instance()
 MultiFilterSortModel::MultiFilterSortModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
 	resetModel(DiveTripModelBase::TREE);
-	setFilterKeyColumn(-1); // filter all columns
-	setFilterRole(DiveTripModelBase::SHOWN_ROLE); // Let the proxy-model known that is has to react to change events involving SHOWN_ROLE
-	setFilterCaseSensitivity(Qt::CaseInsensitive);
 }
 
 void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
@@ -62,9 +59,7 @@ void MultiFilterSortModel::currentDiveChangedSlot(QModelIndex index)
 
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
-	QAbstractItemModel *m = sourceModel();
-	QModelIndex index0 = m->index(source_row, 0, source_parent);
-	return m->data(index0, DiveTripModelBase::SHOWN_ROLE).value<bool>();
+	return true;
 }
 
 bool MultiFilterSortModel::lessThan(const QModelIndex &i1, const QModelIndex &i2) const


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
To avoid ProxyModel-Lasagna, Dirk suggested filtering the dives directly at the core. Indeed, the DiveTripModels have to handle filtering anyway. We hope that this helps in unifying the desktop and mobile models.

This is an attempt at doing so. It is only very lightly tested though, so it *will* break widely. Testing would be very welcome. Note that this is not as easy as one might think. The interesting parts are when modifying dives changes the filter-criterion; when whole trips are hidden and the interaction with the undo-system.

The main commit is admittedly a tad big and should probably be split up.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Move filtering to the DiveTripModels.
2) Remove filtering from the MultiFilterProxyModel (which now has an inappropriate name, btw).
3) Remove some now unused code.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @neolit123 