### PR TITLE
SSL override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix false rejection of Subsurface cloud SSL certificate
 Mobile: fix misdetection of Shearwater Petrel 2 on iOS
 Desktop: fix creation of new cylinder types (names couldn't be the start of already existing names)
 Mobile: fix no-cloud to cloud transition

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -289,6 +289,8 @@ int credential_https_cb(git_cred **out,
 int certificate_check_cb(git_cert *cert, int valid, const char *host, void *payload)
 {
 	UNUSED(payload);
+	if (verbose)
+		SSRF_INFO("certificate callback for host %s with validity %d\n", host, valid);
 	if (same_string(host, "cloud.subsurface-divelog.org") && cert->cert_type == GIT_CERT_X509) {
 		// for some reason the LetsEncrypt certificate makes libgit2 throw up on some
 		// platforms but not on others

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1630,7 +1630,7 @@ static int walk_tree_file(const char *root, const git_tree_entry *entry, struct 
 	dive_trip_t *trip = state->active_trip;
 	const char *name = git_tree_entry_name(entry);
 	if (verbose > 1)
-		fprintf(stderr, "git load handling file %s\n", name);
+		SSRF_INFO("git load handling file %s\n", name);
 	switch (*name) {
 	case '-': case '+':
 		if (dive)

--- a/core/profile.c
+++ b/core/profile.c
@@ -318,7 +318,7 @@ int get_cylinder_index(const struct dive *dive, const struct event *ev)
 	 * We now match up gas change events with their cylinders at dive
 	 * event fixup time.
 	 */
-	fprintf(stderr, "Still looking up cylinder based on gas mix in get_cylinder_index()!\n");
+	SSRF_INFO("Still looking up cylinder based on gas mix in get_cylinder_index()!\n");
 
 	mix = get_gasmix_from_event(dive, ev);
 	best = find_best_gasmix_match(mix, &dive->cylinders);
@@ -1055,7 +1055,7 @@ void calculate_deco_information(struct deco_state *ds, const struct deco_state *
 			entry->ambpressure = depth_to_bar(entry->depth, dive);
 			entry->gfline = get_gf(ds, entry->ambpressure, dive) * (100.0 - AMB_PERCENTAGE) + AMB_PERCENTAGE;
 			if (t0 > t1) {
-				fprintf(stderr, "non-monotonous dive stamps %d %d\n", t0, t1);
+				SSRF_INFO("non-monotonous dive stamps %d %d\n", t0, t1);
 				int xchg = t1;
 				t1 = t0;
 				t0 = xchg;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -161,4 +161,13 @@ char *get_changes_made();
 }
 #endif
 
+// 4) SSRF_INFO macro to replace fprintf calls in our code
+//    (originally based on logging bits from libdivecomputer)
+#if !defined(Q_OS_ANDROID) && !defined(__ANDROID__)
+#define SSRF_INFO(fmt, ...)	fprintf(stderr, "INFO: " fmt "\n", ##__VA_ARGS__)
+#else
+#include <android/log.h>
+#define SSRF_INFO(fmt, ...)	__android_log_print(ANDROID_LOG_INFO, "Subsurface", "INFO: " fmt "\n", ##__VA_ARGS__);
+#endif
+
 #endif // QTHELPER_H

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -448,7 +448,7 @@ static void create_dive_buffer(struct dive *dive, struct membuffer *b)
 	if (dive->dive_site)
 		put_format(b, "divesiteid %08x\n", dive->dive_site->uuid);
 	if (verbose && dive->dive_site)
-		fprintf(stderr, "removed reference to non-existant dive site with uuid %08x\n", dive->dive_site->uuid);
+		SSRF_INFO("removed reference to non-existant dive site with uuid %08x\n", dive->dive_site->uuid);
 	save_overview(b, dive);
 	save_cylinder_info(b, dive);
 	save_weightsystem_info(b, dive);
@@ -491,7 +491,7 @@ static int tree_insert(git_treebuilder *dir, const char *name, int mkunique, git
 	if (ret) {
 		const git_error *gerr = giterr_last();
 		if (gerr) {
-			fprintf(stderr, "tree_insert failed with return %d error %s\n", ret, gerr->message);
+			SSRF_INFO("tree_insert failed with return %d error %s\n", ret, gerr->message);
 		}
 	}
 	return ret;
@@ -1071,7 +1071,7 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 	free((void *)user_agent);
 	free(changes_made);
 	if (verbose)
-		fprintf(stderr, "Commit message:\n\n%s\n", mb_cstring(msg));
+		SSRF_INFO("Commit message:\n\n%s\n", mb_cstring(msg));
 }
 
 static int create_new_commit(git_repository *repo, const char *remote, const char *branch, git_oid *tree_id, bool create_empty)
@@ -1100,7 +1100,7 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 
 		if (saved_git_id) {
 			if (existing_filename && verbose)
-				fprintf(stderr, "existing filename %s\n", existing_filename);
+				SSRF_INFO("existing filename %s\n", existing_filename);
 			const git_oid *id = git_commit_id((const git_commit *) parent);
 			/* if we are saving to the same git tree we got this from, let's make
 			 * sure there is no confusion */
@@ -1199,7 +1199,7 @@ static int write_git_tree(git_repository *repo, struct dir *tree, git_oid *resul
 	if (ret && verbose) {
 		const git_error *gerr = giterr_last();
 		if (gerr)
-			fprintf(stderr, "tree_insert failed with return %d error %s\n", ret, gerr->message);
+			SSRF_INFO("tree_insert failed with return %d error %s\n", ret, gerr->message);
 	}
 
 	/* .. and free the now useless treebuilder */
@@ -1215,7 +1215,7 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 	bool cached_ok;
 
 	if (verbose)
-		fprintf(stderr, "git storage: do git save\n");
+		SSRF_INFO("git storage: do git save\n");
 
 	if (!create_empty) // so we are actually saving the dives
 		git_storage_update_progress(translate("gettextFromC", "Preparing to save data"));
@@ -1238,7 +1238,7 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 			return -1;
 
 	if (verbose)
-		fprintf(stderr, "git storage, write git tree\n");
+		SSRF_INFO("git storage, write git tree\n");
 
 	if (write_git_tree(repo, &tree, &id))
 		return report_error("git tree write failed");

--- a/core/trip.c
+++ b/core/trip.c
@@ -4,6 +4,7 @@
 #include "subsurface-string.h"
 #include "selection.h"
 #include "table.h"
+#include "core/qthelper.h"
 
 struct trip_table trip_table;
 
@@ -87,7 +88,7 @@ void add_dive_to_trip(struct dive *dive, dive_trip_t *trip)
 	if (dive->divetrip == trip)
 		return;
 	if (dive->divetrip)
-		fprintf(stderr, "Warning: adding dive to trip that has trip set\n");
+		SSRF_INFO("Warning: adding dive to trip that has trip set\n");
 	insert_dive(&trip->dives, dive);
 	dive->divetrip = trip;
 }

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -526,7 +526,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 
 				Kirigami.Action {
-					text: qsTr("Enable verbose logging")
+					text: qsTr("Enable verbose logging (currently: %1)").arg(manager.verboseEnabled)
 					onTriggered: {
 						showPassiveNotification(qsTr("Not persistent"), 3000)
 						globalDrawer.close()

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -229,7 +229,7 @@ QStringList DiveSiteSortedModel::allSiteNames() const
 		// (more precisely: the core has more sites than the model is aware of),
 		// we might get an invalid index.
 		if (idx < 0 || idx > dive_site_table.nr) {
-			fprintf(stderr, "DiveSiteSortedModel::allSiteNames(): invalid index");
+			SSRF_INFO("DiveSiteSortedModel::allSiteNames(): invalid index");
 			continue;
 		}
 		locationNames << QString(dive_site_table.dive_sites[idx]->name);

--- a/qt-models/messagehandlermodel.cpp
+++ b/qt-models/messagehandlermodel.cpp
@@ -1,13 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "messagehandlermodel.h"
-
-/* based on logging bits from libdivecomputer */
-#if !defined(Q_OS_ANDROID)
-#define INFO(fmt, ...)	fprintf(stderr, "INFO: " fmt "\n", ##__VA_ARGS__)
-#else
-#include <android/log.h>
-#define INFO(fmt, ...)	__android_log_print(ANDROID_LOG_DEBUG, "Subsurface", "INFO: " fmt "\n", ##__VA_ARGS__);
-#endif
+#include "core/qthelper.h"
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 extern void writeToAppLogFile(QString logText);
@@ -49,7 +42,7 @@ void MessageHandlerModel::addLog(QtMsgType type, const QString& message)
 	beginInsertRows(QModelIndex(), rowCount(), rowCount());
 	m_data.append({message, type});
 	endInsertRows();
-	INFO("%s", qPrintable(message));
+	SSRF_INFO("%s", qPrintable(message));
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	writeToAppLogFile(message);
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It turns out that (at least) on Android libgit2 doesn't appear to (always?) correctly respond to valid SSL certificates. Or maybe it's our openssl that doesn't get it right? It's rather frustrating to try to figure out what exactly is going on.

The SSL code in Qt correctly rejects an invalid SSL certificate, but libgit2 often tells us that our certificate on the cloud server is wrong. We used to have code in `git-access.c` that was supposed to only override things for our old certificate that we haven't used in years, but a bug in that code made it still work. So this PR brings back the certificate callback which now unapologetically acceps any certificate for our cloud server, relying on the fact that we earlier called `canReachCloudServer()` which will have rejected an invalid certificate.

The PR also includes some long overdue cleanup to make debug printouts work on Android.

