### PR TITLE
mobile/gps: make sure updated GPS data are saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix saving newly applied GPS fixes to storage
 Desktop: add starts-with and exact filter modes for textual search
 Mobile: add option to only show one column in portrait mode
 Mobile: fix potential crash when adding / editing dives

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -225,6 +225,7 @@ static void copy_gps_location(struct gpsTracker &gps, struct dive *d)
 #define SET_LOCATION(_dive, _gpsfix, _mark)	\
 {						\
 	copy_gps_location(_gpsfix, _dive);	\
+	invalidate_dive_cache(_dive);		\
 	changed++;				\
 	last = _mark;				\
 }


### PR DESCRIPTION
If we change the gps location of a dive that didn't have a dive site associated
before (which is the normal case when a dive was just downloaded from a dive
computer), a new dive site is created with that GPS fix and added to the dive.
We need to mark that dive as changed in order for the changes to be saved to
storage.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
no

