### PR TITLE
RFD: Improve resolution of profile export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ core: add support for Shearwater Peregrine (requires firmware V79 or newer)
 core: fix renumbering of imported dives [#2731]
 mobile: fix editing tank information
 planner: Handle zero length segments gracefully when replanning
+profile: improve resolution in printing and export
 mobile: disable download button if no connection is selected
 mobile: fix incorrect time stamps on GPS track points created via location service
 core: correctly recognize A1 as BLE dive computer

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -225,11 +225,11 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 void exportProfile(const struct dive *dive, const QString filename)
 {
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
-	profile->plotDive(dive, true, false, true);
 	profile->setToolTipVisibile(false);
 	profile->setPrintMode(true);
 	double scale = profile->getFontPrintScale();
 	profile->setFontPrintScale(4 * scale);
+	profile->plotDive(dive, true, false, true);
 	QImage image = QImage(profile->size() * 4, QImage::Format_RGB32);
 	QPainter paint;
 	paint.begin(&image);
@@ -238,4 +238,5 @@ void exportProfile(const struct dive *dive, const QString filename)
 	profile->setToolTipVisibile(true);
 	profile->setFontPrintScale(scale);
 	profile->setPrintMode(false);
+	profile->plotDive(dive, true);
 }

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -227,7 +227,15 @@ void exportProfile(const struct dive *dive, const QString filename)
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
 	profile->plotDive(dive, true, false, true);
 	profile->setToolTipVisibile(false);
-	QPixmap pix = profile->grab();
+	profile->setPrintMode(true);
+	double scale = profile->getFontPrintScale();
+	profile->setFontPrintScale(4 * scale);
+	QImage image = QImage(profile->size() * 4, QImage::Format_RGB32);
+	QPainter paint;
+	paint.begin(&image);
+	profile->render(&paint);
+	image.save(filename);
 	profile->setToolTipVisibile(true);
-	pix.save(filename);
+	profile->setFontPrintScale(scale);
+	profile->setPrintMode(false);
 }

--- a/desktop-widgets/printdialog.cpp
+++ b/desktop-widgets/printdialog.cpp
@@ -171,6 +171,7 @@ void PrintDialog::createPrinterObj()
 	// create a new printer object
 	if (!printer) {
 		qprinter = new QPrinter();
+		qprinter->setResolution(printOptions.resolution);
 		qprinter->setOrientation((QPrinter::Orientation)printOptions.landscape);
 		printer = new Printer(qprinter, &printOptions, &templateOptions, Printer::PRINT);
 	}

--- a/desktop-widgets/printoptions.cpp
+++ b/desktop-widgets/printoptions.cpp
@@ -44,7 +44,9 @@ void PrintOptions::setup()
 
 	connect(ui.printInColor, SIGNAL(clicked(bool)), this, SLOT(printInColorClicked(bool)));
 	connect(ui.printSelected, SIGNAL(clicked(bool)), this, SLOT(printSelectedClicked(bool)));
-
+	connect(ui.resolution, QOverload<int>::of(&QSpinBox::valueChanged), [this](int value) {
+		printOptions->resolution = value;
+	});
 	hasSetupSlots = true;
 }
 

--- a/desktop-widgets/printoptions.h
+++ b/desktop-widgets/printoptions.h
@@ -15,6 +15,7 @@ struct print_options {
 	bool print_selected;
 	bool color_selected;
 	bool landscape;
+	int resolution;
 };
 
 struct template_options {

--- a/desktop-widgets/printoptions.ui
+++ b/desktop-widgets/printoptions.ui
@@ -93,6 +93,36 @@
         </property>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QSpinBox" name="resolution">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <number>4000</number>
+          </property>
+          <property name="singleStep">
+           <number>10</number>
+          </property>
+          <property name="value">
+           <number>600</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>DPI resolution</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -796,6 +796,9 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 		item->setModel(dataModel);
 		item->setEvent(event, lastgasmix);
 		item->setZValue(2);
+#ifndef SUBSURFACE_MOBILE
+		item->setScale(printMode ? 4 :1);
+#endif
 		scene()->addItem(item);
 		eventItems.push_back(item);
 		if (event_is_gaschange(event))


### PR DESCRIPTION
The way we export the profile image (as direct export but
also used for printing) is that we render the profile
from the screen to a Pixmap and save that to a file. Unfortunately
this results in very bad resultion and a blurred image.

This is an attempt to improve that situation but it's still far
from perfect: Rather than a QPixmap and grab, I now use a QImage
(where I can set the size) and render, and indeed the picture resolution
(when vied at fixed size) get's better this way. The disadvantage
is that icons and text get smaller at the same rate und so
there is a natural limit on how big we can get. Maybe somebody
with better Qt knowledge can take off from here. In my opinion
this is already a step in the right direction.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
