### PR TITLE
delegates: remove TankInfoDelegate::createEditor()

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -247,13 +247,6 @@ void TankInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint
 		mymodel->setData(IDX(CylindersModel::TYPE), currCombo.activeText, CylindersModel::COMMIT_ROLE);
 }
 
-QWidget *TankInfoDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
-{
-	QWidget *delegate = ComboBoxDelegate::createEditor(parent, option, index);
-	MainWindow::instance()->graphics->setReplot(false);
-	return delegate;
-}
-
 TankUseDelegate::TankUseDelegate(QObject *parent) : QStyledItemDelegate(parent)
 {
 }

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -63,7 +63,6 @@ class TankInfoDelegate : public ComboBoxDelegate {
 public:
 	explicit TankInfoDelegate(QObject *parent = 0);
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 public
 slots:
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -376,14 +376,10 @@ void ProfileWidget2::setupItemOnScene()
 	timeAxis->setLinesVisible(true);
 	profileYAxis->setLinesVisible(true);
 	gasYAxis->setZValue(timeAxis->zValue() + 1);
-
-	replotEnabled = true;
 }
 
 void ProfileWidget2::replot(struct dive *d)
 {
-	if (!replotEnabled)
-		return;
 	dataModel->clear();
 	plotDive(d, true, false);
 }
@@ -1401,11 +1397,6 @@ struct int ProfileWidget2::getEntryFromPos(QPointF pos)
 	return plotInfo.nr - 1;
 }
 #endif
-
-void ProfileWidget2::setReplot(bool state)
-{
-	replotEnabled = state;
-}
 
 #ifndef SUBSURFACE_MOBILE
 void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -108,7 +108,6 @@ slots: // Necessary to call from QAction's signals.
 	void actionRequestedReplot(bool triggered);
 	void setEmptyState();
 	void setProfileState();
-	void setReplot(bool state);
 	void replot(dive *d = 0);
 #ifndef SUBSURFACE_MOBILE
 	void plotPictures();
@@ -185,7 +184,6 @@ private:
 	ToolTipItem *toolTipItem;
 #endif
 	bool isPlotZoomed;
-	bool replotEnabled;
 	// All those here should probably be merged into one structure,
 	// So it's esyer to replicate for more dives later.
 	// In the meantime, keep it here.


### PR DESCRIPTION
When creating a TankInfoDelegate editor, reploting of the profile
was disabled to avoid replotting when the user scrolls through
the tank-info list. Since the code was changed to only set the
tank-info when the editor is closed, this became unnecessary
(hopefully). Indeed the clearing of the flag was removed in a
previous flag. This means that we also have to remove the setting
of the flag. Since this is all the TankInfoDelegate::createEditor()
function was doing, we can remove the whole function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a fallout of the cylinder-undo code. The clearing of the don't replot-flag was removed. Therefore, the setting should also be removed.