### PR TITLE
Refactor the xml-params code

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -189,6 +189,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	worldmap-options.h
 	worldmap-save.c
 	worldmap-save.h
+	xmlparams.cpp
+	xmlparams.h
 	xmp_parser.cpp
 	xmp_parser.h
 

--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -13,6 +13,7 @@
 #include "gettext.h"
 #include "import-csv.h"
 #include "qthelper.h"
+#include "xmlparams.h"
 
 #define MATCH(buffer, pattern) \
 	memcmp(buffer, pattern, strlen(pattern))
@@ -103,7 +104,7 @@ static char *parse_dan_new_line(char *buf, const char *NL)
 }
 
 static int try_to_xslt_open_csv(const char *filename, struct memblock *mem, const char *tag);
-static int parse_dan_format(const char *filename, char **params, int pnr, struct dive_table *table,
+static int parse_dan_format(const char *filename, struct xml_params *params, struct dive_table *table,
 			    struct trip_table *trips, struct dive_site_table *sites,
 			    struct filter_preset_table *filter_presets)
 {
@@ -111,9 +112,10 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 	size_t end_ptr = 0;
 	struct memblock mem, mem_csv;
 	char tmpbuf[MAXCOLDIGITS];
+	int params_orig_size = xml_params_count(params);
 
 	char *ptr = NULL;
-	char *NL = NULL;
+	const char *NL = NULL;
 	char *iter = NULL;
 
 	if (readfile(filename, &mem) < 0)
@@ -130,8 +132,8 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 	}
 
 	while ((end_ptr < mem.size) && (ptr = strstr(mem.buffer + end_ptr, "ZDH"))) {
+		xml_params_resize(params, params_orig_size); // restart with original parameter block
 		char *iter_end = NULL;
-		unsigned int pnr_local = pnr;
 
 		mem_csv.buffer = malloc(mem.size + 1);
 		mem_csv.size = mem.size;
@@ -141,8 +143,7 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 		if (iter) {
 			memcpy(tmpbuf, ptr + 4, iter - ptr - 4);
 			tmpbuf[iter - ptr - 4] = 0;
-			params[pnr_local++] = "diveNro";
-			params[pnr_local++] = strdup(tmpbuf);
+			xml_params_add(params, "diveNro", tmpbuf);
 		}
 
 		//fprintf(stderr, "DEBUG: BEGIN end_ptr %d round %d <%s>\n", end_ptr, j++, ptr);
@@ -161,8 +162,7 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 		/* Setting date */
 		memcpy(tmpbuf, iter, 8);
 		tmpbuf[8] = 0;
-		params[pnr_local++] = "date";
-		params[pnr_local++] = strdup(tmpbuf);
+		xml_params_add(params, "date", tmpbuf);
 
 		/* Setting time, gotta prepend it with 1 to
 		 * avoid octal parsing (this is stripped out in
@@ -170,8 +170,7 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 		tmpbuf[0] = '1';
 		memcpy(tmpbuf + 1, iter + 8, 6);
 		tmpbuf[7] = 0;
-		params[pnr_local++] = "time";
-		params[pnr_local++] = strdup(tmpbuf);
+		xml_params_add(params, "time", tmpbuf);
 
 		/* Air temperature */
 		memset(tmpbuf, 0, sizeof(tmpbuf));
@@ -183,11 +182,9 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 
 			if (iter_end) {
 				memcpy(tmpbuf, iter, iter_end - iter);
-				params[pnr_local++] = "airTemp";
-				params[pnr_local++] = strdup(tmpbuf);
+				xml_params_add(params, "airTemp", tmpbuf);
 			}
 		}
-		params[pnr_local] = NULL;
 
 		/* Search for the next line */
 		if (iter)
@@ -210,12 +207,10 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 
 				if (iter_end) {
 					memcpy(tmpbuf, iter, iter_end - iter);
-					params[pnr_local++] = "waterTemp";
-					params[pnr_local++] = strdup(tmpbuf);
+					xml_params_add(params, "waterTemp", tmpbuf);
 				}
 			}
-			params[pnr_local] = NULL;
-			ret |= parse_xml_buffer(filename, "<csv></csv>", 11, table, trips, sites, filter_presets, (const char **)params);
+			ret |= parse_xml_buffer(filename, "<csv></csv>", 11, table, trips, sites, filter_presets, params);
 			continue;
 		}
 
@@ -262,29 +257,25 @@ static int parse_dan_format(const char *filename, char **params, int pnr, struct
 
 				if (iter_end) {
 					memcpy(tmpbuf, iter, iter_end - iter);
-					params[pnr_local++] = "waterTemp";
-					params[pnr_local++] = strdup(tmpbuf);
+					xml_params_add(params, "waterTemp", tmpbuf);
 				}
 			}
-			params[pnr_local] = NULL;
 		}
 
 		if (try_to_xslt_open_csv(filename, &mem_csv, "csv"))
 			return -1;
 
-		ret |= parse_xml_buffer(filename, mem_csv.buffer, mem_csv.size, table, trips, sites, filter_presets, (const char **)params);
+		ret |= parse_xml_buffer(filename, mem_csv.buffer, mem_csv.size, table, trips, sites, filter_presets, params);
 		end_ptr += ptr - (char *)mem_csv.buffer;
 		free(mem_csv.buffer);
 	}
 
 	free(mem.buffer);
-	for (i = 0; params[i]; i += 2)
-		free(params[i + 1]);
 
 	return ret;
 }
 
-int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
+int parse_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate,
 		   struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
 		   struct filter_preset_table *filter_presets)
 {
@@ -306,22 +297,19 @@ int parse_csv_file(const char *filename, char **params, int pnr, const char *csv
 
 	mem.size = 0;
 	if (!strcmp("DL7", csvtemplate)) {
-		return parse_dan_format(filename, params, pnr, table, trips, sites, filter_presets);
-	} else if (strcmp(params[0], "date")) {
+		return parse_dan_format(filename, params, table, trips, sites, filter_presets);
+	} else if (strcmp(xml_params_get_key(params, 0), "date")) {
 		time(&now);
 		timep = localtime(&now);
 
 		strftime(tmpbuf, MAXCOLDIGITS, "%Y%m%d", timep);
-		params[pnr++] = "date";
-		params[pnr++] = strdup(tmpbuf);
+		xml_params_add(params, "date", tmpbuf);
 
 		/* As the parameter is numeric, we need to ensure that the leading zero
 		 * is not discarded during the transform, thus prepend time with 1 */
 
 		strftime(tmpbuf, MAXCOLDIGITS, "1%H%M", timep);
-		params[pnr++] = "time";
-		params[pnr++] = strdup(tmpbuf);
-		params[pnr++] = NULL;
+		xml_params_add(params, "time", tmpbuf);
 	}
 
 	if (try_to_xslt_open_csv(filename, &mem, csvtemplate))
@@ -336,16 +324,14 @@ int parse_csv_file(const char *filename, char **params, int pnr, const char *csv
 #ifndef SUBSURFACE_MOBILE
 	if (verbose >= 2) {
 		fprintf(stderr, "(echo '<csv>'; cat %s;echo '</csv>') | xsltproc ", filename);
-		for (i=0; params[i]; i+=2)
-			fprintf(stderr, "--stringparam %s %s ", params[i], params[i+1]);
+		for (i = 0; i < xml_params_count(params); i++)
+			fprintf(stderr, "--stringparam %s %s ", xml_params_get_key(params, i), xml_params_get_value(params, i));
 		fprintf(stderr, "%s/xslt/%s -\n", SUBSURFACE_SOURCE, csvtemplate);
 	}
 #endif
-	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, (const char **)params);
+	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, params);
 
 	free(mem.buffer);
-	for (i = 0; params[i]; i += 2)
-		free(params[i + 1]);
 
 	return ret;
 }
@@ -807,24 +793,23 @@ int parse_txt_file(const char *filename, const char *csv, struct dive_table *tab
 #define TIMESTR 6
 
 #define SBPARAMS 40
-static int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
+static int parse_seabear_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate,
 				  struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
-	char *params[SBPARAMS];
-	int pnr = 0;
+	struct xml_params *params = alloc_xml_params();
+	int ret;
 
-	pnr = parse_seabear_header(filename, params, pnr);
+	parse_seabear_header(filename, params);
+	ret = parse_seabear_csv_file(filename, params, "csv", table, trips, sites, filter_presets) < 0 ? -1 : 0;
 
-	if (parse_seabear_csv_file(filename, params, pnr, "csv", table, trips, sites, filter_presets) < 0) {
-		return -1;
-	}
+	free_xml_params(params);
 
-	return 0;
+	return ret;
 }
 
 
-static int parse_seabear_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate,
+static int parse_seabear_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate,
 				  struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
 				  struct filter_preset_table *filter_presets)
 {
@@ -847,15 +832,12 @@ static int parse_seabear_csv_file(const char *filename, char **params, int pnr, 
 	timep = localtime(&now);
 
 	strftime(tmpbuf, MAXCOLDIGITS, "%Y%m%d", timep);
-	params[pnr++] = "date";
-	params[pnr++] = strdup(tmpbuf);
+	xml_params_add(params, "date", tmpbuf);
 
 	/* As the parameter is numeric, we need to ensure that the leading zero
 	* is not discarded during the transform, thus prepend time with 1 */
 	strftime(tmpbuf, MAXCOLDIGITS, "1%H%M", timep);
-	params[pnr++] = "time";
-	params[pnr++] = strdup(tmpbuf);
-
+	xml_params_add(params, "time", tmpbuf);
 
 	if (filename == NULL)
 		return report_error("No CSV filename");
@@ -879,8 +861,9 @@ static int parse_seabear_csv_file(const char *filename, char **params, int pnr, 
 			NL = "\n";
 		}
 		ptr_old += 2;
-	} else
+	} else {
 		ptr_old += 4;
+	}
 
 	/*
 	 * If file does not contain empty lines, it is not a valid
@@ -905,25 +888,26 @@ static int parse_seabear_csv_file(const char *filename, char **params, int pnr, 
 	 */
 
 	if (ptr) {
-		ptr += strlen(NL) + 2;
 		/*
-		 * pnr is the index of NULL on the params as filled by
-		 * the init function. The two last entries should be
-		 * date and time. Here we overwrite them with the data
-		 * from the CSV header.
+		 * The two last entries should be date and time.
+		 * Here we overwrite them with the data from the
+		 * CSV header.
 		 */
+		char buf[10];
 
-		memcpy(params[pnr - 3], ptr, 4);
-		memcpy(params[pnr - 3] + 4, ptr + 5, 2);
-		memcpy(params[pnr - 3] + 6, ptr + 8, 2);
-		params[pnr - 3][8] = 0;
+		ptr += strlen(NL) + 2;
+		memcpy(buf, ptr, 4);
+		memcpy(buf + 4, ptr + 5, 2);
+		memcpy(buf + 6, ptr + 8, 2);
+		buf[8] = 0;
+		xml_params_set_value(params, xml_params_count(params) - 2, buf);
 
-		memcpy(params[pnr - 1] + 1, ptr + 11, 2);
-		memcpy(params[pnr - 1] + 3, ptr + 14, 2);
-		params[pnr - 1][5] = 0;
+		buf[0] = xml_params_get_value(params, xml_params_count(params) - 1)[0];
+		memcpy(buf + 1, ptr + 11, 2);
+		memcpy(buf + 3, ptr + 14, 2);
+		buf[5] = 0;
+		xml_params_set_value(params, xml_params_count(params) - 1, buf);
 	}
-
-	params[pnr++] = NULL;
 
 	/* Move the CSV data to the start of mem buffer */
 	memmove(mem.buffer, ptr_old, mem.size - (ptr_old - (char*)mem.buffer));
@@ -940,20 +924,18 @@ static int parse_seabear_csv_file(const char *filename, char **params, int pnr, 
 
 	if (verbose >= 2) {
 		fprintf(stderr, "xsltproc ");
-		for (i=0; params[i]; i+=2)
-			fprintf(stderr, "--stringparam %s %s ", params[i], params[i+1]);
+		for (i = 0; i < xml_params_count(params); i++)
+			fprintf(stderr, "--stringparam %s %s ", xml_params_get_key(params, i), xml_params_get_value(params, i));
 		fprintf(stderr, "xslt/csv2xml.xslt\n");
 	}
 
-	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, (const char **)params);
+	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, params);
 	free(mem.buffer);
-	for (i = 0; params[i]; i += 2)
-		free(params[i + 1]);
 
 	return ret;
 }
 
-int parse_manual_file(const char *filename, char **params, int pnr, struct dive_table *table, struct trip_table *trips,
+int parse_manual_file(const char *filename, struct xml_params *params, struct dive_table *table, struct trip_table *trips,
 		      struct dive_site_table *sites, struct filter_preset_table *filter_presets)
 {
 	struct memblock mem;
@@ -972,11 +954,8 @@ int parse_manual_file(const char *filename, char **params, int pnr, struct dive_
 	* is not discarded during the transform, thus prepend time with 1 */
 	strftime(curtime, TIMESTR, "1%H%M", timep);
 
-	params[pnr++] = strdup("date");
-	params[pnr++] = strdup(curdate);
-	params[pnr++] = strdup("time");
-	params[pnr++] = strdup(curtime);
-	params[pnr++] = NULL;
+	xml_params_add(params, "date", curdate);
+	xml_params_add(params, "time", curtime);
 
 	if (filename == NULL)
 		return report_error("No manual CSV filename");
@@ -988,15 +967,13 @@ int parse_manual_file(const char *filename, char **params, int pnr, struct dive_
 #ifndef SUBSURFACE_MOBILE
 	if (verbose >= 2) {
 		fprintf(stderr, "(echo '<manualCSV>'; cat %s;echo '</manualCSV>') | xsltproc ", filename);
-		for (i=0; params[i]; i+=2)
-			fprintf(stderr, "--stringparam %s %s ", params[i], params[i+1]);
+		for (i = 0; i < xml_params_count(params); i++)
+			fprintf(stderr, "--stringparam %s %s ", xml_params_get_key(params, i), xml_params_get_value(params, i));
 		fprintf(stderr, "%s/xslt/manualcsv2xml.xslt -\n", SUBSURFACE_SOURCE);
 	}
 #endif
-	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, (const char **)params);
+	ret = parse_xml_buffer(filename, mem.buffer, mem.size, table, trips, sites, filter_presets, params);
 
 	free(mem.buffer);
-	for (i = 0; i < pnr - 2; ++i)
-		free(params[i]);
 	return ret;
 }

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -4,6 +4,8 @@
 
 #include "filterpreset.h"
 
+struct xml_params;
+
 enum csv_format {
 	CSV_DEPTH,
 	CSV_TEMP,
@@ -23,14 +25,14 @@ enum csv_format {
 extern "C" {
 #endif
 
-int parse_csv_file(const char *filename, char **params, int pnr, const char *csvtemplate, struct dive_table *table,
+int parse_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate, struct dive_table *table,
 		   struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 int try_to_open_csv(struct memblock *mem, enum csv_format type, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 int parse_txt_file(const char *filename, const char *csv, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
 		     struct filter_preset_table *filter_presets);
-int parse_manual_file(const char *filename, char **params, int pnr, struct dive_table *table, struct trip_table *trips,
+int parse_manual_file(const char *filename, struct xml_params *params, struct dive_table *table, struct trip_table *trips,
 		      struct dive_site_table *sites, struct filter_preset_table *filter_presets);
 
 #ifdef __cplusplus

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -32,11 +32,12 @@
 #include "picture.h"
 #include "qthelper.h"
 #include "tag.h"
+#include "xmlparams.h"
 
 int quit, force_root;
 int last_xml_version = -1;
 
-static xmlDoc *test_xslt_transforms(xmlDoc *doc, const char **params);
+static xmlDoc *test_xslt_transforms(xmlDoc *doc, const struct xml_params *params);
 
 const struct units SI_units = SI_UNITS;
 const struct units IMPERIAL_units = IMPERIAL_UNITS;
@@ -1721,7 +1722,7 @@ static const char *preprocess_divelog_de(const char *buffer)
 
 int parse_xml_buffer(const char *url, const char *buffer, int size,
 		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     struct filter_preset_table *filter_presets, const char **params)
+		     struct filter_preset_table *filter_presets, const struct xml_params *params)
 {
 	UNUSED(size);
 	xmlDoc *doc;
@@ -2308,7 +2309,7 @@ static struct xslt_files {
 	  { NULL, }
   };
 
-static xmlDoc *test_xslt_transforms(xmlDoc *doc, const char **params)
+static xmlDoc *test_xslt_transforms(xmlDoc *doc, const struct xml_params *params)
 {
 	struct xslt_files *info = xslt_files;
 	xmlDoc *transformed;
@@ -2341,7 +2342,7 @@ static xmlDoc *test_xslt_transforms(xmlDoc *doc, const char **params)
 			report_error(translate("gettextFromC", "Can't open stylesheet %s"), info->file);
 			return doc;
 		}
-		transformed = xsltApplyStylesheet(xslt, doc, params);
+		transformed = xsltApplyStylesheet(xslt, doc, xml_params_get(params));
 		xmlFreeDoc(doc);
 		xsltFreeStylesheet(xslt);
 

--- a/core/parse.h
+++ b/core/parse.h
@@ -9,6 +9,8 @@
 
 #include <sqlite3.h>
 
+struct xml_params;
+
 typedef union {
 	struct event event;
 	char allocation[sizeof(struct event) + MAX_EVENT_NAME];
@@ -140,7 +142,7 @@ int atoi_n(char *ptr, unsigned int len);
 
 void parse_xml_init(void);
 int parse_xml_buffer(const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     struct filter_preset_table *filter_presets, const char **params);
+		     struct filter_preset_table *filter_presets, const struct xml_params *params);
 void parse_xml_exit(void);
 int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1617,15 +1617,6 @@ void parse_seabear_header(const char *filename, struct xml_params *params)
 	f.close();
 }
 
-char *intdup(int index)
-{
-	char tmpbuf[21];
-
-	snprintf(tmpbuf, sizeof(tmpbuf) - 2, "%d", index);
-	tmpbuf[20] = 0;
-	return strdup(tmpbuf);
-}
-
 extern "C" void print_qt_versions()
 {
 	printf("%s\n", qPrintable(QStringLiteral("built with Qt Version %1, runtime from Qt Version %2").arg(QT_VERSION_STR).arg(qVersion())));

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -9,6 +9,7 @@
 
 struct picture;
 struct dive_trip;
+struct xml_params;
 
 // 1) Types
 
@@ -148,7 +149,7 @@ char *hashfile_name_string();
 char *picturedir_string();
 const char *subsurface_user_agent();
 enum deco_mode decoMode();
-int parse_seabear_header(const char *filename, char **params, int pnr);
+void parse_seabear_header(const char *filename, struct xml_params *params);
 char *get_current_date();
 time_t get_dive_datetime_from_isostring(char *when);
 void print_qt_versions();

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -45,7 +45,6 @@ extern const QStringList videoExtensionsList;
 QStringList mediaExtensionFilters();
 QStringList imageExtensionFilters();
 QStringList videoExtensionFilters();
-char *intdup(int index);
 char *copy_qstring(const QString &);
 QString get_depth_string(depth_t depth, bool showunit = false, bool showdecimal = true);
 QString get_depth_string(int mm, bool showunit = false, bool showdecimal = true);

--- a/core/xmlparams.cpp
+++ b/core/xmlparams.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "xmlparams.h"
+
+extern "C" struct xml_params *alloc_xml_params()
+{
+	return new xml_params;
+}
+
+extern "C" void free_xml_params(struct xml_params *params)
+{
+	delete params;
+}
+
+extern "C" void xml_params_resize(struct xml_params *params, int count)
+{
+	params->items.resize(count);
+}
+
+extern "C" void xml_params_add(struct xml_params *params, const char *key, const char *value)
+{
+	params->items.push_back({ std::string(key), std::string(value) });
+}
+
+extern "C" void xml_params_add_int(struct xml_params *params, const char *key, int value)
+{
+	params->items.push_back({ std::string(key), std::to_string(value) });
+}
+
+extern "C" int xml_params_count(const struct xml_params *params)
+{
+	return (int)params->items.size();
+}
+
+extern "C" const char *xml_params_get_key(const struct xml_params *params, int idx)
+{
+	return params->items[idx].first.c_str();
+}
+
+extern "C" const char *xml_params_get_value(const struct xml_params *params, int idx)
+{
+	return params->items[idx].second.c_str();
+}
+
+extern void xml_params_set_value(struct xml_params *params, int idx, const char *value)
+{
+	if (idx < 0 || idx >= (int)params->items.size())
+		return;
+	params->items[idx].second = value;
+}
+
+extern "C" const char **xml_params_get(const struct xml_params *params)
+{
+	if (!params)
+		return nullptr;
+	params->data.resize(params->items.size() * 2 + 1);
+	for (size_t i = 0; i < params->items.size(); ++i) {
+		params->data[i * 2] = params->items[i].first.c_str();
+		params->data[i * 2 + 1] = params->items[i].second.c_str();
+	}
+	params->data[params->items.size() * 2] = nullptr;
+	return params->data.data();
+}

--- a/core/xmlparams.h
+++ b/core/xmlparams.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+// Small helper class that keeps track of key/value pairs to
+// pass to the XML-routines as parameters. Uses C++ for memory
+// management, but provides a C interface via anonymous struct.
+
+#ifdef __cplusplus
+#include <string>
+#include <vector>
+
+struct xml_params {
+	std::vector<std::pair<std::string, std::string>> items;
+	mutable std::vector<const char *> data;
+};
+
+#else
+
+struct xml_params;
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Return values marked as "not stable" may be invalidated when calling
+// an xml_params_*() function that takes a non-const xml_params parameter.
+extern struct xml_params *alloc_xml_params();
+extern void free_xml_params(struct xml_params *params);
+extern void xml_params_resize(struct xml_params *params, int count);
+extern void xml_params_add(struct xml_params *params, const char *key, const char *value);
+extern void xml_params_add_int(struct xml_params *params, const char *key, int value);
+extern int xml_params_count(const struct xml_params *params);
+extern const char *xml_params_get_key(const struct xml_params *params, int idx); // not stable
+extern const char *xml_params_get_value(const struct xml_params *params, int idx); // not stable
+extern void xml_params_set_value(struct xml_params *params, int idx, const char *value);
+extern const char **xml_params_get(const struct xml_params *params); // not stable
+
+#ifdef __cplusplus
+}
+#endif

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -15,6 +15,7 @@
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/import-csv.h"
+#include "core/xmlparams.h"
 
 static QString subsurface_mimedata = "subsurface/csvcolumns";
 static QString subsurface_index = "subsurface/csvindex";
@@ -801,64 +802,37 @@ void DiveLogImportDialog::loadFileContents(int value, whatChanged triggeredBy)
 			resultModel->setData(resultModel->index(0, i),headers.at(i),Qt::EditRole);
 }
 
-int DiveLogImportDialog::setup_csv_params(QStringList r, char **params, int pnr)
+void DiveLogImportDialog::setup_csv_params(QStringList r, xml_params &params)
 {
-	params[pnr++] = strdup("dateField");
-	params[pnr++] = intdup(r.indexOf(tr("Date")));
-	params[pnr++] = strdup("datefmt");
-	params[pnr++] = intdup(ui->DateFormat->currentIndex());
-	params[pnr++] = strdup("starttimeField");
-	params[pnr++] = intdup(r.indexOf(tr("Time")));
-	params[pnr++] = strdup("numberField");
-	params[pnr++] = intdup(r.indexOf(tr("Dive #")));
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample time")));
-	params[pnr++] = strdup("depthField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample depth")));
-	params[pnr++] = strdup("tempField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample temperature")));
-	params[pnr++] = strdup("po2Field");
-	params[pnr++] = intdup(r.indexOf(tr("Sample pO₂")));
-	params[pnr++] = strdup("o2sensor1Field");
-	params[pnr++] = intdup(r.indexOf(tr("Sample sensor1 pO₂")));
-	params[pnr++] = strdup("o2sensor2Field");
-	params[pnr++] = intdup(r.indexOf(tr("Sample sensor2 pO₂")));
-	params[pnr++] = strdup("o2sensor3Field");
-	params[pnr++] = intdup(r.indexOf(tr("Sample sensor3 pO₂")));
-	params[pnr++] = strdup("cnsField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample CNS")));
-	params[pnr++] = strdup("ndlField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample NDL")));
-	params[pnr++] = strdup("ttsField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample TTS")));
-	params[pnr++] = strdup("stopdepthField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample stopdepth")));
-	params[pnr++] = strdup("pressureField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample pressure")));
-	params[pnr++] = strdup("heartBeat");
-	params[pnr++] = intdup(r.indexOf(tr("Sample heartrate")));
-	params[pnr++] = strdup("setpointField");
-	params[pnr++] = intdup(r.indexOf(tr("Sample setpoint")));
-	params[pnr++] = strdup("visibilityField");
-	params[pnr++] = intdup(r.indexOf(tr("Visibility")));
-	params[pnr++] = strdup("ratingField");
-	params[pnr++] = intdup(r.indexOf(tr("Rating")));
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(ui->CSVSeparator->currentIndex());
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(ui->CSVUnits->currentIndex());
-	if (hw.length()) {
-		params[pnr++] = strdup("hw");
-		params[pnr++] = copy_qstring(hw);
-	} else if (ui->knownImports->currentText().length() > 0) {
-		params[pnr++] = strdup("hw");
-		params[pnr++] = copy_qstring(ui->knownImports->currentText().prepend("\"").append("\""));
-	}
-	params[pnr++] = NULL;
-
-	return pnr;
+	xml_params_add_int(&params, "dateField", r.indexOf(tr("Date")));
+	xml_params_add_int(&params, "datefmt", ui->DateFormat->currentIndex());
+	xml_params_add_int(&params, "starttimeField", r.indexOf(tr("Time")));
+	xml_params_add_int(&params, "numberField", r.indexOf(tr("Dive #")));
+	xml_params_add_int(&params, "timeField", r.indexOf(tr("Sample time")));
+	xml_params_add_int(&params, "depthField", r.indexOf(tr("Sample depth")));
+	xml_params_add_int(&params, "tempField", r.indexOf(tr("Sample temperature")));
+	xml_params_add_int(&params, "po2Field", r.indexOf(tr("Sample pO₂")));
+	xml_params_add_int(&params, "o2sensor1Field", r.indexOf(tr("Sample sensor1 pO₂")));
+	xml_params_add_int(&params, "o2sensor2Field", r.indexOf(tr("Sample sensor2 pO₂")));
+	xml_params_add_int(&params, "o2sensor3Field", r.indexOf(tr("Sample sensor3 pO₂")));
+	xml_params_add_int(&params, "cnsField", r.indexOf(tr("Sample CNS")));
+	xml_params_add_int(&params, "ndlField", r.indexOf(tr("Sample NDL")));
+	xml_params_add_int(&params, "ttsField", r.indexOf(tr("Sample TTS")));
+	xml_params_add_int(&params, "stopdepthField", r.indexOf(tr("Sample stopdepth")));
+	xml_params_add_int(&params, "pressureField", r.indexOf(tr("Sample pressure")));
+	xml_params_add_int(&params, "heartBeat", r.indexOf(tr("Sample heartrate")));
+	xml_params_add_int(&params, "setpointField", r.indexOf(tr("Sample setpoint")));
+	xml_params_add_int(&params, "visibilityField", r.indexOf(tr("Visibility")));
+	xml_params_add_int(&params, "ratingField", r.indexOf(tr("Rating")));
+	xml_params_add_int(&params, "separatorIndex", ui->CSVSeparator->currentIndex());
+	xml_params_add_int(&params, "units", ui->CSVUnits->currentIndex());
+	if (hw.length())
+		xml_params_add(&params, "hw", qPrintable(hw));
+	else if (ui->knownImports->currentText().length() > 0)
+		xml_params_add(&params, "hw", qPrintable(ui->knownImports->currentText().prepend("\"").append("\"")));
 }
-int DiveLogImportDialog::parseTxtHeader(QString fileName, char **params, int pnr)
+
+void DiveLogImportDialog::parseTxtHeader(QString fileName, xml_params &params)
 {
 	QFile f(fileName);
 	QString date;
@@ -897,11 +871,8 @@ int DiveLogImportDialog::parseTxtHeader(QString fileName, char **params, int pnr
 	}
 	f.close();
 
-	params[pnr++] = strdup("date");
-	params[pnr++] = strdup(date.toLatin1());
-	params[pnr++] = strdup("time");
-	params[pnr++] = strdup(time.toLatin1());
-	return pnr;
+	xml_params_add(&params, "date", qPrintable(date));
+	xml_params_add(&params, "time", qPrintable(time));
 }
 
 void DiveLogImportDialog::on_buttonBox_accepted()
@@ -919,20 +890,17 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				QPair<QString, QString> pair = poseidonFileNames(fileNames[i]);
 				parse_txt_file(qPrintable(pair.second), qPrintable(pair.first), &table, &trips, &sites);
 			} else {
-				char *params[50];
-				int pnr = 0;
+				xml_params params;
 
 				QRegExp apdRe("^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd");
 				if (txtLog) {
-					pnr = parseTxtHeader(fileNames[i], params, pnr);
+					parseTxtHeader(fileNames[i], params);
 				} else if (apdRe.exactMatch(fileNames[i])) {
-					params[pnr++] = strdup("date");
-					params[pnr++] = strdup("20" + apdRe.cap(1).toLatin1());
-					params[pnr++] = strdup("time");
-					params[pnr++] = strdup("1" + apdRe.cap(2).toLatin1());
+					xml_params_add(&params, "date", qPrintable("20" + apdRe.cap(1)));
+					xml_params_add(&params, "time", qPrintable("1" + apdRe.cap(2)));
 				}
-				pnr = setup_csv_params(r, params, pnr);
-				parse_csv_file(qPrintable(fileNames[i]), params, pnr - 1,
+				setup_csv_params(r, params);
+				parse_csv_file(qPrintable(fileNames[i]), &params,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
 						&table, &trips, &sites, &filter_presets);
 			}
@@ -940,82 +908,49 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 	} else {
 		for (int i = 0; i < fileNames.size(); ++i) {
 			if (r.indexOf(tr("Sample time")) < 0) {
-				char *params[61];
-				int pnr = 0;
-				params[pnr++] = strdup("numberField");
-				params[pnr++] = intdup(r.indexOf(tr("Dive #")));
-				params[pnr++] = strdup("dateField");
-				params[pnr++] = intdup(r.indexOf(tr("Date")));
-				params[pnr++] = strdup("timeField");
-				params[pnr++] = intdup(r.indexOf(tr("Time")));
-				params[pnr++] = strdup("durationField");
-				params[pnr++] = intdup(r.indexOf(tr("Duration")));
-				params[pnr++] = strdup("modeField");
-				params[pnr++] = intdup(r.indexOf(tr("Mode")));
-				params[pnr++] = strdup("locationField");
-				params[pnr++] = intdup(r.indexOf(tr("Location")));
-				params[pnr++] = strdup("gpsField");
-				params[pnr++] = intdup(r.indexOf(tr("GPS")));
-				params[pnr++] = strdup("maxDepthField");
-				params[pnr++] = intdup(r.indexOf(tr("Max. depth")));
-				params[pnr++] = strdup("meanDepthField");
-				params[pnr++] = intdup(r.indexOf(tr("Avg. depth")));
-				params[pnr++] = strdup("divemasterField");
-				params[pnr++] = intdup(r.indexOf(tr("Divemaster")));
-				params[pnr++] = strdup("buddyField");
-				params[pnr++] = intdup(r.indexOf(tr("Buddy")));
-				params[pnr++] = strdup("suitField");
-				params[pnr++] = intdup(r.indexOf(tr("Suit")));
-				params[pnr++] = strdup("notesField");
-				params[pnr++] = intdup(r.indexOf(tr("Notes")));
-				params[pnr++] = strdup("weightField");
-				params[pnr++] = intdup(r.indexOf(tr("Weight")));
-				params[pnr++] = strdup("tagsField");
-				params[pnr++] = intdup(r.indexOf(tr("Tags")));
-				params[pnr++] = strdup("separatorIndex");
-				params[pnr++] = intdup(ui->CSVSeparator->currentIndex());
-				params[pnr++] = strdup("units");
-				params[pnr++] = intdup(ui->CSVUnits->currentIndex());
-				params[pnr++] = strdup("datefmt");
-				params[pnr++] = intdup(ui->DateFormat->currentIndex());
-				params[pnr++] = strdup("durationfmt");
-				params[pnr++] = intdup(ui->DurationFormat->currentIndex());
-				params[pnr++] = strdup("cylindersizeField");
-				params[pnr++] = intdup(r.indexOf(tr("Cyl. size")));
-				params[pnr++] = strdup("startpressureField");
-				params[pnr++] = intdup(r.indexOf(tr("Start pressure")));
-				params[pnr++] = strdup("endpressureField");
-				params[pnr++] = intdup(r.indexOf(tr("End pressure")));
-				params[pnr++] = strdup("o2Field");
-				params[pnr++] = intdup(r.indexOf(tr("O₂")));
-				params[pnr++] = strdup("heField");
-				params[pnr++] = intdup(r.indexOf(tr("He")));
-				params[pnr++] = strdup("airtempField");
-				params[pnr++] = intdup(r.indexOf(tr("Air temp.")));
-				params[pnr++] = strdup("watertempField");
-				params[pnr++] = intdup(r.indexOf(tr("Water temp.")));
-				params[pnr++] = strdup("visibilityField");
-				params[pnr++] = intdup(r.indexOf(tr("Visibility")));
-				params[pnr++] = strdup("ratingField");
-				params[pnr++] = intdup(r.indexOf(tr("Rating")));
-				params[pnr++] = NULL;
+				xml_params params;
+				xml_params_add_int(&params, "numberField", r.indexOf(tr("Dive #")));
+				xml_params_add_int(&params, "dateField", r.indexOf(tr("Date")));
+				xml_params_add_int(&params, "timeField", r.indexOf(tr("Time")));
+				xml_params_add_int(&params, "durationField", r.indexOf(tr("Duration")));
+				xml_params_add_int(&params, "modeField", r.indexOf(tr("Mode")));
+				xml_params_add_int(&params, "locationField", r.indexOf(tr("Location")));
+				xml_params_add_int(&params, "gpsField", r.indexOf(tr("GPS")));
+				xml_params_add_int(&params, "maxDepthField", r.indexOf(tr("Max. depth")));
+				xml_params_add_int(&params, "meanDepthField", r.indexOf(tr("Avg. depth")));
+				xml_params_add_int(&params, "divemasterField", r.indexOf(tr("Divemaster")));
+				xml_params_add_int(&params, "buddyField", r.indexOf(tr("Buddy")));
+				xml_params_add_int(&params, "suitField", r.indexOf(tr("Suit")));
+				xml_params_add_int(&params, "notesField", r.indexOf(tr("Notes")));
+				xml_params_add_int(&params, "weightField", r.indexOf(tr("Weight")));
+				xml_params_add_int(&params, "tagsField", r.indexOf(tr("Tags")));
+				xml_params_add_int(&params, "separatorIndex", ui->CSVSeparator->currentIndex());
+				xml_params_add_int(&params, "units", ui->CSVUnits->currentIndex());
+				xml_params_add_int(&params, "datefmt", ui->DateFormat->currentIndex());
+				xml_params_add_int(&params, "durationfmt", ui->DurationFormat->currentIndex());
+				xml_params_add_int(&params, "cylindersizeField", r.indexOf(tr("Cyl. size")));
+				xml_params_add_int(&params, "startpressureField", r.indexOf(tr("Start pressure")));
+				xml_params_add_int(&params, "endpressureField", r.indexOf(tr("End pressure")));
+				xml_params_add_int(&params, "o2Field", r.indexOf(tr("O₂")));
+				xml_params_add_int(&params, "heField", r.indexOf(tr("He")));
+				xml_params_add_int(&params, "airtempField", r.indexOf(tr("Air temp.")));
+				xml_params_add_int(&params, "watertempField", r.indexOf(tr("Water temp.")));
+				xml_params_add_int(&params, "visibilityField", r.indexOf(tr("Visibility")));
+				xml_params_add_int(&params, "ratingField", r.indexOf(tr("Rating")));
 
-				parse_manual_file(qPrintable(fileNames[i]), params, pnr - 1, &table, &trips, &sites, &filter_presets);
+				parse_manual_file(qPrintable(fileNames[i]), &params, &table, &trips, &sites, &filter_presets);
 			} else {
-				char *params[53];
-				int pnr = 0;
+				xml_params params;
 
 				QRegExp apdRe("^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd");
 				if (txtLog) {
-					pnr = parseTxtHeader(fileNames[i], params, pnr);
+					parseTxtHeader(fileNames[i], params);
 				} else if (apdRe.exactMatch(fileNames[i])) {
-					params[pnr++] = strdup("date");
-					params[pnr++] = strdup("20" + apdRe.cap(1).toLatin1());
-					params[pnr++] = strdup("time");
-					params[pnr++] = strdup("1" + apdRe.cap(2).toLatin1());
+					xml_params_add(&params, "date", qPrintable("20" + apdRe.cap(1)));
+					xml_params_add(&params, "time", qPrintable("1" + apdRe.cap(2)));
 				}
-				pnr = setup_csv_params(r, params, pnr);
-				parse_csv_file(qPrintable(fileNames[i]), params, pnr - 1,
+				setup_csv_params(r, params);
+				parse_csv_file(qPrintable(fileNames[i]), &params,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
 						&table, &trips, &sites, &filter_presets);
 			}

--- a/desktop-widgets/divelogimportdialog.h
+++ b/desktop-widgets/divelogimportdialog.h
@@ -13,6 +13,7 @@
 #include "core/dive.h"
 #include "core/divelist.h"
 
+struct xml_params;
 namespace Ui {
 	class DiveLogImportDialog;
 }
@@ -87,8 +88,8 @@ slots:
 	void loadFileContentsSeperatorSelected(int value);
 	void loadFileContentsKnownTypesSelected(int value);
 	void loadFileContents(int value, enum whatChanged triggeredBy);
-	int setup_csv_params(QStringList r, char **params, int pnr);
-	int parseTxtHeader(QString fileName, char **params, int pnr);
+	void setup_csv_params(QStringList r, xml_params &params);
+	void parseTxtHeader(QString fileName, xml_params &params);
 
 private:
 	bool selector;

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -104,6 +104,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../core/uploadDiveShare.cpp \
 	../../core/uploadDiveLogsDE.cpp \
 	../../core/save-profiledata.c \
+	../../core/xmlparams.cpp \
 	../../core/settings/qPref.cpp \
 	../../core/settings/qPrefCloudStorage.cpp \
 	../../core/settings/qPrefDisplay.cpp \
@@ -255,6 +256,7 @@ HEADERS += \
 	../../core/save-profiledata.h \
 	../../core/uploadDiveShare.h \
 	../../core/uploadDiveLogsDE.h \
+	../../core/xmlparams.h \
 	../../core/settings/qPref.h \
 	../../core/settings/qPrefCloudStorage.h \
 	../../core/settings/qPrefDisplay.h \

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -8,6 +8,7 @@
 #include "core/parse.h"
 #include "core/qthelper.h"
 #include "core/subsurface-string.h"
+#include "core/xmlparams.h"
 #include <QTextStream>
 
 /* We have to use a macro since QCOMPARE
@@ -53,62 +54,35 @@ int TestParse::parseCSV(int units, std::string file)
 	//
 	// CSV import should work
 	verbose = 1;
-	char *params[55];
-	int pnr = 0;
+	xml_params params;
 
-	params[pnr++] = strdup("numberField");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("dateField");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("durationField");
-	params[pnr++] = intdup(3);
-	params[pnr++] = strdup("locationField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("gpsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("maxDepthField");
-	params[pnr++] = intdup(4);
-	params[pnr++] = strdup("meanDepthField");
-	params[pnr++] = intdup(5);
-	params[pnr++] = strdup("divemasterField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("buddyField");
-	params[pnr++] = intdup(6);
-	params[pnr++] = strdup("suitField");
-	params[pnr++] = intdup(7);
-	params[pnr++] = strdup("notesField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("weightField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("tagsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(units);
-	params[pnr++] = strdup("datefmt");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("durationfmt");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("cylindersizeField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("startpressureField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("endpressureField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("heField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("airtempField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("watertempField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = NULL;
+	xml_params_add_int(&params, "numberField", 0);
+	xml_params_add_int(&params, "dateField", 1);
+	xml_params_add_int(&params, "timeField", 2);
+	xml_params_add_int(&params, "durationField", 3);
+	xml_params_add_int(&params, "locationField", -1);
+	xml_params_add_int(&params, "gpsField", -1);
+	xml_params_add_int(&params, "maxDepthField", 4);
+	xml_params_add_int(&params, "meanDepthField", 5);
+	xml_params_add_int(&params, "divemasterField", -1);
+	xml_params_add_int(&params, "buddyField", 6);
+	xml_params_add_int(&params, "suitField", 7);
+	xml_params_add_int(&params, "notesField", -1);
+	xml_params_add_int(&params, "weightField", -1);
+	xml_params_add_int(&params, "tagsField", -1);
+	xml_params_add_int(&params, "separatorIndex", 0);
+	xml_params_add_int(&params, "units", units);
+	xml_params_add_int(&params, "datefmt", 1);
+	xml_params_add_int(&params, "durationfmt", 2);
+	xml_params_add_int(&params, "cylindersizeField", -1);
+	xml_params_add_int(&params, "startpressureField", -1);
+	xml_params_add_int(&params, "endpressureField", -1);
+	xml_params_add_int(&params, "o2Field", -1);
+	xml_params_add_int(&params, "heField", -1);
+	xml_params_add_int(&params, "airtempField", -1);
+	xml_params_add_int(&params, "watertempField", -1);
 
-	return parse_manual_file(file.c_str(), params, pnr - 1, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
 }
 
 int TestParse::parseDivingLog()
@@ -179,45 +153,27 @@ void TestParse::testParseDM5()
 
 void TestParse::testParseHUDC()
 {
-	char *params[37];
-	int pnr = 0;
+	xml_params params;
 
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("depthField");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("tempField");
-	params[pnr++] = intdup(5);
-	params[pnr++] = strdup("po2Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor1Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor2Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor3Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("cnsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("ndlField");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("ttsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("stopdepthField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("pressureField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("setpointField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("hw");
-	params[pnr++] = strdup("\"DC text\"");
-	params[pnr++] = NULL;
+	xml_params_add_int(&params, "timeField", 0);
+	xml_params_add_int(&params, "depthField", 1);
+	xml_params_add_int(&params, "tempField", 5);
+	xml_params_add_int(&params, "po2Field", -1);
+	xml_params_add_int(&params, "o2sensor1Field", -1);
+	xml_params_add_int(&params, "o2sensor2Field", -1);
+	xml_params_add_int(&params, "o2sensor3Field", -1);
+	xml_params_add_int(&params, "cnsField", -1);
+	xml_params_add_int(&params, "ndlField", 2);
+	xml_params_add_int(&params, "ttsField", -1);
+	xml_params_add_int(&params, "stopdepthField", -1);
+	xml_params_add_int(&params, "pressureField", -1);
+	xml_params_add_int(&params, "setpointField", -1);
+	xml_params_add_int(&params, "separatorIndex", 2);
+	xml_params_add_int(&params, "units", 0);
+	xml_params_add(&params, "hw", "\"DC text\"");
 
 	QCOMPARE(parse_csv_file(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.csv",
-				params, pnr - 1, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
+				&params, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
 		 0);
 
 	QCOMPARE(dive_table.nr, 1);
@@ -306,67 +262,39 @@ void TestParse::testParseMerge()
 int TestParse::parseCSVmanual(int units, std::string file)
 {
 	verbose = 1;
-	char *params[59];
-	int pnr = 0;
+	xml_params params;
 
 	// Numbers are column numbers
-	params[pnr++] = strdup("numberField");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("dateField");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("durationField");
-	params[pnr++] = intdup(3);
+	xml_params_add_int(&params, "numberField", 0);
+	xml_params_add_int(&params, "dateField", 1);
+	xml_params_add_int(&params, "timeField", 2);
+	xml_params_add_int(&params, "durationField", 3);
 	// 4 Will be SAC, once we add support for reading it
-	params[pnr++] = strdup("maxDepthField");
-	params[pnr++] = intdup(5);
-	params[pnr++] = strdup("meanDepthField");
-	params[pnr++] = intdup(6);
-	params[pnr++] = strdup("modeField");
-	params[pnr++] = intdup(7);
-	params[pnr++] = strdup("airtempField");
-	params[pnr++] = intdup(8);
-	params[pnr++] = strdup("watertempField");
-	params[pnr++] = intdup(9);
-	params[pnr++] = strdup("cylindersizeField");
-	params[pnr++] = intdup(10);
-	params[pnr++] = strdup("startpressureField");
-	params[pnr++] = intdup(11);
-	params[pnr++] = strdup("endpressureField");
-	params[pnr++] = intdup(12);
-	params[pnr++] = strdup("o2Field");
-	params[pnr++] = intdup(13);
-	params[pnr++] = strdup("heField");
-	params[pnr++] = intdup(14);
-	params[pnr++] = strdup("locationField");
-	params[pnr++] = intdup(15);
-	params[pnr++] = strdup("gpsField");
-	params[pnr++] = intdup(16);
-	params[pnr++] = strdup("divemasterField");
-	params[pnr++] = intdup(17);
-	params[pnr++] = strdup("buddyField");
-	params[pnr++] = intdup(18);
-	params[pnr++] = strdup("suitField");
-	params[pnr++] = intdup(19);
-	params[pnr++] = strdup("notesField");
-	params[pnr++] = intdup(22);
-	params[pnr++] = strdup("weightField");
-	params[pnr++] = intdup(23);
-	params[pnr++] = strdup("tagsField");
-	params[pnr++] = intdup(24);
+	xml_params_add_int(&params, "maxDepthField", 5);
+	xml_params_add_int(&params, "meanDepthField", 6);
+	xml_params_add_int(&params, "modeField", 7);
+	xml_params_add_int(&params, "airtempField", 8);
+	xml_params_add_int(&params, "watertempField", 9);
+	xml_params_add_int(&params, "cylindersizeField", 10);
+	xml_params_add_int(&params, "startpressureField", 11);
+	xml_params_add_int(&params, "endpressureField", 12);
+	xml_params_add_int(&params, "o2Field", 13);
+	xml_params_add_int(&params, "heField", 14);
+	xml_params_add_int(&params, "locationField", 15);
+	xml_params_add_int(&params, "gpsField", 16);
+	xml_params_add_int(&params, "divemasterField", 17);
+	xml_params_add_int(&params, "buddyField", 18);
+	xml_params_add_int(&params, "suitField", 19);
+	xml_params_add_int(&params, "notesField", 22);
+	xml_params_add_int(&params, "weightField", 23);
+	xml_params_add_int(&params, "tagsField", 24);
 	// Numbers are indices of possible options
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("datefmt");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("durationfmt");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(units);
-	params[pnr++] = NULL;
+	xml_params_add_int(&params, "separatorIndex", 0);
+	xml_params_add_int(&params, "datefmt", 2);
+	xml_params_add_int(&params, "durationfmt", 2);
+	xml_params_add_int(&params, "units", units);
 
-	return parse_manual_file(file.c_str(), params, pnr - 1, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
 }
 
 void TestParse::exportCSVDiveDetails()
@@ -405,8 +333,7 @@ void TestParse::exportCSVDiveDetails()
 void TestParse::exportSubsurfaceCSV()
 {
 	int saved_sac = 0;
-	char *params[59];
-	int pnr = 0;
+	xml_params params;
 
 	/* Test SubsurfaceCSV with multiple cylinders */
 	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
@@ -421,12 +348,9 @@ void TestParse::exportSubsurfaceCSV()
 
 	clear_dive_file_data();
 
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(1);
-	params[pnr++] = 0;
-	parse_csv_file("testcsvexportmanualimperial-cyl.csv", params, pnr - 1, "SubsurfaceCSV", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	xml_params_add_int(&params, "separatorIndex", 0);
+	xml_params_add_int(&params, "units", 1);
+	parse_csv_file("testcsvexportmanualimperial-cyl.csv", &params, "SubsurfaceCSV", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
 
 	// We do not currently support reading SAC, thus faking it
 	if (dive_table.nr > 0) {
@@ -445,32 +369,21 @@ void TestParse::exportSubsurfaceCSV()
 int TestParse::parseCSVprofile(int units, std::string file)
 {
 	verbose = 1;
-	char *params[55];
-	int pnr = 0;
+	xml_params params;
 
 	// Numbers are column numbers
-	params[pnr++] = strdup("numberField");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("dateField");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("starttimeField");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(3);
-	params[pnr++] = strdup("depthField");
-	params[pnr++] = intdup(4);
-	params[pnr++] = strdup("tempField");
-	params[pnr++] = intdup(5);
-	params[pnr++] = strdup("pressureField");
-	params[pnr++] = intdup(6);
+	xml_params_add_int(&params, "numberField", 0);
+	xml_params_add_int(&params, "dateField", 1);
+	xml_params_add_int(&params, "starttimeField", 2);
+	xml_params_add_int(&params, "timeField", 3);
+	xml_params_add_int(&params, "depthField", 4);
+	xml_params_add_int(&params, "tempField", 5);
+	xml_params_add_int(&params, "pressureField", 6);
 	// Numbers are indices of possible options
-	params[pnr++] = strdup("datefmt");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(units);
-	params[pnr++] = NULL;
+	xml_params_add_int(&params, "datefmt", 2);
+	xml_params_add_int(&params, "units", units);
 
-	return parse_csv_file(file.c_str(), params, pnr - 1, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_csv_file(file.c_str(), &params, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
 }
 
 void TestParse::exportCSVDiveProfile()
@@ -518,54 +431,32 @@ void TestParse::testExport()
 
 void TestParse::parseDL7()
 {
-	char *params[51];
-	int pnr = 0;
+	xml_params params;
 
-	params[pnr++] = strdup("dateField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("datefmt");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("starttimeField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("numberField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("timeField");
-	params[pnr++] = intdup(1);
-	params[pnr++] = strdup("depthField");
-	params[pnr++] = intdup(2);
-	params[pnr++] = strdup("tempField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("po2Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor1Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor2Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("o2sensor3Field");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("cnsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("ndlField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("ttsField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("stopdepthField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("pressureField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("setpointField");
-	params[pnr++] = intdup(-1);
-	params[pnr++] = strdup("separatorIndex");
-	params[pnr++] = intdup(3);
-	params[pnr++] = strdup("units");
-	params[pnr++] = intdup(0);
-	params[pnr++] = strdup("hw");
-	params[pnr++] = strdup("DL7");
-	params[pnr++] = 0;
+	xml_params_add_int(&params, "dateField", -1);
+	xml_params_add_int(&params, "datefmt", 0);
+	xml_params_add_int(&params, "starttimeField", -1);
+	xml_params_add_int(&params, "numberField", -1);
+	xml_params_add_int(&params, "timeField", 1);
+	xml_params_add_int(&params, "depthField", 2);
+	xml_params_add_int(&params, "tempField", -1);
+	xml_params_add_int(&params, "po2Field", -1);
+	xml_params_add_int(&params, "o2sensor1Field", -1);
+	xml_params_add_int(&params, "o2sensor2Field", -1);
+	xml_params_add_int(&params, "o2sensor3Field", -1);
+	xml_params_add_int(&params, "cnsField", -1);
+	xml_params_add_int(&params, "ndlField", -1);
+	xml_params_add_int(&params, "ttsField", -1);
+	xml_params_add_int(&params, "stopdepthField", -1);
+	xml_params_add_int(&params, "pressureField", -1);
+	xml_params_add_int(&params, "setpointField", -1);
+	xml_params_add_int(&params, "separatorIndex", 3);
+	xml_params_add_int(&params, "units", 0);
+	xml_params_add(&params, "hw", "DL7");
 
 	clear_dive_file_data();
 	QCOMPARE(parse_csv_file(SUBSURFACE_TEST_DATA "/dives/DL7.zxu",
-				params, pnr - 1, "DL7", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
+				&params, "DL7", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
 		 0);
 	QCOMPARE(dive_table.nr, 3);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The xml-parameter code leaks memory right and left. Instead of trying to fix this (a very daunting task), I decided to write a small C++ helper class and implement a very simple policy: the function that allocs the parameters is responsible for freeing them. In C++, this is automatic, by making the parameters block a simple value type. In C, call `alloc_xml_params()` then `free_xml_params()` in the same function.

Note: this is totally untested. FWIW, TestParse completes (not much, because TestParse only compares the number of imported dives, not their content!).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create and use C++ xml-parameter helper class..
2) Remove unused function.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mturkia @dirkhh