### PR TITLE
Update INSTALL to correct PCLinuxOS packagelist

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -199,10 +199,12 @@ swap space configured by default. See the dphys-swapfile package.
 
 On PCLinuxOS you appear to need the following packages
 
-su -c "apt-get install -y autoconf automake cmake libtool gcc-c++ git \
-lib64usb1.0-devel lib64zip-devel lib64qt5webkitwidgets-devel qttools5 \
-qttranslations5 lib64qt5xml-devel lib64qt5test-devel lib64qtscript-devel \
-lib64qt5svg-devel lib64qt5concurrent-devel lib64qt5bluetooth-devel"
+su -c "apt-get install -y autoconf automake cmake gcc-c++ git libtool  \
+lib64bluez-devel lib64qt5bluetooth-devel lib64qt5concurrent-devel \
+lib64qt5help-devel lib64qt5location-devel lib64qt5quicktest-devel \
+lib64qt5quickwidgets-devel lib64qt5script-devel lib64qt5svg-devel \
+lib64qt5test-devel lib64qt5webkitwidgets-devel lib64qt5xml-devel \
+lib64ssh2-devel lib64usb1.0-devel lib64zip-devel qttools5 qttranslations5"
 
 In order to build Subsurface, use the supplied build script. This should
 work on most systems that have all the prerequisite packages installed.


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
PCLinuxOS package list was stale, it contained a typo and also had missing
required packages.

### Changes made:
1), Corrected lib64qtscript-devel package to lib64qt5script-devel
2), Added the following packages:
lib64qt5location-devel
lib64bluez-devel
lib64qt5quickwidgets-devel
lib64qt5help-devel
lib64qt5quicktest-devel
lib64ssh2-devel
3), Arranged packages in alphabetical order

### Related issues:

### Additional information:
Pretty minor change, i only added packages, i didn't remove any existing
packages listed.

### Release note:

### Documentation change:

### Mentions:
@dirkhh 
