### PR TITLE
git: don't check for git sha in parse_file()

### DIFF
--- a/core/file.c
+++ b/core/file.c
@@ -12,7 +12,6 @@
 
 #include "dive.h"
 #include "subsurface-string.h"
-#include "divelist.h"
 #include "errorhelper.h"
 #include "file.h"
 #include "git-access.h"
@@ -297,7 +296,6 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 {
 	struct git_repository *git;
 	const char *branch = NULL;
-	char *current_sha = copy_string(saved_git_id);
 	struct memblock mem;
 	char *fmt;
 	int ret;
@@ -308,22 +306,8 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 	    && git == dummy_git_repository) {
 		/* opening the cloud storage repository failed for some reason
 		 * give up here and don't send errors about git repositories */
-		free(current_sha);
 		return -1;
 	}
-	/* if this is a git repository, do we already have this exact state loaded ?
-	 * get the SHA and compare with what we currently have */
-	if (git && git != dummy_git_repository) {
-		const char *sha = get_sha(git, branch);
-		if (!empty_string(sha) &&
-		    same_string(sha, current_sha) &&
-		    !unsaved_changes()) {
-			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
-			free(current_sha);
-			return 0;
-		}
-	}
-	free(current_sha);
 	if (git)
 		return git_load_dives(git, branch, table, trips, sites);
 


### PR DESCRIPTION
parse_file() refused to load from a git repository if we already
had that repository and there were no changes. However, this only
checked the global divelist_changed flag, which does not track
undo-commands. Thus, after editing dives the user couldn't reload
from git.

Remove this check. It is somewhat questionable that the io layer
refuses to load from a repository anyway. Let the caller decide.
There appears to be a check_git_sha function for that purpose(?).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a borderline bug-fix as a user might not be able to reload from cloud after doing some changes. See previous discussion.
