### PR TITLE
[RFC] Add dive(s) to any trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- desktop: allow adding dives to arbitrary trips
 - desktop: respect page-up, page-down, home and end keys for selection change [#2957]
 - Use pO2 from prefernces for MOD display in equipment tab
 - filter: more flexible filtering system based on individual constraints

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -4,6 +4,7 @@
 #include "subsurface-string.h"
 #include "device.h"
 #include "errorhelper.h" // for verbose flag
+#include "selection.h"
 #include "core/settings/qPrefDiveComputer.h"
 
 /*
@@ -305,12 +306,8 @@ extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *
 	for (const DiveComputerNode &node : values) {
 		bool found = false;
 		if (select_only) {
-			int j;
-			struct dive *d;
-			for_each_dive (j, d) {
+			for (dive *d: getDiveSelection()) {
 				struct divecomputer *dc;
-				if (!d->selected)
-					continue;
 				for_each_dc (d, dc) {
 					if (dc->deviceid == node.deviceId) {
 						found = true;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1018,15 +1018,23 @@ extern "C" char *get_current_date()
 	return copy_qstring(current_date);
 }
 
-QString get_trip_date_string(timestamp_t when, int nr, bool getday)
+QString get_trip_string(const dive_trip *trip)
 {
+	if (!trip)
+		return QString();
+
+	int nr = trip->dives.nr;
+	timestamp_t when = trip_date(trip);
+	bool getday = trip_is_single_day(trip);
+
 	QDateTime localTime = timestampToDateTime(when);
 
+	QString prefix = !empty_string(trip->location) ? QString(trip->location) + ", " : QString();
 	QString suffix = " " + gettextFromC::tr("(%n dive(s))", "", nr);
 	if (getday)
-		return loc.toString(localTime, prefs.date_format) + suffix;
+		return prefix + loc.toString(localTime, prefs.date_format) + suffix;
 	else
-		return loc.toString(localTime, "MMM yyyy") + suffix;
+		return prefix + loc.toString(localTime, "MMM yyyy") + suffix;
 }
 
 static QMutex hashOfMutex;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -19,6 +19,7 @@
 #include "exif.h"
 #include "file.h"
 #include "picture.h"
+#include "selection.h"
 #include "tag.h"
 #include "trip.h"
 #include "imagedownloader.h"
@@ -387,12 +388,9 @@ static bool lessThan(const QPair<QString, int> &a, const QPair<QString, int> &b)
 
 QVector<QPair<QString, int>> selectedDivesGasUsed()
 {
-	int i, j;
-	struct dive *d;
+	int j;
 	QMap<QString, int> gasUsed;
-	for_each_dive (i, d) {
-		if (!d->selected)
-			continue;
+	for (dive *d: getDiveSelection()) {
 		volume_t *diveGases = get_gas_used(d);
 		for (j = 0; j < d->cylinders.nr; j++) {
 			if (diveGases[j].mliter) {

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -8,6 +8,7 @@
 #include "subsurface-time.h"
 
 struct picture;
+struct dive_trip;
 
 // 1) Types
 
@@ -79,7 +80,7 @@ QString get_dive_date_string(timestamp_t when);
 QString get_first_dive_date_string();
 QString get_last_dive_date_string();
 QString get_short_dive_date_string(timestamp_t when);
-QString get_trip_date_string(timestamp_t when, int nr, bool getday);
+QString get_trip_string(const dive_trip *trip);
 QString getUiLanguage();
 void initUiLanguage();
 QLocale getLocale();

--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -43,6 +43,7 @@ set (SUBSURFACE_UI
 	shifttimes.ui
 	tableview.ui
 	templateedit.ui
+	tripselectiodialog.ui
 	urldialog.ui
 	webservices.ui
 	tab-widgets/maintab.ui
@@ -130,6 +131,8 @@ set(SUBSURFACE_INTERFACE
 	tagwidget.h
 	textedit.cpp
 	textedit.h
+	tripselectiondialog.cpp
+	tripselectiondialog.h
 	updatemanager.cpp
 	updatemanager.h
 )

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -24,6 +24,7 @@
 #include "core/metrics.h"
 #include "desktop-widgets/simplewidgets.h"
 #include "desktop-widgets/mapwidget.h"
+#include "desktop-widgets/tripselectiondialog.h"
 
 DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	currentLayout(DiveTripModelBase::TREE),
@@ -650,6 +651,16 @@ void DiveListView::splitDives()
 		Command::splitDives(d, duration_t{-1});
 }
 
+void DiveListView::addDivesToTrip()
+{
+	TripSelectionDialog dialog(MainWindow::instance());
+	dive_trip *t = dialog.getTrip();
+	std::vector<dive *> dives = getDiveSelection();
+	if (!t || dives.empty())
+		return;
+	Command::addDivesToTrip(QVector<dive *>::fromStdVector(dives), t);
+}
+
 void DiveListView::renumberDives()
 {
 	RenumberDialog dialog(true, MainWindow::instance());
@@ -845,6 +856,7 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 	if (amount_selected > 1 && consecutive_selected())
 		popup.addAction(tr("Merge selected dives"), this, &DiveListView::mergeDives);
 	if (amount_selected >= 1) {
+		popup.addAction(tr("Add dive(s) to arbitrary trip"), this, &DiveListView::addDivesToTrip);
 		popup.addAction(tr("Renumber dive(s)"), this, &DiveListView::renumberDives);
 		popup.addAction(tr("Shift dive times"), this, &DiveListView::shiftTimes);
 		popup.addAction(tr("Split selected dives"), this, &DiveListView::splitDives);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -609,16 +609,12 @@ static bool can_merge(const struct dive *a, const struct dive *b, enum asked_use
 
 void DiveListView::mergeDives()
 {
-	int i;
-	struct dive *d;
 	enum asked_user have_asked = NOTYET;
 
 	// Collect a vector of batches of dives to merge (i.e. a vector of vector of dives)
 	QVector<QVector<dive *>> merge_batches;
 	QVector<dive *> current_batch;
-	for_each_dive (i, d) {
-		if (!d->selected)
-			continue;
+	for (dive *d: getDiveSelection()) {
 		if (current_batch.empty()) {
 			current_batch.append(d);
 		} else if (can_merge(current_batch.back(), d, &have_asked)) {
@@ -638,16 +634,7 @@ void DiveListView::mergeDives()
 
 void DiveListView::splitDives()
 {
-	int i;
-	struct dive *dive;
-
-	// Let's collect the dives to be split first, so that we don't catch newly inserted dives!
-	QVector<struct dive *> dives;
-	for_each_dive (i, dive) {
-		if (dive->selected)
-			dives.append(dive);
-	}
-	for (struct dive *d: dives)
+	for (struct dive *d: getDiveSelection())
 		Command::splitDives(d, duration_t{-1});
 }
 
@@ -748,15 +735,7 @@ void DiveListView::addToTrip(int delta)
 		// no dive, no trip? get me out of here
 		return;
 
-	QVector<dive *> dives;
-	if (d->selected) { // there are possibly other selected dives that we should add
-		int idx;
-		for_each_dive (idx, d) {
-			if (d->selected)
-				dives.append(d);
-		}
-	}
-	Command::addDivesToTrip(dives, trip);
+	Command::addDivesToTrip(QVector<dive *>::fromStdVector(getDiveSelection()), trip);
 }
 
 void DiveListView::markDiveInvalid()
@@ -775,13 +754,7 @@ void DiveListView::deleteDive()
 	if (!d)
 		return;
 
-	int i;
-	QVector<struct dive*> deletedDives;
-	for_each_dive (i, d) {
-		if (d->selected)
-			deletedDives.append(d);
-	}
-	Command::deleteDive(deletedDives);
+	Command::deleteDive(QVector<dive *>::fromStdVector(getDiveSelection()));
 }
 
 void DiveListView::contextMenuEvent(QContextMenuEvent *event)

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -50,6 +50,7 @@ slots:
 	void mergeDives();
 	void splitDives();
 	void renumberDives();
+	void addDivesToTrip();
 	void shiftTimes();
 	void diveSelectionChanged(const QVector<QModelIndex> &indices);
 	void currentDiveChanged(QModelIndex index);

--- a/desktop-widgets/tripselectiondialog.cpp
+++ b/desktop-widgets/tripselectiondialog.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "tripselectiondialog.h"
+#include "core/trip.h"
+#include "core/qthelper.h"
+#include <QShortcut>
+#include <QPushButton>
+
+TripSelectionDialog::TripSelectionDialog(QWidget *parent) : QDialog(parent)
+{
+	ui.setupUi(this);
+	connect(ui.trips, &QListWidget::itemSelectionChanged, this, &TripSelectionDialog::selectionChanged);
+
+	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
+	connect(close, &QShortcut::activated, this, &QDialog::close);
+	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+	connect(quit, &QShortcut::activated, parent, &QWidget::close);
+
+	// We could use a model, but it seems barely worth the hassle.
+	QStringList list;
+	list.reserve(trip_table.nr);
+	for (int i = 0; i < trip_table.nr; ++i)
+		list.push_back(get_trip_string(trip_table.trips[i]));
+	ui.trips->addItems(list);
+}
+
+void TripSelectionDialog::selectionChanged()
+{
+	ui.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(selectedTrip() != nullptr);
+}
+
+dive_trip *TripSelectionDialog::selectedTrip() const
+{
+	// Accessing the selected index of a QListWidget is ridiculously cumbersome.
+	// Note that "currentItem" is a different beast.
+	QModelIndexList rows = ui.trips->selectionModel()->selectedRows();
+	if (rows.size() != 1)
+		return nullptr;
+	int idx = rows[0].row();
+	if (idx < 0 || idx >= trip_table.nr)
+		return nullptr;
+	return trip_table.trips[idx];
+}
+
+dive_trip *TripSelectionDialog::getTrip()
+{
+	return exec() ? selectedTrip() : nullptr;
+}

--- a/desktop-widgets/tripselectiondialog.h
+++ b/desktop-widgets/tripselectiondialog.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TRIPSELECTIONDIALOG_H
+#define TRIPSELECTIONDIALOG_H
+
+#include <QDialog>
+#include "ui_tripselectiondialog.h"
+
+struct dive_trip;
+
+class TripSelectionDialog : public QDialog {
+	Q_OBJECT
+private
+slots:
+	void selectionChanged();
+public:
+	TripSelectionDialog(QWidget *parent); // Must pass in MainWindow for QShortcut hackery.
+	dive_trip *getTrip(); // NULL if user canceled.
+private:
+	dive_trip *selectedTrip() const;
+	Ui::TripSelectionDialog ui;
+};
+
+#endif // TRIPSELECTIONDIALOG_H

--- a/desktop-widgets/tripselectiondialog.ui
+++ b/desktop-widgets/tripselectiondialog.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TripSelectionDialog</class>
+ <widget class="QDialog" name="TripSelectionDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>560</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select trip</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normalon>:subsurface-icon</normalon>
+   </iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QListWidget" name="trips">
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../subsurface.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TripSelectionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TripSelectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -5,6 +5,7 @@
 #include "core/imagedownloader.h"
 #include "core/picture.h"
 #include "core/qthelper.h"
+#include "core/selection.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "commands/command.h"
 
@@ -87,19 +88,15 @@ void DivePictureModel::updateDivePictures()
 		Thumbnailer::instance()->clearWorkQueue();
 	}
 
-	int i;
-	struct dive *dive;
-	for_each_dive (i, dive) {
-		if (dive->selected) {
-			size_t first = pictures.size();
-			FOR_EACH_PICTURE(dive)
-				pictures.push_back(PictureEntry(dive, *picture));
+	for (struct dive *dive: getDiveSelection()) {
+		size_t first = pictures.size();
+		FOR_EACH_PICTURE(dive)
+			pictures.push_back(PictureEntry(dive, *picture));
 
-			// Sort pictures of this dive by offset.
-			// Thus, the list will be sorted by (dive, offset).
-			std::sort(pictures.begin() + first, pictures.end(),
-				  [](const PictureEntry &a, const PictureEntry &b) { return a.offsetSeconds < b.offsetSeconds; });
-		}
+		// Sort pictures of this dive by offset.
+		// Thus, the list will be sorted by (dive, offset).
+		std::sort(pictures.begin() + first, pictures.end(),
+			  [](const PictureEntry &a, const PictureEntry &b) { return a.offsetSeconds < b.offsetSeconds; });
 	}
 
 	updateThumbnails();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1325,8 +1325,8 @@ void DiveTripModelTree::divesMovedBetweenTrips(dive_trip *from, dive_trip *to, b
 	// Cheating!
 	// Unfortunately, removing the dives means that their selection is lost.
 	// Thus, remember the selection and re-add it later.
-	divesAdded(to, createTo, dives);
 	divesDeletedInternal(from, deleteFrom, dives); // Use internal version to keep current dive
+	divesAdded(to, createTo, dives);
 }
 
 void DiveTripModelTree::divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives)

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -119,14 +119,10 @@ QVariant DiveTripModelBase::tripData(const dive_trip *trip, int column, int role
 		switch (column) {
 		case DiveTripModelBase::NR:
 			QString shownText;
-			bool oneDayTrip = trip_is_single_day(trip);
 			int countShown = trip_shown_dives(trip);
 			if (countShown < trip->dives.nr)
 				shownText = tr("(%1 shown)").arg(countShown);
-			if (!empty_string(trip->location))
-				return QString(trip->location) + ", " + get_trip_date_string(trip_date(trip), trip->dives.nr, oneDayTrip) + " "+ shownText;
-			else
-				return get_trip_date_string(trip_date(trip), trip->dives.nr, oneDayTrip) + shownText;
+			return get_trip_string(trip) + " " + shownText;
 		}
 	}
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [ ] Bug fix
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A user requested on the mailing list that dives be added to any trip. Indeed, the restriction to add dives only to the trip above/below seems illogical. This adds the possibility to add dive(s) to any trip. The trip is selected in a new dialog.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add trip selection dialog.
2) Move trip header formatting to qt-helper.cpp so that code can be reused by the new dialog.
3) Add context menu to add dives to any trip.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
1) Mostly untested
2) I noticed that the add to trip above/below feature is currently broken: Remove a dive from the middle of the top-most trip. The context menu will feature a "add to trip above" entry even though there is *no* trip above.
3) The context menu is getting absurdly long - this is in need of a redesign.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Perhaps?
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh, @willemferguson for possible documentation change...?