### PR TITLE
profile: avoid double-free when reusing plot_info

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -499,6 +499,7 @@ void free_plot_info_data(struct plot_info *pi)
 	free(pi->entry);
 	free(pi->pressures);
 	pi->entry = NULL;
+	pi->pressures = NULL;
 }
 
 static void populate_plot_entries(struct dive *dive, struct divecomputer *dc, struct plot_info *pi)


### PR DESCRIPTION
free_plot_info_data() freed the pressure-data, but didn't set the
value to NULL. Thus, when the plot_info was reused, a double-free()
could ensue.

Crash condition: export the profiles of multiple dives with pressure
data.

Reported-by: Willem Ferguson <willemferguson@zoology.up.ac.za>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a double-free crash reported by @willemferguson on the mailing list.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) set pointer to freed data to null.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: should obviously go in before release. Appears to work for me, however confirmation by @willemferguson would be nice.