### PR TITLE
Allow any cylinder-names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: fix creation of new cylinder types (names couldn't be the start of already existing names)
 Mobile: remove locking of data storage access
 Mobile: performance improvements for dive list
 Mobile: user notification of progress during startup

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -336,19 +336,16 @@ void WSInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelInd
 {
 	WeightModel *mymodel = qobject_cast<WeightModel *>(currCombo.model);
 	WSInfoModel *wsim = WSInfoModel::instance();
-	QModelIndexList matches = wsim->match(wsim->index(0, 0), Qt::DisplayRole, currCombo.activeText, 1, Qt::MatchFixedString | Qt::MatchWrap);
-	int row;
-	if (matches.isEmpty()) {
-		// we need to add this puppy
-		wsim->insertRows(wsim->rowCount(), 1);
-		wsim->setData(wsim->index(wsim->rowCount() - 1, 0), currCombo.activeText);
-		row = wsim->rowCount() - 1;
-	} else {
-		row = matches.first().row();
+	QString weightName = currCombo.activeText;
+	QModelIndexList matches = wsim->match(wsim->index(0, 0), Qt::DisplayRole, weightName, 1, Qt::MatchFixedString | Qt::MatchWrap);
+	int grams = 0;
+	if (!matches.isEmpty()) {
+		int row = matches.first().row();
+		weightName = matches.first().data().toString();
+		grams = wsim->data(wsim->index(row, WSInfoModel::GR)).toInt();
 	}
-	int grams = wsim->data(wsim->index(row, WSInfoModel::GR)).toInt();
 
-	mymodel->setTempWS(currCombo.currRow, weightsystem_t{ { grams }, copy_qstring(currCombo.activeText) });
+	mymodel->setTempWS(currCombo.currRow, weightsystem_t{ { grams }, copy_qstring(weightName) });
 }
 
 WSInfoDelegate::WSInfoDelegate(QObject *parent) : ComboBoxDelegate(WSInfoModel::instance(), parent, true)

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -240,7 +240,7 @@ void TankInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelI
 {
 	QAbstractItemModel *mymodel = currCombo.model;
 	TankInfoModel *tanks = TankInfoModel::instance();
-	QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, currCombo.activeText);
+	QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, currCombo.activeText, 1, Qt::MatchFixedString | Qt::MatchWrap);
 	int row;
 	QString cylinderName = currCombo.activeText;
 	if (matches.isEmpty()) {
@@ -336,7 +336,7 @@ void WSInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelInd
 {
 	WeightModel *mymodel = qobject_cast<WeightModel *>(currCombo.model);
 	WSInfoModel *wsim = WSInfoModel::instance();
-	QModelIndexList matches = wsim->match(wsim->index(0, 0), Qt::DisplayRole, currCombo.activeText);
+	QModelIndexList matches = wsim->match(wsim->index(0, 0), Qt::DisplayRole, currCombo.activeText, 1, Qt::MatchFixedString | Qt::MatchWrap);
 	int row;
 	if (matches.isEmpty()) {
 		// we need to add this puppy


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a spin-off of the cylinder undo. I was puzzled where the new code was wrong. Turns out that the code is broken for a long time!? The user can't create new cylinder-names that are the beginning of already existing names. E.g.: Can't create a cylinder "AL6" if there already exists a cylinder "AL67". Very weird.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use case-insensitive fullstring search instead of starts-with search when accessing cylinders and weightsystems.
2) Remove redundant weight-system code.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
As far as I can tell this is a bug in release, therefore done.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia: paging you since you are the only person testing cylinder code at the moment. Perhaps I'm missing something obvious?