### PR TITLE
cleanup: consistently use get_cylinder() accessor

### DIFF
--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -127,7 +127,7 @@ static std::vector<QString> getWords(const dive *d)
 	for (const tag_entry *tag = d->tag_list; tag; tag = tag->next)
 		tokenize(QString(tag->tag->name), res);
 	for (int i = 0; i < d->cylinders.nr; ++i) {
-		const cylinder_t &cyl = d->cylinders.cylinders[i];
+		const cylinder_t &cyl = *get_cylinder(d, i);
 		tokenize(QString(cyl.type.description), res);
 	}
 	for (int i = 0; i < d->weightsystems.nr; ++i) {

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -357,7 +357,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 	// First, we make a shallow copy of the old cylinder. Then we modify the fields inside that copy.
 	// At the end, we either place an EditCylinder undo command (EquipmentTab) or copy the cylinder back (planner).
 	// Yes, this is not ideal, but the pragmatic thing to do for now.
-	cylinder_t cyl = d->cylinders.cylinders[row];
+	cylinder_t cyl = *get_cylinder(d, row);
 
 	if (index.column() != TYPE && !changed)
 		return false;
@@ -467,7 +467,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		// In the planner - simply overwrite the cylinder in the dive with the modified cylinder.
 		// We have only made a shallow copy, therefore copy the new cylinder first.
 		cylinder_t copy = clone_cylinder(cyl);
-		std::swap(copy, d->cylinders.cylinders[row]);
+		std::swap(copy, *get_cylinder(d, row));
 		free_cylinder(copy);
 		dataChanged(index, index);
 	} else {

--- a/qt-models/divesummarymodel.cpp
+++ b/qt-models/divesummarymodel.cpp
@@ -148,7 +148,7 @@ static void calculateDive(struct dive *dive, Stats &stats)
 
 	// EAN dive ?
 	for (int j = 0; j < dive->cylinders.nr; ++j) {
-		if (dive->cylinders.cylinders[j].gasmix.o2.permille > 210) {
+		if (get_cylinder(dive, j)->gasmix.o2.permille > 210) {
 			stats.divesEAN++;
 			break;
 		}


### PR DESCRIPTION
get_cylinder(d, i) is more readable than d->cylinders.cylinders[i].
Moreover, it does bound checking and is more flexible with respect to
changing the core data structures. Most places already used this accessor,
but some still accessed the cylinders directly.

This patch unifies the accesses by consistently switching to get_cylinder().
The affected code is in C++ and accesses the cylinder as reference or
object, whereas the get_cylinder() function is C and returns a pointer.
This results in funky looking "*get_cylinder(d, i)" expressions.
Arguably still better than the original.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A minor code cleanup, which switches to `get_cylinder()`. Details in the commit message. I left `profilewidget2.cpp` alone - to avoid conflict with #2910. Only compile-tested.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Switch the few remaining direct cylinder accesses to `get_cylinder()`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See discussion in #2910.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Hell, no.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @mwerle