### PR TITLE
media: read timestamp from mvhd header of MP4/QuickTime videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+- media: read timestamp from mvhd atom of QuickTime/MP4 style videos
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -184,6 +184,18 @@ static bool parseMP4(QFile &f, metadata *metadata)
 			// Recurse into "moov", "trak", "mdia" and "udta" atoms
 			atom_stack.push_back(atom_size);
 			continue;
+		} else if (!memcmp(type, "mvhd", 4) && atom_size >= 100 && atom_size < 4096) {
+			std::vector<char> data(atom_size);
+			if (f.read(&data[0], atom_size) != static_cast<int>(atom_size))
+				break;
+
+			timestamp_t timestamp = getBE<uint32_t>(&data[4]);
+
+			// Timestamp is given as seconds since midnight 1904/1/1. To be convertible to the UNIX epoch
+			// it must be larger than 2082844800.
+			// Note that we only set timestamp if not already set, because we give priority to XMP data.
+			if (!metadata->timestamp && timestamp >= 2082844800)
+				metadata->timestamp = timestamp - 2082844800;
 		} else if (!memcmp(type, "mdhd", 4) && atom_size >= 24 && atom_size < 4096) {
 			// Parse "mdhd" (media header).
 			// Sanity check: size between 24 and 4096
@@ -235,9 +247,8 @@ static bool parseMP4(QFile &f, metadata *metadata)
 				break;
 
 			static const char xmp_uid[17] = "\xBE\x7A\xCF\xCB\x97\xA9\x42\xE8\x9C\x71\x99\x94\x91\xE3\xAF\xAC";
-			if (!memcmp(&d[0], xmp_uid, 16)) {
+			if (!memcmp(&d[0], xmp_uid, 16))
 				parseXMP(&d[16], atom_size - 16, metadata);
-			}
 		} else {
 			// Jump over unknown atom
 			if (!f.seek(f.pos() + atom_size)) // TODO: switch to QFile::skip()


### PR DESCRIPTION
ExifTools (and probably other meta-data editors) modifies the
mvhd creation date, but leaves the individual creation dates
in the tracks unchanged. Therefore, use the mvhd atom.

Reported-by: Eric Tanguy <erictanguy2@orange.fr>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This reads the movie creation date from the "mvhd" header, as this is what ExifTool writes and I guess what users expect.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Read creation date from "mvhd" header.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See discussion on mailing list.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.