### PR TITLE
profile: properly update lastgasmix when populating events

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -195,7 +195,6 @@ void DiveEventItem::setupToolTipString(struct gasmix lastgasmix)
 			name += QString::fromUtf8(mb.buffer, mb.len);
 			free_buffer(&mb);
 		}
-		lastgasmix = mix;
 	} else if (same_string(internalEvent->name, "modechange")) {
 		name += QString(": %1").arg(gettextFromC::tr(divemode_text_ui[internalEvent->value]));
 	} else if (value) {

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -802,6 +802,8 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 		item->setZValue(2);
 		scene()->addItem(item);
 		eventItems.push_back(item);
+		if (event_is_gaschange(event))
+			lastgasmix = get_gasmix_from_event(&displayed_dive, event);
 		event = event->next;
 	}
 


### PR DESCRIPTION
When populating the events of a profile, a pointer to the current
gasmix was passed around to properly calculate isobaric_counterdiffusion.
The DiveEventItem::setupToolTipString() function updated this gasmix
when processing gas change events.

I inadvertently broke the code when replacing gasmix-pointers by
values. We could of course simply revert this part of the commit.
However, the data flow was horrible anyway: for example is supposed
that the setup functions were called in the correct order (i.e.
DiveEventItem::setupToolTipString() is called after all other
functions using the gasmix). Not exactly easy to follow.

Therefore, keep passing around the gasmix as value to make it clear
that the functions don't modify it. Keep the gasmix up-to-date at
the caller's site in ProfileWidget2::plotDive().

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This should fix a bug, which I noted while debugging the profile: Wrong gasses were used when calculating `isobaric_counterdiffusion`. Notably, the current gas wasn't updated since I turned pointers to values. This *looks* right, but checking by someone who actually knows what "isobaric counterdiffusion" is would be great.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) update gasmix when populating event items on profile.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 