### PR TITLE
cleanup: silence two compiler warnings in git-access.c

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -505,8 +505,10 @@ static int try_to_update(git_repository *repo, git_remote *origin, git_reference
 	remote_id = git_reference_target(remote);
 
 	if (!local_id || !remote_id) {
-		local_id && SSRF_INFO("git storage: unable to get local SHA");
-		remote_id && SSRF_INFO("git storage: unable to get remote SHA");
+		if (!local_id)
+			SSRF_INFO("git storage: unable to get local SHA");
+		if (!remote_id)
+			SSRF_INFO("git storage: unable to get remote SHA");
 		if (is_subsurface_cloud)
 			goto cloud_data_error;
 		else


### PR DESCRIPTION
gcc complained about two constructs of the kind
	remote_id && SSRF_INFO("...");
And while I am not a fan of excessive warnings, I must say
it has a point here. That's just code obfuscation. In fact,
it appears that the condition was wrong - the SSRF_INFO
should probably be invoked if remote_id is NULL. The way
it was written it would be invoked if it was *not* NULL.

Change both instances to unfancy if statements.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Silence two warnings that have annoyed me for the longest time. With this, I get warning-free compiles on gcc - I believe that we have too low warning levels, TBH. I regularly trip over code that *should* give a warning.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn "fancy" boolean expression with side-effect into run-of-the-mill if statement.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: This actually inverts the condition, please check.