### PR TITLE
undo/mobile: keep track of dive sites

### DIFF
--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -386,6 +386,7 @@ public:
 private:
 	dive *oldDive; // Dive that is going to be overwritten
 	OwningDivePtr newDive; // New data
+	dive_site *newDiveSite;
 	int changedFields;
 
 	dive_site *siteToRemove;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -799,7 +799,7 @@ static void setupDivesite(DiveSiteChange &res, struct dive *d, struct dive_site 
 		res.location = location;
 	} else {
 		res.createdDs.reset(alloc_dive_site_with_name(locationtext));
-		add_dive_to_dive_site(d, res.createdDs.get());
+		d->dive_site = res.createdDs.get();
 	}
 	res.changed = true;
 }
@@ -920,8 +920,7 @@ bool QMLManager::checkLocation(DiveSiteChange &res, const DiveObjectHelper &myDi
 			res.changed = true;
 			ds = res.createdDs.get();
 		}
-		unregister_dive_from_dive_site(d);
-		add_dive_to_dive_site(d, ds);
+		d->dive_site = ds;
 	}
 	// now make sure that the GPS coordinates match - if the user changed the name but not
 	// the GPS coordinates, this still does the right thing as the now new dive site will


### PR DESCRIPTION
When editing the dive site of a dive, the dive-table of the
corresponding dive site was not properly updated by the undo
commands. Try to get this right.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->


This fixes a data-inconsistency when editing the dive site on mobile: the dive-table of the dive site was not updated properly. It's a small wonder that that hasn't caused any crashes. This tries to do it right and in my few tests I couldn't get it to crash.

This code is pretty hairy. I really wish that we could use desktops' fine grained undo to avoid having to get all these subtle things right twice. Idea: do fine grained undo, but only save if the user exits the edit-screen. The question then is: do we save after every undo as well?

PS: I found a weird behavior: If a dive-site has GPS, the user can't simply remove the dive from that site: If the user erases the name, then the code will detect that there are GPS coordinates and attempt to create a new dive site. For that purpose it takes the name of the *old* dive site, which the user wanted to clear:

```
                        setupDivesite(res, d, ds, lat, lon, qPrintable(myDive.location));
```

That appears wrong. But I don't know what happens if we pass the empty string here.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add and remove dive from dive_site in EditDive command.
