### PR TITLE
desktop: don't replot profile when populating dive information tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -316,6 +316,7 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
+	bool replot = false;
 	if (field.visibility)
 		ui->visibility->setCurrentStars(current_dive->visibility);
 	if (field.wavesize)
@@ -326,8 +327,10 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		ui->surge->setCurrentStars(current_dive->surge);
 	if (field.chill)
 		ui->chill->setCurrentStars(current_dive->chill);
-	if (field.mode)
+	if (field.mode) {
 		updateMode(current_dive);
+		replot = true;
+	}
 	if (field.duration || field.depth || field.mode)
 		updateProfile();
 	if (field.air_temp)
@@ -344,6 +347,10 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		salinity_value = current_dive->salinity;
 	ui->waterTypeCombo->setCurrentIndex(updateSalinityComboIndex(salinity_value));
 	ui->salinityText->setText(QString("%1g/ℓ").arg(salinity_value / 10.0));
+	// TODO: The profile should recognize itself when the dive mode changed.
+	// It seem awkward to route this via the dive-information tab.
+	if (replot)
+		MainWindow::instance()->graphics->replot();
 }
 
 void TabDiveInformation::on_visibility_valueChanged(int value)
@@ -379,7 +386,6 @@ void TabDiveInformation::on_chill_valueChanged(int value)
 void TabDiveInformation::updateMode(struct dive *d)
 {
 	ui->diveType->setCurrentIndex(get_dive_dc(d, dc_number)->divemode);
-	MainWindow::instance()->graphics->replot();
 }
 
 void TabDiveInformation::diveModeChanged(int index)

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -7,7 +7,6 @@
 
 DivePlotDataModel::DivePlotDataModel(QObject *parent) :
 	QAbstractTableModel(parent),
-	diveId(0),
 	dcNr(0)
 {
 	init_plot_info(&pInfo);
@@ -176,7 +175,6 @@ void DivePlotDataModel::clear()
 		free(pInfo.pressures);
 		pInfo.entry = nullptr;
 		pInfo.pressures = nullptr;
-		diveId = -1;
 		dcNr = -1;
 		endRemoveRows();
 	}
@@ -185,7 +183,6 @@ void DivePlotDataModel::clear()
 void DivePlotDataModel::setDive(dive *d, const plot_info &info)
 {
 	beginResetModel();
-	diveId = d->id;
 	dcNr = dc_number;
 	free(pInfo.entry);
 	free(pInfo.pressures);

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -92,7 +92,6 @@ public:
 
 private:
 	struct plot_info pInfo;
-	int diveId;
 	unsigned int dcNr;
 	struct deco_state plot_deco_state;
 };


### PR DESCRIPTION
When the dive mode is changed, the profile has to be replot. This
is by a function of the TabDiveInformation. However, that function
was also executed when populating the tab. Thus, when changing dive,
the profile was plot twice.

Move the profile plotting out of the function. Ultimately, the profile
should listen to the appropriate signals itself.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Avoid double profile reloads for *every* selection change. Changing dive-mode still replots the profile as expected.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't replot profile when populating the dive information tab.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
