### PR TITLE
cleanup: don't keep pointer-to-picture in PictureEntry

### DIFF
--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -59,7 +59,7 @@ void DivePictureModel::updateDivePictures()
 		if (dive->selected) {
 			int first = pictures.count();
 			FOR_EACH_PICTURE(dive)
-				pictures.push_back({ dive->id, picture, picture->filename, {}, picture->offset.seconds, {.seconds = 0}});
+				pictures.push_back({ dive->id, picture->filename, {}, picture->offset.seconds, {.seconds = 0}});
 
 			// Sort pictures of this dive by offset.
 			// Thus, the list will be sorted by (diveId, offset).

--- a/qt-models/divepicturemodel.h
+++ b/qt-models/divepicturemodel.h
@@ -10,7 +10,6 @@
 
 struct PictureEntry {
 	int diveId;
-	struct picture *picture;
 	QString filename;
 	QImage image;
 	int offsetSeconds;


### PR DESCRIPTION
The DivePictureModel kept a pointer to picture for each entry.
Firstly, this is dangerous from a data-consistency point of view.
Secondly, the entry wasn't even used anywhere. Remove it.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A rather trivial code cleanup: remove unused field in PictureEntry struct.
