### PR TITLE
follow up on BT/BLE detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-Mobile: fix failure to recognize several Aqualung BLE dive computers
+Core: always include BT/BLE name, even for devices no recognized as dive computer
+Core: fix failure to recognize several Aqualung BLE dive computers
 Mobile: show dive tags on dive details page
 Desktop: update SAC fields and other statistics when editing cylinders
 Desktop: Reconnect the variations checkbox in planner

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -274,8 +274,11 @@ void BTDiscovery::btDeviceDiscoveredMain(const btPairedDevice &device)
 		return;
 	}
 	// Do we want only devices we recognize as dive computers?
-	if (m_showNonDiveComputers)
-		connectionListModel.addAddress(device.address);
+	if (m_showNonDiveComputers) {
+		if (!newDevice.isEmpty())
+			newDevice += " ";
+		connectionListModel.addAddress(newDevice + device.address);
+	}
 	qDebug() << "Not recognized as dive computer";
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a follow up to the previous PR dealing with misrecognized dive computers.
In the process of debugging that I stumbled across the fact that we didn't show the names of devices that weren't recognized as dive computers (which is really quite stupid - did we expect the user to figure out by the magic hex numbers which device to pick)? And that we mixed devices with name (and ALL dive computers that we have seen so far have a name) with those without name.
This rectifies both of those issues

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@neolit123 , I guess :-)
