### PR TITLE
[TRIVIAL] cleanup: make version_printed variable static and local to function

### DIFF
--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -128,9 +128,9 @@ const char *monthname(int mon)
  */
 bool imported = false;
 
-bool version_printed = false;
 void print_version()
 {
+	static bool version_printed = false;
 	if (version_printed)
 		return;
 	printf("Subsurface v%s,\n", subsurface_git_version());


### PR DESCRIPTION
The version_printed variable is used to print version information
only once. It was a global variable, but never used outside of
its function. Therefore, move it into the function and make it
static. Since this is a plain old datatype (POD), it makes no
no difference whatsoever whether the static variable is in block
scope or not. Indeed, it is initialized in the data segment). Well,
we are in C mode and therefore everything has to be POD by definition.
I tested this on gcc and clang.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a completely trivial idle code-cleanup. It could shorten the symbol-table by a byte or two.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh