### PR TITLE
Android updates

### DIFF
--- a/android-mobile/res/xml/device_filter.xml
+++ b/android-mobile/res/xml/device_filter.xml
@@ -20,20 +20,6 @@
     <!-- Mares Icon HD Custom PID -->
     <usb-device vendor-id="0xFFFF" product-id="0x0005"/>
 
-    <!-- USB devices -->
-    <!-- EON Steel -->
-    <usb-device vendor-id="0x1493" product-id="0x30"/>
-    <!-- EON Steel core -->
-    <usb-device vendor-id="0x1493" product-id="0x33"/>
-    <!-- Scubapro G2 (wrist/console/hud) -->
-    <usb-device vendor-id="0x2e6c" product-id="0x3201"/>
-    <usb-device vendor-id="0x2e6c" product-id="0x3211"/>
-    <usb-device vendor-id="0x2e6c" product-id="0x4201"/>
-    <!-- Scubapro Aladin Square -->
-    <usb-device vendor-id="0xc251" product-id="0x2006"/>
-    <!-- Atomics Aquatics Cobalt -->
-    <usb-device vendor-id="0x0471" product-id="0x0888"/>
-
     <!-- devices supported by usb-serial-for-android which aren't included in FTDI chips -->
     <!-- Don't support Arduino / Teensyduino / Leaflabs Maple -->
     <!-- SiLabs CP2102 -->
@@ -54,7 +40,4 @@
     <usb-device vendor-id="0x1a86" product-id="0x7523"/>
     <!-- ARM mBed (possibly not used) -->
     <usb-device vendor-id="0x0d28" product-id="0x0204"/>
-
-
-
 </resources>

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -110,64 +110,12 @@ void DownloadThread::run()
 	updateRememberedDCs();
 }
 
