### PR TITLE
Remove displayed_dive dependency of ExtraDataModel

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveExtraInfo.h"
 #include "ui_TabDiveExtraInfo.h"
+#include "core/dive.h"
 #include "qt-models/divecomputerextradatamodel.h"
 
 TabDiveExtraInfo::TabDiveExtraInfo(QWidget *parent) :
 	TabBase(parent),
 	ui(new Ui::TabDiveExtraInfo()),
-	extraDataModel(new ExtraDataModel())
+	extraDataModel(new ExtraDataModel(this))
 {
 	ui->setupUi(this);
 	ui->extraData->setModel(extraDataModel);
@@ -19,11 +20,10 @@ TabDiveExtraInfo::~TabDiveExtraInfo()
 
 void TabDiveExtraInfo::updateData()
 {
-	extraDataModel->updateDive();
+	extraDataModel->updateDiveComputer(current_dc);
 }
 
 void TabDiveExtraInfo::clear()
 {
-	extraDataModel->updateDive();
+	extraDataModel->clear();
 }
-

--- a/qt-models/divecomputerextradatamodel.cpp
+++ b/qt-models/divecomputerextradatamodel.cpp
@@ -20,33 +20,28 @@ void ExtraDataModel::clear()
 
 QVariant ExtraDataModel::data(const QModelIndex &index, int role) const
 {
-	QVariant ret;
 	struct extra_data *ed = get_dive_dc(&displayed_dive, dc_number)->extra_data;
 	int i = -1;
 	while (ed && ++i < index.row())
 		ed = ed->next;
 	if (!ed)
-		return ret;
+		return QVariant();
 
 	switch (role) {
 	case Qt::FontRole:
-		ret = defaultModelFont();
-		break;
+		return defaultModelFont();
 	case Qt::TextAlignmentRole:
-		ret = int(Qt::AlignLeft | Qt::AlignVCenter);
-		break;
+		return static_cast<int>(Qt::AlignLeft | Qt::AlignVCenter);
 	case Qt::DisplayRole:
 		switch (index.column()) {
 		case KEY:
-			ret = QString(ed->key);
-			break;
+			return ed->key;
 		case VALUE:
-			ret = QString(ed->value);
-			break;
+			return ed->value;
 		}
-		break;
+		return QVariant();
 	}
-	return ret;
+	return QVariant();
 }
 
 int ExtraDataModel::rowCount(const QModelIndex&) const

--- a/qt-models/divecomputerextradatamodel.cpp
+++ b/qt-models/divecomputerextradatamodel.cpp
@@ -13,10 +13,9 @@ ExtraDataModel::ExtraDataModel(QObject *parent) : CleanerTableModel(parent),
 
 void ExtraDataModel::clear()
 {
-	if (rows > 0) {
-		beginRemoveRows(QModelIndex(), 0, rows - 1);
-		endRemoveRows();
-	}
+	beginResetModel();
+	rows = 0;
+	endResetModel();
 }
 
 QVariant ExtraDataModel::data(const QModelIndex &index, int role) const
@@ -57,15 +56,12 @@ int ExtraDataModel::rowCount(const QModelIndex&) const
 
 void ExtraDataModel::updateDive()
 {
-	clear();
+	beginResetModel();
 	rows = 0;
 	struct extra_data *ed = get_dive_dc(&displayed_dive, dc_number)->extra_data;
 	while (ed) {
 		rows++;
 		ed = ed->next;
 	}
-	if (rows > 0) {
-		beginInsertRows(QModelIndex(), 0, rows - 1);
-		endInsertRows();
-	}
+	endResetModel();
 }

--- a/qt-models/divecomputerextradatamodel.h
+++ b/qt-models/divecomputerextradatamodel.h
@@ -4,6 +4,8 @@
 
 #include "cleanertablemodel.h"
 
+struct divecomputer;
+
 /* extra data model for additional dive computer data */
 class ExtraDataModel : public CleanerTableModel {
 	Q_OBJECT
@@ -17,10 +19,14 @@ public:
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
 	void clear();
-	void updateDive();
+	void updateDiveComputer(const struct divecomputer *dc);
 
 private:
-	int rows;
+	struct Item {
+		QString key;
+		QString value;
+	};
+	std::vector<Item> items;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The main goal is to display data of current_dive instead of displayed_dive for consistency and so that we can move displayed_dive to the planner. Thus, there is no risk of forgetting to copy changes to displayed_dive.

While doing so, perform a few assorted cleanups for consistency with the other model code.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - should not be user visible.