### PR TITLE
GitHub Actions: we can't have an action with no on: clause

### DIFF
--- a/.github/workflows/android-dockerimage.yml
+++ b/.github/workflows/android-dockerimage.yml
@@ -8,6 +8,12 @@ name: Android Docker Image CI
 #    - scripts/docker/android-build-container/Dockerfile
 #    - .github/workflows/android-docker*
 
+# this is here to prevent errors about not having an on: clause
+on:
+  repository_dispatch:
+    types:
+    - unused
+
 jobs:
   android-build-container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So in order to disable an action, I'll just use an unused
repository_dispatch.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This way we sholdn't get these annoying error emails.
Of course it took me five attempts to create a fix that actually didn't create an error...
