### PR TITLE
undo: don't add dive to null-trip

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -271,7 +271,8 @@ static OwningTripPtr moveDiveToTrip(DiveToTrip &diveToTrip)
 
 	// Store old trip and get new trip we should associate this dive with
 	std::swap(trip, diveToTrip.trip);
-	add_dive_to_trip(diveToTrip.dive, trip);
+	if (trip)
+		add_dive_to_trip(diveToTrip.dive, trip);
 	invalidate_dive_cache(diveToTrip.dive);		// Ensure that dive is written in git_save()
 	return res;
 }


### PR DESCRIPTION
In moveDiveToTrip(), the dive was first removed from its old trip
and then added to the new trip. This function is also used to
remove the dive from its trip (by moving it to the "null-trip"
if you whish). Even in that case add_dive_to_trip() was called.
The only reason why this didn't crash is that add_dive_to_trip()
checks whether old and new trip are the same. This is the case
when adding to the "null-trip", since the dive was removed from
the trip just before.

To cut a long story short, to trust on add_dive_to_trip() not
crashing if moving from the null-trip to the null-trip is
way to subtly. If we remove a dive from its trip, don't call
add_dive_to_trip() in the first place.

Reported-by: Dirk Hohndel <dirk@hohndel.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code cleanup that removes a horrible subtlety in the way the remove-dive-from-trip code is handled. See commit message.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh