### PR TITLE
[TRIVIAL] cleanup: remove unnecessary includes in divelistview.cpp

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -2,22 +2,17 @@
 /*
  * divelistview.cpp
  *
- * classes for the divelist of Subsurface
+ * class for the divelist of Subsurface
  *
  */
 #include "qt-models/filtermodels.h"
 #include "desktop-widgets/modeldelegates.h"
 #include "desktop-widgets/mainwindow.h"
-#include "desktop-widgets/divepicturewidget.h"
 #include "core/selection.h"
-#include "core/divefilter.h"
-#include "core/divesite.h" // for dive_site_table. TODO: remove once adding pictures is undoified
 #include <unistd.h>
 #include <QSettings>
 #include <QKeyEvent>
 #include <QFileDialog>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
 #include <QStandardPaths>
 #include <QMessageBox>
 #include <QHeaderView>
@@ -26,7 +21,6 @@
 #include "core/qthelper.h"
 #include "core/trip.h"
 #include "desktop-widgets/divelistview.h"
-#include "qt-models/divepicturemodel.h"
 #include "core/metrics.h"
 #include "desktop-widgets/simplewidgets.h"
 #include "desktop-widgets/mapwidget.h"


### PR DESCRIPTION
Most of these became unnecessary when including media in the
undo system.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Tiny cleanup: remove unneeded includes.