### PR TITLE
cleanup: leak fix in taxonomy_set_country() [+more assorted cleanups]

### DIFF
--- a/commands/command_divesite.cpp
+++ b/commands/command_divesite.cpp
@@ -268,7 +268,7 @@ bool EditDiveSiteCountry::workToBeDone()
 void EditDiveSiteCountry::redo()
 {
 	QString old = taxonomy_get_country(&ds->taxonomy);
-	taxonomy_set_country(&ds->taxonomy, copy_qstring(value), taxonomy_origin::GEOMANUAL);
+	taxonomy_set_country(&ds->taxonomy, qPrintable(value), taxonomy_origin::GEOMANUAL);
 	value = old;
 	emit diveListNotifier.diveSiteChanged(ds, LocationInformationModel::TAXONOMY); // Inform frontend of changed dive site.
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -3787,12 +3787,7 @@ struct dive_site *get_dive_site_for_dive(const struct dive *dive)
 const char *get_dive_country(const struct dive *dive)
 {
 	struct dive_site *ds = dive->dive_site;
-	if (ds) {
-		int idx = taxonomy_index_for_category(&ds->taxonomy, TC_COUNTRY);
-		if (idx >= 0)
-			return ds->taxonomy.category[idx].value;
-	}
-	return NULL;
+	return ds ? taxonomy_get_country(&ds->taxonomy) : NULL;
 }
 
 const char *get_dive_location(const struct dive *dive)

--- a/core/divesitehelpers.cpp
+++ b/core/divesitehelpers.cpp
@@ -114,13 +114,13 @@ taxonomy_data reverseGeoLookup(degrees_t latitude, degrees_t longitude)
 				taxonomy_set_category(&taxonomy, (taxonomy_category)idx, qPrintable(value), taxonomy_origin::GEOCODED);
 			}
 		}