-static void fill_supported_mobile_list()
-{
-#if defined(Q_OS_ANDROID)
-	/* USB or FTDI devices that are supported on Android - this does NOT include the BLE or BT only devices */
-	mobileProductList["Aeris"] =
-		QStringList({{"500 AI"}, {"A300"}, {"A300 AI"}, {"A300CS"}, {"Atmos 2"}, {"Atmos AI"}, {"Atmos AI 2"}, {"Compumask"}, {"Elite"}, {"Elite T3"}, {"Epic"}, {"F10"}, {"F11"}, {"Manta"}, {"XR-1 NX"}, {"XR-2"}});
-	mobileProductList["Aqualung"] =
-		QStringList({{"i200"}, {"i300"}, {"i450T"}, {"i550"}, {"i750TC"}});
-	mobileProductList["Beuchat"] =
-		QStringList({{"Mundial 2"}, {"Mundial 3"}, {"Voyager 2G"}});
-	mobileProductList["Cochran"] =
-		QStringList({{"Commander I"}, {"Commander II"}, {"Commander TM"}, {"EMC-14"}, {"EMC-16"}, {"EMC-20H"}});
-	mobileProductList["Cressi"] =
-		QStringList({{"Leonardo"}, {"Giotto"}, {"Newton"}, {"Drake"}, {"Cartesio"}, {"Goa"}});
-	mobileProductList["DiveSystem"] =
-		QStringList({{"Orca"}, {"iDive Pro"}, {"iDive DAN"}, {"iDive Tech"}, {"iDive Reb"}, {"iDive Stealth"}, {"iDive Free"}, {"iDive Easy"}, {"iDive X3M"}, {"iDive Deep"}});
-	mobileProductList["Genesis"] =
-		QStringList({{"React Pro"}, {"React Pro White"}});
-	mobileProductList["Heinrichs Weikamp"] =
-		QStringList({{"Frog"}, {"OSTC"}, {"OSTC 2"}, {"OSTC 2C"}, {"OSTC 2N"}, {"OSTC 3"}, {"OSTC 3+"}, {"OSTC 4"}, {"OSTC Mk2"}, {"OSTC Plus"}, {"OSTC Sport"}, {"OSTC cR"}, {"OSTC 2 TR"}});
-	mobileProductList["Hollis"] =
-		QStringList({{"DG02"}, {"DG03"}, {"TX1"}});
-	mobileProductList["Mares"] =
-		QStringList({{"Puck Pro"}, {"Smart"}, {"Quad"}});
-	mobileProductList["Oceanic"] =
-		QStringList({{"Atom 1.0"}, {"Atom 2.0"}, {"Atom 3.0"}, {"Atom 3.1"}, {"Datamask"}, {"F10"}, {"F11"}, {"Geo"}, {"Geo 2.0"}, {"OC1"}, {"OCS"}, {"OCi"}, {"Pro Plus 2"}, {"Pro Plus 2.1"}, {"Pro Plus 3"}, {"VT 4.1"}, {"VT Pro"}, {"VT3"}, {"VT4"}, {"VTX"}, {"Veo 1.0"}, {"Veo 180"}, {"Veo 2.0"}, {"Veo 200"}, {"Veo 250"}, {"Veo 3.0"}, {"Versa Pro"}});
-	mobileProductList["Ratio"] =
-		QStringList({{"iX3M Pro Fancy"}, {"iX3M Pro Easy"}, {"iX3M Pro Pro"}, {"iX3M Pro Deep"}, {"iX3M Pro Tech+"}, {"iX3M Pro Reb"}, {"iDive Free"}, {"iDive Fancy"}, {"iDive Easy"}, {"iDive Pro"}, {"iDive Deep"}, {"iDive Tech+"}, {"iDive Reb"}, {"iDive Color Free"}, {"iDive Color Fancy"}, {"iDive Color Easy"}, {"iDive Color Pro"}, {"iDive Color Deep"}, {"iDive Color Tech+"}, {"iDive Color Reb"}});
-	mobileProductList["Scubapro"] =
-		QStringList({{"Aladin Square"}, {"G2"}});
-	mobileProductList["Seac"] =
-		QStringList({{"Jack"}, {"Guru"}});
-	mobileProductList["Seemann"] =
-		QStringList({{"XP5"}});
-	mobileProductList["Sherwood"] =
-		QStringList({{"Amphos"}, {"Amphos Air"}, {"Insight"}, {"Insight 2"}, {"Vision"}, {"Wisdom"}, {"Wisdom 2"}, {"Wisdom 3"}});
-	mobileProductList["Subgear"] =
-		QStringList({{"XP-Air"}});
-	mobileProductList["Suunto"] =
-		QStringList({{"Cobra"}, {"Cobra 2"}, {"Cobra 3"}, {"D3"}, {"D4"}, {"D4f"}, {"D4i"}, {"D6"}, {"D6i"}, {"D9"}, {"D9tx"}, {"DX"}, {"EON Core"}, {"EON Steel"}, {"Eon"}, {"Gekko"}, {"HelO2"}, {"Mosquito"}, {"Solution"}, {"Solution Alpha"}, {"Solution Nitrox"}, {"Spyder"}, {"Stinger"}, {"Vyper"}, {"Vyper 2"}, {"Vyper Air"}, {"Vyper Novo"}, {"Vytec"}, {"Zoop"}, {"Zoop Novo"}});
-	mobileProductList["Tusa"] =
-		QStringList({{"Element II (IQ-750)"}, {"Zen (IQ-900)"}, {"Zen Air (IQ-950)"}});
-	mobileProductList["Uwatec"] =
-		QStringList({{"Aladin Air Twin"}, {"Aladin Air Z"}, {"Aladin Air Z Nitrox"}, {"Aladin Air Z O2"}, {"Aladin Pro"}, {"Aladin Pro Ultra"}, {"Aladin Sport Plus"}, {"Memomouse"}});
-	mobileProductList["Atomic Aquatics"] =
-		QStringList({{"Cobalt"}, {"Cobalt 2"}});
-
-#endif
-}
-
 void fill_computer_list()
 {
 	dc_iterator_t *iterator = NULL;
 	dc_descriptor_t *descriptor = NULL;
 
 	unsigned int transportMask = get_supported_transports(NULL);
-
-	fill_supported_mobile_list();
 
 	dc_descriptor_iterator(&iterator);
 	while (dc_iterator_next(iterator, &descriptor) == DC_STATUS_SUCCESS) {
@@ -179,13 +127,6 @@ void fill_computer_list()
 
 		const char *vendor = dc_descriptor_get_vendor(descriptor);
 		const char *product = dc_descriptor_get_product(descriptor);
-#if defined(Q_OS_ANDROID)
-		if ((transports & ~(DC_TRANSPORT_USB | DC_TRANSPORT_USBHID)) == 0)
-			// if the only available transports are USB, then check against
-			// the ones that we explicitly support on Android
-			if (!mobileProductList.contains(vendor) || !mobileProductList[vendor].contains(product))
-				continue;
-#endif
 		if (!vendorList.contains(vendor))
 			vendorList.append(vendor);
 		if (!productList[vendor].contains(product))

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -76,11 +76,6 @@ void DownloadThread::run()
 		qDebug() << "No download possible when DC type is unknown";
 		return;
 	}
-#if defined(Q_OS_ANDROID)
-	// on Android we either use BT, a USB device, or we download via FTDI cable
-	if (!internalData->bluetooth_mode && (same_string(internalData->devname, "FTDI") || same_string(internalData->devname, "")))
-		internalData->devname = "ftdi";
-#endif
 	qDebug() << "Starting download from " << (internalData->bluetooth_mode ? "BT" : internalData->devname);
 	qDebug() << "downloading" << (internalData->force_download ? "all" : "only new") << "dives";
 	clear_dive_table(&downloadTable);

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1235,7 +1235,10 @@ unsigned int get_supported_transports(device_data_t *data)
 #if defined(BLE_SUPPORT)
 	supported |= DC_TRANSPORT_BLE;
 #endif
-
+#if defined(Q_OS_ANDROID)
+	// we cannot support transports that need libusb, hid, filesystem access, or IRDA on Android
+	supported &= ~(DC_TRANSPORT_USB | DC_TRANSPORT_USBHID | DC_TRANSPORT_IRDA | DC_TRANSPORT_USBSTORAGE);
+#endif
 	if (data) {
 		/*
 		 * If we have device data available, we can refine this:

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -508,20 +508,6 @@ Kirigami.ScrollablePage {
 		}
 	}
 
-	function showDownloadPage(vendor, product, connection) {
-		downloadFromDc.dcImportModel.clearTable()
-		pageStack.push(downloadFromDc)
-		if (vendor !== undefined && product !== undefined && connection !== undefined) {
-			/* set up the correct values on the download page */
-			if (vendor !== -1)
-				downloadFromDc.vendor = vendor
-			if (product !== -1)
-				downloadFromDc.product = product
-			if (connection !== -1)
-				downloadFromDc.connection = connection
-		}
-	}
-
 	property QtObject downloadFromDCAction: Kirigami.Action {
 		icon {
 			name: ":/icons/downloadDC"
@@ -529,7 +515,7 @@ Kirigami.ScrollablePage {
 		}
 		text: qsTr("Download dives")
 		onTriggered: {
-			showDownloadPage()
+			rootItem.showDownloadPage()
 		}
 	}
 

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -194,7 +194,7 @@ Kirigami.Page {
 							if ( curVendor === comboVendor.currentText && curDevice.toUpperCase() === currentText)
 								rememberedDCsGrid.setDC(curVendor, curProduct, curDevice)
 						}else if (comboProduct.currentIndex !== -1 && currentText === "FTDI") {
-							if ( curVendor === comboVendor.currentText && cyrProduct === comboProduct.currentText && curDevice.toUpperCase() === currentText) {
+							if ( curVendor === comboVendor.currentText && curProduct === comboProduct.currentText && curDevice.toUpperCase() === currentText) {
 								disableDC(i)
 								break
 							}
@@ -339,12 +339,16 @@ Kirigami.Page {
 				onClicked: {
 					manager.cancelDownloadDC()
 					if (!progressBar.visible) {
-						pageStack.pop();
+						// remove the download page and show dive list
+						pageStack.pop(downloadFromDc)
+						rootItem.showDiveList()
 						download.text = qsTr("Download")
 						divesDownloaded = false
 						manager.progressMessage = ""
+						manager.appendTextToLog("exit DCDownload screen")
+					} else {
+						manager.appendTextToLog("cancel download")
 					}
-					manager.appendTextToLog("exit DCDownload screen")
 				}
 			}
 			TemplateButton {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -710,14 +710,18 @@ if you have network connectivity and want to sync your data to cloud storage."),
 			if (visible) {
 				pageStack.clear()
 				diveList.visible = false
-			} else {
-				pageStack.push(diveList)
 			}
 		}
 
 		Component.onCompleted: {
 			if (!visible) {
-				showDiveList()
+				manager.appendTextToLog("StartPage completed - showing the dive list")
+				showPage(diveList) // we want to make sure that gets on the stack
+				manager.appendTextToLog("if we got started by a plugged in device, switch to download page -- pluggedInDeviceName = " + pluggedInDeviceName)
+				if (pluggedInDeviceName !== "")
+					// if we were started with a dive computer plugged in,
+					// immediately switch to download page
+					showDownloadForPluggedInDevice()
 			}
 		}
 	}
@@ -818,6 +822,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	}
 
 	function showDownloadForPluggedInDevice() {
+		// don't add this unless the dive list is already shown
+		if (pageIndex(diveList) === -1)
+			return
 		manager.appendTextToLog("plugged in device name changed to " + pluggedInDeviceName)
 		/* if we recognized the device, we'll pass in a triple of ComboBox indeces as "vendor;product;connection" */
 		var vendorProductConnection = pluggedInDeviceName.split(';')
@@ -825,7 +832,6 @@ if you have network connectivity and want to sync your data to cloud storage."),
 			showDownloadPage(vendorProductConnection[0], vendorProductConnection[1], vendorProductConnection[2])
 		else
 			showDownloadPage()
-		manager.appendTextToLog("done showing download page")
 	}
 
 	onPluggedInDeviceNameChanged: {
@@ -834,6 +840,9 @@ if you have network connectivity and want to sync your data to cloud storage."),
 			manager.appendTextToLog("Download page requested by Android Intent, but adding/editing dive; no action taken")
 		} else {
 			// we want to show the downloads page
+			// note that if Subsurface-mobile was started because a USB device was plugged in, this is run too early;
+			// we catch this in the function below and instead switch to the download page in the completion signal
+			// handler for the startPage
 			showDownloadForPluggedInDevice()
 		}
 	}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -802,19 +802,39 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		visible: false
 	}
 
