### PR TITLE
replace displayed_dive by current_dive

### DIFF
--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -440,7 +440,7 @@ DiveComponentSelection::DiveComponentSelection(QWidget *parent, struct dive *tar
 
 void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 {
-	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
+	if (current_dive && ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
 		COMPONENT_FROM_UI(divesite);
 		COMPONENT_FROM_UI(divemaster);
 		COMPONENT_FROM_UI(buddy);
@@ -451,28 +451,28 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		COMPONENT_FROM_UI(tags);
 		COMPONENT_FROM_UI(cylinders);
 		COMPONENT_FROM_UI(weights);
-		selective_copy_dive(&displayed_dive, targetDive, *what, true);
+		selective_copy_dive(current_dive, targetDive, *what, true);
 		QClipboard *clipboard = QApplication::clipboard();
 		QTextStream text;
 		QString cliptext;
 		text.setString(&cliptext);
-		if (what->divesite && displayed_dive.dive_site)
-			text << tr("Dive site: ") << displayed_dive.dive_site->name << "\n";
+		if (what->divesite && current_dive->dive_site)
+			text << tr("Dive site: ") << current_dive->dive_site->name << "\n";
 		if (what->divemaster)
-			text << tr("Dive master: ") << displayed_dive.divemaster << "\n";
+			text << tr("Dive master: ") << current_dive->divemaster << "\n";
 		if (what->buddy)
-			text << tr("Buddy: ") << displayed_dive.buddy << "\n";
+			text << tr("Buddy: ") << current_dive->buddy << "\n";
 		if (what->rating)
-			text << tr("Rating: ") + QString("*").repeated(displayed_dive.rating) << "\n";
+			text << tr("Rating: ") + QString("*").repeated(current_dive->rating) << "\n";
 		if (what->visibility)
-			text << tr("Visibility: ") + QString("*").repeated(displayed_dive.visibility) << "\n";
+			text << tr("Visibility: ") + QString("*").repeated(current_dive->visibility) << "\n";
 		if (what->notes)
-			text << tr("Notes:\n") << displayed_dive.notes << "\n";
+			text << tr("Notes:\n") << current_dive->notes << "\n";
 		if (what->suit)
-			text << tr("Suit: ") << displayed_dive.suit << "\n";
+			text << tr("Suit: ") << current_dive->suit << "\n";
 		if (what-> tags) {
 			text << tr("Tags: ");
-			tag_entry *entry = displayed_dive.tag_list;
+			tag_entry *entry = current_dive->tag_list;
 			while (entry) {
 				text << entry->tag->name << " ";
 				entry = entry->next;
@@ -482,16 +482,16 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		if (what->cylinders) {
 			int cyl;
 			text << tr("Cylinders:\n");
-			for (cyl = 0; cyl < displayed_dive.cylinders.nr; cyl++) {
-				if (is_cylinder_used(&displayed_dive, cyl))
-					text << get_cylinder(&displayed_dive, cyl)->type.description << " " << gasname(get_cylinder(&displayed_dive, cyl)->gasmix) << "\n";
+			for (cyl = 0; cyl < current_dive->cylinders.nr; cyl++) {
+				if (is_cylinder_used(current_dive, cyl))
+					text << get_cylinder(current_dive, cyl)->type.description << " " << gasname(get_cylinder(current_dive, cyl)->gasmix) << "\n";
 			}
 		}
 		if (what->weights) {
 			int w;
 			text << tr("Weights:\n");
-			for (w = 0; w < displayed_dive.weightsystems.nr; w++) {
-				weightsystem_t ws = displayed_dive.weightsystems.weightsystems[w];
+			for (w = 0; w < current_dive->weightsystems.nr; w++) {
+				weightsystem_t ws = current_dive->weightsystems.weightsystems[w];
 				text << ws.description << ws.weight.grams / 1000 << "kg\n";
 			}
 		}

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -130,7 +130,8 @@ void TabDiveEquipment::updateData()
 	suitModel.updateModel();
 
 	ui.cylinders->view()->hideColumn(CylindersModel::DEPTH);
-	if (get_dive_dc(&displayed_dive, dc_number)->divemode == CCR)
+	bool is_ccr = current_dive && get_dive_dc(current_dive, dc_number)->divemode == CCR;
+	if (is_ccr)
 		ui.cylinders->view()->showColumn(CylindersModel::USE);
 	else
 		ui.cylinders->view()->hideColumn(CylindersModel::USE);

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -111,6 +111,8 @@ void TabDivePhotos::recalculateSelectedThumbnails()
 
 void TabDivePhotos::saveSubtitles()
 {
+	if (!current_dive)
+		return;
 	QVector<QString> selectedPhotos;
 	if (!ui->photosView->selectionModel()->hasSelection())
 		return;
@@ -131,7 +133,7 @@ void TabDivePhotos::saveSubtitles()
 				if (!duration)
 					continue;
 				struct membuffer b = { 0 };
-				save_subtitles_buffer(&b, &displayed_dive, offset, duration);
+				save_subtitles_buffer(&b, current_dive, offset, duration);
 				char *data = detach_cstring(&b);
 				subtitlefile.open(QIODevice::WriteOnly);
 				subtitlefile.write(data, strlen(data));

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -96,20 +96,18 @@ void TabDiveStatistics::updateData()
 	}
 
 
+	bool is_freedive = current_dive && current_dive->dc.divemode == FREEDIVE;
 	ui->divesAllText->setText(QString::number(stats_selection.selection_size));
-	ui->totalTimeAllText->setText(get_dive_duration_string(stats_selection.total_time.seconds, tr("h"), tr("min"), tr("sec"),
-		" ", displayed_dive.dc.divemode == FREEDIVE));
+	ui->totalTimeAllText->setText(get_dive_duration_string(stats_selection.total_time.seconds, tr("h"), tr("min"), tr("sec"), " ", is_freedive));
 	
 	int seconds = stats_selection.total_time.seconds;
 	if (stats_selection.selection_size)
 		seconds /= stats_selection.selection_size;
 	ui->timeLimits->setAverage(get_dive_duration_string(seconds, tr("h"), tr("min"), tr("sec"),
-			" ", displayed_dive.dc.divemode == FREEDIVE));
+			" ", is_freedive));
 	if (amount_selected > 1) {
-		ui->timeLimits->setMaximum(get_dive_duration_string(stats_selection.longest_time.seconds, tr("h"), tr("min"), tr("sec"),
-			" ", displayed_dive.dc.divemode == FREEDIVE));
-		ui->timeLimits->setMinimum(get_dive_duration_string(stats_selection.shortest_time.seconds, tr("h"), tr("min"), tr("sec"),
-			" ", displayed_dive.dc.divemode == FREEDIVE));
+		ui->timeLimits->setMaximum(get_dive_duration_string(stats_selection.longest_time.seconds, tr("h"), tr("min"), tr("sec"), " ", is_freedive));
+		ui->timeLimits->setMinimum(get_dive_duration_string(stats_selection.shortest_time.seconds, tr("h"), tr("min"), tr("sec"), " ", is_freedive));
 	} else {
 		ui->timeLimits->setMaximum("");
 		ui->timeLimits->setMinimum("");

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -74,8 +74,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	ui.dateEdit->setDisplayFormat(prefs.date_format);
 	ui.timeEdit->setDisplayFormat(prefs.time_format);
 
-	memset(&displayed_dive, 0, sizeof(displayed_dive));
-
 	closeMessage();
 
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &MainTab::divesChanged);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -355,10 +355,10 @@ void MainTab::updateDiveInfo()
 
 	ignoreInput = true; // don't trigger on changes to the widgets
 
-	for (TabBase *widget: extraWidgets)
-		widget->updateData();
-
 	if (current_dive) {
+		for (TabBase *widget: extraWidgets)
+			widget->updateData();
+
 		// If we're on the dive-site tab, we don't want to switch tab when entering / exiting
 		// trip mode. The reason is that
 		// 1) this disrupts the user-experience and

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -58,17 +58,17 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 {
 	ui.setupUi(this);
 
-	extraWidgets << new TabDiveEquipment();
+	extraWidgets << new TabDiveEquipment(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Equipment"));
-	extraWidgets << new TabDiveInformation();
+	extraWidgets << new TabDiveInformation(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Information"));
-	extraWidgets << new TabDiveStatistics();
+	extraWidgets << new TabDiveStatistics(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Statistics"));
-	extraWidgets << new TabDivePhotos();
+	extraWidgets << new TabDivePhotos(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Media"));
-	extraWidgets << new TabDiveExtraInfo();
+	extraWidgets << new TabDiveExtraInfo(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Extra Info"));
-	extraWidgets << new TabDiveSite();
+	extraWidgets << new TabDiveSite(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Dive sites"));
 
 	ui.dateEdit->setDisplayFormat(prefs.date_format);
@@ -176,10 +176,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	new TextHyperlinkEventFilter(ui.notes);//destroyed when ui.notes is destroyed
 
 	ui.diveTripLocation->hide();
-}
-
-MainTab::~MainTab()
-{
 }
 
 void MainTab::hideMessage()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -27,7 +27,6 @@ class MainTab : public QTabWidget {
 	Q_OBJECT
 public:
 	MainTab(QWidget *parent = 0);
-	~MainTab();
 	void clearTabs();
 	void reload();
 	void initialUiSetup();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
displayed_dive is the working copy of the dive for the planner and for editing the profile. Virtually everywhere else we display data from current_dive. Therefore remove data accesses to displayed_dive to avoid potential data inconsistencies and ultimately to make displayed_dive local to the planner.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - purely code reshuffling.
