### PR TITLE
core/bt: match DC descriptor in lower case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix failure to recognize several Aqualung BLE dive computers
 Mobile: show dive tags on dive details page
 Desktop: update SAC fields and other statistics when editing cylinders
 Desktop: Reconnect the variations checkbox in planner

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -83,16 +83,16 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		// number. The model code matches the hex model (so "FQ" is 0x4651,
 		// where 'F' is 46h and 'Q' is 51h in ASCII).
 		vendor = "Aqualung";
-		product = "i200c";
+		product = "i200C";
 	} else if (btName.contains(QRegularExpression("^FH\\d{6}$"))) {
 		vendor = "Aqualung";
-		product = "i300c";
+		product = "i300C";
 	} else if (btName.contains(QRegularExpression("^FQ\\d{6}$"))) {
 		vendor = "Aqualung";
 		product = "i770R";
 	} else if (btName.contains(QRegularExpression("^FR\\d{6}$"))) {
 		vendor = "Aqualung";
-		product = "i550c";
+		product = "i550C";
 	} else if (btName.contains(QRegularExpression("^ER\\d{6}$"))) {
 		vendor = "Oceanic";
 		product = "Pro Plus X";
@@ -111,7 +111,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 
 	// check if we found a known dive computer
 	if (!vendor.isEmpty() && !product.isEmpty()) {
-		dc_descriptor_t *lookup = descriptorLookup.value(vendor + product);
+		dc_descriptor_t *lookup = descriptorLookup.value(vendor.toLower() + product.toLower());
 		if (!lookup)
 			qWarning("known dive computer %s not found in descriptorLookup", qPrintable(QString(vendor + product)));
 		return lookup;

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -68,7 +68,7 @@ DownloadThread::DownloadThread() : downloadTable({ 0 }),
 void DownloadThread::run()
 {
 	auto internalData = m_data->internalData();
-	internalData->descriptor = descriptorLookup[m_data->vendor() + m_data->product()];
+	internalData->descriptor = descriptorLookup[m_data->vendor().toLower() + m_data->product().toLower()];
 	internalData->download_table = &downloadTable;
 	internalData->sites = &diveSiteTable;
 	internalData->btname = strdup(m_data->devBluetoothName().toUtf8());
@@ -127,7 +127,7 @@ void fill_computer_list()
 		if (!productList[vendor].contains(product))
 			productList[vendor].append(product);
 
-		descriptorLookup[QString(vendor) + QString(product)] = descriptor;
+		descriptorLookup[QString(vendor).toLower() + QString(product).toLower()] = descriptor;
 	}
 	dc_iterator_free(iterator);
 	Q_FOREACH (QString vendor, vendorList) {
@@ -157,7 +157,8 @@ void fill_computer_list()
 	if (!productList["Uemis"].contains("Zurich"))
 		productList["Uemis"].push_back("Zurich");
 
-	descriptorLookup["UemisZurich"] = (dc_descriptor_t *)mydescriptor;
+	// note: keys in the descriptorLookup are always lowercase
+	descriptorLookup["uemiszurich"] = (dc_descriptor_t *)mydescriptor;
 #endif
 
 	std::sort(vendorList.begin(), vendorList.end());
@@ -192,7 +193,7 @@ void show_computer_list()
 	Q_FOREACH (QString vendor, vendorList) {
 		QString msg = vendor + ": ";
 		Q_FOREACH (QString product, productList[vendor]) {
-			dc_descriptor_t *descriptor = descriptorLookup[vendor + product];
+			dc_descriptor_t *descriptor = descriptorLookup[vendor.toLower() + product.toLower()];
 			unsigned int transport = dc_descriptor_get_transports(descriptor) & transportMask;
 			QString transportString = getTransportString(transport);
 			msg += product + " (" + transportString + "), ";

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -908,7 +908,7 @@ void ConfigureDiveComputerDialog::getDeviceData()
 	device_data.vendor = copy_qstring(selected_vendor);
 	device_data.product = copy_qstring(selected_product);
 
-	device_data.descriptor = descriptorLookup.value(selected_vendor + selected_product);
+	device_data.descriptor = descriptorLookup.value(selected_vendor.toLower() + selected_product.toLower());
 	device_data.deviceid = device_data.diveid = 0;
 
 	qPrefDiveComputer::set_device(device_data.devname);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -318,7 +318,7 @@ void DownloadFromDCWidget::on_vendor_currentIndexChanged(const QString &vendor)
 	productModel.setStringList(productList[vendor]);
 	ui.product->setCurrentIndex(0);
 
-	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
+	descriptor = descriptorLookup.value(ui.vendor->currentText().toLower() + ui.product->currentText().toLower());
 	transport = dc_descriptor_get_transports(descriptor);
 	fill_device_list(transport);
 }
@@ -542,7 +542,7 @@ void DownloadFromDCWidget::updateDeviceEnabled()
 {
 	// Set up the DC descriptor
 	dc_descriptor_t *descriptor = NULL;
-	descriptor = descriptorLookup.value(ui.vendor->currentText() + ui.product->currentText());
+	descriptor = descriptorLookup.value(ui.vendor->currentText().toLower() + ui.product->currentText().toLower());
 
 	// call dc_descriptor_get_transport to see if the dc_transport_t is DC_TRANSPORT_SERIAL
 	if (dc_descriptor_get_transports(descriptor) & (DC_TRANSPORT_SERIAL | DC_TRANSPORT_USBSTORAGE)) {


### PR DESCRIPTION
This fixes a rather subtle bug.

In btdiscovery.cpp we are detecting dive computers based on their BT name and
are setting up product+vendor as the key for that lookup. QMap always uses case
sensitive comparisons and a tiny inconsistency snuck into our code.
libdivecomputer names for the Aqualung dive computers i200C / i300C / i550C end
in an upper case C (as matches the official branding), but in btdiscovery.cpp
we have those names with lower case c. And therefore didn't recognize these
dive computers.

Obviously this is easy to fix by fixing those three strings, but I decided that
it was silly to set ourselves up for similar oversights in the future. So
instead I switched the matching of the descriptor to simply be allways all
lower case.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
compare names case insensitively. Since `QMap` doesn't support that (really??) simply store the keys and do the lookups after converting to lower case.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
user support request for Subsurface-mobile on iOS

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger for sanity check :-)