### PR TITLE
Cleanup: remove unneeded QtConcurrent includes

### DIFF
--- a/desktop-widgets/divepicturewidget.cpp
+++ b/desktop-widgets/divepicturewidget.cpp
@@ -5,8 +5,6 @@
 #include "core/dive.h"
 #include "core/divelist.h"
 #include <unistd.h>
-#include <QtConcurrentMap>
-#include <QtConcurrentRun>
 #include <QFuture>
 #include <QDir>
 #include <QCryptographicHash>

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -15,7 +15,6 @@
 #include <QStatusBar>
 #include <QNetworkProxy>
 #include <QUndoStack>
-#include <QtConcurrentRun>
 
 #include "core/color.h"
 #include "core/device.h"


### PR DESCRIPTION
These became unneeded owing to code reshuffling.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Idle cleanup: remove unnecessary includes.