### PR TITLE
download: don't warn on unknown gasmixes

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -195,7 +195,7 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 											mbar_to_atm(cyl.type.workingpressure.mbar));
 					}
 				}
-				if (tank.gasmix != i) { // we don't handle this, yet
+				if (tank.gasmix != DC_GASMIX_UNKNOWN && tank.gasmix != i) { // we don't handle this, yet
 					shown_warning = true;
 					report_error("gasmix %d for tank %d doesn't match", tank.gasmix, i);
 				}


### PR DESCRIPTION
Apparently libdivecomputer can return DC_GASMIX_UNKNOWN when
fetching tank info with
  dc_parser_get_field(parser, DC_FIELD_TANK, i, &tank);
This caused emission of a warning, which was annoying users.
Disable the warning in that case.

Fixes #2866

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Don't show warning when we get `DC_GASMIX_UNKNOWN` from libdivecomputer.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2866.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Let's wait for comments.