### PR TITLE
Desktop: fix scrolling through the dive list with cursor keys

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -554,6 +554,19 @@ void DiveListView::mouseReleaseEvent(QMouseEvent *event)
 		selectionChangeDone();
 }
 
+void DiveListView::keyPressEvent(QKeyEvent *event)
+{
+	// Hook into cursor-up and cursor-down events and update selection if necessary.
+	// See comment in mouseReleaseEvent()
+	if (event->key() != Qt::Key_Down && event->key() != Qt::Key_Up)
+		return QTreeView::keyPressEvent(event);
+	QModelIndexList selectionBefore = selectionModel()->selectedRows();
+	QTreeView::keyPressEvent(event);
+	QModelIndexList selectionAfter = selectionModel()->selectedRows();
+	if (selectionBefore != selectionAfter)
+		selectionChangeDone();
+}
+
 void DiveListView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags)
 {
 	// We hook into QTreeView's setSelection() to update the UI

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -66,6 +66,7 @@ slots:
 private:
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
 	void mouseReleaseEvent(QMouseEvent *event) override;
+	void keyPressEvent(QKeyEvent *event) override;
 	void selectAll() override;
 	void selectionChangeDone();
 	DiveTripModelBase::Layout currentLayout;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes scrolling through the dive list with cursor keys. I'm really at a loss here - I don't see how to fix this mess without hooking into all events that can change the selection.

As a recapitulation: The whole problem is that when selecting all items in the tree-view, we get a selection event for every trip. If we have a few hundred trips, the map is repainted a few hundred times, thus freezing the UI for many seconds. Sadly, we don't know when the last selection event is sent.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @willemferguson
