### PR TITLE
[Post-Release] Minor planner-interface disentangling

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -209,7 +209,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	ui.menuFile->insertSeparator(ui.actionQuit);
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCreated()), this, SLOT(planCreated()));
 	connect(DivePlannerPointsModel::instance(), SIGNAL(planCanceled()), this, SLOT(planCanceled()));
-	connect(DivePlannerPointsModel::instance(), SIGNAL(variationsComputed(QString)), this, SLOT(updateVariations(QString)));
 	connect(plannerDetails->printPlan(), SIGNAL(pressed()), divePlannerWidget, SLOT(printDecoPlan()));
 	connect(this, &MainWindow::showError, ui.mainErrorMessage, &NotificationWidget::showError, Qt::AutoConnection);
 
@@ -825,14 +824,6 @@ void MainWindow::planCreated()
 
 void MainWindow::setPlanNotes()
 {
-	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
-}
-
-void MainWindow::updateVariations(QString variations)
-{
-	QString notes = QString(displayed_dive.notes);
-	free(displayed_dive.notes);
-	displayed_dive.notes = copy_qstring(notes.replace("VARIATIONS", variations));
 	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -822,9 +822,9 @@ void MainWindow::planCreated()
 	diveList->setFocus();
 }
 
-void MainWindow::setPlanNotes()
+void MainWindow::setPlanNotes(QString plan)
 {
-	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
+	plannerDetails->divePlanOutput()->setHtml(plan);
 }
 
 void MainWindow::printPlan()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -831,8 +831,11 @@ void MainWindow::printPlan()
 {
 #ifndef NO_PRINTING
 	char *disclaimer = get_planner_disclaimer_formatted();
+	// Prepend a logo and a disclaimer to the plan.
+	// Save the old plan so that it can be restored at the end of the function.
+	QString origPlan = plannerDetails->divePlanOutput()->toHtml();
 	QString diveplan = QStringLiteral("<img height=50 src=\":subsurface-icon\"> ") +
-			   QString(disclaimer) + plannerDetails->divePlanOutput()->toHtml();
+			   QString(disclaimer) + origPlan;
 	free(disclaimer);
 
 	QPrinter printer;
@@ -871,7 +874,7 @@ void MainWindow::printPlan()
 
 	plannerDetails->divePlanOutput()->setHtml(diveplan);
 	plannerDetails->divePlanOutput()->print(&printer);
-	plannerDetails->divePlanOutput()->setHtml(displayed_dive.notes);
+	plannerDetails->divePlanOutput()->setHtml(origPlan); // restore original plan
 #endif
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -875,19 +875,6 @@ void MainWindow::printPlan()
 #endif
 }
 
