### PR TITLE
iostream: fix incorrect rfcomm error case when reading

### DIFF
--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -172,32 +172,27 @@ static dc_status_t qt_serial_write(void *io, const void* data, size_t size, size
 {
 	qt_serial_t *device = (qt_serial_t*) io;
 
-	if (device == NULL || device->socket == NULL)
+	if (device == NULL || device->socket == NULL || !actual)
 		return DC_STATUS_INVALIDARGS;
 
-	size_t nbytes = 0;
-	int rc;
+	*actual = 0;
+	for (;;) {
+		int rc;
 
-	while(nbytes < size && device->socket->state() == QBluetoothSocket::ConnectedState)
-	{
-		rc = device->socket->write((char *) data + nbytes, size - nbytes);
+		if (device->socket->state() != QBluetoothSocket::ConnectedState)
+			return DC_STATUS_IO;
+
+		rc = device->socket->write((char *) data, size);
 
 		if (rc < 0) {
 			if (errno == EINTR || errno == EAGAIN)
-			    continue; // Retry.
-
-			return DC_STATUS_IO; // Something really bad happened :-(
-		} else if (rc == 0) {
-			break;
+				continue;
+			return DC_STATUS_IO;
 		}
 
-		nbytes += rc;
+		*actual = rc;
+		return rc ? DC_STATUS_SUCCESS : DC_STATUS_IO;
 	}
-
-	if (actual)
-		*actual = nbytes;
-
-	return DC_STATUS_SUCCESS;
 }
 
 static dc_status_t qt_serial_poll(void *io, int timeout)


### PR DESCRIPTION
We had two independent bugs here, both of which needed to fire for this
to cause a problem.  This fixes both of them.

The first bug was that our rfcomm code would return DC_STATUS_SUCCESS
with a zero-sized read when a timeout happened, or when the rfcomm
socket had disconnected.  That makes absolutely no sense.  We should
return DC_STATUS_TIMEOUT on timeout, and DC_STATUS_IO if the socket has
disconnected without any data.

The fix to this is to make the whole rfcomm iostream read logic much
simpler: there's no need to loop at all for partial results, because the
libdivecomputer iostream side will do the loop for us (and handle
partial results much better: it knows if the target backend can handle
those partial results or not).

The second bug was in our libdivecomputer iostream read() function,
which reacted very badly to this bad return value.  This updates our
libdivecomputer branch to one that is more careful about things.

Reported-by: linuxcrash <albin@mrty.ch>
Debugged-by: Jef Driesen <jef@libdivecomputer.org>
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
