### PR TITLE
[TRIVIAL] cleanup: replace to "dive.h" includes by more specific includes

### DIFF
--- a/qt-models/CMakeLists.txt
+++ b/qt-models/CMakeLists.txt
@@ -39,14 +39,8 @@ set(SUBSURFACE_DESKTOP_MODELS_LIB_SRCS
 	divepicturemodel.h
 	divesiteimportmodel.cpp
 	divesiteimportmodel.h
-	divetripmodel.cpp
-	divetripmodel.h
 	filtermodels.cpp
 	filtermodels.h
-	models.cpp
-	models.h
-	tankinfomodel.cpp
-	tankinfomodel.h
 	treemodel.cpp
 	treemodel.h
 	weightmodel.cpp

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -5,7 +5,7 @@
 #include <QSortFilterProxyModel>
 
 #include "cleanertablemodel.h"
-#include "core/dive.h"
+#include "core/equipment.h"
 
 /* Encapsulation of the Cylinder Model, that presents the
  * Current cylinders that are used on a dive. */

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -3,7 +3,7 @@
 #define WEIGHTMODEL_H
 
 #include "cleanertablemodel.h"
-#include "core/dive.h"
+#include "core/equipment.h"
 
 /* Encapsulation of the Weight Model, that represents
  * the current weights on a dive. */


### PR DESCRIPTION
The weightsystem- and cylinder-model headers were including "dive.h".
Inclusion of "equipment.h" is sufficient though.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A completely trivial cleanup - replace "dive.h" by "equipment.h" to reduce dependencies.
