### PR TITLE
desktop: avoid spurious undo commands for date/time editing

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -607,23 +607,23 @@ static void shiftTime(QDateTime &dateTime)
 	}
 }
 
-void MainTab::on_dateEdit_dateChanged(const QDate &date)
+void MainTab::on_dateEdit_editingFinished()
 {
 	if (ignoreInput || !current_dive)
 		return;
 	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
 	dateTime.setTimeSpec(Qt::UTC);
-	dateTime.setDate(date);
+	dateTime.setDate(ui.dateEdit->date());
 	shiftTime(dateTime);
 }
 
-void MainTab::on_timeEdit_timeChanged(const QTime &time)
+void MainTab::on_timeEdit_editingFinished()
 {
 	if (ignoreInput || !current_dive)
 		return;
 	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
 	dateTime.setTimeSpec(Qt::UTC);
-	dateTime.setTime(time);
+	dateTime.setTime(ui.timeEdit->time());
 	shiftTime(dateTime);
 }
 

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -57,8 +57,8 @@ slots:
 	void on_notes_editingFinished();
 	void on_duration_editingFinished();
 	void on_depth_editingFinished();
-	void on_dateEdit_dateChanged(const QDate &date);
-	void on_timeEdit_timeChanged(const QTime & time);
+	void on_dateEdit_editingFinished();
+	void on_timeEdit_editingFinished();
 	void on_rating_valueChanged(int value);
 	void on_tagWidget_editingFinished();
 	void hideMessage();


### PR DESCRIPTION
The date and time fields of the main tab posted undo events
for every date/timeChanged signal. Thus, when changing the
day of the month to e.g. 21, this would result in two date
change events: one to the 2nd and one to the 21st. This is
very irritating.

Instead listen to editingFinished() events, which thankfully
exist for these widgets.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a UI nuisance, see commit description.

PS: I dislike the on_*() methods as the signal signature is only runtime checked.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I guess not.