### PR TITLE
mobile/startup: fix potential crash when switching back and forth

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -300,6 +300,7 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 {
+	static bool initializeOnce = false;
 	QString stateText;
 	switch (state) {
 	case Qt::ApplicationActive: stateText = "active"; break;
@@ -313,8 +314,9 @@ void QMLManager::applicationStateChanged(Qt::ApplicationState state)
 	stateText.append((unsaved_changes() ? QLatin1String("") : QLatin1String("no ")) + QLatin1String("unsaved changes"));
 	appendTextToLog(stateText);
 
-	if (state == Qt::ApplicationActive && !m_initialized) {
+	if (state == Qt::ApplicationActive && !m_initialized && !initializeOnce) {
 		// once the app UI is displayed, finish our setup and mark the app as initialized
+		initializeOnce = true;
 		finishSetup();
 		appInitialized();
 	}


### PR DESCRIPTION
If the user switches away from Subsurface-mobile and back while we are
in our initialization phase, that code might run more than once leading
to undesirable results.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
I know just how much @bstoeger loves static variables in functions...
But this seemed like the most obvious way to fix the problem.
