### PR TITLE
Grantlee: Add salinity and water type to grantlee variables

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -5011,6 +5011,8 @@ Only a subset of the dive data is exported:
 |startPressure| (*string*) the start pressure
 |endPressure| (*string*) the end pressure
 |firstGas| (*string*) first used gas
+|salinity| (*string*) the salinity of the water for the dive
+|waterType| (*string*) the type of the water for the dive
 |=====================
 
 Please note that some of the variables like 'notes' need to be extended with '|safe' to support HTML tags:

--- a/core/dive.c
+++ b/core/dive.c
@@ -1196,6 +1196,11 @@ static void fixup_water_salinity(struct dive *dive)
 		dive->salinity = (sum + nr / 2) / nr;
 }
 
+int get_dive_salinity(const struct dive *dive)
+{
+	return dive->user_salinity ? dive->user_salinity : dive->salinity;
+}
+
 static void fixup_meandepth(struct dive *dive)
 {
 	struct divecomputer *dc;

--- a/core/dive.h
+++ b/core/dive.h
@@ -332,6 +332,7 @@ extern void sort_dive_table(struct dive_table *table);
 extern struct dive *fixup_dive(struct dive *dive);
 extern pressure_t calculate_surface_pressure(const struct dive *dive);
 extern pressure_t un_fixup_surface_pressure(const struct dive *d);
+extern int get_dive_salinity(const struct dive *dive);
 extern void fixup_dc_duration(struct divecomputer *dc);
 extern int dive_getUniqID();
 extern unsigned int dc_airtemp(const struct divecomputer *dc);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -621,6 +621,23 @@ QString get_pressure_string(pressure_t pressure, bool showunit)
 	}
 }
 
+QString get_salinity_string(int salinity)
+{
+        return QStringLiteral("%L1%2").arg(salinity / 10.0).arg(gettextFromC::tr("g/ℓ"));
+}
+
+QString get_water_type_string(int salinity)
+{
+	if (salinity < 10050)
+		return waterTypes[FRESHWATER];
+	else if (salinity < 10190)
+		return waterTypes[SALTYWATER];
+	else if (salinity < 10210)
+		return waterTypes[EN13319WATER];
+	else
+		return waterTypes[SALTWATER];
+}
+
 QString getSubsurfaceDataPath(QString folderToFind)
 {
 	QString execdir;
@@ -1142,6 +1159,11 @@ QString localFilePath(const QString &originalFilename)
 	QMutexLocker locker(&hashOfMutex);
 	return localFilenameOf.value(originalFilename, originalFilename);
 }
+
+// the water types need to match the watertypes enum
+const QStringList waterTypes = {
+	gettextFromC::tr("Fresh"), gettextFromC::tr("Salty"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("use dc")
+};
 
 // TODO: Apparently Qt has no simple way of listing the supported video
 // codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -11,6 +11,7 @@ struct picture;
 // 1) Types
 
 enum inertgas {N2, HE};
+enum watertypes {FRESHWATER, SALTYWATER, EN13319WATER, SALTWATER, DC_WATERTYPE};
 
 // 2) Functions visible only to C++ parts
 
@@ -37,6 +38,7 @@ int getCloudURL(QString &filename);
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
 void init_proxy();
 QString getUUID();
+extern const QStringList waterTypes;
 extern const QStringList videoExtensionsList;
 QStringList mediaExtensionFilters();
 QStringList imageExtensionFilters();
@@ -55,6 +57,8 @@ QString get_volume_string(int mliter, bool showunit = false);
 QString get_volume_unit();
 QString get_pressure_string(pressure_t pressure, bool showunit = false);
 QString get_pressure_unit();
+QString get_salinity_string(int salinity);
+QString get_water_type_string(int salinity);
 QString getSubsurfaceDataPath(QString folderToFind);
 QString getPrintingTemplatePathUser();
 QString getPrintingTemplatePathBundle();

--- a/core/subsurface-qt/diveobjecthelper.cpp
+++ b/core/subsurface-qt/diveobjecthelper.cpp
@@ -249,6 +249,19 @@ QStringList getFullCylinderList()
 	return cylinders;
 }
 
+QString formatDiveSalinity(const dive *d)
+{
+	int salinity = get_dive_salinity(d);
+	if (!salinity)
+		return QString();
+	return get_salinity_string(salinity);
+}
+
+QString formatDiveWaterType(const dive *d)
+{
+	return get_water_type_string(get_dive_salinity(d));
+}
+
 // Qt's metatype system insists on generating a default constructed object, even if that makes no sense.
 DiveObjectHelper::DiveObjectHelper()
 {
@@ -286,7 +299,9 @@ DiveObjectHelper::DiveObjectHelper(const struct dive *d) :
 	getCylinder(formatGetCylinder(d)),
 	startPressure(getStartPressure(d)),
 	endPressure(getEndPressure(d)),
-	firstGas(getFirstGas(d))
+	firstGas(getFirstGas(d)),
+	salinity(formatDiveSalinity(d)),
+	waterType(formatDiveWaterType(d))
 {
 #if defined(DEBUG_DOH)
 	void *array[4];

--- a/core/subsurface-qt/diveobjecthelper.h
+++ b/core/subsurface-qt/diveobjecthelper.h
@@ -84,6 +84,8 @@ public:
 	QStringList startPressure;
 	QStringList endPressure;
 	QStringList firstGas;
+	QString salinity;
+	QString waterType;
 };
 
 // This is an extended version of DiveObjectHelper that also keeps track of cylinder data.

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -43,7 +43,6 @@ private:
 	void divesEdited(int);
 	void closeWarning();
 	void showCurrentWidget(bool show, int position);
-	QStringList waterTypes;
 };
 
 #endif


### PR DESCRIPTION
These can be useful in a printed divelog, especially if the
log entry is also showing weight and exposure suit.

Signed-off-by: Monty Taylor <mordred@inaugust.com>

### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Adds two new fields, waterType and salinity to the grantlee exports for use in printed logs.