### PR TITLE
map: remove selectedDivesChanged signal

### DIFF
--- a/map-widget/qml/MapWidget.qml
+++ b/map-widget/qml/MapWidget.qml
@@ -9,13 +9,10 @@ Item {
 	property alias mapHelper: mapHelper
 	property alias map: map
 
-	signal selectedDivesChanged(var list)
-
 	MapWidgetHelper {
 		id: mapHelper
 		map: map
 		editMode: false
-		onSelectedDivesChanged: rootItem.selectedDivesChanged(list)
 		onEditModeChanged: editMessage.isVisible = editMode === true ? 1 : 0
 		onCoordinatesChanged: {}
 		Component.onCompleted: {


### PR DESCRIPTION
The qml-widget seems to catch selectedDivesChanged signals of the
MapWidgetHelper and reemit them. However, there seems to be nobody
listening to this signal?

Let's remove this for now to make debugging of the signals easier.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This removes a signal that, unless I'm missing something, has no listener. Thus, remove it for now to make debugging of a signal with the same name easier.

Dive site selection for me still works after this commit, however I didn't test it thoroughly.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove signal.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2776
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 