+	function showDownloadPage(vendor, product, connection) {
+		manager.appendTextToLog("show download page for " + vendor + " / " + product + " / " + connection)
+		downloadFromDc.dcImportModel.clearTable()
+		if (vendor !== undefined && product !== undefined && connection !== undefined) {
+			/* set up the correct values on the download page */
+			if (vendor !== -1)
+				downloadFromDc.vendor = vendor
+			if (product !== -1)
+				downloadFromDc.product = product
+			if (connection !== -1)
+				downloadFromDc.connection = connection
+		}
+		showPage(downloadFromDc)
+	}
+
+	function showDownloadForPluggedInDevice() {
+		manager.appendTextToLog("plugged in device name changed to " + pluggedInDeviceName)
+		/* if we recognized the device, we'll pass in a triple of ComboBox indeces as "vendor;product;connection" */
+		var vendorProductConnection = pluggedInDeviceName.split(';')
+		if (vendorProductConnection.length === 3)
+			showDownloadPage(vendorProductConnection[0], vendorProductConnection[1], vendorProductConnection[2])
+		else
+			showDownloadPage()
+		manager.appendTextToLog("done showing download page")
+	}
+
 	onPluggedInDeviceNameChanged: {
 		if (detailsWindow.state === 'edit' || detailsWindow.state === 'add') {
 			/* we're in the middle of editing / adding a dive */
 			manager.appendTextToLog("Download page requested by Android Intent, but adding/editing dive; no action taken")
 		} else {
-			manager.appendTextToLog("Show download page for device " + pluggedInDeviceName)
-			/* if we recognized the device, we'll pass in a triple of ComboBox indeces as "vendor;product;connection" */
-			var vendorProductConnection = pluggedInDeviceName.split(';')
-			if (vendorProductConnection.length === 3)
-				diveList.showDownloadPage(vendorProductConnection[0], vendorProductConnection[1], vendorProductConnection[2])
-			else
-				diveList.showDownloadPage()
-			manager.appendTextToLog("done showing download page")
+			// we want to show the downloads page
+			showDownloadForPluggedInDevice()
 		}
 	}
 

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -76,30 +76,31 @@ Kirigami.ApplicationWindow {
 		diveList.scrollToTop()
 	}
 
