### PR TITLE
CylinderModel: remove unnecessary "Is used" header

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -16,7 +16,7 @@ CylindersModel::CylindersModel(QObject *parent) :
 {
 	//	enum {REMOVE, TYPE, SIZE, WORKINGPRESS, START, END, O2, HE, DEPTH, MOD, MND, USE, IS_USED};
 	setHeaderDataStrings(QStringList() << "" << tr("Type") << tr("Size") << tr("Work press.") << tr("Start press.") << tr("End press.") << tr("O₂%") << tr("He%")
-						 << tr("Deco switch at") <<tr("Bot. MOD") <<tr("MND") << tr("Use") << "Is used");
+						 << tr("Deco switch at") <<tr("Bot. MOD") <<tr("MND") << tr("Use"));
 
 	connect(&diveListNotifier, &DiveListNotifier::cylindersReset, this, &CylindersModel::cylindersReset);
 }


### PR DESCRIPTION
This header is a rebase artifact and introduces a pointless
column in the cylinder tables. It was erroneously introduced
in 6622f42aab937e72cc11cb5512012394aa687767.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a UI bug on desktop. The field is an artifact of a discarded attempt at introducing the filtered-cylinders model. Piping the "is used" field through Qt's model/view system was ultimately deemed as being too painful. However, the header of the internal column was inadvertently kept.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unnecessary column.
