### PR TITLE
mobile/edit: don't add dive site twice to table

### DIFF
--- a/core/divesite.c
+++ b/core/divesite.c
@@ -171,6 +171,21 @@ struct dive_site *alloc_dive_site()
 	return ds;
 }
 
+struct dive_site *alloc_dive_site_with_name(const char *name)
+{
+	struct dive_site *ds = alloc_dive_site();
+	ds->name = copy_string(name);
+	return ds;
+}
+
+struct dive_site *alloc_dive_site_with_gps(const char *name, const location_t *loc)
+{
+	struct dive_site *ds = alloc_dive_site_with_name(name);
+	ds->location = *loc;
+
+	return ds;
+}
+
 /* when parsing, dive sites are identified by uuid */
 struct dive_site *alloc_or_get_dive_site(uint32_t uuid, struct dive_site_table *ds_table)
 {
@@ -231,8 +246,7 @@ void delete_dive_site(struct dive_site *ds, struct dive_site_table *ds_table)
 /* allocate a new site and add it to the table */
 struct dive_site *create_dive_site(const char *name, struct dive_site_table *ds_table)
 {
-	struct dive_site *ds = alloc_dive_site();
-	ds->name = copy_string(name);
+	struct dive_site *ds = alloc_dive_site_with_name(name);
 	add_dive_site_to_table(ds, ds_table);
 	return ds;
 }
@@ -240,11 +254,8 @@ struct dive_site *create_dive_site(const char *name, struct dive_site_table *ds_
 /* same as before, but with GPS data */
 struct dive_site *create_dive_site_with_gps(const char *name, const location_t *loc, struct dive_site_table *ds_table)
 {
-	struct dive_site *ds = alloc_dive_site();
-	ds->name = copy_string(name);
-	ds->location = *loc;
+	struct dive_site *ds = alloc_dive_site_with_gps(name, loc);
 	add_dive_site_to_table(ds, ds_table);
-
 	return ds;
 }
 

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -52,6 +52,8 @@ void sort_dive_site_table(struct dive_site_table *ds_table);
 int add_dive_site_to_table(struct dive_site *ds, struct dive_site_table *ds_table);
 struct dive_site *alloc_or_get_dive_site(uint32_t uuid, struct dive_site_table *ds_table);
 struct dive_site *alloc_dive_site();
+struct dive_site *alloc_dive_site_with_name(const char *name);
+struct dive_site *alloc_dive_site_with_gps(const char *name, const location_t *loc);
 int nr_of_dives_at_dive_site(struct dive_site *ds);
 bool is_dive_site_selected(struct dive_site *ds);
 void free_dive_site(struct dive_site *ds);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -922,7 +922,7 @@ static void setupDivesite(DiveSiteChange &res, struct dive *d, struct dive_site 
 		res.editDs = ds;
 		res.location = location;
 	} else {
-		res.createdDs.reset(create_dive_site_with_gps(locationtext, &location, &dive_site_table));
+		res.createdDs.reset(alloc_dive_site_with_name(locationtext));
 		add_dive_to_dive_site(d, res.createdDs.get());
 	}
 	res.changed = true;
@@ -1040,7 +1040,7 @@ bool QMLManager::checkLocation(DiveSiteChange &res, const DiveObjectHelper &myDi
 	if (myDive.location != location) {
 		ds = get_dive_site_by_name(qPrintable(location), &dive_site_table);
 		if (!ds && !location.isEmpty()) {
-			res.createdDs.reset(create_dive_site(qPrintable(location), &dive_site_table));
+			res.createdDs.reset(alloc_dive_site_with_name(qPrintable(location)));
 			res.changed = true;
 			ds = res.createdDs.get();
 		}


### PR DESCRIPTION
When editing a dive on mobile we might have to create a new
dive site. That site is added to the global dive site table
in the undo command. However, the code in QMLManager created
the dive site with create_dive_site*() functions, which already
adds it to the table. The undo command then added the dive
site again leading to a hang of the application.

To solve this problem, create new alloc_dive_site*()
functions that do the same as create_dive_site*()
but do not add it to the table.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a hang when editing a dive site in mobile. Details in the commit-description.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't add dive site to global table twice.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - introduced with divelist changes.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: should be put in beta quickly, since current master hangs when editing dive site!