### PR TITLE
Cloud cache import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: add advanved option to import dives from local cloud cache directories
 Mobile: fix broken editing of location, suit, buddy, and dive master
 Mobile: fix missing translations on Android
 CSV export: support for multiple cylinders

--- a/mobile-widgets/qml/RecoverCache.qml
+++ b/mobile-widgets/qml/RecoverCache.qml
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import org.kde.kirigami 2.4 as Kirigami
+import org.subsurfacedivelog.mobile 1.0
+
+Kirigami.ScrollablePage {
+	id: recoverCache
+	title: qsTr("Cloud Cache Import")
+	objectName: "recoverCache"
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
+	width: parent.width
+	height: parent.height
+
+	Item {
+	TemplateLabel {
+		id: header
+		text: qsTr("Cloud Cache Import")
+		color: subsurfaceTheme.lightPrimaryTextColor
+		background: Rectangle { color: subsurfaceTheme.lightPrimaryColor }
+		font.pointSize: subsurfaceTheme.regularPointSize * 1.5
+		padding: Kirigami.Units.gridUnit
+		width: recoverCache.width - 5 * Kirigami.Units.largeSpacing
+		height: 3.5 * Kirigami.Units.gridUnit
+	}
+	Rectangle {
+		id: subheader
+		z: 5
+		width: recoverCache.width - 5 * Kirigami.Units.largeSpacing
+		height: 3 * Kirigami.Units.gridUnit
+		color: subsurfaceTheme.backgroundColor
+		anchors {
+			left: header.left
+			top: header.bottom
+			right: parent.right
+		}
+		TemplateLabel {
+			height: 2 * Kirigami.Units.gridUnit
+			text: qsTr("import data from the given cache repo")
+			anchors {
+				verticalCenter: parent.verticalCenter
+				horizontalCenter: parent.horizontalCenter
+			}
+		}
+	}
+	Rectangle {
+		id: spacer
+		anchors.top: subheader.bottom
+		height: Kirigami.Units.largeSpacing
+		width: recoverCache.width
+		color: subsurfaceTheme.backgroundColor
+	}
+
+	Rectangle {
+		anchors {
+			left: header.left
+			right: parent.right
+			top: spacer.bottom
+		}
+		z: -5
+		ListView {
+			height: recoverCache.height - 9 * Kirigami.Units.gridUnit
+			width: recoverCache.width
+			model: manager.cloudCacheList
+			delegate: TemplateButton {
+				height: 3 * Kirigami.Units.gridUnit
+				width: parent.width - 2 * Kirigami.Units.gridUnit
+				text: modelData
+				onClicked: {
+					console.log("import " + modelData)
+					manager.importCacheRepo(modelData)
+				}
+			}
+		}
+	}
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -534,6 +534,14 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					}
 				}
 
+				Kirigami.Action {
+					text: qsTr("Access local cloud cache dirs")
+					onTriggered: {
+						globalDrawer.close()
+						showPage(recoverCache)
+					}
+				}
+
 				/* disable for now
 				Kirigami.Action {
 					text: qsTr("Dive planner")
@@ -822,6 +830,12 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		id: mapPage
 		visible: false
 	}
+
+	RecoverCache {
+		id: recoverCache
+		visible: false
+	}
+
 /* this shouldn't be exposed unless someone will finish the work
 	DivePlannerSetup {
 		id: divePlannerSetupWindow

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -162,7 +162,7 @@ Kirigami.ApplicationWindow {
 		height: rootItem.height
 		rightPadding: 0
 		enabled: (Backend.cloud_verification_status === Enums.CS_NOCLOUD ||
-				  Backend.cloud_verification_status === Enums.CS_VERIFIED)
+			          Backend.cloud_verification_status === Enums.CS_VERIFIED)
 		topContent: Image {
 			source: "qrc:/qml/icons/dive.jpg"
 			Layout.fillWidth: true
@@ -681,8 +681,8 @@ if you have network connectivity and want to sync your data to cloud storage."),
 					manager.appendTextToLog("pageStack forced back to map")
 				}
 			} else if (pageStack.currentItem.objectName !== mapPage.objectName &&
-					   pageStack.lastItem.objectName === mapPage.objectName &&
-					   hackToOpenMap === 1 /* MapSelected */) {
+				           pageStack.lastItem.objectName === mapPage.objectName &&
+				           hackToOpenMap === 1 /* MapSelected */) {
 				// if we just picked the mapPage and are suddenly back on a different page
 				// force things back to the mapPage
 				manager.appendTextToLog("pageStack wrong page, switching back to map")

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -41,6 +41,8 @@
 		<file>ThemeTest.qml</file>
 		<file>TripDetails.qml</file>
 		<file>StartPage.qml</file>
+		<file>RecoverCache.qml</file>
+
 		<file>SsrfCheckBox.qml</file>
 		<file>SsrfSwitch.qml</file>
 		<file>SsrfTextField.qml</file>

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2207,6 +2207,18 @@ void QMLManager::setDiveListProcessing(bool value)
 
 }
 
