### PR TITLE
profile: fix displaying of profiles with multiple pressure sensors [Alternative to #2889]

### DIFF
--- a/core/profile.h
+++ b/core/profile.h
@@ -109,12 +109,12 @@ extern int get_maxdepth(const struct plot_info *pi);
 
 static inline int get_plot_pressure_data(const struct plot_info *pi, int idx, enum plot_pressure sensor, int cylinder)
 {
-	return pi->pressures[cylinder * pi->nr + idx].data[sensor];
+	return pi->pressures[cylinder + idx * pi->nr_cylinders].data[sensor];
 }
 
 static inline void set_plot_pressure_data(struct plot_info *pi, int idx, enum plot_pressure sensor, int cylinder, int value)
 {
-	pi->pressures[cylinder * pi->nr + idx].data[sensor] = value;
+	pi->pressures[cylinder + idx * pi->nr_cylinders].data[sensor] = value;
 }
 
 static inline int get_plot_sensor_pressure(const struct plot_info *pi, int idx, int cylinder)


### PR DESCRIPTION
When removing the MAX_CYLINDERS restriction, the layout of the
pressure readings was changed from a (cylinder,sample) to a
(sample,cylinder) scheme. I.e. previously there were one cylinder
block for each sample, then one sample block for one cylinder.

However, after populating the samples, the array size was reduced
to the actual number of used samples. With the new layout this
breaks indexing. Therefore, restore the old layout.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
An alternative fix to #2877. This restores the old memory layout. I did not test this intensely, nor audit the code whether there are direct accesses to the pressure data matrix.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
See commit description

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2877.
Alternative to #2889.
See discussions there.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Yes.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@BartJV @dirkhh