### PR TITLE
Make device table sortable

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -210,7 +210,7 @@ bool device::operator!=(const device &a) const
 
 bool device::operator<(const device &a) const
 {
-	return std::tie(model, deviceId) < std::tie(a.model, a.deviceId);
+	return std::tie(deviceId, model) < std::tie(a.deviceId, a.model);
 }
 
 static const device *getDCExact(const QVector<device> &dcs, const divecomputer *dc)
@@ -291,17 +291,10 @@ extern "C" void clear_device_nodes()
 	device_table.devices.clear();
 }
 
-static bool compareDCById(const device &a, const device &b)
-{
-	return a.deviceId < b.deviceId;
-}
-
 extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *, uint32_t, const char *, const char *, const char *),
 				  bool select_only)
 {
-	QVector<device> values = device_table.devices;
-	std::sort(values.begin(), values.end(), compareDCById);
-	for (const device &node : values) {
+	for (const device &node : device_table.devices) {
 		bool found = false;
 		if (select_only) {
 			for (dive *d: getDiveSelection()) {

--- a/desktop-widgets/divecomputermanagementdialog.cpp
+++ b/desktop-widgets/divecomputermanagementdialog.cpp
@@ -20,7 +20,9 @@ DiveComputerManagementDialog::DiveComputerManagementDialog(QWidget *parent, Qt::
 void DiveComputerManagementDialog::init()
 {
 	model.reset(new DiveComputerModel);
-	ui.tableView->setModel(model.data());
+	proxyModel.setSourceModel(model.get());
+	ui.tableView->setModel(&proxyModel);
+	ui.tableView->setSortingEnabled(true);
 	ui.tableView->resizeColumnsToContents();
 	ui.tableView->setColumnWidth(DiveComputerModel::REMOVE, 22);
 	layout()->activate();

--- a/desktop-widgets/divecomputermanagementdialog.h
+++ b/desktop-widgets/divecomputermanagementdialog.h
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0
 #ifndef DIVECOMPUTERMANAGEMENTDIALOG_H
 #define DIVECOMPUTERMANAGEMENTDIALOG_H
-#include <QDialog>
+
 #include "ui_divecomputermanagementdialog.h"
 #include "qt-models/divecomputermodel.h"
+#include <QDialog>
+#include <memory>
 
 class QModelIndex;
 
@@ -23,7 +25,8 @@ slots:
 private:
 	explicit DiveComputerManagementDialog(QWidget *parent = 0, Qt::WindowFlags f = 0);
 	Ui::DiveComputerManagementDialog ui;
-	QScopedPointer<DiveComputerModel> model;
+	std::unique_ptr<DiveComputerModel> model;
+	DiveComputerSortedModel proxyModel;
 };
 
 #endif // DIVECOMPUTERMANAGEMENTDIALOG_H

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -4,6 +4,7 @@
 
 #include "qt-models/cleanertablemodel.h"
 #include "core/device.h"
+#include <QSortFilterProxyModel>
 
 class DiveComputerModel : public CleanerTableModel {
 	Q_OBJECT
@@ -27,6 +28,13 @@ slots:
 
 private:
 	QVector<device> dcs;
+};
+
+class DiveComputerSortedModel : public QSortFilterProxyModel {
+public:
+	using QSortFilterProxyModel::QSortFilterProxyModel;
+private:
+	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const;
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This makes the device-table sortable. This may seem like a complete waste of time, and indeed, that's not the point of the PR. The real point lies in the second commit: sort the device-table in core in the way core needs it, not how the UI wants it. Let the UI do its own sorting. Implementing arbitrary sorting then was just "low hanging fruit". Ultimately, the goal is to replace the call-back by run-of-the-mill loops.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add prox-model on top of DiveComputerModel to make the list sortable by arbitrary column
2) Sort core table according to id/model
3) Remove copy/sort of core table in call_for_each_dc()

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See previous device.cpp cleanups.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Too trivial/unimportant.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.