### PR TITLE
Save fix

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1272,12 +1272,12 @@ void QMLManager::changesNeedSaving()
 }
 
 void QMLManager::openNoCloudRepo()
-/*
- * Open the No Cloud repo. In case this repo does not (yet)
- * exists, create one first. When done, open the repo, which
- * is obviously empty when just created.
- */
 {
+	/*
+	 * Open the No Cloud repo. In case this repo does not (yet)
+	 * exists, create one first. When done, open the repo, which
+	 * is obviously empty when just created.
+	 */
 	QString filename = nocloud_localstorage();
 	const char *branch;
 	struct git_repository *git;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -260,6 +260,7 @@ private:
 	bool checkLocation(DiveSiteChange &change, const DiveObjectHelper &myDive, struct dive *d, QString location, QString gps);
 	bool checkDuration(const DiveObjectHelper &myDive, struct dive *d, QString duration);
 	bool checkDepth(const DiveObjectHelper &myDive, struct dive *d, QString depth);
+	int openAndMaybeSync(const char *filename);
 	bool currentGitLocalOnly;
 	Q_INVOKABLE DCDeviceData *m_device_data;
 	QString m_progressMessage;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
CRUD.
In local sync only mode we can get into a state where `alreadySaving` is `true` and never gets reset. As a result no changes that the user makes are ever saved :-(

This significantly redesigns the use of that flag to make it much tighter, just around the actual potential storage access.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
still need to add those

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger  I would REALLY appreciate your review - trying to release this within an hour if possible as that could really cause trouble for users.