### PR TITLE
desktop: don't access first data element if no cylinders

### DIFF
--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -180,7 +180,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 					filename.append(".xml");
 				QByteArray bt = QFile::encodeName(filename);
 				std::vector<const dive_site *> sites = getDiveSitesToExport(ui->exportSelected->isChecked());
-				save_dive_sites_logic(bt.data(), &sites[0], (int)sites.size(), ui->anonymize->isChecked());
+				save_dive_sites_logic(bt.data(), sites.data(), (int)sites.size(), ui->anonymize->isChecked());
 			}
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -128,7 +128,8 @@ void TabDiveInformation::updateProfile()
 	volume_t *gases = get_gas_used(current_dive);
 	QString volumes;
 	std::vector<int> mean(current_dive->cylinders.nr), duration(current_dive->cylinders.nr);
-	per_cylinder_mean_depth(current_dive, select_dc(current_dive), &mean[0], &duration[0]);
+	if (current_dive->cylinders.nr >= 0)
+		per_cylinder_mean_depth(current_dive, select_dc(current_dive), mean.data(), duration.data());
 	volume_t sac;
 	QString gaslist, SACs, separator;
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2120,7 +2120,7 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 		case EX_DIVE_SITES_XML:
 			{
 				std::vector<const dive_site *> sites = getDiveSitesToExport(false);
-				save_dive_sites_logic(qPrintable(fileName + ".xml"), &sites[0], (int)sites.size(), anonymize);
+				save_dive_sites_logic(qPrintable(fileName + ".xml"), sites.data(), (int)sites.size(), anonymize);
 				break;
 			}
 		case EX_UDDF:

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -548,8 +548,8 @@ void CylindersModel::remove(QModelIndex index)
 	endRemoveRows();
 
 	std::vector<int> mapping = get_cylinder_map_for_remove(d->cylinders.nr + 1, index.row());
-	cylinder_renumber(d, &mapping[0]);
-	DivePlannerPointsModel::instance()->cylinderRenumber(&mapping[0]);
+	cylinder_renumber(d, mapping.data());
+	DivePlannerPointsModel::instance()->cylinderRenumber(mapping.data());
 }
 
 void CylindersModel::cylinderAdded(struct dive *changed, int pos)
@@ -601,9 +601,9 @@ void CylindersModel::moveAtFirst(int cylid)
 	std::iota(mapping.begin(), mapping.begin() + cylid, 1);
 	mapping[cylid] = 0;
 	std::iota(mapping.begin() + (cylid + 1), mapping.end(), cylid);
-	cylinder_renumber(d, &mapping[0]);
+	cylinder_renumber(d, mapping.data());
 	if (inPlanner)
-		DivePlannerPointsModel::instance()->cylinderRenumber(&mapping[0]);
+		DivePlannerPointsModel::instance()->cylinderRenumber(mapping.data());
 	endMoveRows();
 }
 


### PR DESCRIPTION
TabDiveInformation::updateProfile() does some statistics via the
per_cylinder_mean_depth function. It passes down arrays with one
entry per cylinder, which are allocated by means std::vector.

To pass the array, the expression "&vector[0]" is used. It seems
like some compilers through an assertion violation if vector
has no elements. They are technically correct in that this is
undefined, but still this appears like very unfriendly behavior.
After all, std::vector should behave just like a dynamic C-array
that is automatically freed, when going out of scope.

Replace the "&vector[0]" by "vector.data()" and don't do the
call if there aren't any cylinders for good measure.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another possible crash fix concerning the profile.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Don't do `&vector[0]` for empty arrays.
