### PR TITLE
Unify QDateTime <-> timestamp_t conversion

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -133,7 +133,7 @@ QString GpsLocation::currentPosition()
 	if (!hasLocationsSource())
 		return tr("Unknown GPS location (no GPS source)");
 	if (m_trackers.count()) {
-		QDateTime lastFixTime =	QDateTime().fromMSecsSinceEpoch((m_trackers.lastKey() - gettimezoneoffset(m_trackers.lastKey())) * 1000);
+		QDateTime lastFixTime =	timestampToDateTime(m_trackers.lastKey() - gettimezoneoffset(m_trackers.lastKey()));
 		QDateTime now = QDateTime::currentDateTime();
 		int delta = lastFixTime.secsTo(now);
 		qDebug() << "lastFixTime" << lastFixTime.toString() << "now" << now.toString() << "delta" << delta;
@@ -173,7 +173,7 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 	if (!nr || waitingForPosition || delta > prefs.time_threshold ||
 	    lastCoord.distanceTo(pos.coordinate()) > prefs.distance_threshold) {
 		QString msg = QStringLiteral("received new position %1 after delta %2 threshold %3 (now %4 last %5)");
-		status(qPrintable(msg.arg(pos.coordinate().toString()).arg(delta).arg(prefs.time_threshold).arg(pos.timestamp().toString()).arg(QDateTime().fromMSecsSinceEpoch(lastTime * 1000).toString())));
+		status(qPrintable(msg.arg(pos.coordinate().toString()).arg(delta).arg(prefs.time_threshold).arg(pos.timestamp().toString()).arg(timestampToDateTime(lastTime).toString())));
 		waitingForPosition = false;
 		acquiredPosition();
 		gpsTracker gt;
@@ -182,7 +182,7 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 		gt.location = create_location(pos.coordinate().latitude(), pos.coordinate().longitude());
 		addFixToStorage(gt);
 		gpsTracker gtNew = m_trackers.last();
-		qDebug() << "newest fix is now at" << QDateTime().fromMSecsSinceEpoch(gtNew.when - gettimezoneoffset(gtNew.when) * 1000).toString();
+		qDebug() << "newest fix is now at" << timestampToDateTime(gtNew.when - gettimezoneoffset(gtNew.when)).toString();
 	}
 }
 

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -169,7 +169,7 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 	// if we are waiting for a position update or
 	// if we have no record stored or if at least the configured minimum
 	// time has passed or we moved at least the configured minimum distance
-	int64_t delta = (int64_t)pos.timestamp().toTime_t() + gettimezoneoffset() - lastTime;
+	int64_t delta = dateTimeToTimestamp(pos.timestamp()) + gettimezoneoffset() - lastTime;
 	if (!nr || waitingForPosition || delta > prefs.time_threshold ||
 	    lastCoord.distanceTo(pos.coordinate()) > prefs.distance_threshold) {
 		QString msg = QStringLiteral("received new position %1 after delta %2 threshold %3 (now %4 last %5)");
@@ -177,7 +177,7 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 		waitingForPosition = false;
 		acquiredPosition();
 		gpsTracker gt;
-		gt.when = pos.timestamp().toTime_t();
+		gt.when = dateTimeToTimestamp(pos.timestamp());
 		gt.when += gettimezoneoffset(gt.when);
 		gt.location = create_location(pos.coordinate().latitude(), pos.coordinate().longitude());
 		addFixToStorage(gt);

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -271,7 +271,7 @@ static bool parseDate(const QString &s_in, timestamp_t &timestamp)
 	if (datetime.isValid()) {
 		// Not knowing any better, we suppose that time is give in UTC
 		datetime.setTimeSpec(Qt::UTC);
-		timestamp = datetime.toMSecsSinceEpoch() / 1000;
+		timestamp = dateTimeToTimestamp(datetime);
 		return true;
 	}
 
@@ -312,7 +312,7 @@ static bool parseDate(const QString &s_in, timestamp_t &timestamp)
 	// Not knowing any better, we suppose that time is give in UTC
 	datetime = QDateTime(date, time, Qt::UTC);
 	if (datetime.isValid()) {
-		timestamp = datetime.toMSecsSinceEpoch() / 1000;
+		timestamp = dateTimeToTimestamp(datetime);
 		return true;
 	}
 
@@ -542,9 +542,9 @@ extern "C" mediatype_t get_metadata(const char *filename_in, metadata *data)
 	// have a standard way of storing this datum), use the file creation date of the file.
 	if (data->timestamp == 0)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-		data->timestamp = QFileInfo(filename).birthTime().toMSecsSinceEpoch() / 1000;
+		data->timestamp = dateTimeToTimestamp(QFileInfo(filename).birthTime());
 #else
-		data->timestamp = QFileInfo(filename).created().toMSecsSinceEpoch() / 1000;
+		data->timestamp = dateTimeToTimestamp(QFileInfo(filename).created());
 #endif
 	return res;
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -709,6 +709,11 @@ QDateTime timestampToDateTime(timestamp_t when)
 	return QDateTime::fromMSecsSinceEpoch(1000 * when, Qt::UTC);
 }
 
