### PR TITLE
Use the undo stack to check for unsaved changes on mobile

### DIFF
--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -2,6 +2,7 @@
 
 #include "command_base.h"
 #include "core/qthelper.h" // for updateWindowTitle()
+#include "core/divelist.h" // for unsaved_changes()
 #include "core/subsurface-qt/divelistnotifier.h"
 #include <QVector>
 
@@ -31,7 +32,7 @@ void setClean()
 
 bool isClean()
 {
-	return undoStack.isClean();
+	return !unsaved_changes() && undoStack.isClean();
 }
 
 // this can be used to get access to the signals emitted by the QUndoStack

--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -2,7 +2,7 @@
 
 #include "command_base.h"
 #include "core/qthelper.h" // for updateWindowTitle()
-#include "core/divelist.h" // for unsaved_changes()
+#include "core/divelist.h" // for unsaved_changes() and mark_divelist_changed
 #include "core/subsurface-qt/divelistnotifier.h"
 #include <QVector>
 
@@ -27,6 +27,7 @@ void clear()
 
 void setClean()
 {
+	mark_divelist_changed(false);
 	undoStack.setClean();
 }
 

--- a/core/file.c
+++ b/core/file.c
@@ -12,7 +12,6 @@
 
 #include "dive.h"
 #include "subsurface-string.h"
-#include "divelist.h"
 #include "errorhelper.h"
 #include "file.h"
 #include "git-access.h"
@@ -297,7 +296,6 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 {
 	struct git_repository *git;
 	const char *branch = NULL;
-	char *current_sha = copy_string(saved_git_id);
 	struct memblock mem;
 	char *fmt;
 	int ret;
@@ -308,22 +306,8 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 	    && git == dummy_git_repository) {
 		/* opening the cloud storage repository failed for some reason
 		 * give up here and don't send errors about git repositories */
-		free(current_sha);
 		return -1;
 	}
-	/* if this is a git repository, do we already have this exact state loaded ?
-	 * get the SHA and compare with what we currently have */
-	if (git && git != dummy_git_repository) {
-		const char *sha = get_sha(git, branch);
-		if (!empty_string(sha) &&
-		    same_string(sha, current_sha) &&
-		    !unsaved_changes()) {
-			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
-			free(current_sha);
-			return 0;
-		}
-	}
-	free(current_sha);
 	if (git)
 		return git_load_dives(git, branch, table, trips, sites);
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -582,7 +582,7 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 		return;
 
 	setCurrentFile(qPrintable(filename));
-	setFileClean();
+	Command::setClean();
 }
 
 void MainWindow::on_actionCloudOnline_triggered()
@@ -638,12 +638,6 @@ bool MainWindow::okToClose(QString message)
 	return true;
 }
 
-void MainWindow::setFileClean()
-{
-	mark_divelist_changed(false);
-	Command::setClean();
-}
-
 void MainWindow::closeCurrentFile()
 {
 	/* free the dives and trips */
@@ -655,7 +649,7 @@ void MainWindow::closeCurrentFile()
 	if (!existing_filename)
 		setTitle();
 	disableShortcuts();
-	setFileClean();
+	Command::setClean();
 
 	clear_events();
 
@@ -1568,7 +1562,7 @@ int MainWindow::file_save_as(void)
 		return -1;
 
 	setCurrentFile(qPrintable(filename));
-	setFileClean();
+	Command::setClean();
 	addRecentFile(filename, true);
 	return 0;
 }
@@ -1605,7 +1599,7 @@ int MainWindow::file_save(void)
 	}
 	if (is_cloud)
 		hideProgressBar();
-	setFileClean();
+	Command::setClean();
 	addRecentFile(QString(existing_filename), true);
 	return 0;
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -585,14 +585,6 @@ void MainWindow::on_actionCloudstoragesave_triggered()
 	setFileClean();
 }
 
