### PR TITLE
Prefer "GPS1" for divecomputer download dive site resolution

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -607,6 +607,15 @@ static void parse_string_field(device_data_t *devdata, struct dive *dive, dc_fie
 		char *line = (char *) str->value;
 		location_t location;
 
+		/* Do we already have a divesite? */
+		if (dive->dive_site) {
+			/*
+			 * "GPS1" always takes precedence, anything else
+			 * we'll just pick the first "GPS*" that matches.
+			 */
+			if (strcmp(str->desc, "GPS1") != 0)
+				return;
+		}
 		parse_location(line, &location);
 
 		if (location.lat.udeg && location.lon.udeg) {


### PR DESCRIPTION
I think we only have one dive computer that supports GPS data right now:
the Garmin Descent Mk1.  It reports the dive coordinates as "GPS1" and
"GPS2" for the entry point and exit point respectively.

Often GPS1 is missing, because the dive computer may not have gotten a
GPS lock before the diver jumped into the water, so when that happens
we'll use GPS2 for the dive site location.  But when GPS1 exists, we
should prefer that.

And that's what we already did in logic in dc_get_gps_location(), but
for the initial dive site created at download time, we just picked any
divecomputer reported string that started with "GPS".  And since GPS2 is
reported after GPS1 by the Garmin Descent, it would end up overwriting
the entry point that we _should_ have preferred.

Add the same kind of "explicitly prefer GPS1" logic to the initial dive
download case as we already had elsewhere.

Reported-by: @brysconsulting
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
