### PR TITLE
mobile/dive-details: restrict width of tags field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Mobile: correct UI issue with tags that were longer than page width
 Mobile: add advanved option to import dives from local cloud cache directories
 Mobile: fix broken editing of location, suit, buddy, and dive master
 Mobile: fix missing translations on Android

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -519,9 +519,8 @@ Item {
 		TemplateLabelSmall {
 			text: qsTr("Tags:")
 			opacity: 0.6
-			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.columnSpan: 3
-			Layout.maximumWidth: detailsView.col2Width + detailsView.col3Width
+			Layout.maximumWidth: detailsView.gridWidth
 			Layout.bottomMargin: 0
 			color: subsurfaceTheme.textColor
 		}
@@ -532,6 +531,10 @@ Item {
 			id: txtTags
 			text: tags
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+			elide: Text.ElideRight
+			maximumLineCount: 3
+			Layout.maximumWidth: detailsView.gridWidth
+			height: Kirigami.Units.gridUnit * 3
 			Layout.columnSpan: 3
 			color: subsurfaceTheme.textColor
 		}


### PR DESCRIPTION
Having a lot of tags (or more precisely, a tags string that is very long) could
cause the width of the dive details view to extend past the width of the the
page. The txtTags label was missing a maximum width, and to make the result
more useful, I also added correct wrapping and elide to the mix (stupidly, we
had the wrap and width for the fixed name of the field ('Tags'), but not for
the user determined content of that field).


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
This should fix the UI issues for people with very long tags string

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
simply restrict the width of that field (and add wrap / elide for good measure)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 