### PR TITLE
Cleanup: make device-list integrate better with core

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -239,16 +239,16 @@ bool DiveComputerNode::operator<(const DiveComputerNode &a) const
 	return std::tie(model, deviceId) < std::tie(a.model, a.deviceId);
 }
 
-static const DiveComputerNode *getDCExact(const QVector<DiveComputerNode> &dcs, const QString &m, uint32_t d)
+static const DiveComputerNode *getDCExact(const QVector<DiveComputerNode> &dcs, const divecomputer *dc)
 {
-	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{m, d, {}, {}, {}});
-	return it != dcs.end() && it->model == m && it->deviceId == d ? &*it : NULL;
+	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{dc->model, dc->deviceid, {}, {}, {}});
+	return it != dcs.end() && it->model == dc->model && it->deviceId == dc->deviceid ? &*it : NULL;
 }
 
-static const DiveComputerNode *getDC(const QVector<DiveComputerNode> &dcs, const QString &m)
+static const DiveComputerNode *getDC(const QVector<DiveComputerNode> &dcs, const divecomputer *dc)
 {
-	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{m, 0, {}, {}, {}});
-	return it != dcs.end() && it->model == m ? &*it : NULL;
+	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{dc->model, 0, {}, {}, {}});
+	return it != dcs.end() && it->model == dc->model ? &*it : NULL;
 }
 
 void DiveComputerNode::showchanges(const QString &n, const QString &s, const QString &f) const
@@ -348,9 +348,9 @@ extern "C" void set_dc_nickname(struct dive *dive)
 
 	for_each_dc (dive, dc) {
 		if (!empty_string(dc->model) && dc->deviceid &&
-		    !getDCExact(dcList.dcs, dc->model, dc->deviceid)) {
+		    !getDCExact(dcList.dcs, dc)) {
 			// we don't have this one, yet
-			const DiveComputerNode *existNode = getDC(dcList.dcs, dc->model);
+			const DiveComputerNode *existNode = getDC(dcList.dcs, dc);
 			if (existNode) {
 				// we already have this model but a different deviceid
 				QString simpleNick(dc->model);
@@ -368,7 +368,7 @@ extern "C" void set_dc_nickname(struct dive *dive)
 
 QString get_dc_nickname(const struct divecomputer *dc)
 {
-	const DiveComputerNode *existNode = getDCExact(dcList.dcs, dc->model, dc->deviceid);
+	const DiveComputerNode *existNode = getDCExact(dcList.dcs, dc);
 
 	if (existNode && !existNode->nickName.isEmpty())
 		return existNode->nickName;

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -191,9 +191,9 @@ extern "C" void fake_dc(struct divecomputer *dc)
 	/* Even that didn't work? Give up, there's something wrong */
 }
 
-DiveComputerList dcList;
+struct device_table device_table;
 
-bool DiveComputerNode::operator==(const DiveComputerNode &a) const
+bool device::operator==(const device &a) const
 {
 	return model == a.model &&
 	       deviceId == a.deviceId &&
@@ -202,25 +202,25 @@ bool DiveComputerNode::operator==(const DiveComputerNode &a) const
 	       nickName == a.nickName;
 }
 
-bool DiveComputerNode::operator!=(const DiveComputerNode &a) const
+bool device::operator!=(const device &a) const
 {
 	return !(*this == a);
 }
 
-bool DiveComputerNode::operator<(const DiveComputerNode &a) const
+bool device::operator<(const device &a) const
 {
 	return std::tie(model, deviceId) < std::tie(a.model, a.deviceId);
 }
 
-static const DiveComputerNode *getDCExact(const QVector<DiveComputerNode> &dcs, const divecomputer *dc)
+static const device *getDCExact(const QVector<device> &dcs, const divecomputer *dc)
 {
-	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{dc->model, dc->deviceid, {}, {}, {}});
+	auto it = std::lower_bound(dcs.begin(), dcs.end(), device{dc->model, dc->deviceid, {}, {}, {}});
 	return it != dcs.end() && it->model == dc->model && it->deviceId == dc->deviceid ? &*it : NULL;
 }
 
-static const DiveComputerNode *getDC(const QVector<DiveComputerNode> &dcs, const divecomputer *dc)
+static const device *getDC(const QVector<device> &dcs, const divecomputer *dc)
 {
-	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{dc->model, 0, {}, {}, {}});
+	auto it = std::lower_bound(dcs.begin(), dcs.end(), device{dc->model, 0, {}, {}, {}});
 	return it != dcs.end() && it->model == dc->model ? &*it : NULL;
 }
 
@@ -239,7 +239,7 @@ extern "C" void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid)
 	if (!dc->model)
 		return;
 
