### PR TITLE
desktop: rearrange widgets on the dive site tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveSite.ui
+++ b/desktop-widgets/tab-widgets/TabDiveSite.ui
@@ -17,14 +17,38 @@
    <item>
     <layout class="QHBoxLayout" name="layout">
      <item>
+      <widget class="QLabel" name="filterLabel">
+       <property name="text">
+        <string>Filter</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="filterText">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed"/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QToolButton" name="purgeUnused">
        <property name="text">
         <string>Purge unused dive sites</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="filterText"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Move the more commonly used filter to the left and the less
commonly used "purge unused sites" button to the right. Add
a spacer so that the filter-textbox doesn't extend over the
whole free space.

With apologies to sinistroverse users (is there an option to
make the layout direction depend on the locale?).

Suggested-by: Hartley Horwitz <hhrwtz@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] UI styling

### Pull request long description:
<!-- Describe your pull request in detail. -->
Changes the dive-site tab as suggested on the mailing list.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Swap filter and purge-divesite-button.
2) Add label to filter
3) Add space between filter and button
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