-void MainWindow::setupForAddAndPlan(const char *model)
-{
-	// clean out the dive and give it an id and the correct dc model
-	clear_dive(&displayed_dive);
-	displayed_dive.id = dive_getUniqID();
-	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
-	displayed_dive.dc.model = strdup(model); // don't translate! this is stored in the XML file
-	dc_number = 1;
-	// setup the dive cylinders
-	DivePlannerPointsModel::instance()->clear();
-	DivePlannerPointsModel::instance()->setupCylinders();
-}
-
 void MainWindow::on_actionReplanDive_triggered()
 {
 	if (!plannerStateClean() || !current_dive)
@@ -925,10 +912,9 @@ void MainWindow::on_actionDivePlanner_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	graphics->setPlanState();
+	dc_number = 1;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
-	setupForAddAndPlan("planned dive"); // don't translate, stored in XML file
-	DivePlannerPointsModel::instance()->setupStartTime();
 	DivePlannerPointsModel::instance()->createSimpleDive();
 	// plan the dive in the same mode as the currently selected one
 	if (current_dive) {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1722,31 +1722,21 @@ void MainWindow::on_actionImportDiveSites_triggered()
 
 void MainWindow::editCurrentDive()
 {
-	if (!current_dive)
+	// We only allow editing of the profile for manually added dives.
+	if (!current_dive || !same_string(current_dive->dc.model, "manually added dive"))
 		return;
 
-	if (mainTab->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
-		QMessageBox::warning(this, tr("Warning"), tr("Please, first finish the current edition before trying to do another."));
+	// This shouldn't be possible, but let's make sure no weird "double editing" takes place.
+	if (mainTab->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING)
 		return;
-	}
 
-	struct dive *d = current_dive;
-	QString defaultDC(d->dc.model);
+	disableShortcuts();
 	DivePlannerPointsModel::instance()->clear();
-	if (defaultDC == "manually added dive") {
-		disableShortcuts();
-		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
-		graphics->setAddState();
-		setApplicationState(ApplicationState::EditDive);
-		DivePlannerPointsModel::instance()->loadFromDive(d);
-		mainTab->enableEdition();
-	} else if (defaultDC == "planned dive") {
-		disableShortcuts();
-		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-		setApplicationState(ApplicationState::EditPlannedDive);
-		DivePlannerPointsModel::instance()->loadFromDive(d);
-		mainTab->enableEdition();
-	}
+	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
+	graphics->setAddState();
+	setApplicationState(ApplicationState::EditDive);
+	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
+	mainTab->enableEdition();
 }
 
 void MainWindow::turnOffNdlTts()

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -213,7 +213,6 @@ private:
 	LocationInformationWidget *diveSiteEdit;
 
 	bool plannerStateClean();
-	void setupForAddAndPlan(const char *model);
 	void configureToolbar();
 	void setupSocialNetworkMenu();
 	QDialog *survey;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -167,7 +167,7 @@ slots:
 	void planCanceled();
 	void planCreated();
 	void setEnabledToolbar(bool arg1);
-	void setPlanNotes();
+	void setPlanNotes(QString plan);
 	// Some shortcuts like "change DC" or "copy/paste dive components"
 	// should only be enabled when the profile's visible.
 	void disableShortcuts(bool disablePaste = true);

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -172,7 +172,6 @@ slots:
 	// should only be enabled when the profile's visible.
 	void disableShortcuts(bool disablePaste = true);
 	void enableShortcuts();
-	void updateVariations(QString);
 	void startDiveSiteEdit();
 
 private:

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -45,6 +45,16 @@ void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 
 void DivePlannerPointsModel::createSimpleDive()
 {
+	// clean out the dive and give it an id and the correct dc model
+	clear_dive(&displayed_dive);
+	displayed_dive.id = dive_getUniqID();
+	displayed_dive.when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
+	displayed_dive.dc.model = strdup("planned dive"); // don't translate! this is stored in the XML file
+
+	clear();
+	setupCylinders();
+	setupStartTime();
+
 	// initialize the start time in the plan
 	diveplan.when = displayed_dive.when;
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -984,7 +984,7 @@ void DivePlannerPointsModel::createTemporaryPlan()
 		computeVariations(plan_copy, &plan_deco_state);
 #endif
 		final_deco_state = plan_deco_state;
-		emit calculatedPlanNotes();
+		emit calculatedPlanNotes(QString(displayed_dive.notes));
 	}
 	// throw away the cache
 	free(cache);
@@ -1169,7 +1169,7 @@ void DivePlannerPointsModel::computeVariationsDone(QString variations)
 	QString notes = QString(displayed_dive.notes);
 	free(displayed_dive.notes);
 	displayed_dive.notes = copy_qstring(notes.replace("VARIATIONS", variations));
-	emit calculatedPlanNotes();
+	emit calculatedPlanNotes(QString(displayed_dive.notes));
 }
 
 void DivePlannerPointsModel::createPlan(bool replanCopy)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -422,6 +422,9 @@ DivePlannerPointsModel::DivePlannerPointsModel(QObject *parent) : QAbstractTable
 {
 	memset(&diveplan, 0, sizeof(diveplan));
 	startTime.setTimeSpec(Qt::UTC);
+	// use a Qt-connection to send the variations text across thread boundary (in case we
+	// are calculating the variations in a background thread).
+	connect(this, &DivePlannerPointsModel::variationsComputed, this, &DivePlannerPointsModel::computeVariationsDone);
 }
 
 DivePlannerPointsModel *DivePlannerPointsModel::instance()
@@ -1146,6 +1149,7 @@ void DivePlannerPointsModel::computeVariations(struct diveplan *original_plan, c
 			FRACTION(analyzeVariations(shallower, original, deeper, qPrintable(depth_units)), 60), qPrintable(depth_units),
 			FRACTION(analyzeVariations(shorter, original, longer, qPrintable(time_units)), 60));
 
+		// By using a signal, we can transport the variations to the main thread.
 		emit variationsComputed(QString(buf));
 #ifdef DEBUG_STOPVAR
 		printf("\n\n");
@@ -1158,6 +1162,14 @@ finish:
 	free(cache);
 	free(dive);
 //	setRecalc(oldRecalc);
+}
+
+void DivePlannerPointsModel::computeVariationsDone(QString variations)
+{
+	QString notes = QString(displayed_dive.notes);
+	free(displayed_dive.notes);
+	displayed_dive.notes = copy_qstring(notes.replace("VARIATIONS", variations));
+	emit calculatedPlanNotes();
 }
 
 void DivePlannerPointsModel::createPlan(bool replanCopy)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -8,9 +8,9 @@
 #include "core/qthelper.h"
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/settings/qPrefUnit.h"
-#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
+#if !defined(SUBSURFACE_TESTING)
 #include "commands/command.h"
