### PR TITLE
git: parse into arbitrary table

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -340,7 +340,6 @@ extern struct dive *alloc_dive(void);
 extern void free_dive(struct dive *);
 extern void free_dive_dcs(struct divecomputer *dc);
 extern void record_dive_to_table(struct dive *dive, struct dive_table *table);
-extern void record_dive(struct dive *dive);
 extern void clear_dive(struct dive *dive);
 extern void copy_dive(const struct dive *s, struct dive *d);
 extern void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_components what, bool clear);

--- a/core/file.c
+++ b/core/file.c
@@ -325,7 +325,7 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 	}
 	free(current_sha);
 	if (git)
-		return git_load_dives(git, branch);
+		return git_load_dives(git, branch, table, trips, sites);
 
 	if ((ret = readfile(filename, &mem)) < 0) {
 		/* we don't want to display an error if this was the default file  */

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -19,7 +19,7 @@ extern struct git_repository *is_git_repository(const char *filename, const char
 extern int check_git_sha(const char *filename, git_repository **git_p, const char **branch_p);
 extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
 extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
-extern int git_load_dives(struct git_repository *, const char *);
+extern int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
 extern const char *saved_git_id;

--- a/core/parse.c
+++ b/core/parse.c
@@ -81,11 +81,6 @@ void record_dive_to_table(struct dive *dive, struct dive_table *table)
 	add_to_dive_table(table, table->nr, fixup_dive(dive));
 }
 
-void record_dive(struct dive *dive)
-{
-	record_dive_to_table(dive, &dive_table);
-}
-
 void start_match(const char *type, const char *name, char *buffer)
 {
 	if (verbose > 2)

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -803,7 +803,7 @@ void QMLManager::loadDivesWithValidCredentials()
 	}
 	if (git != dummy_git_repository) {
 		appendTextToLog(QString("have repository and branch %1").arg(branch));
-		error = git_load_dives(git, branch);
+		error = git_load_dives(git, branch, &dive_table, &trip_table, &dive_site_table);
 	} else {
 		appendTextToLog(QString("didn't receive valid git repo, try again"));
 		error = parse_file(fileNamePrt.data(), &dive_table, &trip_table, &dive_site_table);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The `parse_file()` function had a very surprising behavior: If you pass a git repository-style filename it would parse into the global dive table, not the supplied table! Hard to pull of, but still a bug: import dives from a git repository -> disaster.

@dirkhh: This appears like the right thing to do. However, I have no idea if that now breaks the mergeLocalRepo thing - that should be tested.