-		int l3 = taxonomy_index_for_category(&taxonomy, TC_ADMIN_L3);
-		int lt = taxonomy_index_for_category(&taxonomy, TC_LOCALNAME);
-		if (l3 == -1 && lt != -1) {
+		const char *l3 = taxonomy_get_value(&taxonomy, TC_ADMIN_L3);
+		const char *lt = taxonomy_get_value(&taxonomy, TC_LOCALNAME);
+		if (empty_string(l3) && !empty_string(lt)) {
 			// basically this means we did get a local name (what we call town), but just like most places
 			// we didn't get an adminName_3 - which in some regions is the actual city that town belongs to,
 			// then we copy the town into the city
-			taxonomy_set_category(&taxonomy, TC_ADMIN_L3, taxonomy.category[lt].value, taxonomy_origin::GEOCOPIED);
+			taxonomy_set_category(&taxonomy, TC_ADMIN_L3, lt, taxonomy_origin::GEOCOPIED);
 		}
 	} else {
 		report_error("geonames.org did not provide reverse lookup information");

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -309,15 +309,10 @@ static void parse_site_gps(char *line, struct membuffer *str, struct git_parser_
 
 static void parse_site_geo(char *line, struct membuffer *str, struct git_parser_state *state)
 {
-	if (state->active_site->taxonomy.category == NULL)
-		state->active_site->taxonomy.category = alloc_taxonomy();
-	int nr = state->active_site->taxonomy.nr;
-	if (nr < TC_NR_CATEGORIES) {
-		struct taxonomy *t = &state->active_site->taxonomy.category[nr];
-		t->value = detach_cstring(str);
-		sscanf(line, "cat %d origin %d \"", &t->category, (int *)&t->origin);
-		state->active_site->taxonomy.nr++;
-	}
+	int origin;
+	int category;
+	sscanf(line, "cat %d origin %d \"", &category, &origin);
+	taxonomy_set_category(&state->active_site->taxonomy , category, mb_cstring(str), origin);
 }
 
 static char *remove_from_front(struct membuffer *str, int len)

--- a/core/parse.c
+++ b/core/parse.c
@@ -203,6 +203,8 @@ void dive_site_start(struct parser_state *state)
 {
 	if (state->cur_dive_site)
 		return;
+	state->taxonomy_category = -1;
+	state->taxonomy_origin = -1;
 	state->cur_dive_site = calloc(1, sizeof(struct dive_site));
 }
 
@@ -210,10 +212,6 @@ void dive_site_end(struct parser_state *state)
 {
 	if (!state->cur_dive_site)
 		return;
-	if (state->cur_dive_site->taxonomy.nr == 0) {
-		free(state->cur_dive_site->taxonomy.category);
-		state->cur_dive_site->taxonomy.category = NULL;
-	}
 	if (state->cur_dive_site->uuid) {
 		struct dive_site *ds = alloc_or_get_dive_site(state->cur_dive_site->uuid, state->sites);
 		merge_dive_site(ds, state->cur_dive_site);

--- a/core/parse.h
+++ b/core/parse.h
@@ -52,6 +52,7 @@ struct parser_state {
 	struct sample *cur_sample;		/* non-owning */
 	struct picture cur_picture;		/* owning */
 	char *country, *city;			/* owning */
+	int taxonomy_category, taxonomy_origin;
 
 	bool in_settings;
 	bool in_userid;

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -83,26 +83,19 @@ const char *taxonomy_get_country(struct taxonomy_data *t)
 
 void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin)
 {
-	int idx = -1;
+	int idx = taxonomy_index_for_category(t, category);
 
-	// make sure we have taxonomy data allocated
-	alloc_taxonomy_table(t);
-
-	for (int i = 0; i < t->nr; i++) {
-		if (t->category[i].category == category) {
-			free((void *)t->category[i].value);
-			t->category[i].value = NULL;
-			idx = i;
-			break;
-		}
-	}
-	if (idx == -1) {
+	if (idx < 0) {
+		alloc_taxonomy_table(t); // make sure we have taxonomy data allocated
 		if (t->nr == TC_NR_CATEGORIES - 1) {
 			// can't add another one
 			fprintf(stderr, "Error adding taxonomy category\n");
 			return;
 		}
 		idx = t->nr++;
+	} else {
+		free((void *)t->category[idx].value);
+		t->category[idx].value = NULL;
 	}
 	t->category[idx].value = strdup(value);
 	t->category[idx].origin = origin;

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -65,9 +65,10 @@ void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy)
 
 int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat)
 {
-	for (int i = 0; i < t->nr; i++)
+	for (int i = 0; i < t->nr; i++) {
 		if (t->category[i].category == cat)
 			return i;
+	}
 	return -1;
 }
 
@@ -90,6 +91,8 @@ void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum tax
 
 	for (int i = 0; i < t->nr; i++) {
 		if (t->category[i].category == TC_COUNTRY) {
+			free((void *)t->category[i].value);
+			t->category[i].value = NULL;
 			idx = i;
 			break;
 		}

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -72,13 +72,15 @@ int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_cat
 	return -1;
 }
 
-const char *taxonomy_get_country(struct taxonomy_data *t)
+const char *taxonomy_get_value(const struct taxonomy_data *t, enum taxonomy_category cat)
 {
-	for (int i = 0; i < t->nr; i++) {
-		if (t->category[i].category == TC_COUNTRY)
-			return t->category[i].value;
-	}
-	return NULL;
+	int idx = taxonomy_index_for_category(t, cat);
+	return idx >= 0 ? t->category[idx].value : NULL;
+}
+
+const char *taxonomy_get_country(const struct taxonomy_data *t)
+{
+	return taxonomy_get_value(t, TC_COUNTRY);
 }
 
 void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin)

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -26,9 +26,10 @@ char *taxonomy_api_names[TC_NR_CATEGORIES] = {
 	"adminName3"
 };
 
-struct taxonomy *alloc_taxonomy()
+static void alloc_taxonomy_table(struct taxonomy_data *t)
 {
-	return calloc(TC_NR_CATEGORIES, sizeof(struct taxonomy));
+	if (!t->category)
+		t->category = calloc(TC_NR_CATEGORIES, sizeof(struct taxonomy));
 }
 
 void free_taxonomy(struct taxonomy_data *t)
@@ -47,8 +48,7 @@ void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy)
 	if (orig->category == NULL) {
 		free_taxonomy(copy);
 	} else {
-		if (copy->category == NULL)
-			copy->category = alloc_taxonomy();
+		alloc_taxonomy_table(copy);
 		for (int i = 0; i < TC_NR_CATEGORIES; i++) {
 			if (i < copy->nr) {
 				free((void *)copy->category[i].value);
@@ -86,8 +86,7 @@ void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category categ
 	int idx = -1;
 
 	// make sure we have taxonomy data allocated
-	if (!t->category)
-		t->category = alloc_taxonomy();
+	alloc_taxonomy_table(t);
 
 	for (int i = 0; i < t->nr; i++) {
 		if (t->category[i].category == category) {

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -105,7 +105,7 @@ void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category categ
 		}
 		idx = t->nr++;
 	}
-	t->category[idx].value = value;
+	t->category[idx].value = strdup(value);
 	t->category[idx].origin = origin;
 	t->category[idx].category = category;
 }

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -63,7 +63,7 @@ void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy)
 	}
 }
 
-int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat)
+static int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat)
 {
 	for (int i = 0; i < t->nr; i++) {
 		if (t->category[i].category == cat)

--- a/core/taxonomy.c
+++ b/core/taxonomy.c
@@ -81,7 +81,7 @@ const char *taxonomy_get_country(struct taxonomy_data *t)
 	return NULL;
 }
 
-void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin)
+void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin)
 {
 	int idx = -1;
 
@@ -90,7 +90,7 @@ void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum tax
 		t->category = alloc_taxonomy();
 
 	for (int i = 0; i < t->nr; i++) {
-		if (t->category[i].category == TC_COUNTRY) {
+		if (t->category[i].category == category) {
 			free((void *)t->category[i].value);
 			t->category[i].value = NULL;
 			idx = i;
@@ -100,13 +100,18 @@ void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum tax
 	if (idx == -1) {
 		if (t->nr == TC_NR_CATEGORIES - 1) {
 			// can't add another one
-			fprintf(stderr, "Error adding country taxonomy\n");
+			fprintf(stderr, "Error adding taxonomy category\n");
 			return;
 		}
 		idx = t->nr++;
 	}
-	t->category[idx].value = country;
+	t->category[idx].value = value;
 	t->category[idx].origin = origin;
-	t->category[idx].category = TC_COUNTRY;
+	t->category[idx].category = category;
+}
+
+void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin)
+{
 	fprintf(stderr, "%s: set the taxonomy country to %s\n", __func__, country);
+	taxonomy_set_category(t, TC_COUNTRY, country, origin);
 }

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -42,7 +42,8 @@ struct taxonomy_data {
 void free_taxonomy(struct taxonomy_data *t);
 void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy);
 int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat);
-const char *taxonomy_get_country(struct taxonomy_data *t);
+const char *taxonomy_get_value(const struct taxonomy_data *t, enum taxonomy_category cat);
+const char *taxonomy_get_country(const struct taxonomy_data *t);
 void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin);
 void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin);
 

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -44,6 +44,7 @@ void free_taxonomy(struct taxonomy_data *t);
 void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy);
 int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat);
 const char *taxonomy_get_country(struct taxonomy_data *t);
