### PR TITLE
desktop: remove special QGroupBox stylesheet for non-Windows systems

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -38,11 +38,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	connect(ui->diveType, SIGNAL(currentIndexChanged(int)), this, SLOT(diveModeChanged(int)));
 	QString CSSSetSmallLabel = "QLabel { color: mediumblue; font-size: " +                           // Using label height
 		QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}"; // .. set CSS font size of star widget subscripts
-#if defined(Q_OS_WIN)
 	ui->scrollAreaWidgetContents_3->setStyleSheet("QGroupBox::title { color: mediumblue;} ");
-#else
-	ui->scrollAreaWidgetContents_3->setStyleSheet("QGroupBox { border: 1px solid silver; border-radius: 4px; margin-top: 0.65em; background-color: #e7e4e4;} QGroupBox::title { color: mediumblue;} ");
-#endif
 	ui->diveHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);
 	ui->gasHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);
 	ui->environmentHeadingLabel->setStyleSheet(CSS_SET_HEADING_BLUE);


### PR DESCRIPTION
That style-sheet made things look really ugly on most Linux themes.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an uglification of the the DiveInfoTab on Linux.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove special non-Windows QGroupBox stylesheet.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@willemferguson: It seems you wrote that stylesheet for Windows, but actually it was only included for non-Windows?