### PR TITLE
media: invalidate correct dive when removing picture

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3532,7 +3532,7 @@ bool dive_remove_picture(struct dive *d, const char *filename)
 		struct picture *temp = (*picture)->next;
 		free_picture(*picture);
 		*picture = temp;
-		invalidate_dive_cache(current_dive);
+		invalidate_dive_cache(d);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
This fixes a bug: when deleting a picture when multiple dives
were selected, possibly the wrong dive was invalidated.
Thus, the dive wouldn't have been saved to the git repository.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a somewhat obscure bug: select multiple dives, erase picture of dive that isn't the current dive -> it is not marked as invalid and will not be saved.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Invalidate correct dive

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Probably too petty.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
