### PR TITLE
translations: initialize water type strings at run time [Alternative to #2968]

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -626,16 +626,34 @@ QString get_salinity_string(int salinity)
 	return QStringLiteral("%L1%2").arg(salinity / 10.0).arg(gettextFromC::tr("g/ℓ"));
 }
 
+// the water types need to match the watertypes enum
+static const char *waterTypes[] = {
+	QT_TRANSLATE_NOOP("gettextFromC", "Fresh"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Brackish"),
+	QT_TRANSLATE_NOOP("gettextFromC", "EN13319"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Salt"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Use DC")
+};
+
 QString get_water_type_string(int salinity)
 {
 	if (salinity < 10050)
-		return waterTypes[FRESHWATER];
+		return gettextFromC::tr(waterTypes[FRESHWATER]);
 	else if (salinity < 10190)
-		return waterTypes[BRACKISHWATER];
+		return gettextFromC::tr(waterTypes[BRACKISHWATER]);
 	else if (salinity < 10210)
-		return waterTypes[EN13319WATER];
+		return gettextFromC::tr(waterTypes[EN13319WATER]);
 	else
-		return waterTypes[SALTWATER];
+		return gettextFromC::tr(waterTypes[SALTWATER]);
+}
+
+QStringList getWaterTypesAsString()
+{
+	QStringList res;
+	res.reserve(std::end(waterTypes) - std::begin(waterTypes)); // Waiting for C++17's std::size()
+	for (const char *t: waterTypes)
+		res.push_back(gettextFromC::tr(t));
+	return res;
 }
 
 QString getSubsurfaceDataPath(QString folderToFind)
@@ -1177,11 +1195,6 @@ QString localFilePath(const QString &originalFilename)
 	QMutexLocker locker(&hashOfMutex);
 	return localFilenameOf.value(originalFilename, originalFilename);
 }
-
-// the water types need to match the watertypes enum
-const QStringList waterTypes = {
-	gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("Use DC")
-};
 
 // TODO: Apparently Qt has no simple way of listing the supported video
 // codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -38,7 +38,7 @@ int getCloudURL(QString &filename);
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
 void init_proxy();
 QString getUUID();
-extern const QStringList waterTypes;
+QStringList getWaterTypesAsString();
 extern const QStringList videoExtensionsList;
 QStringList mediaExtensionFilters();
 QStringList imageExtensionFilters();

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -27,7 +27,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
-	ui->waterTypeCombo->insertItems(0, waterTypes);
+	ui->waterTypeCombo->insertItems(0, getWaterTypesAsString());
 
 	// This needs to be the same order as enum dive_comp_type in dive.h!
 	QStringList types;


### PR DESCRIPTION
The water type strings were static and therefore passed through
gettextFromC::tr() before main(). One would hope to get a warning
in such a case, but this is not the case.

Therefore, use the QT_TRANSLATE_NOOP macro to register the strings
in Qt's translation system and translate the list when needed.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
First alternative to #2968 - see discussion there.