### PR TITLE
clenup: remove bogus connect statement.

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -347,7 +347,6 @@ void OstcFirmwareCheck::saveOstcFirmware(QNetworkReply *reply)
 	connect(config, SIGNAL(message(QString)), dialog, SLOT(setLabelText(QString)));
 	connect(config, SIGNAL(error(QString)), dialog, SLOT(setLabelText(QString)));
 	connect(config, SIGNAL(progress(int)), dialog, SLOT(setValue(int)));
-	connect(dialog, SIGNAL(finished(int)), config, SLOT(dc_close()));
 	config->dc_open(&devData);
 	config->startFirmwareUpdate(storeFirmware, &devData);
 }


### PR DESCRIPTION
In OstcFirmwareCheck::saveOstcFirmware() we find the connect() call
    connect(dialog, SIGNAL(finished(int)), config, SLOT(dc_close()));
whereby "config" is of the type "ConfigureDiveComputer".
However, the function signature of ConfigureDiveComputer::dc_close
reads as
    void dc_close(device_data_t *data);
and indeed "data" is accessed inside the function. I don't understand
how this doesn't crash, but clearly something is amiss.

Let's remove that connect statement.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I found this super-ominous connect statement (see commit description). I cannot make any sense of this and don't understand how this does not crash. Does one get console messages when updating firmware concerning an invalid connect statement?

Can we remove this, or clear this up, please?

Obviously, I have no device of that kind.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove apparently bogus connect statement

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@glance- @dirkhh 