### PR TITLE
Remove fine-grained startup notifications

### DIFF
--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -148,14 +148,9 @@ void FullText::populate()
 	uiNotification(QObject::tr("start processing"));
 	int i;
 	dive *d;
-	for_each_dive(i, d) {
-		// this makes sure that every once in a while we allow the
-		// UI to respond to events
-		if (i % 100 == 99)
-			uiNotification(QObject::tr("\r%1 dives processed").arg(i + 1));
+	for_each_dive(i, d)
 		registerDive(d);
-	}
-	uiNotification(QObject::tr("\r%1 dives processed").arg(dive_table.nr));
+	uiNotification(QObject::tr("%1 dives processed").arg(dive_table.nr));
 }
 
 void FullText::registerDive(struct dive *d)

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -50,14 +50,7 @@ Kirigami.ApplicationWindow {
 				showPassiveNotification(notificationText, 5000)
 			}
 		} else {
-			var oldText = textBlock.text
-			if (notificationText.startsWith("\r")) {
-				// replace the last line that was sent
-				oldText = oldText.substr(0, oldText.lastIndexOf("\n"))
-				textBlock.text = oldText + "\n" + notificationText.substr(1)
-			} else {
-				textBlock.text = oldText + "\n" + notificationText
-			}
+			textBlock.text = textBlock.text + "\n" + notificationText
 		}
 	}
 	visible: false

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -725,8 +725,6 @@ void DiveTripModelTree::populate()
 	uiNotification(QObject::tr("populate data model"));
 	uiNotification(QObject::tr("start processing"));
 	for (int i = 0; i < dive_table.nr; ++i) {
-		if (i  % 100 == 99)
-			uiNotification(QObject::tr("\r%1 dives processed").arg(i + 1));
 		dive *d = get_dive(i);
 		update_cylinder_related_info(d);
 		if (d->hidden_by_filter)
@@ -754,7 +752,7 @@ void DiveTripModelTree::populate()
 
 	// Remember the index of the current dive
 	oldCurrent = current_dive;
-	uiNotification(QObject::tr("\r%1 dives processed").arg(dive_table.nr));
+	uiNotification(QObject::tr("%1 dives processed").arg(dive_table.nr));
 }
 
 int DiveTripModelTree::rowCount(const QModelIndex &parent) const


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes fine grained startup notifications and subjectively makes startup much faster for me. Part of that is due to an objective speed-up, see commit message.

Note that this is only mobile-on-desktop. On device YMMV.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't do fine grained ui-notifications on startup.
