### PR TITLE
desktop: don't call plotDive with doClearPictures = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: fix plotting of thumbnails on profile [#2833]
 Core: always include BT/BLE name, even for devices no recognized as dive computer
 Core: fix failure to recognize several Aqualung BLE dive computers
 Mobile: show dive tags on dive details page

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -449,7 +449,7 @@ void MainWindow::selectionChanged()
 		configureToolbar();
 		enableDisableOtherDCsActions();
 	}
-	graphics->plotDive(current_dive, false, true);
+	graphics->plotDive(current_dive, false);
 	MapWidget::instance()->selectionChanged();
 }
 
@@ -1080,7 +1080,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, false, true);
+	graphics->plotDive(current_dive, false);
 	mainTab->updateDiveInfo();
 }
 
@@ -1089,7 +1089,7 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, false, true);
+	graphics->plotDive(current_dive, false);
 	mainTab->updateDiveInfo();
 }
 


### PR DESCRIPTION
This was an old "optimization" to avoid double plotting of the
pictures, first by the profile itself, then by the picture tab.
Since the profile now updates the pictures itself, this must
be removed: The picture tab doesn't do it anymore.

Fixes #2833

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This makes sure that the picture thumbnails on the profile are replot when changing dives.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't call plotDive with doClearPictures = true, except when printing.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2833
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done - though I'm not sure if this is in release? Should be a fallout of picture undo.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
