### PR TITLE
Better pan zoom

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -277,6 +277,16 @@ Item {
 						// pass events through to the parent and eventually into the ListView
 						propagateComposedEvents: true
 
+						// for testing / debugging on a desktop
+						scrollGestureEnabled: true
+						onWheel: {
+							manager.appendTextToLog("wheel " + wheel.angleDelta)
+							if (wheel.angleDelta.y > 0)
+								qmlProfile.scale += 0.2
+							if (wheel.angleDelta.y < 0 && qmlProfile.scale > 1.1)
+								qmlProfile.scale -= 0.2
+						}
+
 						anchors.fill: parent
 						drag.target: qmlProfile
 						drag.axis: Drag.XAndYAxis

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -239,6 +239,10 @@ Item {
 					anchors.fill: parent
 					pinch.dragAxis: Pinch.XAndYAxis
 					onPinchStarted: {
+						// it's possible that we thought this was a pan and reduced opacity
+						// before realizing that this is actually a pinch/zoom. So let's reset this
+						// just in case
+						qmlProfile.opacity = 1.0
 						if (manager.verboseEnabebled)
 							manager.appendTextToLog("pinch started w/ previousScale " + qmlProfile.lastScale)
 					}

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -24,7 +24,18 @@ QMLProfile::QMLProfile(QQuickItem *parent) :
 	m_profileWidget->setPrintMode(true);
 	m_profileWidget->setFontPrintScale(fontScale);
 	connect(QMLManager::instance(), &QMLManager::sendScreenChanged, this, &QMLProfile::screenChanged);
+	connect(this, &QMLProfile::scaleChanged, this, &QMLProfile::triggerUpdate);
 	setDevicePixelRatio(QMLManager::instance()->lastDevicePixelRatio());
+}
+
+// we need this so we can connect update() to the scaleChanged() signal - which the connect above cannot do
+// directly as it chokes on the default parameter for update().
+// If the scale changes we may need to change our offsets to ensure that we still only show a subset of
+// the profile and not empty space around it, which the paint() method below will take care of, which will
+// eventually get called after we call update()
+void QMLProfile::triggerUpdate()
+{
+	update();
 }
 
 void QMLProfile::paint(QPainter *painter)

--- a/profile-widget/qmlprofile.h
+++ b/profile-widget/qmlprofile.h
@@ -28,6 +28,8 @@ public:
 public slots:
 	void setMargin(int margin);
 	void screenChanged(QScreen *screen);
+	void triggerUpdate();
+
 private:
 	int m_diveId;
 	qreal m_devicePixelRatio;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
As @mturkia suggested, we shouldn't allow the user to pan/zoom the profile in a way that shows the empty space outside of the profile.
This took an embarrassing number of attempts to get right, but in the end the code is really clean and simple, I think.

### Changes made:
1) allow simulation of zoom on the desktop (so much easier for debugging)
2) implement upper and lower constraints for the x and y offsets
3) ensure that we enforce those constraints when zooming

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
none, this is improving a features that hasn't been released, yet

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I don't think that's needed. This seems fairly intuitive

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 
@bstoeger -- just because I want to show off using std::min and std::max for clamping the value... (and I even looked up that this will be available as std::clamp in C++17 which we aren't quite ready for, yet) 