-#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
+#endif // !SUBSURFACE_TESTING
 #include "core/gettextfromc.h"
 #include "core/deco.h"
 #include <QApplication>
@@ -1243,22 +1243,22 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 	if (!current_dive || displayed_dive.id != current_dive->id) {
 		// we were planning a new dive, not re-planning an existing one
 		displayed_dive.divetrip = nullptr; // Should not be necessary, just in case!
-#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
+#if !defined(SUBSURFACE_TESTING)
 		Command::addDive(&displayed_dive, autogroup, true);
-#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
+#endif // !SUBSURFACE_TESTING
 	} else {
 		copy_events_until(current_dive, &displayed_dive, preserved_until.seconds);
 		if (replanCopy) {
 			// we were planning an old dive and save as a new dive
 			displayed_dive.id = dive_getUniqID(); // Things will break horribly if we create dives with the same id.
-#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
+#if !defined(SUBSURFACE_TESTING)
 			Command::addDive(&displayed_dive, false, false);
-#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
+#endif // !SUBSURFACE_TESTING
 		} else {
 			// we were planning an old dive and rewrite the plan
-#if not defined(SUBSURFACE_MOBILE) && not defined(SUBSURFACE_TESTING)
+#if !defined(SUBSURFACE_TESTING)
 			Command::replanDive(&displayed_dive);
-#endif // SUBSURFACE_MOBILE SUBSURFACE_TESTING
+#endif // !SUBSURFACE_TESTING
 		}
 	}
 

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -126,6 +126,7 @@ private:
 	void createPlan(bool replanCopy);
 	struct diveplan diveplan;
 	struct divedatapoint *cloneDiveplan(struct diveplan *plan_src, struct diveplan *plan_copy);
+	void computeVariationsDone(QString text);
 	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -118,7 +118,7 @@ signals:
 	void cylinderModelEdited();
 	void startTimeChanged(QDateTime);
 	void recreationChanged(bool);
-	void calculatedPlanNotes();
+	void calculatedPlanNotes(QString);
 	void variationsComputed(QString);
 
 private:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is some minor planner interface disentangling. The idea is to bit-by-bit move displayed_dive to the planner so that we get a better separation of the different modules.

A side-effect might be that we get better code-reuse in the case that we port the planner to mobile.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde: please give these changes a critical review. Notably, I found no way to turn displaying of the variations on, so I couldn't test that part at all! There is no planner-tab in the preferences and setting the "show variations" in the planner likewise did not set that flag?

Thanks!