### PR TITLE
minor libdc interface cleanup

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1114,10 +1114,9 @@ static void event_cb(dc_device_t *device, dc_event_type_t event, const void *dat
 		if (!strcmp(devdata->vendor, "Suunto"))
 			serial = fixup_suunto_versions(devdata, devinfo);
 		devdata->deviceid = calculate_sha1(devinfo->model, devinfo->firmware, serial);
-		/* really, serial and firmware version are NOT numbers. We'll try to save them here
+		/* really, firmware version is NOT a number. We'll try to save it here
 		 * in something that might work, but this really needs to be handled with the
 		 * DC_FIELD_STRING interface instead */
-		devdata->libdc_serial = devinfo->serial;
 		devdata->libdc_firmware = devinfo->firmware;
 
 		lookup_fingerprint(device, devdata);

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -543,7 +543,6 @@ static uint32_t calculate_diveid(const unsigned char *fingerprint, unsigned int 
 	return csum[0];
 }
 
-#ifdef DC_FIELD_STRING
 static uint32_t calculate_string_hash(const char *str)
 {
 	return calculate_diveid((const unsigned char *)str, strlen(str));
@@ -624,7 +623,6 @@ static void parse_string_field(device_data_t *devdata, struct dive *dive, dc_fie
 		}
 	}
 }
-#endif
 
 static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devdata, struct dive *dive)
 {
@@ -727,7 +725,6 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 	if (rc == DC_STATUS_SUCCESS)
 		dive->dc.surface_pressure.mbar = lrint(surface_pressure * 1000.0);
 
-#ifdef DC_FIELD_STRING
 	// The dive parsing may give us more device information
 	int idx;
 	for (idx = 0; idx < 100; idx++) {
@@ -739,7 +736,6 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 			break;
 		parse_string_field(devdata, dive, &str);
 	}
-#endif
 
 	dc_divemode_t divemode;
 	rc = dc_parser_get_field(parser, DC_FIELD_DIVEMODE, 0, &divemode);

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -36,7 +36,7 @@ typedef struct dc_user_device_t
 	const char *model, *btname;
 	unsigned char *fingerprint;
 	unsigned int fsize, fdiveid;
-	uint32_t libdc_firmware, libdc_serial;
+	uint32_t libdc_firmware;
 	uint32_t deviceid, diveid;
 	dc_device_t *device;
 	dc_context_t *context;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Very minor cleanups.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove obsolete conditional compilation. We bundle our own libdc, so that shouldn't be necessary.
2) Remove an unused field in `device_data_t`. Serials are now handled as strings.

@dirkhh @torvalds