### PR TITLE
[TRIVIAL] cleanup: replace Q_ASSERT by qWarning

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -262,7 +262,7 @@ int DiveEventItem::depthAtTime(int time)
 {
 	QModelIndexList result = dataModel->match(dataModel->index(0, DivePlotDataModel::TIME), Qt::DisplayRole, time);
 	if (result.isEmpty()) {
-		Q_ASSERT("can't find a spot in the dataModel");
+		qWarning("can't find a spot in the dataModel");
 		hide();
 		return DEPTH_NOT_FOUND;
 	}
@@ -276,7 +276,7 @@ void DiveEventItem::recalculatePos(int speed)
 
 	QModelIndexList result = dataModel->match(dataModel->index(0, DivePlotDataModel::TIME), Qt::DisplayRole, internalEvent->time.seconds);
 	if (result.isEmpty()) {
-		Q_ASSERT("can't find a spot in the dataModel");
+		qWarning("can't find a spot in the dataModel");
 		hide();
 		return;
 	}


### PR DESCRIPTION
These two Q_ASSERTs made no sense - their expression (a string
literal) always evaluated to true. A qWarning() was intended here.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial code hygiene change - see commit message.
