### PR TITLE
mobile/dive-list: correctly update view when changing dive date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+mobile: fix manually adding dives in the past [#2971]
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1414,7 +1414,7 @@ void QMLManager::selectDive(int id)
 			amount_selected++;
 	}
 	if (amount_selected == 0)
-		qWarning("QManager::selectDive() called with unknown id");
+		qWarning("QManager::selectDive() called with unknown id %d",id);
 }
 
 void QMLManager::deleteDive(int id)

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -538,9 +538,6 @@ static ShownChange updateShownAll()
 
 void DiveTripModelBase::currentChanged()
 {
-	if (oldCurrent == current_dive)
-		return;
-
 	// On Desktop we use a signal to forward current-dive changed, on mobile we use ROLE_CURRENT.
 	// TODO: Unify - use the role for both.
 #if defined(SUBSURFACE_MOBILE)
@@ -549,11 +546,13 @@ void DiveTripModelBase::currentChanged()
 		QModelIndex oldIdx = diveToIdx(oldCurrent);
 		dataChanged(oldIdx, oldIdx, roles);
 	}
-	if (current_dive) {
+	if (current_dive && oldCurrent != current_dive) {
 		QModelIndex newIdx = diveToIdx(current_dive);
 		dataChanged(newIdx, newIdx, roles);
 	}
 #else
+	if (oldCurrent == current_dive)
+		return;
 	if (current_dive) {
 		QModelIndex newIdx = diveToIdx(current_dive);
 		emit currentDiveChanged(newIdx);


### PR DESCRIPTION
If the dive timestamp changes, the dive could move in the dive list. But the
current dive actually doesn't change (it's still the same dive, right?). Yet
we need to update the dive list as well as the shown dive (especially if this
is after adding a dive, which is first inserted with the current time and then
updated with whatever the user enters).

Fixes: #2971

Suggested-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was first noticed when manually adding dives that were prior to dives that are already in the dive list.
In that case we didn't show that new dive after completing the edit. The reason was that the current dive stayed the same, so our role update didn't get propagated.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- make sure the added dive is indeed selected
- on mobile, propagate updates even if the current dive didn't change

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2971 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done 

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
N/A

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 