### PR TITLE
serial_ftdi: adjust callbacks structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+core: fix crashes when using user space FTDI driver
 mobile: add information about the cloud sync state to the Subsurface plate in the menu
 
 ---

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -284,10 +284,18 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 
 	static const dc_custom_cbs_t callbacks = {
 		.set_timeout	= qt_ble_set_timeout,
+		.set_break	= nullptr,
+		.set_dtr	= nullptr,
+		.set_rts	= nullptr,
+		.get_lines	= nullptr,
+		.get_available	= nullptr,
+		.configure	= nullptr,
 		.poll		= qt_ble_poll,
 		.read		= qt_ble_read,
 		.write		= qt_ble_write,
 		.ioctl		= qt_ble_ioctl,
+		.flush		= nullptr,
+		.purge		= nullptr,
 		.sleep		= qt_custom_sleep,
 		.close		= qt_ble_close,
 	};
@@ -310,11 +318,17 @@ rfcomm_stream_open(dc_iostream_t **iostream, dc_context_t *context, const char* 
 
 	static const dc_custom_cbs_t callbacks = {
 		.set_timeout	= qt_serial_set_timeout,
+		.set_break	= nullptr,
+		.set_dtr	= nullptr,
+		.set_rts	= nullptr,
+		.get_lines	= nullptr,
 		.get_available	= qt_serial_get_available,
+		.configure	= nullptr,
 		.poll		= qt_serial_poll,
 		.read		= qt_serial_read,
 		.write		= qt_serial_write,
 		.ioctl		= qt_serial_ioctl,
+		.flush		= nullptr,
 		.purge		= qt_serial_purge,
 		.sleep		= qt_custom_sleep,
 		.close		= qt_serial_close,

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -283,21 +283,13 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 	void *io = NULL;
 
 	static const dc_custom_cbs_t callbacks = {
-		qt_ble_set_timeout, /* set_timeout */
-		NULL, /* set_break */
-		NULL, /* set_dtr */
-		NULL, /* set_rts */
-		NULL, /* get_lines */
-		NULL, /* get_received */
-		NULL, /* configure */
-		qt_ble_poll, /* poll */
-		qt_ble_read, /* read */
-		qt_ble_write, /* write */
-		qt_ble_ioctl, /* ioctl */
-		NULL, /* flush */
-		NULL, /* purge */
-		qt_custom_sleep, /* sleep */
-		qt_ble_close, /* close */
+		.set_timeout	= qt_ble_set_timeout,
+		.poll		= qt_ble_poll,
+		.read		= qt_ble_read,
+		.write		= qt_ble_write,
+		.ioctl		= qt_ble_ioctl,
+		.sleep		= qt_custom_sleep,
+		.close		= qt_ble_close,
 	};
 
 	rc = qt_ble_open(&io, context, devaddr, (dc_user_device_t *) userdata);
@@ -317,21 +309,15 @@ rfcomm_stream_open(dc_iostream_t **iostream, dc_context_t *context, const char* 
 	qt_serial_t *io = NULL;
 
 	static const dc_custom_cbs_t callbacks = {
-		qt_serial_set_timeout, /* set_timeout */
-		NULL, /* set_break */
-		NULL, /* set_dtr */
-		NULL, /* set_rts */
-		NULL, /* get_lines */
-		qt_serial_get_available, /* get_received */
-		NULL, /* configure */
-		qt_serial_poll, /* poll */
-		qt_serial_read, /* read */
-		qt_serial_write, /* write */
-		qt_serial_ioctl, /* ioctl */
-		NULL, /* flush */
-		qt_serial_purge, /* purge */
-		qt_custom_sleep, /* sleep */
-		qt_serial_close, /* close */
+		.set_timeout	= qt_serial_set_timeout,
+		.get_available	= qt_serial_get_available,
+		.poll		= qt_serial_poll,
+		.read		= qt_serial_read,
+		.write		= qt_serial_write,
+		.ioctl		= qt_serial_ioctl,
+		.purge		= qt_serial_purge,
+		.sleep		= qt_custom_sleep,
+		.close		= qt_serial_close,
 	};
 
 	rc = qt_serial_open(&io, context, devaddr);

--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -78,7 +78,7 @@ typedef struct ftdi_serial_t {
 	unsigned int parity;
 } ftdi_serial_t;
 
-static dc_status_t serial_ftdi_get_received (void *io, size_t *value)
+static dc_status_t serial_ftdi_get_available (void *io, size_t *value)
 {
 	ftdi_serial_t *device = io;
 
@@ -471,7 +471,7 @@ static dc_status_t serial_ftdi_purge (void *io, dc_direction_t queue)
 		return DC_STATUS_INVALIDARGS;
 
 	size_t input;
-	serial_ftdi_get_received (io, &input);
+	serial_ftdi_get_available (io, &input);
 	INFO (device->context, "Flush: queue=%u, input=%lu, output=%i", queue, input,
 	      serial_ftdi_get_transmitted (device));
 
@@ -557,20 +557,17 @@ dc_status_t ftdi_open(dc_iostream_t **iostream, dc_context_t *context)
 	void *io = NULL;
 
 	static const dc_custom_cbs_t callbacks = {
-		serial_ftdi_set_timeout, /* set_timeout */
-		NULL, /* set_latency */
-		serial_ftdi_set_break, /* set_break */
-		serial_ftdi_set_dtr, /* set_dtr */
-		serial_ftdi_set_rts, /* set_rts */
-		NULL, /* get_lines */
-		serial_ftdi_get_received, /* get_received */
-		serial_ftdi_configure, /* configure */
-		serial_ftdi_read, /* read */
-		serial_ftdi_write, /* write */
-		NULL, /* flush */
-		serial_ftdi_purge, /* purge */
-		serial_ftdi_sleep, /* sleep */
-		serial_ftdi_close, /* close */
+		.set_timeout	= serial_ftdi_set_timeout,
+		.set_break	= serial_ftdi_set_break,
+		.set_dtr	= serial_ftdi_set_dtr,
+		.set_rts	= serial_ftdi_set_rts,
+		.get_available	= serial_ftdi_get_available,
+		.configure	= serial_ftdi_configure,
+		.read		= serial_ftdi_read,
+		.write		= serial_ftdi_write,
+		.purge		= serial_ftdi_purge,
+		.sleep		= serial_ftdi_sleep,
+		.close		= serial_ftdi_close,
 	};
 
 	INFO(device->contxt, "%s", "in ftdi_open");


### PR DESCRIPTION
The set_latency has been removed from libdivecomputer and poll and ioctl have
been added. This caused the callbacks to no longer be aligned correctly and the
functions were called with the wrong arguments through the wrong function
pointers, leading to crashes.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
UGH... this is bad. REALLY bad.
When the function pointer table changed in libdivecomputer, we didn't update serial_ftdi
So this is broken on all platforms that link against that; I need to double check what the current state is on Windows (I think I disabled it there), so this MAY be only Mac, and there, of course, it was missing from the last to releases by mistake... but still.
UGH

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
need to add that. don't merge until then

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@torvalds 