### PR TITLE
[TRIVIAL] cleanup: remove unused function is_default_dive_computer()

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -317,11 +317,6 @@ extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *
 	}
 }
 
-extern "C" int is_default_dive_computer(const char *vendor, const char *product)
-{
-	return qPrefDiveComputer::vendor() == vendor && qPrefDiveComputer::product() == product;
-}
-
 extern "C" int is_default_dive_computer_device(const char *name)
 {
 	return qPrefDiveComputer::device() == name;

--- a/core/display.h
+++ b/core/display.h
@@ -30,7 +30,6 @@ extern struct divecomputer *select_dc(struct dive *);
 extern unsigned int dc_number;
 
 extern int is_default_dive_computer_device(const char *);
-extern int is_default_dive_computer(const char *, const char *);
 
 typedef void (*device_callback_t)(const char *name, void *userdata);
 


### PR DESCRIPTION
The last actual user was apparently removed back in 2013(!):
34db6dc2bea6173c070c9820a2e57a511b9ca0b1

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial dead code removal - nothing more to say, really...!