+void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin);
 void taxonomy_set_country(struct taxonomy_data *t, const char *country, enum taxonomy_origin origin);
 
 #ifdef __cplusplus

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -39,7 +39,6 @@ struct taxonomy_data {
 	struct taxonomy *category;
 };
 
-struct taxonomy *alloc_taxonomy();
 void free_taxonomy(struct taxonomy_data *t);
 void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy);
 int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat);

--- a/core/taxonomy.h
+++ b/core/taxonomy.h
@@ -41,7 +41,6 @@ struct taxonomy_data {
 
 void free_taxonomy(struct taxonomy_data *t);
 void copy_taxonomy(const struct taxonomy_data *orig, struct taxonomy_data *copy);
-int taxonomy_index_for_category(const struct taxonomy_data *t, enum taxonomy_category cat);
 const char *taxonomy_get_value(const struct taxonomy_data *t, enum taxonomy_category cat);
 const char *taxonomy_get_country(const struct taxonomy_data *t);
 void taxonomy_set_category(struct taxonomy_data *t, enum taxonomy_category category, const char *value, enum taxonomy_origin origin);

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -404,12 +404,12 @@ void LocationFilterDelegate::paint(QPainter *painter, const QStyleOptionViewItem
 	for (int i = 0; i < 3; i++) {
 		if (prefs.geocoding.category[i] == TC_NONE)
 			continue;
-		int idx = taxonomy_index_for_category(&ds->taxonomy, prefs.geocoding.category[i]);
-		if (idx == -1)
+		const char *value = taxonomy_get_value(&ds->taxonomy, prefs.geocoding.category[i]);
+		if (empty_string(value))
 			continue;
 		if(!bottomText.isEmpty())
 			bottomText += " / ";
-		bottomText += QString(ds->taxonomy.category[idx].value);
+		bottomText += QString(value);
 	}
 
 	if (bottomText.isEmpty())


### PR DESCRIPTION
When overwriting a country, the old string was not freed. Fix this.
Contains an unrelated coding-style fix: use braces if code block
contains more than one line.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes what looks like a small resource leak in C code. Only compile-and-run tested. Please have a check whether my interpretation is correct.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Free string before overwriting it.
2) Add braces as per coding style.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Found while trying to understand #2935.


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mwerle @dirkhh 