### PR TITLE
More device code reshuffling

### DIFF
--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -565,7 +565,7 @@ static unsigned char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive
 		dt_dive->dc.deviceid = 0;
 	else
 		dt_dive->dc.deviceid = 0xffffffff;
-	create_device_node(dt_dive->dc.model, dt_dive->dc.deviceid, "", "", dt_dive->dc.model);
+	create_device_node(&device_table, dt_dive->dc.model, dt_dive->dc.deviceid, "", "", dt_dive->dc.model);
 	dt_dive->dc.next = NULL;
 	if (!is_SCR && dt_dive->cylinders.nr > 0) {
 		get_cylinder(dt_dive, 0)->end.mbar = get_cylinder(dt_dive, 0)->start.mbar -

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -203,11 +203,6 @@ bool device::operator==(const device &a) const
 	       nickName == a.nickName;
 }
 
-bool device::operator!=(const device &a) const
-{
-	return !(*this == a);
-}
-
 bool device::operator<(const device &a) const
 {
 	return std::tie(deviceId, model) < std::tie(a.deviceId, a.model);

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -285,27 +285,24 @@ extern "C" void clear_device_nodes()
 	device_table.devices.clear();
 }
 
+/* Returns whether the given device is used by a selected dive. */
+extern "C" bool device_used_by_selected_dive(const struct device *dev)
+{
+	for (dive *d: getDiveSelection()) {
+		struct divecomputer *dc;
+		for_each_dc (d, dc) {
+			if (dc->deviceid == dev->deviceId)
+				return true;
+		}
+	}
+	return false;
+}
+
 extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *, uint32_t, const char *, const char *, const char *),
 				  bool select_only)
 {
-	for (const device &node : device_table.devices) {
-		bool found = false;
-		if (select_only) {
-			for (dive *d: getDiveSelection()) {
-				struct divecomputer *dc;
-				for_each_dc (d, dc) {
-					if (dc->deviceid == node.deviceId) {
-						found = true;
-						break;
-					}
-				}
-				if (found)
-					break;
-			}
-		} else {
-			found = true;
-		}
-		if (found)
+	for (const device &node: device_table.devices) {
+		if (!select_only || device_used_by_selected_dive(&node))
 			callback(f, node.model.c_str(), node.deviceId, node.nickName.c_str(),
 						 node.serialNumber.c_str(), node.firmware.c_str());
 	}

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -358,3 +358,40 @@ const char *get_dc_nickname(const struct divecomputer *dc)
 	else
 		return dc->model;
 }
+
+extern "C" int nr_devices(const struct device_table *table)
+{
+	return (int)table->devices.size();
+}
+
+extern "C" const struct device *get_device(const struct device_table *table, int i)
+{
+	if (i < 0 || i > nr_devices(table))
+		return NULL;
+	return &table->devices[i];
+}
+
+extern "C" const char *device_get_model(const struct device *dev)
+{
+	return dev ? dev->model.c_str() : NULL;
+}
+
+extern "C" const uint32_t device_get_id(const struct device *dev)
+{
+	return dev ? dev->deviceId : -1;
+}
+
+extern "C" const char *device_get_serial(const struct device *dev)
+{
+	return dev ? dev->serialNumber.c_str() : NULL;
+}
+
+extern "C" const char *device_get_firmware(const struct device *dev)
+{
+	return dev ? dev->firmware.c_str() : NULL;
+}
+
+extern "C" const char *device_get_nickname(const struct device *dev)
+{
+	return dev ? dev->nickName.c_str() : NULL;
+}

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -314,10 +314,9 @@ extern "C" void set_dc_nickname(struct dive *dive, struct device_table *device_t
 		if (!empty_string(dc->model) && dc->deviceid &&
 		    !get_device_for_dc(device_table, dc)) {
 			// we don't have this one, yet
-			auto it = std::find_if(device_table->devices.begin(), device_table->devices.end(),
-					       [dc] (const device &dev)
-					       { return !strcasecmp(dev.model.c_str(), dc->model); });
-			if (it != device_table->devices.end()) {
+			if (std::any_of(device_table->devices.begin(), device_table->devices.end(),
+				        [dc] (const device &dev)
+				        { return !strcasecmp(dev.model.c_str(), dc->model); })) {
 				// we already have this model but a different deviceid
 				std::string simpleNick(dc->model);
 				if (dc->deviceid == 0)

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -213,7 +213,7 @@ bool device::operator<(const device &a) const
 	return std::tie(deviceId, model) < std::tie(a.deviceId, a.model);
 }
 
-static const device *getDCExact(const QVector<device> &dcs, const divecomputer *dc)
+static const device *getDCExact(const std::vector<device> &dcs, const divecomputer *dc)
 {
 	auto it = std::lower_bound(dcs.begin(), dcs.end(), device{dc->model, dc->deviceid, {}, {}, {}});
 	return it != dcs.end() && it->model == dc->model && it->deviceId == dc->deviceid ? &*it : NULL;
@@ -258,7 +258,7 @@ void device::showchanges(const std::string &n, const std::string &s, const std::
 		qDebug("new firmware version %s for DC model %s deviceId 0x%x", f.c_str(), model.c_str(), deviceId);
 }
 
-static void addDC(QVector<device> &dcs, const std::string &m, uint32_t d, const std::string &n, const std::string &s, const std::string &f)
+static void addDC(std::vector<device> &dcs, const std::string &m, uint32_t d, const std::string &n, const std::string &s, const std::string &f)
 {
 	if (m.empty() || d == 0)
 		return;

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -238,10 +238,14 @@ extern "C" void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid)
 	if (!node)
 		return;
 
-	if (!node->serialNumber.isEmpty() && empty_string(dc->serial))
+	if (!node->serialNumber.isEmpty() && empty_string(dc->serial)) {
+		free((void *)dc->serial);
 		dc->serial = copy_qstring(node->serialNumber);
-	if (!node->firmware.isEmpty() && empty_string(dc->fw_version))
+	}
+	if (!node->firmware.isEmpty() && empty_string(dc->fw_version)) {
+		free((void *)dc->fw_version);
 		dc->fw_version = copy_qstring(node->firmware);
+	}
 }
 
 void device::showchanges(const QString &n, const QString &s, const QString &f) const

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -205,7 +205,12 @@ bool device::operator==(const device &a) const
 
 bool device::operator<(const device &a) const
 {
-	return std::tie(deviceId, model) < std::tie(a.deviceId, a.model);
+	if (deviceId != a.deviceId)
+		return deviceId < a.deviceId;
+
+	// Use strcoll to compare model-strings, since these might be unicode
+	// and therefore locale dependent? Let's hope that not, but who knows?
+	return strcoll(model.c_str(), a.model.c_str()) < 0;
 }
 
 const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc)

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -298,16 +298,6 @@ extern "C" bool device_used_by_selected_dive(const struct device *dev)
 	return false;
 }
 
-extern "C" void call_for_each_dc (void *f, void (*callback)(void *, const char *, uint32_t, const char *, const char *, const char *),
-				  bool select_only)
-{
-	for (const device &node: device_table.devices) {
-		if (!select_only || device_used_by_selected_dive(&node))
-			callback(f, node.model.c_str(), node.deviceId, node.nickName.c_str(),
-						 node.serialNumber.c_str(), node.firmware.c_str());
-	}
-}
-
 extern "C" int is_default_dive_computer_device(const char *name)
 {
 	return qPrefDiveComputer::device() == name;

--- a/core/device.h
+++ b/core/device.h
@@ -22,8 +22,6 @@ extern void set_dc_nickname(struct dive *dive);
 extern void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
 extern int nr_devices(const struct device_table *table);
 extern const struct device *get_device(const struct device_table *table, int i);
-extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uint32_t,
-						       const char *, const char *, const char *), bool select_only);
 extern void clear_device_nodes();
 const char *get_dc_nickname(const struct divecomputer *dc);
 extern bool device_used_by_selected_dive(const struct device *dev);

--- a/core/device.h
+++ b/core/device.h
@@ -45,8 +45,7 @@ const char *device_get_nickname(const struct device *dev);
 #include <string>
 #include <vector>
 struct device {
-	bool operator==(const device &a) const;
-	bool operator!=(const device &a) const;
+	bool operator==(const device &a) const; // TODO: remove, once devices are integrated in the undo system
 	bool operator<(const device &a) const;
 	void showchanges(const std::string &n, const std::string &s, const std::string &f) const;
 	std::string model;

--- a/core/device.h
+++ b/core/device.h
@@ -26,6 +26,8 @@ extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uin
 extern void clear_device_nodes();
 const char *get_dc_nickname(const struct divecomputer *dc);
 
+extern const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc);
+
 // struct device accessors for C-code. The returned strings are not stable!
 const char *device_get_model(const struct device *dev);
 const uint32_t device_get_id(const struct device *dev);

--- a/core/device.h
+++ b/core/device.h
@@ -11,6 +11,7 @@ extern "C" {
 struct divecomputer;
 struct device;
 struct device_table;
+struct dive_table;
 
 // global device table
 extern struct device_table device_table;
@@ -25,6 +26,7 @@ extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uin
 						       const char *, const char *, const char *), bool select_only);
 extern void clear_device_nodes();
 const char *get_dc_nickname(const struct divecomputer *dc);
+extern bool device_used_by_selected_dive(const struct device *dev);
 
 extern const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc);
 

--- a/core/device.h
+++ b/core/device.h
@@ -16,6 +16,7 @@ extern void create_device_node(const char *model, uint32_t deviceid, const char 
 extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uint32_t,
 						       const char *, const char *, const char *), bool select_only);
 extern void clear_device_nodes();
+const char *get_dc_nickname(const struct divecomputer *dc);
 
 #ifdef __cplusplus
 }
@@ -24,18 +25,18 @@ extern void clear_device_nodes();
 // Functions and global variables that are only available to C++ code
 #ifdef __cplusplus
 
-#include <QString>
+#include <string>
 #include <QVector>
 struct device {
 	bool operator==(const device &a) const;
 	bool operator!=(const device &a) const;
 	bool operator<(const device &a) const;
-	void showchanges(const QString &n, const QString &s, const QString &f) const;
-	QString model;
+	void showchanges(const std::string &n, const std::string &s, const std::string &f) const;
+	std::string model;
 	uint32_t deviceId;
-	QString serialNumber;
-	QString firmware;
-	QString nickName;
+	std::string serialNumber;
+	std::string firmware;
+	std::string nickName;
 };
 
 struct device_table {
@@ -43,7 +44,6 @@ struct device_table {
 	QVector<device> devices;
 };
 
-QString get_dc_nickname(const struct divecomputer *dc);
 extern struct device_table device_table;
 
 #endif

--- a/core/device.h
+++ b/core/device.h
@@ -9,14 +9,29 @@ extern "C" {
 #endif
 
 struct divecomputer;
+struct device;
+struct device_table;
+
+// global device table
+extern struct device_table device_table;
+
 extern void fake_dc(struct divecomputer *dc);
 extern void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid);
 extern void set_dc_nickname(struct dive *dive);
 extern void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
+extern int nr_devices(const struct device_table *table);
+extern const struct device *get_device(const struct device_table *table, int i);
 extern void call_for_each_dc(void *f, void (*callback)(void *, const char *, uint32_t,
 						       const char *, const char *, const char *), bool select_only);
 extern void clear_device_nodes();
 const char *get_dc_nickname(const struct divecomputer *dc);
+
+// struct device accessors for C-code. The returned strings are not stable!
+const char *device_get_model(const struct device *dev);
+const uint32_t device_get_id(const struct device *dev);
+const char *device_get_serial(const struct device *dev);
+const char *device_get_firmware(const struct device *dev);
+const char *device_get_nickname(const struct device *dev);
 
 #ifdef __cplusplus
 }
@@ -43,8 +58,6 @@ struct device_table {
 	// Keep the dive computers in a vector sorted by (model, deviceId)
 	std::vector<device> devices;
 };
-
-extern struct device_table device_table;
 
 #endif
 

--- a/core/device.h
+++ b/core/device.h
@@ -26,7 +26,7 @@ const char *get_dc_nickname(const struct divecomputer *dc);
 #ifdef __cplusplus
 
 #include <string>
-#include <QVector>
+#include <vector>
 struct device {
 	bool operator==(const device &a) const;
 	bool operator!=(const device &a) const;
@@ -41,7 +41,7 @@ struct device {
 
 struct device_table {
 	// Keep the dive computers in a vector sorted by (model, deviceId)
-	QVector<device> devices;
+	std::vector<device> devices;
 };
 
 extern struct device_table device_table;

--- a/core/device.h
+++ b/core/device.h
@@ -17,12 +17,13 @@ struct dive_table;
 extern struct device_table device_table;
 
 extern void fake_dc(struct divecomputer *dc);
-extern void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid);
-extern void set_dc_nickname(struct dive *dive);
-extern void create_device_node(const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
+extern void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid, const struct device_table *table);
+
+extern void set_dc_nickname(struct dive *dive, struct device_table *table);
+extern void create_device_node(struct device_table *table, const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
 extern int nr_devices(const struct device_table *table);
 extern const struct device *get_device(const struct device_table *table, int i);
-extern void clear_device_nodes();
+extern void clear_device_nodes(struct device_table *table);
 const char *get_dc_nickname(const struct divecomputer *dc);
 extern bool device_used_by_selected_dive(const struct device *dev);
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -1595,7 +1595,7 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 {
 	/* Add device information to table */
 	if (dc->deviceid && (dc->serial || dc->fw_version))
-		create_device_node(dc->model, dc->deviceid, dc->serial, dc->fw_version, "");
+		create_device_node(&device_table, dc->model, dc->deviceid, dc->serial, dc->fw_version, "");
 
 	/* Fixup duration and mean depth */
 	fixup_dc_duration(dc);

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -826,7 +826,7 @@ void process_loaded_dives()
 	for_each_dive(i, dive) {
 		if (!dive->hidden_by_filter)
 			shown_dives++;
-		set_dc_nickname(dive);
+		set_dc_nickname(dive, &device_table);
 	}
 
 	sort_dive_table(&dive_table);
@@ -1161,12 +1161,13 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
 	/* check if we need a nickname for the divecomputer for newly downloaded dives;
 	 * since we know they all came from the same divecomputer we just check for the
 	 * first one */
-	if (flags & IMPORT_IS_DOWNLOADED)
-		set_dc_nickname(import_table->dives[0]);
-	else
+	if (flags & IMPORT_IS_DOWNLOADED) {
+		set_dc_nickname(import_table->dives[0], &device_table);
+	} else {
 		/* they aren't downloaded, so record / check all new ones */
 		for (i = 0; i < import_table->nr; i++)
-			set_dc_nickname(import_table->dives[i]);
+			set_dc_nickname(import_table->dives[i], &device_table);
+	}
 
 	/* Sort the table of dives to be imported and combine mergable dives */
 	sort_dive_table(import_table);
@@ -1375,7 +1376,7 @@ void clear_dive_file_data()
 	}
 
 	clear_dive(&displayed_dive);
-	clear_device_nodes();
+	clear_device_nodes(&device_table);
 	clear_events();
 	clear_filter_presets();
 

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -931,7 +931,7 @@ static unsigned int fixup_suunto_versions(device_data_t *devdata, const dc_event
 			 (devinfo->firmware >> 8) & 0xff,
 			 (devinfo->firmware >> 0) & 0xff);
 	}
-	create_device_node(devdata->model, devdata->deviceid, serial_nr, firmware, "");
+	create_device_node(&device_table, devdata->model, devdata->deviceid, serial_nr, firmware, "");
 
 	return serial;
 }

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -552,25 +552,6 @@ static uint32_t calculate_string_hash(const char *str)
 }
 
 /*
- * Find an existing device ID for this device model and serial number
- */
-static void dc_match_serial(void *_dc, const char *model, uint32_t deviceid, const char *nickname, const char *serial, const char *firmware)
-{
-	UNUSED(nickname);
-	UNUSED(firmware);
-
-	struct divecomputer *dc = _dc;
-
-	if (!deviceid)
-		return;
-	if (!dc->model || !model || strcasecmp(dc->model, model))
-		return;
-	if (!dc->serial || !serial || strcasecmp(dc->serial, serial))
-		return;
-	dc->deviceid = deviceid;
-}
-
-/*
  * Set the serial number.
  *
  * This also sets the device ID by looking for existing devices that
@@ -581,8 +562,12 @@ static void dc_match_serial(void *_dc, const char *model, uint32_t deviceid, con
  */
 static void set_dc_serial(struct divecomputer *dc, const char *serial)
 {
+	const struct device *device;
+
 	dc->serial = serial;
-	call_for_each_dc(dc, dc_match_serial, false);
+	if ((device = get_device_for_dc(&device_table, dc)) != NULL)
+		dc->deviceid = device_get_id(device);
+
 	if (!dc->deviceid)
 		dc->deviceid = calculate_string_hash(serial);
 }

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -712,7 +712,7 @@ static void parse_dc_date(char *line, struct membuffer *str, struct git_parser_s
 { UNUSED(str); update_date(&state->active_dc->when, line); }
 
 static void parse_dc_deviceid(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); set_dc_deviceid(state->active_dc, get_hex(line)); }
