### PR TITLE
filter: use 64-bit integer literal for generating bit fields

### DIFF
--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -1059,7 +1059,7 @@ static bool check_year_range(const filter_constraint &c, const struct dive *d)
 
 static bool check_multiple_choice(const filter_constraint &c, int v)
 {
-	bool has_bit = c.data.multiple_choice & (1 << v);
+	bool has_bit = c.data.multiple_choice & (1ULL << v);
 	return has_bit != c.negate;
 }
 

--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -324,7 +324,7 @@ void FilterConstraintWidget::update()
 	if (multipleChoice) {
 		uint64_t bits = idx.data(FilterConstraintModel::MULTIPLE_CHOICE_ROLE).value<uint64_t>();
 		for (int i = 0; i < multipleChoice->count(); ++i)
-			multipleChoice->item(i)->setSelected(bits & (1 << i));
+			multipleChoice->item(i)->setSelected(bits & (1ULL << i));
 	}
 
 	// Update the unit strings in case the locale was changed
@@ -392,9 +392,11 @@ void FilterConstraintWidget::multipleChoiceEdited()
 	uint64_t bits = 0;
 	for (const QModelIndex &idx: multipleChoice->selectionModel()->selectedIndexes()) {
 		int row = idx.row();
-		if (row >= 64)
+		if (row >= 64) {
 			qWarning("FilterConstraint: multiple-choice with more than 64 entries not supported");
-		bits |= 1 << row;
+			continue;
+		}
+		bits |= 1ULL << row;
 	}
 	QModelIndex idx = model->index(row, 0);
 	model->setData(idx, qulonglong(bits), FilterConstraintModel::MULTIPLE_CHOICE_ROLE);


### PR DESCRIPTION
For multiple-choice constraints we use a bit field of type
uint64_t. This means we theoretically support up to 64 items.
Currently use at most seven.

Coverity complained (correctly) that we use the expression
"1 << x" to generate the bitfields. However 1 is a 32-bit
literal on most platforms, which makes this undefined
behavior for x >= 32. Change the integer literal to 64-bit
1ULL.

Moreover, when detecting items with an index >= 64, don't
even attempt to set the according bit, since this is
undefined behavior and the compiler is free to do as it
pleases in such a case.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix of a latent bug, which solves a Coverity warning. Not visible now, but could become active if we have multiple-choice constraints with more than 31 entries. 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use 64-bit integer literals to create bit fields.
2) Don't attempt to create bit fields with invalid indexes.
