### PR TITLE
Update cylinder UI fields when cylinders are edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: update SAC fields and other statistics when editing cylinders
 Desktop: Reconnect the variations checkbox in planner
 Desktop: add support for dive mode on CSV import and export
 Desktop: fix profile display of planned dives with surface segments

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1061,6 +1061,7 @@ void AddCylinder::undo()
 		if (d->cylinders.nr <= 0)
 			continue;
 		remove_cylinder(d, d->cylinders.nr - 1);
+		update_cylinder_related_info(d);
 		emit diveListNotifier.cylinderRemoved(d, d->cylinders.nr);
 		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
@@ -1070,6 +1071,7 @@ void AddCylinder::redo()
 {
 	for (dive *d: dives) {
 		add_cloned_cylinder(&d->cylinders, cyl);
+		update_cylinder_related_info(d);
 		emit diveListNotifier.cylinderAdded(d, d->cylinders.nr - 1);
 		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
@@ -1168,6 +1170,7 @@ void RemoveCylinder::undo()
 	for (size_t i = 0; i < dives.size(); ++i) {
 		std::vector<int> mapping = get_cylinder_map_for_add(dives[i]->cylinders.nr, indexes[i]);
 		add_cylinder(&dives[i]->cylinders, indexes[i], clone_cylinder(cyl[i]));
+		update_cylinder_related_info(dives[i]);
 		emit diveListNotifier.cylinderAdded(dives[i], indexes[i]);
 		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}
@@ -1179,6 +1182,7 @@ void RemoveCylinder::redo()
 		std::vector<int> mapping = get_cylinder_map_for_remove(dives[i]->cylinders.nr, indexes[i]);
 		remove_cylinder(dives[i], indexes[i]);
 		cylinder_renumber(dives[i], &mapping[0]);
+		update_cylinder_related_info(dives[i]);
 		emit diveListNotifier.cylinderRemoved(dives[i], indexes[i]);
 		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}
@@ -1255,6 +1259,7 @@ void EditCylinder::redo()
 {
 	for (size_t i = 0; i < dives.size(); ++i) {
 		std::swap(dives[i]->cylinders.cylinders[indexes[i]], cyl[i]);
+		update_cylinder_related_info(dives[i]);
 		emit diveListNotifier.cylinderEdited(dives[i], indexes[i]);
 		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -21,6 +21,9 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 {
 	ui->setupUi(this);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveInformation::divesChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &TabDiveInformation::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveInformation::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveInformation::cylinderChanged);
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
@@ -290,6 +293,14 @@ void TabDiveInformation::on_waterTypeCombo_activated(int index) {
 		ui->salinityOverWrittenIcon->setVisible(false);
 	else
 		ui->salinityOverWrittenIcon->setVisible(true);
+}
+
+void TabDiveInformation::cylinderChanged(dive *d)
+{
+	// If this isn't the current dive, do nothing
+	if (current_dive != d)
+		return;
+	updateProfile();
 }
 
 // This function gets called if a field gets updated by an undo command.

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -18,6 +18,7 @@ public:
 	void clear() override;
 private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void cylinderChanged(dive *d);
 	void diveModeChanged(int index);
 	void on_atmPressVal_editingFinished();
 	void on_atmPressType_currentIndexChanged(int index);

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -22,6 +22,9 @@ TabDiveStatistics::TabDiveStatistics(QWidget *parent) : TabBase(parent), ui(new 
 	ui->timeLimits->overrideAvgToolTipText(tr("Average length of all selected dives"));
 
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveStatistics::divesChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &TabDiveStatistics::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveStatistics::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveStatistics::cylinderChanged);
 
 	const auto l = findChildren<QLabel *>(QString(), Qt::FindDirectChildrenOnly);
 	for (QLabel *label: l) {
@@ -55,6 +58,14 @@ void TabDiveStatistics::divesChanged(const QVector<dive *> &dives, DiveField fie
 	// TODO: make this more fine grained. Currently, the core can only calculate *all* statistics.
 	if (field.duration || field.depth || field.mode || field.air_temp || field.water_temp)
 		updateData();
+}
+
+void TabDiveStatistics::cylinderChanged(dive *d)
+{
+	// If the changed dive is not selected, do nothing
+	if (!d->selected)
+		return;
+	updateData();
 }
 
 void TabDiveStatistics::updateData()

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.h
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.h
@@ -19,6 +19,7 @@ public:
 
 private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void cylinderChanged(dive *d);
 
 private:
 	Ui::TabDiveStatistics *ui;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -716,6 +716,9 @@ DiveTripModelTree::DiveTripModelTree(QObject *parent) : DiveTripModelBase(parent
 	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelTree::divesSelected);
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &DiveTripModelTree::tripChanged);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelTree::filterReset);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &DiveTripModelTree::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &DiveTripModelTree::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &DiveTripModelTree::cylinderChanged);
 
 	populate();
 }
@@ -1253,6 +1256,11 @@ void DiveTripModelTree::divesChanged(const QVector<dive *> &dives)
 		      { divesChangedTrip(trip, divesInTrip); });
 }
 
+void DiveTripModelTree::cylinderChanged(dive *d)
+{
+	divesChanged(QVector<dive *> { d });
+}
+
 void DiveTripModelTree::divesChangedTrip(dive_trip *trip, const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = divesIn;
@@ -1469,6 +1477,9 @@ DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent
 	connect(&diveListNotifier, &DiveListNotifier::divesTimeChanged, this, &DiveTripModelList::divesTimeChanged);
 	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelList::divesSelected);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelList::filterReset);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &DiveTripModelList::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &DiveTripModelList::cylinderChanged);
+	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &DiveTripModelList::cylinderChanged);
 
 	populate();
 }
@@ -1620,6 +1631,11 @@ void DiveTripModelList::divesChanged(const QVector<dive *> &divesIn)
 	// TODO: This is way to heavy, as it reloads the whole selection!
 	if (shownChange.currentChanged)
 		initSelection();
+}
+
+void DiveTripModelList::cylinderChanged(dive *d)
+{
+	divesChanged(QVector<dive *> { d });
 }
 
 void DiveTripModelList::divesTimeChanged(timestamp_t delta, const QVector<dive *> &divesIn)

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -115,6 +115,7 @@ public slots:
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
+	void cylinderChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives);
 	void tripChanged(dive_trip *trip, TripField);
@@ -190,6 +191,7 @@ public slots:
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
 	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
+	void cylinderChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes #2814 and related bugs.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) update dive->sac when cylinders are edited
2) update dive list when cylinders are edited
3) update information tab when cylinders are edited
4) update statistics tab when cylinders are edited
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2814.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
no.
