### PR TITLE
[TRIVIAL] cleanup: remove TagWidget::fixPopupPosition()

### DIFF
--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -196,14 +196,6 @@ void TagWidget::wheelEvent(QWheelEvent *event)
 	}
 }
 
-void TagWidget::fixPopupPosition(int delta)
-{
-	if(m_completer->popup()->isVisible()){
-		QRect toGlobal = m_completer->popup()->geometry();
-		m_completer->popup()->setGeometry(toGlobal.x(), toGlobal.y() + delta +10, toGlobal.width(), toGlobal.height());
-	}
-}
-
 // Since we capture enter / return / tab, we never send an editingFinished() signal.
 // Therefore, override the focusOutEvent()
 void TagWidget::focusOutEvent(QFocusEvent *ev)

--- a/desktop-widgets/tagwidget.h
+++ b/desktop-widgets/tagwidget.h
@@ -18,7 +18,6 @@ public:
 	void clear();
 	void setCursorPosition(int position);
 	void wheelEvent(QWheelEvent *event);
-	void fixPopupPosition(int delta);
 public
 slots:
 	void reparse();


### PR DESCRIPTION
No user of that member function!

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removes an unused function. Nothing more to say, really.