### PR TITLE
mobile/edits: ensure changesNeedSaving is called

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1410,6 +1410,7 @@ void QMLManager::toggleDiveInvalid(int id)
 		return;
 	}
 	Command::editInvalid(!d->invalid, true);
+	changesNeedSaving();
 }
 
 bool QMLManager::toggleDiveSite(bool toggle)
@@ -1510,6 +1511,7 @@ void QMLManager::pasteDiveData(int id)
 		return;
 	}
 	Command::pasteDives(m_copyPasteDive, what);
+	changesNeedSaving();
 }
 
 void QMLManager::cancelDownloadDC()
@@ -1533,6 +1535,8 @@ int QMLManager::addDive()
 	fixup_dive(&d);
 
 	// addDive takes over the dive and clears out the structure passed in
+	// we do NOT save the modified data at this stage because of the UI flow here... this will
+	// be saved once the user finishes editing the newly added dive
 	Command::addDive(&d, autogroup, true);
 
 	if (verbose)


### PR DESCRIPTION
These appear to be the only cases where we forgot to ensure data is
saved.  And pastDiveData is currently not called as the UI to use it has
been removed.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
belts and suspenders with checking the undo code for outstanding changes that need saving

