### PR TITLE
divelist: when removing/adding a dive unregister/register fulltext

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -73,6 +73,7 @@ dive *DiveListBase::addDive(DiveToAdd &d)
 	res->hidden_by_filter = true;
 
 	int idx = dive_table_get_insertion_index(&dive_table, res);
+	fulltext_register(res);				// Register the dive's fulltext cache
 	add_to_dive_table(&dive_table, idx, res);	// Return ownership to backend
 	invalidate_dive_cache(res);		// Ensure that dive is written in git_save()
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -753,6 +753,9 @@ struct dive *unregister_dive(int idx)
 	struct dive *dive = get_dive(idx);
 	if (!dive)
 		return NULL; /* this should never happen */
+	/* When removing a dive from the global dive table,
+	 * we also have to unregister its fulltext cache. */
+	fulltext_unregister(dive);
 	remove_from_dive_table(&dive_table, idx);
 	if (dive->selected)
 		amount_selected--;


### PR DESCRIPTION
This fixes a crash: when the undo commands removed a dive from
the list, the fulltext cache was not cleared. If now the divelist
is reset and then the undo-command deleted, deletion of the owned
dive tries to remove it's fulltext cache, which doesn't exist
anymore.

For reasons of symmetry, when readding the dive, its fulltext
has to be registered.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Properly unregister fulltext cache when removing dive from the core. This hopefully fixes a crash reported on mobile.
