### PR TITLE
desktop: more Qt 5.15 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 		# and with Qt 5.11 we need another library that isn't copied by macdeployqt
 		install(CODE "execute_process(COMMAND cp -a ${_qt5Core_install_prefix}/lib/QtPositioningQuick.framework ${CMAKE_BINARY_DIR}/${APP_BUNDLE_DIR}/Contents/Frameworks)")
 	endif()
+	if(NOT Qt5Core_VERSION VERSION_LESS 5.14.0)
+		# and with Qt 5.14 we need another library that isn't always copied by macdeployqt
+		install(CODE "execute_process(COMMAND cp -a ${_qt5Core_install_prefix}/lib/QtQmlWorkerScript.framework ${CMAKE_BINARY_DIR}/${APP_BUNDLE_DIR}/Contents/Frameworks)")
+	endif()
 	if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
 		install(CODE "execute_process(COMMAND cp -a ${_qt5Core_install_prefix}/qml/QtQuick ${CMAKE_BINARY_DIR}/${APP_BUNDLE_DIR}/Contents/Resources/qml)")
 		install(CODE "execute_process(COMMAND cp -a ${_qt5Core_install_prefix}/qml/QtGraphicalEffects ${CMAKE_BINARY_DIR}/${APP_BUNDLE_DIR}/Contents/Resources/qml)")

--- a/desktop-widgets/tableview.cpp
+++ b/desktop-widgets/tableview.cpp
@@ -60,7 +60,10 @@ TableView::TableView(QWidget *parent) : QGroupBox(parent)
 		iconSize = btnSize - 2*min_gap;
 	}
 	plusBtn->setIconSize(QSize(iconSize, iconSize));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+	// with Qt 5.15, this leads to an inoperable button
 	plusBtn->resize(btnSize, btnSize);
+#endif
 	connect(plusBtn, SIGNAL(clicked(bool)), this, SIGNAL(addButtonClicked()));
 }
 

--- a/packaging/macosx/make-package.sh
+++ b/packaging/macosx/make-package.sh
@@ -18,7 +18,19 @@ VERSION=$(cd ${DIR}/subsurface; ./scripts/get-version linux)
 # first build and install Subsurface and then clean up the staging area
 # make sure we didn't lose the minimum OS version
 rm -rf ./Subsurface.app
-cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk .
+if [ -d /Developer/SDKs ] ; then
+	SDKROOT=/Developer/SDKs
+elif [ -d /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs ] ; then
+	SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
+else
+	echo "Cannot find SDK sysroot (usually /Developer/SDKs or"
+	echo "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs)"
+	exit 1;
+fi
+BASESDK=$(ls $SDKROOT | grep "MacOSX10\.1.\.sdk" | head -1 | sed -e "s/MacOSX//;s/\.sdk//")
+OLDER_MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_SYSROOT=${SDKROOT}/MacOSX${BASESDK}.sdk/"
+export PKG_CONFIG_PATH=${DIR}/install-root/lib/pkgconfig:$PKG_CONFIG_PATH
+cmake $OLDER_MAC_CMAKE .
 LIBRARY_PATH=${DIR}/install-root/lib make -j8
 LIBRARY_PATH=${DIR}/install-root/lib make install
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -280,6 +280,20 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	# because that always requires the latest OS (how stupid is that - and they consider it a
 	# feature). So we painfully need to build the dependencies ourselves.
 	cd "$SRC"
+
+	./${SRC_DIR}/scripts/get-dep-lib.sh single . libz
+	pushd libz
+	# no, don't install pkgconfig files in .../libs/share/pkgconf - that's just weird
+	sed -i .bak 's/share\/pkgconfig/pkgconfig/' CMakeLists.txt
+	mkdir -p build
+	cd build
+	cmake "$OLDER_MAC_CMAKE" -DCMAKE_BUILD_TYPE="$DEBUGRELEASE" \
+		-DCMAKE_INSTALL_PREFIX="$INSTALL_ROOT" \
+		..
+	make -j4
+	make install
+	popd
+
 	./${SRC_DIR}/scripts/get-dep-lib.sh single . libcurl
 	pushd libcurl
 	bash ./buildconf
@@ -377,6 +391,17 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	mkdir -p build
 	cd build
 	CFLAGS="$OLDER_MAC" ../configure --prefix="$INSTALL_ROOT" --disable-examples
+	make -j4
+	make install
+	popd
+
+	./${SRC_DIR}/scripts/get-dep-lib.sh single . libftdi1
+	pushd libftdi1
+	mkdir -p build
+	cd build
+	cmake "$OLDER_MAC_CMAKE" -DCMAKE_BUILD_TYPE="$DEBUGRELEASE" \
+		-DCMAKE_INSTALL_PREFIX="$INSTALL_ROOT" \
+		..
 	make -j4
 	make install
 	popd

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -2,6 +2,7 @@
 #
 
 # set version of 3rd party libraries
+CURRENT_LIBZ="v1.2.11"
 CURRENT_LIBZIP="rel-1-5-1"
 CURRENT_LIBGIT2="v0.26.0"
 CURRENT_HIDAPI="hidapi-0.7.0"
@@ -176,6 +177,9 @@ for package in "${PACKAGES[@]}" ; do
 			;;
 		openssl)
 			git_checkout_library openssl $CURRENT_OPENSSL https://github.com/openssl/openssl.git
+			;;
+		libz)
+			git_checkout_library libz $CURRENT_LIBZ https://github.com/madler/zlib.git
 			;;
 		libzip)
 			git_checkout_library libzip $CURRENT_LIBZIP https://github.com/nih-at/libzip.git


### PR DESCRIPTION
This now gets me a working Qt 5.15 based build - even on BigSur

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
I don't love the way the TableView change looks, but at least the widget is functional again.
I'm not sure what a better fix would do, though.

The other commits help me create a self contained build that runs on 10.15/11.0 (but not on older versions).
