### PR TITLE
cleanup: copy saved_git_id, don't use local buffer

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1677,15 +1677,17 @@ static int load_dives_from_tree(git_repository *repo, git_tree *tree, struct git
 
 void clear_git_id(void)
 {
+	free((void *)saved_git_id);
 	saved_git_id = NULL;
 }
 
 void set_git_id(const struct git_oid *id)
 {
-	static char git_id_buffer[GIT_OID_HEXSZ + 1];
+	char git_id_buffer[GIT_OID_HEXSZ + 1];
 
 	git_oid_tostr(git_id_buffer, sizeof(git_id_buffer), id);
-	saved_git_id = git_id_buffer;
+	free((void *)saved_git_id);
+	saved_git_id = strdup(git_id_buffer);
 }
 
 static int find_commit(git_repository *repo, const char *branch, git_commit **commit_p)


### PR DESCRIPTION
In an attempt to reduce the number of global variables, don't use
a local buffer to store the currently loaded git-id. The git-id
itself is still a global variable, which in the future can hopefully
be encapsulated in a "struct File" or similar.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A tiny step in reducing the number of global variables.