### PR TITLE
[RFC] Remove dive-number editing code

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -163,11 +163,6 @@ int editMode(int index, int newValue, bool currentDiveOnly)
 	return execute_edit(new EditMode(index, newValue, currentDiveOnly));
 }
 
-int editNumber(int newValue, bool currentDiveOnly)
-{
-	return execute_edit(new EditNumber(newValue, currentDiveOnly));
-}
-
 int editSuit(const QString &newValue, bool currentDiveOnly)
 {
 	return execute_edit(new EditSuit(newValue, currentDiveOnly));

--- a/commands/command.h
+++ b/commands/command.h
@@ -61,7 +61,6 @@ void purgeUnusedDiveSites();
 int editNotes(const QString &newValue, bool currentDiveOnly);
 int editSuit(const QString &newValue, bool currentDiveOnly);
 int editMode(int index, int newValue, bool currentDiveOnly);
-int editNumber(int newValue, bool currentDiveOnly);
 int editRating(int newValue, bool currentDiveOnly);
 int editVisibility(int newValue, bool currentDiveOnly);
 int editWaveSize(int newValue, bool currentDiveOnly);

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -569,28 +569,6 @@ DiveField EditMode::fieldId() const
 	return DiveField::MODE;
 }
 
-// ***** Number *****
-void EditNumber::set(struct dive *d, int number) const
-{
-	d->number = number;
-}
-
-int EditNumber::data(struct dive *d) const
-{
-	return d->number;
-}
-
-QString EditNumber::fieldName() const
-{
-	return tr("number");
-}
-
-DiveField EditNumber::fieldId() const
-{
-	return DiveField::NR;
-}
-
-
 // ***** Tag based commands *****
 EditTagsBase::EditTagsBase(const QStringList &newListIn, bool currentDiveOnly) :
 	EditDivesBase(currentDiveOnly),

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -222,15 +222,6 @@ public:
 	DiveField fieldId() const override;
 };
 
-class EditNumber : public EditBase<int> {
-public:
-	using EditBase<int>::EditBase;	// Use constructor of base class.
-	void set(struct dive *d, int number) const override;
-	int data(struct dive *d) const override;
-	QString fieldName() const override;
-	DiveField fieldId() const override;
-};
-
 // Fields that work with tag-lists (tags, buddies, divemasters) work differently and therefore
 // have their own base class. In this case, it's not a template, as all these lists are base
 // on strings.

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -406,32 +406,6 @@ Qt::ItemFlags DiveTripModelBase::flags(const QModelIndex &index) const
 	return d && index.column() == NR ? base | Qt::ItemIsEditable : base;
 }
 
-bool DiveTripModelBase::setData(const QModelIndex &index, const QVariant &value, int role)
-{
-	// We only support setting of data for dives and there, only the number.
-	dive *d = diveOrNull(index);
-	if (!d)
-		return false;
-	if (role != Qt::EditRole)
-		return false;
-	if (index.column() != NR)
-		return false;
-
-	int v = value.toInt();
-	if (v == 0)
-		return false;
-
-	// Only accept numbers that are not already in use by other dives.
-	int i;
-	struct dive *dive;
-	for_each_dive (i, dive) {
-		if (dive->number == v)
-			return false;
-	}
-	Command::editNumber(v, d);
-	return true;
-}
-
 // Update visibility status of dive and return dives whose visibility changed.
 // Attention: the changed dives are removed from the original vector!
 static ShownChange updateShown(QVector<dive *> &dives)

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -67,7 +67,6 @@ public:
 
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	DiveTripModelBase(QObject *parent = 0);
 	int columnCount(const QModelIndex&) const;
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While looking at the divelist commits, it occurred to me that the dive-number can't be edited directly anymore (since when)? Instead, one has to use the "renumber dives" context menu. Since no-one complained, let's just remove to corresponding code.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove dead code.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @mturkia @atdotde 