### PR TITLE
[TRIVIAL] cleanup: remove indirection when passing arguments to parser functions

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1364,11 +1364,9 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 }
 
 /* We're in the top-level trip xml. Try to convert whatever value to a trip value */
-static void try_to_fill_trip(dive_trip_t **dive_trip_p, const char *name, char *buf, struct parser_state *state)
+static void try_to_fill_trip(dive_trip_t *dive_trip, const char *name, char *buf, struct parser_state *state)
 {
 	start_match("trip", name, buf);
-
-	dive_trip_t *dive_trip = *dive_trip_p;
 
 	if (MATCH("location", utf8_string, &dive_trip->location))
 		return;
@@ -1379,11 +1377,10 @@ static void try_to_fill_trip(dive_trip_t **dive_trip_p, const char *name, char *
 }
 
 /* We're processing a divesite entry - try to fill the components */
-static void try_to_fill_dive_site(struct dive_site **ds_p, const char *name, char *buf)
+static void try_to_fill_dive_site(struct dive_site *ds, const char *name, char *buf)
 {
 	start_match("divesite", name, buf);
 
-	struct dive_site *ds = *ds_p;
 	if (ds->taxonomy.category == NULL)
 		ds->taxonomy.category = alloc_taxonomy();
 
@@ -1426,7 +1423,7 @@ static bool entry(const char *name, char *buf, struct parser_state *state)
 		return true;
 	}
 	if (state->cur_dive_site) {
-		try_to_fill_dive_site(&state->cur_dive_site, name, buf);
+		try_to_fill_dive_site(state->cur_dive_site, name, buf);
 		return true;
 	}
 	if (!state->cur_event.deleted) {
@@ -1446,7 +1443,7 @@ static bool entry(const char *name, char *buf, struct parser_state *state)
 		return true;
 	}
 	if (state->cur_trip) {
-		try_to_fill_trip(&state->cur_trip, name, buf, state);
+		try_to_fill_trip(state->cur_trip, name, buf, state);
 		return true;
 	}
 	return true;


### PR DESCRIPTION
For unkown reasons, the dive site and trips to be parsed into were
passed as pointers to pointers. A simple pointer seems to be enough,
since the object is not allocated by the function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial cleanup, which removes a pointer indirection in the parser. Probably an artifact.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.