+void QMLManager::importCacheRepo(QString repo)
+{
+	struct dive_table table = empty_dive_table;
+	struct trip_table trips = empty_trip_table;
+	struct dive_site_table sites = empty_dive_site_table;
+	QString repoPath = QString("%1/cloudstorage/%2").arg(system_default_directory()).arg(repo);
+	appendTextToLog(QString("importing %1").arg(repoPath));
+	parse_file(qPrintable(repoPath), &table, &trips, &sites);
+	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	changesNeedSaving();
+}
+
 QStringList QMLManager::cloudCacheList() const
 {
 	QDir localCacheDir(QString("%1/cloudstorage/").arg(system_default_directory()));

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -40,6 +40,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
 	Q_PROPERTY(QStringList locationList READ locationList NOTIFY locationListChanged)
 	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
+	Q_PROPERTY(QStringList cloudCacheList READ cloudCacheList NOTIFY cloudCacheListChanged)
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
 	Q_PROPERTY(bool btEnabled MEMBER m_btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
 
@@ -161,6 +162,7 @@ public:
 	QStringList divemasterList() const;
 	QStringList locationList() const;
 	QStringList cylinderInit() const;
+	QStringList cloudCacheList() const;
 	Q_INVOKABLE void setStatusbarColor(QColor color);
 	void btHostModeChange(QBluetoothLocalDevice::HostMode state);
 	QObject *qmlWindow;
@@ -303,6 +305,7 @@ signals:
 	void buddyListChanged();
 	void divemasterListChanged();
 	void locationListChanged();
+	void cloudCacheListChanged();
 	void waitingForPositionChanged();
 	void pluggedInDeviceNameChanged();
 	void showNonDiveComputersChanged();
@@ -315,7 +318,6 @@ signals:
 	// From upload process
 	void uploadFinish(bool success, const QString &text);
 	void uploadProgress(qreal percentage);
-
 
 private slots:
 	void uploadFinishSlot(bool success, const QString &text, const QByteArray &html);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -119,6 +119,7 @@ public:
 	Q_INVOKABLE void setFilter(const QString filterText, int mode);
 	Q_INVOKABLE void selectRow(int row);
 	Q_INVOKABLE void selectSwipeRow(int row);
+	Q_INVOKABLE void importCacheRepo(QString repo);
 
 	static QMLManager *instance();
 	Q_INVOKABLE void registerError(QString error);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
This came out of my work with a user debugging an error situation they had
run into, specifically due to some issues with creating the cloud storage repo
on the back end, that was overwritten with an empty dive log, again, and subsequently
we moved the valid local cache on their mobile device out of the way and made all the
dives that they entered inaccessible to them.

This is a bit of a hack, but I think it should be very safe to use. I still decided to hide
it in the developer options, because actually explaining how it works basically requires
that the user understands how our git connection with the cloud works. But it's quite
easy for me to walk a user through how to recover otherwise lost dive data - without
`adb` or rooting an iPhone.

All it does is add a way to show the user the local cache dirs that are available (including
the local no-cloud repo, if it exists) and then import the dives in such a directory into the
current dive list. Which magically recovers otherwise lost data.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This tends to always be in support emails with me about "lost" data. Be it failed no-cloud conversions or the error I described above.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No, I don't think I want to try to document this :-)

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
I'd love if someone could take a look - I'll ping Linus as well.