### PR TITLE
Idle cleanup:  remove dialog singletons

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -647,8 +647,8 @@ void DiveListView::splitDives()
 
 void DiveListView::renumberDives()
 {
-	RenumberDialog::instance()->renumberOnlySelected();
-	RenumberDialog::instance()->show();
+	RenumberDialog dialog(true, MainWindow::instance());
+	dialog.exec();
 }
 
 void DiveListView::merge_trip(const QModelIndex &a, int offset)

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -860,7 +860,8 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 
 void DiveListView::shiftTimes()
 {
-	ShiftTimesDialog::instance()->show();
+	ShiftTimesDialog dialog(MainWindow::instance());
+	dialog.exec();
 }
 
 void DiveListView::loadImages()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -921,8 +921,8 @@ void MainWindow::on_actionAddDive_triggered()
 
 void MainWindow::on_actionRenumber_triggered()
 {
-	RenumberDialog::instance()->renumberOnlySelected(false);
-	RenumberDialog::instance()->show();
+	RenumberDialog dialog(false, this);
+	dialog.exec();
 }
 
 void MainWindow::on_actionAutoGroup_triggered()

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -124,27 +124,6 @@ void MinMaxAvgWidget::setAvgVisibility(bool visible)
 	avgValue->setVisible(visible);
 }
 
-RenumberDialog *RenumberDialog::instance()
-{
-	static RenumberDialog *self = new RenumberDialog(MainWindow::instance());
-	return self;
-}
-
-void RenumberDialog::renumberOnlySelected(bool selected)
-{
-	if (selected && amount_selected == 1)
-		ui.renumberText->setText(tr("New number"));
-	else
-		ui.renumberText->setText(tr("New starting number"));
-
-	if (selected)
-		ui.groupBox->setTitle(tr("Renumber selected dives"));
-	else
-		ui.groupBox->setTitle(tr("Renumber all dives"));
-
-	selectedOnly = selected;
-}
-
 void RenumberDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
@@ -163,7 +142,7 @@ void RenumberDialog::buttonClicked(QAbstractButton *button)
 	}
 }
 
-RenumberDialog::RenumberDialog(QWidget *parent) : QDialog(parent), selectedOnly(false)
+RenumberDialog::RenumberDialog(bool selectedOnlyIn, QWidget *parent) : QDialog(parent), selectedOnly(selectedOnlyIn)
 {
 	ui.setupUi(this);
 	connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
@@ -171,6 +150,16 @@ RenumberDialog::RenumberDialog(QWidget *parent) : QDialog(parent), selectedOnly(
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
+
+	if (selectedOnly && amount_selected == 1)
+		ui.renumberText->setText(tr("New number"));
+	else
+		ui.renumberText->setText(tr("New starting number"));
+
+	if (selectedOnly)
+		ui.groupBox->setTitle(tr("Renumber selected dives"));
+	else
+		ui.groupBox->setTitle(tr("Renumber all dives"));
 }
 
 void SetpointDialog::buttonClicked(QAbstractButton *button)

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -179,12 +179,6 @@ SetpointDialog::SetpointDialog(struct dive *dIn, int dcNrIn, int seconds) : QDia
 	connect(quit, &QShortcut::activated, MainWindow::instance(), &QWidget::close);
 }
 
-ShiftTimesDialog *ShiftTimesDialog::instance()
-{
-	static ShiftTimesDialog *self = new ShiftTimesDialog(MainWindow::instance());
-	return self;
-}
-
 void ShiftTimesDialog::buttonClicked(QAbstractButton *button)
 {
 	int amount;
@@ -196,10 +190,7 @@ void ShiftTimesDialog::buttonClicked(QAbstractButton *button)
 		if (amount != 0)
 			Command::shiftTime(getDiveSelection(), amount);
 	}
-}
 
-void ShiftTimesDialog::showEvent(QShowEvent*)
-{
 	ui.timeEdit->setTime(QTime(0, 0, 0, 0));
 	when = get_times(); //get time of first selected dive
 	ui.currentTime->setText(get_dive_date_string(when));

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -50,14 +50,12 @@ public:
 class RenumberDialog : public QDialog {
 	Q_OBJECT
 public:
-	static RenumberDialog *instance();
-	void renumberOnlySelected(bool selected = true);
+	explicit RenumberDialog(bool selectedOnly, QWidget *parent);
 private
 slots:
 	void buttonClicked(QAbstractButton *button);
 
 private:
-	explicit RenumberDialog(QWidget *parent);
 	Ui::RenumberDialog ui;
 	bool selectedOnly;
 };

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -78,15 +78,13 @@ private:
 class ShiftTimesDialog : public QDialog {
 	Q_OBJECT
 public:
-	static ShiftTimesDialog *instance();
-	void showEvent(QShowEvent *event);
+	explicit ShiftTimesDialog(QWidget *parent);
 private
 slots:
 	void buttonClicked(QAbstractButton *button);
 	void changeTime();
 
 private:
-	explicit ShiftTimesDialog(QWidget *parent);
 	int64_t when;
 	Ui::ShiftTimesDialog ui;
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an idle code-cleanup: remove dialog singletons. Create the dialogs only when they are needed instead of keeping a global object. This reduces global state and dependencies. These are modal dialogs and now all dialogs in `simplewidget.cpp` are un-singletonized.

I tested all three invocations and they still work.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove two dialog singletons.