### PR TITLE
Workaround mdbtools crash

### DIFF
--- a/scripts/smtk2ssrf-build.sh
+++ b/scripts/smtk2ssrf-build.sh
@@ -151,7 +151,7 @@ cmake   -DBTSUPPORT=OFF \
 	build
 cd build || aborting "Couldn't cd into $SSRF_PATH/build directory"
 make clean
-make "$JOBS" || STATUS=1
+LIBRARY_PATH=$INSTALL_ROOT/lib make "$JOBS" || STATUS=1
 
 # Restore initial state of subsurface building system:
 echo "----> Restoring Subsurface tree state"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
memcpy() called from mdbtool's mdb_ole_read_full() was throwing a segfault.
As the issue seems mdbtools or even glibc related, we need a workaround to avoid the crashing call.  Patch 2 simply avoids the faulting call although means a wider rework for some utilities  and functions.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) smtk_open_table() now builds an array of strings and an array for the lengths of the db fields (this second one on demand, just make the pointer NULL to avoid building the lengths array).  The lengths can't be built along with the MdbColumn, so we drop this last one and will build it where needed (just in main function to get dc's header and profile)
2) As we know in advance the length of the profile we can avoid calling the faulty function on zero-length profiles which seemed to cause the segfault (weirdly enough, as zero-length profiles are very common in older Aladin DC models and we never had such crashes).
3) Except for the main function smartrak_import(), use the values bounded by smtk_open_table(). In the main func we can still use them through the MdbColumn pointer as the columns are built for this function.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
