### PR TITLE
Add an "Edit Gas Change" right-click option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: add an "Edit Gas Change" right-click option [#2910]
 core: add support for Shearwater Peregrine (requires firmware V79 or newer)
 core: fix renumbering of imported dives [#2731]
 mobile: fix editing tank information


### PR DESCRIPTION
This new option allows a user to select a new destination tank for an existing Gas Change event. This is useful when Subsurface's heuristics get tanks wrong after an import from a divecomputer.

Signed-off-by: Michael Werle <micha@michaelwerle.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Feature Discussion
This PR is mainly to discuss whether or not such a feature is of interest.  Posting on the dev mailing list garnered little  responses save to submit the PR and see.

The "proper" way to implement this would be to fix the import heuristics. However, that is prone to danger as it might break existing workflows and heuristics. Hence this "safe" approach is proposed which gives the user full control of any changes made to their data and which will have zero impact on existing functionality.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add UI to make it easier to fix an edge use-case when diving sidemount with two AI transmitters as well as one (or more)  deco cylinders containing a different gas mix.  Subsurface only generates 2 cylinders in this situation and gets very confused as regards sensor data vs gas switch events from the dive computer. The current desktop UI does not have an easy way to fix this situation.

The new UI menu item allows manually changing the destination cylinder of a gas switch event. It might be useful to allow more fields to be edited (eg, the timestamp; not so useful for divecomputer-supplied gas switch events, but might be nice for manually-added events).

The proposed workflow is now as follows:
1. Import from divecomputer.
2. Use UI to add additional tank(s) and fix gas mixture in all cylinders.
3. Use the new menu item to fix gas switch events to the correct cylinders.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add a new "Edit Gas Change" action to  ProfileWidget2
2) Implement the action to open a dialog allowing the user to choose a new cylinder.


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None, but has been discussed in the Google Forum as well as briefly mentioned on the developer list.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
TODO if PR is considered useful.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
TODO if PR is considered useful.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
TODO if PR is considered useful.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
