### PR TITLE
android usb serial: Prepare device / driver select

### DIFF
--- a/android-mobile/AndroidManifest.xml
+++ b/android-mobile/AndroidManifest.xml
@@ -92,6 +92,7 @@
         android:normalScreens="true"
         android:smallScreens="true" />
 
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!--
          The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions.

--- a/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
@@ -14,6 +14,8 @@ import android.content.Intent;
 import org.subsurfacedivelog.mobile.SubsurfaceMobileActivity;
 
 import java.lang.System;
+import java.lang.Class;
+import java.lang.reflect.Constructor;
 import java.lang.Thread;
 import java.util.Queue;
 import java.util.List;
@@ -83,38 +85,69 @@ public class AndroidSerial {
 		this.usbSerialPort = usbSerialPort;
 	}
 
-	public static AndroidSerial open_android_serial()
+	public static AndroidSerial open_android_serial(UsbDevice usbDevice, String driverClassName)
 	{
 		try {
 			Log.d(TAG, "in " + Thread.currentThread().getStackTrace()[2].getMethodName());
 			// Find all available drivers from attached devices.
 			Context context = SubsurfaceMobileActivity.getAppContext();
 			UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
-			ProbeTable usbSerialProbetable = UsbSerialProber.getDefaultProbeTable();
 
-			usbSerialProbetable.addProduct(0x0403, 0xf460, FtdiSerialDriver.class); // Oceanic Custom PID
-			usbSerialProbetable.addProduct(0x0403, 0xf680, FtdiSerialDriver.class); // Suunto Custom PID
-			usbSerialProbetable.addProduct(0x0403, 0x87d0, FtdiSerialDriver.class); // Cressi (Leonardo) Custom PID
+			if (usbDevice == null) {
+					Log.e(TAG, "usbDevice == null");
+					return null;
+			}
 
-			usbSerialProbetable.addProduct(0x04B8, 0x0521, ProlificSerialDriver.class); // Mares (Nemo Sport) / Cressi Custom PID
-			usbSerialProbetable.addProduct(0x04B8, 0x0521, ProlificSerialDriver.class); // Zeagle Custom PID
-			usbSerialProbetable.addProduct(0xFFFF, 0x0005, CdcAcmSerialDriver.class); // Mares Icon HD Custom PID
+			UsbSerialDriver driver = null;
 
-			UsbSerialProber usbSerialProber = new UsbSerialProber(usbSerialProbetable);
+			if (driverClassName.length() == 0) {
+				ProbeTable usbSerialProbetable = UsbSerialProber.getDefaultProbeTable();
 
-			List<UsbSerialDriver> availableDrivers = usbSerialProber.findAllDrivers(manager);
-			if (availableDrivers.isEmpty()) {
-				Log.w(TAG, "no usb-to-serial devices found!");
-				return null;
+				usbSerialProbetable.addProduct(0x0403, 0xf460, FtdiSerialDriver.class); // Oceanic Custom PID
+				usbSerialProbetable.addProduct(0x0403, 0xf680, FtdiSerialDriver.class); // Suunto Custom PID
+				usbSerialProbetable.addProduct(0x0403, 0x87d0, FtdiSerialDriver.class); // Cressi (Leonardo) Custom PID
+
+				usbSerialProbetable.addProduct(0x04B8, 0x0521, ProlificSerialDriver.class); // Mares (Nemo Sport) / Cressi Custom PID
+				usbSerialProbetable.addProduct(0x04B8, 0x0521, ProlificSerialDriver.class); // Zeagle Custom PID
+				usbSerialProbetable.addProduct(0xFFFF, 0x0005, CdcAcmSerialDriver.class); // Mares Icon HD Custom PID
+
+				UsbSerialProber usbSerialProber = new UsbSerialProber(usbSerialProbetable);
+
+				driver = usbSerialProber.probeDevice(usbDevice);
+
+				if (driver == null) {
+					Log.w(TAG, "Could not find a driver for the usb device " + usbDevice);
+					return null;
+				}
+
+				Log.i(TAG, "Using autodetected driver class " + driver.getClass().getSimpleName());
+
+			}
+			else {
+				final Class<? extends UsbSerialDriver> driverClass = Class.forName("com.hoho.android.usbserial.driver." + driverClassName).asSubclass(UsbSerialDriver.class);
+
+				if (driverClass == null) {
+					Log.w(TAG, "Could not find driver class " + driverClassName);
+					return null;
+				}
+
+				try {
+					final Constructor<? extends UsbSerialDriver> ctor =
+							driverClass.getConstructor(UsbDevice.class);
+					driver = ctor.newInstance(usbDevice);
+				} catch (Exception e) {
+					Log.w(TAG, "Could not load user-specified driver class " + driverClassName, e);
+					return null;
+				}
+				Log.i(TAG, "Using user-specified driver class " + driver.getClass().getSimpleName());
 			}
 
 			// Open a connection to the first available driver.
-			UsbSerialDriver driver = availableDrivers.get(0);
-			UsbDeviceConnection connection = manager.openDevice(driver.getDevice());
+			UsbDeviceConnection connection = manager.openDevice(usbDevice);
 
 			if (connection == null) {
-				manager.requestPermission(driver.getDevice(), PendingIntent.getBroadcast(context, 0, new Intent("org.subsurfacedivelog.mobile.USB_PERMISSION"), 0));
-				Log.w(TAG, "Could not open device!");
+				manager.requestPermission(usbDevice, PendingIntent.getBroadcast(context, 0, new Intent("org.subsurfacedivelog.mobile.USB_PERMISSION"), 0));
+				Log.w(TAG, "Could not open device. Requesting permission.");
 				return null;
 			}
 

--- a/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
@@ -5,6 +5,8 @@ import com.hoho.android.usbserial.driver.*;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbManager;
 import android.hardware.usb.UsbDevice;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
 
 import android.content.Context;
 import android.util.Log;
@@ -69,6 +71,7 @@ public class AndroidSerial {
 	private UsbSerialPort usbSerialPort;
 	private int timeout = 0;
 	private LinkedList<Byte> readBuffer = new LinkedList<Byte>();
+	private WakeLock wakeLock = null;
 
 	private static String printQueue(LinkedList<Byte> readBuffer)
 	{
@@ -83,6 +86,10 @@ public class AndroidSerial {
 	private AndroidSerial(UsbSerialPort usbSerialPort)
 	{
 		this.usbSerialPort = usbSerialPort;
+
+		PowerManager powerManager = (PowerManager) SubsurfaceMobileActivity.getAppContext().getSystemService(Context.POWER_SERVICE);
+		wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Subsurface::AndroidSerialWakelock");
+		wakeLock.acquire();
 	}
 
 	public static AndroidSerial open_android_serial(UsbDevice usbDevice, String driverClassName)
@@ -321,6 +328,8 @@ public class AndroidSerial {
 		Log.d(TAG, "in " + Thread.currentThread().getStackTrace()[2].getMethodName());
 		try {
 			usbSerialPort.close();
+			if(wakeLock != null)
+				wakeLock.release();
 			return AndroidSerial.DC_STATUS_SUCCESS;
 		} catch (Exception e) {
 			Log.e(TAG, "Error in " + Thread.currentThread().getStackTrace()[2].getMethodName(), e);

--- a/android-mobile/src/org/subsurfacedivelog/mobile/SubsurfaceMobileActivity.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/SubsurfaceMobileActivity.java
@@ -50,6 +50,11 @@ public class SubsurfaceMobileActivity extends QtActivity
 				isIntentPending = true;
 			}
 		}
+
+		// Register the usb permission intent filter.
+		IntentFilter filter = new IntentFilter("org.subsurfacedivelog.mobile.USB_PERMISSION");
+		registerReceiver(usbReceiver, filter);
+
 	} // onCreate
 
 	// if we are opened from other apps:
@@ -102,6 +107,24 @@ public class SubsurfaceMobileActivity extends QtActivity
 		Log.i(TAG + " processIntent device name", device.getDeviceName());
 		setDeviceString(device.toString());
 	} // processIntent
+
+
+	private final BroadcastReceiver usbReceiver = new BroadcastReceiver() {
+		public void onReceive(Context context, Intent intent) {
+			String action = intent.getAction();
+			if ("org.subsurfacedivelog.mobile.USB_PERMISSION".equals(action)) {
+				synchronized (this) {
+					if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+						Log.d(TAG, "USB device permission granted");
+						// Stub: press the download button here :)
+					}
+					else {
+						Log.d(TAG, "USB device permission granted");
+					}
+				}
+			}
+		}
+	};
 
 
 	public static Context getAppContext()

--- a/core/serial_usb_android.cpp
+++ b/core/serial_usb_android.cpp
@@ -124,7 +124,7 @@ static dc_status_t serial_usb_android_get_available (void *io, size_t *value)
 
 static dc_status_t serial_usb_android_read(void *io, void *data, size_t size, size_t *actual)
 {
-	TRACE (device->context, "%s: size: %i", __FUNCTION__, size);
+	TRACE (device->context, "%s: size: %zu", __FUNCTION__, size);
 
 	QAndroidJniObject *device = static_cast<QAndroidJniObject *>(io);
 	if (device == NULL)
@@ -154,7 +154,7 @@ static dc_status_t serial_usb_android_read(void *io, void *data, size_t size, si
 
 static dc_status_t serial_usb_android_write(void *io, const void *data, size_t size, size_t *actual)
 {
-	TRACE (device->context, "%s: size: %i", __FUNCTION__, size);
+	TRACE (device->context, "%s: size: %zu", __FUNCTION__, size);
 
 	QAndroidJniObject *device = static_cast<QAndroidJniObject *>(io);
 	if (device == NULL)

--- a/core/serial_usb_android.cpp
+++ b/core/serial_usb_android.cpp
@@ -7,6 +7,7 @@
 #include <QAndroidJniObject>
 #include <QAndroidJniEnvironment>
 #include <QtAndroid>
+#include <QRegularExpression>
 
 #include <thread>
 
@@ -207,6 +208,59 @@ dc_status_t serial_usb_android_open(dc_iostream_t **iostream, dc_context_t *cont
 	return dc_custom_open(iostream, context, DC_TRANSPORT_SERIAL, &callbacks, device);
 }
 
+android_usb_serial_device_descriptor getDescriptor(QAndroidJniObject usbDevice)
+{
+	QAndroidJniEnvironment env;
+
+	android_usb_serial_device_descriptor descriptor;
+
+	descriptor.usbDevice = usbDevice;
+	descriptor.pid = usbDevice.callMethod<jint>("getProductId");
+	descriptor.vid = usbDevice.callMethod<jint>("getVendorId");
+
+	// descriptor.manufacturer = UsbDevice.getManufacturerName();
+	QAndroidJniObject usbManufacturerName = usbDevice.callObjectMethod<jstring>("getManufacturerName");
+	if (usbManufacturerName.isValid()) {
+		const char *charArray = env->GetStringUTFChars(usbManufacturerName.object<jstring>(), nullptr);
+		descriptor.manufacturer = std::string(charArray);
+		env->ReleaseStringUTFChars(usbManufacturerName.object<jstring>(), charArray);
+	}
+
+	// descriptor.product = UsbDevice.getProductName();
+	QAndroidJniObject usbProductName = usbDevice.callObjectMethod<jstring>("getProductName");
+	if (usbManufacturerName.isValid()) {
+		const char *charArray = env->GetStringUTFChars(usbProductName.object<jstring>(), nullptr);
+		descriptor.product = std::string(charArray);
+		env->ReleaseStringUTFChars(usbProductName.object<jstring>(), charArray);
+	}
+
+	// Get busnum and portnum
+	QAndroidJniObject usbDeviceNameString = usbDevice.callObjectMethod<jstring>("getDeviceName");
+	const char *charArray = env->GetStringUTFChars(usbDeviceNameString.object<jstring>(), nullptr);
+	QRegularExpression reg("/dev/bus/usb/(\\d*)/(\\d*)");
+	QRegularExpressionMatch match = reg.match(charArray);
+	int busnum = match.captured(1).toInt();
+	int portnum = match.captured(2).toInt();
+	env->ReleaseStringUTFChars(usbDeviceNameString.object<jstring>(), charArray);
+
+	// The ui representation
+	char buffer[128];
+	if (descriptor.manufacturer.empty()) {
+		sprintf(buffer, "USB Device [%i:%i]", busnum, portnum);
+	}
+	else if (descriptor.manufacturer.size() <= 16) {
+		sprintf(buffer, "%s [%i:%i]", descriptor.manufacturer.c_str(), busnum, portnum);
+	}
+	else {
+		sprintf(buffer, "%.16s… [%i:%i]", descriptor.manufacturer.c_str(), busnum, portnum);
+	}
+	descriptor.uiRepresentation = buffer;
+
+	return descriptor;
+}
+
+
+
 std::vector<android_usb_serial_device_descriptor>
 serial_usb_android_get_devices(bool driverSelection)
 {
@@ -235,7 +289,10 @@ serial_usb_android_get_devices(bool driverSelection)
 		// UsbDevice usbDevice = arrayOfDevices[0]
 		jobject value = env->GetObjectArrayElement(arrayOfDevices.object<jobjectArray>(), 0);
 		QAndroidJniObject usbDevice(value);
-		return std::vector<android_usb_serial_device_descriptor> { {QAndroidJniObject(usbDevice), "", "USB Connection"} };
+		android_usb_serial_device_descriptor descriptor = getDescriptor(usbDevice);
+		descriptor.uiRepresentation = "USB Connection";
+
+		return {descriptor};
 	}
 	else {
 		std::vector<android_usb_serial_device_descriptor> retval;
@@ -244,23 +301,17 @@ serial_usb_android_get_devices(bool driverSelection)
 			jobject value = env->GetObjectArrayElement(arrayOfDevices.object<jobjectArray>(), i);
 			QAndroidJniObject usbDevice(value);
 
-			// std::string deviceName = usbDevice.getDeviceName()
-			QAndroidJniObject usbDeviceNameString = usbDevice.callObjectMethod<jstring>("getDeviceName");
-			const char *charArray = env->GetStringUTFChars(usbDeviceNameString.object<jstring>(), nullptr);
-			std::string deviceName(charArray);
-			env->ReleaseStringUTFChars(usbDeviceNameString.object<jstring>(), charArray);
-
-			// TODO the deviceName should probably be something better... Currently it's the /dev-filename.
-
 			for (std::string driverName : driverNames) {
-				std::string uiDeviceName;
+				android_usb_serial_device_descriptor descriptor = getDescriptor(usbDevice);
+
+				descriptor.className = driverName;
 				if (driverName != "") {
-					uiDeviceName = deviceName + " (" + driverName + ")";
+					descriptor.uiRepresentation += " (" + driverName + ")";
 				}
 				else {
-					uiDeviceName = deviceName + " (autoselect driver)";
+					descriptor.uiRepresentation += " (autoselect driver)";
 				}
-				retval.push_back({QAndroidJniObject(usbDevice), driverName, uiDeviceName});
+				retval.push_back(descriptor);
 			}
 		}
 		return retval;
@@ -273,6 +324,27 @@ serial_usb_android_get_devices(bool driverSelection)
  */
 dc_status_t serial_usb_android_open(dc_iostream_t **iostream, dc_context_t *context)
 {
+	// Testing of the method only!
+	{
+		TRACE(device->contxt, "List of devices with specific drivers:");
+		      std::vector<android_usb_serial_device_descriptor> devices = serial_usb_android_get_devices(true);
+		for (auto device : devices) {
+			TRACE(device->contxt,
+			      "USB Device: uiRepresentation=%s, className=%s, manufacturer=%s, product=%s, pid=%i, vid=%i",
+			      device.uiRepresentation.c_str(), device.className.c_str(), device.manufacturer.c_str(),
+			      device.product.c_str(), device.pid, device.vid);
+		}
+
+		TRACE(device->contxt, "List of devices simple:");
+		devices = serial_usb_android_get_devices(false);
+		for (auto device : devices) {
+			TRACE(device->contxt,
+			      "USB Device: uiRepresentation=%s, className=%s, manufacturer=%s, product=%s, pid=%i, vid=%i",
+			      device.uiRepresentation.c_str(), device.className.c_str(), device.manufacturer.c_str(),
+			      device.product.c_str(), device.pid, device.vid);
+		}
+	}
+
 	std::vector<android_usb_serial_device_descriptor> devices = serial_usb_android_get_devices(false);
 
 	if(devices.empty())

--- a/core/serial_usb_android.h
+++ b/core/serial_usb_android.h
@@ -1,0 +1,17 @@
+#ifndef SERIAL_USB_ANDROID_H
+#define SERIAL_USB_ANDROID_H
+
+#include <string>
+#include <vector>
+
+/* USB Device Information */
+struct android_usb_serial_device_descriptor {
+	QAndroidJniObject usbDevice; /* the UsbDevice */
+	std::string className; /* the driver class name. If empty, then "autodetect" */
+	std::string uiRepresentation; /* The string that can be used for the user interface. */
+};
+
+std::vector<android_usb_serial_device_descriptor>
+serial_usb_android_get_devices(bool driverSelection);
+
+#endif

--- a/core/serial_usb_android.h
+++ b/core/serial_usb_android.h
@@ -9,6 +9,12 @@ struct android_usb_serial_device_descriptor {
 	QAndroidJniObject usbDevice; /* the UsbDevice */
 	std::string className; /* the driver class name. If empty, then "autodetect" */
 	std::string uiRepresentation; /* The string that can be used for the user interface. */
+
+	// Device information
+	std::string manufacturer;
+	std::string product;
+	uint16_t pid;
+	uint16_t vid;
 };
 
 std::vector<android_usb_serial_device_descriptor>

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
 void set_non_bt_addresses()
 {
 #if defined(Q_OS_ANDROID)
-	connectionListModel.addAddress("usb-serial");
+	connectionListModel.addAddress("usb-serial"); /* obsolete, can be removed when the new USB device selection is implemented. */
 #elif defined(Q_OS_LINUX) // since this is in the else, it does NOT include Android
 	connectionListModel.addAddress("/dev/ttyS0");
 	connectionListModel.addAddress("/dev/ttyS1");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This PR contains the serial_android_usb part of the changes proposed
in issue #2657.

This commit keeps compatibility with the current UI-Code in the case that only one USB-Device is connected. If two devices are connected, only the first one is tried (instead of all are tried, and the first for which usb-serial-for-android finds a driver is used)

### Changes made:

1) A data structure that contains all the data that can be used to describe an usb device (including user-facing string).
2) A function to get a list of all attached usb devices (optionally with selectable driver class).
3) Changes in the serial_android_usb_open-function and in the Java part to use the information about the usb device and optionally selected driver when connecting.


### Related issues:
#2657
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

There are still some small things to do:
- Change the user-facing string to something more descriptive.
- Parts which aren't uesd anymore when the UI-Part is implemented are simply marked as obsolete (to keep compatibility for now).

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

When the UI changes are done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

When the UI changes are done.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 
