### PR TITLE
cleanup: make QMLManager member functions private

### DIFF
--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -215,8 +215,6 @@ public slots:
 	void copyAppLogToClipboard();
 	bool createSupportEmail();
 	void finishSetup();
-	void openLocalThenRemote(QString url);
-	void mergeLocalRepo();
 	QString getNumber(const QString& diveId);
 	QString getDate(const QString& diveId);
 	QString getCurrentPosition();
@@ -279,6 +277,8 @@ private:
 	void loadDivesWithValidCredentials();
 	void revertToNoCloudIfNeeded();
 	void consumeFinishedLoad();
+	void mergeLocalRepo();
+	void openLocalThenRemote(QString url);
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	QString appLogFileName;


### PR DESCRIPTION
The
	- mergeLocalRepo()
	- openLocalThenRemove()
functions were not invoked from outside QMLManager.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Weird - why did I miss those yesterday...?
