### PR TITLE
[RFC] libdc: free value strings given by libdc's dc_parser_get_field()

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -564,7 +564,7 @@ static void set_dc_serial(struct divecomputer *dc, const char *serial)
 {
 	const struct device *device;
 
-	dc->serial = serial;
+	dc->serial = strdup(serial);
 	if ((device = get_device_for_dc(&device_table, dc)) != NULL)
 		dc->deviceid = device_get_id(device);
 
@@ -723,6 +723,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		if (!str.desc || !str.value)
 			break;
 		parse_string_field(devdata, dive, &str);
+		free((void *)str.value); // libdc gives us copies of the value-string.
 	}
 
 	dc_divemode_t divemode;


### PR DESCRIPTION
Apparently libdc gives us copies of strings. The API is very
scary, because (at least according to my reading of the code),
the key/value pair may be stored in a cache. Thus on free()ing
the string in the cache becomes invalid and we must not access
it twice. Very obscure.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes what I believe to be a memory hole in the libdc-interface. However, it could be that I'm reading the code totally wrong. Only compile tested, as I have no device on me.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) copy serial-number provided by libdc in analogy to firmware
2) free value-strings provided by libdc

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@torvalds, @dirkhh: Please tell me that I'm missing something obvious.