### PR TITLE
planner: horror-hack: create fake cylinder at end of cylinder table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: fix profile display of planned dives with surface segments
 maps: show the dive site as marker when opening Google Maps
 Mobile: fix false rejection of Subsurface cloud SSL certificate
 Mobile: fix misdetection of Shearwater Petrel 2 on iOS

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1167,7 +1167,7 @@ void RemoveCylinder::undo()
 {
 	for (size_t i = 0; i < dives.size(); ++i) {
 		std::vector<int> mapping = get_cylinder_map_for_add(dives[i]->cylinders.nr, indexes[i]);
-		add_to_cylinder_table(&dives[i]->cylinders, indexes[i], clone_cylinder(cyl[i]));
+		add_cylinder(&dives[i]->cylinders, indexes[i], clone_cylinder(cyl[i]));
 		emit diveListNotifier.cylinderAdded(dives[i], indexes[i]);
 		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}

--- a/core/cochran.c
+++ b/core/cochran.c
@@ -682,7 +682,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 			cyl.gasmix.o2.permille = (log[CMD_O2_PERCENT] / 256
 				+ log[CMD_O2_PERCENT + 1]) * 10;
 			cyl.gasmix.he.permille = 0;
-			add_to_cylinder_table(&dive->cylinders, 0, cyl);
+			add_cylinder(&dive->cylinders, 0, cyl);
 		} else {
 			dc->model = "Commander";
 			dc->deviceid = array_uint32_le(buf + 0x31e);	// serial no
@@ -692,7 +692,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 				cyl.gasmix.o2.permille = (log[CMD_O2_PERCENT + g * 2] / 256
 					+ log[CMD_O2_PERCENT + g * 2 + 1]) * 10;
 				cyl.gasmix.he.permille = 0;
-				add_to_cylinder_table(&dive->cylinders, g, cyl);
+				add_cylinder(&dive->cylinders, g, cyl);
 			}
 		}
 
@@ -739,7 +739,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 			cyl.gasmix.he.permille =
 				(log[EMC_HE_PERCENT + g * 2] / 256
 				+ log[EMC_HE_PERCENT + g * 2 + 1]) * 10;
-			add_to_cylinder_table(&dive->cylinders, g, cyl);
+			add_cylinder(&dive->cylinders, g, cyl);
 		}
 
 		tm.tm_year = log[EMC_YEAR];

