### PR TITLE
divelist: don't initialize invalidFont at startup

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -190,16 +190,7 @@ static QString displayWeight(const struct dive *d, bool units)
 		return s + gettextFromC::tr("lbs");
 }
 
-static QFont struckOutFont()
-{
-	QFont font;
-	font.setStrikeOut(true);
-	return font;
-}
-static QBrush invalidForeground(Qt::gray);
-static QFont invalidFont = struckOutFont();
-
-QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
+QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role) const
 {
 #ifdef SUBSURFACE_MOBILE
 	// Special roles for mobile
@@ -509,8 +500,10 @@ void DiveTripModelBase::reset()
 	emit diveListNotifier.numShownChanged();
 }
 
-DiveTripModelBase::DiveTripModelBase(QObject *parent) : QAbstractItemModel(parent)
+DiveTripModelBase::DiveTripModelBase(QObject *parent) : QAbstractItemModel(parent),
+	invalidForeground(Qt::gray)
 {
+	invalidFont.setStrikeOut(true);
 }
 
 int DiveTripModelBase::columnCount(const QModelIndex&) const

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -5,6 +5,8 @@
 #include "core/dive.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include <QAbstractItemModel>
+#include <QBrush>
+#include <QFont>
 
 class DiveFilter;
 
@@ -88,9 +90,11 @@ signals:
 	void currentDiveChanged(QModelIndex index);
 protected:
 	dive *oldCurrent;
+	QBrush invalidForeground;
+	QFont invalidFont;
 
 	// Access trip and dive data
-	static QVariant diveData(const struct dive *d, int column, int role);
+	QVariant diveData(const struct dive *d, int column, int role) const;	// Not static because we have to access invalidFont
 	static QVariant tripData(const dive_trip *trip, int column, int role);
 	static QString tripTitle(const dive_trip *trip);
 	static QString tripShortDate(const dive_trip *trip);


### PR DESCRIPTION
To mark invalid dives, we use a struck out font, which was a static
variable at translation unit scope, i.e. initialized at application
startup. Sadly, this crashes on iOS.

It is unclear when we can initialize fonts. Try to move initialization
to the constructore of DiveTripModelBase and make the font a member
of that class. For consistency, also make the invalidBrush a member
of this class.

This now means that the diveData function cannot be static anymore,
since it needs access to the font and brush. But OK.

Reported-by: Dirk Hohndel <dirk@hohndel.org>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This attempts to fix a startup-crash on iOS. Apparently you can't initialize fonts on application startup, so defer to when the model is created. Let's hope that this is "late enough".

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh