### PR TITLE
Cleanup: make filter_preset_table a regular struct

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -18,7 +18,7 @@ void addDive(dive *d, bool autogroup, bool newNumber)
 }
 
 void importDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites,
-		 filter_preset_table_t *presets, int flags, const QString &source)
+		 struct filter_preset_table *presets, int flags, const QString &source)
 {
 	execute(new ImportDives(dives, trips, sites, presets, flags, source));
 }

--- a/commands/command.h
+++ b/commands/command.h
@@ -33,7 +33,7 @@ QString changesMade();			// return a string with the texts from all commands on 
 // insertion position.
 void addDive(dive *d, bool autogroup, bool newNumber);
 void importDives(struct dive_table *dives, struct trip_table *trips,
-		 struct dive_site_table *sites, filter_preset_table_t *filter_presets,
+		 struct dive_site_table *sites, struct filter_preset_table *filter_presets,
 		 int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);
 void shiftTime(const std::vector<dive *> &changedDives, int amount);

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -470,7 +470,7 @@ void AddDive::undoit()
 }
 
 ImportDives::ImportDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites,
-			 filter_preset_table_t *filter_presets, int flags, const QString &source)
+			 struct filter_preset_table *filter_presets, int flags, const QString &source)
 {
 	setText(Command::Base::tr("import %n dive(s) from %1", "", dives->nr).arg(source));
 

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -99,7 +99,7 @@ class ImportDives : public DiveListBase {
 public:
 	// Note: dives and trips are consumed - after the call they will be empty.
 	ImportDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites,
-		    filter_preset_table_t *filter_presets, int flags, const QString &source);
+		    struct filter_preset_table *filter_presets, int flags, const QString &source);
 private:
 	void undoit() override;
 	void redoit() override;

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -285,7 +285,7 @@ extern "C" void create_device_node(struct device_table *device_table, const char
 	addDC(device_table->devices, model ?: "", deviceid, nickname ?: "", serial ?: "", firmware ?: "");
 }
 
-extern "C" void clear_device_nodes(struct device_table *device_table)
+extern "C" void clear_device_table(struct device_table *device_table)
 {
 	device_table->devices.clear();
 }

--- a/core/device.h
+++ b/core/device.h
@@ -23,7 +23,7 @@ extern void set_dc_nickname(struct dive *dive, struct device_table *table);
 extern void create_device_node(struct device_table *table, const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
 extern int nr_devices(const struct device_table *table);
 extern const struct device *get_device(const struct device_table *table, int i);
-extern void clear_device_nodes(struct device_table *table);
+extern void clear_device_table(struct device_table *table);
 const char *get_dc_nickname(const struct divecomputer *dc);
 extern bool device_used_by_selected_dive(const struct device *dev);
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1376,7 +1376,7 @@ void clear_dive_file_data()
 	}
 
 	clear_dive(&displayed_dive);
-	clear_device_nodes(&device_table);
+	clear_device_table(&device_table);
 	clear_events();
 	clear_filter_presets();
 

--- a/core/file.c
+++ b/core/file.c
@@ -77,7 +77,7 @@ out:
 
 
 static void zip_read(struct zip_file *file, const char *filename, struct dive_table *table, struct trip_table *trips,
-		     struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+		     struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	int size = 1024, n, read = 0;
 	char *mem = malloc(size);
@@ -93,7 +93,7 @@ static void zip_read(struct zip_file *file, const char *filename, struct dive_ta
 }
 
 int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		    filter_preset_table_t *filter_presets)
