### PR TITLE
git: return strdup()ed empty string on error in pop_cstring

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -334,11 +334,11 @@ static char *pop_cstring(struct membuffer *str, const char *err)
 
 	if (!str) {
 		report_error("git-load: string marker without any strings ('%s')", err);
-		return "";
+		return strdup("");
 	}
 	if (!str->len) {
 		report_error("git-load: string marker after running out of strings ('%s')", err);
-		return "";
+		return strdup("");
 	}
 	len = strlen(mb_cstring(str)) + 1;
 	return remove_from_front(str, len);


### PR DESCRIPTION
The pop_cstring() function is used by the git parser to
duplicate a quoted string. On error, it returns an empty
string literal. Since the caller expects a copied string
and takes ownership of that string, it will ultimately
been freed.

Concrete example: a log with erroneous cylinder data was opened
getting such an empty string literal as description. On closing or
syncing with the cloud, the dive is freed, leading to a free
of the string literal -> crash.

Return a copy of the empty string instead.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a crash when opening and closing erroneous git logs. The whole proposition of the code appears scary to me: the parsing functions are either called with copies of strings or pointers into shared data depending on whether the textual data is quoted or not.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Return copies of the empty string from `pop_cstring()` on error to be consistent with the non-error case.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - this is an obscure bug that can only be hit with broken git-logs.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @torvalds