### PR TITLE
cleanup: capitalize use dc

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1040,10 +1040,10 @@ right allows two ways of expressing atmospheric pressure: mbar or m/ft above sea
 The altitude unit (metric/imperial) is taken from the settings in the _Units Preferences_ screen. A
 third option is to use the atmospheric pressure provided by the dive computer. In order to specify
 the pressure/altitude, first select the appropriate unit in the dropbox (in the case of the image on the left
-these are "mbar/m/use dc", then type an appropriate value into the text box. In the case
+these are "mbar/m/Use DC", then type an appropriate value into the text box. In the case
 of m/ft the altitude typed into the text box is automatically converted to the
 mean expected atmospheric pressure (mbar) at the specified altitude.
-In the case of "use dc", no value is required in the text box. Atmospheric pressure provided by a dive
+In the case of "Use DC", no value is required in the text box. Atmospheric pressure provided by a dive
 computer does not need any editing.
 
 Recording of five dive conditions that can be done on a five star rating scale. The convention is that the most comfortable

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1162,7 +1162,7 @@ QString localFilePath(const QString &originalFilename)
 
 // the water types need to match the watertypes enum
 const QStringList waterTypes = {
-	gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("use dc")
+	gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("Use DC")
 };
 
 // TODO: Apparently Qt has no simple way of listing the supported video

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -21,7 +21,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 {
 	ui->setupUi(this);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveInformation::divesChanged);
-	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("use dc")};
+	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
 	ui->waterTypeCombo->insertItems(0, waterTypes);


### PR DESCRIPTION
It was suggested in a review of a previous patchset that we should
capitalize the use of "use dc" to "Use DC" - but if we were going
to do that we should do it everywhere, not just in the one place.

This is the followup to do that.

### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Mentions:
@neolit123 
