### PR TITLE
[Post-Release] Move selection of trips to core

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -13,6 +13,14 @@
 
 namespace Command {
 
+// Helper function that takes care to unselect trips that are removed from the backend
+static void remove_trip_from_backend(dive_trip *trip)
+{
+	if (trip->selected)
+		deselect_trip(trip);
+	remove_trip(trip, &trip_table);	// Remove trip from backend
+}
+
 // This helper function removes a dive, takes ownership of the dive and adds it to a DiveToAdd structure.
 // If the trip the dive belongs to becomes empty, it is removed and added to the tripsToAdd vector.
 // It is crucial that dives are added in reverse order of deletion, so that the indices are correctly
@@ -32,7 +40,7 @@ DiveToAdd DiveListBase::removeDive(struct dive *d, std::vector<OwningTripPtr> &t
 		diveSiteCountChanged(d->dive_site);
 	res.site = unregister_dive_from_dive_site(d);
 	if (res.trip && res.trip->dives.nr == 0) {
-		remove_trip(res.trip, &trip_table);	// Remove trip from backend
+		remove_trip_from_backend(res.trip);	// Remove trip from backend
 		tripsToAdd.emplace_back(res.trip);	// Take ownership of trip
 	}
 
@@ -265,7 +273,7 @@ static OwningTripPtr moveDiveToTrip(DiveToTrip &diveToTrip)
 	// Remove dive from trip - if this is the last dive in the trip, remove the whole trip.
 	dive_trip *trip = unregister_dive_from_trip(diveToTrip.dive);
 	if (trip && trip->dives.nr == 0) {
-		remove_trip(trip, &trip_table);	// Remove trip from backend
+		remove_trip_from_backend(trip);	// Remove trip from backend
 		res.reset(trip);
 	}
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1354,6 +1354,7 @@ int get_dive_id_closest_to(timestamp_t when)
 void clear_dive_file_data()
 {
 	fulltext_unregister_all();
+	clear_selection();
 
 	while (dive_table.nr)
 		delete_single_dive(0);

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -3,12 +3,13 @@
 
 #include "selection.h"
 #include "divelist.h"
-#include "display.h" // for amount_selected
+#include "trip.h"
 #include "subsurface-qt/divelistnotifier.h"
 
 #include <QVector>
 
 int amount_selected;
+static int amount_trips_selected;
 
 extern "C" void select_dive(struct dive *dive)
 {
@@ -155,6 +156,11 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive)
 	QVector<dive *> divesToSelect;
 	divesToSelect.reserve(selection.size());
 
+	// Since we select only dives, there are no selected trips!
+	amount_trips_selected = 0;
+	for (int i = 0; i < trip_table.nr; ++i)
+		trip_table.trips[i]->selected = false;
+
 	// TODO: We might want to keep track of selected dives in a more efficient way!
 	int i;
 	dive *d;
@@ -230,4 +236,20 @@ extern "C" void select_newest_visible_dive()
 
 	// No visible dive -> deselect all
 	select_single_dive(nullptr);
+}
+
+extern "C" void select_trip(struct dive_trip *trip)
+{
+	if (trip && !trip->selected) {
+		trip->selected = true;
+		amount_trips_selected++;
+	}
+}
+
+extern "C" void deselect_trip(struct dive_trip *trip)
+{
+	if (trip && trip->selected) {
+		trip->selected = false;
+		amount_trips_selected--;
+	}
 }

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -253,3 +253,16 @@ extern "C" void deselect_trip(struct dive_trip *trip)
 		amount_trips_selected--;
 	}
 }
+
+extern "C" void clear_selection(void)
+{
+	current_dive = nullptr;
+	amount_selected = 0;
+	amount_trips_selected = 0;
+	int i;
+	struct dive *dive;
+	for_each_dive (i, dive)
+		dive->selected = false;
+	for (int i = 0; i < trip_table.nr; ++i)
+		trip_table.trips[i]->selected = false;
+}

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -254,6 +254,18 @@ extern "C" void deselect_trip(struct dive_trip *trip)
 	}
 }
 
