### PR TITLE
debug: try to capture changes that don't invalidate git cache

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -688,7 +688,6 @@ void EditTagsBase::undo()
 #else
 	emit diveListNotifier.divesChanged(QVector<dive *>::fromStdVector(dives), id);
 #endif
-
 	setSelection(selectedDives, current);
 }
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -22,6 +22,7 @@
 #include "core/applicationstate.h"
 #include "core/gpslocation.h"
 #include "core/dive.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 
 #define NUM_RECENT_FILES 4
 
@@ -252,6 +253,7 @@ private:
 	GpsLocation *locationProvider;
 	QMenu *connections;
 	QAction *share_on_fb;
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 };
 
 #endif // MAINWINDOW_H

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -264,6 +264,11 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	what.tags = true;
 	what.cylinders = true;
 	what.weights = true;
+
+	// monitor when dives changed - but only in verbose mode
+	// careful - changing verbose at runtime isn't enough (of course that could be added if we want it)
+	if (verbose)
+		connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &QMLManager::divesChanged);
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)
@@ -2187,5 +2192,15 @@ void QMLManager::setOldStatus(const qPrefCloudStorage::cloud_status value)
 	if (m_oldStatus != value) {
 		m_oldStatus = value;
 		emit oldStatusChanged();
+	}
+}
+
+void QMLManager::divesChanged(const QVector<dive *> &dives, DiveField field)
+{
+	Q_UNUSED(field)
+	for (struct dive *d: dives) {
+		qDebug() << "dive #" << d->number << "changed, cache is" << (dive_cache_is_valid(d) ? "valid" : "invalidated");
+		// a brute force way to deal with that would of course be to call
+		// invalidate_dive_cache(d);
 	}
 }

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -17,6 +17,7 @@
 #include "qt-models/completionmodels.h"
 #include "qt-models/divelocationmodel.h"
 #include "core/settings/qPrefCloudStorage.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 
 #define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
 
@@ -226,6 +227,7 @@ public slots:
 	void hasLocationSourceChanged();
 	void btRescan();
 	void showDownloadPage(QString deviceString);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 
 private:
 	BuddyCompletionModel buddyModel;


### PR DESCRIPTION
At least in those cases where we are sending a divesChanged signal we can
easily check if the cache was properly invalidated. Of course this won't help
in cases where we don't notify the dive list about changes, either.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature
- [x] New debug tool

### Pull request long description:
<!-- Describe your pull request in detail. -->
It's not really a new feature. It's a cute hack that helps track down situations where we correctly notify the model of changes, but forget to invalidate the dive for git storage. This has helped me find a bug or two in the past.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 