+		    struct filter_preset_table *filter_presets)
 {
 	int success = 0;
 	/* Grr. libzip needs to re-open the file, it can't take a buffer */
@@ -227,7 +227,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
  */
 static int open_by_filename(const char *filename, const char *fmt, struct memblock *mem,
 			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-			    filter_preset_table_t *filter_presets)
+			    struct filter_preset_table *filter_presets)
 {
 	// hack to be able to provide a comment for the translated string
 	static char *csv_warning = QT_TRANSLATE_NOOP3("gettextFromC",
@@ -258,7 +258,7 @@ static int open_by_filename(const char *filename, const char *fmt, struct memblo
 }
 
 static int parse_file_buffer(const char *filename, struct memblock *mem, struct dive_table *table,
-			     struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+			     struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	char *fmt = strrchr(filename, '.');
@@ -305,7 +305,7 @@ int check_git_sha(const char *filename, struct git_repository **git_p, const cha
 	return 1;
 }
 
-int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	struct git_repository *git;
 	const char *branch = NULL;

--- a/core/file.h
+++ b/core/file.h
@@ -26,8 +26,8 @@ extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct
 extern void ostctools_import(const char *file, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 extern int readfile(const char *filename, struct memblock *mem);
-extern int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets);
-extern int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets);
+extern int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+extern int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 
 // Platform specific functions
 extern int subsurface_rename(const char *path, const char *newpath);

--- a/core/filterpreset.cpp
+++ b/core/filterpreset.cpp
@@ -3,7 +3,7 @@
 #include "qthelper.h"
 #include "subsurface-string.h"
 
-std::vector<filter_preset> filter_preset_table;
+struct filter_preset_table filter_preset_table;
 
 extern "C" void clear_filter_presets(void)
 {
@@ -74,7 +74,7 @@ extern "C" void filter_preset_set_name(struct filter_preset *preset, const char 
 	preset->name = name;
 }
 
-static int filter_preset_add_to_table(const QString &name, const FilterData &d, filter_preset_table_t &table)
+static int filter_preset_add_to_table(const QString &name, const FilterData &d, struct filter_preset_table &table)
 {
 	// std::lower_bound does a binary search - the vector must be sorted.
 	filter_preset newEntry { name, d };
@@ -86,7 +86,7 @@ static int filter_preset_add_to_table(const QString &name, const FilterData &d, 
 }
 
 // Take care that the name doesn't already exist by adding numbers
-static QString get_unique_preset_name(const QString &orig, const filter_preset_table_t &table)
+static QString get_unique_preset_name(const QString &orig, const struct filter_preset_table &table)
 {
 	QString res = orig;
 	int count = 2;
@@ -99,7 +99,7 @@ static QString get_unique_preset_name(const QString &orig, const filter_preset_t
 	return res;
 }
 
-extern "C" void add_filter_preset_to_table(const struct filter_preset *preset, filter_preset_table_t *table)
+extern "C" void add_filter_preset_to_table(const struct filter_preset *preset, struct filter_preset_table *table)
 {
 	QString name = get_unique_preset_name(preset->name, *table);
 	filter_preset_add_to_table(name, preset->data, *table);

--- a/core/filterpreset.h
+++ b/core/filterpreset.h
@@ -24,12 +24,18 @@ struct filter_preset {
 	FilterData data;
 };
 
-using filter_preset_table_t = std::vector<filter_preset>;
-extern filter_preset_table_t filter_preset_table;
+// Subclassing standard library containers is generally
+// not recommended. However, this makes interaction with
+// C-code easier and since we don't add any member functions,
+// this is not a problem.
+struct filter_preset_table : public std::vector<filter_preset>
+{
+};
+
+extern struct filter_preset_table filter_preset_table;
 #else
 struct filter_preset;
 struct filter_preset_table;
-typedef struct filter_preset_table filter_preset_table_t;
 #endif
 
 
@@ -49,7 +55,7 @@ extern struct filter_preset *alloc_filter_preset();
 extern void free_filter_preset(const struct filter_preset *preset);
 extern void filter_preset_set_name(struct filter_preset *preset, const char *name);
 extern void filter_preset_set_fulltext(struct filter_preset *preset, const char *fulltext, const char *fulltext_string_mode);
-extern void add_filter_preset_to_table(const struct filter_preset *preset, filter_preset_table_t *table);
+extern void add_filter_preset_to_table(const struct filter_preset *preset, struct filter_preset_table *table);
 extern void filter_preset_add_constraint(struct filter_preset *preset, const char *type, const char *string_mode,
 					 const char *range_mode, bool negate, const char *data); // called by the parser, therefore data passed as strings.
 

--- a/core/filterpreset.h
+++ b/core/filterpreset.h
@@ -28,7 +28,8 @@ using filter_preset_table_t = std::vector<filter_preset>;
 extern filter_preset_table_t filter_preset_table;
 #else
 struct filter_preset;
-typedef void filter_preset_table_t;
+struct filter_preset_table;
+typedef struct filter_preset_table filter_preset_table_t;
 #endif
 
 

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -21,7 +21,7 @@ extern int check_git_sha(const char *filename, git_repository **git_p, const cha
 extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
 extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
 extern int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
-			  struct dive_site_table *sites, filter_preset_table_t *filter_presets);
+			  struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
 extern const char *saved_git_id;

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -105,7 +105,7 @@ static char *parse_dan_new_line(char *buf, const char *NL)
 static int try_to_xslt_open_csv(const char *filename, struct memblock *mem, const char *tag);
 static int parse_dan_format(const char *filename, char **params, int pnr, struct dive_table *table,
 			    struct trip_table *trips, struct dive_site_table *sites,
-			    filter_preset_table_t *filter_presets)
+			    struct filter_preset_table *filter_presets)
 {
 	int ret = 0, i;
 	size_t end_ptr = 0;
@@ -286,7 +286,7 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 
 int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
 		   struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		   filter_preset_table_t *filter_presets)
+		   struct filter_preset_table *filter_presets)
 {
 	int ret, i;
 	struct memblock mem;
@@ -808,8 +808,8 @@ int parse_txt_file(const char *filename, const char *csv, struct dive_table *tab
 
 #define SBPARAMS 40
 static int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
-				  struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets);
-int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+				  struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	char *params[SBPARAMS];
 	int pnr = 0;
@@ -826,7 +826,7 @@ int parse_seabear_log(const char *filename, struct dive_table *table, struct tri
 
 static int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
 				  struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-				  filter_preset_table_t *filter_presets)
+				  struct filter_preset_table *filter_presets)
 {
 	int ret, i;
 	struct memblock mem;
@@ -954,7 +954,7 @@ static int parse_seabear_csv_file(const char *filename, char **params, int pnr, 
 }
 
 int parse_manual_file(const char *filename, char **params, int pnr, struct dive_table *table, struct trip_table *trips,
-		      struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+		      struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	struct memblock mem;
 	time_t now;

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -24,14 +24,14 @@ extern "C" {
 #endif
 
 int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate, struct dive_table *table,
-		   struct trip_table *trips, struct dive_site_table *sites, filter_preset_table_t *filter_presets);
+		   struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 int try_to_open_csv(struct memblock *mem, enum csv_format type, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 int parse_txt_file(const char *filename, const char *csv, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     filter_preset_table_t *filter_presets);
+		     struct filter_preset_table *filter_presets);
 int parse_manual_file(const char *filename, char **params, int pnr, struct dive_table *table, struct trip_table *trips,
-		      struct dive_site_table *sites, filter_preset_table_t *filter_presets);
+		      struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 
 #ifdef __cplusplus
 }

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -47,7 +47,7 @@ struct git_parser_state {
 	struct dive_table *table;
 	struct trip_table *trips;
 	struct dive_site_table *sites;
-	filter_preset_table_t *filter_presets;
+	struct filter_preset_table *filter_presets;
 	int o2pressure_sensor;
 };
 
@@ -1879,7 +1879,7 @@ const char *get_sha(git_repository *repo, const char *branch)
  * or report an error and return 1 if the load failed.
  */
 int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
-		   struct dive_site_table *sites, filter_preset_table_t *filter_presets)
+		   struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	struct git_parser_state state = { 0 };

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1721,7 +1721,7 @@ static const char *preprocess_divelog_de(const char *buffer)
 
 int parse_xml_buffer(const char *url, const char *buffer, int size,
 		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     filter_preset_table_t *filter_presets, const char **params)
+		     struct filter_preset_table *filter_presets, const char **params)
 {
 	UNUSED(size);
 	xmlDoc *doc;

--- a/core/parse.h
+++ b/core/parse.h
@@ -73,10 +73,10 @@ struct parser_state {
 	int sample_rate;
 	struct extra_data cur_extra_data;
 	struct units xml_parsing_units;
-	struct dive_table *target_table;	/* non-owning */
-	struct trip_table *trips;		/* non-owning */
-	struct dive_site_table *sites;		/* non-owning */
-	filter_preset_table_t *filter_presets;	/* non-owning */
+	struct dive_table *target_table;		/* non-owning */
+	struct trip_table *trips;			/* non-owning */
+	struct dive_site_table *sites;			/* non-owning */
+	struct filter_preset_table *filter_presets;	/* non-owning */
 
 	sqlite3 *sql_handle;			/* for SQL based parsers */
 	event_allocation_t event_allocation;
@@ -140,7 +140,7 @@ int atoi_n(char *ptr, unsigned int len);
 
 void parse_xml_init(void);
 int parse_xml_buffer(const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     filter_preset_table_t *filter_presets, const char **params);
+		     struct filter_preset_table *filter_presets, const char **params);
 void parse_xml_exit(void);
 int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -909,7 +909,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QStringList r = resultModel->result();
 	if (ui->knownImports->currentText() != "Manual import") {
 		for (int i = 0; i < fileNames.size(); ++i) {

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1644,10 +1644,11 @@ void MainWindow::on_actionImportDiveSites_triggered()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct filter_preset_table filter_presets;
 
 	for (const QString &s: fileNames) {
 		QByteArray fileNamePtr = QFile::encodeName(s);
-		parse_file(fileNamePtr.data(), &table, &trips, &sites, &filter_preset_table);
+		parse_file(fileNamePtr.data(), &table, &trips, &sites, &filter_presets);
 	}
 	// The imported dive sites still have pointers to imported dives - remove them
 	for (int i = 0; i < sites.nr; ++i)

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1549,7 +1549,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -456,7 +456,7 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 		struct dive_table table = empty_dive_table;
 		struct trip_table trips = empty_trip_table;
 		struct dive_site_table sites = empty_dive_site_table;
-		filter_preset_table_t filter_presets;
+		struct filter_preset_table filter_presets;
 		parse_file(QFile::encodeName(zipFile.fileName()), &table, &trips, &sites, &filter_presets);
 		Command::importDives(&table, &trips, &sites, nullptr, IMPORT_MERGE_ALL_TRIPS, QStringLiteral("divelogs.de"));
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -451,7 +451,7 @@ void QMLManager::mergeLocalRepo()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &filter_presets);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 }
@@ -2236,7 +2236,7 @@ void QMLManager::importCacheRepo(QString repo)
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QString repoPath = QString("%1/cloudstorage/%2").arg(system_default_directory()).arg(repo);
 	appendTextToLog(QString("importing %1").arg(repoPath));
 	parse_file(qPrintable(repoPath), &table, &trips, &sites, &filter_presets);

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -25,7 +25,7 @@ void TestMerge::testMergeEmpty()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &filter_presets), 0);
@@ -52,7 +52,7 @@ void TestMerge::testMergeBackwards()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &filter_presets), 0);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -17,7 +17,7 @@ void TestRenumber::testMerge()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table, &trips, &sites, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 1);
@@ -30,7 +30,7 @@ void TestRenumber::testMergeAndAppend()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
-	filter_preset_table_t filter_presets;
+	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table, &trips, &sites, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 2);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This makes `filter_preset_table` an anonymous struct instead of void in C code, so that warnings are generated when passing the wrong arguments. Moreover, remove the typedef `filter_preset_table_t`, since we generally don't use that for the other tables.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) make `filter_preset_table` an anonymous struct.
2) remove `filter_preset_table_t` typedef.
