### PR TITLE
[TRIVIAL] cleanup: remove CleanerTableModel::warningMessage signal

### DIFF
--- a/qt-models/cleanertablemodel.h
+++ b/qt-models/cleanertablemodel.h
@@ -26,11 +26,6 @@ public:
 
 protected:
 	void setHeaderDataStrings(const QStringList &headers);
-signals:
-
-	/* instead of using QMessageBox directly, wire a QWidget to this signal and display the result.
-	 * This is because the QModels will be used from the Mobile version and the desktop version. */
-	void warningMessage(const QString& title, const QString& message);
 
 private:
 	QStringList headers;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -26,9 +26,7 @@ CylindersModel *DivePlannerPointsModel::cylindersModel()
 	return &cylinders;
 }
 
-/* TODO: Port this to CleanerTableModel to remove a bit of boilerplate and
- * use the signal warningMessage() to communicate errors to the MainWindow.
- */
+/* TODO: Port this to CleanerTableModel to remove a bit of boilerplate. */
 void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 {
 	if (!rows.count())


### PR DESCRIPTION
Nobody was ever listening to this signal(?) and the last sender
was removed in ac52034778bc5c82bb6c689d765b337b6d75b24a.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial cleanup - see commit message.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unused signal.