+{ UNUSED(str); set_dc_deviceid(state->active_dc, get_hex(line), &device_table); }
 
 static void parse_dc_diveid(char *line, struct membuffer *str, struct git_parser_state *state)
 { UNUSED(str); state->active_dc->diveid = get_hex(line); }
@@ -1000,7 +1000,7 @@ static void parse_settings_divecomputerid(char *line, struct membuffer *str, str
 			break;
 		line = parse_keyvalue_entry(parse_divecomputerid_keyvalue, &id, line, str);
 	}
-	create_device_node(id.model, id.deviceid, id.serial, id.firmware, id.nickname);
+	create_device_node(&device_table, id.model, id.deviceid, id.serial, id.firmware, id.nickname);
 }
 
 static void parse_picture_filename(char *line, struct membuffer *str, struct git_parser_state *state)

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -829,7 +829,7 @@ static void try_to_fill_dc(struct divecomputer *dc, const char *name, char *buf,
 	if (MATCH("model", utf8_string, &dc->model))
 		return;
 	if (MATCH("deviceid", hex_value, &deviceid)) {
-		set_dc_deviceid(dc, deviceid);
+		set_dc_deviceid(dc, deviceid, &device_table);
 		return;
 	}
 	if (MATCH("diveid", hex_value, &dc->diveid))

--- a/core/parse.c
+++ b/core/parse.c
@@ -201,7 +201,7 @@ void dc_settings_start(struct parser_state *state)
 
 void dc_settings_end(struct parser_state *state)
 {
-	create_device_node(state->cur_settings.dc.model, state->cur_settings.dc.deviceid, state->cur_settings.dc.serial_nr,
+	create_device_node(&device_table, state->cur_settings.dc.model, state->cur_settings.dc.deviceid, state->cur_settings.dc.serial_nr,
 			   state->cur_settings.dc.firmware, state->cur_settings.dc.nickname);
 	reset_dc_settings(state);
 }

--- a/qt-models/divecomputermodel.cpp
+++ b/qt-models/divecomputermodel.cpp
@@ -20,9 +20,9 @@ QVariant DiveComputerModel::data(const QModelIndex &index, int role) const
 		case ID:
 			return QString("0x").append(QString::number(node.deviceId, 16));
 		case MODEL:
-			return node.model;
+			return QString::fromStdString(node.model);
 		case NICKNAME:
-			return node.nickName;
+			return QString::fromStdString(node.nickName);
 		}
 	}
 
@@ -59,7 +59,7 @@ bool DiveComputerModel::setData(const QModelIndex &index, const QVariant &value,
 		return false;
 
 	device &node = dcs[index.row()];
-	node.nickName = value.toString();
+	node.nickName = value.toString().toStdString();
 	emit dataChanged(index, index);
 	return true;
 }

--- a/qt-models/divecomputermodel.cpp
+++ b/qt-models/divecomputermodel.cpp
@@ -11,7 +11,7 @@ DiveComputerModel::DiveComputerModel(QObject *parent) : CleanerTableModel(parent
 
 QVariant DiveComputerModel::data(const QModelIndex &index, int role) const
 {
-	if (index.row() < 0 || index.row() >= dcs.size())
+	if (index.row() < 0 || index.row() >= (int)dcs.size())
 		return QVariant();
 	const device &node = dcs[index.row()];
 
@@ -55,7 +55,7 @@ Qt::ItemFlags DiveComputerModel::flags(const QModelIndex &index) const
 bool DiveComputerModel::setData(const QModelIndex &index, const QVariant &value, int)
 {
 	// We should test if the role == Qt::EditRole
-	if (index.row() < 0 || index.row() >= dcs.size())
+	if (index.row() < 0 || index.row() >= (int)dcs.size())
 		return false;
 
 	device &node = dcs[index.row()];
@@ -66,10 +66,10 @@ bool DiveComputerModel::setData(const QModelIndex &index, const QVariant &value,
 
 void DiveComputerModel::remove(const QModelIndex &index)
 {
-	if (index.row() < 0 || index.row() >= dcs.size())
+	if (index.row() < 0 || index.row() >= (int)dcs.size())
 		return;
 	beginRemoveRows(QModelIndex(), index.row(), index.row());
-	dcs.remove(index.row());
+	dcs.erase(dcs.begin() + index.row());
 	endRemoveRows();
 }
 

--- a/qt-models/divecomputermodel.h
+++ b/qt-models/divecomputermodel.h
@@ -27,7 +27,7 @@ slots:
 	void remove(const QModelIndex &index);
 
 private:
-	QVector<device> dcs;
+	std::vector<device> dcs;
 };
 
 class DiveComputerSortedModel : public QSortFilterProxyModel {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Continued work to unglobalize parser and downloader-state. This makes the device-list accessible from C and adds device-table pointers to functions. Thus, every place that accesses the global device-table can now be easily grep-ed for.

To make things accessible from C, turn QStrings into UTF8 std::strings. The latter are stored as C strings and don't have to be converted. However, that requires more defensive code, since you can't construct an std::string with a null-pointer.

This also contains a functional change: models are now compared as case-insensitive for consistency with the old code in core/libdivecomputer.cpp

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

See previous changes.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

This needs some testing! I will test the export-part in the upcoming days, but I can't easily test the download from different devices of the same model part.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh