### PR TITLE
Make MND display depend on O2 narcotic preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+planner: Honor the "O2 narcotic" preference when computing MND
 desktop: fix broken merging of dives with multiple cylinders
 mobile: add information about the cloud sync state to the Subsurface plate in the menu
 

--- a/backend-shared/plannershared.cpp
+++ b/backend-shared/plannershared.cpp
@@ -126,7 +126,7 @@ void PlannerShared::set_o2narcotic(bool value)
 {
 	qPrefDivePlanner::set_o2narcotic(value);
 	DivePlannerPointsModel::instance()->emitDataChanged();
-	DivePlannerPointsModel::instance()->cylindersModel()->updateBestMixes();
+	DivePlannerPointsModel::instance()->cylindersModel()->emitDataChanged();
 }
 
 double PlannerShared::bottompo2()

--- a/core/dive.c
+++ b/core/dive.c
@@ -3767,7 +3767,10 @@ depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int rou
 	pressure_t ppo2n2;
 	ppo2n2.mbar = depth_to_mbar(end.mm, dive);
 
-	int maxambient = (int)lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0));
+	int maxambient = prefs.o2narcotic ?
+					(int)lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0))
+			      :
+					(int)lrint(ppo2n2.mbar * N2_IN_AIR / (1000 - get_he(mix) - get_o2(mix)));
 	rounded_depth.mm = (int)lrint(((double)mbar_to_depth(maxambient, dive)) / roundto) * roundto;
 	return rounded_depth;
 }

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -663,8 +663,12 @@ bool CylindersModel::updateBestMixes()
 	/* This slot is called when the bottom pO2 and END preferences are updated, we want to
 	 * emit dataChanged so MOD and MND are refreshed, even if the gas mix hasn't been changed */
 	if (gasUpdated)
-		emit dataChanged(createIndex(0, 0), createIndex(d->cylinders.nr - 1, COLUMNS - 1));
+		emitDataChanged();
 	return gasUpdated;
+}
+
+void CylindersModel::emitDataChanged() {
+	emit dataChanged(createIndex(0, 0), createIndex(d->cylinders.nr - 1, COLUMNS - 1));
 }
 
 void CylindersModel::cylindersReset(const QVector<dive *> &dives)

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -49,6 +49,7 @@ public:
 	void moveAtFirst(int cylid);
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 	bool updateBestMixes();
+	void emitDataChanged();
 	bool cylinderUsed(int i) const;
 
 signals:


### PR DESCRIPTION
A while ago, we introduced a preference whether O2 should
be considered narcotic. We used this when computing
best mix or when entering the He content via MND. But
we forgot to make the displayed MND depend on this
preference. This patch add this.

Fixes #2895

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
