### PR TITLE
Remove Bühlmann factor cache

### DIFF
--- a/core/deco.c
+++ b/core/deco.c
@@ -30,6 +30,7 @@
 #include "planner.h"
 #include "qthelper.h"
 
+enum inertgas { N2, HE };
 #define cube(x) (x * x * x)
 
 // Subsurface until v4.6.2 appeared to produce marginally less conservative plans than our benchmarks.

--- a/core/deco.c
+++ b/core/deco.c
@@ -290,18 +290,10 @@ double tissue_tolerance_calc(struct deco_state *ds, const struct dive *dive, dou
 }
 
 /*
- * Return buelman factor for a particular period and tissue index.
- *
- * We cache the factor, since we commonly call this with the
- * same values... We have a special "fixed cache" for the one second
- * case, although I wonder if that's even worth it considering the
- * more general-purpose cache.
+ * Return Buehlmann factor for a particular period and tissue index.
  */
-
-
 static double factor(int period_in_seconds, int ci, enum inertgas gas)
 {
-	double factor;
 	if (period_in_seconds == 1) {
 		if (gas == N2)
 			return buehlmann_N2_factor_expositon_one_second[ci];
@@ -309,17 +301,11 @@ static double factor(int period_in_seconds, int ci, enum inertgas gas)
 			return buehlmann_He_factor_expositon_one_second[ci];
 	}
 
-	factor = cache_value(ci, period_in_seconds, gas);
-	if (!factor) {
-		// ln(2)/60 = 1.155245301e-02
-		if (gas == N2)
-			factor = 1 - exp(-period_in_seconds * 1.155245301e-02 / buehlmann_N2_t_halflife[ci]);
-		else
-			factor = 1 - exp(-period_in_seconds * 1.155245301e-02 / buehlmann_He_t_halflife[ci]);
-		cache_insert(ci, period_in_seconds, gas, factor);
-	}
-
-	return factor;
+	// ln(2)/60 = 1.155245301e-02
+	if (gas == N2)
+		return 1.0 - exp(-period_in_seconds * 1.155245301e-02 / buehlmann_N2_t_halflife[ci]);
+	else
+		return 1.0 - exp(-period_in_seconds * 1.155245301e-02 / buehlmann_He_t_halflife[ci]);
 }
 
 static double calc_surface_phase(double surface_pressure, double he_pressure, double n2_pressure, double he_time_constant, double n2_time_constant)

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1601,31 +1601,6 @@ char *intdup(int index)
 	return strdup(tmpbuf);
 }
 
-QHash<int, double> factor_cache;
-
-QReadWriteLock factorCacheLock;
-extern "C" double cache_value(int tissue, int timestep, enum inertgas inertgas)
-{
-	double value;
-	int key = (timestep << 5) + (tissue << 1);
-	if (inertgas == HE)
-		++key;
-	factorCacheLock.lockForRead();
-	value = factor_cache.value(key);
-	factorCacheLock.unlock();
-	return value;
-}
-
-extern "C" void cache_insert(int tissue, int timestep, enum inertgas inertgas, double value)
-{
-	int key = (timestep << 5) + (tissue << 1);
-	if (inertgas == HE)
-		++key;
-	factorCacheLock.lockForWrite();
-	factor_cache.insert(key, value);
-	factorCacheLock.unlock();
-}
-
 extern "C" void print_qt_versions()
 {
 	printf("%s\n", qPrintable(QStringLiteral("built with Qt Version %1, runtime from Qt Version %2").arg(QT_VERSION_STR).arg(qVersion())));

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -146,8 +146,6 @@ const char *subsurface_user_agent();
 enum deco_mode decoMode();
 int parse_seabear_header(const char *filename, char **params, int pnr);
 char *get_current_date();
-double cache_value(int tissue, int timestep, enum inertgas gas);
-void cache_insert(int tissue, int timestep, enum inertgas gas, double value);
 void print_qt_versions();
 void lock_planner();
 void unlock_planner();

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -10,7 +10,6 @@ struct picture;
 
 // 1) Types
 
-enum inertgas {N2, HE};
 enum watertypes {FRESHWATER, BRACKISHWATER, EN13319WATER, SALTWATER, DC_WATERTYPE};
 
 // 2) Functions visible only to C++ parts


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While looking at the `inertgas` enum I stumbled over this cache and had my doubts that a thread-synchronized hashmap would be significantly faster than an `exp(...)` function. Indeed, after making the function global and calling it from a different translation unit with
```
        QElapsedTimer t;
        t.start();
        double res = 0.0;
        for (int i = 0; i < 1'000'000; ++i) {
                for (int ci = 0; ci < 16; ++ci) {
                        res += factor(200, ci, HE);
                        res += factor(200, ci, N2);
                }
        }
        printf("elapsed: %llu res: %lf\n", t.elapsed(), res);
```
I got a speed increase from 604 ms to 266 ms by removing the cache. Moreover, note that these are 32 million calls that take only 266 ms. It therefore seems that optimizing this particular function is not worth it.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) remove Bühlmann factor cache.
2) move `inertgas` enum to `deco.c` source file.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No user visible change.
