### PR TITLE
cleanup: fix NOCLOUD_LOCALSTORAGE leak

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -374,13 +374,17 @@ void QMLManager::updateAllGlobalLists()
 	updateSiteList();
 }
 
+static QString nocloud_localstorage()
+{
+	return QString(system_default_directory()) + "/cloudstorage/localrepo[master]";
+}
+
 void QMLManager::mergeLocalRepo()
 {
-	char *filename = NOCLOUD_LOCALSTORAGE;
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	parse_file(filename, &table, &trips, &sites);
+	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 }
 
@@ -453,7 +457,7 @@ void QMLManager::finishSetup()
 	} else if (!empty_string(existing_filename) &&
 				qPrefCloudStorage::cloud_verification_status() != qPrefCloudStorage::CS_UNKNOWN) {
 		setOldStatus((qPrefCloudStorage::cloud_status)qPrefCloudStorage::cloud_verification_status());
-		set_filename(NOCLOUD_LOCALSTORAGE);
+		set_filename(qPrintable(nocloud_localstorage()));
 		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_NOCLOUD);
 		saveCloudCredentials(qPrefCloudStorage::cloud_storage_email(), qPrefCloudStorage::cloud_storage_password(), qPrefCloudStorage::cloud_storage_pin());
 		appendTextToLog(tr("working in no-cloud mode"));
@@ -813,7 +817,7 @@ void QMLManager::revertToNoCloudIfNeeded()
 		qPrefCloudStorage::set_cloud_storage_password("");
 		setOldStatus((qPrefCloudStorage::cloud_status)qPrefCloudStorage::cloud_verification_status());
 		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_NOCLOUD);
-		set_filename(NOCLOUD_LOCALSTORAGE);
+		set_filename(qPrintable(nocloud_localstorage()));
 		setStartPageText(RED_FONT + tr("Failed to connect to cloud server, reverting to no cloud status") + END_FONT);
 	}
 	alreadySaving = false;
@@ -1285,17 +1289,17 @@ void QMLManager::openNoCloudRepo()
  * is obviously empty when just created.
  */
 {
-	char *filename = NOCLOUD_LOCALSTORAGE;
+	QString filename = nocloud_localstorage();
 	const char *branch;
 	struct git_repository *git;
 
-	git = is_git_repository(filename, &branch, NULL, false);
+	git = is_git_repository(qPrintable(filename), &branch, NULL, false);
 
 	if (git == dummy_git_repository) {
-		git_create_local_repo(filename);
-		set_filename(filename);
+		git_create_local_repo(qPrintable(filename));
+		set_filename(qPrintable(filename));
 		auto s = qPrefLog::instance();
-		s->set_default_filename(filename);
+		s->set_default_filename(qPrintable(filename));
 		s->set_default_file_behavior(LOCAL_DEFAULT_FILE);
 	}
 
@@ -1307,11 +1311,11 @@ void QMLManager::saveChangesLocal()
 	if (unsaved_changes()) {
 		if (qPrefCloudStorage::cloud_verification_status() == qPrefCloudStorage::CS_NOCLOUD) {
 			if (empty_string(existing_filename)) {
-				char *filename = NOCLOUD_LOCALSTORAGE;
-				git_create_local_repo(filename);
-				set_filename(filename);
+				QString filename = nocloud_localstorage();
+				git_create_local_repo(qPrintable(filename));
+				set_filename(qPrintable(filename));
 				auto s = qPrefLog::instance();
-				s->set_default_filename(filename);
+				s->set_default_filename(qPrintable(filename));
 				s->set_default_file_behavior(LOCAL_DEFAULT_FILE);
 			}
 		} else if (!m_loadFromCloud) {

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -18,8 +18,6 @@
 #include "qt-models/divelocationmodel.h"
 #include "core/settings/qPrefCloudStorage.h"
 
-#define NOCLOUD_LOCALSTORAGE format_string("%s/cloudstorage/localrepo[master]", system_default_directory())
-
 class QMLManager : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(QString logText READ logText WRITE setLogText NOTIFY logTextChanged)


### PR DESCRIPTION
The macro NOCLOUD_LOCALSTORAGE creates the path to the local git
repository as a C-string. None of the users were freeing the string
and thus leaking memory.

Replace the macro by an inline function that creates a QString
and pass down to C-functions using the qPrintable() macro.
Note that every qPrintable() invocation does a UTF16->UTF8
conversion. This could be avoided by either using a std::string
or a QByteArray. However, we are talking about microseconds of
CPU time in operations that typically take seconds. Not worth
it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a leak concerning the local git repository.