### PR TITLE
Android usb ui tuning

### DIFF
--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -366,7 +366,14 @@ Kirigami.Page {
 				text: qsTr("Rescan")
 				enabled: manager.btEnabled
 				onClicked: {
+					// refresh both USB and BT/BLE and make sure a reasonable entry is selected
+					var current = comboConnection.currentText
 					manager.rescanConnections()
+					// check if the same entry is still available; if not pick the first entry
+					var idx = comboConnection.find(current)
+					if (idx === -1)
+						idx = 0
+					comboConnection.currentIndex = idx
 				}
 			}
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -158,8 +158,8 @@ void QMLManager::btRescan()
 void QMLManager::rescanConnections()
 {
 	connectionListModel.removeAllAddresses();
-	btRescan();
 	usbRescan();
+	btRescan();
 #if defined(SERIAL_FTDI)
 	connectionListModel.addAddress("FTDI");
 #endif


### PR DESCRIPTION
simply implementing the two suggestions @charno made (well, one with a twist)

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
- show USB devices before BT/BLE devices on Android
- try to keep the same connection selected when user taps refresh - if the previous selection isn't available anymore, pick first one in the list

