### PR TITLE
parser: fix potential crash when parsing DAN files(?)

### DIFF
--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -104,8 +104,8 @@ static char *parse_dan_new_line(char *buf, const char *NL)
 
 static int try_to_xslt_open_csv(const char *filename, struct memblock *mem, const char *tag);
 static int parse_dan_format(const char *filename, char **params, int pnr, struct dive_table *table,
-			    struct trip_table *trips, filter_preset_table_t *filter_presets,
-			    struct dive_site_table *sites)
+			    struct trip_table *trips, struct dive_site_table *sites,
+			    filter_preset_table_t *filter_presets)
 {
 	int ret = 0, i;
 	size_t end_ptr = 0;


### PR DESCRIPTION
The last two parameters of the parse_dan_format() function were
mixed up: sites should come before filter_presets.

This should have caused crashes, for DAN files with dive sites.
I don't understand why this didn't cause compiler warnings.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In my opinion, this should fix a crash when importing DAN files with dive-sites (is there such a thing?).
However, what I really don't understand here: why don't I get compiler warnings - neither with gcc nor clang? Am I missing something?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix parameters in parse_dan_format()

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: Can you explain the lack of compiler warnings!?