### PR TITLE
Git cache branch name

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -703,7 +703,7 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 {
 	git_repository *repo;
 	git_config *conf;
-	char *variable_name, *merge_head;
+	char *variable_name, *head;
 
 	if (verbose)
 		fprintf(stderr, "git storage: create and push remote\n");
@@ -711,9 +711,12 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 	/* first make sure the directory for the local cache exists */
 	subsurface_mkdir(localdir);
 
+	head = format_string("refs/heads/%s", branch);
+
 	/* set up the origin to point to our remote */
 	git_repository_init_options init_opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
 	init_opts.origin_url = remote;
+	init_opts.initial_head = head;
 
 	/* now initialize the repository with */
 	git_repository_init_ext(&repo, localdir, &init_opts);
@@ -725,9 +728,8 @@ static git_repository *create_and_push_remote(const char *localdir, const char *
 	free(variable_name);
 
 	variable_name = format_string("branch.%s.merge", branch);
-	merge_head = format_string("refs/heads/%s", branch);
-	git_config_set_string(conf, variable_name, merge_head);
-	free(merge_head);
+	git_config_set_string(conf, variable_name, head);
+	free(head);
 	free(variable_name);
 
 	/* finally create an empty commit and push it to the remote */

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -652,6 +652,7 @@ static git_repository *update_local_repo(const char *localdir, const char *remot
 {
 	int error;
 	git_repository *repo = NULL;
+	git_reference *head;
 
 	if (verbose)
 		fprintf(stderr, "git storage: update local repo\n");
@@ -664,6 +665,22 @@ static git_repository *update_local_repo(const char *localdir, const char *remot
 			report_error("Unable to open git cache repository at %s: %s", localdir, giterr_last()->message);
 		return NULL;
 	}
+
+	/* Check the HEAD being the right branch */
+	if (!git_repository_head(&head, repo)) {
+		const char *name;
+		if (!git_branch_name(&name, head)) {
+			if (strcmp(name, branch)) {
+				char *branchref = format_string("refs/heads/%s", branch);
+
+				report_error("Setting cache branch from '%s' to '%s'", name, branch);
+				git_repository_set_head(repo, branchref);
+				free(branchref);
+			}
+		}
+		git_reference_free(head);
+	}
+
 	if (!git_local_only)
 		sync_with_remote(repo, remote, branch, rt);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

This should fix the issue with the local cached git repo not having the right branch name.

I tested the "local repo was on 'master'" case by hand, but I haven't actually tested the initial creation of an empty repository. I'm expecting that Dirk's git storage tests would catch that one, and this pull request is more of a "if Dirk finds it easier to do a pull than take the patch from my email".

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
