### PR TITLE
Idle whitespace and other cleanups concerning model delegates

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -112,10 +112,10 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	comboDelegate->view()->installEventFilter(const_cast<QObject *>(qobject_cast<const QObject *>(this)));
 	QAbstractItemView *comboPopup = comboDelegate->lineEdit()->completer()->popup();
 	comboPopup->setMouseTracking(true);
-	connect(comboDelegate, SIGNAL(highlighted(QString)), this, SLOT(testActivation(QString)));
-	connect(comboDelegate, SIGNAL(activated(QString)), this, SLOT(fakeActivation()));
-	connect(comboPopup, SIGNAL(entered(QModelIndex)), this, SLOT(testActivation(QModelIndex)));
-	connect(comboPopup, SIGNAL(activated(QModelIndex)), this, SLOT(fakeActivation()));
+	connect(comboDelegate, QOverload<const QString &>::of(&QComboBox::highlighted), this, &ComboBoxDelegate::testActivationString);
+	connect(comboDelegate, QOverload<int>::of(&QComboBox::activated), this, &ComboBoxDelegate::fakeActivation);
+	connect(comboPopup, &QAbstractItemView::entered, this, &ComboBoxDelegate::testActivationIndex);
+	connect(comboPopup, &QAbstractItemView::activated, this, &ComboBoxDelegate::fakeActivation);
 	currCombo.comboEditor = comboDelegate;
 	currCombo.currRow = index.row();
 	currCombo.model = const_cast<QAbstractItemModel *>(index.model());
@@ -138,15 +138,15 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
  * One thing is important, if the user writes a *new* cylinder or weight type, it will
  * be ADDED to the list, and the user will need to fill the other data.
  */
-void ComboBoxDelegate::testActivation(const QString &currText)
+void ComboBoxDelegate::testActivationString(const QString &currText)
 {
 	currCombo.activeText = currText.isEmpty() ? currCombo.comboEditor->currentText() : currText;
 	setModelData(currCombo.comboEditor, currCombo.model, QModelIndex());
 }
 
-void ComboBoxDelegate::testActivation(const QModelIndex &currIndex)
+void ComboBoxDelegate::testActivationIndex(const QModelIndex &currIndex)
 {
-	testActivation(currIndex.data().toString());
+	testActivationString(currIndex.data().toString());
 }
 
 // HACK, send a fake event so Qt thinks we hit 'enter' on the line edit.

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -29,7 +29,7 @@
 #include <QAbstractItemView>
 #include <QSpinBox>
 
-QSize DiveListDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const
+QSize DiveListDelegate::sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const
 {
 	const QFontMetrics metrics(qApp->font());
 	return QSize(50, qMax(22, metrics.height()));
@@ -42,7 +42,7 @@ QSize DiveListDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&
 StarWidgetsDelegate::StarWidgetsDelegate(QWidget *parent) : QStyledItemDelegate(parent),
 	parentWidget(parent)
 {
-	const IconMetrics& metrics = defaultIconMetrics();
+	const IconMetrics &metrics = defaultIconMetrics();
 	minStarSize = QSize(metrics.sz_small * TOTALSTARS + metrics.spacing * (TOTALSTARS - 1), metrics.sz_small);
 }
 
@@ -62,7 +62,7 @@ void StarWidgetsDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 	painter->setRenderHint(QPainter::Antialiasing, true);
 	const QPixmap active = QPixmap::fromImage(StarWidget::starActive());
 	const QPixmap inactive = QPixmap::fromImage(StarWidget::starInactive());
-	const IconMetrics& metrics = defaultIconMetrics();
+	const IconMetrics &metrics = defaultIconMetrics();
 
 	for (int i = 0; i < rating; i++)
 		painter->drawPixmap(option.rect.x() + i * metrics.sz_small + metrics.spacing, option.rect.y() + deltaY, active);
@@ -71,12 +71,12 @@ void StarWidgetsDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 	painter->restore();
 }
 
-QSize StarWidgetsDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const
+QSize StarWidgetsDelegate::sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const
 {
 	return minStarSize;
 }
 
-const QSize& StarWidgetsDelegate::starSize() const
+const QSize &StarWidgetsDelegate::starSize() const
 {
 	return minStarSize;
 }
@@ -99,7 +99,7 @@ void ComboBoxDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
 	c->lineEdit()->setSelection(0, c->lineEdit()->text().length());
 }
 
-QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem&, const QModelIndex &index) const
+QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
 	QComboBox *comboDelegate = new QComboBox(parent);
 	comboDelegate->setModel(model);
@@ -122,7 +122,7 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	currCombo.activeText = currCombo.model->data(index).toString();
 
 	// Current display of things on Gnome3 looks like shit, so
-	// let`s fix that.
+	// let's fix that.
 	if (isGnome3Session()) {
 		QPalette p;
 		p.setColor(QPalette::Window, QColor(Qt::white));
@@ -198,7 +198,7 @@ bool ComboBoxDelegate::eventFilter(QObject *object, QEvent *event)
 	return QStyledItemDelegate::eventFilter(object, event);
 }
 
-void ComboBoxDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex&) const
+void ComboBoxDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const
 {
 	QRect defaultRect = option.rect;
 	defaultRect.setX(defaultRect.x() - 1);
@@ -208,7 +208,7 @@ void ComboBoxDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionV
 	editor->setGeometry(defaultRect);
 }
 
-void TankInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelIndex&) const
+void TankInfoDelegate::setModelData(QWidget *, QAbstractItemModel *, const QModelIndex &) const
 {
 	QAbstractItemModel *mymodel = currCombo.model;
 	TankInfoModel *tanks = TankInfoModel::instance();
@@ -235,7 +235,7 @@ TankInfoDelegate::TankInfoDelegate(QObject *parent) : ComboBoxDelegate(TankInfoM
 {
 }
 
-void TankInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint hint)
+void TankInfoDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint hint)
 {
 	QAbstractItemModel *mymodel = currCombo.model;
 	// Ugly hack: We misuse setData() with COMMIT_ROLE or REVERT_ROLE to commit or
@@ -251,7 +251,7 @@ TankUseDelegate::TankUseDelegate(QObject *parent) : QStyledItemDelegate(parent)
 {
 }
 
-QWidget *TankUseDelegate::createEditor(QWidget * parent, const QStyleOptionViewItem&, const QModelIndex&) const
+QWidget *TankUseDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &) const
 {
 	QComboBox *comboBox = new QComboBox(parent);
 	for (int i = 0; i < NUM_GAS_USE; i++)
@@ -259,20 +259,20 @@ QWidget *TankUseDelegate::createEditor(QWidget * parent, const QStyleOptionViewI
 	return comboBox;
 }
 
-void TankUseDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
+void TankUseDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
-	QComboBox *comboBox = qobject_cast<QComboBox*>(editor);
+	QComboBox *comboBox = qobject_cast<QComboBox *>(editor);
 	QString indexString = index.data().toString();
 	comboBox->setCurrentIndex(cylinderuse_from_text(qPrintable(indexString)));
 }
 
-void TankUseDelegate::setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const
+void TankUseDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
-	QComboBox *comboBox = qobject_cast<QComboBox*>(editor);
+	QComboBox *comboBox = qobject_cast<QComboBox *>(editor);
 	model->setData(index, comboBox->currentIndex());
 }
 
-void WSInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint hint)
+void WSInfoDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint hint)
 {
 	WeightModel *mymodel = qobject_cast<WeightModel *>(currCombo.model);
 	if (hint == QAbstractItemDelegate::RevertModelCache)
@@ -281,7 +281,7 @@ void WSInfoDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint h
 		mymodel->commitTempWS();
 }
 
-void WSInfoDelegate::setModelData(QWidget*, QAbstractItemModel*, const QModelIndex&) const
+void WSInfoDelegate::setModelData(QWidget *, QAbstractItemModel *, const QModelIndex &) const
 {
 	WeightModel *mymodel = qobject_cast<WeightModel *>(currCombo.model);
 	WSInfoModel *wsim = WSInfoModel::instance();
@@ -301,7 +301,7 @@ WSInfoDelegate::WSInfoDelegate(QObject *parent) : ComboBoxDelegate(WSInfoModel::
 {
 }
 
-void AirTypesDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint)
+void AirTypesDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint)
 {
 }
 
@@ -317,7 +317,7 @@ AirTypesDelegate::AirTypesDelegate(QObject *parent) : ComboBoxDelegate(GasSelect
 {
 }
 
-void DiveTypesDelegate::editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint)
+void DiveTypesDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint)
 {
 }
 
@@ -380,7 +380,7 @@ void LocationFilterDelegate::paint(QPainter *painter, const QStyleOptionViewItem
 	QFont fontSmaller = qApp->font();
 	QFontMetrics fmBigger(fontBigger);
 	QStyleOptionViewItem opt = option;
-	const QAbstractProxyModel *proxyModel = dynamic_cast<const QAbstractProxyModel*>(origIdx.model());
+	const QAbstractProxyModel *proxyModel = dynamic_cast<const QAbstractProxyModel *>(origIdx.model());
 	if (!proxyModel)
 		return;
 	QModelIndex index = proxyModel->mapToSource(origIdx);

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -34,12 +34,14 @@ class ComboBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit ComboBoxDelegate(QAbstractItemModel *model, QObject *parent = 0, bool allowEdit = true);
-public
+private
 slots:
-	void testActivation(const QString &currString);
-	void testActivation(const QModelIndex &currIndex);
+	void testActivationString(const QString &currString);
+	void testActivationIndex(const QModelIndex &currIndex);
 	//HACK: try to get rid of this in the future.
 	void fakeActivation();
+protected
+slots:
 	virtual void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) = 0;
 private:
 	bool editable;

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -21,11 +21,11 @@ class StarWidgetsDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit StarWidgetsDelegate(QWidget *parent = 0);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	const QSize &starSize() const;
 
 private:
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	QWidget *parentWidget;
 	QSize minStarSize;
 };
@@ -34,19 +34,19 @@ class ComboBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit ComboBoxDelegate(QAbstractItemModel *model, QObject *parent = 0, bool allowEdit = true);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
-	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	bool eventFilter(QObject *object, QEvent *event) override;
 public
 slots:
-	void testActivation(const QString &currString = QString());
+	void testActivation(const QString &currString);
 	void testActivation(const QModelIndex &currIndex);
 	//HACK: try to get rid of this in the future.
 	void fakeActivation();
 	virtual void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) = 0;
 private:
 	bool editable;
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	bool eventFilter(QObject *object, QEvent *event) override;
 protected:
 	QAbstractItemModel *model;
 	mutable struct CurrSelected {
@@ -63,15 +63,15 @@ class TankInfoDelegate : public ComboBoxDelegate {
 public:
 	explicit TankInfoDelegate(QObject *parent = 0);
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-public
-slots:
-	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+private:
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 };
 
 class TankUseDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit TankUseDelegate(QObject *parent = 0);
+private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
@@ -81,38 +81,35 @@ class WSInfoDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit WSInfoDelegate(QObject *parent = 0);
+private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-public
-slots:
-	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 };
 
 class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit AirTypesDelegate(QObject *parent = 0);
+private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-public
-slots:
-	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 };
 
 class DiveTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit DiveTypesDelegate(QObject *parent = 0);
+private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-public
-slots:
-	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint);
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 };
 
 class SpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	SpinBoxDelegate(int min, int max, int step, QObject *parent = 0);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 private:
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	int min;
 	int max;
 	int step;
@@ -122,8 +119,8 @@ class DoubleSpinBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	DoubleSpinBoxDelegate(double min, double max, double step, QObject *parent = 0);
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 private:
+	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	double min;
 	double max;
 	double step;
@@ -133,10 +130,10 @@ class LocationFilterDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	LocationFilterDelegate(QObject *parent = 0);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setCurrentLocation(location_t loc);
 private:
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	location_t currentLocation;
 };
 

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -23,7 +23,7 @@ public:
 	explicit StarWidgetsDelegate(QWidget *parent = 0);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	const QSize& starSize() const;
+	const QSize &starSize() const;
 
 private:
 	QWidget *parentWidget;
@@ -74,7 +74,7 @@ public:
 	explicit TankUseDelegate(QObject *parent = 0);
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
-	void setEditorData(QWidget * editor, const QModelIndex & index) const override;
+	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 };
 
 class WSInfoDelegate : public ComboBoxDelegate {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are some idle cleanups, but they have bothered me for the longest time and I feel better now. The only somewhat tricky commit that could lead to a change is the last one. Reason being that it was not really well defined what it was doing before. However, I think that both of the overloaded signals were emitted, so it shouldn't change a thing, except that the functions might now be called only once.
