### PR TITLE
[TRIVIAL] cleanup: remove loadFromCloud() declaration from QMLManager.h

### DIFF
--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -132,7 +132,6 @@ public:
 	bool verboseEnabled() const;
 	void setVerboseEnabled(bool verboseMode);
 
-	bool loadFromCloud() const;
 	void setLoadFromCloud(bool done);
 	void syncLoadFromCloud();
 


### PR DESCRIPTION
This getter functions was not defined anywhere.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This trivial cleanup is self-explanatory. Let's see if CI passes.
