### PR TITLE
[Bug #2930] Fix crash bug in LocationInformationWidget

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -313,12 +313,15 @@ void LocationInformationWidget::on_diveSiteDistance_textChanged(const QString &s
 
 void LocationInformationWidget::reverseGeocode()
 {
+	dive_site *ds = diveSite; /* Save local copy; possibility of user closing the widget while reverseGeoLookup is running (see #2930) */
 	location_t location = parseGpsText(ui.diveSiteCoordinates->text());
-	if (!diveSite || !has_location(&location))
+	if (!ds || !has_location(&location))
 		return;
 	taxonomy_data taxonomy = { 0, 0 };
 	reverseGeoLookup(location.lat, location.lon, &taxonomy);
-	Command::editDiveSiteTaxonomy(diveSite, taxonomy);
+	if (ds != diveSite)
+		return;
+	Command::editDiveSiteTaxonomy(ds, taxonomy);
 }
 
 DiveLocationFilterProxyModel::DiveLocationFilterProxyModel(QObject *) : currentLocation(zero_location)


### PR DESCRIPTION
If a user exits the LocationInformationWidget (Edit  Dive Site)
while a reverseGeocode lookup is in progress, the object's
diveSite variable is set to null.

When the reverseGeocode lookup completes, this variable is
dereferenced causing an application crash.

Signed-off-by: Michael Werle <micha@michaelwerle.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixed by keeping a local reference to the divesite.  This means that when the reverseGeocode lookup completes, the information is entered into the divesite.

An alternative approach would be to check the variable again (or only check it after the geocode lookup) and abort the process if it is now null.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2930 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

To repro and test:

1. Edit a dive site.
2. Click on the "Reverse Geocode Lookup" button
3. As quickly as possible, click the "Done" button

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
N/A

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
N/A

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