+timestamp_t dateTimeToTimestamp(const QDateTime &t)
+{
+	return t.toSecsSinceEpoch();
+}
+
 QString render_seconds_to_string(int seconds)
 {
 	if (seconds % 60 == 0)

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -696,10 +696,17 @@ int gettimezoneoffset(timestamp_t when)
 	if (when == 0)
 		dt1 = QDateTime::currentDateTime();
 	else
-		dt1 = QDateTime::fromMSecsSinceEpoch(when * 1000);
+		dt1 = timestampToDateTime(when);
 	dt2 = dt1.toUTC();
 	dt1.setTimeSpec(Qt::UTC);
 	return dt2.secsTo(dt1);
+}
+
+QDateTime timestampToDateTime(timestamp_t when)
+{
+	// Subsurface always uses "local time" as in "whatever was the local time at the location"
+	// so all time stamps have no time zone information and are in UTC
+	return QDateTime::fromMSecsSinceEpoch(1000 * when, Qt::UTC);
 }
 
 QString render_seconds_to_string(int seconds)
@@ -984,8 +991,7 @@ QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 {
 	struct tm tm;
 	utc_mkdate(when, &tm);
-	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000*when,Qt::UTC);
-	localTime.setTimeSpec(Qt::UTC);
+	QDateTime localTime = timestampToDateTime(when);
 
 	QString suffix = " " + gettextFromC::tr("(%n dive(s))", "", nr);
 	if (getday)

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -989,8 +989,6 @@ extern "C" char *get_current_date()
 
 QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 {
-	struct tm tm;
-	utc_mkdate(when, &tm);
 	QDateTime localTime = timestampToDateTime(when);
 
 	QString suffix = " " + gettextFromC::tr("(%n dive(s))", "", nr);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -62,6 +62,7 @@ QString getSubsurfaceDataPath(QString folderToFind);
 QString getPrintingTemplatePathUser();
 QString getPrintingTemplatePathBundle();
 int gettimezoneoffset(timestamp_t when = 0);
+QDateTime timestampToDateTime(timestamp_t when);
 int parseDurationToSeconds(const QString &text);
 int parseLengthToMm(const QString &text);
 int parseTemperatureToMkelvin(const QString &text);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -63,6 +63,7 @@ QString getPrintingTemplatePathUser();
 QString getPrintingTemplatePathBundle();
 int gettimezoneoffset(timestamp_t when = 0);
 QDateTime timestampToDateTime(timestamp_t when);
+timestamp_t dateTimeToTimestamp(const QDateTime &t);
 int parseDurationToSeconds(const QString &text);
 int parseLengthToMm(const QString &text);
 int parseTemperatureToMkelvin(const QString &text);

--- a/core/subsurface-qt/diveobjecthelper.cpp
+++ b/core/subsurface-qt/diveobjecthelper.cpp
@@ -328,15 +328,13 @@ DiveObjectHelperGrantlee::DiveObjectHelperGrantlee(const struct dive *d) :
 
 QString DiveObjectHelper::date() const
 {
-	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * timestamp, Qt::UTC);
-	localTime.setTimeSpec(Qt::UTC);
+	QDateTime localTime = timestampToDateTime(timestamp);
 	return localTime.date().toString(prefs.date_format_short);
 }
 
 QString DiveObjectHelper::time() const
 {
-	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * timestamp, Qt::UTC);
-	localTime.setTimeSpec(Qt::UTC);
+	QDateTime localTime = timestampToDateTime(timestamp);
 	return localTime.time().toString(prefs.time_format);
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -865,7 +865,7 @@ void MainWindow::on_actionReplanDive_triggered()
 	graphics->clearHandlers();
 	setApplicationState(ApplicationState::PlanDive);
 	divePlannerWidget->setReplanButton(true);