+extern "C" struct dive_trip *single_selected_trip()
+{
+	if (amount_trips_selected != 1)
+		return NULL;
+	for (int i = 0; i < trip_table.nr; ++i) {
+		if (trip_table.trips[i]->selected)
+			return trip_table.trips[i];
+	}
+	fprintf(stderr, "warning: found no selected trip even though one should be selected\n");
+	return NULL; // shouldn't happen
+}
+
 extern "C" void clear_selection(void)
 {
 	current_dive = nullptr;

--- a/core/selection.h
+++ b/core/selection.h
@@ -21,6 +21,8 @@ extern struct dive *last_selected_dive(void);
 extern bool consecutive_selected(void);
 extern void select_newest_visible_dive();
 extern void select_single_dive(struct dive *d); // wrapper for setSelection() with a single dive. NULL clears the selection.
+extern void select_trip(struct dive_trip *trip);
+extern void deselect_trip(struct dive_trip *trip);
 
 #if DEBUG_SELECTION_TRACKING
 extern void dump_selection(void);

--- a/core/selection.h
+++ b/core/selection.h
@@ -23,6 +23,7 @@ extern void select_newest_visible_dive();
 extern void select_single_dive(struct dive *d); // wrapper for setSelection() with a single dive. NULL clears the selection.
 extern void select_trip(struct dive_trip *trip);
 extern void deselect_trip(struct dive_trip *trip);
+extern void clear_selection(void);
 
 #if DEBUG_SELECTION_TRACKING
 extern void dump_selection(void);

--- a/core/selection.h
+++ b/core/selection.h
@@ -23,6 +23,7 @@ extern void select_newest_visible_dive();
 extern void select_single_dive(struct dive *d); // wrapper for setSelection() with a single dive. NULL clears the selection.
 extern void select_trip(struct dive_trip *trip);
 extern void deselect_trip(struct dive_trip *trip);
+extern struct dive_trip *single_selected_trip(); // returns trip if exactly one trip is selected, NULL otherwise.
 extern void clear_selection(void);
 
 #if DEBUG_SELECTION_TRACKING

--- a/core/trip.h
+++ b/core/trip.h
@@ -17,6 +17,7 @@ typedef struct dive_trip
 	/* Used by the io-routines to mark trips that have already been written. */
 	bool saved;
 	bool autogen;
+	bool selected;
 } dive_trip_t;
 
 typedef struct trip_table {

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -554,10 +554,13 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 			continue;
 		const QAbstractItemModel *model = index.model();
 		struct dive *dive = model->data(index, DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
-		if (!dive) // it's a trip!
-			deselect_dives_in_trip(model->data(index, DiveTripModelBase::TRIP_ROLE).value<dive_trip *>());
-		else
+		if (!dive) { // it's a trip!
+			dive_trip *trip = model->data(index, DiveTripModelBase::TRIP_ROLE).value<dive_trip *>();
+			deselect_trip(trip);
+			deselect_dives_in_trip(trip);
+		} else {
 			deselect_dive(dive);
+		}
 	}
 	Q_FOREACH (const QModelIndex &index, newSelected.indexes()) {
 		if (index.column() != 0)
@@ -566,9 +569,11 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 		const QAbstractItemModel *model = index.model();
 		struct dive *dive = model->data(index, DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
 		if (!dive) { // it's a trip!
+			dive_trip *trip = model->data(index, DiveTripModelBase::TRIP_ROLE).value<dive_trip *>();
+			select_trip(trip);
+			select_dives_in_trip(trip);
 			if (model->rowCount(index)) {
 				QItemSelection selection;
-				select_dives_in_trip(model->data(index, DiveTripModelBase::TRIP_ROLE).value<dive_trip *>());
 				selection.select(index.child(0, 0), index.child(model->rowCount(index) - 1, 0));
 				selectionModel()->select(selection, QItemSelectionModel::Select | QItemSelectionModel::Rows);
 				selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select | QItemSelectionModel::NoUpdate);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -263,9 +263,8 @@ void DiveListView::rowsInserted(const QModelIndex &parent, int start, int end)
 // Shouldn't the core-layer call us?
 void DiveListView::tripChanged(dive_trip *trip, TripField)
 {
-	// First check if the trip is already selected (and only
-	// this trip, as only then is it displayed). Is so, then do nothing.
-	if (singleSelectedTrip() == trip)
+	// First check if the trip is already selected (and only this trip, as only then is it displayed).
+	if (single_selected_trip() == trip)
 		return;
 
 	unselectDives();
@@ -295,23 +294,6 @@ void DiveListView::unselectDives()
 	clear_selection();
 	// clear the Qt selection
 	selectionModel()->clearSelection();
-}
-
-// This function returns a trip if there is one selected trip or NULL.
-// Returning all selected trips turned out to be too slow.
-dive_trip_t *DiveListView::singleSelectedTrip()
-{
-	dive_trip_t *res = nullptr;
-	for (const QModelIndex &index: selectionModel()->selectedRows()) {
-		if (index.parent().isValid())
-			continue;
-		if (dive_trip_t *trip = index.data(DiveTripModelBase::TRIP_ROLE).value<dive_trip *>()) {
-			if (res)
-				return nullptr; // More than one
-			res = trip;
-		}
-	}
-	return res;
 }
 
 bool DiveListView::eventFilter(QObject *, QEvent *event)

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -292,20 +292,9 @@ void DiveListView::selectTrip(dive_trip_t *trip)
 
 void DiveListView::unselectDives()
 {
-	// make sure we don't try to redraw the dives during the selection change
-	current_dive = nullptr;
-	amount_selected = 0;
+	clear_selection();
 	// clear the Qt selection
 	selectionModel()->clearSelection();
-	// clearSelection should emit selectionChanged() but sometimes that
-	// appears not to happen
-	// since we are unselecting all dives there is no need to use deselect_dive() - that
-	// would only cause pointless churn
-	int i;
-	struct dive *dive;
-	for_each_dive (i, dive) {
-		dive->selected = false;
-	}
 }
 
 // This function returns a trip if there is one selected trip or NULL.

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -25,7 +25,6 @@ public:
 	~DiveListView();
 	void setSortOrder(int i, Qt::SortOrder order); // Call to set sort order
 	void reload(); // Call to reload model data
-	dive_trip *singleSelectedTrip();
 	static QString lastUsedImageDir();
 	static void updateLastUsedImageDir(const QString &s);
 	void loadImages();

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -365,7 +365,8 @@ void MainTab::updateDiveInfo()
 		// 2) the filter is reset, potentially erasing the current trip under our feet.
 		// TODO: Don't hard code tab location!
 		bool onDiveSiteTab = ui.tabWidget->currentIndex() == 6;
-		if ((currentTrip = MainWindow::instance()->diveList->singleSelectedTrip()) != nullptr) {
+		currentTrip = single_selected_trip();
+		if (currentTrip) {
 			// Remember the tab selected for last dive but only if we're not on the dive site tab
 			if (lastSelectedDive && !onDiveSiteTab)
 				lastTabSelectedDive = ui.tabWidget->currentIndex();
@@ -412,7 +413,6 @@ void MainTab::updateDiveInfo()
 			if (!lastSelectedDive && !onDiveSiteTab)
 				ui.tabWidget->setCurrentIndex(lastTabSelectedDive);
 			lastSelectedDive = true;
-			currentTrip = NULL;
 			// make all the fields visible writeable
 			ui.diveTripLocation->hide();
 			ui.location->show();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In analogy to dives, move the management of trip selection to the core. The main reason is that checking whether a single trip is selected can be painfully slow, which in turn slows down updating of the main tab.

For a 3500 dive test file, this PR reduced the maintab update from 130 to 5 ms, when selecting all dives.

Sadly, the first CTRL-A is still very slow. It appears that the proxy-model has to populate its cache or something. I will have to investigate further.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Introduce a trip->selected flag in analogy to dive->selected.
2) Use said flag to improve speed when many dives are selected.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Probably not.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
