### PR TITLE
RFC: Qmlmanager cleanup

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -327,11 +327,12 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 
 void QMLManager::openLocalThenRemote(QString url)
 {
+	// clear out the models and the fulltext index
 	MobileModels::instance()->clear();
 	setNotificationText(tr("Open local dive data file"));
-	if (verbose)
-		appendTextToLog(QString("Open local dive data file %1").arg(url));
+	appendTextToLog(QString("Open dive data file %1 - git_local only is %2").arg(url).arg(git_local_only));
 	QByteArray fileNamePrt = QFile::encodeName(url);
+
 	/* if this is a cloud storage repo and we have no local cache (i.e., it's the first time
 	 * we try to open this), parse_file will ALWAYS connect to the remote and populate the cache.
 	 * Otherwise parse_file will respect the git_local_only flag and only update if that isn't set */
@@ -494,6 +495,7 @@ QString QMLManager::getCombinedLogs()
 
 void QMLManager::finishSetup()
 {
+	appendTextToLog("finishSetup called");
 	// Initialize cloud credentials.
 	git_local_only = !prefs.cloud_auto_sync;
 

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -170,12 +170,7 @@ public slots:
 	void appInitialized();
 	void applicationStateChanged(Qt::ApplicationState state);
 	void saveCloudCredentials(const QString &email, const QString &password, const QString &pin);
-	void tryRetrieveDataFromBackend();
-	void handleError(QNetworkReply::NetworkError nError);
-	void handleSslErrors(const QList<QSslError> &errors);
-	void retrieveUserid();
 	void loadDivesWithValidCredentials();
-	void provideAuth(QNetworkReply *reply, QAuthenticator *auth);
 	void commitChanges(QString diveId, QString number, QString date, QString location, QString gps,
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a rather drastic change. Mostly driven by the fact that the more I read the code, the less sense it made. I simply wasn't able to construct a use case where that whole convoluted second run through carefully validating credentials, syncing with the remote, etc, made any sense at all.
Maybe back when we synced the webservice ID there was a point to it? But then, why re-sync the git repo?
Clearly, this needs massive amounts of testing. And I'm not sure how to make sure that happens without creating an Android beta - and thereby risking that we mess things up (potentially badly) for people who are mostly just trying to get the latest features / USB Android, etc.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
rip out that whole second round of connecting to the backend

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @charno @mturkia @janmulder @atdotde @glance- @torvalds 
This really, really needs some testing of Subsurface-mobile. I think it should be fine to do that testing as mobile-on-desktop, but of course testing on device wouldn't hurt, either.