### PR TITLE
desktop: ask user when quitting application while planning

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -741,21 +741,9 @@ void MainWindow::on_actionPreferences_triggered()
 
 void MainWindow::on_actionQuit_triggered()
 {
-	if (mainTab->isEditing()) {
-		mainTab->rejectChanges();
-		if (mainTab->isEditing())
-			// didn't discard the edits
-			return;
-	}
-	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
-		DivePlannerPointsModel::instance()->cancelPlan();
-		if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING)
-			// The planned dive was not discarded
-			return;
-	}
-
-	if (unsavedChanges() && (askSaveChanges() == false))
+	if (!okToClose(tr("Please save or cancel the current dive edit before quiting the application.")))
 		return;
+
 	writeSettings();
 	QApplication::quit();
 }


### PR DESCRIPTION
We used to cancel a plan (or profile edit) when the user quit
the application while planning. This is inconsistent with
respect to closing or opening a different log, where the user
was asked for confirmation.

Thus, for consistency and to avoid loss of a planned dive,
use the okToClose() function in on_actionClose_triggered() of
MainWindow. As an added bonus, this saves a few SLOC.

Fixes #1078

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a UI issue reported by @willemferguson in #1078. The crash of the report I couldn't reproduce though (on Kubuntu 20.04).
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Ask user instead of canceling a plan when closing the application.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1078.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I don't think so.

Willem, please let me know if this behavior is what you had in mind.