### PR TITLE
Three fixes

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -352,6 +352,7 @@ extern struct dive *merge_dives(const struct dive *a, const struct dive *b, int 
 extern struct dive *try_to_merge(struct dive *a, struct dive *b, bool prefer_downloaded);
 extern struct event *clone_event(const struct event *src_ev);
 extern void copy_events(const struct divecomputer *s, struct divecomputer *d);
+extern void copy_events_until(const struct dive *sd, struct dive *dd, int time);
 extern void free_events(struct event *ev);
 extern void copy_cylinders(const struct cylinder_table *s, struct cylinder_table *d);
 extern void copy_used_cylinders(const struct dive *s, struct dive *d, bool used_only);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1287,7 +1287,9 @@ static struct dive *get_last_valid_dive()
  */
 int get_dive_nr_at_idx(int idx)
 {
-	struct dive *last_dive = get_last_valid_dive(dive_table.nr - 1);
+	if (idx < dive_table.nr)
+		return 0;
+	struct dive *last_dive = get_last_valid_dive();
 	if (!last_dive)
 		return 1;
 	return last_dive->number ? last_dive->number + 1 : 0;

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -771,8 +771,8 @@ static int get_divemode(const char *divemodestring) {
  */
 struct parse_event {
 	const char *name;
-	struct event ev;
 	int has_divemode;
+	struct event ev;
 };
 
 static void parse_event_keyvalue(void *_parse, const char *key, const char *value)

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -136,6 +136,7 @@ private:
 	QDateTime startTime;
 	int instanceCounter = 0;
 	struct deco_state ds_after_previous_dives;
+	duration_t preserved_until;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

I was made aware that editing a dive in the planner loses the dive computer events attached to the dive. Commit 2/3 adds code to preserve those. The other two commits fix two complaints by the compiler (the fixes look right to me but are not in parts of the code that i know too well).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Reshuffle members of a struct to make the variable length part last again
2) After editing a dive in the planner, copy events from the original dive until the point where we modified the dive by deleting waypoints
3) Remove an extra argument in a function call

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
