### PR TITLE
Remove empty vertical space from filter QListWidget

### DIFF
--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -45,7 +45,9 @@ static QListWidget *makeMultipleChoice(const QModelIndex &index, int role)
 		return nullptr;
 	QListWidget *res = new QListWidget;
 	res->addItems(list);
+	res->setSizePolicy(QSizePolicy::Maximum,QSizePolicy::Maximum);
 	res->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	res->setFixedSize(res->sizeHintForColumn(0) + 2 * res->frameWidth(), res->sizeHintForRow(0) * res->count() + 2 * res->frameWidth());
 	return res;
 }
 


### PR DESCRIPTION
In the filter the dropdown lists for selecting dive mode or day-of-week
have a lot of white space at the bottom. This PR removes that white space.
Actually the white space at the bottom of a QListWidget appears to
be a known bug (actually an omission) for the current Qt V15. The above
solution is a brute-force workaround to achieve the same end result.
The active line is actually the setFixedSize(). The other line, however,
comprises good QT layout policy to minimise widget size. The setFixedSize()
function does: "scale the widget to the width of the only column and to
n-times the height of one row and add the size of the 'frame' twice".

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:

@bstoeger @dirkhh 