### PR TITLE
membuffer: be defensive about bad C library vsnprintf implementations

### DIFF
--- a/core/membuffer.c
+++ b/core/membuffer.c
@@ -110,6 +110,18 @@ void put_vformat(struct membuffer *b, const char *fmt, va_list args)
 		len = vsnprintf(target, room, fmt, copy);
 		va_end(copy);
 
+		// Buggy C library?
+		if (len < 0) {
+			// We have to just give up at some point
+			if (room > 1000)
+				return;
+
+			// We don't know how big an area we should ask for,
+			// so just expand our allocation by 50%
+			room = room * 3 / 2;
+			continue;
+		}
+
 		if (len < room) {
 			b->len += len;
 			return;


### PR DESCRIPTION
Dirk reports that some Windows users have had odd corruption in the
commit messages in the cloud storage.  They make no sense at all unless
there is some very weird Windows library bug.

The prime suspect is 'vsnprintf()' returning a negative error when the
target buffer is too small (rather than the proper "this is how much
space it would need").  That is a very traditional C library bug that I
thougth had been fixed everywhere, but there doesn't really seem to be a
lot of other likely causes.

So let's make our membuffer code be defensive against bad libraries that
return negative error numbers from vsnprintf.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
