### PR TITLE
Erase deco obligation when NDL is positive again

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -334,8 +334,14 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 		// values will be overwritten by new data if available
 		sample->in_deco = in_deco;
 		sample->ndl.seconds = ndl;
-		sample->stoptime.seconds = stoptime;
-		sample->stopdepth.mm = stopdepth;
+		// A positive NDL erases any previous deco obligations
+		if (ndl > 0) {
+			sample->stoptime.seconds = 0;
+			sample->stopdepth.mm = 0;
+		} else {
+			sample->stoptime.seconds = stoptime;
+			sample->stopdepth.mm = stopdepth;
+		}
 		sample->setpoint.mbar = po2;
 		sample->cns = cns;
 		sample->heartbeat = heartbeat;
@@ -363,6 +369,11 @@ sample_cb(dc_sample_type_t type, dc_sample_value_t value, void *userdata)
 #ifdef DC_SAMPLE_TTS
 	case DC_SAMPLE_TTS:
 		sample->tts.seconds = value.time;
+		if (value.time == 0xFFFFFFFF) {
+			// This is libdivecomputer's way to say INVALID
+			sample->stoptime.seconds = 0;
+			sample->stopdepth.mm = 0;
+		}
 		break;
 #endif
 	case DC_SAMPLE_HEARTBEAT:


### PR DESCRIPTION
Logs from Ratio dive computers appeared to never clear
dc reported deco. According to Jef, the end of deco
is communicated by libdivecomputer as a non-zero
NDL. So this patch should implement this.

I don't have access to any Ratio dive computer, so
I cannot test, this actually works. Neither do I know
if some other divecomputer might confusingly report
both a positive NDL and a deco obligation (but it shouldn't)

Fixes #1351

One could argue that the problem is not in Subsurface but in libdivecomputer but let's not.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