-	divePlannerWidget->setupStartTime(QDateTime::fromMSecsSinceEpoch(1000 * current_dive->when, Qt::UTC));
+	divePlannerWidget->setupStartTime(timestampToDateTime(current_dive->when));
 	if (current_dive->surface_pressure.mbar)
 		divePlannerWidget->setSurfacePressure(current_dive->surface_pressure.mbar);
 	if (current_dive->salinity)

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -279,7 +279,7 @@ void ShiftImageTimesDialog::dcDateTimeChanged(const QDateTime &newDateTime)
 	if (!dcImageEpoch)
 		return;
 	newtime.setTimeSpec(Qt::UTC);
-	setOffset(newtime.toTime_t() - dcImageEpoch);
+	setOffset(dateTimeToTimestamp(newtime) - dcImageEpoch);
 }
 
 void ShiftImageTimesDialog::matchAllImagesToggled(bool state)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -598,7 +598,7 @@ void MainTab::on_depth_editingFinished()
 // all dives are shifted by an offset.
 static void shiftTime(QDateTime &dateTime)
 {
-	timestamp_t when = dateTime.toTime_t();
+	timestamp_t when = dateTimeToTimestamp(dateTime);
 	if (current_dive && current_dive->when != when) {
 		timestamp_t offset = when - current_dive->when;
 		Command::shiftTime(getDiveSelection(), (int)offset);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -307,14 +307,6 @@ void MainTab::updateNotes(const struct dive *d)
 	}
 }
 
-static QDateTime timestampToDateTime(timestamp_t when)
-{
-	// Subsurface always uses "local time" as in "whatever was the local time at the location"
-	// so all time stamps have no time zone information and are in UTC
-	QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * when, Qt::UTC);
-	localTime.setTimeSpec(Qt::UTC);
-	return localTime;
-}
 void MainTab::updateDateTime(const struct dive *d)
 {
 	QDateTime localTime = timestampToDateTime(d->when);
@@ -617,8 +609,7 @@ void MainTab::on_dateEdit_editingFinished()
 {
 	if (ignoreInput || !current_dive)
 		return;
-	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
-	dateTime.setTimeSpec(Qt::UTC);
+	QDateTime dateTime = timestampToDateTime(current_dive->when);
 	dateTime.setDate(ui.dateEdit->date());
 	shiftTime(dateTime);
 }
@@ -627,8 +618,7 @@ void MainTab::on_timeEdit_editingFinished()
 {
 	if (ignoreInput || !current_dive)
 		return;
-	QDateTime dateTime = QDateTime::fromMSecsSinceEpoch(1000*current_dive->when, Qt::UTC);
-	dateTime.setTimeSpec(Qt::UTC);
+	QDateTime dateTime = timestampToDateTime(current_dive->when);
 	dateTime.setTime(ui.timeEdit->time());
 	shiftTime(dateTime);
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -908,7 +908,7 @@ parsed:
 			// add a hundred years.
 			if (newDate.addYears(100) < QDateTime::currentDateTime().addYears(1))
 				newDate = newDate.addYears(100);
-			d->dc.when = d->when = newDate.toMSecsSinceEpoch() / 1000;
+			d->dc.when = d->when = dateTimeToTimestamp(newDate);
 			return true;
 		}
 		appendTextToLog("none of our parsing attempts worked for the date string");

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -85,7 +85,7 @@ void DivePlannerPointsModel::setupStartTime()
 	if (dive_table.nr) {
 		struct dive *d = get_dive(dive_table.nr - 1);
 		time_t ends = dive_endtime(d);
-		time_t diff = ends - startTime.toTime_t();
+		time_t diff = ends - dateTimeToTimestamp(startTime);
 		if (diff > 0) {
 			startTime = startTime.addSecs(diff + 3600);
 		}
@@ -700,7 +700,7 @@ void DivePlannerPointsModel::setSurfaceSegment(int duration)
 void DivePlannerPointsModel::setStartDate(const QDate &date)
 {
 	startTime.setDate(date);
-	diveplan.when = startTime.toTime_t();
+	diveplan.when = dateTimeToTimestamp(startTime);
 	displayed_dive.when = diveplan.when;
 	emitDataChanged();
 }
@@ -708,7 +708,7 @@ void DivePlannerPointsModel::setStartDate(const QDate &date)
 void DivePlannerPointsModel::setStartTime(const QTime &t)
 {
 	startTime.setTime(t);
-		diveplan.when = startTime.toTime_t();
+		diveplan.when = dateTimeToTimestamp(startTime);
 	displayed_dive.when = diveplan.when;
 	emitDataChanged();
 }

--- a/qt-models/divesummarymodel.cpp
+++ b/qt-models/divesummarymodel.cpp
@@ -263,7 +263,7 @@ void DiveSummaryModel::calc(int column, int period)
 	if (startTime == currentTime)
 		start = 0;
 	else
-		start = startTime.toMSecsSinceEpoch() / 1000L + gettimezoneoffset();
+		start = dateTimeToTimestamp(startTime) + gettimezoneoffset();
 
 	// Loop over all dives and sum up data
 	Stats stats = loopDives(start);

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -63,7 +63,7 @@ QString DiveTripModelBase::tripShortDate(const dive_trip *trip)
 {
 	if (!trip)
 		return QString();
-	QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(trip), Qt::UTC);
+	QDateTime firstTime = timestampToDateTime(trip_date(trip));
 	QString firstMonth = firstTime.toString("MMM");
 	return QStringLiteral("%1\n'%2").arg(firstMonth,firstTime.toString("yy"));
 }
@@ -79,10 +79,10 @@ QString DiveTripModelBase::tripTitle(const dive_trip *trip)
 
 	if (title.isEmpty()) {
 		// so use the date range
-		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(trip), Qt::UTC);
+		QDateTime firstTime = timestampToDateTime(trip_date(trip));
 		QString firstMonth = firstTime.toString("MMM");
 		QString firstYear = firstTime.toString("yyyy");
-		QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*trip->dives.dives[0]->when, Qt::UTC);
+		QDateTime lastTime = timestampToDateTime(trip->dives.dives[0]->when);
 		QString lastMonth = lastTime.toString("MMM");
 		QString lastYear = lastTime.toString("yyyy");
 		if (lastMonth == firstMonth && lastYear == firstYear)
@@ -201,8 +201,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	// variable in the QtQuick list view. That has to be a string because it will try
 	// to do locale-aware sorting. And amazingly this can't be changed.
 	case MobileListModel::DateTimeRole: {
-		QDateTime localTime = QDateTime::fromMSecsSinceEpoch(1000 * d->when, Qt::UTC);
-		localTime.setTimeSpec(Qt::UTC);
+		QDateTime localTime = timestampToDateTime(d->when);
 		return QStringLiteral("%1 %2").arg(localTime.date().toString(prefs.date_format_short),
 						   localTime.time().toString(prefs.time_format));
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was an inconsistent mess. Let's use two helper functions for the `QDateTime` <-> `timestamp_t` conversions., one for each direction. Should I have messed up, let's hope that the tests catch this.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This is a spin-off of the filter-constraints work.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.