### PR TITLE
Fix crash in planner

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -238,7 +238,7 @@ static struct RevertCylinderData {
 
 void TankInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelIndex&) const
 {
-	CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
+	QAbstractItemModel *mymodel = currCombo.model;
 	TankInfoModel *tanks = TankInfoModel::instance();
 	QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, currCombo.activeText);
 	int row;
@@ -255,8 +255,8 @@ void TankInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelI
 	int tankPressure = tanks->data(tanks->index(row, TankInfoModel::BAR)).toInt();
 
 	mymodel->setData(IDX(CylindersModel::TYPE), cylinderName, Qt::EditRole);
-	mymodel->passInData(IDX(CylindersModel::WORKINGPRESS), tankPressure);
-	mymodel->passInData(IDX(CylindersModel::SIZE), tankSize);
+	mymodel->setData(IDX(CylindersModel::WORKINGPRESS), tankPressure, CylindersModel::PASS_IN_ROLE);
+	mymodel->setData(IDX(CylindersModel::SIZE), tankSize, CylindersModel::PASS_IN_ROLE);
 }
 
 TankInfoDelegate::TankInfoDelegate(QObject *parent) : ComboBoxDelegate(TankInfoModel::instance(), parent, true)
@@ -277,10 +277,10 @@ void TankInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint
 {
 	if (hint == QAbstractItemDelegate::NoHint ||
 	    hint == QAbstractItemDelegate::RevertModelCache) {
-		CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
+		QAbstractItemModel *mymodel = currCombo.model;
 		mymodel->setData(IDX(CylindersModel::TYPE), currCylinderData.type, Qt::EditRole);
-		mymodel->passInData(IDX(CylindersModel::WORKINGPRESS), currCylinderData.pressure);
-		mymodel->passInData(IDX(CylindersModel::SIZE), currCylinderData.size);
+		mymodel->setData(IDX(CylindersModel::WORKINGPRESS), currCylinderData.pressure, CylindersModel::PASS_IN_ROLE);
+		mymodel->setData(IDX(CylindersModel::SIZE), currCylinderData.size, CylindersModel::PASS_IN_ROLE);
 	}
 }
 
@@ -289,11 +289,11 @@ QWidget *TankInfoDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	// ncreate editor needs to be called before because it will populate a few
 	// things in the currCombo global var.
 	QWidget *delegate = ComboBoxDelegate::createEditor(parent, option, index);
-	CylindersModelFiltered *mymodel = qobject_cast<CylindersModelFiltered *>(currCombo.model);
-	cylinder_t *cyl = mymodel->cylinderAt(index);
-	currCylinderData.type = cyl->type.description;
-	currCylinderData.pressure = cyl->type.workingpressure.mbar;
-	currCylinderData.size = cyl->type.size.mliter;
+	QAbstractItemModel *model = currCombo.model;
+	int row = index.row();
+	currCylinderData.type = model->data(model->index(row, CylindersModel::TYPE)).value<QString>();
+	currCylinderData.pressure = model->data(model->index(row, CylindersModel::WORKINGPRESS_INT)).value<int>();
+	currCylinderData.size = model->data(model->index(row, CylindersModel::SIZE_INT)).value<int>();
 	MainWindow::instance()->graphics->setReplot(false);
 	return delegate;
 }

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -8,6 +8,7 @@
 #include "qt-models/diveplannermodel.h"
 #include "core/gettextfromc.h"
 #include "core/subsurface-qt/divelistnotifier.h"
+#include "core/subsurface-string.h"
 
 CylindersModel::CylindersModel(QObject *parent) :
 	CleanerTableModel(parent),
@@ -317,13 +318,11 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 	}
 
 	switch (index.column()) {
-	case TYPE:
-		if (!value.isNull()) {
-			QByteArray ba = value.toByteArray();
-			const char *text = ba.constData();
-			if (!cyl->type.description || strcmp(cyl->type.description, text)) {
+	case TYPE: {
+			QString type = value.toString();
+			if (!same_string(qPrintable(type), cyl->type.description)) {
 				free((void *)cyl->type.description);
-				cyl->type.description = strdup(text);
+				cyl->type.description = strdup(qPrintable(type));
 				changed = true;
 			}
 		}

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -322,6 +322,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 			QByteArray ba = value.toByteArray();
 			const char *text = ba.constData();
 			if (!cyl->type.description || strcmp(cyl->type.description, text)) {
+				free((void *)cyl->type.description);
 				cyl->type.description = strdup(text);
 				changed = true;
 			}

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -647,11 +647,6 @@ void CylindersModelFiltered::remove(QModelIndex index)
 	source.remove(mapToSource(index));
 }
 
-cylinder_t *CylindersModelFiltered::cylinderAt(const QModelIndex &index)
-{
-	return source.cylinderAt(mapToSource(index));
-}
-
 bool CylindersModelFiltered::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
 	return prefs.display_unused_tanks || source.cylinderUsed(source_row);

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -45,7 +45,6 @@ public:
 	void updateDecoDepths(pressure_t olddecopo2);
 	void updateTrashIcon();
 	void moveAtFirst(int cylid);
-	cylinder_t *cylinderAt(const QModelIndex &index);
 	bool changed;
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 	bool updateBestMixes();
@@ -58,6 +57,7 @@ slots:
 
 private:
 	int rows;
+	cylinder_t *cylinderAt(const QModelIndex &index);
 };
 
 // Cylinder model that hides unused cylinders if the pref.show_unused_cylinders flag is not set
@@ -70,7 +70,6 @@ public:
 	void clear();
 	void add();
 	void updateDive();
-	cylinder_t *cylinderAt(const QModelIndex &index);
 public
 slots:
 	void remove(QModelIndex index);

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -25,16 +25,20 @@ public:
 		MOD,
 		MND,
 		USE,
+		WORKINGPRESS_INT,
+		SIZE_INT,
 		COLUMNS
 	};
 
+	enum Roles {
+		PASS_IN_ROLE = Qt::UserRole + 1 // For setting data: don't do any conversions
+	};
 	explicit CylindersModel(QObject *parent = 0);
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 
-	void passInData(const QModelIndex &index, const QVariant &value);
 	void add();
 	void clear();
 	void updateDive();
@@ -67,7 +71,6 @@ public:
 	void add();
 	void updateDive();
 	cylinder_t *cylinderAt(const QModelIndex &index);
-	void passInData(const QModelIndex &index, const QVariant &value);
 public
 slots:
 	void remove(QModelIndex index);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a crash in the planner introduced with the "CylindersModelFiltered": Since the planner doesn't use this model, the delegate must not cast to this model. To solve this dilemma, use Qt's model-view mechanism instead to store/load data. It's a bit hairy, so testing would be welcome.

To reproduce the crash simply go to the planner and select a different cylinder type.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Access data via Qt's model-view system instead of custom functions.
2) Don't downcast the model.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not in release - no.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @dirkhh 