### PR TITLE
Fix loading bailout events

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -722,7 +722,7 @@ static int get_divemode(const char *divemodestring) {
 		if (!strcmp(divemodestring, divemode_text[i]))
 			return i;
 	}
-	return 0;
+	return -1;
 }
 
 static void parse_event_keyvalue(void *_event, const char *key, const char *value)
@@ -799,6 +799,11 @@ static void parse_dc_event(char *line, struct membuffer *str, struct git_parser_
 	name = "";
 	if (str->len)
 		name = mb_cstring(str);
+	int divemode = get_divemode(name);
+	if (divemode >= 0) {
+		name = strdup("modechange");
+		event.value = divemode;
+	}
 	ev = add_event(state->active_dc, event.time.seconds, event.type, event.flags, event.value, name);
 
 	/*


### PR DESCRIPTION
The parsing of events mistakes the new divemode name
as the event name. Let's use the fact that dive modes
have distinct names from other events and simply
fix those events whose name matches a divemode.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a bit of a hack since it relies on the "only one string per line" feature of git loading. But it is simple. If a dive mode name ends up as an event name, make that a mode change event and fix the value.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2613 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
