### PR TITLE
dive list: on reload update filter status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- make sure current dive is selected [#2961]
 - update filter status when loading file [#2961]
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+- update filter status when loading file [#2961]
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -119,7 +119,10 @@ extern "C" void dump_selection(void)
 // or a newly selected dive. In both cases, try to select the
 // dive that is newer that is newer than the given date.
 // This mimics the old behavior when the current dive changed.
-static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &selection)
+// If a current dive outside of the selection was set, add
+// it to the list of selected dives, so that we never end up
+// in a situation where we display a non-selected dive.
+static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &selection, QVector<dive *> &divesToSelect)
 {
 	// Start from back until we get the first dive that is before
 	// the supposed-to-be selected dive. (Note: this mimics the
@@ -144,6 +147,8 @@ static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &s
 	// return null, but that just means unsetting the current dive (as no
 	// dive is visible anyway).
 	current_dive = find_next_visible_dive(when);
+	if (current_dive)
+		divesToSelect.push_back(current_dive);
 }
 
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
@@ -194,7 +199,7 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive)
 	current_dive = currentDive;
 	if (current_dive && !currentDive->selected) {
 		// Current not visible -> find a different dive.
-		setClosestCurrentDive(currentDive->when, selection);
+		setClosestCurrentDive(currentDive->when, selection, divesToSelect);
 	}
 
 	// Send the new selection

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -714,6 +714,8 @@ DiveTripModelTree::DiveTripModelTree(QObject *parent) : DiveTripModelBase(parent
 
 void DiveTripModelTree::populate()
 {
+	DiveFilter::instance()->updateAll(); // The data was reset - update filter status. TODO: should this really be done here?
+
 	// we want this to be two calls as the second text is overwritten below by the lines starting with "\r"
 	uiNotification(QObject::tr("populate data model"));
 	uiNotification(QObject::tr("start processing"));
@@ -1479,6 +1481,8 @@ DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent
 
 void DiveTripModelList::populate()
 {
+	DiveFilter::instance()->updateAll(); // The data was reset - update filter status. TODO: should this really be done here?
+
 	// Fill model
 	items.reserve(dive_table.nr);
 	for (int i = 0; i < dive_table.nr; ++i) {


### PR DESCRIPTION
At some time, when introducing the global reset signal the filter
stopped being reloaded when loading a new log. This leads to very
strange UI behavior: dives disappear when editing fields unrelated
to the filter.

Therefore, when reloading the model, reset the filter. One might
argue whether this is the correct place. On the other hand, we
might even make the filter a sub-object of the dive-list model.
Let's think about this.

Partially solves #2961

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The filter-status of individual dives was not reset when loading a file, leading to very strange UI behavior.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Explicitly apply filter when reloading dive list.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See discussion in #2961.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@fmatray @dirkhh