### PR TITLE
desktop: don't close application if pressing CTRL-Q in setpoint dialog

### DIFF
--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -205,7 +205,7 @@ SetpointDialog::SetpointDialog(QWidget *parent) : QDialog(parent),
 	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
-	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
+	connect(quit, SIGNAL(activated()), this, SLOT(close()));
 }
 
 ShiftTimesDialog *ShiftTimesDialog::instance()


### PR DESCRIPTION
The CTRL-Q signal in the setpoint dialog was connected to the close
slot of the main-window instead of the dialog. Thus, pressing CTRL-Q
would close the application, not the dialog.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a funny bug: pressing CTRL-Q closes the application not the setpoint dialog. This commit is implicitly contained in a commit of #2643. I'm not sure if we want the extra commit here for documentation purposes. @dirkhh: up to you. Feel free to trash this PR if it appears too trivial.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) connect CTRL-Q to the appropriate receiver.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - too trivial / obscure.