### PR TITLE
mobile: don't call main loop for notifications once initialized

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1710,7 +1710,12 @@ void QMLManager::setNotificationText(QString text)
 	appendTextToLog(QStringLiteral("showProgress: ") + text);
 	m_notificationText = text;
 	emit notificationTextChanged();
-	qApp->processEvents();
+	// Once we're initialized, this may be called from signal context, notably when selecting an action from a context menu.
+	// Processing events may now cause the menu to be deleted. Deleting a QML object which sent a signal causes QML to quit the application.
+	// Therefore, don't process events once the application is started.
+	// During startup this is needed so that the notifications are shown.
+	if (!m_initialized)
+		qApp->processEvents();
 }
 
 qreal QMLManager::lastDevicePixelRatio()


### PR DESCRIPTION
Calling qApp->processEvents() in QMLManager::setNotificationText()
caused crashes, because it could lead to the context-menu that
initialized the call being deleted. Something that QML apparently
doesn't like.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes the reproducible crash that I reported yesterday on the mailing list. I simply have to delete a dive from the dive context menu (long click on dive in list).

Perhaps this impedes notification? Alternatively, we could simply clear the notification callback once initialization is done, but I feel that version would not be welcomed.
