### PR TITLE
cleanup: refactor subsurfacesysinfo.cpp

### DIFF
--- a/core/subsurfacesysinfo.cpp
+++ b/core/subsurfacesysinfo.cpp
@@ -1,73 +1,10 @@
 // SPDX-License-Identifier: LGPL-2.1+
-/****************************************************************************
-**
-** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Copyright (C) 2014 Intel Corporation
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtCore module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-****************************************************************************/
-
 #include "subsurfacesysinfo.h"
-#include <QString>
+#include <QSysInfo>
 
-#ifdef Q_OS_UNIX
-#include <sys/utsname.h>
-#endif
-
-QString SubsurfaceSysInfo::prettyOsName()
-{
-	// Matches the pre-release version of Qt 5.4
-	QString pretty = prettyProductName();
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(Q_OS_ANDROID)
-	// QSysInfo::kernelType() returns lowercase ("linux" instead of "Linux")
-	struct utsname u;
-	if (uname(&u) == 0)
-		return QString::fromLatin1(u.sysname) + QLatin1String(" (") + pretty + QLatin1Char(')');
-#endif
-	return pretty;
-}
-
-extern "C" {
-bool isWin7Or8()
-{
 #ifdef Q_OS_WIN
+extern "C" bool isWin7Or8()
+{
 	return (QSysInfo::WindowsVersion & QSysInfo::WV_NT_based) >= QSysInfo::WV_WINDOWS7;
-#else
-	return false;
+}
 #endif
-}
-}

--- a/core/subsurfacesysinfo.h
+++ b/core/subsurfacesysinfo.h
@@ -1,55 +1,14 @@
-// SPDX-License-Identifier: LGPL-2.1+
-/****************************************************************************
-**
-** Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-** Copyright (C) 2014 Intel Corporation
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtCore module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-****************************************************************************/
-
 #ifndef SUBSURFACESYSINFO_H
 #define SUBSURFACESYSINFO_H
 
-#include <QSysInfo>
+#include <QtGlobal>
 
-class SubsurfaceSysInfo : public QSysInfo {
-public:
-	static QString prettyOsName();
-};
+#ifdef Q_OS_WIN
+#ifdef __cplusplus
+extern "C"
+#endif
 
+bool isWin7Or8();
+#endif
 
 #endif // SUBSURFACESYSINFO_H

--- a/core/windows.c
+++ b/core/windows.c
@@ -7,6 +7,7 @@
 #include "display.h"
 #include "file.h"
 #include "errorhelper.h"
+#include "subsurfacesysinfo.h"
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x500
 #include <windows.h>
@@ -22,8 +23,6 @@ const char non_standard_system_divelist_default_font[] = "Calibri";
 const char current_system_divelist_default_font[] = "Segoe UI";
 const char *system_divelist_default_font = non_standard_system_divelist_default_font;
 double system_divelist_default_font_size = -1;
-
-extern bool isWin7Or8();
 
 void subsurface_OS_pref_setup(void)
 {


### PR DESCRIPTION
This used to be a copy of QSysInfo. However, once the requirement
was raised to Qt5.4, this was replaced by a subclass of the original
QSysInfo - which made the whole file mostly obsolete.

Just use QSysInfo directly where needed.

Only for windows.c, which can't call directly into Qt, keep the
isWin7Or8() helper function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Idle code-hygiene thing: This removes a rather bizarre artifact. There used to be a copy of QSysInfo, which accordingly had full Qt attribution. Since that was removed, the whole thing became somewhat pointless. Just access QSysInfo directly where needed (qthelper.cpp). Reminds me that it is time to split qthelper.cpp into sensible pieces (e.g. string-formatting and other helpers).

I hope I didn't mess up the user string and the windows code!

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh 