### PR TITLE
devices: remove new devices on undo of import/download

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -18,9 +18,10 @@ void addDive(dive *d, bool autogroup, bool newNumber)
 }
 
 void importDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites,
-		 struct filter_preset_table *presets, int flags, const QString &source)
+		 struct device_table *devices, struct filter_preset_table *presets,
+		 int flags, const QString &source)
 {
-	execute(new ImportDives(dives, trips, sites, presets, flags, source));
+	execute(new ImportDives(dives, trips, sites, devices, presets, flags, source));
 }
 
 void deleteDive(const QVector<struct dive*> &divesToDelete)

--- a/commands/command.h
+++ b/commands/command.h
@@ -3,7 +3,6 @@
 #define COMMAND_H
 
 #include "core/dive.h"
-#include "core/filterpreset.h"
 #include "core/pictureobj.h"
 #include <QVector>
 #include <QAction>
@@ -11,6 +10,8 @@
 
 struct DiveAndLocation;
 struct FilterData;
+struct filter_preset_table;
+struct device_table;
 
 // We put everything in a namespace, so that we can shorten names without polluting the global namespace
 namespace Command {
@@ -33,7 +34,8 @@ QString changesMade();			// return a string with the texts from all commands on 
 // insertion position.
 void addDive(dive *d, bool autogroup, bool newNumber);
 void importDives(struct dive_table *dives, struct trip_table *trips,
-		 struct dive_site_table *sites, struct filter_preset_table *filter_presets,
+		 struct dive_site_table *sites, struct device_table *devices,
+		 struct filter_preset_table *filter_presets,
 		 int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);
 void shiftTime(const std::vector<dive *> &changedDives, int amount);

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -6,6 +6,7 @@
 
 #include "command_base.h"
 #include "core/filterpreset.h"
+#include "core/device.h"
 
 #include <QVector>
 
@@ -99,7 +100,8 @@ class ImportDives : public DiveListBase {
 public:
 	// Note: dives and trips are consumed - after the call they will be empty.
 	ImportDives(struct dive_table *dives, struct trip_table *trips, struct dive_site_table *sites,
-		    struct filter_preset_table *filter_presets, int flags, const QString &source);
+		    struct device_table *devices, struct filter_preset_table *filter_presets, int flags,
+		    const QString &source);
 private:
 	void undoit() override;
 	void redoit() override;
@@ -108,6 +110,7 @@ private:
 	// For redo and undo
 	DivesAndTripsToAdd	divesToAdd;
 	DivesAndSitesToRemove	divesAndSitesToRemove;
+	struct device_table	devicesToAddAndRemove;
 
 	// For redo
 	std::vector<OwningDiveSitePtr>	sitesToAdd;

--- a/core/datatrak.c
+++ b/core/datatrak.c
@@ -177,6 +177,8 @@ static unsigned char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive
 	char is_nitrox = 0, is_O2 = 0, is_SCR = 0;
 
 	device_data_t *devdata = calloc(1, sizeof(device_data_t));
+	devdata->sites = sites;
+	devdata->devices = devices;
 
 	/*
 	 * Parse byte to byte till next dive entry

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -416,3 +416,13 @@ extern "C" const char *device_get_nickname(const struct device *dev)
 {
 	return dev ? dev->nickName.c_str() : NULL;
 }
+
+extern "C" struct device_table *alloc_device_table()
+{
+	return new struct device_table;
+}
+
+extern "C" void free_device_table(struct device_table *devices)
+{
+	delete devices;
+}

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -299,17 +299,24 @@ extern "C" void create_device_node(struct device_table *device_table, const char
 }
 
 /* Does not check for duplicates! */
-extern "C" void add_to_device_table(struct device_table *device_table, const struct device *dev)
+extern "C" int add_to_device_table(struct device_table *device_table, const struct device *dev)
 {
 	auto it = std::lower_bound(device_table->devices.begin(), device_table->devices.end(), *dev);
+	int idx = it - device_table->devices.begin();
 	device_table->devices.insert(it, *dev);
+	return idx;
 }
 
-extern "C" void remove_device(struct device_table *device_table, const struct device *dev)
+extern "C" int remove_device(struct device_table *device_table, const struct device *dev)
 {
 	auto it = std::lower_bound(device_table->devices.begin(), device_table->devices.end(), *dev);
-	if (it != device_table->devices.end() && same_device(*it, *dev))
+	if (it != device_table->devices.end() && same_device(*it, *dev)) {
+		int idx = it - device_table->devices.begin();
 		device_table->devices.erase(it);
+		return idx;
+	} else {
+		return -1;
+	}
 }
 
 extern "C" void clear_device_table(struct device_table *device_table)

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -342,12 +342,12 @@ extern "C" int is_default_dive_computer_device(const char *name)
 	return qPrefDiveComputer::device() == name;
 }
 
-extern "C" void set_dc_nickname(struct dive *dive, struct device_table *device_table)
+extern "C" void add_devices_of_dive(const struct dive *dive, struct device_table *device_table)
 {
 	if (!dive)
 		return;
 
-	struct divecomputer *dc;
+	const struct divecomputer *dc;
 
 	for_each_dc (dive, dc) {
 		if (!empty_string(dc->model) && dc->deviceid &&

--- a/core/device.h
+++ b/core/device.h
@@ -39,6 +39,10 @@ const char *device_get_serial(const struct device *dev);
 const char *device_get_firmware(const struct device *dev);
 const char *device_get_nickname(const struct device *dev);
 
+// for C code that needs to alloc/free a device table. (Let's try to get rid of those)
+extern struct device_table *alloc_device_table();
+extern void free_device_table(struct device_table *devices);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/device.h
+++ b/core/device.h
@@ -19,7 +19,7 @@ extern struct device_table device_table;
 extern void fake_dc(struct divecomputer *dc);
 extern void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid, const struct device_table *table);
 
-extern void set_dc_nickname(struct dive *dive, struct device_table *table);
+extern void add_devices_of_dive(const struct dive *dive, struct device_table *table);
 extern void create_device_node(struct device_table *table, const char *model, uint32_t deviceid, const char *serial, const char *firmware, const char *nickname);
 extern int nr_devices(const struct device_table *table);
 extern const struct device *get_device(const struct device_table *table, int i);

--- a/core/device.h
+++ b/core/device.h
@@ -29,8 +29,8 @@ extern bool device_used_by_selected_dive(const struct device *dev);
 
 extern const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc);
 extern bool device_exists(const struct device_table *table, const struct device *dev);
-extern void add_to_device_table(struct device_table *table, const struct device *dev);
-extern void remove_device(struct device_table *table, const struct device *dev);
+extern int add_to_device_table(struct device_table *table, const struct device *dev); // returns index
+extern int remove_device(struct device_table *table, const struct device *dev); // returns index or -1 if not found
 
 // struct device accessors for C-code. The returned strings are not stable!
 const char *device_get_model(const struct device *dev);

--- a/core/device.h
+++ b/core/device.h
@@ -28,6 +28,9 @@ const char *get_dc_nickname(const struct divecomputer *dc);
 extern bool device_used_by_selected_dive(const struct device *dev);
 
 extern const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc);
+extern bool device_exists(const struct device_table *table, const struct device *dev);
+extern void add_to_device_table(struct device_table *table, const struct device *dev);
+extern void remove_device(struct device_table *table, const struct device *dev);
 
 // struct device accessors for C-code. The returned strings are not stable!
 const char *device_get_model(const struct device *dev);