-// Currently we have two markers for unsaved changes:
-// 1) unsaved_changes() returns true for non-undoable changes.
-// 2) Command::isClean() returns false for undoable changes.
-static bool unsavedChanges()
-{
-	return unsaved_changes() || !Command::isClean();
-}
-
 void MainWindow::on_actionCloudOnline_triggered()
 {
 	bool isOffline = !ui.actionCloudOnline->isChecked();
@@ -612,7 +604,7 @@ void MainWindow::on_actionCloudOnline_triggered()
 	git_local_only = isOffline;
 	if (!isOffline) {
 		// User requests to go online. Try to sync cloud storage
-		if (unsavedChanges()) {
+		if (!Command::isClean()) {
 			// If there are unsaved changes, ask the user if they want to save them.
 			// If they don't, they have to sync manually.
 			if (QMessageBox::warning(this, tr("Save changes?"),
@@ -640,7 +632,7 @@ bool MainWindow::okToClose(QString message)
 		QMessageBox::warning(this, tr("Warning"), message);
 		return false;
 	}
-	if (unsavedChanges() && askSaveChanges() == false)
+	if (!Command::isClean() && askSaveChanges() == false)
 		return false;
 
 	return true;
@@ -758,7 +750,7 @@ void MainWindow::on_actionQuit_triggered()
 			return;
 	}
 
-	if (unsavedChanges() && (askSaveChanges() == false))
+	if (!Command::isClean() && (askSaveChanges() == false))
 		return;
 	writeSettings();
 	QApplication::quit();
@@ -1427,7 +1419,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 		return;
 	}
 
-	if (unsavedChanges() && (askSaveChanges() == false)) {
+	if (!Command::isClean() && (askSaveChanges() == false)) {
 		event->ignore();
 		return;
 	}
@@ -1652,7 +1644,7 @@ void MainWindow::setTitle()
 		return;
 	}
 
-	QString unsaved = (unsavedChanges() ? " *" : "");
+	QString unsaved = (!Command::isClean() ? " *" : "");
 	QString shown = QString(" (%1)").arg(filterWidget2.shownText());
 	setWindowTitle("Subsurface: " + displayedFilename(existing_filename) + unsaved + shown);
 }

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -205,7 +205,6 @@ private:
 	void writeSettings();
 	int file_save();
 	int file_save_as();
-	void setFileClean();
 	void beginChangeState(CurrentState s);
 	void saveSplitterSizes();
 	void toggleCollapsible(bool toggle);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -301,10 +301,10 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 	}
 	stateText.prepend("AppState changed to ");
 	stateText.append(" with ");
-	stateText.append((unsaved_changes() ? QLatin1String("") : QLatin1String("no ")) + QLatin1String("unsaved changes"));
+	stateText.append((!Command::isClean() ? QLatin1String("") : QLatin1String("no ")) + QLatin1String("unsaved changes"));
 	appendTextToLog(stateText);
 
-	if (state == Qt::ApplicationInactive && unsaved_changes()) {
+	if (state == Qt::ApplicationInactive && !Command::isClean()) {
 		// saveChangesCloud ensures that we don't have two conflicting saves going on
 		appendTextToLog("trying to save data as user switched away from app");
 		saveChangesCloud(false);
@@ -1304,7 +1304,7 @@ void QMLManager::openNoCloudRepo()
 
 void QMLManager::saveChangesLocal()
 {
-	if (unsaved_changes()) {
+	if (!Command::isClean()) {
 		if (qPrefCloudStorage::cloud_verification_status() == qPrefCloudStorage::CS_NOCLOUD) {
 			if (empty_string(existing_filename)) {
 				QString filename = nocloud_localstorage();
@@ -1335,7 +1335,7 @@ void QMLManager::saveChangesLocal()
 			set_filename(NULL);
 			return;
 		}
-		mark_divelist_changed(false);
+		Command::setClean();
 	} else {
 		appendTextToLog("local save requested with no unsaved changes");
 	}
@@ -1343,7 +1343,7 @@ void QMLManager::saveChangesLocal()
 
 void QMLManager::saveChangesCloud(bool forceRemoteSync)
 {
-	if (!unsaved_changes() && !forceRemoteSync) {
+	if (Command::isClean() && !forceRemoteSync) {
 		appendTextToLog("asked to save changes but no unsaved changes");
 		return;
 	}
@@ -1729,7 +1729,7 @@ void QMLManager::screenChanged(QScreen *screen)
 
 void QMLManager::quit()
 {
-	if (unsaved_changes())
+	if (!Command::isClean())
 		saveChangesCloud(false);
 	QApplication::quit();
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Mobile doesn't use the undo stack when determining whether there are unsaved changes, which lead to not saving, when it should have saved. Therefore move this functionality from mainwindow.cpp to qthelper.cpp.

This currently breaks the tests, since I didn't figure out how to compile the undo-commands for the tests. Note that we will have to do this in the future anyway, because we *want* to test the undo commands and their interaction with the mobile models.
