### PR TITLE
desktop: make completion of equipment types substring search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: do substring search for equipment types
 planner: properly initialize salinity
 desktop: add an "Edit Gas Change" right-click option [#2910]
 core: add support for Shearwater Peregrine (requires firmware V79 or newer)

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -106,6 +106,7 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	comboDelegate->setEditable(true);
 	comboDelegate->completer()->setCaseSensitivity(Qt::CaseInsensitive);
 	comboDelegate->completer()->setCompletionMode(QCompleter::PopupCompletion);
+	comboDelegate->completer()->setFilterMode(Qt::MatchContains);
 	comboDelegate->view()->setEditTriggers(QAbstractItemView::AllEditTriggers);
 	comboDelegate->lineEdit()->installEventFilter(const_cast<QObject *>(qobject_cast<const QObject *>(this)));
 	comboDelegate->lineEdit()->setEnabled(editable);


### PR DESCRIPTION
User request: when entering a cylinder type, do a substring
search. For example, when entering "100" also find "AL100".
Currently, a starts-with search was used.

This is simply done by setting the "filterMode" of the
ComboBoxDelegate to "Qt::MatchContains".

Suggested-by: Miika Turkia <miika.turkia@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Do substring searches for the equipment type combobox completers.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See discussion in #2937.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 