### PR TITLE
Fix event merging when merging dives

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1962,20 +1962,15 @@ static void merge_events(struct dive *d, struct divecomputer *res,
 		const int *cylinders_map;
 		int event_offset;
 
-		if (!b) {
-			*p = clone_event(a);
-			event_renumber(*p, cylinders_map1);
-			break;
-		}
-		if (!a) {
-			*p = clone_event(b);
-			(*p)->time.seconds += offset;
-			event_renumber(*p, cylinders_map2);
-			break;
-		}
+		if (!b)
+			goto pick_a;
+
+		if (!a)
+			goto pick_b;
+
 		s = sort_event(a, b, a->time.seconds, b->time.seconds + offset);
 
-		/* Identical events? Just skip one of them (we pick a) */
+		/* Identical events? Just skip one of them (we skip a) */
 		if (!s) {
 			a = a->next;
 			continue;
@@ -1983,11 +1978,13 @@ static void merge_events(struct dive *d, struct divecomputer *res,
 
 		/* Otherwise, pick the one that sorts first */
 		if (s < 0) {
+pick_a:
 			pick = a;
 			a = a->next;
 			event_offset = 0;
 			cylinders_map = cylinders_map1;
 		} else {
+pick_b:
 			pick = b;
 			b = b->next;
 			event_offset = offset;


### PR DESCRIPTION
The merge_events() function was subtly and not-so-subtly broken in a
couple of ways:

 - in commit 8c2383b49 ("Undo: don't modify source-dives on merge"), we
   stopped walking the event list after we merged the first event from a
   dive when the other dive computer had run out of events.

   In particular, this meant that when merging consecutive dives, the
   second dive only had the first event copied over to the merged dive.

   This happened because the original code just moved the whole old list
   over when there was nothing left from the other dive, so the old code
   didn't need to iterate over the event list. The new code didn't
   realize that the pointer movement used to copy the whole rest of the
   list, and also stopped iterating.

   In all fairness, the new code did get the time offset right, which
   the old code didn't. So this was always buggy.

 - similarly, the "avoid redundant gas changes" case was not handled for
   the "we ran out of events for the other dive computer" case.

This fixes both issues.

Cc: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
