### PR TITLE
dive sites: properly reload dive site model on desktop

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -490,6 +490,7 @@ void DiveTripModelBase::clear()
 	emit diveListNotifier.numShownChanged();
 }
 
+// Currently only used by the mobile models
 void DiveTripModelBase::reset()
 {
 	beginResetModel();

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -6,6 +6,7 @@
 #include "core/subsurface-string.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "qt-models/divetripmodel.h"
+#include "qt-models/divelocationmodel.h"
 
 MultiFilterSortModel *MultiFilterSortModel::instance()
 {
@@ -29,6 +30,7 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 	connect(model.get(), &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
 	connect(model.get(), &DiveTripModelBase::currentDiveChanged, this, &MultiFilterSortModel::currentDiveChangedSlot);
 	model->initSelection();
+	LocationInformationModel::instance()->update();
 }
 
 void MultiFilterSortModel::clear()


### PR DESCRIPTION
In 9310d72943390f95d6742c2d5b40f025a40b4008, resetting of the dive
sites was moved to DiveTripModelBase::reset(). This seemed like a
good idea, because it means that the location list is reloaded
every time the dive list is reset.

Unfortunately that function is only used on mobile, thus on desktop
the dive site model is not updated. Do that in
MultiFilterSortModel::resetModel(), because this is always called
when the dive list is reset. Desktop differs from mobile in that
two different models are used depending on whether we are in list
or in tree mode.

Fixes #2749

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix for #2749. See commit description.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Properly reset dive site model on desktop
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2749.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - bug not in release.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: release-blocker.