### PR TITLE
[RFC] Foundation for fulltext filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 Mobile: enable profile zoom and pan
+Mobile: add people- and tags-filter modes
+Desktop: fix tab-order in filter widget
+Desktop: implement fulltext search
 Mobile: fix saving newly applied GPS fixes to storage
 Desktop: add starts-with and exact filter modes for textual search
 Mobile: add option to only show one column in portrait mode

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -88,6 +88,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	file.h
 	format.cpp
 	format.h
+	fulltext.cpp
+	fulltext.h
 	gas.c
 	gas.h
 	gas-model.c

--- a/core/dive.c
+++ b/core/dive.c
@@ -17,6 +17,10 @@
 #include "tag.h"
 #include "trip.h"
 #include "structured_list.h"
+#ifndef SUBSURFACE_MOBILE
+#include "fulltext.h"
+#endif
+
 
 /* one could argue about the best place to have this variable -
  * it's used in the UI, but it seems to make the most sense to have it
@@ -356,6 +360,9 @@ static void free_dive_structures(struct dive *d)
 {
 	if (!d)
 		return;
+#ifndef SUBSURFACE_MOBILE
+	fulltext_unregister(d);
+#endif
 	/* free the strings */
 	free(d->buddy);
 	free(d->divemaster);
@@ -401,6 +408,9 @@ static void copy_dive_nodc(const struct dive *s, struct dive *d)
 	*d = *s;
 	memset(&d->cylinders, 0, sizeof(d->cylinders));
 	memset(&d->weightsystems, 0, sizeof(d->weightsystems));
+#ifndef SUBSURFACE_MOBILE
+	d->full_text = NULL;
+#endif
 	invalidate_dive_cache(d);
 	d->buddy = copy_string(s->buddy);
 	d->divemaster = copy_string(s->divemaster);

--- a/core/dive.c
+++ b/core/dive.c
@@ -17,9 +17,7 @@
 #include "tag.h"
 #include "trip.h"
 #include "structured_list.h"
-#ifndef SUBSURFACE_MOBILE
 #include "fulltext.h"
-#endif
 
 
 /* one could argue about the best place to have this variable -
@@ -360,9 +358,7 @@ static void free_dive_structures(struct dive *d)
 {
 	if (!d)
 		return;
-#ifndef SUBSURFACE_MOBILE
 	fulltext_unregister(d);
-#endif
 	/* free the strings */
 	free(d->buddy);
 	free(d->divemaster);
@@ -408,9 +404,7 @@ static void copy_dive_nodc(const struct dive *s, struct dive *d)
 	*d = *s;
 	memset(&d->cylinders, 0, sizeof(d->cylinders));
 	memset(&d->weightsystems, 0, sizeof(d->weightsystems));
-#ifndef SUBSURFACE_MOBILE
 	d->full_text = NULL;
-#endif
 	invalidate_dive_cache(d);
 	d->buddy = copy_string(s->buddy);
 	d->divemaster = copy_string(s->divemaster);

--- a/core/dive.h
+++ b/core/dive.h
@@ -140,6 +140,7 @@ struct dive_site;
 struct dive_site_table;
 struct dive_trip;
 struct trip_table;