--- a/core/dive.c
+++ b/core/dive.c
@@ -1593,10 +1593,6 @@ static void fixup_no_o2sensors(struct divecomputer *dc)
 
 static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 {
-	/* Add device information to table */
-	if (dc->deviceid && (dc->serial || dc->fw_version))
-		create_device_node(&device_table, dc->model, dc->deviceid, dc->serial, dc->fw_version, "");
-
 	/* Fixup duration and mean depth */
 	fixup_dc_duration(dc);
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -826,7 +826,7 @@ void process_loaded_dives()
 	for_each_dive(i, dive) {
 		if (!dive->hidden_by_filter)
 			shown_dives++;
-		set_dc_nickname(dive, &device_table);
+		add_devices_of_dive(dive, &device_table);
 	}
 
 	sort_dive_table(&dive_table);
@@ -1185,11 +1185,11 @@ void process_imported_dives(struct dive_table *import_table, struct trip_table *
 	 * since we know they all came from the same divecomputer we just check for the
 	 * first one */
 	if (flags & IMPORT_IS_DOWNLOADED) {
-		set_dc_nickname(import_table->dives[0], devices_to_add);
+		add_devices_of_dive(import_table->dives[0], devices_to_add);
 	} else {
 		/* they aren't downloaded, so record / check all new ones */
 		for (i = 0; i < import_table->nr; i++)
-			set_dc_nickname(import_table->dives[i], devices_to_add);
+			add_devices_of_dive(import_table->dives[i], devices_to_add);
 	}
 
 	/* Sort the table of dives to be imported and combine mergable dives */

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -11,6 +11,7 @@ extern "C" {
 struct dive;
 struct trip_table;
 struct dive_site_table;
+struct device_table;
 struct deco_state;
 extern int shown_dives;
 
@@ -36,12 +37,15 @@ extern void process_loaded_dives();
 #define	IMPORT_IS_DOWNLOADED (1 << 1)
 #define	IMPORT_MERGE_ALL_TRIPS (1 << 2)
 #define	IMPORT_ADD_TO_NEW_TRIP (1 << 3)
-extern void add_imported_dives(struct dive_table *import_table, struct trip_table *import_trip_table, struct dive_site_table *import_sites_table,
+extern void add_imported_dives(struct dive_table *import_table, struct trip_table *import_trip_table,
+			       struct dive_site_table *import_sites_table, struct device_table *devices_to_add,
 			       int flags);
-extern void process_imported_dives(struct dive_table *import_table, struct trip_table *import_trip_table, struct dive_site_table *import_sites_table,
+extern void process_imported_dives(struct dive_table *import_table, struct trip_table *import_trip_table,
+				   struct dive_site_table *import_sites_table, struct device_table *import_devices_table,
 				   int flags,
 				   struct dive_table *dives_to_add, struct dive_table *dives_to_remove,
-				   struct trip_table *trips_to_add, struct dive_site_table *sites_to_add);
+				   struct trip_table *trips_to_add, struct dive_site_table *sites_to_add,
+				   struct device_table *devices_to_add);
 extern char *get_dive_gas_string(const struct dive *dive);
 
 extern int dive_table_get_insertion_index(struct dive_table *table, struct dive *dive);

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -92,6 +92,7 @@ void DownloadThread::run()
 	internalData->descriptor = descriptorLookup[m_data->vendor().toLower() + m_data->product().toLower()];
 	internalData->download_table = &downloadTable;
 	internalData->sites = &diveSiteTable;
+	internalData->devices = &deviceTable;
 	internalData->btname = strdup(m_data->devBluetoothName().toUtf8());
 	if (!internalData->descriptor) {
 		qDebug() << "No download possible when DC type is unknown";
@@ -110,6 +111,7 @@ void DownloadThread::run()
 	qDebug() << "downloading" << (internalData->force_download ? "all" : "only new") << "dives";
 	clear_dive_table(&downloadTable);
 	clear_dive_site_table(&diveSiteTable);
+	clear_device_table(&deviceTable);
 
 	Q_ASSERT(internalData->download_table != nullptr);
 	const char *errorText;

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -7,6 +7,7 @@
 #include <QLoggingCategory>
 
 #include "divesite.h"
+#include "device.h"
 #include "libdivecomputer.h"
 #include "connectionlistmodel.h"
 #if BT_SUPPORT
@@ -77,6 +78,7 @@ public:
 	QString error;
 	struct dive_table downloadTable;
 	struct dive_site_table diveSiteTable;
+	struct device_table deviceTable;
 
 private:
 	DCDeviceData *m_data;

--- a/core/file.c
+++ b/core/file.c
@@ -325,7 +325,7 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 		return -1;
 	}
 	if (git)
-		return git_load_dives(git, branch, table, trips, sites, filter_presets);
+		return git_load_dives(git, branch, table, trips, sites, devices, filter_presets);
 
 	if ((ret = readfile(filename, &mem)) < 0) {
 		/* we don't want to display an error if this was the default file  */

--- a/core/file.c
+++ b/core/file.c
@@ -361,9 +361,9 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 		wl_name = strcat(wl_name, ".add");
 		if((ret = readfile(wl_name, &wl_mem)) < 0) {
 			fprintf(stderr, "No file %s found. No WLog extensions.\n", wl_name);
-			ret = datatrak_import(&mem, NULL, table, trips, sites);
+			ret = datatrak_import(&mem, NULL, table, trips, sites, devices);
 		} else {
-			ret = datatrak_import(&mem, &wl_mem, table, trips, sites);
+			ret = datatrak_import(&mem, &wl_mem, table, trips, sites, devices);
 			free(wl_mem.buffer);
 		}
 		free(mem.buffer);

--- a/core/file.c
+++ b/core/file.c
@@ -77,7 +77,7 @@ out:
 
 
 static void zip_read(struct zip_file *file, const char *filename, struct dive_table *table, struct trip_table *trips,
-		     struct dive_site_table *sites, struct filter_preset_table *filter_presets)
+		     struct dive_site_table *sites, struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int size = 1024, n, read = 0;
 	char *mem = malloc(size);
@@ -88,12 +88,12 @@ static void zip_read(struct zip_file *file, const char *filename, struct dive_ta
 		mem = realloc(mem, size);
 	}
 	mem[read] = 0;
-	(void) parse_xml_buffer(filename, mem, read, table, trips, sites, filter_presets, NULL);
+	(void) parse_xml_buffer(filename, mem, read, table, trips, sites, devices, filter_presets, NULL);
 	free(mem);
 }
 
 int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		    struct filter_preset_table *filter_presets)
+		    struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int success = 0;
 	/* Grr. libzip needs to re-open the file, it can't take a buffer */
@@ -108,7 +108,7 @@ int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_
 			/* skip parsing the divelogs.de pictures */
 			if (strstr(zip_get_name(zip, index, 0), "pictures/"))
 				continue;
-			zip_read(file, filename, table, trips, sites, filter_presets);
+			zip_read(file, filename, table, trips, sites, devices, filter_presets);
 			zip_fclose(file);
 			success++;
 		}
@@ -128,7 +128,8 @@ static int db_test_func(void *param, int columns, char **data, char **column)
 	return *data[0] == '0';
 }
 
-static int try_to_open_db(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+static int try_to_open_db(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips,
+			  struct dive_site_table *sites, struct device_table *devices)
 {
 	sqlite3 *handle;
 	char dm4_test[] = "select count(*) from sqlite_master where type='table' and name='Dive' and sql like '%ProfileBlob%'";
@@ -150,7 +151,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Suunto DM5 database format */
 	retval = sqlite3_exec(handle, dm5_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_dm5_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_dm5_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -158,7 +159,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Suunto DM4 database format */
 	retval = sqlite3_exec(handle, dm4_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_dm4_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_dm4_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -166,7 +167,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Shearwater database format */
 	retval = sqlite3_exec(handle, shearwater_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_shearwater_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_shearwater_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -174,7 +175,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Shearwater cloud database format */
 	retval = sqlite3_exec(handle, shearwater_cloud_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_shearwater_cloud_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_shearwater_cloud_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -182,7 +183,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Atomic Cobalt database format */
 	retval = sqlite3_exec(handle, cobalt_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_cobalt_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_cobalt_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -190,7 +191,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Divinglog database format */
 	retval = sqlite3_exec(handle, divinglog_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_divinglog_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_divinglog_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -198,7 +199,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
 	/* Testing if DB schema resembles Seac database format */
 	retval = sqlite3_exec(handle, seacsync_test, &db_test_func, 0, NULL);
 	if (!retval) {
-		retval = parse_seac_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites);
+		retval = parse_seac_buffer(handle, filename, mem->buffer, mem->size, table, trips, sites, devices);
 		sqlite3_close(handle);
 		return retval;
 	}
@@ -227,7 +228,7 @@ static int try_to_open_db(const char *filename, struct memblock *mem, struct div
  */
 static int open_by_filename(const char *filename, const char *fmt, struct memblock *mem,
 			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-			    struct filter_preset_table *filter_presets)
+			    struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	// hack to be able to provide a comment for the translated string
 	static char *csv_warning = QT_TRANSLATE_NOOP3("gettextFromC",
@@ -236,7 +237,7 @@ static int open_by_filename(const char *filename, const char *fmt, struct memblo
 
 	/* Suunto Dive Manager files: SDE, ZIP; divelogs.de files: DLD */
 	if (!strcasecmp(fmt, "SDE") || !strcasecmp(fmt, "ZIP") || !strcasecmp(fmt, "DLD"))
-		return try_to_open_zip(filename, table, trips, sites, filter_presets);
+		return try_to_open_zip(filename, table, trips, sites, devices, filter_presets);
 
 	/* CSV files */
 	if (!strcasecmp(fmt, "CSV"))
@@ -258,17 +259,18 @@ static int open_by_filename(const char *filename, const char *fmt, struct memblo
 }
 
 static int parse_file_buffer(const char *filename, struct memblock *mem, struct dive_table *table,
-			     struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
+			     struct trip_table *trips, struct dive_site_table *sites,
+			     struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	char *fmt = strrchr(filename, '.');
-	if (fmt && (ret = open_by_filename(filename, fmt + 1, mem, table, trips, sites, filter_presets)) != 0)
+	if (fmt && (ret = open_by_filename(filename, fmt + 1, mem, table, trips, sites, devices, filter_presets)) != 0)
 		return ret;
 
 	if (!mem->size || !mem->buffer)
 		return report_error("Out of memory parsing file %s\n", filename);
 
-	return parse_xml_buffer(filename, mem->buffer, mem->size, table, trips, sites, filter_presets, NULL);
+	return parse_xml_buffer(filename, mem->buffer, mem->size, table, trips, sites, devices, filter_presets, NULL);
 }
 
 int check_git_sha(const char *filename, struct git_repository **git_p, const char **branch_p)
@@ -305,7 +307,8 @@ int check_git_sha(const char *filename, struct git_repository **git_p, const cha
 	return 1;
 }
 
-int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets)
+int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+	       struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	struct git_repository *git;
 	const char *branch = NULL;
@@ -336,7 +339,7 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 
 	fmt = strrchr(filename, '.');
 	if (fmt && (!strcasecmp(fmt + 1, "DB") || !strcasecmp(fmt + 1, "BAK") || !strcasecmp(fmt + 1, "SQL"))) {
-		if (!try_to_open_db(filename, &mem, table, trips, sites)) {
+		if (!try_to_open_db(filename, &mem, table, trips, sites, devices)) {
 			free(mem.buffer);
 			return 0;
 		}
@@ -344,7 +347,7 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 
 	/* Divesoft Freedom */
 	if (fmt && (!strcasecmp(fmt + 1, "DLF"))) {
-		ret = parse_dlf_buffer(mem.buffer, mem.size, table, trips, sites);
+		ret = parse_dlf_buffer(mem.buffer, mem.size, table, trips, sites, devices);
 		free(mem.buffer);
 		return ret;
 	}
@@ -375,7 +378,7 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 		return 0;
 	}
 
-	ret = parse_file_buffer(filename, &mem, table, trips, sites, filter_presets);
+	ret = parse_file_buffer(filename, &mem, table, trips, sites, devices, filter_presets);
 	free(mem.buffer);
 	return ret;
 }

--- a/core/file.h
+++ b/core/file.h
@@ -13,6 +13,7 @@ struct memblock {
 };
 
 struct trip_table;
+struct device_table;
 struct dive_site_table;
 struct dive_table;
 struct zip;
@@ -26,8 +27,10 @@ extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct
 extern void ostctools_import(const char *file, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 extern int readfile(const char *filename, struct memblock *mem);
-extern int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
-extern int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+extern int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+		      struct device_table *devices, struct filter_preset_table *filter_presets);
+extern int try_to_open_zip(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+			   struct device_table *devices, struct filter_preset_table *filter_presets);
 
 // Platform specific functions
 extern int subsurface_rename(const char *path, const char *newpath);

--- a/core/file.h
+++ b/core/file.h
@@ -23,7 +23,8 @@ extern "C" {
 #endif
 extern int try_to_open_cochran(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 extern int try_to_open_liquivision(const char *filename, struct memblock *mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
+extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct dive_table *table, struct trip_table *trips,
+			   struct dive_site_table *sites, struct device_table *devices);
 extern void ostctools_import(const char *file, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
 
 extern int readfile(const char *filename, struct memblock *mem);

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -15,13 +15,15 @@ enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
 
 struct git_oid;
 struct git_repository;
+struct device_table;
 #define dummy_git_repository ((git_repository *)3ul) /* Random bogus pointer, not NULL */
 extern struct git_repository *is_git_repository(const char *filename, const char **branchp, const char **remote, bool dry_run);
 extern int check_git_sha(const char *filename, git_repository **git_p, const char **branch_p);
 extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
 extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
 extern int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
-			  struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+			  struct dive_site_table *sites, struct device_table *devices,
+			  struct filter_preset_table *filter_presets);
 extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
 extern const char *saved_git_id;

--- a/core/import-cobalt.c
+++ b/core/import-cobalt.c
@@ -217,7 +217,8 @@ static int cobalt_dive(void *param, int columns, char **data, char **column)
 
 
 int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+			    struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -229,6 +230,7 @@ int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buffer, in
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select Id,strftime('%s',DiveStartTime),LocationId,'buddy','notes',Units,(MaxDepthPressure*10000/SurfacePressure)-10000,DiveMinutes,SurfacePressure,SerialNumber,'model' from Dive where IsViewDeleted = 0";

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -26,14 +26,16 @@ extern "C" {
 #endif
 
 int parse_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate, struct dive_table *table,
-		   struct trip_table *trips, struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+		   struct trip_table *trips, struct dive_site_table *sites, struct device_table *devices,
+		   struct filter_preset_table *filter_presets);
 int try_to_open_csv(struct memblock *mem, enum csv_format type, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_txt_file(const char *filename, const char *csv, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
+int parse_txt_file(const char *filename, const char *csv, struct dive_table *table, struct trip_table *trips,
+		   struct dive_site_table *sites, struct device_table *devices);
 
 int parse_seabear_log(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     struct filter_preset_table *filter_presets);
+		      struct device_table *devices, struct filter_preset_table *filter_presets);
 int parse_manual_file(const char *filename, struct xml_params *params, struct dive_table *table, struct trip_table *trips,
-		      struct dive_site_table *sites, struct filter_preset_table *filter_presets);
+		      struct dive_site_table *sites, struct device_table *devices, struct filter_preset_table *filter_presets);
 
 #ifdef __cplusplus
 }

--- a/core/import-divinglog.c
+++ b/core/import-divinglog.c
@@ -389,7 +389,8 @@ static int divinglog_dive(void *param, int columns, char **data, char **column)
 
 
 int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+			    struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -401,6 +402,7 @@ int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buffer,
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select Number,strftime('%s',Divedate || ' ' || ifnull(Entrytime,'00:00')),Country || ' - ' || City || ' - ' || Place,Buddy,Comments,Depth,Divetime,Divemaster,Airtemp,Watertemp,Weight,Divesuit,Computer,ID,Visibility,SupplyType from Logbook where UUID not in (select UUID from DeletedRecords)";

--- a/core/import-seac.c
+++ b/core/import-seac.c
@@ -260,7 +260,8 @@ static int seac_dive(void *param, int columns, char **data, char **column)
  * table, to read in the sample values.
  */
 int parse_seac_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+		     struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -273,6 +274,7 @@ int parse_seac_buffer(sqlite3 *handle, const char *url, const char *buffer, int 
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	const char *get_dives = "SELECT dive_number, device_sn, date, timezone, time, elapsed_surface_time, dive_type, start_mode, water_type, comment, total_dive_time, max_depth, firmware_version FROM headers_dive";

--- a/core/import-shearwater.c
+++ b/core/import-shearwater.c
@@ -485,7 +485,8 @@ static int shearwater_cloud_dive(void *param, int columns, char **data, char **c
 }
 
 int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+			    struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -497,6 +498,7 @@ int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	// So far have not seen any sample rate in Shearwater Desktop
@@ -516,7 +518,8 @@ int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer
 }
 
 int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+			    struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+			    struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -528,6 +531,7 @@ int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select l.number,strftime('%s', DiveDate),location||' / '||site,buddy,notes,imperialUnits,maxDepth,DiveLengthTime,startSurfacePressure,computerSerial,computerModel,d.diveId,l.sampleRateMs / 1000 FROM dive_details AS d JOIN dive_logs AS l ON d.diveId=l.diveId";

--- a/core/import-suunto.c
+++ b/core/import-suunto.c
@@ -290,7 +290,8 @@ static int dm4_dive(void *param, int columns, char **data, char **column)
 }
 
 int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+		     struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -303,6 +304,7 @@ int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int s
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	/* StartTime is converted from Suunto's nano seconds to standard
@@ -560,7 +562,8 @@ static int dm5_dive(void *param, int columns, char **data, char **column)
 }
 
 int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buffer, int size,
-		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
+		     struct device_table *devices)
 {
 	UNUSED(buffer);
 	UNUSED(size);
@@ -573,6 +576,7 @@ int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buffer, int s
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.sql_handle = handle;
 
 	/* StartTime is converted from Suunto's nano seconds to standard

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -28,6 +28,7 @@ extern "C" {
 
 struct dive;
 struct dive_computer;
+struct devices;
 
 typedef struct {
 	dc_descriptor_t *descriptor;
@@ -47,6 +48,7 @@ typedef struct {
 	FILE *libdc_logfile;
 	struct dive_table *download_table;
 	struct dive_site_table *sites;
+	struct device_table *devices;
 	void *androidUsbDeviceDescriptor;
 } device_data_t;
 

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -29,8 +29,7 @@ extern "C" {
 struct dive;
 struct dive_computer;
 
-typedef struct dc_user_device_t
-{
+typedef struct {
 	dc_descriptor_t *descriptor;
 	const char *vendor, *product, *devname;
 	const char *model, *btname;

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -47,6 +47,7 @@ struct git_parser_state {
 	struct dive_table *table;
 	struct trip_table *trips;
 	struct dive_site_table *sites;
+	struct device_table *devices;
 	struct filter_preset_table *filter_presets;
 	int o2pressure_sensor;
 };
@@ -1879,7 +1880,7 @@ const char *get_sha(git_repository *repo, const char *branch)
  * or report an error and return 1 if the load failed.
  */
 int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
-		   struct dive_site_table *sites, struct filter_preset_table *filter_presets)
+		   struct dive_site_table *sites, struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	struct git_parser_state state = { 0 };
@@ -1887,6 +1888,7 @@ int git_load_dives(struct git_repository *repo, const char *branch, struct dive_
 	state.table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.filter_presets = filter_presets;
 
 	if (repo == dummy_git_repository)

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -830,7 +830,8 @@ static void try_to_fill_dc(struct divecomputer *dc, const char *name, char *buf,
 	if (MATCH("model", utf8_string, &dc->model))
 		return;
 	if (MATCH("deviceid", hex_value, &deviceid)) {
-		set_dc_deviceid(dc, deviceid, &device_table);
+		set_dc_deviceid(dc, deviceid, &device_table); // prefer already known serial/firmware over those from the loaded log
+		set_dc_deviceid(dc, deviceid, state->devices);
 		return;
 	}
 	if (MATCH("diveid", hex_value, &dc->diveid))

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1722,7 +1722,8 @@ static const char *preprocess_divelog_de(const char *buffer)
 
 int parse_xml_buffer(const char *url, const char *buffer, int size,
 		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     struct filter_preset_table *filter_presets, const struct xml_params *params)
+		     struct device_table *devices, struct filter_preset_table *filter_presets,
+		     const const struct xml_params *params)
 {
 	UNUSED(size);
 	xmlDoc *doc;
@@ -1734,6 +1735,7 @@ int parse_xml_buffer(const char *url, const char *buffer, int size,
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 	state.filter_presets = filter_presets;
 	doc = xmlReadMemory(res, strlen(res), url, NULL, 0);
 	if (!doc)
@@ -1776,7 +1778,8 @@ static timestamp_t parse_dlf_timestamp(unsigned char *buffer)
 	return offset + 946684800;
 }
 
-int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites)
+int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table, struct trip_table *trips,
+		     struct dive_site_table *sites, struct device_table *devices)
 {
 	unsigned char *ptr = buffer;
 	unsigned char event;
@@ -1800,6 +1803,7 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *tabl
 	state.target_table = table;
 	state.trips = trips;
 	state.sites = sites;
+	state.devices = devices;
 
 	// Check for the correct file magic
 	if (ptr[0] != 'D' || ptr[1] != 'i' || ptr[2] != 'v' || ptr[3] != 'E')

--- a/core/parse.c
+++ b/core/parse.c
@@ -201,7 +201,7 @@ void dc_settings_start(struct parser_state *state)
 
 void dc_settings_end(struct parser_state *state)
 {
-	create_device_node(&device_table, state->cur_settings.dc.model, state->cur_settings.dc.deviceid, state->cur_settings.dc.serial_nr,
+	create_device_node(state->devices, state->cur_settings.dc.model, state->cur_settings.dc.deviceid, state->cur_settings.dc.serial_nr,
 			   state->cur_settings.dc.firmware, state->cur_settings.dc.nickname);
 	reset_dc_settings(state);
 }

--- a/core/parse.h
+++ b/core/parse.h
@@ -78,6 +78,7 @@ struct parser_state {
 	struct dive_table *target_table;		/* non-owning */
 	struct trip_table *trips;			/* non-owning */
 	struct dive_site_table *sites;			/* non-owning */
+	struct device_table *devices;			/* non-owning */
 	struct filter_preset_table *filter_presets;	/* non-owning */
 
 	sqlite3 *sql_handle;			/* for SQL based parsers */
@@ -142,16 +143,24 @@ int atoi_n(char *ptr, unsigned int len);
 
 void parse_xml_init(void);
 int parse_xml_buffer(const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
-		     struct filter_preset_table *filter_presets, const struct xml_params *params);
+		     struct device_table *devices, struct filter_preset_table *filter_presets, const struct xml_params *params);
 void parse_xml_exit(void);
-int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_seac_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
-int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites);
+int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+		     struct dive_site_table *sites, struct device_table *devices);
+int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+		     struct dive_site_table *sites, struct device_table *devices);
+int parse_seac_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+		      struct dive_site_table *sites, struct device_table *devices);
+int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+			    struct dive_site_table *sites, struct device_table *devices);
+int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+				  struct dive_site_table *sites, struct device_table *devices);
+int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+			struct dive_site_table *sites, struct device_table *devices);
+int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buf, int size, struct dive_table *table, struct trip_table *trips,
+			   struct dive_site_table *sites, struct device_table *devices);
+int parse_dlf_buffer(unsigned char *buffer, size_t size, struct dive_table *table, struct trip_table *trips,
+		     struct dive_site_table *sites, struct device_table *devices);
 #ifdef __cplusplus
 }
 #endif

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -229,7 +229,7 @@ void BLEObject::addService(const QBluetoothUuid &newService)
 	}
 }
 
-BLEObject::BLEObject(QLowEnergyController *c, dc_user_device_t *d)
+BLEObject::BLEObject(QLowEnergyController *c, device_data_t *d)
 {
 	controller = c;
 	device = d;
@@ -520,13 +520,13 @@ dc_status_t BLEObject::setupHwTerminalIo(const QList<QLowEnergyCharacteristic> &
 // Bluez is broken, and doesn't have a sane way to query
 // whether to use a random address or not. So we have to
 // fake it.
-static int use_random_address(dc_user_device_t *user_device)
+static int use_random_address(device_data_t *user_device)
 {
 	return IS_SHEARWATER(user_device) || IS_GARMIN(user_device);
 }
 #endif
 
-dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, dc_user_device_t *user_device)
+dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_data_t *user_device)
 {
 	debugCounter = 0;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -18,7 +18,7 @@ class BLEObject : public QObject
 	Q_OBJECT
 
 public:
-	BLEObject(QLowEnergyController *c, dc_user_device_t *);
+	BLEObject(QLowEnergyController *c, device_data_t *);
 	~BLEObject();
 	inline void set_timeout(int value) { timeout = value; }
 	dc_status_t write(const void* data, size_t size, size_t *actual);
@@ -50,7 +50,7 @@ private:
 	QLowEnergyService *preferred = nullptr;
 	QList<QByteArray> receivedPackets;
 	bool isCharacteristicWritten;
-	dc_user_device_t *device;
+	device_data_t *device;
 	unsigned int hw_credit = 0;
 	unsigned int desc_written = 0;
 	int timeout;
@@ -65,7 +65,7 @@ private:
 
 
 extern "C" {
-dc_status_t qt_ble_open(void **io, dc_context_t *context, const char *devaddr, dc_user_device_t *user_device);
+dc_status_t qt_ble_open(void **io, dc_context_t *context, const char *devaddr, device_data_t *user_device);
 dc_status_t qt_ble_set_timeout(void *io, int timeout);
 dc_status_t qt_ble_poll(void *io, int timeout);
 dc_status_t qt_ble_read(void *io, void* data, size_t size, size_t *actual);

--- a/core/qtserialbluetooth.cpp
+++ b/core/qtserialbluetooth.cpp
@@ -300,7 +300,7 @@ ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* dev
 		.close		= qt_ble_close,
 	};
 
-	rc = qt_ble_open(&io, context, devaddr, (dc_user_device_t *) userdata);
+	rc = qt_ble_open(&io, context, devaddr, (device_data_t *) userdata);
 	if (rc != DC_STATUS_SUCCESS) {
 		return rc;
 	}

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -10,6 +10,8 @@
 
 #include <QObject>
 
+struct device;
+
 // Dive and trip fields that can be edited. Use bit fields so that we can pass multiple fields at once.
 // Provides an inlined flag-based constructur because sadly C-style designated initializers are only supported since C++20.
 struct DiveField {
@@ -124,6 +126,10 @@ signals:
 	void pictureOffsetChanged(dive *d, QString filename, offset_t offset);
 	void picturesRemoved(dive *d, QVector<QString> filenames);
 	void picturesAdded(dive *d, QVector<PictureObj> pics);
+
+	// Devices related signals
+	void deviceAdded(int index);
+	void deviceDeleted(int index);
 
 	// Filter related signals
 	void filterPresetAdded(int index);

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -13,6 +13,7 @@
 #include "core/filterpreset.h"
 #include "core/qthelper.h"
 #include "core/divesite.h"
+#include "core/device.h"
 #include "core/trip.h"
 #include "core/import-csv.h"
 #include "core/xmlparams.h"
@@ -880,15 +881,16 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QStringList r = resultModel->result();
 	if (ui->knownImports->currentText() != "Manual import") {
 		for (int i = 0; i < fileNames.size(); ++i) {
 			if (ui->knownImports->currentText() == "Seabear CSV") {
-				parse_seabear_log(qPrintable(fileNames[i]), &table, &trips, &sites, &filter_presets);
+				parse_seabear_log(qPrintable(fileNames[i]), &table, &trips, &sites, &devices, &filter_presets);
 			} else if (ui->knownImports->currentText() == "Poseidon MkVI") {
 				QPair<QString, QString> pair = poseidonFileNames(fileNames[i]);
-				parse_txt_file(qPrintable(pair.second), qPrintable(pair.first), &table, &trips, &sites);
+				parse_txt_file(qPrintable(pair.second), qPrintable(pair.first), &table, &trips, &sites, &devices);
 			} else {
 				xml_params params;
 
@@ -902,7 +904,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				setup_csv_params(r, params);
 				parse_csv_file(qPrintable(fileNames[i]), &params,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
-						&table, &trips, &sites, &filter_presets);
+						&table, &trips, &sites, &devices, &filter_presets);
 			}
 		}
 	} else {
@@ -938,7 +940,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				xml_params_add_int(&params, "visibilityField", r.indexOf(tr("Visibility")));
 				xml_params_add_int(&params, "ratingField", r.indexOf(tr("Rating")));
 
-				parse_manual_file(qPrintable(fileNames[i]), &params, &table, &trips, &sites, &filter_presets);
+				parse_manual_file(qPrintable(fileNames[i]), &params, &table, &trips, &sites, &devices, &filter_presets);
 			} else {
 				xml_params params;
 
@@ -952,7 +954,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 				setup_csv_params(r, params);
 				parse_csv_file(qPrintable(fileNames[i]), &params,
 						specialCSV.contains(ui->knownImports->currentIndex()) ? qPrintable(CSVApps[ui->knownImports->currentIndex()].name) : "csv",
-						&table, &trips, &sites, &filter_presets);
+						&table, &trips, &sites, &devices, &filter_presets);
 			}
 		}
 	}

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -960,7 +960,7 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 	}
 
 	QString source = fileNames.size() == 1 ? fileNames[0] : tr("multiple files");
-	Command::importDives(&table, &trips, &sites, nullptr, IMPORT_MERGE_ALL_TRIPS, source);
+	Command::importDives(&table, &trips, &sites, &devices, nullptr, IMPORT_MERGE_ALL_TRIPS, source);
 }
 
 TagDragDelegate::TagDragDelegate(QObject *parent) : QStyledItemDelegate(parent)

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1557,7 +1557,7 @@ void MainWindow::importFiles(const QStringList fileNames)
 		parse_file(fileNamePtr.data(), &table, &trips, &sites, &devices, &filter_presets);
 	}
 	QString source = fileNames.size() == 1 ? fileNames[0] : tr("multiple files");
-	Command::importDives(&table, &trips, &sites, &filter_presets, IMPORT_MERGE_ALL_TRIPS, source);
+	Command::importDives(&table, &trips, &sites, &devices, &filter_presets, IMPORT_MERGE_ALL_TRIPS, source);
 }
 
 void MainWindow::loadFiles(const QStringList fileNames)

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -530,7 +530,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 
 	showProgressBar();
 	QByteArray fileNamePtr = QFile::encodeName(filename);
-	if (!parse_file(fileNamePtr.data(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table))
+	if (!parse_file(fileNamePtr.data(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table))
 		setCurrentFile(fileNamePtr.data());
 	process_loaded_dives();
 	hideProgressBar();
@@ -1549,11 +1549,12 @@ void MainWindow::importFiles(const QStringList fileNames)
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
 
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		parse_file(fileNamePtr.data(), &table, &trips, &sites, &filter_presets);
+		parse_file(fileNamePtr.data(), &table, &trips, &sites, &devices, &filter_presets);
 	}
 	QString source = fileNames.size() == 1 ? fileNames[0] : tr("multiple files");
 	Command::importDives(&table, &trips, &sites, &filter_presets, IMPORT_MERGE_ALL_TRIPS, source);
@@ -1570,7 +1571,7 @@ void MainWindow::loadFiles(const QStringList fileNames)
 	showProgressBar();
 	for (int i = 0; i < fileNames.size(); ++i) {
 		fileNamePtr = QFile::encodeName(fileNames.at(i));
-		if (!parse_file(fileNamePtr.data(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table)) {
+		if (!parse_file(fileNamePtr.data(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table)) {
 			setCurrentFile(fileNamePtr.data());
 			addRecentFile(fileNamePtr, false);
 		}
@@ -1644,11 +1645,12 @@ void MainWindow::on_actionImportDiveSites_triggered()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
 
 	for (const QString &s: fileNames) {
 		QByteArray fileNamePtr = QFile::encodeName(s);
-		parse_file(fileNamePtr.data(), &table, &trips, &sites, &filter_presets);
+		parse_file(fileNamePtr.data(), &table, &trips, &sites, &devices, &filter_presets);
 	}
 	// The imported dive sites still have pointers to imported dives - remove them
 	for (int i = 0; i < sites.nr; ++i)

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -5,6 +5,7 @@
 #include "core/settings/qPrefCloudStorage.h"
 #include "desktop-widgets/mainwindow.h"
 #include "commands/command.h"
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/errorhelper.h"
@@ -456,8 +457,9 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 		struct dive_table table = empty_dive_table;
 		struct trip_table trips = empty_trip_table;
 		struct dive_site_table sites = empty_dive_site_table;
+		struct device_table devices;
 		struct filter_preset_table filter_presets;
-		parse_file(QFile::encodeName(zipFile.fileName()), &table, &trips, &sites, &filter_presets);
+		parse_file(QFile::encodeName(zipFile.fileName()), &table, &trips, &sites, &devices, &filter_presets);
 		Command::importDives(&table, &trips, &sites, nullptr, IMPORT_MERGE_ALL_TRIPS, QStringLiteral("divelogs.de"));
 
 		/* store last entered user/pass in config */

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -460,7 +460,7 @@ void DivelogsDeWebServices::buttonClicked(QAbstractButton *button)
 		struct device_table devices;
 		struct filter_preset_table filter_presets;
 		parse_file(QFile::encodeName(zipFile.fileName()), &table, &trips, &sites, &devices, &filter_presets);
-		Command::importDives(&table, &trips, &sites, nullptr, IMPORT_MERGE_ALL_TRIPS, QStringLiteral("divelogs.de"));
+		Command::importDives(&table, &trips, &sites, &devices, nullptr, IMPORT_MERGE_ALL_TRIPS, QStringLiteral("divelogs.de"));
 
 		/* store last entered user/pass in config */
 		qPrefCloudStorage::set_divelogde_user(ui.userID->text());

--- a/export-html.cpp
+++ b/export-html.cpp
@@ -9,6 +9,7 @@
 #include "core/qt-gui.h"
 #include "core/qthelper.h"
 #include "core/file.h"
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/save-html.h"
@@ -44,7 +45,7 @@ int main(int argc, char **argv)
 		qDebug() << "need --source and --output";
 		exit(1);
 	}
-	int ret = parse_file(qPrintable(source), &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	int ret = parse_file(qPrintable(source), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 	if (ret) {
 		fprintf(stderr, "parse_file returned %d\n", ret);
 		exit(1);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -454,7 +454,7 @@ void QMLManager::mergeLocalRepo()
 	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &devices, &filter_presets);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 }
 
 void QMLManager::copyAppLogToClipboard()
@@ -2242,7 +2242,7 @@ void QMLManager::importCacheRepo(QString repo)
 	QString repoPath = QString("%1/cloudstorage/%2").arg(system_default_directory()).arg(repo);
 	appendTextToLog(QString("importing %1").arg(repoPath));
 	parse_file(qPrintable(repoPath), &table, &trips, &sites, &devices, &filter_presets);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	changesNeedSaving();
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -708,7 +708,7 @@ void QMLManager::loadDivesWithValidCredentials()
 		}
 		if (git != dummy_git_repository) {
 			appendTextToLog(QString("have repository and branch %1").arg(branch));
-			error = git_load_dives(git, branch, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+			error = git_load_dives(git, branch, &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 		} else {
 			appendTextToLog(QString("didn't receive valid git repo, try again"));
 			error = parse_file(fileNamePrt.data(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -353,7 +353,7 @@ void QMLManager::openLocalThenRemote(QString url)
 	 * we try to open this), parse_file (which is called by openAndMaybeSync) will ALWAYS connect
 	 * to the remote and populate the cache.
 	 * Otherwise parse_file will respect the git_local_only flag and only update if that isn't set */
-	int error = parse_file(encodedFilename.constData(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	int error = parse_file(encodedFilename.constData(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 	if (error) {
 		/* there can be 2 reasons for this:
 		 * 1) we have cloud credentials, but there is no local repo (yet).
@@ -452,7 +452,7 @@ void QMLManager::mergeLocalRepo()
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
 	struct filter_preset_table filter_presets;
-	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &filter_presets);
+	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &device_table, &filter_presets);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 }
 
@@ -526,7 +526,7 @@ void QMLManager::finishSetup()
 		qPrefCloudStorage::set_cloud_verification_status(qPrefCloudStorage::CS_NOCLOUD);
 		saveCloudCredentials(qPrefCloudStorage::cloud_storage_email(), qPrefCloudStorage::cloud_storage_password(), qPrefCloudStorage::cloud_storage_pin());
 		appendTextToLog(tr("working in no-cloud mode"));
-		int error = parse_file(existing_filename, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+		int error = parse_file(existing_filename, &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 		if (error) {
 			// we got an error loading the local file
 			setNotificationText(tr("Error parsing local storage, giving up"));
@@ -710,7 +710,7 @@ void QMLManager::loadDivesWithValidCredentials()
 			error = git_load_dives(git, branch, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
 		} else {
 			appendTextToLog(QString("didn't receive valid git repo, try again"));
-			error = parse_file(fileNamePrt.data(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+			error = parse_file(fileNamePrt.data(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 		}
 		setDiveListProcessing(false);
 		if (!error) {
@@ -2236,10 +2236,11 @@ void QMLManager::importCacheRepo(QString repo)
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QString repoPath = QString("%1/cloudstorage/%2").arg(system_default_directory()).arg(repo);
 	appendTextToLog(QString("importing %1").arg(repoPath));
-	parse_file(qPrintable(repoPath), &table, &trips, &sites, &filter_presets);
+	parse_file(qPrintable(repoPath), &table, &trips, &sites, &devices, &filter_presets);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	changesNeedSaving();
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -451,8 +451,9 @@ void QMLManager::mergeLocalRepo()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
-	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &device_table, &filter_presets);
+	parse_file(qPrintable(nocloud_localstorage()), &table, &trips, &sites, &devices, &filter_presets);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 }
 

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -129,6 +129,7 @@ void DiveImportedModel::downloadThreadFinished()
 	// Move the table data from thread to model
 	move_dive_table(&thread.downloadTable, &diveTable);
 	move_dive_site_table(&thread.diveSiteTable, &sitesTable);
+	deviceTable = std::move(thread.deviceTable);
 
 	checkStates.resize(diveTable.nr);
 	std::fill(checkStates.begin(), checkStates.end(), true);

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -143,22 +143,24 @@ void DiveImportedModel::startDownload()
 	thread.start();
 }
 
-std::pair<struct dive_table, struct dive_site_table> DiveImportedModel::consumeTables()
+std::tuple<struct dive_table, struct dive_site_table, struct device_table> DiveImportedModel::consumeTables()
 {
 	beginResetModel();
 
 	// Move tables to result
 	struct dive_table dives = empty_dive_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	move_dive_table(&diveTable, &dives);
 	move_dive_site_table(&sitesTable, &sites);
+	devices = std::move(deviceTable);
 
 	// Reset indices
 	checkStates.clear();
 
 	endResetModel();
 
-	return std::make_pair(dives, sites);
+	return std::make_tuple(dives, sites, devices);
 }
 
 int DiveImportedModel::numDives() const
@@ -191,17 +193,18 @@ void DiveImportedModel::recordDives(int flags)
 	deleteDeselected();
 
 	// TODO: use structured bindings once we go C++17
-	std::pair<struct dive_table, struct dive_site_table> tables = consumeTables();
-	if (tables.first.nr > 0) {
+	std::tuple<struct dive_table, struct dive_site_table, struct device_table> tables = consumeTables();
+	if (std::get<0>(tables).nr > 0) {
 		auto data = thread.data();
-		Command::importDives(&tables.first, nullptr, &tables.second, nullptr, flags, data->devName());
+		Command::importDives(&std::get<0>(tables), nullptr, &std::get<1>(tables),
+				     &std::get<2>(tables), nullptr, flags, data->devName());
 	} else {
-		clear_dive_site_table(&tables.second);
+		clear_dive_site_table(&std::get<1>(tables));
 	}
 	// The dives and dive sites have been consumed, but the arrays of the tables
 	// still exist. Free them.
-	free(tables.first.dives);
-	free(tables.second.dive_sites);
+	free(std::get<0>(tables).dives);
+	free(std::get<1>(tables).dive_sites);
 }
 
 QHash<int, QByteArray> DiveImportedModel::roleNames() const {

--- a/qt-models/diveimportedmodel.h
+++ b/qt-models/diveimportedmodel.h
@@ -1,11 +1,11 @@
 #ifndef DIVEIMPORTEDMODEL_H
 #define DIVEIMPORTEDMODEL_H
 
-#include <QAbstractTableModel>
-#include <vector>
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/divelist.h"
 #include "core/downloadfromdcthread.h"
+#include <QAbstractTableModel>
 
 class DiveImportedModel : public QAbstractTableModel
 {
@@ -23,7 +23,7 @@ public:
 	Q_INVOKABLE void clearTable();
 	QHash<int, QByteArray> roleNames() const;
 	void deleteDeselected();
-	std::pair<struct dive_table, struct dive_site_table> consumeTables(); // Returns dives and sites and resets model.
+	std::tuple<struct dive_table, struct dive_site_table, struct device_table> consumeTables(); // Returns downloaded tables and resets model.
 
 	int numDives() const;
 	Q_INVOKABLE void recordDives(int flags = IMPORT_PREFER_IMPORTED | IMPORT_IS_DOWNLOADED);
@@ -48,6 +48,7 @@ private:
 	std::vector<char> checkStates; // char instead of bool to avoid silly pessimization of std::vector.
 	struct dive_table diveTable;
 	struct dive_site_table sitesTable;
+	struct device_table deviceTable;
 };
 
 #endif

--- a/tests/testAirPressure.cpp
+++ b/tests/testAirPressure.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testAirPressure.h"
+#include "core/device.h"
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/trip.h"
@@ -19,7 +20,8 @@ void TestAirPressure::get_dives()
 	struct dive *dive;
 	verbose = 1;
 
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TestAtmPress.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TestAtmPress.xml", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	dive = get_dive(0);
 	dive->selected = true;
 	QVERIFY(dive != NULL);
@@ -54,7 +56,8 @@ void TestAirPressure::testWriteReadBackAirPressure()
 	dive->surface_pressure.mbar = ap;
 	QCOMPARE(save_dives("./testout.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file("./testout.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file("./testout.ssrf", &dive_table, &trip_table, &dive_site_table,
+			    &device_table, &filter_preset_table), 0);
 	dive = get_dive(0);
 	QVERIFY(dive != NULL);
 	dive->selected = true;

--- a/tests/testdivesiteduplication.cpp
+++ b/tests/testdivesiteduplication.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testdivesiteduplication.h"
+#include "core/device.h"
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/trip.h"
@@ -7,7 +8,8 @@
 
 void TestDiveSiteDuplication::testReadV2()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(dive_site_table.nr, 2);
 }
 

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -2,6 +2,7 @@
 #include "testgitstorage.h"
 #include "git2.h"
 
+#include "core/device.h"
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/file.h"
@@ -153,7 +154,8 @@ void TestGitStorage::initTestCase()
 
 	// cleanup local and remote branches
 	localRemoteCleanup();
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 }
 
 void TestGitStorage::cleanupTestCase()
@@ -185,7 +187,8 @@ void TestGitStorage::testGitStorageLocal()
 {
 	// test writing and reading back from local git storage
 	git_repository *repo;
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QFETCH(QString, testDirName);
 	QFETCH(QString, prefixRead);
 	QFETCH(QString, prefixWrite);
@@ -198,7 +201,8 @@ void TestGitStorage::testGitStorageLocal()
 	QCOMPARE(save_dives(qPrintable(repoNameWrite + "[test]")), 0);
 	QCOMPARE(save_dives("./SampleDivesV3.ssrf"), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(repoNameRead + "[test]"), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(repoNameRead + "[test]"), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viagit.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -216,10 +220,12 @@ void TestGitStorage::testGitStorageCloud()
 	// test writing and reading back from cloud storage
 	// connect to the ssrftest repository on the cloud server
 	// and repeat the same test as before with the local git storage
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/SampleDivesV2.ssrf", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3.ssrf");
 	org.open(QFile::ReadOnly);
@@ -237,8 +243,10 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	// make a change to local cache repo (pretending that we did some offline changes)
 	// and then open the remote one again and check that things were propagated correctly
 	// read the local repo from the previous test and add dive 10
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	// calling process_loaded_dives() sorts the table, but calling add_imported_dives()
 	// causes it to try to update the window title... let's not do that
 	process_loaded_dives();
@@ -249,7 +257,8 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	clear_dive_file_data();
 	// now pretend that we are online again and open the cloud storage and compare
 	git_local_only = false;
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10viacloud.ssrf"), 0);
 	QFile org("./SampleDivesV3plus10local.ssrf");
 	org.open(QFile::ReadOnly);
@@ -264,7 +273,8 @@ void TestGitStorage::testGitStorageCloudOfflineSync()
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 	moveDir(localCacheDir, localCacheDir + "save");
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesV3plus10fromcloud.ssrf"), 0);
 	org.close();
 	org.open(QFile::ReadOnly);
@@ -293,8 +303,10 @@ void TestGitStorage::testGitStorageCloudMerge()
 
 	// (1) open the repo, add dive test11 and save to the cloud
 	git_local_only = false;
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
@@ -305,27 +317,34 @@ void TestGitStorage::testGitStorageCloudMerge()
 
 	// (3) open the repo from the old cache and add dive test12 while offline
 	git_local_only = true;
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	clear_dive_file_data();
 
 	// (4) now take things back online
 	git_local_only = false;
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	clear_dive_file_data();
 
 	// (5) now we should have all the dives in our repo on the second client
 	// first create the reference data from the xml files:
-	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file("./SampleDivesV3plus10local.ssrf", &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test11.xml", &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test12.xml", &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12.ssrf"), 0);
 	// then load from the cloud
 	clear_dive_file_data();
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12-merged.ssrf"), 0);
 	// finally compare what we have
@@ -342,7 +361,8 @@ void TestGitStorage::testGitStorageCloudMerge()
 
 	// (6) move ourselves back to the first client and compare data there
 	moveDir(localCacheDir + "client1", localCacheDir);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QCOMPARE(save_dives("./SampleDivesV3plus10-11-12-merged-client1.ssrf"), 0);
 	QFile client1("./SampleDivesV3plus10-11-12-merged-client1.ssrf");
@@ -358,7 +378,8 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	// edit the same dive in the cloud repo
 	// merge
 	// (1) open repo, delete second dive, save offline
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	struct dive *dive = get_dive(1);
 	delete_single_dive(1);
@@ -372,7 +393,8 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	moveDir(localCacheDir, localCacheDir + "save");
 
 	// (3) now we open the cloud storage repo and modify that second dive
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	dive = get_dive(1);
 	QVERIFY(dive != NULL);
@@ -384,7 +406,8 @@ void TestGitStorage::testGitStorageCloudMerge2()
 	// (4) move the saved local cache  backinto place and try to open the cloud repo
 	//     -> this forces a merge
 	moveDir(localCacheDir + "save", localCacheDir);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesMinus1-merged.ssrf"), 0);
 	QCOMPARE(save_dives(qPrintable(cloudTestRepo)), 0);
 	QFile org("./SampleDivesMinus1-merged.ssrf");
@@ -407,7 +430,8 @@ void TestGitStorage::testGitStorageCloudMerge3()
 
 
 	// (1) open repo, edit notes of first three dives
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	struct dive *dive;
 	QVERIFY((dive = get_dive(0)) != 0);
@@ -423,7 +447,8 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	clear_dive_file_data();
 
 	// (2) make different edits offline
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QVERIFY((dive = get_dive(0)) != 0);
 	free(dive->notes);
@@ -442,7 +467,8 @@ void TestGitStorage::testGitStorageCloudMerge3()
 	// (3) simulate a second system by moving the cache away and open the cloud storage repo and modify
 	//     those first dive notes differently while online
 	moveDir(localCacheDir, localCacheDir + "save");
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 	QVERIFY((dive = get_dive(0)) != 0);
 	free(dive->notes);
@@ -458,7 +484,8 @@ void TestGitStorage::testGitStorageCloudMerge3()
 
 	// (4) move the saved local cache back into place and open the cloud repo -> this forces a merge
 	moveDir(localCacheDir + "save", localCacheDir);
-	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(qPrintable(cloudTestRepo), &dive_table, &trip_table,
+		 &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./SampleDivesMerge3.ssrf"), 0);
 	// we are not trying to compare this to a pre-determined result... what this test
 	// checks is that there are no parsing errors with the merge

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testmerge.h"
+#include "core/device.h"
 #include "core/dive.h" // for save_dives()
 #include "core/divesite.h"
 #include "core/file.h"
@@ -25,10 +26,11 @@ void TestMerge::testMergeEmpty()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
@@ -52,10 +54,11 @@ void TestMerge::testMergeBackwards()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test48+47.xml");

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -29,9 +29,9 @@ void TestMerge::testMergeEmpty()
 	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test47+48.xml");
 	org.open(QFile::ReadOnly);
@@ -57,9 +57,9 @@ void TestMerge::testMergeBackwards()
 	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test48.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(save_dives("./testmerge47+48.ssrf"), 0);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/test48+47.xml");
 	org.open(QFile::ReadOnly);

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testparse.h"
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/errorhelper.h"
 #include "core/trip.h"
@@ -82,7 +83,8 @@ int TestParse::parseCSV(int units, std::string file)
 	xml_params_add_int(&params, "airtempField", -1);
 	xml_params_add_int(&params, "watertempField", -1);
 
-	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table,
+				 &dive_site_table, &device_table, &filter_preset_table);
 }
 
 int TestParse::parseDivingLog()
@@ -93,7 +95,7 @@ int TestParse::parseDivingLog()
 
 	int ret = sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql", &_sqlite3_handle);
 	if (ret == 0)
-		ret = parse_divinglog_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table);
+		ret = parse_divinglog_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table, &device_table);
 	else
 		fprintf(stderr, "Can't open sqlite3 db: " SUBSURFACE_TEST_DATA "/dives/TestDivingLog4.1.1.sql");
 
@@ -103,13 +105,15 @@ int TestParse::parseDivingLog()
 int TestParse::parseV2NoQuestion()
 {
 	// parsing of a V2 file should work
-	return parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table,
+			  &dive_site_table, &device_table, &filter_preset_table);
 }
 
 int TestParse::parseV3()
 {
 	// parsing of a V3 files should succeed
-	return parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml", &dive_table, &trip_table,
+			  &dive_site_table, &device_table, &filter_preset_table);
 }
 
 void TestParse::testParse()
@@ -134,7 +138,7 @@ void TestParse::testParse()
 void TestParse::testParseDM4()
 {
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &_sqlite3_handle), 0);
-	QCOMPARE(parse_dm4_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table), 0);
+	QCOMPARE(parse_dm4_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table, &device_table), 0);
 
 	QCOMPARE(save_dives("./testdm4out.ssrf"), 0);
 	FILE_COMPARE("./testdm4out.ssrf",
@@ -144,7 +148,7 @@ void TestParse::testParseDM4()
 void TestParse::testParseDM5()
 {
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM5.db", &_sqlite3_handle), 0);
-	QCOMPARE(parse_dm5_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table), 0);
+	QCOMPARE(parse_dm5_buffer(_sqlite3_handle, 0, 0, 0, &dive_table, &trip_table, &dive_site_table, &device_table), 0);
 
 	QCOMPARE(save_dives("./testdm5out.ssrf"), 0);
 	FILE_COMPARE("./testdm5out.ssrf",
@@ -173,7 +177,8 @@ void TestParse::testParseHUDC()
 	xml_params_add(&params, "hw", "\"DC text\"");
 
 	QCOMPARE(parse_csv_file(SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.csv",
-				&params, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
+				&params, "csv", &dive_table, &trip_table, &dive_site_table,
+				&device_table, &filter_preset_table),
 		 0);
 
 	QCOMPARE(dive_table.nr, 1);
@@ -218,7 +223,8 @@ void TestParse::testParseNewFormat()
 							       "/dives/")
 						   .append(files.at(i))
 						   .toLatin1()
-						   .data(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
+						   .data(), &dive_table, &trip_table, &dive_site_table,
+						   &device_table, &filter_preset_table),
 			 0);
 		QCOMPARE(dive_table.nr, i + 1);
 	}
@@ -237,7 +243,7 @@ void TestParse::testParseDLD()
 	QString filename = SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.DLD";
 
 	QVERIFY(readfile(filename.toLatin1().data(), &mem) > 0);
-	QVERIFY(try_to_open_zip(filename.toLatin1().data(), &dive_table, &trip_table, &dive_site_table, &filter_preset_table) > 0);
+	QVERIFY(try_to_open_zip(filename.toLatin1().data(), &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table) > 0);
 
 	fprintf(stderr, "number of dives from DLD: %d \n", dive_table.nr);
 
@@ -252,8 +258,10 @@ void TestParse::testParseMerge()
 	/*
 	 * check that we correctly merge mixed cylinder dives
 	 */
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml", &dive_table, &trip_table, &dive_site_table,
+			    &device_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml", &dive_table, &trip_table, &dive_site_table,
+			    &device_table, &filter_preset_table), 0);
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
 	FILE_COMPARE("./testmerge.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
@@ -293,15 +301,16 @@ int TestParse::parseCSVmanual(int units, std::string file)
 	xml_params_add_int(&params, "datefmt", 2);
 	xml_params_add_int(&params, "durationfmt", 2);
 	xml_params_add_int(&params, "units", units);
-
-	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_manual_file(file.c_str(), &params, &dive_table, &trip_table,
+				 &dive_site_table, &device_table, &filter_preset_table);
 }
 
 void TestParse::exportCSVDiveDetails()
 {
 	int saved_sac = 0;
 
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test25.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test25.xml", &dive_table, &trip_table, &dive_site_table,
+		   &device_table, &filter_preset_table);
 
 	export_dives_xslt("testcsvexportmanual.csv", 0, 0, "xml2manualcsv.xslt", false);
 	export_dives_xslt("testcsvexportmanualimperial.csv", 0, 1, "xml2manualcsv.xslt", false);
@@ -336,7 +345,8 @@ void TestParse::exportSubsurfaceCSV()
 	xml_params params;
 
 	/* Test SubsurfaceCSV with multiple cylinders */
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table,
+		   &dive_site_table, &device_table, &filter_preset_table);
 
 	export_dives_xslt("testcsvexportmanual-cyl.csv", 0, 0, "xml2manualcsv.xslt", false);
 	export_dives_xslt("testcsvexportmanualimperial-cyl.csv", 0, 1, "xml2manualcsv.xslt", false);
@@ -350,7 +360,8 @@ void TestParse::exportSubsurfaceCSV()
 
 	xml_params_add_int(&params, "separatorIndex", 0);
 	xml_params_add_int(&params, "units", 1);
-	parse_csv_file("testcsvexportmanualimperial-cyl.csv", &params, "SubsurfaceCSV", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_csv_file("testcsvexportmanualimperial-cyl.csv", &params, "SubsurfaceCSV", &dive_table, &trip_table,
+		       &dive_site_table, &device_table, &filter_preset_table);
 
 	// We do not currently support reading SAC, thus faking it
 	if (dive_table.nr > 0) {
@@ -383,12 +394,14 @@ int TestParse::parseCSVprofile(int units, std::string file)
 	xml_params_add_int(&params, "datefmt", 2);
 	xml_params_add_int(&params, "units", units);
 
-	return parse_csv_file(file.c_str(), &params, "csv", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	return parse_csv_file(file.c_str(), &params, "csv", &dive_table, &trip_table,
+			      &dive_site_table, &device_table, &filter_preset_table);
 }
 
 void TestParse::exportCSVDiveProfile()
 {
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table,
+		   &dive_site_table, &device_table, &filter_preset_table);
 
 	export_dives_xslt("testcsvexportprofile.csv", 0, 0, "xml2csv.xslt", false);
 	export_dives_xslt("testcsvexportprofileimperial.csv", 0, 1, "xml2csv.xslt", false);
@@ -406,13 +419,14 @@ void TestParse::exportCSVDiveProfile()
 
 void TestParse::exportUDDF()
 {
-	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file(SUBSURFACE_TEST_DATA "/dives/test40.xml", &dive_table, &trip_table,
+		   &dive_site_table, &device_table, &filter_preset_table);
 
 	export_dives_xslt("testuddfexport.uddf", 0, 1, "uddf-export.xslt", false);
 
 	clear_dive_file_data();
 
-	parse_file("testuddfexport.uddf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file("testuddfexport.uddf", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 	export_dives_xslt("testuddfexport2.uddf", 0, 1, "uddf-export.xslt", false);
 
 	FILE_COMPARE("testuddfexport.uddf",
@@ -456,7 +470,7 @@ void TestParse::parseDL7()
 
 	clear_dive_file_data();
 	QCOMPARE(parse_csv_file(SUBSURFACE_TEST_DATA "/dives/DL7.zxu",
-				&params, "DL7", &dive_table, &trip_table, &dive_site_table, &filter_preset_table),
+				&params, "DL7", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table),
 		 0);
 	QCOMPARE(dive_table.nr, 3);
 

--- a/tests/testparseperformance.cpp
+++ b/tests/testparseperformance.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testparseperformance.h"
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/file.h"
@@ -63,7 +64,8 @@ void TestParsePerformance::parseSsrf()
 		return;
 	}
 	QBENCHMARK {
-		parse_file(SUBSURFACE_TEST_DATA "/dives/large-anon.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+		parse_file(SUBSURFACE_TEST_DATA "/dives/large-anon.ssrf", &dive_table, &trip_table,
+			   &dive_site_table, &device_table, &filter_preset_table);
 	}
 }
 
@@ -74,12 +76,14 @@ void TestParsePerformance::parseGit()
 
 	// first parse this once to populate the local cache - this way network
 	// effects don't dominate the parse time
-	parse_file(LARGE_TEST_REPO "[git]", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file(LARGE_TEST_REPO "[git]", &dive_table, &trip_table, &dive_site_table,
+		   &device_table, &filter_preset_table);
 
 	cleanup();
 
 	QBENCHMARK {
-		parse_file(LARGE_TEST_REPO "[git]", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+		parse_file(LARGE_TEST_REPO "[git]", &dive_table, &trip_table, &dive_site_table,
+			   &device_table, &filter_preset_table);
 	}
 }
 

--- a/tests/testpicture.cpp
+++ b/tests/testpicture.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testpicture.h"
+#include "core/device.h"
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/errorhelper.h"
@@ -26,7 +27,7 @@ void TestPicture::addPicture()
 	struct picture *pic1, *pic2;
 	verbose = 1;
 
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test44.xml", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table), 0);
 	dive = get_dive(0);
 	// Pictures will be added to selected dives
 	dive->selected = true;

--- a/tests/testprofile.cpp
+++ b/tests/testprofile.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testprofile.h"
+#include "core/device.h"
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/file.h"
@@ -12,10 +13,9 @@
 // ..dives/exportprofilereference.csv) and copy the former over the later and commit that change
 // as well.
 
-
 void TestProfile::testProfileExport()
 {
-	parse_file("../dives/abitofeverything.ssrf", &dive_table, &trip_table, &dive_site_table, &filter_preset_table);
+	parse_file("../dives/abitofeverything.ssrf", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table);
 	save_profiledata("exportprofile.csv", false);
 	QFile org("../dives/exportprofilereference.csv");
 	org.open(QFile::ReadOnly);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -21,7 +21,7 @@ void TestRenumber::testMerge()
 	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
 	mark_divelist_changed(false);
@@ -35,7 +35,7 @@ void TestRenumber::testMergeAndAppend()
 	struct device_table devices;
 	struct filter_preset_table filter_presets;
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
-	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
+	add_imported_dives(&table, &trips, &sites, &devices, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);
 	struct dive *d = get_dive(1);

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testrenumber.h"
+#include "core/device.h"
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/trip.h"
@@ -8,7 +9,7 @@
 
 void TestRenumber::setup()
 {
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table, &trip_table, &dive_site_table, &filter_preset_table), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 }
 
@@ -17,8 +18,9 @@ void TestRenumber::testMerge()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47b.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 1);
 	QCOMPARE(unsaved_changes(), 1);
@@ -30,8 +32,9 @@ void TestRenumber::testMergeAndAppend()
 	struct dive_table table = empty_dive_table;
 	struct trip_table trips = empty_trip_table;
 	struct dive_site_table sites = empty_dive_site_table;
+	struct device_table devices;
 	struct filter_preset_table filter_presets;
-	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table, &trips, &sites, &filter_presets), 0);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47c.xml", &table, &trips, &sites, &devices, &filter_presets), 0);
 	add_imported_dives(&table, &trips, &sites, IMPORT_MERGE_ALL_TRIPS);
 	QCOMPARE(dive_table.nr, 2);
 	QCOMPARE(unsaved_changes(), 1);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
So far, download / import would directly add to the global device table. This means that on undo of download / import, the devices stayed there. This changes the download / import code to parse into a separate table, which is then imported by the ImportDives undo-command. Thus, direct write-access of global state is reduces (there is still some left - e.g. autogroup).

Warning: I quickly tested import, but download is untested and will probably crash. I will try to do that in the upcoming days.

Note: In the not-so-distant future, I plan to collect all the tables in a `struct divelog`. This should make the whole parser-state thing more palatable.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add devices to non-global table
2) Make adding of devices undoable

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.