### PR TITLE
build-system: use working version of Breeze icons

### DIFF
--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -14,7 +14,7 @@ CURRENT_SQLITE="3190200"
 CURRENT_LIBXML2="v2.9.4"
 CURRENT_LIBFTDI="1.3"
 CURRENT_KIRIGAMI="v5.62.0"
-CURRENT_BREEZE_ICONS=""
+CURRENT_BREEZE_ICONS="4daac191fb33c8c03bba8356db9767816cb8ee02"
 CURRENT_GRANTLEE="v5.1.0"
 CURRENT_MDBTOOLS="master"
 CURRENT_QT_ANDROID_CMAKE="e3bd0c4930dfa154cacb71d8960474ec00ceca4f"
@@ -163,7 +163,7 @@ for package in "${PACKAGES[@]}" ; do
 			git_checkout_library libxslt $CURRENT_XSLT https://github.com/GNOME/libxslt.git
 			;;
 		breeze-icons)
-			git_checkout_library breeze-icons master https://github.com/kde/breeze-icons.git
+			git_checkout_library breeze-icons $CURRENT_BREEZE_ICONS https://github.com/kde/breeze-icons.git
 			;;
 		googlemaps)
 			git_checkout_library googlemaps master https://github.com/Subsurface-divelog/googlemaps.git


### PR DESCRIPTION
As of today some of the icons that we need are no longer in the git repoo but
instead created via script. Instead of making this work everywhere, let's just
use a working SHA...

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Build system change

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger