### PR TITLE
core/BLE: add detection of Scubapro Aladin A1

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -58,11 +58,12 @@ static dc_descriptor_t *getDeviceType(QString btName)
 	} else if (btName.startsWith("Suunto D5")) {
 		vendor = "Suunto";
 		product = "D5";
-	} else if (btName.startsWith("G2")  || btName.startsWith("Aladin") || btName.startsWith("HUD")) {
+	} else if (btName.startsWith("G2")  || btName.startsWith("Aladin") || btName.startsWith("HUD") || btName.startsWith("A1")) {
 		vendor = "Scubapro";
 		if (btName.startsWith("G2")) product = "G2";
 		if (btName.startsWith("HUD")) product = "G2 HUD";
 		if (btName.startsWith("Aladin")) product = "Aladin Sport Matrix";
+		if (btName.startsWith("A1")) product = "Aladin A1";
 	} else if (btName.startsWith("Mares")) {
 		vendor = "Mares";
 		// we don't know which of the dive computers it is,


### PR DESCRIPTION
This was supported in libdivecomputer, but not recognized as dive computer by
our core BLE code.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
we didn't recognize the BLE name of the A1 (which is, err, "A1")

