### PR TITLE
cleanup: Change Salty to Brackish

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1018,9 +1018,10 @@ without dive computer information, select the desired water type
 using the dropdown box. The following water types are available:
 
 1. Fresh water, usually at inland dive sites or in caves.
-2. Salty water, i.e. water that contains a little salt (called brackish water).
-3. EN13319, an average value that represents neither fresh water or sea water. This value is available
-on some dive computers and is regarded by some as a safe value for both fresh water and sea water.
+2. Brackish water, water that contains a little salt.
+3. EN13319, an value defined in the European CE standard for dive computers that represents neither
+ fresh water or sea water. This value is available on some dive computers and is regarded by some
+ as a safe value for both fresh water and sea water.
 4. Salt water encountered in the sea.
 
 The topic of water salinity is complex because it differs sonewhat between different oceans. A warning icon

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -631,7 +631,7 @@ QString get_water_type_string(int salinity)
 	if (salinity < 10050)
 		return waterTypes[FRESHWATER];
 	else if (salinity < 10190)
-		return waterTypes[SALTYWATER];
+		return waterTypes[BRACKISHWATER];
 	else if (salinity < 10210)
 		return waterTypes[EN13319WATER];
 	else
@@ -1162,7 +1162,7 @@ QString localFilePath(const QString &originalFilename)
 
 // the water types need to match the watertypes enum
 const QStringList waterTypes = {
-	gettextFromC::tr("Fresh"), gettextFromC::tr("Salty"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("use dc")
+	gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("use dc")
 };
 
 // TODO: Apparently Qt has no simple way of listing the supported video

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -11,7 +11,7 @@ struct picture;
 // 1) Types
 
 enum inertgas {N2, HE};
-enum watertypes {FRESHWATER, SALTYWATER, EN13319WATER, SALTWATER, DC_WATERTYPE};
+enum watertypes {FRESHWATER, BRACKISHWATER, EN13319WATER, SALTWATER, DC_WATERTYPE};
 
 // 2) Functions visible only to C++ parts
 

--- a/core/units.h
+++ b/core/units.h
@@ -32,6 +32,7 @@ extern "C" {
 /* Salinity is expressed in weight in grams per 10l */
 #define SEAWATER_SALINITY 10300
 #define EN13319_SALINITY 10200
+#define BRACKISH_SALINITY 10100
 #define FRESHWATER_SALINITY 10000
 
 #include <stdint.h>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -179,7 +179,7 @@ int TabDiveInformation::updateSalinityComboIndex(int salinity)
 	else if (salinity < 10050)
 		return FRESHWATER;
 	else if (salinity < 10190)
-		return SALTYWATER;
+		return BRACKISHWATER;
 	else if (salinity < 10210)
 		return EN13319WATER;
 	else
@@ -261,8 +261,8 @@ void TabDiveInformation::on_waterTypeCombo_activated(int index) {
 	case FRESHWATER:
 		combobox_salinity = FRESHWATER_SALINITY;
 		break;
-	case SALTYWATER:
-		combobox_salinity = 10100;
+	case BRACKISHWATER:
+		combobox_salinity = BRACKISH_SALINITY;
 		break;
 	case EN13319WATER:
 		combobox_salinity = EN13319_SALINITY;


### PR DESCRIPTION
In the code, the difference between SALTYWATER and SALTWATER is hard
to see. More importantly, in the UI - Brackish is the word for water
that has more salt that freshwater but less salt that seawater. The
docs already use the word to clarify what is meant.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Documentation change:
Reference to salty in the documentation updated to use the word brackish.

### Mentions:
@willemferguson
