### PR TITLE
Android: install translations into the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix missing translations on Android
 CSV export: support for multiple cylinders
 CSV import: support for multiple cylinders for Subsurface CSV files
 CSV import: multiple bug fixes for Subsurface CSV files

--- a/packaging/android/build.sh
+++ b/packaging/android/build.sh
@@ -413,8 +413,8 @@ fi
 
 # now make the translations
 make translations
-mkdir -p assets/translations
-cp -a translations/*.qm assets/translations
+mkdir -p subsurface-mobile-"$ANDROID_ABI"/assets/translations
+cp -a translations/*.qm subsurface-mobile-"$ANDROID_ABI"/assets/translations
 
 # now build Subsurface and use the rest of the command line arguments
 make "$@"


### PR DESCRIPTION
When updating the NDK I forgot to adjust the install destination for the
translations.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Side effect of the changes to the Android tools

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
simply copy the translations into the right folder

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