-	function showMap() {
+	function showPage(page) {
 		if (globalDrawer.drawerOpen)
 			globalDrawer.close()
-		var i=pageIndex(mapPage)
+		var i=pageIndex(page)
 		if (i === -1)
-			pageStack.push(mapPage)
+			pageStack.push(page)
 		else
 			pageStack.currentIndex = i
+		manager.appendTextToLog("switched to page " + page.title)
+	}
+
+	function showMap() {
+		showPage(mapPage)
 	}
 
 	function showDiveList() {
-		if (globalDrawer.drawerOpen)
-			globalDrawer.close()
-		var i=pageIndex(diveList)
-		if (i === -1)
-			pageStack.push(diveList)
-		else
-			pageStack.currentIndex = i
+		showPage(diveList)
 	}
 
 	function pageIndex(pageToFind) {
-		for (var i = 0; i < pageStack.contentItem.contentChildren.length; i++) {
-			if (pageStack.contentItem.contentChildren[i] === pageToFind)
-				return i
+		if (pageStack.contentItem !== null) {
+			for (var i = 0; i < pageStack.contentItem.contentChildren.length; i++) {
+				if (pageStack.contentItem.contentChildren[i] === pageToFind)
+					return i
+			}
 		}
 		return -1
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2031,49 +2031,10 @@ void QMLManager::showDownloadPage(QString deviceString)
 				.arg(productList["Heinrichs Weikamp"].indexOf("OSTC 3"))
 				.arg(connectionListModel.indexOf("usb-serial"));
 	} else if (deviceString.contains("HeinrichsWeikamp OSTC 2N")) {
-			name = QString("%1;%2;%3")
-					.arg(vendorList.indexOf("Heinrichs Weikamp"))
-					.arg(productList["Heinrichs Weikamp"].indexOf("OSTC 2N"))
-					.arg(connectionListModel.indexOf("usb-serial"));
-	} else if (deviceString.contains("mManufacturerName=ATOMIC AQUATICS") &&
-		   deviceString.contains("mProductName=COBALT")) {
-		if (deviceString.contains("mVersion=2")) {
-			name = QString("%1;%2;%3")
-					.arg(vendorList.indexOf("Atomic Aquatics"))
-					.arg(productList["Atomic Aquatics"].indexOf("Cobalt 2"))
-					.arg(connectionListModel.indexOf("USB device"));
-		} else {
-			name = QString("%1;%2;%3")
-					.arg(vendorList.indexOf("Atomic Aquatics"))
-					.arg(productList["Atomic Aquatics"].indexOf("Cobalt"))
-					.arg(connectionListModel.indexOf("USB device"));
-		}
-	} else if (deviceString.contains("mVendorId=5267") && // 0x1493 / 0x0030
-		   deviceString.contains("mProductId=48")) {
 		name = QString("%1;%2;%3")
-				.arg(connectionListModel.indexOf("Suunto"))
-				.arg(productList["Suunto"].indexOf("EON Steel"))
-				.arg(connectionListModel.indexOf("USB device"));
-	} else if (deviceString.contains("mVendorId=5267") && // 0x1493 / 0x0033
-		   deviceString.contains("mProductId=51")) {
-		name = QString("%1;%2;%3")
-				.arg(connectionListModel.indexOf("Suunto"))
-				.arg(productList["Suunto"].indexOf("EON Core"))
-				.arg(connectionListModel.indexOf("USB device"));
-	} else if (deviceString.contains("mVendorId=11884") && // 0x2e6c / 0x3201,0x3211,0x4201
-		   (deviceString.contains("mProductId=12801") ||
-		    deviceString.contains("mProductId=12817") ||
-		    deviceString.contains("mProductId=16897"))) {
-		name = QString("%1;%2;%3")
-				.arg(connectionListModel.indexOf("Scubapro"))
-				.arg(productList["Scubapro"].indexOf("G2"))
-				.arg(connectionListModel.indexOf("USB device"));
-	} else if (deviceString.contains("mVendorId=49745") && // 0xc251 / 0x2006
-		   deviceString.contains("mProductId=8198")) {
-		name = QString("%1;%2;%3")
-				.arg(connectionListModel.indexOf("Scubapro"))
-				.arg(productList["Scubapro"].indexOf("Aladin Square"))
-				.arg(connectionListModel.indexOf("USB device"));
+				.arg(vendorList.indexOf("Heinrichs Weikamp"))
+				.arg(productList["Heinrichs Weikamp"].indexOf("OSTC 2N"))
+				.arg(connectionListModel.indexOf("usb-serial"));
 	} else if (deviceString.contains("mVendorId=1027") && // FTDI: 0x0403 / 0x6001,0x6010,0x6011,0x6014,0x6015
 		   (deviceString.contains("mProductId=24577") ||
 		    deviceString.contains("mProductId=24592") ||


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This tries to get the dive computers listed on Android right...
And it fixes the issue where we wouldn't show the download page if Subsurface-mobile gets started by plugging in the dive computer

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) toss out the manual selection of FTDI dive computers (which was bogus, anyway, as the cable defines the chip, not the dive computer, and some dive computers are supported by multiple cables with different chips)
2) try to select only those transports we support
3) make sure we check if we need to switch to the download page after finished processing main.qml

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@charno 
I haven't tested this enough... but it looked right when I wrote it :-)