### PR TITLE
Properly update fulltext filter when editing a dive

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1248,8 +1248,11 @@ void EditDive::exchangeDives()
 	// it by swapping the dive data.
 	newDive->hidden_by_filter = oldDive->hidden_by_filter;
 
-	// Bluntly exchange dive data by shallow copy
+	// Bluntly exchange dive data by shallow copy.
+	// Don't forget to unregister the old and register the new dive!
+	fulltext_unregister(oldDive);
 	std::swap(*newDive, *oldDive);
+	fulltext_register(oldDive);
 	invalidate_dive_cache(oldDive);
 
 	// Changing times may have unsorted the dive and trip tables

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1242,6 +1242,12 @@ void EditDive::redo()
 
 void EditDive::exchangeDives()
 {
+	// Set the filter flag of the new dive to the old dive.
+	// Reason: When we send the dive-changed signal, the model will
+	// track the *change* of the filter flag, so we must not overwrite
+	// it by swapping the dive data.
+	newDive->hidden_by_filter = oldDive->hidden_by_filter;
+
 	// Bluntly exchange dive data by shallow copy
 	std::swap(*newDive, *oldDive);
 	invalidate_dive_cache(oldDive);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is supposed to fix a bug reported on the ML. When editing a dive, the fulltext filter must be updated. The desktop versions do this, but not the mobile version.

I'm not 100% convinced of the resolution, but already too tired to think about this.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Update hidden_by_filter flag
2) Update fulltext filter
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh