### PR TITLE
mobile/dive-edit: fix broken editable combo boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: fix broken editing of location, suit, buddy, and dive master
 Mobile: fix missing translations on Android
 CSV export: support for multiple cylinders
 CSV import: support for multiple cylinders for Subsurface CSV files

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -161,11 +161,6 @@ Item {
 				id: locationBox
 				editable: true
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					manager.locationList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -273,11 +268,6 @@ Item {
 				id: suitBox
 				editable: true
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					manager.suitList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -299,11 +289,6 @@ Item {
 			Controls.ComboBox {
 				id: buddyBox
 				editable: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					manager.buddyList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -325,11 +310,6 @@ Item {
 			Controls.ComboBox {
 				id: divemasterBox
 				editable: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					manager.divemasterList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -365,11 +345,6 @@ Item {
 			Controls.ComboBox {
 				id: cylinderBox0
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -427,11 +402,6 @@ Item {
 				visible: usedCyl[1] != null ? true : false
 				id: cylinderBox1
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -496,11 +466,6 @@ Item {
 				id: cylinderBox2
 				currentIndex: find(usedCyl[2])
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -564,11 +529,6 @@ Item {
 				id: cylinderBox3
 				currentIndex: find(usedCyl[3])
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText
@@ -633,11 +593,6 @@ Item {
 				id: cylinderBox4
 				currentIndex: find(usedCyl[4])
 				flat: true
-				contentItem: Text {
-					text: parent.displayText
-					color: subsurfaceTheme.textColor
-					verticalAlignment: Text.AlignVCenter
-				}
 				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
 					diveDetailsListView.currentItem.modelData.cylinderList : null
 				inputMethodHints: Qt.ImhNoPredictiveText


### PR DESCRIPTION
The changes in commit 99438121c4 ("mobile/dive-edit: use template components
and theme colors") unintentionally broke our ability to actually edit the
content of one of those fields. 

The more time I wasted trying to get this back to work the clearer it became that the ComboBox theming is flat out broken and the documentation is flat out wrong.

I should care enough to file a bug report.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
Yuck. See why I hate the dark theme? That change was made to accommodate the dark theme. And ended up breaking things badly.
That said, the documentation of Customizing a ComboBox https://doc.qt.io/qt-5/qtquickcontrols2-customize.html#customizing-combobox could mention the fact that this flat out breaks the ability to edit the text...

I simply reverted the part of the change that broke the ComboBox. Even though it implemented EXACTLY what was suggested in the linked documentation. Whatever. So don't use the dark theme. It's simple.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Add another template type to simplify our code.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
I got quite a few support requests when that got broken.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

Since no one seems to ever test the QML stuff that I push, I'll make a new Android beta release instead and wait for people to yell at me.