### PR TITLE
DataTrak import: Add support for WLog extensions.

### DIFF
--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -582,7 +582,7 @@ bail:
  * Parses the header of the .add file, returns the number of dives in
  * the archive (must be the same than number of dives in .log file).
  */
-static unsigned int wlog_header_parser (struct memblock *mem)
+static int wlog_header_parser (struct memblock *mem)
 {
 	int tmp;
 	unsigned char *runner = (unsigned char *) mem->buffer;

--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -128,7 +128,7 @@ static int dtrak_prepare_data(int model, device_data_t *dev_data)
  * Just get the first in the user's list for given size.
  * Reaching the end of the list means there is no tank of this size.
  */
-static char *cyl_type_by_size(int size)
+static const char *cyl_type_by_size(int size)
 {
 	struct tank_info_t *ti = tank_info;
 

--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -588,10 +588,9 @@ static int wlog_header_parser (struct memblock *mem)
 	unsigned char *runner = (unsigned char *) mem->buffer;
 	if (!runner)
 		return -1;
-	tmp = (runner[1] << 8) + runner[0];
-	if (tmp == 0x0252) {
+	if (!memcmp(runner, "\x52\x02", 2)) {
 		runner += 8;
-		tmp = (runner[1] << 8) + runner[0];
+		tmp = (int) two_bytes_to_int(runner[1], runner[0]);
 		return tmp;
 	} else {
 		fprintf(stderr, "Error, not a Wlog .add file\n");
@@ -631,7 +630,7 @@ static void wlog_compl_parser(struct memblock *wl_mem, struct dive *dt_dive, int
 	/*
 	 * Weight in Kg * 100
 	 */
-	tmp = (runner[pos_weight + 1] << 8) + runner[pos_weight];
+	tmp = (int) two_bytes_to_int(runner[pos_weight + 1], runner[pos_weight]);
 	if (tmp != 0x7fff) {
 		weightsystem_t ws = { {lrint(tmp * 10)}, QT_TRANSLATE_NOOP("gettextFromC", "unknown") };
 		add_cloned_weightsystem(&dt_dive->weightsystems, ws);
@@ -641,7 +640,7 @@ static void wlog_compl_parser(struct memblock *wl_mem, struct dive *dt_dive, int
 	 * Visibility in m * 100.  Arbitrarily choosed to be 5 stars if >= 25m and
 	 * then assign a star for each 5 meters, resulting 0 stars if < 5 m
 	 */
-	tmp = (runner[pos_viz + 1] << 8) + runner[pos_viz];
+	tmp = (int) two_bytes_to_int(runner[pos_viz + 1], runner[pos_viz]);
 	if (tmp != 0x7fff) {
 		tmp = tmp > 2500 ? 2500 / 100 : tmp / 100;
 		dt_dive->visibility = (int) floor(tmp / 5);
@@ -651,7 +650,7 @@ static void wlog_compl_parser(struct memblock *wl_mem, struct dive *dt_dive, int
 	 * Tank initial pressure in bar * 100
 	 * If we know initial pressure, rework end pressure.
 	 */
-	tmp = (runner[pos_tank_init + 1] << 8) + runner[pos_tank_init];
+	tmp = (int) two_bytes_to_int(runner[pos_tank_init + 1], runner[pos_tank_init]);
 	if (tmp != 0x7fff) {
 		get_cylinder(dt_dive, 0)->start.mbar = tmp * 10;
 		get_cylinder(dt_dive, 0)->end.mbar =  get_cylinder(dt_dive, 0)->start.mbar - lrint(get_cylinder(dt_dive, 0)->gas_used.mliter / get_cylinder(dt_dive, 0)->type.size.mliter) * 1000;

--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -137,7 +137,7 @@ static char *cyl_type_by_size(int size)
 	if (ti == tank_info + MAX_TANK_INFO)
 		return "";
 	else
-		return copy_string(ti->name);
+		return ti->name;
 }
 
 /*

--- a/core/file.c
+++ b/core/file.c
@@ -338,8 +338,20 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 
 	/* DataTrak/Wlog */
 	if (fmt && !strcasecmp(fmt + 1, "LOG")) {
-		ret = datatrak_import(&mem, table, trips, sites);
+		struct memblock wl_mem;
+		const char *t = strrchr(filename, '.');
+		char *wl_name = memcpy(calloc(t - filename + 1, 1), filename, t - filename);
+		wl_name = realloc(wl_name, strlen(wl_name) + 5);
+		wl_name = strcat(wl_name, ".add");
+		if((ret = readfile(wl_name, &wl_mem)) < 0) {
+			fprintf(stderr, "No file %s found. No WLog extensions.\n", wl_name);
+			ret = datatrak_import(&mem, NULL, table, trips, sites);
+		} else {
+			ret = datatrak_import(&mem, &wl_mem, table, trips, sites);
+			free(wl_mem.buffer);
+		}
 		free(mem.buffer);
+		free(wl_name);
 		return ret;
 	}
 

--- a/core/file.h
+++ b/core/file.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 extern int try_to_open_cochran(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 extern int try_to_open_liquivision(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-extern int datatrak_import(struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
+extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 extern void ostctools_import(const char *file, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 extern int readfile(const char *filename, struct memblock *mem);


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
WLog is a Win32 based ancient shareware program whose target was:
1) fully support divelogs coming from DataTrak (DOS or Win)
2) fill some meaningful data which wasn't supported by Uwatec software
3) have a more user-friendly GUI than Datatrak had
The problem achieving goals 1) and 2) at the same time was solved by
adding a complementary file with .add extension and - mandatory - same
base name than .log file (including directory tree).

This .add file has a fixed structure composed of a 12 bytes header,
including file type check and Nº of dives following; then a fixed 850
bytes size for each dive in the log file. Data fields size and position
are fixed inside these blocks and heavily zero padded, so they are easy
to parse.

A serious restriction imposed to the WLog user was *Do not edit the logs
with other software than Wlog*; this was due the order of dives in .log
file being the same than the order of dives in .add file. Thought you
could show a WLog divelog in Datatrak, editing it resulted in mixing all
extended data for dives following the edited one.
Thus, we have to trust files are correct and is to the user ensure this
is so. If extended data are mangled, they are mangled in WLog too and we
are not trying to fix the mess, just importing.

On the technical side, we try to be smart about tank names as neither
DataTrak nor WLog record them. So we just take the first tank in users
list matching the volume recorded in WLog.
For weights we add a translatable "unknown" string as an empty string
results in weight not being shown in subsurface-mobile (which could be a
reportable issue, BTW).
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
