### PR TITLE
Remove 'string marker after running out of strings' warning

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -348,10 +348,6 @@ static char *pop_cstring(struct membuffer *str, const char *err)
 		report_error("git-load: string marker without any strings ('%s')", err);
 		return strdup("");
 	}
-	if (!str->len) {
-		report_error("git-load: string marker after running out of strings ('%s')", err);
-		return strdup("");
-	}
 	len = strlen(mb_cstring(str)) + 1;
 	return remove_from_front(str, len);
 }


### PR DESCRIPTION
This warning is unnecessarily scary - we had a problem with parsing
multiple strings on the same line, but it should be all solved, and
while it does mean that people may have old incorrect git save files
with empty strings, scaring users about it isn't going to help.

And with the warning removed, we can just remove the whole test for an
empty string, because the normal code sequence handles that case just
fine.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
