### PR TITLE
Fulltext: attempt to not crash when regenerating the fulltext cache

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -831,7 +831,7 @@ void process_loaded_dives()
 	/* Autogroup dives if desired by user. */
 	autogroup_dives(&dive_table, &trip_table);
 
-	fulltext_reload();
+	fulltext_populate();
 }
 
 /*

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -146,7 +146,6 @@ void FullText::populate()
 	// we want this to be two calls as the second text is overwritten below by the lines starting with "\r"
 	uiNotification(QObject::tr("Create full text index"));
 	uiNotification(QObject::tr("start processing"));
-	words.clear();
 	int i;
 	dive *d;
 	for_each_dive(i, d) {

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -18,7 +18,7 @@ class FullText {
 	std::map<QString, std::vector<dive *>> words; // Dives that belong to each word
 public:
 
-	void reload(); // Rebuild from current dive_table
+	void populate(); // Rebuild from current dive_table
 	void registerDive(struct dive *d); // Note: can be called repeatedly
 	void unregisterDive(struct dive *d); // Note: can be called repeatedly
 	void unregisterAll(); // Unregister all dives in the dive table
@@ -51,9 +51,9 @@ void fulltext_unregister_all()
 	self.unregisterAll();
 }
 
-void fulltext_reload()
+void fulltext_populate()
 {
-	self.reload();
+	self.populate();
 }
 
 } // extern "C"
@@ -141,7 +141,7 @@ static std::vector<QString> getWords(const dive *d)
 	return res;
 }
 
-void FullText::reload()
+void FullText::populate()
 {
 	// we want this to be two calls as the second text is overwritten below by the lines starting with "\r"
 	uiNotification(QObject::tr("Create full text index"));

--- a/core/fulltext.h
+++ b/core/fulltext.h
@@ -24,7 +24,7 @@ struct dive;
 void fulltext_register(struct dive *d); // Note: can be called repeatedly
 void fulltext_unregister(struct dive *d); // Note: can be called repeatedly
 void fulltext_unregister_all(); // Unregisters all dives in the dive table
-void fulltext_reload(); // Registers all dives in the dive table
+void fulltext_populate(); // Registers all dives in the dive table
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is code hygiene and hopefully a crash-fix.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) The fulltext_reload() function was supposed to create the initial fulltext cache. Therefore rename it to fulltext_populate()
2) It was crashing if called on a dive list that had was already indexed previously. Fix that by not clearing the word chache.


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: Please try if this fixes your problem with the git-test. However, I fear that the whole parse directly into the existing dive-list is problematic.