### PR TITLE
Disable SAC factor setting for CCR dives

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -825,11 +825,12 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 	if ((divemode == CCR || divemode == PSCR) && prefs.dobailout) {
 		divemode = OC;
 		po2 = 0;
+		int bailoutsegment = MAX(prefs.min_switch_duration, 60 * prefs.problemsolvingtime);
 		add_segment(ds, depth_to_bar(depth, dive),
 			get_cylinder(dive, current_cylinder)->gasmix,
-			prefs.min_switch_duration, po2, divemode, prefs.bottomsac);
-		plan_add_segment(diveplan, prefs.min_switch_duration, depth, current_cylinder, po2, false, divemode);
-		clock += prefs.min_switch_duration;
+			bailoutsegment, po2, divemode, prefs.bottomsac);
+		plan_add_segment(diveplan, bailoutsegment, depth, current_cylinder, po2, false, divemode);
+		clock += bailoutsegment;
 		last_segment_min_switch = true;
 	}
 	previous_deco_time = 100000000;

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -606,6 +606,7 @@ void PlannerSettingsWidget::setBackgasBreaks(bool dobreaks)
 void PlannerSettingsWidget::setBailoutVisibility(int mode)
 {
 		ui.bailout->setDisabled(!(mode == CCR || mode == PSCR));
+		ui.sacFactor->setDisabled(mode == CCR);
 }
 
 PlannerDetails::PlannerDetails(QWidget *parent) : QWidget(parent)


### PR DESCRIPTION
The SAC factor is only used for minimal gas calculations which
don't make sense in the CCR context.

Additionally, make bailout stop for at least minimum switch
time or problem solving time.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

This is a small addition that had been sitting on my hard drive for a while but which could go into 4.9.7
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
