### PR TITLE
profile: set empty state when there is no current dive to show

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -566,8 +566,10 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 #endif
 	if (currentState != ADD && currentState != PLAN) {
 		if (!d) {
-			if (!current_dive)
+			if (!current_dive) {
+				setEmptyState();
 				return;
+			}
 			d = current_dive; // display the current dive
 		}
 


### PR DESCRIPTION
The profile data was not properly cleared when not showing a
dive.

Fixes #2787

Reported-by: Robert C. Helling <helling@atdotde.de>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a tiny "backport" of #2757, which fixes #2787. Since this is the minimal version, I guess it is preferred for now.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Properly clear profile if no dive is shown.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde @dirkhh 