--- a/core/dive.c
+++ b/core/dive.c
@@ -227,7 +227,10 @@ struct event *add_event(struct divecomputer *dc, unsigned int time, int type, in
 void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int seconds, int idx)
 {
 	/* sanity check so we don't crash */
-	if (idx < 0 || idx >= dive->cylinders.nr) {
+	/* FIXME: The planner uses a dummy cylinder one past the official number of cylinders
+	 * in the table to mark no-cylinder surface interavals. This is horrendous. Fix ASAP. */
+	//if (idx < 0 || idx >= dive->cylinders.nr) {
+	if (idx < 0 || idx >= dive->cylinders.nr + 1 || idx >= dive->cylinders.allocated) {
 		report_error("Unknown cylinder index: %d", idx);
 		return;
 	}

--- a/core/dive.c
+++ b/core/dive.c
@@ -339,14 +339,16 @@ enum divemode_t get_current_divemode(const struct divecomputer *dc, int time, co
 
 struct gasmix get_gasmix_from_event(const struct dive *dive, const struct event *ev)
 {
-	struct gasmix dummy = gasmix_air;
 	if (ev && event_is_gaschange(ev)) {
 		int index = ev->gas.index;
+		// FIXME: The planner uses one past cylinder-count to signify "surface air". Remove in due course.
+		if (index == dive->cylinders.nr)
+			return gasmix_air;
 		if (index >= 0 && index < dive->cylinders.nr)
 			return get_cylinder(dive, index)->gasmix;
 		return ev->gas.mix;
 	}
-	return dummy;
+	return gasmix_air;
 }
 
 // we need this to be uniq. oh, and it has no meaning whatsoever

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -56,7 +56,7 @@ MAKE_CLEAR_TABLE(weightsystem_table, weightsystems, weightsystem)
 //static MAKE_GET_IDX(cylinder_table, cylinder_t, cylinders)
 static MAKE_GROW_TABLE(cylinder_table, cylinder_t, cylinders)
 //static MAKE_GET_INSERTION_INDEX(cylinder_table, cylinder_t, cylinders, cylinder_less_than)
-MAKE_ADD_TO(cylinder_table, cylinder_t, cylinders)
+static MAKE_ADD_TO(cylinder_table, cylinder_t, cylinders)
 MAKE_REMOVE_FROM(cylinder_table, cylinders)
 //MAKE_SORT(cylinder_table, cylinder_t, cylinders, comp_cylinders)
 //MAKE_REMOVE(cylinder_table, cylinder_t, cylinder)
@@ -144,11 +144,23 @@ cylinder_t clone_cylinder(cylinder_t cyl)
 	return res;
 }
 
+void add_cylinder(struct cylinder_table *t, int idx, cylinder_t cyl)
+{
+	add_to_cylinder_table(t, idx, cyl);
+	/* FIXME: This is a horrible hack: we make sure that at the end of
+	 * every single cylinder table there is an empty cylinder that can
+	 * be used by the planner as "surface air" cylinder. Fix this.
+	 */
+	add_to_cylinder_table(t, t->nr, empty_cylinder);
+	t->nr--;
+	t->cylinders[t->nr].cylinder_use = NOT_USED;
+}
+
 /* Add a clone of a cylinder to the end of a cylinder table.
  * Cloned in means that the description-string is copied. */
 void add_cloned_cylinder(struct cylinder_table *t, cylinder_t cyl)
 {
-	add_to_cylinder_table(t, t->nr, clone_cylinder(cyl));
+	add_cylinder(t, t->nr, clone_cylinder(cyl));
 }
 
 bool same_weightsystem(weightsystem_t w1, weightsystem_t w2)
@@ -342,7 +354,7 @@ cylinder_t *add_empty_cylinder(struct cylinder_table *t)
 {
 	cylinder_t cyl = empty_cylinder;
 	cyl.type.description = strdup("");
-	add_to_cylinder_table(t, t->nr, cyl);
+	add_cylinder(t, t->nr, cyl);
 	return &t->cylinders[t->nr - 1];
 }
 

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -368,7 +368,10 @@ cylinder_t *add_empty_cylinder(struct cylinder_table *t)
  */
 cylinder_t *get_cylinder(const struct dive *d, int idx)
 {
-	if (idx < 0 || idx >= d->cylinders.nr) {
+	/* FIXME: The planner uses a dummy cylinder one past the official number of cylinders
+	 * in the table to mark no-cylinder surface interavals. This is horrendous. Fix ASAP. */
+	// if (idx < 0 || idx >= d->cylinders.nr) {
+	if (idx < 0 || idx >= d->cylinders.nr + 1 || idx >= d->cylinders.allocated) {
 		fprintf(stderr, "Warning: accessing invalid cylinder %d (%d existing)\n", idx, d->cylinders.nr);
 		return NULL;
 	}

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -39,7 +39,7 @@ static const cylinder_t empty_cylinder = { { { 0 }, { 0 }, (const char *)0}, { {
  * *not* pointers to cylinders. This has two crucial consequences:
  * 1) Pointers to cylinders are not stable. They may be
  *    invalidated if the table is reallocated.
- * 2) add_to_cylinder_table(), etc. take ownership of the
+ * 2) add_cylinder(), etc. take ownership of the
  *    cylinder. Notably of the description string. */
 struct cylinder_table {
 	int nr, allocated;
@@ -102,7 +102,7 @@ extern void add_to_weightsystem_table(struct weightsystem_table *, int idx, weig
 
 /* Cylinder table functions */
 extern void clear_cylinder_table(struct cylinder_table *);
-extern void add_to_cylinder_table(struct cylinder_table *, int idx, cylinder_t cyl);
+extern void add_cylinder(struct cylinder_table *, int idx, cylinder_t cyl);
 
 void get_gas_string(struct gasmix gasmix, char *text, int len);
 const char *gasname(struct gasmix gasmix);

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -228,7 +228,7 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 		if (empty_string(cyl.type.description))
 			cyl.type.description = strdup(translate("gettextFromC", "unknown"));
 
-		add_to_cylinder_table(&dive->cylinders, dive->cylinders.nr, cyl);
+		add_cylinder(&dive->cylinders, dive->cylinders.nr, cyl);
 	}
 	return DC_STATUS_SUCCESS;
 }

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -151,7 +151,7 @@ static void parse_dives(int log_version, const unsigned char *buf, unsigned int 
 		for (i = 0; i < 1; i++) {
 			cylinder_t cyl = empty_cylinder;
 			fill_default_cylinder(dive, &cyl);
-			add_to_cylinder_table(&dive->cylinders, i, cyl);
+			add_cylinder(&dive->cylinders, i, cyl);
 		}
 
 		// Model 0=Xen, 1,2=Xeo, 4=Lynx, other=Liquivision

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -455,7 +455,7 @@ static void parse_dive_cylinder(char *line, struct membuffer *str, struct git_pa
 	if (cylinder.cylinder_use == OXYGEN)
 		state->o2pressure_sensor = state->active_dive->cylinders.nr;
 
-	add_to_cylinder_table(&state->active_dive->cylinders, state->active_dive->cylinders.nr, cylinder);
+	add_cylinder(&state->active_dive->cylinders, state->active_dive->cylinders.nr, cylinder);
 }
 
 static void parse_weightsystem_keyvalue(void *_ws, const char *key, const char *value)

--- a/core/planner.c
+++ b/core/planner.c
@@ -1074,7 +1074,7 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 		// If no empty cylinder is found, keep using last deco gas
 		cylinder_t cyl = empty_cylinder;
 		cyl.cylinder_use = NOT_USED;
-		add_to_cylinder_table(&dive->cylinders, dive->cylinders.nr, cyl);
+		add_cylinder(&dive->cylinders, dive->cylinders.nr, cyl);
 		current_cylinder = dive->cylinders.nr - 1;
 		plan_add_segment(diveplan, prefs.surface_segment, 0, current_cylinder, 0, false, OC);
 	}

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -490,7 +490,7 @@ void CylindersModel::add()
 	int row = d->cylinders.nr;
 	cylinder_t cyl = create_new_cylinder(d);
 	beginInsertRows(QModelIndex(), row, row);
-	add_to_cylinder_table(&d->cylinders, row, cyl);
+	add_cylinder(&d->cylinders, row, cyl);
 	endInsertRows();
 	emit dataChanged(createIndex(row, 0), createIndex(row, COLUMNS - 1));
 }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -174,14 +174,14 @@ void DivePlannerPointsModel::setupCylinders()
 		cylinder_t cyl = empty_cylinder;
 		fill_default_cylinder(&displayed_dive, &cyl);
 		cyl.start = cyl.type.workingpressure;
-		add_to_cylinder_table(&displayed_dive.cylinders, 0, cyl);
+		add_cylinder(&displayed_dive.cylinders, 0, cyl);
 	} else {
 		cylinder_t cyl = empty_cylinder;
 		// roughly an AL80
 		cyl.type.description = copy_qstring(tr("unknown"));
 		cyl.type.size.mliter = 11100;
 		cyl.type.workingpressure.mbar = 207000;
-		add_to_cylinder_table(&displayed_dive.cylinders, 0, cyl);
+		add_cylinder(&displayed_dive.cylinders, 0, cyl);
 	}
 	reset_cylinders(&displayed_dive, false);
 	cylinders.updateDive(&displayed_dive);


### PR DESCRIPTION
When we had fixed-sized cylinder arrays, the planner used the last
empty cylinder for "surface air". This was not recognized by the UI
as a separate cylinder, because "empty cylinder" was the sentinel for
the end of the table. The conversion to dynamically sized cylinder
tables broke this code: everytime the surface segment is changed,
a new dummy cylinder is added, which is visible in the UI.

As a very temporary stop-gap fix, emulate the old code by creating
a cylinder and then setting the end-of-table to before that cylinder.
This means that we have to loosen the out-of-bound checks.

That's all very scary and should be removed as soon as possible.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is supposed to sketch a temporary fix to #2788. I feel very bad for this and would prefer a proper fix. However, that might be too short before release.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Create dummy cylinder at end of cylinder table for "surface air".

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
see discussion in #2788

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde