### PR TITLE
Fix incorrect Farenheit to Kelvin formula.

### DIFF
--- a/core/cochran.c
+++ b/core/cochran.c
@@ -586,7 +586,7 @@ static void cochran_parse_samples(struct dive *dive, const unsigned char *log,
 		sample->in_deco = in_deco;
 		sample->stoptime.seconds = deco_time;
 		sample->stopdepth.mm = lrint(deco_ceiling * FEET * 1000);
-		sample->temperature.mkelvin = C_to_mkelvin((temp - 32) / 1.8);
+		sample->temperature.mkelvin = F_to_mkelvin(temp);
 		sample->sensor[0] = 0;
 		sample->pressure[0].mbar = lrint(psi * PSI / 100);
 
@@ -713,7 +713,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 			log[CMD_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000);
 		dc->meandepth.mm = lrint((log[CMD_AVG_DEPTH] +
 			log[CMD_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000);
-		dc->watertemp.mkelvin = C_to_mkelvin((log[CMD_MIN_TEMP] / 32) - 1.8);
+		dc->watertemp.mkelvin = F_to_mkelvin(log[CMD_MIN_TEMP]);
 		dc->surface_pressure.mbar = lrint(ATM / BAR * pow(1 - 0.0000225577
 			* (double) log[CMD_ALTITUDE] * 250 * FEET, 5.25588) * 1000);
 		dc->salinity = 10000 + 150 * log[CMD_WATER_CONDUCTIVITY];
@@ -759,7 +759,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 			log[EMC_MAX_DEPTH + 1] * 256) / 4 * FEET * 1000);
 		dc->meandepth.mm = lrint((log[EMC_AVG_DEPTH] +
 			log[EMC_AVG_DEPTH + 1] * 256) / 4 * FEET * 1000);
-		dc->watertemp.mkelvin = C_to_mkelvin((log[EMC_MIN_TEMP] - 32) / 1.8);
+		dc->watertemp.mkelvin = F_to_mkelvin(log[EMC_MIN_TEMP]);
 		dc->surface_pressure.mbar = lrint(ATM / BAR * pow(1 - 0.0000225577
 			* (double) log[EMC_ALTITUDE] * 250 * FEET, 5.25588) * 1000);
 		dc->salinity = 10000 + 150 * (log[EMC_WATER_CONDUCTIVITY] & 0x3);
@@ -789,7 +789,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 	if (corrupt_dive) {
 		dc->maxdepth.mm = lrint(max_depth * FEET * 1000);
 		dc->meandepth.mm = lrint(avg_depth * FEET * 1000);
-		dc->watertemp.mkelvin = C_to_mkelvin((min_temp - 32) / 1.8);
+		dc->watertemp.mkelvin = F_to_mkelvin(min_temp);
 		dc->duration.seconds = duration;
 	}
 


### PR DESCRIPTION
Use defined function instead.

Signed-off-by: Paul Buxton <paulbuxton.mail@googlemail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The existing code was using a formula to convert from F -> C (incorrectly in one case) and then the defined C_to_mkelvin function to convert C -> mK. Replace this with directly calling the function F_to_mkelvin
 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
I have no way of testing this!

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
