### PR TITLE
[cleanup] switch divecomputer-configuration signals to pointer-to-member versions.

### DIFF
--- a/core/configuredivecomputer.h
+++ b/core/configuredivecomputer.h
@@ -55,6 +55,7 @@ private:
 	WriteSettingsThread *writeThread;
 	ResetSettingsThread *resetThread;
 	FirmwareUpdateThread *firmwareThread;
+	void connectThreadSignals(DeviceThread *thread);
 	void setState(states newState);
 private
 slots:

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -111,21 +111,20 @@ ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDia
 
 	deviceDetails = new DeviceDetails(this);
 	config = new ConfigureDiveComputer();
-	connect(config, SIGNAL(progress(int)), ui.progressBar, SLOT(setValue(int)));
-	connect(config, SIGNAL(error(QString)), this, SLOT(configError(QString)));
-	connect(config, SIGNAL(message(QString)), this, SLOT(configMessage(QString)));
-	connect(config, SIGNAL(deviceDetailsChanged(DeviceDetails *)),
-		this, SLOT(deviceDetailsReceived(DeviceDetails *)));
-	connect(ui.retrieveDetails, SIGNAL(clicked()), this, SLOT(readSettings()));
-	connect(ui.resetButton, SIGNAL(clicked()), this, SLOT(resetSettings()));
-	connect(ui.resetButton_4, SIGNAL(clicked()), this, SLOT(resetSettings()));
+	connect(config, &ConfigureDiveComputer::progress, ui.progressBar, &QProgressBar::setValue);
+	connect(config, &ConfigureDiveComputer::error, this, &ConfigureDiveComputerDialog::configError);
+	connect(config, &ConfigureDiveComputer::message, this, &ConfigureDiveComputerDialog::configMessage);
+	connect(config, &ConfigureDiveComputer::deviceDetailsChanged, this, &ConfigureDiveComputerDialog::deviceDetailsReceived);
+	connect(ui.retrieveDetails, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::readSettings);
+	connect(ui.resetButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::resetSettings);
+	connect(ui.resetButton_4, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::resetSettings);
 	ui.chooseLogFile->setEnabled(ui.logToFile->isChecked());
-	connect(ui.chooseLogFile, SIGNAL(clicked()), this, SLOT(pickLogFile()));
-	connect(ui.logToFile, SIGNAL(stateChanged(int)), this, SLOT(checkLogFile(int)));
-	connect(ui.connectButton, SIGNAL(clicked()), this, SLOT(dc_open()));
-	connect(ui.disconnectButton, SIGNAL(clicked()), this, SLOT(dc_close()));
+	connect(ui.chooseLogFile, &QToolButton::clicked, this, &ConfigureDiveComputerDialog::pickLogFile);
+	connect(ui.logToFile, &QCheckBox::stateChanged, this, &ConfigureDiveComputerDialog::checkLogFile);
+	connect(ui.connectButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::dc_open);
+	connect(ui.disconnectButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::dc_close);
 #ifdef BT_SUPPORT
-	connect(ui.bluetoothMode, SIGNAL(clicked(bool)), this, SLOT(selectRemoteBluetoothDevice()));
+	connect(ui.bluetoothMode, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::selectRemoteBluetoothDevice);
 #else
 	ui.bluetoothMode->setVisible(false);
 #endif
@@ -248,7 +247,7 @@ OstcFirmwareCheck::OstcFirmwareCheck(QString product) : parent(0)
 	} else { // not one of the known dive computers
 		return;
 	}
-	connect(&manager, SIGNAL(finished(QNetworkReply *)), this, SLOT(parseOstcFwVersion(QNetworkReply *)));
+	connect(&manager, &QNetworkAccessManager::finished, this, &OstcFirmwareCheck::parseOstcFwVersion);
 	QNetworkRequest download(url);
 	manager.get(download);
 }
@@ -259,7 +258,7 @@ void OstcFirmwareCheck::parseOstcFwVersion(QNetworkReply *reply)
 	int firstOpenBracket = parse.indexOf('[');
 	int firstCloseBracket = parse.indexOf(']');
 	latestFirmwareAvailable = parse.mid(firstOpenBracket + 1, firstCloseBracket - firstOpenBracket - 1);
-	disconnect(&manager, SIGNAL(finished(QNetworkReply *)), this, SLOT(parseOstcFwVersion(QNetworkReply *)));
+	disconnect(&manager, &QNetworkAccessManager::finished, this, &OstcFirmwareCheck::parseOstcFwVersion);
 }
 
 void OstcFirmwareCheck::checkLatest(QWidget *_parent, device_data_t *data)
@@ -325,7 +324,7 @@ void OstcFirmwareCheck::upgradeFirmware()
 	if (storeFirmware.isEmpty())
 		return;
 
-	connect(&manager, SIGNAL(finished(QNetworkReply *)), this, SLOT(saveOstcFirmware(QNetworkReply *)));
+	connect(&manager, &QNetworkAccessManager::finished, this, &OstcFirmwareCheck::saveOstcFirmware);
 	QNetworkRequest download(latestFirmwareHexFile);
 	manager.get(download);
 }
@@ -344,9 +343,9 @@ void OstcFirmwareCheck::saveOstcFirmware(QNetworkReply *reply)
 	dialog->setCancelButton(0);
 	dialog->setAutoClose(true);
 	ConfigureDiveComputer *config = new ConfigureDiveComputer();
-	connect(config, SIGNAL(message(QString)), dialog, SLOT(setLabelText(QString)));
-	connect(config, SIGNAL(error(QString)), dialog, SLOT(setLabelText(QString)));
-	connect(config, SIGNAL(progress(int)), dialog, SLOT(setValue(int)));
+	connect(config, &ConfigureDiveComputer::message, dialog, &QProgressDialog::setLabelText);
+	connect(config, &ConfigureDiveComputer::error, dialog, &QProgressDialog::setLabelText);
+	connect(config, &ConfigureDiveComputer::progress, dialog, &QProgressDialog::setValue);
 	config->dc_open(&devData);
 	config->startFirmwareUpdate(storeFirmware, &devData);
 }

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -124,7 +124,7 @@ private:
 #endif
 };
 
-class OstcFirmwareCheck : QObject {
+class OstcFirmwareCheck : public QObject {
 	Q_OBJECT
 public:
 	explicit OstcFirmwareCheck(QString product);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a followup to #3003: use compile-time checked connect statements. Since I can't test this part of the code it is even more important to have compile-time checks, in case I mess things up.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn string-based into pointer-to-member-function based connect statements.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Followup to #3003.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
I can't test this!