### PR TITLE
desktop: on weight type change, don't overwrite weight if already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: don't overwrite already set weights when changing weight type [#2938]
 desktop: do substring search for equipment types
 planner: properly initialize salinity
 desktop: add an "Edit Gas Change" right-click option [#2910]

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -127,7 +127,7 @@ void add_weightsystem_description(const weightsystem_t *weightsystem)
 
 weightsystem_t clone_weightsystem(weightsystem_t ws)
 {
-	weightsystem_t res = { ws.weight, copy_string(ws.description) };
+	weightsystem_t res = { ws.weight, copy_string(ws.description), ws.auto_filled };
 	return res;
 }
 

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -50,9 +50,10 @@ typedef struct
 {
 	weight_t weight;
 	const char *description; /* "integrated", "belt", "ankle" */
+	bool auto_filled; /* weight was automatically derived from the type */
 } weightsystem_t;
 
-static const weightsystem_t empty_weightsystem = { { 0 }, 0 };
+static const weightsystem_t empty_weightsystem = { { 0 }, 0, false };
 
 /* Table of weightsystems. Attention: this stores weightsystems,
  * *not* pointers * to weightsystems. This has two crucial

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -86,11 +86,16 @@ void WeightModel::setTempWS(int row, weightsystem_t ws)
 	// It is really hard to get the editor-close-hints and setModelData calls under
 	// control. Therefore, if the row is set to the already existing entry, don't
 	// enter temporary mode.
-	if (same_string(d->weightsystems.weightsystems[row].description, ws.description)) {
+	const weightsystem_t &oldWS = d->weightsystems.weightsystems[row];
+	if (same_string(oldWS.description, ws.description)) {
 		free_weightsystem(ws);
 	} else {
 		tempRow = row;
 		tempWS = ws;
+
+		// If the user had already set a weight, don't overwrite that
+		if (oldWS.weight.grams)
+			tempWS.weight = oldWS.weight;
 	}
 	dataChanged(index(row, TYPE), index(row, WEIGHT));
 }

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -94,8 +94,10 @@ void WeightModel::setTempWS(int row, weightsystem_t ws)
 		tempWS = ws;
 
 		// If the user had already set a weight, don't overwrite that
-		if (oldWS.weight.grams)
+		if (oldWS.weight.grams && !oldWS.auto_filled)
 			tempWS.weight = oldWS.weight;
+		else
+			tempWS.auto_filled = true;
 	}
 	dataChanged(index(row, TYPE), index(row, WEIGHT));
 }
@@ -133,6 +135,7 @@ bool WeightModel::setData(const QModelIndex &index, const QVariant &value, int r
 	switch (index.column()) {
 	case WEIGHT:
 		ws.weight = string_to_weight(qPrintable(vString));
+		ws.auto_filled = false;
 		int count = Command::editWeight(index.row(), ws, false);
 		emit divesEdited(count);
 		return true;


### PR DESCRIPTION
When importing from other software, it happens that weights are imported
without their type. When the user changes the type, the imported weight
is overwritten, which is not exactly a friendly behavior.

On the other hand, when changing the type after creation of a weight
entry, it is preferrable to set a default weight. This is convenient
for people who commonly use the same weight.

As a compromise, set the default weight only if it was unset. We
recognize this by a weight value of 0 g.

Fixes #2938

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This implements the compromise suggested in #2938. Code is in principle trivial, but needs some real world testing.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) When weight is already set, don't fill with default value when changing weight type

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2938.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@sveinmagnus