+struct full_text_cache;
 struct dive {
 	struct dive_trip *divetrip;
 	timestamp_t when;

--- a/core/dive.h
+++ b/core/dive.h
@@ -170,6 +170,9 @@ struct dive {
 	bool notrip; /* Don't autogroup this dive to a trip */
 	bool selected;
 	bool hidden_by_filter;
+#if !defined(SUBSURFACE_MOBILE)
+	struct full_text_cache *full_text; /* word cache for full text search */
+#endif
 #if defined(SUBSURFACE_MOBILE)
 	uint8_t collapsed; /* four values: 0 = don't show, 1 = show as dive, 2 = show corresponding trip, 3 = show dive and trip */
 #endif

--- a/core/dive.h
+++ b/core/dive.h
@@ -171,9 +171,7 @@ struct dive {
 	bool notrip; /* Don't autogroup this dive to a trip */
 	bool selected;
 	bool hidden_by_filter;
-#if !defined(SUBSURFACE_MOBILE)
 	struct full_text_cache *full_text; /* word cache for full text search */
-#endif
 #if defined(SUBSURFACE_MOBILE)
 	uint8_t collapsed; /* four values: 0 = don't show, 1 = show as dive, 2 = show corresponding trip, 3 = show dive and trip */
 #endif

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0
 
 #include "divefilter.h"
+#include "divelist.h"
+
+static void updateDiveStatus(dive *d, bool newStatus, ShownChange &change)
+{
+	if (filter_dive(d, newStatus)) {
+		if (newStatus)
+			change.newShown.push_back(d);
+		else
+			change.newHidden.push_back(d);
+	}
+}
 
 #ifdef SUBSURFACE_MOBILE
 
@@ -30,16 +41,6 @@ ShownChange DiveFilter::updateAll() const
 #include "core/trip.h"
 #include "core/divesite.h"
 #include "qt-models/filtermodels.h"
-
-void DiveFilter::updateDiveStatus(dive *d, bool newStatus, ShownChange &change) const
-{
-	if (filter_dive(d, newStatus)) {
-		if (newStatus)
-			change.newShown.push_back(d);
-		else
-			change.newHidden.push_back(d);
-	}
-}
 
 ShownChange DiveFilter::update(const QVector<dive *> &dives) const
 {

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -73,16 +73,16 @@ namespace {
 	// Check whether either all, any or none of the items of the first list is
 	// in the second list as a super string.
 	// The mode is controlled by the second argument
-	bool check(const QStringList &items, const QStringList &list, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool check(const QStringList &items, const QStringList &list, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		bool negate = mode == FilterData::Mode::NONE_OF;
 		bool any_of = mode == FilterData::Mode::ANY_OF;
 		StrCheck strchk =
-			stringMode == FilterData::StringMode::SUBSTRING ?
+			stringMode == StringFilterMode::SUBSTRING ?
 				[](const QString &s1, const QString &s2) { return s1.contains(s2, Qt::CaseInsensitive); } :
-			stringMode == FilterData::StringMode::STARTSWITH ?
+			stringMode == StringFilterMode::STARTSWITH ?
 				[](const QString &s1, const QString &s2) { return s1.startsWith(s2, Qt::CaseInsensitive); } :
-			/* FilterData::StringMode::EXACT */
+			/* StringFilterMode::EXACT */
 				[](const QString &s1, const QString &s2) { return s1.compare(s2, Qt::CaseInsensitive) == 0; };
 		auto fun = [&list, negate, strchk](const QString &item)
 			   { return listContainsSuperstring(list, item, strchk) != negate; };
@@ -90,7 +90,7 @@ namespace {
 			      : std::all_of(items.begin(), items.end(), fun);
 	}
 
-	bool hasTags(const QStringList &tags, const struct dive *d, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool hasTags(const QStringList &tags, const struct dive *d, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		if (tags.isEmpty())
 			return true;
@@ -99,7 +99,7 @@ namespace {
 		return check(tags, dive_tags, mode, stringMode);
 	}
 
-	bool hasPersons(const QStringList &people, const struct dive *d, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool hasPersons(const QStringList &people, const struct dive *d, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		if (people.isEmpty())
 			return true;
@@ -108,7 +108,7 @@ namespace {
 		return check(people, dive_people, mode, stringMode);
 	}
 
-	bool hasLocations(const QStringList &locations, const struct dive *d, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool hasLocations(const QStringList &locations, const struct dive *d, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		if (locations.isEmpty())
 			return true;
@@ -123,12 +123,12 @@ namespace {
 	}
 
 	// TODO: Finish this implementation.
-	bool hasEquipment(const QStringList &, const struct dive *, FilterData::Mode, FilterData::StringMode)
+	bool hasEquipment(const QStringList &, const struct dive *, FilterData::Mode, StringFilterMode)
 	{
 		return true;
 	}
 
-	bool hasSuits(const QStringList &suits, const struct dive *d, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool hasSuits(const QStringList &suits, const struct dive *d, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		if (suits.isEmpty())
 			return true;
@@ -138,7 +138,7 @@ namespace {
 		return check(suits, diveSuits, mode, stringMode);
 	}
 
-	bool hasNotes(const QStringList &dnotes, const struct dive *d, FilterData::Mode mode, FilterData::StringMode stringMode)
+	bool hasNotes(const QStringList &dnotes, const struct dive *d, FilterData::Mode mode, StringFilterMode stringMode)
 	{
 		if (dnotes.isEmpty())
 			return true;

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -10,10 +10,14 @@ DiveFilter::DiveFilter()
 
 ShownChange DiveFilter::update(const QVector<dive *> &) const
 {
+	ShownChange res;
+	return res;
 }
 
 ShownChange DiveFilter::updateAll() const
 {
+	ShownChange res;
+	return res;
 }
 
 #else // SUBSURFACE_MOBILE

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -13,12 +13,6 @@ struct ShownChange {
 	bool currentChanged;
 };
 
-enum class StringFilterMode {
-	SUBSTRING = 0,
-	STARTSWITH = 1,
-	EXACT = 2
-};
-
 // The dive filter for mobile is currently much simpler than for desktop.
 // Therefore, for now we have two completely separate implementations.
 // This should be unified in the future.
@@ -36,6 +30,7 @@ private:
 
 #else
 
+#include "fulltext.h"
 #include <QDateTime>
 #include <QStringList>
 
@@ -72,12 +67,14 @@ struct FilterData {
 	QStringList suit;
 	QStringList dnotes;
 	QStringList equipment;
+	FullTextQuery fullText;
 	Mode tagsMode = Mode::ALL_OF;
 	Mode peopleMode = Mode::ALL_OF;
 	Mode locationMode = Mode::ANY_OF;
 	Mode dnotesMode = Mode::ALL_OF;
 	Mode suitMode = Mode::ANY_OF;
 	Mode equipmentMode = Mode::ALL_OF;
+	StringFilterMode fulltextStringMode = StringFilterMode::STARTSWITH;
 	StringFilterMode tagsStringMode = StringFilterMode::SUBSTRING;
 	StringFilterMode peopleStringMode = StringFilterMode::SUBSTRING;
 	StringFilterMode locationStringMode = StringFilterMode::SUBSTRING;
@@ -102,7 +99,7 @@ public:
 	ShownChange updateAll() const; // Update filter status of all dives and return dives whose status changed
 private:
 	DiveFilter();
-	void updateDiveStatus(dive *d, ShownChange &change) const;
+	void updateDiveStatus(dive *d, bool newStatus, ShownChange &change) const;
 	bool showDive(const struct dive *d) const; // Should that dive be shown?
 
 	QVector<dive_site *> dive_sites;

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -4,6 +4,7 @@
 #define DIVE_FILTER_H
 
 #include <QVector>
+#include <QStringList>
 #include "fulltext.h"
 
 struct dive;
@@ -31,7 +32,7 @@ struct FilterData {
 
 	Mode mode = Mode::NONE;
 	FullTextQuery fullText; // For fulltext
-	QString text; // For people and tags
+	QStringList tags; // For people and tags
 };
 
 class DiveFilter {
@@ -50,7 +51,6 @@ private:
 #else
 
 #include <QDateTime>
-#include <QStringList>
 
 struct dive_trip;
 struct dive_site;

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -4,6 +4,8 @@
 #define DIVE_FILTER_H
 
 #include <QVector>
+#include "fulltext.h"
+
 struct dive;
 
 // Structure describing changes of shown status upon applying the filter
@@ -18,19 +20,35 @@ struct ShownChange {
 // This should be unified in the future.
 #ifdef SUBSURFACE_MOBILE
 
+struct FilterData {
+	// On mobile, we support searching fulltext (all fields), people (buddies and divemasters) and tags
+	enum class Mode {
+		NONE = 0,
+		FULLTEXT = 1,
+		PEOPLE = 2,
+		TAGS = 3
+	};
+
+	Mode mode = Mode::NONE;
+	FullTextQuery fullText; // For fulltext
+	QString text; // For people and tags
+};
+
 class DiveFilter {
 public:
 	static DiveFilter *instance();
 
 	ShownChange update(const QVector<dive *> &dives) const; // Update filter status of given dives and return dives whose status changed
 	ShownChange updateAll() const; // Update filter status of all dives and return dives whose status changed
+	void setFilter(const FilterData &data);
 private:
 	DiveFilter();
+
+	FilterData filterData;
 };
 
 #else
 
-#include "fulltext.h"
 #include <QDateTime>
 #include <QStringList>
 

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -99,7 +99,6 @@ public:
 	ShownChange updateAll() const; // Update filter status of all dives and return dives whose status changed
 private:
 	DiveFilter();
-	void updateDiveStatus(dive *d, bool newStatus, ShownChange &change) const;
 	bool showDive(const struct dive *d) const; // Should that dive be shown?
 
 	QVector<dive_site *> dive_sites;

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -13,6 +13,12 @@ struct ShownChange {
 	bool currentChanged;
 };
 
+enum class StringFilterMode {
+	SUBSTRING = 0,
+	STARTSWITH = 1,
+	EXACT = 2
+};
+
 // The dive filter for mobile is currently much simpler than for desktop.
 // Therefore, for now we have two completely separate implementations.
 // This should be unified in the future.
@@ -43,11 +49,6 @@ struct FilterData {
 		ANY_OF = 1,
 		NONE_OF = 2
 	};
-	enum class StringMode {
-		SUBSTRING = 0,
-		STARTSWITH = 1,
-		EXACT = 2
-	};
 
 	bool validFilter = false;
 	int minVisibility = 0;
@@ -77,12 +78,12 @@ struct FilterData {
 	Mode dnotesMode = Mode::ALL_OF;
 	Mode suitMode = Mode::ANY_OF;
 	Mode equipmentMode = Mode::ALL_OF;
-	StringMode tagsStringMode = StringMode::SUBSTRING;
-	StringMode peopleStringMode = StringMode::SUBSTRING;
-	StringMode locationStringMode = StringMode::SUBSTRING;
-	StringMode dnotesStringMode = StringMode::SUBSTRING;
-	StringMode suitStringMode = StringMode::SUBSTRING;
-	StringMode equipmentStringMode = StringMode::SUBSTRING;
+	StringFilterMode tagsStringMode = StringFilterMode::SUBSTRING;
+	StringFilterMode peopleStringMode = StringFilterMode::SUBSTRING;
+	StringFilterMode locationStringMode = StringFilterMode::SUBSTRING;
+	StringFilterMode dnotesStringMode = StringFilterMode::SUBSTRING;
+	StringFilterMode suitStringMode = StringFilterMode::SUBSTRING;
+	StringFilterMode equipmentStringMode = StringFilterMode::SUBSTRING;
 	bool logged = true;
 	bool planned = true;
 };

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -5,6 +5,7 @@
 #include "deco.h"
 #include "divesite.h"
 #include "divelist.h"
+#include "fulltext.h"
 #include "planner.h"
 #include "qthelper.h"
 #include "gettext.h"
@@ -829,6 +830,10 @@ void process_loaded_dives()
 
 	/* Autogroup dives if desired by user. */
 	autogroup_dives(&dive_table, &trip_table);
+
+#ifndef SUBSURFACE_MOBILE
+	fulltext_reload();
+#endif
 }
 
 /*
@@ -1338,6 +1343,10 @@ int get_dive_id_closest_to(timestamp_t when)
 
 void clear_dive_file_data()
 {
+#ifndef SUBSURFACE_MOBILE
+	fulltext_unregister_all();
+#endif
+
 	while (dive_table.nr)
 		delete_single_dive(0);
 	current_dive = NULL;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -831,9 +831,7 @@ void process_loaded_dives()
 	/* Autogroup dives if desired by user. */
 	autogroup_dives(&dive_table, &trip_table);
 
-#ifndef SUBSURFACE_MOBILE
 	fulltext_reload();
-#endif
 }
 
 /*
@@ -1343,9 +1341,7 @@ int get_dive_id_closest_to(timestamp_t when)
 
 void clear_dive_file_data()
 {
-#ifndef SUBSURFACE_MOBILE
 	fulltext_unregister_all();
-#endif
 
 	while (dive_table.nr)
 		delete_single_dive(0);

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include "fulltext.h"
+#include "dive.h"
+#include "divesite.h"
+#include "trip.h"
+#include <QLocale>
+#include <map>
+
+#ifndef SUBSURFACE_MOBILE
+
+// This class caches each dives words, so that we can unregister a dive from the full text search
+struct full_text_cache {
+	std::vector<QString> words;
+};
+
+// The FullText-search class
+class FullText {
+	std::map<QString, std::vector<dive *>> words; // Dives that belong to each word
+public:
+
+	void reload(); // Rebuild from current dive_table
+	void registerDive(struct dive *d); // Note: can be called repeatedly
+	void unregisterDive(struct dive *d); // Note: can be called repeatedly
+	void unregisterAll(); // Unregister all dives in the dive table
+	FullTextResult find(const FullTextQuery &q, StringFilterMode mode) const; // Find dives matchin all words.
+private:
+	void registerWords(struct dive *d, const std::vector<QString> &w);
+	void unregisterWords(struct dive *d, const std::vector<QString> &w);
+	std::vector<dive *> findDives(const QString &s, StringFilterMode mode) const; // Find dives matching a given word.
+};
+
+// This class doesn't depend on any other objects, we might just initialize it at startup.
+static FullText self;
+
+// C-interface functions
+
+extern "C" {
+
+void fulltext_register(struct dive *d)
+{
+	self.registerDive(d);
+}
+
+void fulltext_unregister(struct dive *d)
+{
+	self.unregisterDive(d);
+}
+
+void fulltext_unregister_all()
+{
+	self.unregisterAll();
+}
+
+void fulltext_reload()
+{
+	self.reload();
+}
+
+} // extern "C"
+
+// C++-only interface functions
+FullTextResult fulltext_find_dives(const FullTextQuery &q, StringFilterMode mode)
+{
+	return self.find(q, mode);
+}
+
+// Check whether a single dive matches the fulltext criterion
+bool fulltext_dive_matches(const struct dive *d, const FullTextQuery &q, StringFilterMode mode)
+{
+	if (!q.doit())
+		return true;
+	if (!d->full_text)
+		return false;
+	auto matchFunc =
+		mode == StringFilterMode::EXACT ? [](const QString &s1, const QString &s2) { return s1 == s2; } :
+		mode == StringFilterMode::STARTSWITH ? [](const QString &s1, const QString &s2) { return s1.startsWith(s2); } :
+		/* mode == StringFilterMode::SUBSTRING ? */ [](const QString &s1, const QString &s2) { return s1.contains(s2); };
+	const std::vector<QString> &words = d->full_text->words;
+	for (const QString &search: q.words) {
+		if (std::any_of(words.begin(), words.end(), [&search,matchFunc](const QString &w) { return matchFunc(w, search); }))
+			return true;
+	}
+	return false;
+}
+
+// Class implementation
+
+// Take a text and tokenize it into words. Normalize the words to upper case
+// and add to a given list, if not already in list.
+// We might think about limiting the lower size of words we store.
+// Note: we convert to QString before tokenization because we rely in
+// Qt's isPunct() function.
+static void tokenize(QString s, std::vector<QString> &res)
+{
+	if (s.isEmpty())
+		return;
+
+	QLocale loc;
+	int size = s.size();
+	int pos = 0;
+	while (pos < size) {
+		// Skip whitespace and punctuation
+		while (s[pos].isSpace() || s[pos].isPunct()) {
+			if (++pos >= size)
+				return;
+		}
+		int end = pos;
+		while (end < size && !s[end].isSpace() && !s[end].isPunct())
+			++end;
+		QString word = loc.toUpper(s.mid(pos, end - pos)); // Sad: Locale::toUpper can't use QStringRef - we have to copy the substring!
+		pos = end;
+
+		if (find(res.begin(), res.end(), word) == res.end())
+			res.push_back(word);
+	}
+}
+
+// Get all words of a dive
+static std::vector<QString> getWords(const dive *d)
+{
+	std::vector<QString> res;
+	tokenize(QString(d->notes), res);
+	tokenize(QString(d->divemaster), res);
+	tokenize(QString(d->buddy), res);
+	tokenize(QString(d->suit), res);
+	for (int i = 0; i < d->cylinders.nr; ++i) {
+		const cylinder_t &cyl = d->cylinders.cylinders[i];
+		tokenize(QString(cyl.type.description), res);
+	}
+	for (int i = 0; i < d->weightsystems.nr; ++i) {
+		const weightsystem_t &ws = d->weightsystems.weightsystems[i];
+		tokenize(QString(ws.description), res);
+	}
+	// TODO: We should tokenize all dive-sites and trips first and then
+	// take the tokens from a cache.
+	if (d->dive_site)
+		tokenize(d->dive_site->name, res);
+	// TODO: We should index trips separately!
+	if (d->divetrip)
+		tokenize(d->divetrip->location, res);
+	return res;
+}
+
+void FullText::reload()
+{
+	words.clear();
+	int i;
+	dive *d;
+	for_each_dive(i, d)
+		registerDive(d);
+}
+
+void FullText::registerDive(struct dive *d)
+{
+	if (d->full_text) {
+		unregisterWords(d, d->full_text->words);
+	} else {
+		d->full_text = new full_text_cache;
+	}
+	d->full_text->words = getWords(d);
+	registerWords(d, d->full_text->words);
+}
+
+void FullText::unregisterDive(struct dive *d)
+{
+	if (!d->full_text)
+		return;
+	unregisterWords(d, d->full_text->words);
+	delete d->full_text;
+	d->full_text = nullptr;
+}
+
+void FullText::unregisterAll()
+{
+	int i;
+	dive *d;
+	for_each_dive(i, d) {
+		delete d->full_text;
+		d->full_text = nullptr;
+	}
+	words.clear();
+}
+
+// Register words of a dive.
+void FullText::registerWords(struct dive *d, const std::vector<QString> &w)
+{
+	for (const QString &word: w) {
+		std::vector<dive *> &entry = words[word];
+		if (std::find(entry.begin(), entry.end(), d) == entry.end())
+			entry.push_back(d);
+	}
+}
+
+// Unregister words of a dive.
+void FullText::unregisterWords(struct dive *d, const std::vector<QString> &w)
+{
+	for (const QString &word: w) {
+		auto it = words.find(word);
+		if (it == words.end()) {
+			qWarning("FullText::unregisterWords: didn't find word '%s' in index!?", qPrintable(word));
+			continue;
+		}
+		std::vector<dive *> &entry = it->second;
+		entry.erase(std::remove(entry.begin(), entry.end(), d));
+		if (entry.empty())
+			words.erase(it);
+	}
+}
+
+// Add dives from second array to first, if not yet there
+void combineDives(std::vector<dive *> &to, const std::vector<dive *> &from)
+{
+	for (dive *d: from) {
+		if (std::find(to.begin(), to.end(), d) == to.end())
+			to.push_back(d);
+	}
+}
+
+std::vector<dive *> FullText::findDives(const QString &s, StringFilterMode mode) const
+{
+	switch (mode) {
+	case StringFilterMode::EXACT:
+	default: {
+		// Try to access a single word
+		auto it = words.find(s);
+		if (it == words.end())
+			return {};
+		return it->second;
+	}
+	case StringFilterMode::STARTSWITH: {
+		// Find all words that start with a substring. We use the fact
+		// that these words must form a contiguous block, since the words are
+		// ordered lexicographically.
+		auto it = words.lower_bound(s);
+		if (it == words.end() || !it->first.startsWith(s))
+			return {};
+		std::vector<dive *> res = it->second;
+		++it;
+		while (it != words.end() && it->first.startsWith(s)) {
+			combineDives(res, it->second);
+			++it;
+		}
+		return res;
+	}
+	case StringFilterMode::SUBSTRING: {
+		// Find all words that contain a substring. Here, we have to check all words!
+		std::vector<dive *> res;
+		for (auto it = words.begin(); it != words.end(); ++it) {
+			if (it->first.contains(s))
+				combineDives(res, it->second);
+		}
+		return res;
+	}
+	}
+}
+
+FullTextResult FullText::find(const FullTextQuery &q, StringFilterMode mode) const
+{
+	if (q.words.empty())
+		return FullTextResult();
+
+	std::vector<dive *> res = findDives(q.words[0], mode);
+	for (size_t i = 1; i < q.words.size(); ++i) {
+		std::vector<dive *> res2 = findDives(q.words[i], mode);
+		// Remove dives from res that are not in res2
+		res.erase(std::remove_if(res.begin(), res.end(),
+				[&res2] (dive *d) { return std::find(res2.begin(), res2.end(), d) == res2.end(); }), res.end());
+	}
+
+	return { res };
+}
+
+FullTextQuery &FullTextQuery::operator=(const QString &s)
+{
+	words.clear();
+	tokenize(s, words);
+	return *this;
+}
+
+bool FullTextQuery::doit() const
+{
+	return !words.empty();
+}
+
+bool FullTextResult::dive_matches(const struct dive *d) const
+{
+	return std::find(dives.begin(), dives.end(), d) != dives.end();
+}
+
+#endif

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -7,8 +7,6 @@
 #include <QLocale>
 #include <map>
 
-#ifndef SUBSURFACE_MOBILE
-
 // This class caches each dives words, so that we can unregister a dive from the full text search
 struct full_text_cache {
 	std::vector<QString> words;
@@ -287,5 +285,3 @@ bool FullTextResult::dive_matches(const struct dive *d) const
 {
 	return std::find(dives.begin(), dives.end(), d) != dives.end();
 }
-
-#endif

--- a/core/fulltext.h
+++ b/core/fulltext.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0
+
+// A class for performing full text searches on dives.
+// Search is case-insensitive. Even though QString has many design
+// issues such as COW semantics and UTF-16 encoding, it provides
+// platform independence and reasonable performance. Therefore,
+// this is based in QString instead of std::string.
+//
+// To make this accessible from C, this does manual memory management:
+// Every dive is associated with a cache of words. Thus, when deleting
+// a dive, a function freeing that data has to be called.
+
+#ifndef FULLTEXT_H
+#define FULLTEXT_H
+
+// For now only compile on desktop
+#ifndef SUBSURFACE_MOBILE
+
+// 1) The C-accessible interface
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct full_text_cache;
+struct dive;
+void fulltext_register(struct dive *d); // Note: can be called repeatedly
+void fulltext_unregister(struct dive *d); // Note: can be called repeatedly
+void fulltext_unregister_all(); // Unregisters all dives in the dive table
+void fulltext_reload(); // Registers all dives in the dive table
+
+#ifdef __cplusplus
+}
+#endif
+
+// 2) The C++-only interface
+#ifdef __cplusplus
+
+#include <QString>
+#include <vector>
+
+enum class StringFilterMode {
+	SUBSTRING = 0,
+	STARTSWITH = 1,
+	EXACT = 2
+};
+
+// A fulltext query. Basically a list of normalized words we search for
+struct FullTextQuery {
+	std::vector<QString> words;
+	FullTextQuery &operator=(const QString &); // Initialize by assigning a user-provided search string
+	bool doit() const; // true if we should to a fulltext search
+};
+
+// Describes the result of a fulltext search
+struct FullTextResult {
+	std::vector<dive *> dives;
+	bool dive_matches(const struct dive *d) const;
+};
+
+// Two search modes:
+//	1) Find all dives matching the query.
+//	2) Test if a given dive matches the query.
+FullTextResult fulltext_find_dives(const FullTextQuery &q, StringFilterMode);
+bool fulltext_dive_matches(const struct dive *d, const FullTextQuery &q, StringFilterMode);
+
+#endif
+#endif // SUBSURFACE_MOBILE
+#endif

--- a/core/fulltext.h
+++ b/core/fulltext.h
@@ -13,9 +13,6 @@
 #ifndef FULLTEXT_H
 #define FULLTEXT_H
 
-// For now only compile on desktop
-#ifndef SUBSURFACE_MOBILE
-
 // 1) The C-accessible interface
 
 #ifdef __cplusplus
@@ -65,5 +62,4 @@ FullTextResult fulltext_find_dives(const FullTextQuery &q, StringFilterMode);
 bool fulltext_dive_matches(const struct dive *d, const FullTextQuery &q, StringFilterMode);
 
 #endif
-#endif // SUBSURFACE_MOBILE
 #endif

--- a/core/pref.h
+++ b/core/pref.h
@@ -121,8 +121,6 @@ struct preferences {
 	int         o2consumption; // ml per min
 	int         pscr_ratio; // dump ratio times 1000
 	bool        use_default_file;
-	bool        filterFullTextNotes; // mobile only - include notes information in full text searh
-	bool        filterCaseSensitive; // mobile only - make fltering case sensitive
 	bool        extraEnvironmentalDefault;
 	bool        salinityEditDefault;
 

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1426,23 +1426,6 @@ QString getUUID()
 	return uuidString;
 }
 
-static bool contains(const char *s, const QString &filterstring, Qt::CaseSensitivity cs)
-{
-	return !empty_string(s) && QString(s).contains(filterstring, cs);
-}
-
-bool diveContainsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes)
-{
-	if (!d)
-		return false;
-	return contains(get_dive_location(d), filterstring, cs) ||
-	       (d->divetrip && contains(d->divetrip->location, filterstring, cs)) ||
-	       contains(d->buddy, filterstring, cs) ||
-	       contains(d->divemaster, filterstring, cs) ||
-	       contains(d->suit, filterstring, cs) ||
-	       get_taglist_string(d->tag_list).contains(filterstring, cs) ||
-	       (includeNotes && contains(d->notes, filterstring, cs));
-}
 int parse_seabear_header(const char *filename, char **params, int pnr)
 {
 	QFile f(filename);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -81,7 +81,6 @@ QLocale getLocale();
 QVector<QPair<QString, int>> selectedDivesGasUsed();
 QString getUserAgent();
 QString printGPSCoords(const location_t *loc);
-bool diveContainsText(const struct dive *d, const QString &filterstring, Qt::CaseSensitivity cs, bool includeNotes);
 
 #if defined __APPLE__
 #define TITLE_OR_TEXT(_t, _m) "", _t + "\n" + _m

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -21,8 +21,6 @@ void qPrefGeneral::loadSync(bool doSync)
 	disk_defaultsetpoint(doSync);
 	disk_o2consumption(doSync);
 	disk_pscr_ratio(doSync);
-	disk_filterFullTextNotes(doSync);
-	disk_filterCaseSensitive(doSync);
 
 	if (!doSync) {
 		load_diveshareExport_uid();
@@ -39,7 +37,3 @@ HANDLE_PREFERENCE_INT(General, "pscr_ratio", pscr_ratio);
 HANDLE_PROP_QSTRING(General, "diveshareExport/uid", diveshareExport_uid);
 
 HANDLE_PROP_BOOL(General, "diveshareExport/private", diveshareExport_private);
-
-HANDLE_PREFERENCE_BOOL(General, "filterFullTextNotes", filterFullTextNotes);
-
-HANDLE_PREFERENCE_BOOL(General, "filterCaseSensitive", filterCaseSensitive);

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -12,8 +12,6 @@ class qPrefGeneral : public QObject {
 	Q_PROPERTY(int pscr_ratio READ pscr_ratio WRITE set_pscr_ratio NOTIFY pscr_ratioChanged)
 	Q_PROPERTY(QString diveshareExport_uid READ diveshareExport_uid WRITE set_diveshareExport_uid NOTIFY diveshareExport_uidChanged)
 	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged)
-	Q_PROPERTY(bool filterFullTextNotes READ filterFullTextNotes WRITE set_filterFullTextNotes NOTIFY filterFullTextNotesChanged)
-	Q_PROPERTY(bool filterCaseSensitive READ filterCaseSensitive WRITE set_filterCaseSensitive NOTIFY filterCaseSensitiveChanged)
 
 public:
 	static qPrefGeneral *instance();
@@ -29,8 +27,6 @@ public:
 	static int pscr_ratio() { return prefs.pscr_ratio; }
 	static QString diveshareExport_uid() { return st_diveshareExport_uid; }
 	static bool diveshareExport_private() { return st_diveshareExport_private; }
-	static bool filterFullTextNotes() { return prefs.filterFullTextNotes; }
-	static bool filterCaseSensitive() { return prefs.filterCaseSensitive; }
 
 public slots:
 	static void set_defaultsetpoint(int value);
@@ -38,8 +34,6 @@ public slots:
 	static void set_pscr_ratio(int value);
 	static void set_diveshareExport_uid(const QString& value);
 	static void set_diveshareExport_private(bool value);
-	static void set_filterFullTextNotes(bool value);
-	static void set_filterCaseSensitive(bool value);
 
 signals:
 	void defaultsetpointChanged(int value);
@@ -47,9 +41,7 @@ signals:
 	void pscr_ratioChanged(int value);
 	void diveshareExport_uidChanged(const QString& value);
 	void diveshareExport_privateChanged(bool value);
-	void filterFullTextNotesChanged(bool value);
 	void salinityEditDefaultChanged(bool value);
-	void filterCaseSensitiveChanged(bool value);
 
 private:
 	qPrefGeneral() {}
@@ -57,8 +49,6 @@ private:
 	static void disk_defaultsetpoint(bool doSync);
 	static void disk_o2consumption(bool doSync);
 	static void disk_pscr_ratio(bool doSync);
-	static void disk_filterFullTextNotes(bool doSync);
-	static void disk_filterCaseSensitive(bool doSync);
 
 	// class variables are load only
 	static void load_diveshareExport_uid();

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -101,8 +101,6 @@ struct preferences default_prefs = {
 	.auto_recalculate_thumbnails = true,
 	.extract_video_thumbnails = true,
 	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
-	.filterCaseSensitive = false,
-	.filterFullTextNotes = true,
 };
 
 int run_survey;

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -264,6 +264,7 @@ void FilterWidget2::updatePlanned(int value)
 void FilterWidget2::showEvent(QShowEvent *event)
 {
 	QWidget::showEvent(event);
+	ui.fullText->setFocus();
 	filterDataChanged(filterData);
 }
 

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -226,12 +226,12 @@ void FilterWidget2::updateFilter()
 	filterData.suitMode = (FilterData::Mode)ui.suitMode->currentIndex();
 	filterData.dnotesMode = (FilterData::Mode)ui.dnotesMode->currentIndex();
 	filterData.equipmentMode = (FilterData::Mode)ui.equipmentMode->currentIndex();
-	filterData.tagsStringMode = (FilterData::StringMode)ui.tagsStringMode->currentIndex();
-	filterData.peopleStringMode = (FilterData::StringMode)ui.peopleStringMode->currentIndex();
-	filterData.locationStringMode = (FilterData::StringMode)ui.locationStringMode->currentIndex();
-	filterData.suitStringMode = (FilterData::StringMode)ui.suitStringMode->currentIndex();
-	filterData.dnotesStringMode = (FilterData::StringMode)ui.dnotesStringMode->currentIndex();
-	filterData.equipmentStringMode = (FilterData::StringMode)ui.equipmentStringMode->currentIndex();
+	filterData.tagsStringMode = (StringFilterMode)ui.tagsStringMode->currentIndex();
+	filterData.peopleStringMode = (StringFilterMode)ui.peopleStringMode->currentIndex();
+	filterData.locationStringMode = (StringFilterMode)ui.locationStringMode->currentIndex();
+	filterData.suitStringMode = (StringFilterMode)ui.suitStringMode->currentIndex();
+	filterData.dnotesStringMode = (StringFilterMode)ui.dnotesStringMode->currentIndex();
+	filterData.equipmentStringMode = (StringFilterMode)ui.equipmentStringMode->currentIndex();
 	filterData.logged = ui.logged->isChecked();
 	filterData.planned = ui.planned->isChecked();
 

--- a/desktop-widgets/filterwidget2.cpp
+++ b/desktop-widgets/filterwidget2.cpp
@@ -78,6 +78,12 @@ FilterWidget2::FilterWidget2(QWidget* parent) :
 	connect(ui.toTime, &QDateTimeEdit::timeChanged,
 		this, &FilterWidget2::updateFilter);
 
+	connect(ui.fullText, &QLineEdit::textChanged,
+		this, &FilterWidget2::updateFilter);
+
+	connect(ui.fulltextStringMode, QOverload<int>::of(&QComboBox::currentIndexChanged),
+		this, &FilterWidget2::updateFilter);
+
 	connect(ui.tags, &QLineEdit::textChanged,
 		this, &FilterWidget2::updateFilter);
 
@@ -170,6 +176,7 @@ void FilterWidget2::clearFilter()
 	ui.suitMode->setCurrentIndex((int)filterData.suitMode);
 	ui.dnotesMode->setCurrentIndex((int)filterData.dnotesMode);
 	ui.equipmentMode->setCurrentIndex((int)filterData.equipmentMode);
+	ui.fulltextStringMode->setCurrentIndex((int)filterData.fulltextStringMode);
 	ui.tagsStringMode->setCurrentIndex((int)filterData.tagsStringMode);
 	ui.peopleStringMode->setCurrentIndex((int)filterData.peopleStringMode);
 	ui.locationStringMode->setCurrentIndex((int)filterData.locationStringMode);
@@ -214,6 +221,7 @@ void FilterWidget2::updateFilter()
 	filterData.fromTime = ui.fromTime->time();
 	filterData.toDate = ui.toDate->dateTime();
 	filterData.toTime = ui.toTime->time();
+	filterData.fullText = ui.fullText->text();
 	filterData.tags = ui.tags->text().split(",", QString::SkipEmptyParts);
 	filterData.people = ui.people->text().split(",", QString::SkipEmptyParts);
 	filterData.location = ui.location->text().split(",", QString::SkipEmptyParts);
@@ -226,6 +234,7 @@ void FilterWidget2::updateFilter()
 	filterData.suitMode = (FilterData::Mode)ui.suitMode->currentIndex();
 	filterData.dnotesMode = (FilterData::Mode)ui.dnotesMode->currentIndex();
 	filterData.equipmentMode = (FilterData::Mode)ui.equipmentMode->currentIndex();
+	filterData.fulltextStringMode = (StringFilterMode)ui.fulltextStringMode->currentIndex();
 	filterData.tagsStringMode = (StringFilterMode)ui.tagsStringMode->currentIndex();
 	filterData.peopleStringMode = (StringFilterMode)ui.peopleStringMode->currentIndex();
 	filterData.locationStringMode = (StringFilterMode)ui.locationStringMode->currentIndex();

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -617,20 +617,43 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>fulltextStringMode</tabstop>
+  <tabstop>fullText</tabstop>
   <tabstop>minRating</tabstop>
   <tabstop>maxRating</tabstop>
   <tabstop>minVisibility</tabstop>
   <tabstop>maxVisibility</tabstop>
+  <tabstop>minWaterTemp</tabstop>
+  <tabstop>maxWaterTemp</tabstop>
+  <tabstop>minAirTemp</tabstop>
+  <tabstop>maxAirTemp</tabstop>
   <tabstop>fromDate</tabstop>
   <tabstop>fromTime</tabstop>
   <tabstop>toDate</tabstop>
   <tabstop>toTime</tabstop>
   <tabstop>logged</tabstop>
   <tabstop>planned</tabstop>
+  <tabstop>tagsMode</tabstop>
+  <tabstop>tagsStringMode</tabstop>
   <tabstop>tags</tabstop>
+  <tabstop>peopleMode</tabstop>
+  <tabstop>peopleStringMode</tabstop>
   <tabstop>people</tabstop>
+  <tabstop>locationMode</tabstop>
+  <tabstop>locationStringMode</tabstop>
   <tabstop>location</tabstop>
+  <tabstop>suitMode</tabstop>
+  <tabstop>suitStringMode</tabstop>
+  <tabstop>suit</tabstop>
+  <tabstop>dnotesMode</tabstop>
+  <tabstop>dnotesStringMode</tabstop>
+  <tabstop>dnotes</tabstop>
+  <tabstop>equipmentMode</tabstop>
+  <tabstop>equipmentStringMode</tabstop>
   <tabstop>equipment</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>clear</tabstop>
+  <tabstop>close</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/desktop-widgets/filterwidget2.ui
+++ b/desktop-widgets/filterwidget2.ui
@@ -35,488 +35,7 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="2">
-        <widget class="QDoubleSpinBox" name="minWaterTemp"/>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Tags</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="4" colspan="2">
-        <widget class="QLineEdit" name="tags"/>
-       </item>
-       <item row="9" column="4" colspan="2">
-        <widget class="QLineEdit" name="people"/>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>Suit</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>People</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QToolButton" name="close">
-         <property name="toolTip">
-          <string>Close filters</string>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>:filter-close</normaloff>:filter-close</iconset>
-         </property>
-         <property name="autoRaise">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="QLabel" name="label_15">
-         <property name="text">
-          <string>Max</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Min</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="4">
-        <widget class="QCheckBox" name="planned">
-         <property name="text">
-          <string>Planned</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="4" colspan="2">
-        <widget class="QLineEdit" name="equipment"/>
-       </item>
-       <item row="13" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string>Min</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="4" colspan="2">
-        <widget class="QLineEdit" name="location"/>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Rating</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="5">
-        <widget class="StarWidget" name="maxRating" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="5">
-        <widget class="StarWidget" name="maxVisibility" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Min</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QToolButton" name="clear">
-         <property name="toolTip">
-          <string>Reset filters</string>
-         </property>
-         <property name="icon">
-          <iconset>
-           <normaloff>:edit-clear-icon</normaloff>:edit-clear-icon</iconset>
-         </property>
-         <property name="autoRaise">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="labelEquipment">
-         <property name="text">
-          <string>Equipment</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Visibility</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="4">
-        <widget class="QLabel" name="label_16">
-         <property name="text">
-          <string>Max</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Location</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>To</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="label_17">
-         <property name="text">
-          <string>Min</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QCheckBox" name="logged">
-         <property name="text">
-          <string>Logged</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1" colspan="2">
-        <widget class="QDateTimeEdit" name="fromDate">
-         <property name="calendarPopup">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="label_19">
-         <property name="text">
-          <string>Notes</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="4" colspan="2">
-        <widget class="QLineEdit" name="suit"/>
-       </item>
-       <item row="4" column="2">
-        <widget class="QDoubleSpinBox" name="minAirTemp"/>
-       </item>
-       <item row="5" column="4">
-        <widget class="QTimeEdit" name="fromTime"/>
-       </item>
-       <item row="3" column="4">
-        <widget class="QLabel" name="label_13">
-         <property name="text">
-          <string>Max</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Air Temp</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="StarWidget" name="minVisibility" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="5">
-        <widget class="QDoubleSpinBox" name="maxAirTemp"/>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>Water Temp</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="5">
-        <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
-       </item>
-       <item row="1" column="2">
-        <widget class="StarWidget" name="minRating" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="4" colspan="2">
-        <widget class="QLineEdit" name="dnotes"/>
-       </item>
-       <item row="6" column="1" colspan="2">
-        <widget class="QDateTimeEdit" name="toDate">
-         <property name="calendarPopup">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="4">
-        <widget class="QLabel" name="label_18">
-         <property name="text">
-          <string>Max</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="filterButtonExplanation">
-         <property name="text">
-          <string>Reset / close</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="4">
-        <widget class="QTimeEdit" name="toTime"/>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>From</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QComboBox" name="tagsMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="8" column="2">
-        <widget class="QComboBox" name="tagsStringMode">
-         <item>
-          <property name="text">
-           <string>Substring</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Starts with</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Exact</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QComboBox" name="peopleMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="9" column="2">
-        <widget class="QComboBox" name="peopleStringMode">
-         <item>
-          <property name="text">
-           <string>Substring</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Starts with</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Exact</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QComboBox" name="locationMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="10" column="2">
-        <widget class="QComboBox" name="locationStringMode">
-         <item>
-          <property name="text">
-           <string>Substring</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Starts with</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Exact</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QComboBox" name="suitMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="12" column="1">
-        <widget class="QComboBox" name="dnotesMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="13" column="1">
-        <widget class="QComboBox" name="equipmentMode">
-         <item>
-          <property name="text">
-           <string>All of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Any of</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>None of</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="11" column="2">
+       <item row="13" column="2">
         <widget class="QComboBox" name="suitStringMode">
          <item>
           <property name="text">
@@ -535,7 +54,272 @@
          </item>
         </widget>
        </item>
+       <item row="6" column="4">
+        <widget class="QTimeEdit" name="fromTime"/>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Suit</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="4">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="4">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="5">
+        <widget class="StarWidget" name="maxRating" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::TabFocus</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="4">
+        <widget class="QTimeEdit" name="toTime"/>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Air Temp</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
+        <widget class="QLabel" name="labelEquipment">
+         <property name="text">
+          <string>Equipment</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="StarWidget" name="minRating" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::TabFocus</enum>
+         </property>
+        </widget>
+       </item>
        <item row="12" column="2">
+        <widget class="QComboBox" name="locationStringMode">
+         <item>
+          <property name="text">
+           <string>Substring</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Starts with</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Exact</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="3" column="5">
+        <widget class="StarWidget" name="maxVisibility" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::TabFocus</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Tags</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Water Temp</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
+        <widget class="QComboBox" name="equipmentMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="QLabel" name="label_15">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>People</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="5">
+        <widget class="QDoubleSpinBox" name="maxAirTemp"/>
+       </item>
+       <item row="5" column="2">
+        <widget class="QDoubleSpinBox" name="minAirTemp"/>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="13" column="4" colspan="2">
+        <widget class="QLineEdit" name="equipment"/>
+       </item>
+       <item row="8" column="4">
+        <widget class="QCheckBox" name="planned">
+         <property name="text">
+          <string>Planned</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="QComboBox" name="dnotesMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="10" column="4" colspan="2">
+        <widget class="QLineEdit" name="tags"/>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Location</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_19">
+         <property name="text">
+          <string>Notes</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Visibility</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="4" colspan="2">
+        <widget class="QLineEdit" name="suit"/>
+       </item>
+       <item row="3" column="2">
+        <widget class="StarWidget" name="minVisibility" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::TabFocus</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="2">
         <widget class="QComboBox" name="dnotesStringMode">
          <item>
           <property name="text">
@@ -554,7 +338,121 @@
          </item>
         </widget>
        </item>
-       <item row="13" column="2">
+       <item row="12" column="4" colspan="2">
+        <widget class="QLineEdit" name="location"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="filterButtonExplanation">
+         <property name="text">
+          <string>Reset / close</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Rating</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="4" colspan="2">
+        <widget class="QLineEdit" name="dnotes"/>
+       </item>
+       <item row="11" column="4" colspan="2">
+        <widget class="QLineEdit" name="people"/>
+       </item>
+       <item row="0" column="1">
+        <widget class="QToolButton" name="clear">
+         <property name="toolTip">
+          <string>Reset filters</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>:edit-clear-icon</normaloff>:edit-clear-icon</iconset>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QComboBox" name="peopleStringMode">
+         <item>
+          <property name="text">
+           <string>Substring</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Starts with</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Exact</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="minWaterTemp"/>
+       </item>
+       <item row="6" column="1" colspan="2">
+        <widget class="QDateTimeEdit" name="fromDate">
+         <property name="calendarPopup">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
+        <widget class="QComboBox" name="suitMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="4" column="5">
+        <widget class="QDoubleSpinBox" name="maxWaterTemp"/>
+       </item>
+       <item row="10" column="2">
+        <widget class="QComboBox" name="tagsStringMode">
+         <item>
+          <property name="text">
+           <string>Substring</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Starts with</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Exact</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>From</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="2">
         <widget class="QComboBox" name="equipmentStringMode">
          <item>
           <property name="text">
@@ -572,6 +470,137 @@
           </property>
          </item>
         </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QComboBox" name="locationMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QCheckBox" name="logged">
+         <property name="text">
+          <string>Logged</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1" colspan="2">
+        <widget class="QDateTimeEdit" name="toDate">
+         <property name="calendarPopup">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QComboBox" name="peopleMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QComboBox" name="tagsMode">
+         <item>
+          <property name="text">
+           <string>All of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Any of</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>None of</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>To</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QToolButton" name="close">
+         <property name="toolTip">
+          <string>Close filters</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>:filter-close</normaloff>:filter-close</iconset>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_20">
+         <property name="text">
+          <string>Fulltext</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="fulltextStringMode">
+         <item>
+          <property name="text">
+           <string>Substring</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Starts with</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Full word</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="1" column="2" colspan="4">
+        <widget class="QLineEdit" name="fullText"/>
        </item>
       </layout>
      </widget>

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -444,6 +444,21 @@ Kirigami.ScrollablePage {
 				anchors.right: parent.right
 				anchors.leftMargin: Kirigami.Units.gridUnit / 2
 				anchors.rightMargin: Kirigami.Units.gridUnit / 2
+				TemplateComboBox {
+					id: sitefilterMode
+					editable: false
+					model: ListModel {
+						ListElement {text: qsTr("Fulltext")}
+						ListElement {text: qsTr("People")}
+						ListElement {text: qsTr("Tags")}
+					}
+					font.pointSize: subsurfaceTheme.smallPointSize
+					Layout.preferredWidth: parent.width * 0.2
+					Layout.maximumWidth: parent.width * 0.3
+					onActivated:  {
+						manager.setFilter(sitefilter.text, currentIndex)
+					}
+				}
 				Controls.TextField  {
 					id: sitefilter
 					z: 10
@@ -452,7 +467,7 @@ Kirigami.ScrollablePage {
 					text: ""
 					placeholderText: "Full text search"
 					onAccepted: {
-						manager.setFilter(text)
+						manager.setFilter(text, sitefilterMode.currentIndex)
 					}
 					onEnabledChanged: {
 						// reset the filter when it gets toggled
@@ -539,7 +554,7 @@ Kirigami.ScrollablePage {
 		text: qsTr("Filter dives")
 		onTriggered: {
 			rootItem.filterToggle = !rootItem.filterToggle
-			manager.setFilter("")
+			manager.setFilter("", 0)
 			numShownText = diveModel.shown()
 		}
 	}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -465,7 +465,7 @@ Kirigami.ScrollablePage {
 					verticalAlignment: TextInput.AlignVCenter
 					Layout.fillWidth: true
 					text: ""
-					placeholderText: "Full text search"
+					placeholderText: sitefilterMode.currentText
 					onAccepted: {
 						manager.setFilter(text, sitefilterMode.currentIndex)
 					}

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -17,7 +17,6 @@ Kirigami.ScrollablePage {
 	property color secondaryTextColor: subsurfaceTheme.secondaryTextColor
 	property int horizontalPadding: Kirigami.Units.gridUnit / 2 - Kirigami.Units.smallSpacing  + 1
 	property QtObject diveListModel: diveTripModel
-	property string numShownText
 
 	opacity: 0
 	Behavior on opacity {
@@ -481,7 +480,7 @@ Kirigami.ScrollablePage {
 					id: numShown
 					z: 10
 					verticalAlignment: Text.AlignVCenter
-					text: numShownText
+					text: diveModel.shown
 				}
 			}
 		}
@@ -503,9 +502,6 @@ Kirigami.ScrollablePage {
 		section.criteria: ViewSection.FullString
 		section.delegate: tripHeading
 		section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
-		onModelChanged: {
-			numShownText = diveModel.shown()
-		}
 		Connections {
 			target: detailsWindow
 			onCurrentIndexChanged: diveListView.currentIndex = detailsWindow.currentIndex
@@ -555,7 +551,6 @@ Kirigami.ScrollablePage {
 		onTriggered: {
 			rootItem.filterToggle = !rootItem.filterToggle
 			manager.setFilter("", 0)
-			numShownText = diveModel.shown()
 		}
 	}
 

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -546,50 +546,6 @@ TemplatePage {
 				visible: sectionAdvanced.isExpanded
 			}
 			GridLayout {
-				id: filterPrefs
-				visible: sectionAdvanced.isExpanded
-				columns: 2
-
-				TemplateLabel {
-					text: qsTr("Filter preferences")
-					font.pointSize: subsurfaceTheme.headingPointSize
-					font.weight: Font.Light
-					Layout.topMargin: Kirigami.Units.largeSpacing
-					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-					Layout.columnSpan: 2
-				}
-				TemplateLabel {
-					text: qsTr("Include notes in full text filtering")
-					Layout.preferredWidth: gridWidth * 0.75
-				}
-
-				SsrfSwitch {
-					id: fullTextNotes
-					checked: PrefGeneral.filterFullTextNotes
-					Layout.preferredWidth: gridWidth * 0.25
-					onClicked: {
-						PrefGeneral.filterFullTextNotes = checked
-					}
-				}
-
-				TemplateLabel {
-					text: qsTr("Match filter case sensitive")
-					Layout.preferredWidth: gridWidth * 0.75
-				}
-
-				SsrfSwitch {
-					id: filterCaseSensitive
-					checked: PrefGeneral.filterCaseSensitive
-					Layout.preferredWidth: gridWidth * 0.25
-					onClicked: {
-						PrefGeneral.filterCaseSensitive = checked
-					}
-				}
-			}
-			TemplateLine {
-				visible: sectionAdvanced.isExpanded
-			}
-			GridLayout {
 				id: whichBluetoothDevices
 				visible: sectionAdvanced.isExpanded
 				columns: 2

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -60,19 +60,9 @@ Kirigami.ApplicationWindow {
 		busy.running = true
 	}
 
-	function showBusyAndDisconnectModel() { // this is used by QMLManager when operating the filter
-		busy.running = true
-		diveList.diveListModel = null
-	}
-
 	function hideBusy() {
 		busy.running = false
 		showPassiveNotification("", 10) // this hides a notification messssage that's still shown
-	}
-
-	function hideBusyAndConnectModel() { // this is used by QMLManager when done filtering
-		busy.running = false
-		diveList.diveListModel = diveTripModel
 	}
 
 	function returnTopPage() {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2094,13 +2094,20 @@ void QMLManager::showDownloadPage(QString deviceString)
 	emit pluggedInDeviceNameChanged();
 }
 
-void QMLManager::setFilter(const QString filterText)
+void QMLManager::setFilter(const QString filterText, int index)
 {
+	FilterData::Mode mode;
+	switch(index) {
+		default:
+		case 0: mode = FilterData::Mode::FULLTEXT; break;
+		case 1: mode = FilterData::Mode::PEOPLE; break;
+		case 2: mode = FilterData::Mode::TAGS; break;
+	}
 	// show that we are doing something, then do something in another thread in order not to block the UI
 	QMetaObject::invokeMethod(qmlWindow, "showBusyAndDisconnectModel");
 	QtConcurrent::run(QThreadPool::globalInstance(),
-			  [this,filterText]{
-				DiveListSortModel::instance()->setFilter(filterText);
+			  [this,filterText,mode]{
+				DiveListSortModel::instance()->setFilter(filterText, mode);
 				CollapsedDiveListSortModel::instance()->updateFilterState();
 				QMetaObject::invokeMethod(qmlWindow, "hideBusyAndConnectModel");
 			  });

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2097,20 +2097,15 @@ void QMLManager::showDownloadPage(QString deviceString)
 void QMLManager::setFilter(const QString filterText, int index)
 {
 	FilterData::Mode mode;
+	// This is ugly - the indexes of the mode are hardcoded!
 	switch(index) {
 		default:
 		case 0: mode = FilterData::Mode::FULLTEXT; break;
 		case 1: mode = FilterData::Mode::PEOPLE; break;
 		case 2: mode = FilterData::Mode::TAGS; break;
 	}
-	// show that we are doing something, then do something in another thread in order not to block the UI
-	QMetaObject::invokeMethod(qmlWindow, "showBusyAndDisconnectModel");
-	QtConcurrent::run(QThreadPool::globalInstance(),
-			  [this,filterText,mode]{
-				DiveListSortModel::instance()->setFilter(filterText, mode);
-				CollapsedDiveListSortModel::instance()->updateFilterState();
-				QMetaObject::invokeMethod(qmlWindow, "hideBusyAndConnectModel");
-			  });
+	DiveListSortModel::instance()->setFilter(filterText, mode);
+	CollapsedDiveListSortModel::instance()->updateFilterState();
 }
 
 void QMLManager::setShowNonDiveComputers(bool show)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -104,7 +104,7 @@ public:
 	Q_INVOKABLE int getDetectedProductIndex(const QString &currentVendorText);
 	Q_INVOKABLE int getConnectionIndex(const QString &deviceSubstr);
 	Q_INVOKABLE void setGitLocalOnly(const bool &value);
-	Q_INVOKABLE void setFilter(const QString filterText);
+	Q_INVOKABLE void setFilter(const QString filterText, int mode);
 
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -41,11 +41,13 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/subsurfacesysinfo.cpp \
 	../../core/windowtitleupdate.cpp \
 	../../core/file.c \
+	../../core/fulltext.cpp \
 	../../core/subsurfacestartup.c \
 	../../core/ios.cpp \
 	../../core/profile.c \
 	../../core/device.c \
 	../../core/dive.c \
+	../../core/divefilter.cpp \
 	../../core/divelist.c \
 	../../core/gas-model.c \
 	../../core/gaspressures.c \
@@ -195,11 +197,13 @@ HEADERS += \
 	../../core/deco.h \
 	../../core/display.h \
 	../../core/divecomputer.h \
+	../../core/divefilter.h \
 	../../core/divelist.h \
 	../../core/divelogexportlogic.h \
 	../../core/divesitehelpers.h \
 	../../core/exif.h \
 	../../core/file.h \
+	../../core/fulltext.h \
 	../../core/gaspressures.h \
 	../../core/gettext.h \
 	../../core/gettextfromc.h \

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -195,6 +195,7 @@ DiveListSortModel *DiveListSortModel::instance()
 void DiveListSortModel::updateFilterState()
 {
 	DiveFilter::instance()->updateAll();
+	emit shownChanged();
 }
 
 void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -207,13 +207,16 @@ void DiveListSortModel::setSourceModel(QAbstractItemModel *sourceModel)
 	updateFilterState();
 }
 
-void DiveListSortModel::setFilter(QString f)
+void DiveListSortModel::setFilter(QString f, FilterData::Mode mode)
 {
 	f = f.trimmed();
 	FilterData data;
 	if (!f.isEmpty()) {
-		data.mode = FilterData::Mode::FULLTEXT;
-		data.fullText = f;
+		data.mode = mode;
+		if (mode == FilterData::Mode::FULLTEXT)
+			data.fullText = f;
+		else
+			data.tags = f.split(",", QString::SkipEmptyParts);
 	}
 	DiveFilter::instance()->setFilter(data);
 	CollapsedDiveListSortModel::instance()->updateFilterState();

--- a/qt-models/divelistmodel.cpp
+++ b/qt-models/divelistmodel.cpp
@@ -191,11 +191,6 @@ DiveListSortModel *DiveListSortModel::instance()
 	return &self;
 }
 
-QString DiveListSortModel::getFilterString() const
-{
-	return filterString;
-}
-
 void DiveListSortModel::updateFilterState()
 {
 	if (filterString.isEmpty()) {

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -43,7 +43,6 @@ class DiveListSortModel : public QSortFilterProxyModel
 public:
 	static DiveListSortModel *instance();
 	void setSourceModel(QAbstractItemModel *sourceModel);
-	QString getFilterString() const;
 	Q_INVOKABLE void reload();
 	QString filterString;
 	void updateFilterState();

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -5,6 +5,7 @@
 #include <QAbstractListModel>
 #include <QSortFilterProxyModel>
 
+#include "core/divefilter.h"
 #include "core/subsurface-qt/diveobjecthelper.h"
 
 class CollapsedDiveListSortModel : public QSortFilterProxyModel
@@ -48,7 +49,7 @@ public:
 	void updateFilterState();
 public slots:
 	int getIdxForId(int id);
-	void setFilter(QString f);
+	void setFilter(QString f, FilterData::Mode mode);
 	void resetFilter();
 	int shown();
 protected:

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -47,11 +47,14 @@ public:
 	Q_INVOKABLE void reload();
 	QString filterString;
 	void updateFilterState();
+	Q_PROPERTY(int shown READ shown NOTIFY shownChanged);
+	int shown();
 public slots:
 	int getIdxForId(int id);
 	void setFilter(QString f, FilterData::Mode mode);
 	void resetFilter();
-	int shown();
+signals:
+	void shownChanged();
 protected:
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 private:

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -14,7 +14,7 @@ CURRENT_SQLITE="3190200"
 CURRENT_LIBXML2="v2.9.4"
 CURRENT_LIBFTDI="1.3"
 CURRENT_KIRIGAMI="v5.62.0"
-CURRENT_BREEZE_ICONS=""
+CURRENT_BREEZE_ICONS="4daac191fb33c8c03bba8356db9767816cb8ee02"
 CURRENT_GRANTLEE="v5.1.0"
 CURRENT_MDBTOOLS="master"
 CURRENT_QT_ANDROID_CMAKE="e3bd0c4930dfa154cacb71d8960474ec00ceca4f"
@@ -163,7 +163,7 @@ for package in "${PACKAGES[@]}" ; do
 			git_checkout_library libxslt $CURRENT_XSLT https://github.com/GNOME/libxslt.git
 			;;
 		breeze-icons)
-			git_checkout_library breeze-icons master https://github.com/kde/breeze-icons.git
+			git_checkout_library breeze-icons $CURRENT_BREEZE_ICONS https://github.com/kde/breeze-icons.git
 			;;
 		googlemaps)
 			git_checkout_library googlemaps master https://github.com/Subsurface-divelog/googlemaps.git


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a primitive first implementation of a fulltext index. There are two reasons for this:
1) The filterwidget on desktop is getting horrendously complex and I wonder if many usecases couldn't be replaced by a simple fulltext search. My suggestion would be to show only the fulltext search first and then let the user expand "advanced options".
2) IIRC we do fulltext search on mobile in a background thread, which appears to be very brittle. Therefore, I suggest using the same fulltext code on mobile and desktop.

Be warned that this is at concept stage, though it worked in my preliminary tests. It is 100% unoptimized and there is ample room for optimization. However, when testing on a ~4000 dives testlog, the actual fulltext search was always faster than 10 ms. If the search-words reach three letters or more, it typically got even <1 ms. I wonder if optimizing the actual search is even worth it.

There is one big downside: currently, loading the testlog mentioned above is slowed by ~750 ms, because the index is generated on loading. A first attempt at generating the index in a background thread failed: The profile widget clears the `displayed_dive`, which accesses the cache and thus waits for the index generation. Moreover, the background thread would somehow have to lock on the dive-list, which we don't even support. Ugh.

If someone suggests an external fulltext-library that is easy to hook into, I'm fine with that too!

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Let's stabilize this first.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Let's stabilize this first.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @willemferguson @atdotde 