### PR TITLE
[RFC] mobile: don't call saveChangesLocal() twice on non-iOS

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1267,8 +1267,9 @@ void QMLManager::changesNeedSaving()
 	// on iOS
 	// on all other platforms we just save the changes and be done with it
 	mark_divelist_changed(true);
+#if defined(Q_OS_IOS)
 	saveChangesLocal();
-#if !defined(Q_OS_IOS)
+#else
 	saveChangesCloud(false);
 #endif
 	updateAllGlobalLists();


### PR DESCRIPTION
QMLManager::changesNeedSaving() behaves differently on iOS:
it only saves locally with saveChangesLocal(), whereas all
other OS save to cloud with saveChangesCloud(). Nevertheless,
even for other OS saveChangesLocal() is called even though
that will be called in saveChancesCloud anyway. Therefore,
compile the saveChangesLocal() call in changesNeedSaving
conditionally.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Unless I'm missing something, there appears to be no reason to call saveChangesLocal() twice on non-iOS?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Conditionally compile saveChangesLocal() - this makes the code a bit more logical to me, YMMV.

The call-graph then becomes:
![call2](https://user-images.githubusercontent.com/32835590/78027194-44b3ac80-735d-11ea-890e-71f7de7e9ddf.png)
