### PR TITLE
core: improve merging of cylinders pressures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - desktop: allow adding dives to arbitrary trips
+- core: improve merging of cylinder pressures [#2884]
 - desktop: respect page-up, page-down, home and end keys for selection change [#2957]
 - Use pO2 from prefernces for MOD display in equipment tab
 - filter: more flexible filtering system based on individual constraints

--- a/core/dive.c
+++ b/core/dive.c
@@ -2276,14 +2276,11 @@ static void merge_one_cylinder(cylinder_t *a, const cylinder_t *b)
 
 	/* If either cylinder has manually entered pressures, try to merge them.
 	 * Use pressures from divecomputer samples if only one cylinder has such a value.
-	 * Yes, this is an actual use case we encountered. */
+	 * Yes, this is an actual use case we encountered.
+	 * Note that we don't merge the sample-derived pressure values, as this is
+	 * perfomed after merging in fixup_dive() */
 	a->start = merge_pressures(a->start, a->sample_start, b->start, b->sample_start, false);
 	a->end = merge_pressures(a->end, a->sample_end, b->end, b->sample_end, true);
-
-	if (a->sample_start.mbar && b->sample_start.mbar)
-		a->sample_start.mbar = a->sample_start.mbar > b->sample_start.mbar ?  a->sample_start.mbar : b->sample_start.mbar;
-	if (a->sample_end.mbar && b->sample_end.mbar)
-		a->sample_end.mbar = a->sample_end.mbar < b->sample_end.mbar ?  a->sample_end.mbar : b->sample_end.mbar;
 
 	/* Really? */
 	a->gas_used.mliter += b->gas_used.mliter;


### PR DESCRIPTION
When merging cylinders pressures derived from samples were taken
as maximum of the start and minimum of the end pressure, which
makes sense, since we believe that this is the same cylinder.

However, for manually entered pressures, this was not done.

Moreover, when one dive had manual pressures and the other only
pressure from samples, the manual pressure was taken. However,
that could have been the wrong one, for example if the end
pressure was manually set for the cylinder of the first part of
the dive, but not the last.

Therefore, improve merging of manuall set pressures in two ways:
1) use maximum/minimum for start/end pressure
2) if the pressure of one cylinder was manually set, but not for
   the other, complete with the sample pressure (if that exists).

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This "fixes" the merging issue in #2884, which is actually two issues:
1) When merging manually added pressures minimum/maximum was not taken in contrast to sample pressures.
2) We have to consider the case that a cylinder with and one without manual pressures is merged.

Note that I have no idea what the semantics should be in such a case.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use max/min when merging manual start/end pressures.
2) Complement with sample pressures when merging cylinders with and without manual pressures.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #2884.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @torvalds 