### PR TITLE
Revert "core: use set_lang_locale to modify prefs.locale.lang_locale"

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -471,7 +471,7 @@ QString uiLanguage(QLocale *callerLoc)
 	else
 		uiLang = languages[0];
 
-	qPrefLanguage::set_lang_locale(uiLang);
+	prefs.locale.lang_locale = copy_qstring(uiLang);
 
 	// there's a stupid Qt bug on MacOS where uiLanguages doesn't give us the country info
 	if (!uiLang.contains('-') && uiLang != loc.bcp47Name()) {


### PR DESCRIPTION
This reverts commit 573a4a5e2da9531fbaa9e82da57131edc691a851.

The commit broke setting the language in the desktop preferences:
Instead of setting the locale in the prefs struct, the locale
is set via qPrefLanguage. However, that saves the default language
(extracted from the system) to disk. Now when the language is
read from the preferences, we get that default value.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This reverts a commit that made setting the language in the preferences ineffective. The original commit says that it fixes an issue on mobile, though is not clear about which issue. Therefore - to be sure - we might conditionally compile this for the moment until we get a proper fix. However that bears the risk of having this conditional compilation forever without anybody knowing why. So I'd prefer to fix the issue right away.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug introduced in release cycle.
