### PR TITLE
mobile UI: re-enable download status when restarting download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix missing download info on retry
 Mobile: enable profile zoom and pan
 Mobile: add people- and tags-filter modes
 Desktop: fix tab-order in filter widget

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -329,6 +329,7 @@ Kirigami.Page {
 					message += " downloading " + (manager.DC_forceDownload ? "all" : "only new" ) + " dives";
 					manager.appendTextToLog(message)
 					progressBar.visible = true
+					divesDownloaded = false // this allows the progressMessage to be displayed
 					importModel.startDownload()
 				}
 			}


### PR DESCRIPTION
When tapping on 'retry' we didn't clear the flag that decided which message to display.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
Make sure the `divesDownloaded` flag gets reset when we retry the download

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes: #2651

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@charno 