-	const DiveComputerNode *node = getDCExact(dcList.dcs, dc);
+	const device *node = getDCExact(device_table.devices, dc);
 	if (!node)
 		return;
 
@@ -249,7 +249,7 @@ extern "C" void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid)
 		dc->fw_version = copy_qstring(node->firmware);
 }
 
-void DiveComputerNode::showchanges(const QString &n, const QString &s, const QString &f) const
+void device::showchanges(const QString &n, const QString &s, const QString &f) const
 {
 	if (nickName != n && !n.isEmpty())
 		qDebug("new nickname %s for DC model %s deviceId 0x%x", qPrintable(n), qPrintable(model), deviceId);
@@ -259,11 +259,11 @@ void DiveComputerNode::showchanges(const QString &n, const QString &s, const QSt
 		qDebug("new firmware version %s for DC model %s deviceId 0x%x", qPrintable(f), qPrintable(model), deviceId);
 }
 
-static void addDC(QVector<DiveComputerNode> &dcs, const QString &m, uint32_t d, const QString &n, const QString &s, const QString &f)
+static void addDC(QVector<device> &dcs, const QString &m, uint32_t d, const QString &n, const QString &s, const QString &f)
 {
 	if (m.isEmpty() || d == 0)
 		return;
-	auto it = std::lower_bound(dcs.begin(), dcs.end(), DiveComputerNode{m, d, {}, {}, {}});
+	auto it = std::lower_bound(dcs.begin(), dcs.end(), device{m, d, {}, {}, {}});
 	if (it != dcs.end() && it->model == m && it->deviceId == d) {
 		// debugging: show changes
 		if (verbose)
@@ -276,21 +276,21 @@ static void addDC(QVector<DiveComputerNode> &dcs, const QString &m, uint32_t d, 
 		if (!f.isEmpty())
 			it->firmware = f;
 	} else {
-		dcs.insert(it, DiveComputerNode{m, d, s, f, n});
+		dcs.insert(it, device{m, d, s, f, n});
 	}
 }
 
 extern "C" void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname)
 {
-	addDC(dcList.dcs, model, deviceid, nickname, serial, firmware);
+	addDC(device_table.devices, model, deviceid, nickname, serial, firmware);
 }
 
 extern "C" void clear_device_nodes()
 {
-	dcList.dcs.clear();
+	device_table.devices.clear();
 }
 
-static bool compareDCById(const DiveComputerNode &a, const DiveComputerNode &b)
+static bool compareDCById(const device &a, const device &b)
 {
 	return a.deviceId < b.deviceId;
 }
@@ -298,9 +298,9 @@ static bool compareDCById(const DiveComputerNode &a, const DiveComputerNode &b)
 extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *, uint32_t, const char *, const char *, const char *),
 				  bool select_only)
 {
-	QVector<DiveComputerNode> values = dcList.dcs;
+	QVector<device> values = device_table.devices;
 	std::sort(values.begin(), values.end(), compareDCById);
-	for (const DiveComputerNode &node : values) {
+	for (const device &node : values) {
 		bool found = false;
 		if (select_only) {
 			int j;
@@ -346,9 +346,9 @@ extern "C" void set_dc_nickname(struct dive *dive)
 
 	for_each_dc (dive, dc) {
 		if (!empty_string(dc->model) && dc->deviceid &&
-		    !getDCExact(dcList.dcs, dc)) {
+		    !getDCExact(device_table.devices, dc)) {
 			// we don't have this one, yet
-			const DiveComputerNode *existNode = getDC(dcList.dcs, dc);
+			const device *existNode = getDC(device_table.devices, dc);
 			if (existNode) {
 				// we already have this model but a different deviceid
 				QString simpleNick(dc->model);
@@ -356,9 +356,9 @@ extern "C" void set_dc_nickname(struct dive *dive)
 					simpleNick.append(" (unknown deviceid)");
 				else
 					simpleNick.append(" (").append(QString::number(dc->deviceid, 16)).append(")");
-				addDC(dcList.dcs, dc->model, dc->deviceid, simpleNick, {}, {});
+				addDC(device_table.devices, dc->model, dc->deviceid, simpleNick, {}, {});
 			} else {
-				addDC(dcList.dcs, dc->model, dc->deviceid, {}, {}, {});
+				addDC(device_table.devices, dc->model, dc->deviceid, {}, {}, {});
 			}
 		}
 	}
@@ -366,7 +366,7 @@ extern "C" void set_dc_nickname(struct dive *dive)
 
 QString get_dc_nickname(const struct divecomputer *dc)
 {
-	const DiveComputerNode *existNode = getDCExact(dcList.dcs, dc);
+	const device *existNode = getDCExact(device_table.devices, dc);
 
 	if (existNode && !existNode->nickName.isEmpty())
 		return existNode->nickName;

--- a/core/device.h
+++ b/core/device.h
@@ -26,8 +26,7 @@ extern void clear_device_nodes();
 
 #include <QString>
 #include <QVector>
-class DiveComputerNode {
-public:
+struct DiveComputerNode {
 	bool operator==(const DiveComputerNode &a) const;
 	bool operator!=(const DiveComputerNode &a) const;
 	bool operator<(const DiveComputerNode &a) const;
@@ -39,12 +38,7 @@ public:
 	QString nickName;
 };
 
-class DiveComputerList {
-public:
-	const DiveComputerNode *getExact(const QString &m, uint32_t d);
-	const DiveComputerNode *get(const QString &m);
-	void addDC(QString m, uint32_t d, QString n = QString(), QString s = QString(), QString f = QString());
-
+struct DiveComputerList {
 	// Keep the dive computers in a vector sorted by (model, deviceId)
 	QVector<DiveComputerNode> dcs;
 };

--- a/core/device.h
+++ b/core/device.h
@@ -26,10 +26,10 @@ extern void clear_device_nodes();
 
 #include <QString>
 #include <QVector>
-struct DiveComputerNode {
-	bool operator==(const DiveComputerNode &a) const;
-	bool operator!=(const DiveComputerNode &a) const;
-	bool operator<(const DiveComputerNode &a) const;
+struct device {
+	bool operator==(const device &a) const;
+	bool operator!=(const device &a) const;
+	bool operator<(const device &a) const;
 	void showchanges(const QString &n, const QString &s, const QString &f) const;
 	QString model;
 	uint32_t deviceId;
@@ -38,13 +38,13 @@ struct DiveComputerNode {
 	QString nickName;
 };
 
-struct DiveComputerList {
+struct device_table {
 	// Keep the dive computers in a vector sorted by (model, deviceId)
-	QVector<DiveComputerNode> dcs;
+	QVector<device> devices;
 };
 
 QString get_dc_nickname(const struct divecomputer *dc);
-extern DiveComputerList dcList;
+extern struct device_table device_table;
 
 #endif
 

--- a/qt-models/divecomputermodel.cpp
+++ b/qt-models/divecomputermodel.cpp
@@ -4,7 +4,7 @@
 #include "core/divelist.h"
 
 DiveComputerModel::DiveComputerModel(QObject *parent) : CleanerTableModel(parent),
-	dcs(dcList.dcs)
+	dcs(device_table.devices)
 {
 	setHeaderDataStrings(QStringList() << "" << tr("Model") << tr("Device ID") << tr("Nickname"));
 }
@@ -13,7 +13,7 @@ QVariant DiveComputerModel::data(const QModelIndex &index, int role) const
 {
 	if (index.row() < 0 || index.row() >= dcs.size())
 		return QVariant();
-	const DiveComputerNode &node = dcs[index.row()];
+	const device &node = dcs[index.row()];
 
 	if (role == Qt::DisplayRole || role == Qt::EditRole) {
 		switch (index.column()) {
@@ -58,7 +58,7 @@ bool DiveComputerModel::setData(const QModelIndex &index, const QVariant &value,
 	if (index.row() < 0 || index.row() >= dcs.size())
 		return false;
 
-	DiveComputerNode &node = dcs[index.row()];
+	device &node = dcs[index.row()];
 	node.nickName = value.toString();
 	emit dataChanged(index, index);
 	return true;
@@ -75,7 +75,7 @@ void DiveComputerModel::remove(const QModelIndex &index)
 
 void DiveComputerModel::keepWorkingList()
 {
-	if (dcList.dcs != dcs)
+	if (device_table.devices != dcs)
 		mark_divelist_changed(true);
-	dcList.dcs = dcs;
+	device_table.devices = dcs;
 }

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -26,7 +26,7 @@ slots:
 	void remove(const QModelIndex &index);
 
 private:
-	QVector<DiveComputerNode> dcs;
+	QVector<device> dcs;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Some cleanups concerning the device list. This tries to make things more consistent: `dive_computer` represents dive computer data of a particular dive and `device` a particular dive computer. The ambiguity `dive_computer` vs. `DiveComputerNode` was very confusing.

This is a small step in unglobalization of parser state. Currently, the parser tramples over global state, which means that for example device nodes are imported only when *reading* a log.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Some code reshuffling
2) Some type / variable renaming
