### PR TITLE
profile: avoid invalid accesses in setup_gas_sensor_pressure

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -961,10 +961,13 @@ static int same_rounded_pressure(pressure_t a, pressure_t b)
  * tell us what the first gas is with a gas change event in the first sample.
  * Sneakily we'll use a return value of 0 (or FALSE) when there is no explicit
  * first cylinder - in which case cylinder 0 is indeed the first cylinder.
- * We likewise return 0 if the event concerns a cylinder that doesn't exist. */
+ * We likewise return 0 if the event concerns a cylinder that doesn't exist.
+ * If the dive has no cylinders, -1 is returned. */
 int explicit_first_cylinder(const struct dive *dive, const struct divecomputer *dc)
 {
 	int res = 0;
+	if (!dive->cylinders.nr)
+		return -1;
 	if (dc) {
 		const struct event *ev = get_next_event(dc->events, "gaschange");
 		if (ev && ((dc->sample && ev->time.seconds == dc->sample[0].time.seconds) || ev->time.seconds <= 1))

--- a/core/profile.c
+++ b/core/profile.c
@@ -844,6 +844,10 @@ static void setup_gas_sensor_pressure(const struct dive *dive, const struct dive
 {
 	int prev, i;
 	const struct event *ev;
+
+	if (pi->nr_cylinders == 0)
+		return;
+
 	int *seen = malloc(pi->nr_cylinders * sizeof(*seen));
 	int *first = malloc(pi->nr_cylinders * sizeof(*first));
 	int *last = malloc(pi->nr_cylinders * sizeof(*last));


### PR DESCRIPTION
Since we removed MAX_CYLINDERS, we have to possibility of dives
with no cylinders. In such a case, setup_gas_sensor_pressure()
would do invalid read- and write-accesses. Therefore, return
early in such a case.

Reported-by: Chirana Gheorghita Eugeniu Theodor <office@adaptcom.ro>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an invalid access, which is probably the cause of a crash reported on the mailing list. Note: I have no time and did not think this through. In any case it shouldn't hurt.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Return early from setup_gas_sensor_pressure() if there are no cylinders.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.