### PR TITLE
[Bug #2934] Geo Lookup - support for remote dive sites

### DIFF
--- a/core/divesitehelpers.h
+++ b/core/divesitehelpers.h
@@ -5,8 +5,8 @@
 #include "taxonomy.h"
 #include "units.h"
 
-// Perform a reverse geo-lookup and put data in the provided taxonomy field.
-// Original data with the exception of OCEAN will be overwritten.
-void reverseGeoLookup(degrees_t latitude, degrees_t longitude, taxonomy_data *taxonomy);
+/// Performs a reverse geo-lookup and returns the data.
+/// It is up to the caller to merge the data with any existing data.
+taxonomy_data reverseGeoLookup(degrees_t latitude, degrees_t longitude);
 
 #endif // DIVESITEHELPERS_H

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -42,7 +42,7 @@ void free_taxonomy(struct taxonomy_data *t)
 	}
 }
 
-void copy_taxonomy(struct taxonomy_data *orig, struct taxonomy_data *copy)
+void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy)
 {
 	if (orig->category == NULL) {
 		free_taxonomy(copy);
@@ -63,7 +63,7 @@ void copy_taxonomy(struct taxonomy_data *orig, struct taxonomy_data *copy)
 	}
 }
 
-int taxonomy_index_for_category(struct taxonomy_data *t, enum taxonomy_category cat)
+int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat)
 {
 	for (int i = 0; i < t->nr; i++)
 		if (t->category[i].category == cat)

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -41,8 +41,8 @@ struct taxonomy_data {
 
 struct taxonomy *alloc_taxonomy();
 void free_taxonomy(struct taxonomy_data *t);
-void copy_taxonomy(struct taxonomy_data *orig, struct taxonomy_data *copy);
-int taxonomy_index_for_category(struct taxonomy_data *t, enum taxonomy_category cat);
+void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy);
+int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat);
 const char *taxonomy_get_country(struct taxonomy_data *t);
 void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin);
 

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -317,10 +317,12 @@ void LocationInformationWidget::reverseGeocode()
 	location_t location = parseGpsText(ui.diveSiteCoordinates->text());
 	if (!ds || !has_location(&location))
 		return;
-	taxonomy_data taxonomy = { 0, 0 };
-	reverseGeoLookup(location.lat, location.lon, &taxonomy);
-	if (ds != diveSite)
+	taxonomy_data taxonomy = reverseGeoLookup(location.lat, location.lon);
+	if (ds != diveSite) {
+		free_taxonomy(&taxonomy);
 		return;
+	}
+	// This call transfers ownership of the taxonomy memory into an EditDiveSiteTaxonomy object
 	Command::editDiveSiteTaxonomy(ds, taxonomy);
 }
 


### PR DESCRIPTION
Some remote dive sites have no populated places (towns, cities)
nearby. For such sites, we now fall back to looking up
unpopulated place names, such as the reef or island name.

Also refactor the code; the actual network access is now
encapsulated in its own function making the reverseGeoLookup
function much more readable.

Signed-off-by: Michael Werle <micha@michaelwerle.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
If 'geonames.findNearbyPlaceNameJSON' returns no data, a call to 'geonames.findNearbyJSON' is now made, which will (always?) return some data for the lookup.

### Changes made:
1) Moved the already duplicated network code to its own function 'doAsyncRest'.
2) Refactored 'reverseGeoLookup' to use 'doAsyncRest'
3) Added a lookup to http://api.geonames.org/findNearbyJSON if http://api.geonames.org/findNearbyPlaceNameJSON returns no data

### Related issues:
Fixes #2934 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Use Lady Musgrave Island, Australia (23°54'16.344"S 152°24'28.721"E) as an example of a remote dive site.
