### PR TITLE
filter: update fulltext index when editing dive

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -2,6 +2,7 @@
 
 #include "command_edit.h"
 #include "core/divelist.h"
+#include "core/fulltext.h"
 #include "core/qthelper.h" // for copy_qstring
 #include "core/selection.h"
 #include "core/subsurface-string.h"
@@ -108,6 +109,7 @@ void EditBase<T>::undo()
 
 	for (dive *d: dives) {
 		set(d, value);
+		fulltext_register(d); // Update the fulltext cache
 		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
 
@@ -678,8 +680,9 @@ void EditTagsBase::undo()
 			if (!tags.contains(tag))
 				tags.push_back(tag);
 		}
-		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 		set(d, tags);
+		fulltext_register(d); // Update the fulltext cache
+		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
 
 	std::swap(tagsToAdd, tagsToRemove);


### PR DESCRIPTION
In edit commands, the fulltext might have changed and therefore
we have to update the fulltext index.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a bug whereby the fulltext index was not updated correctly when editing a dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Update fulltext when editing a dive.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - introduced with fulltext index.