### PR TITLE
[TRIVIAL?] cleanup: when planning a dive, set dive computer to first dc

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -905,7 +905,7 @@ MoveDiveComputerToFront::MoveDiveComputerToFront(dive *d, int dc_num)
 }
 
 DeleteDiveComputer::DeleteDiveComputer(dive *d, int dc_num)
-	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num), std::min(count_divecomputers(d) - 1, dc_num))
+	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num), std::min((int)number_of_computers(d) - 1, dc_num))
 {
 	setText(Command::Base::tr("delete dive computer"));
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -3558,12 +3558,6 @@ static void delete_divecomputer(struct dive *d, int num)
 			free_dc(dc);
 		}
 	}
-
-	/* If this is the currently displayed dive, we might have to adjust
-	 * the currently displayed dive computer. */
-	if (d == current_dive && dc_number >= number_of_computers(d))
-		dc_number--;
-	invalidate_dive_cache(d);
 }
 
 /* Clone a dive and delete goven dive computer */

--- a/core/dive.c
+++ b/core/dive.c
@@ -3533,17 +3533,6 @@ struct dive *make_first_dc(const struct dive *d, int dc_number)
 	return res;
 }
 
-int count_divecomputers(const struct dive *d)
-{
-	int ret = 1;
-	struct divecomputer *dc = d->dc.next;
-	while (dc) {
-		ret++;
-		dc = dc->next;
-	}
-	return ret;
-}
-
 static void delete_divecomputer(struct dive *d, int num)
 {
 	int i;
@@ -3572,7 +3561,7 @@ static void delete_divecomputer(struct dive *d, int num)
 
 	/* If this is the currently displayed dive, we might have to adjust
 	 * the currently displayed dive computer. */
-	if (d == current_dive && dc_number >= count_divecomputers(d))
+	if (d == current_dive && dc_number >= number_of_computers(d))
 		dc_number--;
 	invalidate_dive_cache(d);
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -3571,7 +3571,6 @@ struct dive *clone_delete_divecomputer(const struct dive *d, int dc_number)
 
 	/* make a new unique id, since we still can't handle two equal ids */
 	res->id = dive_getUniqID();
-	invalidate_dive_cache(res);
 
 	delete_divecomputer(res, dc_number);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -249,7 +249,6 @@ extern struct divecomputer *get_dive_dc(struct dive *dive, int nr);
 extern timestamp_t dive_endtime(const struct dive *dive);
 
 extern struct dive *make_first_dc(const struct dive *d, int dc_number);
-extern int count_divecomputers(const struct dive *d);
 extern struct dive *clone_delete_divecomputer(const struct dive *d, int dc_number);
 void split_divecomputer(const struct dive *src, int num, struct dive **out1, struct dive **out2);
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -885,7 +885,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	graphics->setPlanState();
-	dc_number = 1;
+	dc_number = 0;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
 	DivePlannerPointsModel::instance()->createSimpleDive();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1436,13 +1436,13 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 			parentItem = parentItem->parentItem();
 		}
 		if (isDCName) {
-			if (dc_number == 0 && count_divecomputers(current_dive) == 1)
+			if (dc_number == 0 && number_of_computers(current_dive) == 1)
 				// nothing to do, can't delete or reorder
 				return;
 			// create menu to show when right clicking on dive computer name
 			if (dc_number > 0)
 				m.addAction(tr("Make first dive computer"), this, &ProfileWidget2::makeFirstDC);
-			if (count_divecomputers(current_dive) > 1) {
+			if (number_of_computers(current_dive) > 1) {
 				m.addAction(tr("Delete this dive computer"), this, &ProfileWidget2::deleteCurrentDC);
 				m.addAction(tr("Split this dive computer into own dive"), this, &ProfileWidget2::splitCurrentDC);
 			}


### PR DESCRIPTION
When planning a dive, dc_number was set to 1, which actually is
the second dc! The code seems to handle this gracefully, however
it appears weird. Let's set dc_number to 0 instead.

Originally, the assignment was introduced in a422957cd6525b9753
and moved later in 4f5621c4c6acc3a.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a cosmetic change of a code-oddity. This shouldn't be user visible.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) On planning set displayed DC to first, not second (which probably doesn't exist).

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde: Perhaps I'm missing something and this was intended...?