### PR TITLE
[TRIVIAL] cleanup: remove unnecessary profile update after adding new dive

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -86,7 +86,6 @@ namespace {
 	};
 }
 
-
 extern "C" int updateProgress(const char *text)
 {
 	if (verbose)
@@ -969,10 +968,6 @@ void MainWindow::on_actionAddDive_triggered()
 	fixup_dive(&d);
 
 	Command::addDive(&d, autogroup, true);
-
-	// Plot dive actually copies current_dive to displayed_dive and therefore ensures that the
-	// correct data are displayed!
-	graphics->plotDive(nullptr, false, true);
 }
 
 void MainWindow::on_actionRenumber_triggered()


### PR DESCRIPTION
MainWindow::on_actionAddDive_triggered() updated the profile after
calling Command::addDive(). However, that is redundant because the
undo-machinery does the profile reload. Remove the call.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial cleanup that removes a redundant profile replot. Tried it and things still work as normal.