### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,8 +211,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         # this is only needed on Ubuntu
         # but shouldn't hurt on other Linux versions
         # in some builds we appear to be missing libz for some strange reason...
-	# Add ssh2 at the end for openSUSE builds (for recent cmake?)
-        set(SUBSURFACE_LINK_LIBRARIES ${SUBSURFACE_LINK_LIBRARIES} -lssh2 -lz -lpthread)
+        set(SUBSURFACE_LINK_LIBRARIES ${SUBSURFACE_LINK_LIBRARIES} -lz -lpthread)
 
         # Test for ARM processor (Raspberry Pi) and add libGLESv2 if found
         if (CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "armv6l")

--- a/INSTALL
+++ b/INSTALL
@@ -140,10 +140,11 @@ On Fedora you need
 
 sudo dnf install autoconf automake bluez-libs-devel cmake gcc-c++ git \
 	libcurl-devel libsqlite3x-devel libssh2-devel libtool libudev-devel \
-	libusbx-devel libxml2-devel libxslt-devel libzlib-devel make \
+	libusbx-devel libxml2-devel libxslt-devel make \
 	qt5-qtbase-devel qt5-qtconnectivity-devel qt5-qtdeclarative-devel \
 	qt5-qtlocation-devel qt5-qtscript-devel qt5-qtsvg-devel \
-	qt5-qttools-devel qt5-qtwebkit-devel redhat-rpm-config
+	qt5-qttools-devel qt5-qtwebkit-devel redhat-rpm-config \
+	bluez-libs-devel libgit2-devel libzip-devel
 
 
 Package names are sadly different on OpenSUSE
@@ -153,7 +154,8 @@ sudo zypper install git gcc-c++ make autoconf automake libtool cmake libzip-deve
 	libqt5-linguist-devel libqt5-qttools-devel libQt5WebKitWidgets-devel \
 	libqt5-qtbase-devel libQt5WebKit5-devel libqt5-qtsvg-devel \
 	libqt5-qtscript-devel libqt5-qtdeclarative-devel \
-	libqt5-qtconnectivity-devel libqt5-qtlocation-devel libcurl-devel
+	libqt5-qtconnectivity-devel libqt5-qtlocation-devel libcurl-devel \
+	bluez-devel libgit2-devel
 
 On Debian Buster this seems to work
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an odd one. I believe we used to need that on some Linux flavors when we built libgit2 from source and because of that didn't automatically pick up the full required link line (or something - I don't quite recall). But when using the distro provided libgit2 (as we can now do on all supported distros that I'm aware of) we don't actually need -lssh2 anymore and so we'd have to install a library that we don't need, just to be able to link against it for no reason... that doesn't seem smart.

Also, playing with Subsurface builds on a bunch of VMs both on a Raspberry Pi and on my Intel NUCs against current distros I realized that our INSTALL file was no longer current WRT packages needed. Time permitting I may continue to explore those instructions a little more :-)

