### PR TITLE
core: fix dive renumbering logic on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+core: fix renumbering of imported dives [#2731]
 mobile: fix editing tank information
 mobile: disable download button if no connection is selected
 mobile: fix incorrect time stamps on GPS track points created via location service


### PR DESCRIPTION
0249e12 split up the dive import logic in multiple steps. Thereby,
the one of the conditions for renumbering the imported dives (is
the last old dive numbered) got messed up: The first number of the
new dive was compared to the total number of old dives, which makes
no sense.

- Simply check for the number of the last existing dive (if any).
- Don't remember the number of old dives - the original table is
  not modified anyway.

Fixes #2731

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Bug fix for #2731. This is completely untested and I am very tired - please check.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Correctly test for whether the last dive was numbered.
2) Don't pointlessly remember the number of dives in the old table - it isn't modified anyway.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2731.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Yes.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
I'm very tired, this needs at least one more pair of eyes. @dirkhh @torvalds @mwerle.