### PR TITLE
[TEST] cleanup: don't compile subsurface-helper.cpp for tests

### DIFF
--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -33,7 +33,6 @@ QString getAndroidHWInfo(); // from android.cpp
 #include <QFontDatabase>
 #endif /* Q_OS_ANDROID */
 
-#ifndef SUBSURFACE_TEST_DATA
 QObject *qqWindowObject = NULL;
 
 // Forward declaration
@@ -181,7 +180,6 @@ static void register_meta_types()
 {
 	qRegisterMetaType<duration_t>();
 }
-#endif // not SUBSURFACE_TEST_DATA
 
 template <typename T>
 static void register_qml_type(const char *name)
@@ -195,8 +193,6 @@ static void register_qml_types(QQmlEngine *engine)
 	// register qPref*
 	qPref::registerQML(engine);
 
-#ifndef SUBSURFACE_TEST_DATA
-
 #ifdef SUBSURFACE_MOBILE
 	register_qml_type<QMLManager>("QMLManager");
 	register_qml_type<QMLProfile>("QMLProfile");
@@ -206,5 +202,4 @@ static void register_qml_types(QQmlEngine *engine)
 
 	register_qml_type<MapWidgetHelper>("MapWidgetHelper");
 	register_qml_type<MapLocationModel>("MapLocationModel");
-#endif // not SUBSURFACE_TEST_DATA
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,8 +88,7 @@ add_definitions(-g)
 add_definitions(-DSUBSURFACE_TEST_DATA="${SUBSURFACE_TEST_DATA}")
 
 # Build QML test runner
-# add_executable demands relative path, therefore ../
-add_executable(TestQML testqml.cpp ../subsurface-helper.cpp )
+add_executable(TestQML testqml.cpp)
 target_link_libraries(
 	TestQML
 	subsurface_corelib


### PR DESCRIPTION
It is unclear why the subsurface-helper.cpp file was linked with the
tests. In any case, it led to comlicated ifdef-ery, so let's remove
that for now and readd later if the need arises.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is mostly for CI. I don't understand why the subsurface-helper.cpp file was compiled for the tests, since most of the file was ifdef-ed out anyway. Perhaps CI will tell me.