### PR TITLE
Mobile dive invalid ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: support marking dives as invalid
 Desktop: implement dive invalidation
 Mobile-android: remove libusb/FTDI support (largely non-functional)
 Mobile-android: Continue download after obtaining USB permission

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -187,6 +187,7 @@ Kirigami.ScrollablePage {
 								id: locationText
 								text: (undefined !== location && "" != location) ? location : qsTr("<unnamed dive site>")
 								font.weight: Font.Medium
+								font.strikeout: isInvalid
 								font.pointSize: subsurfaceTheme.smallPointSize
 								elide: Text.ElideRight
 								maximumLineCount: 1 // needed for elide to work at all
@@ -211,6 +212,7 @@ Kirigami.ScrollablePage {
 									text: (undefined !== dateTime) ? dateTime : ""
 									width: Math.max(locationText.width * 0.45, paintedWidth) // helps vertical alignment throughout listview
 									font.pointSize: subsurfaceTheme.smallPointSize
+									font.strikeout: isInvalid
 									color: selected ? subsurfaceTheme.darkerPrimaryTextColor : subsurfaceTheme.secondaryTextColor
 								}
 								// spacer, just in case
@@ -223,6 +225,7 @@ Kirigami.ScrollablePage {
 									text: (undefined !== depthDuration) ? depthDuration : ""
 									width: Math.max(Kirigami.Units.gridUnit * 3, paintedWidth) // helps vertical alignment throughout listview
 									font.pointSize: subsurfaceTheme.smallPointSize
+									font.strikeout: isInvalid
 									color: selected ? subsurfaceTheme.darkerPrimaryTextColor : subsurfaceTheme.secondaryTextColor
 								}
 							}
@@ -230,6 +233,7 @@ Kirigami.ScrollablePage {
 								id: numberText
 								text: "#" + number
 								font.pointSize: subsurfaceTheme.smallPointSize
+								font.strikeout: isInvalid
 								color: selected ? subsurfaceTheme.darkerPrimaryTextColor : subsurfaceTheme.secondaryTextColor
 								anchors {
 									right: parent.right

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -276,6 +276,12 @@ Kirigami.ScrollablePage {
 			manager.addDiveToTrip(currentItem.myData.id, currentItem.myData.tripBelow)
 		}
 	}
+	property QtObject toggleInvalidAction: Kirigami.Action {
+		text: currentItem && currentItem.myData && currentItem.myData.isInvalid ? qsTr("Mark dive as valid") : qsTr("Mark dive as invalid")
+		// icon: { name: "TBD" }
+		visible: currentItem && currentItem.myData && !currentItem.myData.isTrip
+		onTriggered: manager.toggleDiveInvalid(currentItem.myData.id)
+	}
 	property QtObject deleteAction: Kirigami.Action {
 		text: qsTr("Delete dive")
 		icon { name: ":/icons/trash-empty.svg" }
@@ -315,7 +321,7 @@ Kirigami.ScrollablePage {
 		enabled: manager.redoText !== ""
 		onTriggered: manager.redo()
 	}
-	property variant contextactions: [ removeDiveFromTripAction, addDiveToTripAboveAction, addDiveToTripBelowAction, deleteAction, mapAction, tripDetailsEdit, undoAction, redoAction ]
+	property variant contextactions: [ removeDiveFromTripAction, addDiveToTripAboveAction, addDiveToTripBelowAction, toggleInvalidAction, deleteAction, mapAction, tripDetailsEdit, undoAction, redoAction ]
 
 	function setupActions() {
 		if (Backend.cloud_verification_status === Enums.CS_VERIFIED || Backend.cloud_verification_status === Enums.CS_NOCLOUD) {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1404,6 +1404,16 @@ void QMLManager::deleteDive(int id)
 	changesNeedSaving();
 }
 
+void QMLManager::toggleDiveInvalid(int id)
+{
+	struct dive *d = get_dive_by_uniq_id(id);
+	if (!d) {
+		appendTextToLog("trying to toggle invalid flag of non-existing dive");
+		return;
+	}
+	Command::editInvalid(!d->invalid, true);
+}
+
 bool QMLManager::toggleDiveSite(bool toggle)
 {
 	if (toggle)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -185,6 +185,7 @@ public slots:
 	void saveChangesCloud(bool forceRemoteSync);
 	void selectDive(int id);
 	void deleteDive(int id);
+	void toggleDiveInvalid(int id);
 	void copyDiveData(int id);
 	void pasteDiveData(int id);
 	bool toggleDiveSite(bool toggle);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -244,6 +244,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	case MobileListModel::FirstGasRole: return getFirstGas(d);
 	case MobileListModel::SelectedRole: return d->selected;
 	case MobileListModel::DiveInTripRole: return d->divetrip != NULL;
+	case MobileListModel::IsInvalidRole: return d->invalid;
 	}
 #endif
 	switch (role) {

--- a/qt-models/mobilelistmodel.cpp
+++ b/qt-models/mobilelistmodel.cpp
@@ -51,6 +51,7 @@ QHash<int, QByteArray> MobileListModelBase::roleNames() const
 	roles[TripBelow] = "tripBelow";
 	roles[TripLocationRole] = "tripLocation";
 	roles[TripNotesRole] = "tripNotes";
+	roles[IsInvalidRole] = "isInvalid";
 	return roles;
 }
 

--- a/qt-models/mobilelistmodel.h
+++ b/qt-models/mobilelistmodel.h
@@ -59,6 +59,7 @@ public:
 		TripBelow,
 		TripLocationRole,
 		TripNotesRole,
+		IsInvalidRole
 	};
 	QHash<int, QByteArray> roleNames() const override;
 protected:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
this simply adds support for showing invalid dives with strikeout (just like on desktop) and to toggle the invalid flag on a dive
Arguably one might want to extend invalid support further: a setting to just not show them at all, ability to ignore them in the dive summary, etc

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
most likely needed, including screenshots

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 
This is a testament as how wonderful the undo commands are.
Implementing this was ridiculously trivial as I simply can reuse the existing undo command.