### PR TITLE
mobile/credentials: email address must be lower case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: convert entered email to lower case
 desktop: update date and time fields on maintab if user changes preferences
 mobile: small improvements to usability with dark theme
 Core: improve service selection for BLE, adding white list and black list

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -558,24 +558,27 @@ void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &ne
 	bool cloudCredentialsChanged = false;
 	bool noCloud = qPrefCloudStorage::cloud_verification_status() == qPrefCloudStorage::CS_NOCLOUD;
 
+	// email address MUST be lower case or bad things happen
+	QString email = newEmail.toLower();
+
 	// make sure we only have letters, numbers, and +-_. in password and email address
 	QRegularExpression regExp("^[a-zA-Z0-9@.+_-]+$");
 	if (!noCloud) {
 		// in case of NO_CLOUD, the email address + passwd do not care, so do not check it.
 		if (newPassword.isEmpty() ||
 			!regExp.match(newPassword).hasMatch() ||
-			!regExp.match(newEmail).hasMatch()) {
+			!regExp.match(email).hasMatch()) {
 			setStartPageText(RED_FONT + tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.") + END_FONT);
 			return;
 		}
 		// use the same simplistic regex as the backend to check email addresses
 		regExp = QRegularExpression("^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.+_-]+\\.[a-zA-Z0-9]+");
-		if (!regExp.match(newEmail).hasMatch()) {
+		if (!regExp.match(email).hasMatch()) {
 			setStartPageText(RED_FONT + tr("Invalid format for email address") + END_FONT);
 			return;
 		}
 	}
-	if (!same_string(prefs.cloud_storage_email, qPrintable(newEmail))) {
+	if (!same_string(prefs.cloud_storage_email, qPrintable(email))) {
 		cloudCredentialsChanged = true;
 	}
 
@@ -589,11 +592,11 @@ void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &ne
 		qPrefCloudStorage::set_cloud_verification_status(m_oldStatus);
 	}
 
-	if (!noCloud && !verifyCredentials(newEmail, newPassword, pin)) {
+	if (!noCloud && !verifyCredentials(email, newPassword, pin)) {
 		appendTextToLog("saveCloudCredentials: given cloud credentials didn't verify");
 		return;
 	}
-	qPrefCloudStorage::set_cloud_storage_email(newEmail);
+	qPrefCloudStorage::set_cloud_storage_email(email);
 	qPrefCloudStorage::set_cloud_storage_password(newPassword);
 
 	if (m_oldStatus == qPrefCloudStorage::CS_NOCLOUD && cloudCredentialsChanged && dive_table.nr) {


### PR DESCRIPTION
I could have sworn that I have fixed this several times in various places,
but apparently (as shown by todays support emails) it's still possible to
setup a mixed case email address. So let's try to solve this problem at
the very top.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Force the email address to be lower case.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed. This is well documented everywhere. And I thought we enforced this.
But clearly we didn't.

