### PR TITLE
Planner: Properly initialize salinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+planner: properly initialize salinity
 desktop: add an "Edit Gas Change" right-click option [#2910]
 core: add support for Shearwater Peregrine (requires firmware V79 or newer)
 core: fix renumbering of imported dives [#2731]

--- a/core/dive.c
+++ b/core/dive.c
@@ -3729,7 +3729,7 @@ double depth_to_atm(int depth, const struct dive *dive)
 int rel_mbar_to_depth(int mbar, const struct dive *dive)
 {
 	int cm;
-	double specific_weight = 1.03 * 0.981;
+	double specific_weight = SEAWATER_SALINITY * 0.981 / 10000.0;
 	if (dive->dc.salinity)
 		specific_weight = dive->dc.salinity / 10000.0 * 0.981;
 	/* whole mbar gives us cm precision */

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -895,6 +895,8 @@ void MainWindow::on_actionDivePlanner_triggered()
 		divePlannerSettingsWidget->setBailoutVisibility(current_dive->dc.divemode);
 		if (current_dive->salinity)
 			divePlannerWidget->setSalinity(current_dive->salinity);
+		else	// No salinity means salt water
+			divePlannerWidget->setSalinity(SEAWATER_SALINITY);
 	}
 	divePlannerWidget->setReplanButton(false);
 }


### PR DESCRIPTION
When the dive has no explicity salinity, our conversion
between pressure and depth assumed salt water. Make this
explicity by using the corresponding macro.

When the planner starts and no salinity is set explicity,
set the water type chooser to salt water to reflect
our default assumption.

This was pointed out on scuba board.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
