### PR TITLE
Minor cleanups concerning the equipment tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -210,9 +210,8 @@ static QVector<dive *> getSelectedDivesCurrentLast()
 	return res;
 }
 
-// TODO: This are only temporary functions until undo of weightsystems and cylinders is implemented.
+// TODO: This is a temporary functions until undo of cylinders is implemented.
 // Therefore it is not worth putting it in a header.
-extern bool weightsystems_equal(const dive *d1, const dive *d2);
 extern bool cylinders_equal(const dive *d1, const dive *d2);
 
 void TabDiveEquipment::acceptChanges()

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -50,7 +50,6 @@ struct Completers {
 
 MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	editMode(NONE),
-	modified(false),
 	lastSelectedDive(true),
 	lastTabSelectedDive(0),
 	lastTabSelectedDiveTrip(0),
@@ -211,7 +210,6 @@ void MainTab::enableEdition(EditMode newEditMode)
 {
 	if (((newEditMode == DIVE || newEditMode == NONE) && current_dive == NULL) || editMode != NONE)
 		return;
-	modified = false;
 	if ((newEditMode == DIVE || newEditMode == NONE) &&
 	    current_dive->dc.model &&
 	    strcmp(current_dive->dc.model, "manually added dive") == 0) {
@@ -592,8 +590,7 @@ void MainTab::rejectChanges()
 	EditMode lastMode = editMode;
 
 	if (lastMode != NONE && current_dive &&
-	    (modified ||
-	     !cylinders_equal(current_dive, &displayed_dive) ||
+	    (!cylinders_equal(current_dive, &displayed_dive) ||
 	     !weightsystems_equal(current_dive, &displayed_dive))) {
 		if (QMessageBox::warning(MainWindow::instance(), TITLE_OR_TEXT(tr("Discard the changes?"),
 									       tr("You are about to discard your changes.")),

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -589,9 +589,7 @@ void MainTab::rejectChanges()
 {
 	EditMode lastMode = editMode;
 
-	if (lastMode != NONE && current_dive &&
-	    (!cylinders_equal(current_dive, &displayed_dive) ||
-	     !weightsystems_equal(current_dive, &displayed_dive))) {
+	if (lastMode != NONE && current_dive && !cylinders_equal(current_dive, &displayed_dive)) {
 		if (QMessageBox::warning(MainWindow::instance(), TITLE_OR_TEXT(tr("Discard the changes?"),
 									       tr("You are about to discard your changes.")),
 					 QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard) != QMessageBox::Discard) {

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -611,10 +611,6 @@ void MainTab::rejectChanges()
 		clear_dive(&displayed_dive);
 	updateDiveInfo();
 
-	for (auto widget: extraWidgets) {
-		widget->updateData();
-	}
-
 	// TODO: This is a temporary hack until the equipment tab is included in the undo system:
 	// The equipment tab is hardcoded at the first place of the "extra widgets".
 	((TabDiveEquipment *)extraWidgets[0])->rejectChanges();

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -80,7 +80,6 @@ private:
 	BuddyCompletionModel buddyModel;
 	DiveMasterCompletionModel diveMasterModel;
 	TagCompletionModel tagModel;
-	bool modified;
 	bool lastSelectedDive;
 	int lastTabSelectedDive;
 	int lastTabSelectedDiveTrip;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
These are just minor cleanups as a consequence of the undo work. They don't (shouldn't) change the user interaction. Note that the "are you sure to revert" message is not properly shown if the profile is edited. However, that problem also exists without this PR.
1) Remove an unused member variable.
2) Remove pointless checking for changed weightsystems.
3) Avoid double update of tabs on reject-changes.

