### PR TITLE
Macro for "gravity conversion"

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -212,7 +212,6 @@ extern fraction_t best_o2(depth_t depth, const struct dive *dive);
 extern fraction_t best_he(depth_t depth, const struct dive *dive, bool o2narcotic, fraction_t fo2);
 
 extern int get_surface_pressure_in_mbar(const struct dive *dive, bool non_null);
-extern int calculate_depth_to_mbar(int depth, pressure_t surface_pressure, int salinity);
 extern int depth_to_mbar(int depth, const struct dive *dive);
 extern double depth_to_bar(int depth, const struct dive *dive);
 extern double depth_to_atm(int depth, const struct dive *dive);


### PR DESCRIPTION
This adds a common macro to convert salinity (which is
given as a density in terms of g per 10l) to a specific
weight with units of mbar / mm = bar / m that is used
to translate between pressures and depths.

The weired factor of 10 (from the unusual unit of salinity)
is included in the macro. It is there for historical reasons,
as it goes back to 05b55542c8 from 2012 where it was introduced
in code for downloading from Uemis dive computers.

Now, salinity appears in too many places to easily remove
this unconventional factor of 10 everywhere without breaking
to many things (including various dive computer downloads).

As suggested by @dirkhh in #2932
Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
