### PR TITLE
Fix deselection of dives

### DIFF
--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -192,7 +192,7 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive)
 	}
 
 	// Send the new selection
-	emit diveListNotifier.divesSelected(divesToSelect, current_dive);
+	emit diveListNotifier.divesSelected(divesToSelect);
 }
 
 extern "C" void select_single_dive(dive *d)

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -94,7 +94,7 @@ signals:
 	void tripChanged(dive_trip *trip, TripField field);
 
 	// Selection changes
-	void divesSelected(const QVector<dive *> &dives, dive *current);
+	void divesSelected(const QVector<dive *> &dives);
 
 	// Dive site signals. Add and delete events are sent per dive site and
 	// provide an index into the global dive site table.

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1407,8 +1407,6 @@ QModelIndex DiveTripModelTree::diveToIdx(const dive *d) const
 void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *current)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
-	if (dives.empty())
-		return;
 
 	// We got a number of dives that have been selected. Turn this into QModelIndexes and
 	// emit a signal, so that views can change the selection.

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -475,7 +475,7 @@ void DiveTripModelBase::clear()
 	clear_dive_file_data();
 	clearData();
 	oldCurrent = nullptr;
-	emit diveListNotifier.divesSelected({}, nullptr); // Inform profile, etc of changed selection
+	emit diveListNotifier.divesSelected({}); // Inform profile, etc of changed selection
 	endResetModel();
 	emit diveListNotifier.numShownChanged();
 }
@@ -1404,7 +1404,7 @@ QModelIndex DiveTripModelTree::diveToIdx(const dive *d) const
 	}
 }
 
-void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *current)
+void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
 
@@ -1664,7 +1664,7 @@ QModelIndex DiveTripModelList::diveToIdx(const dive *d) const
 	return createIndex(it - items.begin(), 0);
 }
 
-void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *current)
+void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = visibleDives(divesIn);
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -113,7 +113,7 @@ public slots:
 	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *current);
+	void divesSelected(const QVector<dive *> &dives);
 	void tripChanged(dive_trip *trip, TripField);
 	void filterReset();
 
@@ -190,7 +190,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *current);
+	void divesSelected(const QVector<dive *> &dives);
 	void filterReset();
 
 public:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug, where the display was not cleared if no dive was selected.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't forget to clear the display of no dive is selected
2) Remove redundant current_dive parameter to selectionChanged signal

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2643: perhaps the confusing behavior described therein is caused by this. Not likely, but worth a try.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.