### PR TITLE
translations: initialize water type strings on demand [second alternative to #2968]

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -626,8 +626,17 @@ QString get_salinity_string(int salinity)
 	return QStringLiteral("%L1%2").arg(salinity / 10.0).arg(gettextFromC::tr("g/ℓ"));
 }
 
+const QStringList &getWaterTypesAsString()
+{
+	static QStringList waterTypes = {
+		gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("Use DC")
+	};
+	return waterTypes;
+}
+
 QString get_water_type_string(int salinity)
 {
+	const QStringList &waterTypes = getWaterTypesAsString();
 	if (salinity < 10050)
 		return waterTypes[FRESHWATER];
 	else if (salinity < 10190)
@@ -1177,11 +1186,6 @@ QString localFilePath(const QString &originalFilename)
 	QMutexLocker locker(&hashOfMutex);
 	return localFilenameOf.value(originalFilename, originalFilename);
 }
-
-// the water types need to match the watertypes enum
-const QStringList waterTypes = {
-	gettextFromC::tr("Fresh"), gettextFromC::tr("Brackish"), gettextFromC::tr("EN13319"), gettextFromC::tr("Salt"), gettextFromC::tr("Use DC")
-};
 
 // TODO: Apparently Qt has no simple way of listing the supported video
 // codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -38,7 +38,7 @@ int getCloudURL(QString &filename);
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
 void init_proxy();
 QString getUUID();
-extern const QStringList waterTypes;
+const QStringList &getWaterTypesAsString();
 extern const QStringList videoExtensionsList;
 QStringList mediaExtensionFilters();
 QStringList imageExtensionFilters();

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -27,7 +27,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
-	ui->waterTypeCombo->insertItems(0, waterTypes);
+	ui->waterTypeCombo->insertItems(0, getWaterTypesAsString());
 
 	// This needs to be the same order as enum dive_comp_type in dive.h!
 	QStringList types;


### PR DESCRIPTION
The water type strings were global static and therefore passed through
gettextFromC::tr() before main(). One would hope to get a warning
in such a case, but this is not the case.

Therefore, make the array local to a function, which guarantees
that it will be initialized on first invocation in a thread safe
manner. This is in principle the idiomatic C++ "singleton" pattern.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Second alternative to #2968. The diff is distinctly smaller. Completely untested.
