### PR TITLE
[testing needed] usb-serial-for-android: Implement timeout-handling

### DIFF
--- a/core/serial_usb_android.cpp
+++ b/core/serial_usb_android.cpp
@@ -141,7 +141,11 @@ static dc_status_t serial_usb_android_read(void *io, void *data, size_t size, si
 	env->GetByteArrayRegion(array, 0, retval, (jbyte *) data);
 	env->DeleteLocalRef(array);
 	TRACE (device->context, "%s: actual read size: %i", __FUNCTION__, retval);
-	return DC_STATUS_SUCCESS;
+
+	if (retval < size)
+		return DC_STATUS_TIMEOUT;
+	else
+		return DC_STATUS_SUCCESS;
 }
 
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Since the Android USB stack and subsequently the usb-serial-for-android
driver have problems with read-timeouts, the read-timeout is now
implemented in AndroidSerial.java. Also, DC_STATUS_TIMEOUT is returned
if there are less bytes returned than expected.

Different chipsets seem to behave differently with
usb-serial-for-android. On CP210x the read blocks until there is some
data here, but on FTDI the chip seems to return whatever is currently in
the buffer (so 0 bytes if the buffer is empty). This different behaviour
should be mitigated by the changes by this commit.

### Changes made:
1) Return DC_STATUS_TIMEOUT if less bytes than expected are read
2) Use a loop to read bytes from the serial device until enough bytes are present or until timeout runs out.

### Related issues:

### Additional information:
Tested devices:
- [x] Mares Puck Pro

### Release note:
### Documentation change:

### Mentions:
@dirkhh 
