### PR TITLE
[TRIVIAL] cleanup: remove double const qualifier

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1724,7 +1724,7 @@ static const char *preprocess_divelog_de(const char *buffer)
 int parse_xml_buffer(const char *url, const char *buffer, int size,
 		     struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,
 		     struct device_table *devices, struct filter_preset_table *filter_presets,
-		     const const struct xml_params *params)
+		     const struct xml_params *params)
 {
 	UNUSED(size);
 	xmlDoc *doc;


### PR DESCRIPTION
The redundant qualifier was introduced in an erroneous rebase.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove double const, which causes warnings. This is so trivial that as an exception I may commit this when CI completes.