### PR TITLE
build-system: switch to current libhidapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- macOS: fix issue with HID dive computers like Suunto Eon Core/Steel [#2999]
 - windows: add missing modern Vista theme
 - desktop: allow adding dives to arbitrary trips
 - core: improve merging of cylinder pressures [#2884]

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -5,7 +5,6 @@
 CURRENT_LIBZ="v1.2.11"
 CURRENT_LIBZIP="rel-1-5-1"
 CURRENT_LIBGIT2="v0.26.0"
-CURRENT_HIDAPI="hidapi-0.7.0"
 CURRENT_LIBCURL="curl-7_54_1"
 CURRENT_LIBUSB="v1.0.21"
 CURRENT_OPENSSL="OpenSSL_1_1_0h"
@@ -169,7 +168,7 @@ for package in "${PACKAGES[@]}" ; do
 			git_checkout_library googlemaps master https://github.com/Subsurface/googlemaps.git
 			;;
 		hidapi)
-			git_checkout_library hidapi master https://github.com/signal11/hidapi.git
+			git_checkout_library hidapi master https://github.com/libusb/hidapi.git
 			;;
 		kirigami)
 			git_checkout_library kirigami $CURRENT_KIRIGAMI https://github.com/KDE/kirigami.git


### PR DESCRIPTION
A few years ago the upstream for libhidapi changed - it became part of the
libusb GitHub org. Switching to the latest version appears to fix some odd
problems with talking to the Suunto Eon Steele/Core dive computers on macOS (at
least I can no longer reproduce the problem after switching to the current
version).


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Build system change


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2999 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
N/A

