### PR TITLE
desktop: fix paging through dive list with page-up key, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- desktop: respect page-up, page-down, home and end keys for selection change [#2957]
 - Use pO2 from prefernces for MOD display in equipment tab
 - filter: more flexible filtering system based on individual constraints
 - mobile: fix manually adding dives in the past [#2971]

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -448,10 +448,21 @@ void DiveListView::mouseReleaseEvent(QMouseEvent *event)
 
 void DiveListView::keyPressEvent(QKeyEvent *event)
 {
-	// Hook into cursor-up and cursor-down events and update selection if necessary.
-	// See comment in mouseReleaseEvent()
-	if (event->key() != Qt::Key_Down && event->key() != Qt::Key_Up)
-		return QTreeView::keyPressEvent(event);
+	// Hook into key events that change the selection (i.e. cursor-up, cursor-down,
+	// page-up, page-down, home and end) and update selection if necessary.
+	// See comment in mouseReleaseEvent().
+	switch (event->key()) {
+		case Qt::Key_Up:
+		case Qt::Key_Down:
+		case Qt::Key_PageUp:
+		case Qt::Key_PageDown:
+		case Qt::Key_Home:
+		case Qt::Key_End:
+			break;
+		default:
+			return QTreeView::keyPressEvent(event);
+	}
+
 	QModelIndexList selectionBefore = selectionModel()->selectedRows();
 	QTreeView::keyPressEvent(event);
 	QModelIndexList selectionAfter = selectionModel()->selectedRows();


### PR DESCRIPTION
In the dive list we have horrible code, which intercepts all events
to save the selection before/after the event. This was necessary
because we couldn't get Qt's selection data flow under control.

This means intercepting all events that can change the selection.
The page-up, page-down, home and end keys were forgotten. Add these
cases.

Fixes #2957.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes paging through the dive list with page-up, page-down, etc. These cases have been overlooked.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Intercept page-up etc. key-presses in analogy to up- and down-arrow.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2957.
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia 