### PR TITLE
[Serious Bug!] Fix editing of trips.

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -2,7 +2,6 @@
 
 #include "command_divelist.h"
 #include "core/divelist.h"
-#include "core/display.h" // for amount_selected
 #include "core/qthelper.h"
 #include "core/selection.h"
 #include "core/subsurface-qt/divelistnotifier.h"

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -786,15 +786,6 @@ void delete_single_dive(int idx)
 	delete_dive_from_table(&dive_table, idx);
 }
 
-/* add a dive at the end of the global dive table and keep track
- * of the number of selected dives. */
-void append_dive(struct dive *dive)
-{
-	add_to_dive_table(&dive_table, dive_table.nr, dive);
-	if (dive->selected)
-		amount_selected++;
-}
-
 int shown_dives = 0;
 bool filter_dive(struct dive *d, bool shown)
 {

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -46,7 +46,6 @@ extern char *get_dive_gas_string(const struct dive *dive);
 
 extern int dive_table_get_insertion_index(struct dive_table *table, struct dive *dive);
 extern void add_to_dive_table(struct dive_table *table, int idx, struct dive *dive);
-extern void append_dive(struct dive *dive);
 extern void insert_dive(struct dive_table *table, struct dive *d);
 extern void get_dive_gas(const struct dive *dive, int *o2_p, int *he_p, int *o2low_p);
 extern int get_divenr(const struct dive *dive);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -365,7 +365,7 @@ void MainTab::updateDiveInfo()
 		// 2) the filter is reset, potentially erasing the current trip under our feet.
 		// TODO: Don't hard code tab location!
 		bool onDiveSiteTab = ui.tabWidget->currentIndex() == 6;
-		if (dive_trip *currentTrip = MainWindow::instance()->diveList->singleSelectedTrip()) {
+		if ((currentTrip = MainWindow::instance()->diveList->singleSelectedTrip()) != nullptr) {
 			// Remember the tab selected for last dive but only if we're not on the dive site tab
 			if (lastSelectedDive && !onDiveSiteTab)
 				lastTabSelectedDive = ui.tabWidget->currentIndex();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a show-stopper recently introduced, whereby editing of trip notes would edit the notes of the dives in the trip instead.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace a function-local variable by the member variable

@dirkhh: Since this is so serious, I will commit once CI is happy!