### PR TITLE
[WIP] Implement a statistics application state on desktop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ endif()
 #set up the subsurface_link_libraries variable
 set(SUBSURFACE_LINK_LIBRARIES ${SUBSURFACE_LINK_LIBRARIES} ${LIBDIVECOMPUTER_LIBRARIES} ${LIBGIT2_LIBRARIES} ${LIBUSB_LIBRARIES} ${LIBMTP_LIBRARIES})
 if (NOT SUBSURFACE_TARGET_EXECUTABLE MATCHES "DownloaderExecutable")
-	qt5_add_resources(SUBSURFACE_RESOURCES subsurface.qrc map-widget/qml/map-widget.qrc)
+	qt5_add_resources(SUBSURFACE_RESOURCES subsurface.qrc map-widget/qml/map-widget.qrc stats/qml/statsview.qrc)
 endif()
 
 # hack to build successfully on LGTM
@@ -320,6 +320,7 @@ if (NOT SUBSURFACE_TARGET_EXECUTABLE MATCHES "DownloaderExecutable")
 add_subdirectory(profile-widget)
 add_subdirectory(map-widget)
 add_subdirectory(mobile-widgets)
+add_subdirectory(stats)
 endif()
 add_subdirectory(backend-shared)
 
@@ -389,6 +390,7 @@ elseif (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DesktopExecutable")
 		subsurface_models_desktop
 		subsurface_commands
 		subsurface_corelib
+		subsurface_stats
 		${SUBSURFACE_LINK_LIBRARIES}
 	)
 	add_dependencies(subsurface_desktop_preferences subsurface_generated_ui)

--- a/core/applicationstate.cpp
+++ b/core/applicationstate.cpp
@@ -12,4 +12,3 @@ void setAppState(ApplicationState state)
 {
 	appState = state;
 }
-

--- a/core/applicationstate.h
+++ b/core/applicationstate.h
@@ -12,6 +12,7 @@ enum class ApplicationState {
 	EditPlannedDive,
 	EditDiveSite,
 	FilterDive,
+	Statistics,
 	Count
 };
 

--- a/core/gas.c
+++ b/core/gas.c
@@ -22,7 +22,7 @@ bool isobaric_counterdiffusion(struct gasmix oldgasmix, struct gasmix newgasmix,
 	return get_he(oldgasmix) > 0 && results->dN2 > 0 && results->dHe < 0 && get_he(oldgasmix) && results->dN2 > 0 && 5 * results->dN2 > -results->dHe;
 }
 
-static bool gasmix_is_invalid(struct gasmix mix)
+bool gasmix_is_invalid(struct gasmix mix)
 {
 	return mix.o2.permille < 0;
 }

--- a/core/gas.c
+++ b/core/gas.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "gas.h"
 #include "pref.h"
+#include "gettext.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -138,4 +139,27 @@ void fill_pressures(struct gas_pressures *pressures, const double amb_pressure, 
 			pressures->n2 = get_n2(mix) / 1000.0 * amb_pressure;
 		}
 	}
+}
+
+enum gastype gasmix_to_type(struct gasmix mix)
+{
+	if (gasmix_is_air(mix))
+		return GASTYPE_AIR;
+	if (mix.he.permille == 0)
+		return mix.o2.permille >= 230 ? GASTYPE_NITROX : GASTYPE_AIR;
+	return mix.he.permille <= 300 ? GASTYPE_NORMOXIC : GASTYPE_TRIMIX;
+}
+
+static const char *gastype_names[] = {
+	QT_TRANSLATE_NOOP("gettextFromC", "Air"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Nitrox"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Normoxic"),
+	QT_TRANSLATE_NOOP("gettextFromC", "Trimix")
+};
+
+const char *gastype_name(enum gastype type)
+{
+	if (type < 0 || type >= GASTYPE_COUNT)
+		return "";
+	return translate("gettextFromC", gastype_names[type]);
 }

--- a/core/gas.h
+++ b/core/gas.h
@@ -67,6 +67,7 @@ extern fraction_t get_gas_component_fraction(struct gasmix mix, enum gas_compone
 extern void fill_pressures(struct gas_pressures *pressures, double amb_pressure, struct gasmix mix, double po2, enum divemode_t dctype);
 
 extern bool gasmix_is_air(struct gasmix gasmix);
+extern bool gasmix_is_invalid(struct gasmix mix);
 extern enum gastype gasmix_to_type(struct gasmix mix);
 extern const char *gastype_name(enum gastype type);
 

--- a/core/gas.h
+++ b/core/gas.h
@@ -22,6 +22,14 @@ struct gasmix {
 static const struct gasmix gasmix_invalid = { { -1 }, { -1 } };
 static const struct gasmix gasmix_air = { { 0 }, { 0 } };
 
+enum gastype {
+	GASTYPE_AIR,
+	GASTYPE_NITROX,
+	GASTYPE_NORMOXIC,
+	GASTYPE_TRIMIX,
+	GASTYPE_COUNT
+};
+
 struct icd_data { // This structure provides communication between function isobaric_counterdiffusion() and the calling software.
 	int dN2;      // The change in fraction (permille) of nitrogen during the change
 	int dHe;      // The change in fraction (permille) of helium during the change
@@ -59,6 +67,8 @@ extern fraction_t get_gas_component_fraction(struct gasmix mix, enum gas_compone
 extern void fill_pressures(struct gas_pressures *pressures, double amb_pressure, struct gasmix mix, double po2, enum divemode_t dctype);
 
 extern bool gasmix_is_air(struct gasmix gasmix);
+extern enum gastype gasmix_to_type(struct gasmix mix);
+extern const char *gastype_name(enum gastype type);
 
 #ifdef __cplusplus
 }

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -11,8 +11,8 @@
 #include <QString>
 #include <QImageReader>
 #include <QDataStream>
-#include <QSvgRenderer>
 #include <QPainter>
+#include <QSvgRenderer>
 
 #include <QtConcurrent>
 
@@ -154,19 +154,9 @@ Thumbnailer::Thumbnail Thumbnailer::getHashedImage(const QString &filename, bool
 	return thumbnail;
 }
 
-static QImage renderIcon(const char *id, int size)
-{
-	QImage res(size, size, QImage::Format_RGB32);
-	res.fill(Qt::white);
-	QSvgRenderer svg{QString(id)};
-	QPainter painter(&res);
-	svg.render(&painter);
-	return res;
-}
-
-// As renderIcon, but render to a fixed width and scale height accordingly
+// As renderSVGIcon(), but render to a fixed width and scale height accordingly
 // and have a transparent background.
-static QImage renderIconWidth(const char *id, int size)
+static QImage renderSVGIconWidth(const char *id, int size)
 {
 	QSvgRenderer svg{QString(id)};
 	QSize svgSize = svg.defaultSize();
@@ -176,11 +166,11 @@ static QImage renderIconWidth(const char *id, int size)
 	return res;
 }
 
-Thumbnailer::Thumbnailer() : failImage(renderIcon(":filter-close", maxThumbnailSize())), // TODO: Don't misuse filter close icon
-			     dummyImage(renderIcon(":camera-icon", maxThumbnailSize())),
-			     videoImage(renderIcon(":video-icon", maxThumbnailSize())),
-			     videoOverlayImage(renderIconWidth(":video-overlay", maxThumbnailSize())),
-			     unknownImage(renderIcon(":unknown-icon", maxThumbnailSize()))
+Thumbnailer::Thumbnailer() : failImage(renderSVGIcon(":filter-close", maxThumbnailSize())), // TODO: Don't misuse filter close icon
+			     dummyImage(renderSVGIcon(":camera-icon", maxThumbnailSize())),
+			     videoImage(renderSVGIcon(":video-icon", maxThumbnailSize())),
+			     videoOverlayImage(renderSVGIconWidth(":video-overlay", maxThumbnailSize())),
+			     unknownImage(renderSVGIcon(":unknown-icon", maxThumbnailSize()))
 {
 	// Currently, we only process one image at a time. Stefan Fuchs reported problems when
 	// calculating multiple thumbnails at once and this hopefully helps.

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -166,11 +166,11 @@ static QImage renderSVGIconWidth(const char *id, int size)
 	return res;
 }
 
-Thumbnailer::Thumbnailer() : failImage(renderSVGIcon(":filter-close", maxThumbnailSize())), // TODO: Don't misuse filter close icon
-			     dummyImage(renderSVGIcon(":camera-icon", maxThumbnailSize())),
-			     videoImage(renderSVGIcon(":video-icon", maxThumbnailSize())),
+Thumbnailer::Thumbnailer() : failImage(renderSVGIcon(":filter-close", maxThumbnailSize(), false)), // TODO: Don't misuse filter close icon
+			     dummyImage(renderSVGIcon(":camera-icon", maxThumbnailSize(), false)),
+			     videoImage(renderSVGIcon(":video-icon", maxThumbnailSize(), false)),
 			     videoOverlayImage(renderSVGIconWidth(":video-overlay", maxThumbnailSize())),
-			     unknownImage(renderSVGIcon(":unknown-icon", maxThumbnailSize()))
+			     unknownImage(renderSVGIcon(":unknown-icon", maxThumbnailSize(), false))
 {
 	// Currently, we only process one image at a time. Stefan Fuchs reported problems when
 	// calculating multiple thumbnails at once and this hopefully helps.

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -36,7 +36,9 @@
 #include <QFont>
 #include <QApplication>
 #include <QTextDocument>
+#include <QPainter>
 #include <QProgressDialog>	// TODO: remove with convertThumbnails()
+#include <QSvgRenderer>
 #include <cstdarg>
 #include <cstdint>
 #ifdef Q_OS_UNIX
@@ -1700,4 +1702,14 @@ std::vector<int> get_cylinder_map_for_add(int count, int n)
 extern "C" void emit_reset_signal()
 {
 	emit diveListNotifier.dataReset();
+}
+
+QImage renderSVGIcon(const char *id, int size)
+{
+	QImage res(size, size, QImage::Format_RGB32);
+	res.fill(Qt::white);
+	QSvgRenderer svg{QString(id)};
+	QPainter painter(&res);
+	svg.render(&painter);
+	return res;
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1704,10 +1704,10 @@ extern "C" void emit_reset_signal()
 	emit diveListNotifier.dataReset();
 }
 
-QImage renderSVGIcon(const char *id, int size)
+QImage renderSVGIcon(const char *id, int size, bool transparent)
 {
-	QImage res(size, size, QImage::Format_RGB32);
-	res.fill(Qt::white);
+	QImage res(size, size, transparent ? QImage::Format_ARGB32 : QImage::Format_RGB32);
+	res.fill(transparent ? Qt::transparent : Qt::white);
 	QSvgRenderer svg{QString(id)};
 	QPainter painter(&res);
 	svg.render(&painter);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -21,6 +21,7 @@ enum watertypes {FRESHWATER, BRACKISHWATER, EN13319WATER, SALTWATER, DC_WATERTYP
 
 #include <QString>
 #include "core/gettextfromc.h"
+class QImage;
 
 QString weight_string(int weight_in_grams);
 QString distance_string(int distanceInMeters);
@@ -86,6 +87,7 @@ QString getUserAgent();
 QString printGPSCoords(const location_t *loc);
 std::vector<int> get_cylinder_map_for_remove(int count, int n);
 std::vector<int> get_cylinder_map_for_add(int count, int n);
+QImage renderSVGIcon(const char *id, int size);
 
 extern QString (*changesCallback)();
 void uiNotification(const QString &msg);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -87,7 +87,7 @@ QString getUserAgent();
 QString printGPSCoords(const location_t *loc);
 std::vector<int> get_cylinder_map_for_remove(int count, int n);
 std::vector<int> get_cylinder_map_for_add(int count, int n);
-QImage renderSVGIcon(const char *id, int size);
+QImage renderSVGIcon(const char *id, int size, bool transparent);
 
 extern QString (*changesCallback)();
 void uiNotification(const QString &msg);

--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -40,6 +40,7 @@ set (SUBSURFACE_UI
 	setpoint.ui
 	shiftimagetimes.ui
 	shifttimes.ui
+	statswidget.ui
 	tableview.ui
 	templateedit.ui
 	tripselectiodialog.ui
@@ -104,6 +105,8 @@ set(SUBSURFACE_INTERFACE
 	simplewidgets.cpp
 	simplewidgets.h
 	starwidget.cpp
+	statswidget.h
+	statswidget.cpp
 	starwidget.h
 	subsurfacewebservices.cpp
 	subsurfacewebservices.h

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -50,6 +50,7 @@
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "desktop-widgets/updatemanager.h"
 #include "desktop-widgets/simplewidgets.h"
+#include "desktop-widgets/statswidget.h"
 #include "commands/command.h"
 
 #include "profile-widget/profilewidget2.h"
@@ -141,6 +142,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	graphics = new ProfileWidget2(this);
 	MapWidget *mapWidget = MapWidget::instance();
 	plannerWidgets.reset(new PlannerWidgets);
+	StatsWidget *statistics = new StatsWidget(this);
 
 	// what is a sane order for those icons? we should have the ones the user is
 	// most likely to want towards the top so they are always visible
@@ -183,6 +185,8 @@ MainWindow::MainWindow() : QMainWindow(),
 								   { diveList, FLAG_DISABLED }, { mapWidget, FLAG_NONE } });
 	registerApplicationState(ApplicationState::FilterDive, { { mainTab.get(), FLAG_NONE }, { profileContainer, FLAG_NONE },
 								 { diveList, FLAG_NONE },      { &filterWidget, FLAG_NONE } });
+	registerApplicationState(ApplicationState::Statistics, { { statistics, FLAG_NONE }, { profileContainer, FLAG_NONE },
+								 { diveList, FLAG_DISABLED },   { &filterWidget, FLAG_NONE } });
 	setApplicationState(ApplicationState::Default);
 
 	setWindowIcon(QIcon(":subsurface-icon"));
@@ -1593,6 +1597,15 @@ void MainWindow::on_actionFilterTags_triggered()
 		showFilterIfEnabled();
 }
 
+void MainWindow::on_actionStats_triggered()
+{
+	setApplicationState(getAppState() == ApplicationState::Statistics ? ApplicationState::Default : ApplicationState::Statistics);
+	toggleCollapsible(true);
+	ui.topSplitter->setSizes({ EXPANDED, COLLAPSED });
+	ui.mainSplitter->setSizes({ EXPANDED, EXPANDED });
+	ui.bottomSplitter->setSizes({ EXPANDED, EXPANDED });
+}
+
 void MainWindow::showFilterIfEnabled()
 {
 	if (getAppState() == ApplicationState::FilterDive) {
@@ -1642,6 +1655,11 @@ void MainWindow::setApplicationState(ApplicationState state)
 	setQuadrant(quadrants.topRight, ui.topRight);
 	setQuadrant(quadrants.bottomLeft, ui.bottomLeft);
 	setQuadrant(quadrants.bottomRight, ui.bottomRight);
+
+	// The statistics view does its own thing with respect to visibility
+	// of quadrants. So in case we leave that state, change to the
+	// original visibility of the quadrants.
+	enterState(this->state);
 }
 
 void MainWindow::showProgressBar()

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -52,7 +52,7 @@ public:
 		MAP_MAXIMIZED,
 		INFO_MAXIMIZED,
 		PROFILE_MAXIMIZED,
-		LIST_MAXIMIZED,
+		LIST_MAXIMIZED
 	};
 
 	MainWindow();
@@ -132,6 +132,7 @@ slots:
 	void on_copy_triggered();
 	void on_paste_triggered();
 	void on_actionFilterTags_triggered();
+	void on_actionStats_triggered();
 	void on_actionConfigure_Dive_Computer_triggered();
 	void setDefaultState();
 	void setAutomaticTitle();

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -97,6 +97,7 @@
     <addaction name="actionAutoGroup"/>
     <addaction name="separator"/>
     <addaction name="actionFilterTags"/>
+    <addaction name="actionStats"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -107,6 +108,7 @@
     <addaction name="actionViewProfile"/>
     <addaction name="actionViewInfo"/>
     <addaction name="actionViewMap"/>
+    <addaction name="actionViewStats"/>
     <addaction name="separator"/>
     <addaction name="actionYearlyStatistics"/>
     <addaction name="actionPreviousDC"/>
@@ -638,6 +640,14 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+F</string>
+   </property>
+  </action>
+  <action name="actionStats">
+   <property name="text">
+    <string>Dive statistics</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+T</string>
    </property>
   </action>
   <action name="profTissues">

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -7,9 +7,15 @@ StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
 	ui.setupUi(this);
 
 	connect(ui.close, &QToolButton::clicked, this, &StatsWidget::closeStats);
+	connect(ui.plot, &QToolButton::clicked, this, &StatsWidget::plot);
 }
 
 void StatsWidget::closeStats()
 {
 	MainWindow::instance()->setApplicationState(ApplicationState::Default);
+}
+
+void StatsWidget::plot()
+{
+	ui.stats->plot();
 }

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statswidget.h"
+#include "mainwindow.h"
+
+StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
+{
+	ui.setupUi(this);
+
+	connect(ui.close, &QToolButton::clicked, this, &StatsWidget::closeStats);
+}
+
+void StatsWidget::closeStats()
+{
+	MainWindow::instance()->setApplicationState(ApplicationState::Default);
+}

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statswidget.h"
 #include "mainwindow.h"
+#include "stats/statsview.h"
 
 StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
 {
@@ -8,6 +9,13 @@ StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
 
 	connect(ui.close, &QToolButton::clicked, this, &StatsWidget::closeStats);
 	connect(ui.plot, &QToolButton::clicked, this, &StatsWidget::plot);
+
+	ui.chartType->addItems(StatsView::getChartTypes());
+	connect(ui.chartType, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::chartTypeChanged);
+	connect(ui.firstAxis, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::firstAxisChanged);
+	connect(ui.secondAxis, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::secondAxisChanged);
+
+	chartTypeChanged(0);
 }
 
 void StatsWidget::closeStats()
@@ -17,5 +25,101 @@ void StatsWidget::closeStats()
 
 void StatsWidget::plot()
 {
-	ui.stats->plot();
+	ui.stats->plot(
+		ui.chartType->currentIndex(),
+		ui.chartSubType->currentIndex(),
+		ui.firstAxis->currentIndex(),
+		ui.firstAxisBin->currentIndex(),
+		ui.firstAxisOperation->currentIndex(),
+		ui.secondAxis->currentIndex(),
+		ui.secondAxisBin->currentIndex(),
+		ui.secondAxisOperation->currentIndex()
+	);
+}
+
+void StatsWidget::chartTypeChanged(int idx)
+{
+	QStringList subTypes = StatsView::getChartSubTypes(idx);
+	ui.chartSubType->clear();
+	if (subTypes.isEmpty()) {
+		ui.chartSubType->hide();
+	} else {
+		ui.chartSubType->addItems(subTypes);
+		ui.chartSubType->show();
+	}
+
+	QStringList firstAxisTypes = StatsView::getFirstAxisTypes(idx);
+	ui.firstAxis->clear();
+	if (firstAxisTypes.isEmpty()) {
+		ui.firstAxis->hide();
+		ui.firstAxisBin->hide();
+		ui.firstAxisOperation->hide();
+		ui.secondAxis->hide();
+		ui.secondAxisBin->hide();
+		ui.secondAxisOperation->hide();
+		return;
+	}
+
+	ui.firstAxis->addItems(firstAxisTypes);
+	ui.firstAxis->show();
+	firstAxisChanged(0);
+}
+
+void StatsWidget::firstAxisChanged(int idx)
+{
+	int chartType = ui.chartType->currentIndex();
+	QStringList firstAxisBins = StatsView::getFirstAxisBins(chartType, idx);
+	ui.firstAxisBin->clear();
+	if (firstAxisBins.size() <= 1) {
+		ui.firstAxisBin->hide();
+	} else {
+		ui.firstAxisBin->addItems(firstAxisBins);
+		ui.firstAxisBin->show();
+	}
+
+	QStringList firstAxisOperations = StatsView::getFirstAxisOperations(chartType, idx);
+	ui.firstAxisOperation->clear();
+	if (firstAxisOperations.size() <= 1) {
+		ui.firstAxisOperation->hide();
+	} else {
+		ui.firstAxisOperation->addItems(firstAxisOperations);
+		ui.firstAxisOperation->show();
+	}
+
+	QStringList secondAxisTypes = StatsView::getSecondAxisTypes(chartType, idx);
+	ui.secondAxis->clear();
+	if (secondAxisTypes.isEmpty()) {
+		ui.secondAxis->hide();
+		ui.secondAxisBin->hide();
+		ui.secondAxisOperation->hide();
+		return;
+	}
+
+	ui.secondAxis->addItems(secondAxisTypes);
+	ui.secondAxis->show();
+	secondAxisChanged(0);
+}
+
+void StatsWidget::secondAxisChanged(int idx)
+{
+	int chartType = ui.chartType->currentIndex();
+	int firstAxisType = ui.firstAxis->currentIndex();
+	QStringList secondAxisBins = StatsView::getSecondAxisBins(chartType, firstAxisType, idx);
+	ui.secondAxisBin->clear();
+	if (secondAxisBins.size() <= 1) {
+		ui.secondAxisBin->hide();
+	} else {
+		ui.secondAxisBin->addItems(secondAxisBins);
+		ui.secondAxisBin->show();
+	}
+
+	QStringList secondAxisOperations = StatsView::getSecondAxisOperations(chartType, firstAxisType, idx);
+	ui.secondAxisOperation->clear();
+	if (secondAxisOperations.size() <= 1) {
+		ui.secondAxisOperation->hide();
+	} else {
+		ui.secondAxisOperation->addItems(secondAxisOperations);
+		ui.secondAxisOperation->show();
+	}
+
 }

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -11,6 +11,9 @@ public:
 private
 slots:
 	void closeStats();
+	void chartTypeChanged(int);
+	void firstAxisChanged(int);
+	void secondAxisChanged(int);
 	void plot();
 private:
 	Ui::StatsWidget ui;

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -11,6 +11,7 @@ public:
 private
 slots:
 	void closeStats();
+	void plot();
 private:
 	Ui::StatsWidget ui;
 };

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef STATSWIDGET_H
+#define STATSWIDGET_H
+
+#include "ui_statswidget.h"
+
+class StatsWidget : public QWidget {
+	Q_OBJECT
+public:
+	StatsWidget(QWidget *parent = 0);
+private
+slots:
+	void closeStats();
+private:
+	Ui::StatsWidget ui;
+};
+
+#endif // STATSWIDGET_H

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -2,7 +2,12 @@
 #ifndef STATSWIDGET_H
 #define STATSWIDGET_H
 
+#include "stats/statsstate.h"
 #include "ui_statswidget.h"
+#include <vector>
+#include <memory>
+
+class QCheckBox;
 
 class StatsWidget : public QWidget {
 	Q_OBJECT
@@ -12,11 +17,18 @@ private
 slots:
 	void closeStats();
 	void chartTypeChanged(int);
-	void firstAxisChanged(int);
-	void secondAxisChanged(int);
-	void plot();
+	void var1Changed(int);
+	void var2Changed(int);
+	void var1BinnerChanged(int);
+	void var2BinnerChanged(int);
+	void var2OperationChanged(int);
+	void featureChanged(int, bool);
 private:
 	Ui::StatsWidget ui;
+	StatsState state;
+	void updateUi();
+	std::vector<std::unique_ptr<QCheckBox>> features;
+	void showEvent(QShowEvent *) override;
 };
 
 #endif // STATSWIDGET_H

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -3,6 +3,7 @@
 #define STATSWIDGET_H
 
 #include "stats/statsstate.h"
+#include "stats/chartlistmodel.h"
 #include "ui_statswidget.h"
 #include <vector>
 #include <memory>
@@ -28,6 +29,9 @@ private:
 	StatsState state;
 	void updateUi();
 	std::vector<std::unique_ptr<QCheckBox>> features;
+
+	ChartListModel charts;
+	//QStringListModel charts;
 	void showEvent(QShowEvent *) override;
 };
 

--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -12,33 +12,56 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QToolButton" name="close">
-     <property name="text">
-      <string>Close</string>
-     </property>
-     <property name="icon">
-      <iconset><normaloff>:filter-close</normaloff>:filter-close</iconset>
-     </property>
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonTextBesideIcon</enum>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="headerLayout">
+     <item>
+      <widget class="QToolButton" name="close">
+       <property name="text">
+        <string>Close</string>
+       </property>
+       <property name="icon">
+        <iconset><normaloff>:filter-close</normaloff>:filter-close</iconset>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="plot">
+       <property name="text">
+        <string>Plot</string>
+       </property>
+      </widget>
+     </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+    </layout>
    </item>
    <item>
-    <widget class="QToolButton" name="stats">
+    <widget class="StatsView" name="stats">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string>Placeholder</string>
-     </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>StatsView</class>
+   <extends>QQuickWidget</extends>
+   <header>stats/statsview.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../subsurface.qrc"/>
  </resources>

--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -10,9 +10,9 @@
     <height>848</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <layout class="QHBoxLayout" name="headerLayout">
+    <layout class="QVBoxLayout" name="headerLayout">
      <item>
       <widget class="QToolButton" name="close">
        <property name="text">
@@ -27,19 +27,72 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="chartTypeLabel">
+       <property name="text">
+        <string>Chart type</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="chartType">
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="chartSubType">
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="firstAxisLabel">
+       <property name="text">
+        <string>First axis</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="firstAxis">
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="firstAxisBin">
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="firstAxisOperation">
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="secondAxisLabel">
+       <property name="text">
+        <string>Second axis</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="secondAxis">
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="secondAxisBin">
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="secondAxisOperation">
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="plot">
        <property name="text">
         <string>Plot</string>
        </property>
       </widget>
      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </spacer>
-      </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </spacer>
+     </item>
     </layout>
    </item>
    <item>

--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StatsWidget</class>
+ <widget class="QWidget" name="Statistics">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>555</width>
+    <height>848</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QToolButton" name="close">
+     <property name="text">
+      <string>Close</string>
+     </property>
+     <property name="icon">
+      <iconset><normaloff>:filter-close</normaloff>:filter-close</iconset>
+     </property>
+     <property name="toolButtonStyle">
+      <enum>Qt::ToolButtonTextBesideIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="stats">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Placeholder</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../subsurface.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -27,6 +27,26 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="var1Label">
+       <property name="text">
+        <string>Plot against</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="var1" />
+     </item>
+     <item>
+      <widget class="QLabel" name="var2Label">
+       <property name="text">
+        <string>Variable</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="var2" />
+     </item>
+     <item>
       <widget class="QLabel" name="chartTypeLabel">
        <property name="text">
         <string>Chart type</string>
@@ -34,57 +54,28 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="chartType">
-      </widget>
+      <widget class="QComboBox" name="chartType" />
      </item>
      <item>
-      <widget class="QComboBox" name="chartSubType">
-      </widget>
+      <widget class="QLabel" name="var1BinnerLabel" />
      </item>
      <item>
-      <widget class="QLabel" name="firstAxisLabel">
-       <property name="text">
-        <string>First axis</string>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="var1Binner" />
      </item>
      <item>
-      <widget class="QComboBox" name="firstAxis">
-      </widget>
+      <widget class="QLabel" name="var2BinnerLabel" />
      </item>
      <item>
-      <widget class="QComboBox" name="firstAxisBin">
-      </widget>
+      <widget class="QComboBox" name="var2Binner" />
      </item>
      <item>
-      <widget class="QComboBox" name="firstAxisOperation">
-      </widget>
+      <widget class="QLabel" name="var2OperationLabel" />
      </item>
      <item>
-      <widget class="QLabel" name="secondAxisLabel">
-       <property name="text">
-        <string>Second axis</string>
-       </property>
-      </widget>
+      <widget class="QComboBox" name="var2Operation" />
      </item>
      <item>
-      <widget class="QComboBox" name="secondAxis">
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="secondAxisBin">
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="secondAxisOperation">
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="plot">
-       <property name="text">
-        <string>Plot</string>
-       </property>
-      </widget>
+      <layout class="QVBoxLayout" name="features" />
      </item>
      <item>
       <spacer name="verticalSpacer">

--- a/icons/chart_bar_grouped_horizontal.svg
+++ b/icons/chart_bar_grouped_horizontal.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="197.10001"
+       y="-99.900002"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect2083"
+       width="4.8000011"
+       height="87.095314"
+       x="208.35001"
+       y="-87.19532"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3490"
+       width="4.8000011"
+       height="46.714348"
+       x="215.85001"
+       y="-46.814358"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3492"
+       width="4.8000011"
+       height="32.264889"
+       x="223.35001"
+       y="-32.36491"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3494"
+       width="4.8000011"
+       height="61.806065"
+       x="238.35001"
+       y="-61.906078"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3496"
+       width="4.8000011"
+       height="23.830708"
+       x="245.85001"
+       y="-23.930706"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3498"
+       width="4.8000011"
+       height="76.250023"
+       x="253.35001"
+       y="-76.350029"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3500"
+       width="4.8000011"
+       height="46.882599"
+       x="268.35001"
+       y="-46.982616"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3502"
+       width="4.8000011"
+       height="58.173393"
+       x="275.85001"
+       y="-58.273403"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3504"
+       width="4.8000011"
+       height="25.311098"
+       x="283.35001"
+       y="-25.411114"
+       transform="rotate(90)" />
+  </g>
+</svg>

--- a/icons/chart_bar_grouped_vertical.svg
+++ b/icons/chart_bar_grouped_vertical.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="0.1"
+       y="197.10001" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect2083"
+       width="4.8000011"
+       height="87.095314"
+       x="11.35"
+       y="209.80469" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3490"
+       width="4.8000011"
+       height="46.714348"
+       x="18.85"
+       y="250.18565" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3492"
+       width="4.8000011"
+       height="32.264889"
+       x="26.35"
+       y="264.6351" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3494"
+       width="4.8000011"
+       height="61.806065"
+       x="41.349998"
+       y="235.09393" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3496"
+       width="4.8000011"
+       height="23.830708"
+       x="48.849998"
+       y="273.06931" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3498"
+       width="4.8000011"
+       height="76.250023"
+       x="56.349998"
+       y="220.64998" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3500"
+       width="4.8000011"
+       height="46.882599"
+       x="71.349998"
+       y="250.0174" />
+    <rect
+       style="fill:#55d400;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3502"
+       width="4.8000011"
+       height="58.173393"
+       x="78.849998"
+       y="238.72661" />
+    <rect
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.199999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3504"
+       width="4.8000011"
+       height="25.311098"
+       x="86.349998"
+       y="271.5889" />
+  </g>
+</svg>

--- a/icons/chart_bar_horizontal.svg
+++ b/icons/chart_bar_horizontal.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="197.10002"
+       y="-99.900002"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect853"
+       width="19.799999"
+       height="46.130878"
+       x="207.10002"
+       y="-46.230877"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect855"
+       width="19.799999"
+       height="87.386894"
+       x="237.10002"
+       y="-87.486885"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect857"
+       width="19.799999"
+       height="66.071342"
+       x="267.10004"
+       y="-66.171333"
+       transform="rotate(90)" />
+  </g>
+</svg>

--- a/icons/chart_bar_stacked_horizontal.svg
+++ b/icons/chart_bar_stacked_horizontal.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="197.10002"
+       y="-99.900002"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect853"
+       width="19.799999"
+       height="46.130878"
+       x="207.10002"
+       y="-46.230877"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect855"
+       width="19.799999"
+       height="87.386894"
+       x="237.10002"
+       y="-87.486885"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect857"
+       width="19.799999"
+       height="66.071342"
+       x="267.10004"
+       y="-66.171333"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1447"
+       width="19.799999"
+       height="33.238956"
+       x="207.10002"
+       y="-33.33897"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1449"
+       width="19.799999"
+       height="16.670628"
+       x="207.10002"
+       y="-16.770641"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1451"
+       width="19.799999"
+       height="70.848572"
+       x="237.10002"
+       y="-70.948586"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1453"
+       width="19.799999"
+       height="19.758835"
+       x="237.10002"
+       y="-19.858837"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1455"
+       width="19.799999"
+       height="30.866888"
+       x="267.10004"
+       y="-30.9669"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1457"
+       width="19.799999"
+       height="12.261885"
+       x="267.10004"
+       y="-12.361889"
+       transform="rotate(90)" />
+  </g>
+</svg>

--- a/icons/chart_bar_stacked_vertical.svg
+++ b/icons/chart_bar_stacked_vertical.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="0.1"
+       y="197.10001" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect853"
+       width="19.799999"
+       height="46.130878"
+       x="10.1"
+       y="250.76913" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect855"
+       width="19.799999"
+       height="87.386894"
+       x="40.099998"
+       y="209.51312" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect857"
+       width="19.799999"
+       height="66.071342"
+       x="70.099998"
+       y="230.82867" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1447"
+       width="19.799999"
+       height="33.238956"
+       x="10.1"
+       y="263.66104" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1449"
+       width="19.799999"
+       height="16.670628"
+       x="10.1"
+       y="280.22937" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1451"
+       width="19.799999"
+       height="70.848572"
+       x="40.099998"
+       y="226.05144" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1453"
+       width="19.799999"
+       height="19.758835"
+       x="40.099998"
+       y="277.14117" />
+    <rect
+       style="fill:#55d400;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1455"
+       width="19.799999"
+       height="30.866888"
+       x="70.099998"
+       y="266.03311" />
+    <rect
+       style="fill:#ff6600;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect1457"
+       width="19.799999"
+       height="12.261885"
+       x="70.099998"
+       y="284.63812" />
+  </g>
+</svg>

--- a/icons/chart_bar_vertical.svg
+++ b/icons/chart_bar_vertical.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="0.1"
+       y="197.10001" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect853"
+       width="19.799999"
+       height="46.130878"
+       x="10.1"
+       y="250.76913" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect855"
+       width="19.799999"
+       height="87.386894"
+       x="40.099998"
+       y="209.51312" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect857"
+       width="19.799999"
+       height="66.071342"
+       x="70.099998"
+       y="230.82867" />
+    <rect
+       style="fill:#87aade;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect2083"
+       width="19.799999"
+       height="46.130878"
+       x="10.1"
+       y="250.76913" />
+  </g>
+</svg>

--- a/icons/chart_box.svg
+++ b/icons/chart_box.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="0.1"
+       y="197.10001" />
+    <rect
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2838"
+       width="19.5"
+       height="32.33989"
+       x="8.3708344"
+       y="227.3101" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3708329,211.43484 H 27.870831"
+       id="path2840" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3708329,269.64321 H 27.870831"
+       id="path2842" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3708329,237.89319 H 27.870831"
+       id="path2844" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 18.370832,259.64974 V 269.6619"
+       id="path2846" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.370832,211.4605 v 15.868"
+       id="path2848" />
+    <rect
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2850"
+       width="19.5"
+       height="19.226391"
+       x="40.120831"
+       y="248.47679" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 40.120834,232.60152 H 59.620833"
+       id="path2852" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 40.120834,290.80989 H 59.620833"
+       id="path2854" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 40.120834,255.35568 H 59.620833"
+       id="path2856" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 50.120834,267.77074 v 23.05784"
+       id="path2858" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 50.120834,232.62718 v 15.868"
+       id="path2860" />
+    <rect
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2862"
+       width="19.5"
+       height="52.065151"
+       x="71.870834"
+       y="216.72676" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 71.870836,200.8515 H 91.370835"
+       id="path2864" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 71.870836,285.51822 H 91.370835"
+       id="path2866" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 71.870836,243.18486 H 91.370835"
+       id="path2868" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 81.870836,268.83021 v 16.7067"
+       id="path2870" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 81.870836,200.87716 v 15.868"
+       id="path2872" />
+  </g>
+</svg>

--- a/icons/chart_pie.svg
+++ b/icons/chart_pie.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="197.10001"
+       y="-99.900002"
+       transform="rotate(90)" />
+    <ellipse
+       style="fill:#ff6600;fill-opacity:1;stroke:#000000;stroke-width:0.499999"
+       id="path3628"
+       cx="50"
+       cy="247.00002"
+       rx="39.870003"
+       ry="39.870007" />
+    <path
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:0.499999"
+       id="ellipse3630"
+       d="m 50,207.13001 a 39.870003,39.870007 0 0 1 39.870003,39.87001 H 50 Z" />
+  </g>
+</svg>

--- a/icons/chart_points.svg
+++ b/icons/chart_points.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,-197)">
+    <rect
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect833"
+       width="99.800003"
+       height="99.800003"
+       x="0.1"
+       y="197.10001" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path2784"
+       cx="9.3999996"
+       cy="267.37744"
+       rx="4.9000001"
+       ry="4.8999996" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="ellipse2810"
+       cx="25.275002"
+       cy="256.79413"
+       rx="4.9000001"
+       ry="4.8999996" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="ellipse2812"
+       cx="41.150002"
+       cy="214.46077"
+       rx="4.9000001"
+       ry="4.8999996" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="ellipse2814"
+       cx="57.025002"
+       cy="230.33578"
+       rx="4.9000001"
+       ry="4.8999996" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="ellipse2816"
+       cx="72.900002"
+       cy="277.96075"
+       rx="4.9000001"
+       ry="4.8999996" />
+    <ellipse
+       style="fill:#87aade;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="ellipse2818"
+       cx="88.774994"
+       cy="240.91913"
+       rx="4.9000001"
+       ry="4.8999996" />
+  </g>
+</svg>

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -1,0 +1,15 @@
+# the stats-graph widget
+include_directories(.
+	${CMAKE_CURRENT_BINARY_DIR}
+	${CMAKE_BINARY_DIR}
+)
+
+set(SUBSURFACE_STATS_SRCS
+	statsview.h
+	statsview.cpp
+)
+
+source_group("Subsurface statistics sourcecode" FILES ${SUBSURFACE_STATS_SRCS})
+
+add_library(subsurface_stats STATIC ${SUBSURFACE_STATS_SRCS})
+target_link_libraries(subsurface_stats ${QT_LIBRARIES})

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -7,6 +7,8 @@ include_directories(.
 set(SUBSURFACE_STATS_SRCS
 	statsview.h
 	statsview.cpp
+	statstypes.h
+	statstypes.cpp
 )
 
 source_group("Subsurface statistics sourcecode" FILES ${SUBSURFACE_STATS_SRCS})

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -7,6 +7,8 @@ include_directories(.
 set(SUBSURFACE_STATS_SRCS
 	barseries.h
 	barseries.cpp
+	informationbox.h
+	informationbox.cpp
 	scatterseries.h
 	scatterseries.cpp
 	statsview.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SUBSURFACE_STATS_SRCS
 	scatterseries.cpp
 	statsview.h
 	statsview.cpp
+	statstranslations.h
 	statstypes.h
 	statstypes.cpp
 )

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SUBSURFACE_STATS_SRCS
 	scatterseries.cpp
 	statsview.h
 	statsview.cpp
+	statsstate.h
+	statsstate.cpp
 	statstranslations.h
 	statstypes.h
 	statstypes.cpp

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -5,6 +5,8 @@ include_directories(.
 )
 
 set(SUBSURFACE_STATS_SRCS
+	scatterseries.h
+	scatterseries.cpp
 	statsview.h
 	statsview.cpp
 	statstypes.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -7,6 +7,8 @@ include_directories(.
 set(SUBSURFACE_STATS_SRCS
 	barseries.h
 	barseries.cpp
+	boxseries.h
+	boxseries.cpp
 	informationbox.h
 	informationbox.cpp
 	scatterseries.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SUBSURFACE_STATS_SRCS
 	informationbox.cpp
 	scatterseries.h
 	scatterseries.cpp
+	statsaxis.h
+	statsaxis.cpp
 	statsview.h
 	statsview.cpp
 	statsstate.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -5,6 +5,8 @@ include_directories(.
 )
 
 set(SUBSURFACE_STATS_SRCS
+	barseries.h
+	barseries.cpp
 	scatterseries.h
 	scatterseries.cpp
 	statsview.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SUBSURFACE_STATS_SRCS
 	barseries.cpp
 	boxseries.h
 	boxseries.cpp
+	chartlistmodel.h
+	chartlistmodel.cpp
 	informationbox.h
 	informationbox.cpp
 	scatterseries.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SUBSURFACE_STATS_SRCS
 	chartlistmodel.cpp
 	informationbox.h
 	informationbox.cpp
+	legend.h
+	legend.cpp
 	scatterseries.h
 	scatterseries.cpp
 	statsaxis.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SUBSURFACE_STATS_SRCS
 	informationbox.cpp
 	legend.h
 	legend.cpp
+	pieseries.h
+	pieseries.cpp
 	scatterseries.h
 	scatterseries.cpp
 	statsaxis.h

--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SUBSURFACE_STATS_SRCS
 	statsaxis.cpp
 	statsview.h
 	statsview.cpp
+	statsseries.h
+	statsseries.cpp
 	statsstate.h
 	statsstate.cpp
 	statstranslations.h

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "barseries.h"
+#include "statstranslations.h"
+#include "statstypes.h"
+#include <QChart>
+
+// Constants that control the bar layout
+static const double barWidth = 0.8; // 1.0 = full width of category
+static const QColor barColor(0x66, 0xb2, 0xff);
+static const QColor barBorderColor(0x66, 0xb2, 0xff);
+static const QColor barHighlightedColor(Qt::yellow);
+static const QColor barHighlightedBorderColor(0xaa, 0xaa, 0x22);
+
+BarSeries::BarSeries(bool horizontal) : horizontal(horizontal), highlighted(-1)
+{
+}
+
+BarSeries::BarLabel::BarLabel(const std::vector<QString> &labels,
+			      double value, double height,
+			      bool horizontal, 
+			      QtCharts::QChart *chart, QtCharts::QAbstractSeries *series) :
+	value(value), height(height),
+	totalWidth(0.0), totalHeight(0.0)
+{
+	items.reserve(labels.size());
+	for (const QString &label: labels) {
+		items.emplace_back(new QGraphicsSimpleTextItem(chart));
+		items.back()->setText(label);
+		items.back()->setZValue(10.0); // ? What is a sensible value here ?
+		QRectF rect = items.back()->boundingRect();
+		if (rect.width() > totalWidth)
+			totalWidth = rect.width();
+		totalHeight += rect.height();
+	}
+	updatePosition(chart, series, horizontal);
+}
+
+void BarSeries::BarLabel::updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series, bool horizontal)
+{
+	if (!horizontal) {
+		QPointF pos = chart->mapToPosition(QPointF(value, height), series);
+		QPointF lowPos = chart->mapToPosition(QPointF(value, 0.0), series);
+		// Attention: the lower position is at the bottom and therefore has the higher y-coordinate on the screen. Ugh.
+		double barHeight = lowPos.y() - pos.y();
+		// Heuristics: if the label fits nicely into the bar (bar height is at least twice the label height),
+		// then put the label in the middle of the bar. Otherwise, put it on top of the bar.
+		if (barHeight >= 2.0 * totalHeight)
+			pos.ry() = lowPos.y() - (barHeight + totalHeight) / 2.0;
+		else
+			pos.ry() -= totalHeight + 2.0; // Leave two pixels(?) space
+		for (auto &it: items) {
+			QPointF itemPos = pos;
+			QRectF rect = it->boundingRect();
+			itemPos.rx() -= rect.width() / 2.0;
+			it->setPos(itemPos);
+			pos.ry() += rect.height();
+		}
+	} else {
+		QPointF pos = chart->mapToPosition(QPointF(height, value), series);
+		QPointF lowPos = chart->mapToPosition(QPointF(0.0, value), series);
+		double barWidth = pos.x() - lowPos.x();
+		// Heuristics: if the label fits nicely into the bar (bar width is at least twice the label height),
+		// then put the label in the middle of the bar. Otherwise, put it to the right of the bar.
+		if (barWidth >= 2.0 * totalWidth)
+			pos.rx() = lowPos.x() + (barWidth - totalWidth) / 2.0;
+		else
+			pos.rx() += totalWidth / 2.0 + 2.0; // Leave two pixels(?) space
+		pos.ry() -= totalHeight / 2.0;
+		for (auto &it: items) {
+			QPointF itemPos = pos;
+			QRectF rect = it->boundingRect();
+			itemPos.rx() -= rect.width() / 2.0;
+			it->setPos(itemPos);
+			pos.ry() += rect.height();
+		}
+	}
+}
+
+BarSeries::Item::Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, double value, bool horizontal) :
+	item(new QGraphicsRectItem(chart)),
+	lowerBound(lowerBound),
+	upperBound(upperBound),
+	value(value)
+{
+	item->setZValue(5.0); // ? What is a sensible value here ?
+	highlight(false);
+	updatePosition(chart, series, horizontal);
+}
+
+void BarSeries::Item::highlight(bool highlight)
+{
+	if (highlight) {
+		item->setBrush(QBrush(barHighlightedColor));
+		item->setPen(QPen(barHighlightedBorderColor));
+	} else {
+		item->setBrush(QBrush(barColor));
+		item->setPen(QPen(barBorderColor));
+	}
+}
+
+void BarSeries::Item::updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal)
+{
+	double delta = (upperBound - lowerBound) * barWidth;
+	double from = (lowerBound + upperBound - delta) / 2.0;
+	double to = (lowerBound + upperBound + delta) / 2.0;
+
+	QPointF topLeft, bottomRight;
+	if (horizontal) {
+		topLeft = chart->mapToPosition(QPointF(0.0, to), series);
+		bottomRight = chart->mapToPosition(QPointF(value, from), series);
+	} else {
+		topLeft = chart->mapToPosition(QPointF(from, value), series);
+		bottomRight = chart->mapToPosition(QPointF(to, 0.0), series);
+	}
+	item->setRect(QRectF(topLeft, bottomRight));
+}
+
+void BarSeries::append(double lowerBound, double upperBound, double value, const std::vector<QString> &label)
+{
+	QtCharts::QChart *c = chart();
+	items.emplace_back(c, this, lowerBound, upperBound, value, horizontal);
+	// Add label if provided
+	if (!label.empty()) {
+		double mid = (lowerBound + upperBound) / 2.0;
+		barLabels.emplace_back(label, mid, value, horizontal, c, this);
+	}
+}
+
+void BarSeries::updatePositions()
+{
+	QtCharts::QChart *c = chart();
+	for (Item &item: items)
+		item.updatePosition(c, this, horizontal);
+	for (BarLabel &label: barLabels)
+		label.updatePosition(c, this, horizontal);
+}
+
+// Attention: this supposes that items are sorted by position and no bar is inside another bar!
+int BarSeries::getItemUnderMouse(const QPointF &point)
+{
+	// Search the first item whose "end" position is greater than the cursor position.
+	auto it = horizontal ? std::lower_bound(items.begin(), items.end(), point.y(),
+						[] (const Item &item, double y) { return item.item->rect().top() > y; })
+			     : std::lower_bound(items.begin(), items.end(), point.x(),
+						[] (const Item &item, double x) { return item.item->rect().right() < x; });
+	return it != items.end() && it->item->rect().contains(point) ? it - items.begin() : -1;
+}
+
+// Highlight item when hovering over item
+void BarSeries::highlight(int index)
+{
+	if (index == highlighted)
+		return;
+	// Unhighlight old highlighted item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted].highlight(false);
+	highlighted = index;
+
+	// Highlight new item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size()) {
+		Item &item = items[highlighted];
+		item.highlight(true);
+	}
+}

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "barseries.h"
 #include "informationbox.h"
+#include "statscolors.h"
 #include "statstranslations.h"
 #include "statstypes.h"
 #include <QChart>
@@ -8,10 +9,6 @@
 
 // Constants that control the bar layout
 static const double barWidth = 0.8; // 1.0 = full width of category
-static const QColor barColor(0x66, 0xb2, 0xff);
-static const QColor barBorderColor(0x66, 0xb2, 0xff);
-static const QColor barHighlightedColor(Qt::yellow);
-static const QColor barHighlightedBorderColor(0xaa, 0xaa, 0x22);
 
 BarSeries::BarSeries(bool horizontal, const QString &categoryName, const StatsType *valueType) :
 	horizontal(horizontal), categoryName(categoryName), valueType(valueType), highlighted(-1)
@@ -101,11 +98,11 @@ BarSeries::Item::Item(QtCharts::QChart *chart, BarSeries *series, double lowerBo
 void BarSeries::Item::highlight(bool highlight)
 {
 	if (highlight) {
-		item->setBrush(QBrush(barHighlightedColor));
-		item->setPen(QPen(barHighlightedBorderColor));
+		item->setBrush(QBrush(highlightedColor));
+		item->setPen(QPen(highlightedBorderColor));
 	} else {
-		item->setBrush(QBrush(barColor));
-		item->setPen(QPen(barBorderColor));
+		item->setBrush(QBrush(fillColor));
+		item->setPen(QPen(::borderColor));
 	}
 }
 

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -4,14 +4,33 @@
 #include "statscolors.h"
 #include "statstranslations.h"
 #include "statstypes.h"
+#include <math.h> // for lrint()
 #include <QChart>
 #include <QLocale>
 
 // Constants that control the bar layout
 static const double barWidth = 0.8; // 1.0 = full width of category
+static const double subBarWidth = 0.9; // For grouped bar charts
 
-BarSeries::BarSeries(bool horizontal, const QString &categoryName, const StatsType *valueType) :
-	horizontal(horizontal), categoryName(categoryName), valueType(valueType), highlighted(-1)
+BarSeriesIndex BarSeries::invalidIndex()
+{
+	return { -1, -1};
+}
+
+bool BarSeries::isValidIndex(BarSeriesIndex idx)
+{
+	return idx.bar >= 0;
+}
+
+static bool operator==(const BarSeriesIndex &i1, const BarSeriesIndex &i2)
+{
+	return std::tie(i1.bar, i1.subitem) == std::tie(i2.bar, i2.subitem);
+}
+
+BarSeries::BarSeries(bool horizontal, bool stacked, const QString &categoryName,
+		     const StatsType *valueType, std::vector<QString> valueBinNames) :
+	horizontal(horizontal), stacked(stacked), categoryName(categoryName),
+	valueType(valueType), valueBinNames(std::move(valueBinNames)), highlighted(invalidIndex())
 {
 }
 
@@ -19,11 +38,7 @@ BarSeries::~BarSeries()
 {
 }
 
-BarSeries::BarLabel::BarLabel(const std::vector<QString> &labels,
-			      double value, double height,
-			      bool horizontal, 
-			      QtCharts::QChart *chart, QtCharts::QAbstractSeries *series) :
-	value(value), height(height),
+BarSeries::BarLabel::BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels) :
 	totalWidth(0.0), totalHeight(0.0)
 {
 	items.reserve(labels.size());
@@ -36,22 +51,35 @@ BarSeries::BarLabel::BarLabel(const std::vector<QString> &labels,
 			totalWidth = rect.width();
 		totalHeight += rect.height();
 	}
-	updatePosition(chart, series, horizontal);
 }
 
-void BarSeries::BarLabel::updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series, bool horizontal)
+void BarSeries::BarLabel::setVisible(bool visible)
+{
+	for (auto &item: items)
+		item->setVisible(visible);
+}
+
+void BarSeries::BarLabel::updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series,
+					 bool horizontal, bool center, const QRectF &rect)
 {
 	if (!horizontal) {
-		QPointF pos = chart->mapToPosition(QPointF(value, height), series);
-		QPointF lowPos = chart->mapToPosition(QPointF(value, 0.0), series);
-		// Attention: the lower position is at the bottom and therefore has the higher y-coordinate on the screen. Ugh.
-		double barHeight = lowPos.y() - pos.y();
+		if (totalWidth > rect.width()) {
+			setVisible(false);
+			return;
+		}
+		QPointF pos = rect.center();
+
 		// Heuristics: if the label fits nicely into the bar (bar height is at least twice the label height),
-		// then put the label in the middle of the bar. Otherwise, put it on top of the bar.
-		if (barHeight >= 2.0 * totalHeight)
-			pos.ry() = lowPos.y() - (barHeight + totalHeight) / 2.0;
-		else
-			pos.ry() -= totalHeight + 2.0; // Leave two pixels(?) space
+		// then put the label in the middle of the bar. Otherwise, put it at the top of the bar.
+		if (!center && rect.height() < 2.0 * totalHeight) {
+			pos.ry() = rect.top() - (totalHeight + 2.0); // Leave two pixels(?) space
+		} else {
+			if (totalHeight > rect.height()) {
+				setVisible(false);
+				return;
+			}
+			pos.ry() -= totalHeight / 2.0;
+		}
 		for (auto &it: items) {
 			QPointF itemPos = pos;
 			QRectF rect = it->boundingRect();
@@ -60,16 +88,23 @@ void BarSeries::BarLabel::updatePosition(QtCharts::QChart *chart, QtCharts::QAbs
 			pos.ry() += rect.height();
 		}
 	} else {
-		QPointF pos = chart->mapToPosition(QPointF(height, value), series);
-		QPointF lowPos = chart->mapToPosition(QPointF(0.0, value), series);
-		double barWidth = pos.x() - lowPos.x();
+		if (totalHeight > rect.height()) {
+			setVisible(false);
+			return;
+		}
+		QPointF pos = rect.center();
+		pos.ry() -= totalHeight / 2.0;
+
 		// Heuristics: if the label fits nicely into the bar (bar width is at least twice the label height),
 		// then put the label in the middle of the bar. Otherwise, put it to the right of the bar.
-		if (barWidth >= 2.0 * totalWidth)
-			pos.rx() = lowPos.x() + (barWidth - totalWidth) / 2.0;
-		else
-			pos.rx() += totalWidth / 2.0 + 2.0; // Leave two pixels(?) space
-		pos.ry() -= totalHeight / 2.0;
+		if (!center && rect.width() < 2.0 * totalWidth) {
+			pos.rx() = rect.right() + (totalWidth / 2.0 + 2.0); // Leave two pixels(?) space
+		} else {
+			if (totalWidth > rect.width()) {
+				setVisible(false);
+				return;
+			}
+		}
 		for (auto &it: items) {
 			QPointF itemPos = pos;
 			QRectF rect = it->boundingRect();
@@ -78,49 +113,126 @@ void BarSeries::BarLabel::updatePosition(QtCharts::QChart *chart, QtCharts::QAbs
 			pos.ry() += rect.height();
 		}
 	}
+	setVisible(true);
 }
 
-BarSeries::Item::Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, const QString &binName,
-		      double value, const StatsOperationResults &res, int total, bool horizontal) :
-	item(new QGraphicsRectItem(chart)),
+BarSeries::Item::Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound,
+		      std::vector<SubItem> subitemsIn,
+		      const QString &binName, const StatsOperationResults &res, int total,
+		      bool horizontal, bool stacked, int binCount) :
 	lowerBound(lowerBound),
 	upperBound(upperBound),
-	value(value),
+	subitems(std::move(subitemsIn)),
 	binName(binName),
 	res(res),
 	total(total)
 {
-	item->setZValue(5.0); // ? What is a sensible value here ?
-	highlight(false);
-	updatePosition(chart, series, horizontal);
+	for (SubItem &item: subitems) {
+		item.item->setZValue(5.0); // ? What is a sensible value here ?
+		item.highlight(false);
+	}
+	updatePosition(chart, series, horizontal, stacked, binCount);
 }
 
-void BarSeries::Item::highlight(bool highlight)
+void BarSeries::Item::highlight(int subitem, bool highlight)
+{
+	if (subitem < 0 || subitem >= (int)subitems.size())
+		return;
+	subitems[subitem].highlight(highlight);
+}
+
+void BarSeries::SubItem::highlight(bool highlight)
 {
 	if (highlight) {
 		item->setBrush(QBrush(highlightedColor));
 		item->setPen(QPen(highlightedBorderColor));
 	} else {
-		item->setBrush(QBrush(fillColor));
+		item->setBrush(QBrush(binColor(bin_nr)));
 		item->setPen(QPen(::borderColor));
 	}
 }
 
-void BarSeries::Item::updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal)
+void BarSeries::Item::updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked, int binCount)
 {
-	double delta = (upperBound - lowerBound) * barWidth;
-	double from = (lowerBound + upperBound - delta) / 2.0;
-	double to = (lowerBound + upperBound + delta) / 2.0;
+	if (subitems.empty())
+		return;
 
+	int num = stacked ? 1 : binCount;
+
+	// barWidth gives the total width of the rod or group of rods.
+	// subBarWidth gives the the width of each bar in the case of grouped bar charts.
+	// calculated the group width such that after applying the latter, the former is obtained.
+	double groupWidth = (upperBound - lowerBound) * barWidth * num / (num - 1 + subBarWidth);
+	double from = (lowerBound + upperBound - groupWidth) / 2.0;
+	double to = (lowerBound + upperBound + groupWidth) / 2.0;
+
+	double fullSubWidth = (to - from) / num; // width including gap
+	double subWidth = fullSubWidth * subBarWidth; // width without gap
+	for (SubItem &item: subitems) {
+		int idx = stacked ? 0 : item.bin_nr;
+		double center = (idx + 0.5) * fullSubWidth + from;
+		item.updatePosition(chart, series, horizontal, stacked, center - subWidth / 2.0, center + subWidth / 2.0);
+	}
+	rect = subitems[0].item->rect();
+	for (auto it = std::next(subitems.begin()); it != subitems.end(); ++it)
+		rect = rect.united(it->item->rect());
+}
+
+void BarSeries::SubItem::updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked,
+					double from, double to)
+{
 	QPointF topLeft, bottomRight;
 	if (horizontal) {
-		topLeft = chart->mapToPosition(QPointF(0.0, to), series);
-		bottomRight = chart->mapToPosition(QPointF(value, from), series);
+		topLeft = chart->mapToPosition(QPointF(value_from, to), series);
+		bottomRight = chart->mapToPosition(QPointF(value_to, from), series);
 	} else {
-		topLeft = chart->mapToPosition(QPointF(from, value), series);
-		bottomRight = chart->mapToPosition(QPointF(to, 0.0), series);
+		topLeft = chart->mapToPosition(QPointF(from, value_to), series);
+		bottomRight = chart->mapToPosition(QPointF(to, value_from), series);
 	}
-	item->setRect(QRectF(topLeft, bottomRight));
+	QRectF rect(topLeft, bottomRight);
+	item->setRect(rect);
+	if (label)
+		label->updatePosition(chart, series, horizontal, stacked, rect);
+}
+
+std::vector<BarSeries::SubItem> BarSeries::makeSubItems(const std::vector<std::pair<double, std::vector<QString>>> &values) const
+{
+	std::vector<SubItem> res;
+	res.reserve(values.size());
+	double from = 0.0;
+	int bin_nr = 0;
+	for (auto &[v, label]: values) {
+		if (v > 0.0) {
+			res.push_back({ std::make_unique<QGraphicsRectItem>(chart()), {}, from, from + v, bin_nr });
+			if (!label.empty())
+				res.back().label = std::make_unique<BarLabel>(chart(), label);
+		}
+		if (stacked)
+			from += v;
+		++bin_nr;
+	}
+	return res;
+}
+
+std::vector<BarSeries::SubItem> BarSeries::makeSubItems(double value, const std::vector<QString> &label) const
+{
+	return makeSubItems(std::vector<std::pair<double, std::vector<QString>>>{ { value, label } });
+}
+
+int BarSeries::binCount() const
+{
+	return std::max(1, (int)valueBinNames.size());
+}
+
+void BarSeries::add_item(double lowerBound, double upperBound, std::vector<SubItem> subitems,
+			 const QString &binName, const StatsOperationResults &res, int total, bool horizontal,
+			 bool stacked)
+{
+	// Don't add empty items, as that messes with the "find item under mouse" routine.
+	if (subitems.empty())
+		return;
+	items.emplace_back(chart(), this, lowerBound, upperBound, std::move(subitems), binName, res,
+			   total, horizontal, stacked, binCount());
 }
 
 void BarSeries::append(double lowerBound, double upperBound, int count, const std::vector<QString> &label,
@@ -129,58 +241,82 @@ void BarSeries::append(double lowerBound, double upperBound, int count, const st
 	StatsOperationResults res;
 	res.count = count;
 	double value = count;
-	items.emplace_back(chart(), this, lowerBound, upperBound, binName, value, res, total, horizontal);
-	addLabel(lowerBound, upperBound, value, label);
+	add_item(lowerBound, upperBound, makeSubItems(value, label),
+		 binName, res, total, horizontal, stacked);
 }
 
 void BarSeries::append(double lowerBound, double upperBound, double value, const std::vector<QString> &label,
 		       const QString &binName, const StatsOperationResults res)
 {
-	items.emplace_back(chart(), this, lowerBound, upperBound, binName, value, res, -1, horizontal);
-	addLabel(lowerBound, upperBound, value, label);
+	add_item(lowerBound, upperBound, makeSubItems(value, label),
+		 binName, res, -1, horizontal, stacked);
 }
 
-void BarSeries::addLabel(double lowerBound, double upperBound, double value, const std::vector<QString> &label)
+void BarSeries::append(double lowerBound, double upperBound,
+		       std::vector<std::pair<int, std::vector<QString>>> countLabels, const QString &binName)
 {
-	// Add label if provided
-	if (!label.empty()) {
-		double mid = (lowerBound + upperBound) / 2.0;
-		barLabels.emplace_back(label, mid, value, horizontal, chart(), this);
+	StatsOperationResults res;
+	std::vector<std::pair<double, std::vector<QString>>> valuesLabels;
+	valuesLabels.reserve(countLabels.size());
+	int total = 0;
+	for (auto &[count, label]: countLabels) {
+		valuesLabels.push_back({ static_cast<double>(count), std::move(label) });
+		total += count;
 	}
+	add_item(lowerBound, upperBound, makeSubItems(valuesLabels),
+		 binName, res, total, horizontal, stacked);
 }
 
 void BarSeries::updatePositions()
 {
 	QtCharts::QChart *c = chart();
 	for (Item &item: items)
-		item.updatePosition(c, this, horizontal);
-	for (BarLabel &label: barLabels)
-		label.updatePosition(c, this, horizontal);
+		item.updatePosition(c, this, horizontal, stacked, binCount());
 }
 
 // Attention: this supposes that items are sorted by position and no bar is inside another bar!
-int BarSeries::getItemUnderMouse(const QPointF &point)
+BarSeriesIndex BarSeries::getItemUnderMouse(const QPointF &point) const
 {
 	// Search the first item whose "end" position is greater than the cursor position.
 	auto it = horizontal ? std::lower_bound(items.begin(), items.end(), point.y(),
-						[] (const Item &item, double y) { return item.item->rect().top() > y; })
+						[] (const Item &item, double y) { return item.rect.top() > y; })
 			     : std::lower_bound(items.begin(), items.end(), point.x(),
-						[] (const Item &item, double x) { return item.item->rect().right() < x; });
-	return it != items.end() && it->item->rect().contains(point) ? it - items.begin() : -1;
+						[] (const Item &item, double x) { return item.rect.right() < x; });
+	if (it == items.end() || !it->rect.contains(point))
+		return invalidIndex();
+	int subitem = it->getSubItemUnderMouse(point, horizontal, stacked);
+	return subitem >= 0 ? BarSeriesIndex{(int)(it - items.begin()), subitem} : invalidIndex();
+}
+
+// Attention: this supposes that sub items are sorted by position and no subitem is inside another bar!
+int BarSeries::Item::getSubItemUnderMouse(const QPointF &point, bool horizontal, bool stacked) const
+{
+	// Search the first item whose "end" position is greater than the cursor position.
+	bool search_x = horizontal == stacked;
+	auto it = search_x ? std::lower_bound(subitems.begin(), subitems.end(), point.x(),
+					      [] (const SubItem &item, double x) { return item.item->rect().right() < x; })
+			   : std::lower_bound(subitems.begin(), subitems.end(), point.y(),
+					      [] (const SubItem &item, double y) { return item.item->rect().top() > y; });
+	return it != subitems.end() && it->item->rect().contains(point) ? it - subitems.begin() : -1;
 }
 
 // Format information in a count-based bar chart.
 // Essentially, the name of the bin and the number and percentages of dives.
-static std::vector<QString> makeCountInfo(const QString &binName, const QString &axisName, int count, int total)
+static std::vector<QString> makeCountInfo(const QString &binName, const QString &axisName,
+					  const QString &valueBinName, const QString &valueAxisName,
+					  int count, int total)
 {
 	double percentage = count * 100.0 / total;
 	QString countString = QString("%L1").arg(count);
 	QString percentageString = QString("%L1%").arg(percentage, 0, 'f', 1);
 	QString totalString = QString("%L1").arg(total);
-	return {
-		QStringLiteral("%1: %2").arg(axisName, binName),
-		QStringLiteral("%1 (%2 of %3) dives").arg(countString, percentageString, totalString)
-	};
+	std::vector<QString> res;
+	res.reserve(3);
+	res.push_back(QStringLiteral("%1: %2").arg(axisName, binName));
+	if (!valueAxisName.isEmpty())
+		res.push_back(QStringLiteral("%1: %2").arg(valueAxisName, valueBinName));
+	res.push_back(StatsTranslations::tr("%1 (%2 of %3) dives").arg(countString, percentageString, totalString));
+	return res;
 }
 
 // Format information in a value bar chart: the name of the bin and the value with unit.
@@ -203,8 +339,26 @@ static std::vector<QString> makeValueInfo(const QString &binName, const QString 
 	return res;
 }
 
+std::vector<QString> BarSeries::makeInfo(const Item &item, int subitem_idx) const
+{
+	if (!valueBinNames.empty() && valueType) {
+		if (subitem_idx < 0 || subitem_idx >= (int)item.subitems.size())
+			return {};
+		const SubItem &subitem = item.subitems[subitem_idx];
+		if (subitem.bin_nr < 0 || subitem.bin_nr >= (int)valueBinNames.size())
+			return {};
+		int count = (int)lrint(subitem.value_to - subitem.value_from);
+		return makeCountInfo(item.binName, categoryName, valueBinNames[subitem.bin_nr],
+				     valueType->name(), count, item.total);
+	} else if (valueType) {
+		return makeValueInfo(item.binName, categoryName, *valueType, item.res);
+	} else {
+		return makeCountInfo(item.binName, categoryName, QString(), QString(), item.res.count, item.total);
+	}
+}
+
 // Highlight item when hovering over item
-void BarSeries::highlight(int index, QPointF pos)
+void BarSeries::highlight(BarSeriesIndex index, QPointF pos)
 {
 	if (index == highlighted) {
 		if (information)
@@ -213,20 +367,17 @@ void BarSeries::highlight(int index, QPointF pos)
 	}
 
 	// Unhighlight old highlighted item (if any)
-	if (highlighted >= 0 && highlighted < (int)items.size())
-		items[highlighted].highlight(false);
+	if (highlighted.bar >= 0 && highlighted.bar < (int)items.size())
+		items[highlighted.bar].highlight(highlighted.subitem, false);
 	highlighted = index;
 
 	// Highlight new item (if any)
-	if (highlighted >= 0 && highlighted < (int)items.size()) {
-		Item &item = items[highlighted];
-		item.highlight(true);
+	if (highlighted.bar >= 0 && highlighted.bar < (int)items.size()) {
+		Item &item = items[highlighted.bar];
+		item.highlight(index.subitem, true);
 		if (!information)
 			information.reset(new InformationBox(chart()));
-		std::vector<QString> info = valueType ?
-			makeValueInfo(item.binName, categoryName, *valueType, item.res) :
-			makeCountInfo(item.binName, categoryName, item.res.count, item.total);
-		information->setText(info, pos);
+		information->setText(makeInfo(item, highlighted.subitem), pos);
 	} else {
 		information.reset();
 	}

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -44,6 +44,7 @@ BarSeries::BarLabel::BarLabel(QtCharts::QChart *chart, const std::vector<QString
 	items.reserve(labels.size());
 	for (const QString &label: labels) {
 		items.emplace_back(new QGraphicsSimpleTextItem(chart));
+		items.back()->setBrush(QBrush(labelColor));
 		items.back()->setText(label);
 		items.back()->setZValue(10.0); // ? What is a sensible value here ?
 		QRectF rect = items.back()->boundingRect();

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -194,7 +194,7 @@ void BarSeries::SubItem::highlight(bool highlight, int binCount)
 		item->setBrush(QBrush(highlightedColor));
 		item->setPen(QPen(highlightedBorderColor));
 	} else {
-		item->setBrush(QBrush(binColor(bin_nr)));
+		item->setBrush(QBrush(binColor(bin_nr, binCount)));
 		item->setPen(QPen(::borderColor));
 	}
 }

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -84,13 +84,13 @@ BarSeries::~BarSeries()
 {
 }
 
-BarSeries::BarLabel::BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels) :
+BarSeries::BarLabel::BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels, int bin_nr, int numBins) :
 	totalWidth(0.0), totalHeight(0.0)
 {
 	items.reserve(labels.size());
 	for (const QString &label: labels) {
 		items.emplace_back(new QGraphicsSimpleTextItem(chart));
-		items.back()->setBrush(QBrush(labelColor));
+		items.back()->setBrush(QBrush(labelColor(bin_nr, numBins)));
 		items.back()->setText(label);
 		items.back()->setZValue(10.0); // ? What is a sensible value here ?
 		QRectF rect = items.back()->boundingRect();
@@ -252,7 +252,7 @@ std::vector<BarSeries::SubItem> BarSeries::makeSubItems(const std::vector<std::p
 		if (v > 0.0) {
 			res.push_back({ std::make_unique<QGraphicsRectItem>(chart()), {}, from, from + v, bin_nr });
 			if (!label.empty())
-				res.back().label = std::make_unique<BarLabel>(chart(), label);
+				res.back().label = std::make_unique<BarLabel>(chart(), label, bin_nr, binCount());
 		}
 		if (stacked)
 			from += v;

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0
+// A small custom bar series, which displays information
+// when hovering over a bar. The QtCharts bar series were
+// too inflexible with respect to placement of the bars.
+#ifndef BAR_SERIES_H
+#define BAR_SERIES_H
+
+#include <memory>
+#include <vector>
+#include <QGraphicsRectItem>
+#include <QScatterSeries>
+
+namespace QtCharts {
+	class QAbstractAxis;
+	class QChart;
+}
+class StatsType;
+
+// We derive from a proper scatter series to get access to the map-to
+// and map-from coordinates calls. But we don't use any of its functionality.
+// Can we avoid that?
+
+class BarSeries : public QtCharts::QScatterSeries {
+public:
+	// If the horizontal flag is true, independent variable is plotted on the y-axis.
+	BarSeries(bool horizontal);
+
+	// Call if chart geometry changed
+	void updatePositions();
+
+	// Note: this expects that all items are added with increasing pos
+	// and that no bar is inside another bar, i.e. lowerBound and upperBound
+	// are ordered identically.
+	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label);
+
+	// Get item under mous pointer, or -1 if none
+	int getItemUnderMouse(const QPointF &f);
+
+	// Highlight item when hovering over item
+	void highlight(int index);
+private:
+	// A label that is composed of multiple lines
+	struct BarLabel {
+		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
+		double value, height; // Position and size of bar in graph
+		double totalWidth, totalHeight; // Size of the item
+		BarLabel(const std::vector<QString> &labels, double value, double height, bool horizontal,
+			 QtCharts::QChart *chart, QtCharts::QAbstractSeries *series);
+		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series, bool horizontal);
+	};
+
+	struct Item {
+		std::unique_ptr<QGraphicsRectItem> item;
+		double lowerBound, upperBound, value;
+		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, double value, bool horizontal);
+		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal);
+		void highlight(bool highlight);
+	};
+
+	std::vector<Item> items;
+	std::vector<BarLabel> barLabels;
+	bool horizontal;
+	int highlighted; // -1: no item highlighted
+};
+
+#endif

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -14,6 +14,7 @@ namespace QtCharts {
 	class QAbstractAxis;
 	class QChart;
 }
+class InformationBox;
 class StatsType;
 
 // We derive from a proper scatter series to get access to the map-to
@@ -24,6 +25,7 @@ class BarSeries : public QtCharts::QScatterSeries {
 public:
 	// If the horizontal flag is true, independent variable is plotted on the y-axis.
 	BarSeries(bool horizontal);
+	~BarSeries();
 
 	// Call if chart geometry changed
 	void updatePositions();
@@ -31,13 +33,13 @@ public:
 	// Note: this expects that all items are added with increasing pos
 	// and that no bar is inside another bar, i.e. lowerBound and upperBound
 	// are ordered identically.
-	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label);
+	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label, std::vector<QString> info);
 
 	// Get item under mous pointer, or -1 if none
 	int getItemUnderMouse(const QPointF &f);
 
 	// Highlight item when hovering over item
-	void highlight(int index);
+	void highlight(int index, QPointF pos);
 private:
 	// A label that is composed of multiple lines
 	struct BarLabel {
@@ -52,11 +54,14 @@ private:
 	struct Item {
 		std::unique_ptr<QGraphicsRectItem> item;
 		double lowerBound, upperBound, value;
-		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, double value, bool horizontal);
+		std::vector<QString> info; // Textual information
+		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, double value,
+		     std::vector<QString> info, bool horizontal);
 		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal);
 		void highlight(bool highlight);
 	};
 
+	std::unique_ptr<InformationBox> information;
 	std::vector<Item> items;
 	std::vector<BarLabel> barLabels;
 	bool horizontal;

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -5,6 +5,7 @@
 #ifndef BAR_SERIES_H
 #define BAR_SERIES_H
 
+#include "stats/statstypes.h"
 #include <memory>
 #include <vector>
 #include <QGraphicsRectItem>
@@ -15,7 +16,6 @@ namespace QtCharts {
 	class QChart;
 }
 class InformationBox;
-class StatsType;
 
 // We derive from a proper scatter series to get access to the map-to
 // and map-from coordinates calls. But we don't use any of its functionality.
@@ -24,7 +24,7 @@ class StatsType;
 class BarSeries : public QtCharts::QScatterSeries {
 public:
 	// If the horizontal flag is true, independent variable is plotted on the y-axis.
-	BarSeries(bool horizontal);
+	BarSeries(bool horizontal, const QString &categoryName, const StatsType *valueType);
 	~BarSeries();
 
 	// Call if chart geometry changed
@@ -33,7 +33,12 @@ public:
 	// Note: this expects that all items are added with increasing pos
 	// and that no bar is inside another bar, i.e. lowerBound and upperBound
 	// are ordered identically.
-	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label, std::vector<QString> info);
+	// There are two version: one for value-based (mean, etc) charts and one for counts
+	// based charts.
+	void append(double lowerBound, double upperBound, int count, const std::vector<QString> &label,
+		    const QString &binName, int total);
+	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label,
+		    const QString &binName, const StatsOperationResults);
 
 	// Get item under mous pointer, or -1 if none
 	int getItemUnderMouse(const QPointF &f);
@@ -46,17 +51,22 @@ private:
 		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
 		double value, height; // Position and size of bar in graph
 		double totalWidth, totalHeight; // Size of the item
+		StatsOperationResults res;
+		int total;
 		BarLabel(const std::vector<QString> &labels, double value, double height, bool horizontal,
 			 QtCharts::QChart *chart, QtCharts::QAbstractSeries *series);
 		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series, bool horizontal);
 	};
+	void addLabel(double lowerBound, double upperBound, double value, const std::vector<QString> &label);
 
 	struct Item {
 		std::unique_ptr<QGraphicsRectItem> item;
 		double lowerBound, upperBound, value;
-		std::vector<QString> info; // Textual information
-		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound, double value,
-		     std::vector<QString> info, bool horizontal);
+		const QString binName;
+		StatsOperationResults res;
+		int total;
+		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound,
+		     const QString &binName, double value, const StatsOperationResults &res, int total, bool horizontal);
 		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal);
 		void highlight(bool highlight);
 	};
@@ -65,6 +75,8 @@ private:
 	std::vector<Item> items;
 	std::vector<BarLabel> barLabels;
 	bool horizontal;
+	QString categoryName;
+	const StatsType *valueType; // null: this is count based
 	int highlighted; // -1: no item highlighted
 };
 

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -83,7 +83,7 @@ private:
 	struct BarLabel {
 		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
 		double totalWidth, totalHeight; // Size of the item
-		BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels);
+		BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels, int bin_nr, int numBins);
 		void setVisible(bool visible);
 		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series,
 				    bool horizontal, bool center, const QRectF &rect);

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -17,6 +17,11 @@ namespace QtCharts {
 }
 class InformationBox;
 
+struct BarSeriesIndex {
+	int bar;
+	int subitem;
+};
+
 // We derive from a proper scatter series to get access to the map-to
 // and map-from coordinates calls. But we don't use any of its functionality.
 // Can we avoid that?
@@ -24,7 +29,11 @@ class InformationBox;
 class BarSeries : public QtCharts::QScatterSeries {
 public:
 	// If the horizontal flag is true, independent variable is plotted on the y-axis.
-	BarSeries(bool horizontal, const QString &categoryName, const StatsType *valueType);
+	// A non-empty valueBinNames vector flags that this is a stacked bar chart.
+	// In that case, a valueType must also be provided.
+	// For count-based bar series in one variable, valueType is null.
+	BarSeries(bool horizontal, bool stacked, const QString &categoryName, const StatsType *valueType,
+		  std::vector<QString> valueBinNames);
 	~BarSeries();
 
 	// Call if chart geometry changed
@@ -33,51 +42,76 @@ public:
 	// Note: this expects that all items are added with increasing pos
 	// and that no bar is inside another bar, i.e. lowerBound and upperBound
 	// are ordered identically.
-	// There are two version: one for value-based (mean, etc) charts and one for counts
-	// based charts.
+	// There are three versions: for value-based (mean, etc) charts, for counts
+	// based charts and for stacked bar charts with multiple items.
 	void append(double lowerBound, double upperBound, int count, const std::vector<QString> &label,
 		    const QString &binName, int total);
 	void append(double lowerBound, double upperBound, double value, const std::vector<QString> &label,
 		    const QString &binName, const StatsOperationResults);
+	void append(double lowerBound, double upperBound, std::vector<std::pair<int, std::vector<QString>>> countLabels,
+		    const QString &binName);
 
-	// Get item under mous pointer, or -1 if none
-	int getItemUnderMouse(const QPointF &f);
+	// Get item under mouse pointer, or -1 if none
+	BarSeriesIndex getItemUnderMouse(const QPointF &f) const;
+	static BarSeriesIndex invalidIndex();
+	static bool isValidIndex(BarSeriesIndex);
 
 	// Highlight item when hovering over item
-	void highlight(int index, QPointF pos);
+	void highlight(BarSeriesIndex index, QPointF pos);
 private:
 	// A label that is composed of multiple lines
 	struct BarLabel {
 		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
-		double value, height; // Position and size of bar in graph
 		double totalWidth, totalHeight; // Size of the item
-		StatsOperationResults res;
-		int total;
-		BarLabel(const std::vector<QString> &labels, double value, double height, bool horizontal,
-			 QtCharts::QChart *chart, QtCharts::QAbstractSeries *series);
-		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series, bool horizontal);
+		BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels);
+		void setVisible(bool visible);
+		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series,
+				    bool horizontal, bool center, const QRectF &rect);
 	};
-	void addLabel(double lowerBound, double upperBound, double value, const std::vector<QString> &label);
+
+	struct SubItem {
+		std::unique_ptr<QGraphicsRectItem> item;
+		std::unique_ptr<BarLabel> label;
+		double value_from;
+		double value_to;
+		int bin_nr;
+		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked,
+				    double from, double to);
+		void highlight(bool highlight);
+	};
 
 	struct Item {
-		std::unique_ptr<QGraphicsRectItem> item;
-		double lowerBound, upperBound, value;
+		double lowerBound, upperBound;
+		std::vector<SubItem> subitems;
+		QRectF rect;
 		const QString binName;
 		StatsOperationResults res;
 		int total;
 		Item(QtCharts::QChart *chart, BarSeries *series, double lowerBound, double upperBound,
-		     const QString &binName, double value, const StatsOperationResults &res, int total, bool horizontal);
-		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal);
-		void highlight(bool highlight);
+		     std::vector<SubItem> subitems,
+		     const QString &binName, const StatsOperationResults &res, int total, bool horizontal,
+		     bool stacked, int binCount);
+		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked, int binCount);
+		void highlight(int subitem, bool highlight);
+		int getSubItemUnderMouse(const QPointF &f, bool horizontal, bool stacked) const;
 	};
 
 	std::unique_ptr<InformationBox> information;
 	std::vector<Item> items;
 	std::vector<BarLabel> barLabels;
 	bool horizontal;
+	bool stacked;
 	QString categoryName;
 	const StatsType *valueType; // null: this is count based
-	int highlighted; // -1: no item highlighted
+	std::vector<QString> valueBinNames;
+	BarSeriesIndex highlighted;
+	std::vector<SubItem> makeSubItems(double value, const std::vector<QString> &label) const;
+	std::vector<SubItem> makeSubItems(const std::vector<std::pair<double, std::vector<QString>>> &values) const;
+	void add_item(double lowerBound, double upperBound, std::vector<SubItem> subitems,
+		      const QString &binName, const StatsOperationResults &res, int total, bool horizontal,
+		      bool stacked);
+	std::vector<QString> makeInfo(const Item &item, int subitem) const;
+	int binCount() const;
 };
 
 #endif

--- a/stats/boxseries.cpp
+++ b/stats/boxseries.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "boxseries.h"
 #include "informationbox.h"
+#include "statscolors.h"
 #include "statstranslations.h"
 #include <QChart>
 #include <QLocale>
@@ -8,10 +9,6 @@
 // Constants that control the bar layout
 static const double boxWidth = 0.8; // 1.0 = full width of category
 static const int boxBorderWidth = 2;
-static const QColor boxColor(0x66, 0xb2, 0xff);
-static const QColor boxBorderColor(0x33, 0x66, 0xa0);
-static const QColor boxHighlightedColor(Qt::yellow);
-static const QColor boxHighlightedBorderColor(0xaa, 0xaa, 0x22);
 
 BoxSeries::BoxSeries(const QString &variable, const QString &unit, int decimals) :
 	variable(variable), unit(unit), decimals(decimals), highlighted(-1)
@@ -47,8 +44,8 @@ BoxSeries::Item::~Item()
 
 void BoxSeries::Item::highlight(bool highlight)
 {
-	QBrush brush = highlight ? QBrush(boxHighlightedColor) : QBrush(boxColor);
-	QPen pen = highlight ? QPen(boxHighlightedBorderColor, boxBorderWidth) : QPen(boxBorderColor, boxBorderWidth);
+	QBrush brush = highlight ? QBrush(highlightedColor) : QBrush(fillColor);
+	QPen pen = highlight ? QPen(highlightedBorderColor, boxBorderWidth) : QPen(::borderColor, boxBorderWidth);
 	box.setBrush(brush);
 	box.setPen(pen);
 	topWhisker.setPen(pen);

--- a/stats/boxseries.cpp
+++ b/stats/boxseries.cpp
@@ -10,6 +10,16 @@
 static const double boxWidth = 0.8; // 1.0 = full width of category
 static const int boxBorderWidth = 2;
 
+int BoxSeries::invalidIndex()
+{
+	return -1;
+}
+
+bool BoxSeries::isValidIndex(int idx)
+{
+	return idx >= 0;
+}
+
 BoxSeries::BoxSeries(const QString &variable, const QString &unit, int decimals) :
 	variable(variable), unit(unit), decimals(decimals), highlighted(-1)
 {

--- a/stats/boxseries.cpp
+++ b/stats/boxseries.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "boxseries.h"
+#include "informationbox.h"
+#include "statstranslations.h"
+#include <QChart>
+#include <QLocale>
+
+// Constants that control the bar layout
+static const double boxWidth = 0.8; // 1.0 = full width of category
+static const int boxBorderWidth = 2;
+static const QColor boxColor(0x66, 0xb2, 0xff);
+static const QColor boxBorderColor(0x33, 0x66, 0xa0);
+static const QColor boxHighlightedColor(Qt::yellow);
+static const QColor boxHighlightedBorderColor(0xaa, 0xaa, 0x22);
+
+BoxSeries::BoxSeries(const QString &variable, const QString &unit, int decimals) :
+	variable(variable), unit(unit), decimals(decimals), highlighted(-1)
+{
+}
+
+BoxSeries::~BoxSeries()
+{
+}
+
+BoxSeries::Item::Item(QtCharts::QChart *chart, BoxSeries *series, double lowerBound, double upperBound,
+		      const StatsQuartiles &q, const QString &binName) :
+	box(chart),
+	topWhisker(chart), bottomWhisker(chart),
+	topBar(chart), bottomBar(chart),
+	center(chart),
+	lowerBound(lowerBound), upperBound(upperBound), q(q),
+	binName(binName)
+{
+	box.setZValue(5.0); // ? What is a sensible value here ?
+	topWhisker.setZValue(5.0);
+	bottomWhisker.setZValue(5.0);
+	topBar.setZValue(5.0);
+	bottomBar.setZValue(5.0);
+	center.setZValue(5.0);
+	highlight(false);
+	updatePosition(chart, series);
+}
+
+BoxSeries::Item::~Item()
+{
+}
+
+void BoxSeries::Item::highlight(bool highlight)
+{
+	QBrush brush = highlight ? QBrush(boxHighlightedColor) : QBrush(boxColor);
+	QPen pen = highlight ? QPen(boxHighlightedBorderColor, boxBorderWidth) : QPen(boxBorderColor, boxBorderWidth);
+	box.setBrush(brush);
+	box.setPen(pen);
+	topWhisker.setPen(pen);
+	bottomWhisker.setPen(pen);
+	topBar.setPen(pen);
+	bottomBar.setPen(pen);
+	center.setPen(pen);
+}
+
+void BoxSeries::Item::updatePosition(QtCharts::QChart *chart, BoxSeries *series)
+{
+	double delta = (upperBound - lowerBound) * boxWidth;
+	double from = (lowerBound + upperBound - delta) / 2.0;
+	double to = (lowerBound + upperBound + delta) / 2.0;
+	double mid = (from + to) / 2.0;
+
+	QPointF topLeft, bottomRight;
+	QMarginsF margins(boxBorderWidth / 2.0, boxBorderWidth / 2.0, boxBorderWidth / 2.0, boxBorderWidth / 2.0);
+	topLeft = chart->mapToPosition(QPointF(from, q.max), series);
+	bottomRight = chart->mapToPosition(QPointF(to, q.min), series);
+	bounding = QRectF(topLeft, bottomRight).marginsAdded(margins);
+	double left = topLeft.x();
+	double right = bottomRight.x();
+	double width = right - left;
+	double top = topLeft.y();
+	double bottom = bottomRight.y();
+	QPointF q1 = chart->mapToPosition(QPointF(mid, q.q1), series);
+	QPointF q2 = chart->mapToPosition(QPointF(mid, q.q2), series);
+	QPointF q3 = chart->mapToPosition(QPointF(mid, q.q3), series);
+	box.setRect(left, q3.y(), width, q1.y() - q3.y());
+	topWhisker.setLine(q3.x(), top, q3.x(), q3.y());
+	bottomWhisker.setLine(q1.x(), q1.y(), q1.x(), bottom);
+	topBar.setLine(left, top, right, top);
+	bottomBar.setLine(left, bottom, right, bottom);
+	center.setLine(left, q2.y(), right, q2.y());
+}
+
+void BoxSeries::append(double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName)
+{
+	QtCharts::QChart *c = chart();
+	items.emplace_back(new Item(c, this, lowerBound, upperBound, q, binName));
+}
+
+void BoxSeries::updatePositions()
+{
+	QtCharts::QChart *c = chart();
+	for (auto &item: items)
+		item->updatePosition(c, this);
+}
+
+// Attention: this supposes that items are sorted by position and no box is inside another box!
+int BoxSeries::getItemUnderMouse(const QPointF &point)
+{
+	// Search the first item whose "end" position is greater than the cursor position.
+	auto it = std::lower_bound(items.begin(), items.end(), point.x(),
+			   [] (const std::unique_ptr<Item> &item, double x) { return item->bounding.right() < x; });
+	return it != items.end() && (*it)->bounding.contains(point) ? it - items.begin() : -1;
+}
+
+static QString infoItem(const QString &name, const QString &unit, int decimals, double value)
+{
+	QLocale loc;
+	QString formattedValue = loc.toString(value, 'f', decimals);
+	return unit.isEmpty() ? QStringLiteral(" %1: %2").arg(name, formattedValue)
+			      : QStringLiteral(" %1: %2 %3").arg(name, formattedValue, unit);
+}
+
+std::vector<QString> BoxSeries::formatInformation(const Item &item) const
+{
+	QLocale loc;
+	return {
+		item.binName,
+		QStringLiteral("%1:").arg(variable),
+		infoItem(StatsTranslations::tr("min"), unit, decimals, item.q.min),
+		infoItem(StatsTranslations::tr("Q1"), unit, decimals, item.q.q1),
+		infoItem(StatsTranslations::tr("mean"), unit, decimals, item.q.q2),
+		infoItem(StatsTranslations::tr("Q3"), unit, decimals, item.q.q3),
+		infoItem(StatsTranslations::tr("max"), unit, decimals, item.q.max)
+	};
+}
+
+// Highlight item when hovering over item
+void BoxSeries::highlight(int index, QPointF pos)
+{
+	if (index == highlighted) {
+		if (information)
+			information->setPos(pos);
+		return;
+	}
+
+	// Unhighlight old highlighted item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted]->highlight(false);
+	highlighted = index;
+
+	// Highlight new item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size()) {
+		Item &item = *items[highlighted];
+		item.highlight(true);
+		if (!information)
+			information.reset(new InformationBox(chart()));
+		information->setText(formatInformation(item), pos);
+	} else {
+		information.reset();
+	}
+}

--- a/stats/boxseries.cpp
+++ b/stats/boxseries.cpp
@@ -10,17 +10,9 @@
 static const double boxWidth = 0.8; // 1.0 = full width of category
 static const int boxBorderWidth = 2;
 
-int BoxSeries::invalidIndex()
-{
-	return -1;
-}
-
-bool BoxSeries::isValidIndex(int idx)
-{
-	return idx >= 0;
-}
-
-BoxSeries::BoxSeries(const QString &variable, const QString &unit, int decimals) :
+BoxSeries::BoxSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis,
+		     const QString &variable, const QString &unit, int decimals) :
+	StatsSeries(chart, xAxis, yAxis),
 	variable(variable), unit(unit), decimals(decimals), highlighted(-1)
 {
 }
@@ -138,17 +130,16 @@ std::vector<QString> BoxSeries::formatInformation(const Item &item) const
 }
 
 // Highlight item when hovering over item
-void BoxSeries::highlight(int index, QPointF pos)
+bool BoxSeries::hover(QPointF pos)
 {
+	int index = getItemUnderMouse(pos);
 	if (index == highlighted) {
 		if (information)
 			information->setPos(pos);
-		return;
+		return index >= 0;
 	}
 
-	// Unhighlight old highlighted item (if any)
-	if (highlighted >= 0 && highlighted < (int)items.size())
-		items[highlighted]->highlight(false);
+	unhighlight();
 	highlighted = index;
 
 	// Highlight new item (if any)
@@ -161,4 +152,12 @@ void BoxSeries::highlight(int index, QPointF pos)
 	} else {
 		information.reset();
 	}
+	return highlighted >= 0;
+}
+
+void BoxSeries::unhighlight()
+{
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted]->highlight(false);
+	highlighted = -1;
 }

--- a/stats/boxseries.h
+++ b/stats/boxseries.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0
+// A small custom box plot series, which displays quartiles.
+// The QtCharts bar series were  too inflexible with respect
+// to placement of the bars.
+#ifndef BOX_SERIES_H
+#define BOX_SERIES_H
+
+#include "statstypes.h" // for StatsQuartiles
+
+#include <memory>
+#include <vector>
+#include <QScatterSeries>
+#include <QGraphicsLineItem>
+#include <QGraphicsRectItem>
+
+namespace QtCharts {
+	class QAbstractAxis;
+	class QChart;
+}
+class InformationBox;
+class StatsType;
+
+// We derive from a proper scatter series to get access to the map-to
+// and map-from coordinates calls. But we don't use any of its functionality.
+// Can we avoid that?
+
+class BoxSeries : public QtCharts::QScatterSeries {
+public:
+	BoxSeries(const QString &variable, const QString &unit, int decimals);
+	~BoxSeries();
+
+	// Call if chart geometry changed
+	void updatePositions();
+
+	// Note: this expects that all items are added with increasing pos
+	// and that no bar is inside another bar, i.e. lowerBound and upperBound
+	// are ordered identically.
+	void append(double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName);
+
+	// Get item under mous pointer, or -1 if none
+	int getItemUnderMouse(const QPointF &f);
+
+	// Highlight item when hovering over item
+	void highlight(int index, QPointF pos);
+private:
+	struct Item {
+		QGraphicsRectItem box;
+		QGraphicsLineItem topWhisker, bottomWhisker;
+		QGraphicsLineItem topBar, bottomBar;
+		QGraphicsLineItem center;
+		QRectF bounding; // bounding box in screen coordinates
+		~Item();
+		double lowerBound, upperBound;
+		StatsQuartiles q;
+		QString binName;
+		Item(QtCharts::QChart *chart, BoxSeries *series, double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName);
+		void updatePosition(QtCharts::QChart *chart, BoxSeries *series);
+		void highlight(bool highlight);
+	};
+
+	QString variable, unit;
+	int decimals;
+
+	std::vector<QString> formatInformation(const Item &item) const;
+	std::unique_ptr<InformationBox> information;
+	std::vector<std::unique_ptr<Item>> items;
+	int highlighted; // -1: no item highlighted
+};
+
+#endif

--- a/stats/boxseries.h
+++ b/stats/boxseries.h
@@ -5,46 +5,36 @@
 #ifndef BOX_SERIES_H
 #define BOX_SERIES_H
 
+#include "statsseries.h"
 #include "statstypes.h" // for StatsQuartiles
 
 #include <memory>
 #include <vector>
-#include <QScatterSeries>
 #include <QGraphicsLineItem>
 #include <QGraphicsRectItem>
 
-namespace QtCharts {
-	class QAbstractAxis;
-	class QChart;
-}
 class InformationBox;
 class StatsType;
 
-// We derive from a proper scatter series to get access to the map-to
-// and map-from coordinates calls. But we don't use any of its functionality.
-// Can we avoid that?
-
-class BoxSeries : public QtCharts::QScatterSeries {
+class BoxSeries : public StatsSeries {
 public:
-	BoxSeries(const QString &variable, const QString &unit, int decimals);
+	BoxSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis,
+		  const QString &variable, const QString &unit, int decimals);
 	~BoxSeries();
 
-	// Call if chart geometry changed
-	void updatePositions();
+	void updatePositions() override;
+	bool hover(QPointF pos) override;
+	void unhighlight() override;
 
 	// Note: this expects that all items are added with increasing pos
 	// and that no bar is inside another bar, i.e. lowerBound and upperBound
 	// are ordered identically.
 	void append(double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName);
 
-	// Get item under mous pointer, or -1 if none
-	int getItemUnderMouse(const QPointF &f);
-	static int invalidIndex();
-	static bool isValidIndex(int idx);
-
-	// Highlight item when hovering over item
-	void highlight(int index, QPointF pos);
 private:
+	// Get item under mouse pointer, or -1 if none
+	int getItemUnderMouse(const QPointF &f);
+
 	struct Item {
 		QGraphicsRectItem box;
 		QGraphicsLineItem topWhisker, bottomWhisker;

--- a/stats/boxseries.h
+++ b/stats/boxseries.h
@@ -39,6 +39,8 @@ public:
 
 	// Get item under mous pointer, or -1 if none
 	int getItemUnderMouse(const QPointF &f);
+	static int invalidIndex();
+	static bool isValidIndex(int idx);
 
 	// Highlight item when hovering over item
 	void highlight(int index, QPointF pos);

--- a/stats/chartlistmodel.cpp
+++ b/stats/chartlistmodel.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "chartlistmodel.h"
+#include "core/metrics.h"
+#include <QIcon>
+#include <QFontMetrics>
+
+ChartListModel::ChartListModel() :
+	itemFont(defaultModelFont()), 
+	headerFont(itemFont.family(), itemFont.pointSize(), itemFont.weight(), true)
+{
+	QFontMetrics fm(itemFont);
+	int fontHeight = fm.height();
+	warningIcon = QIcon::fromTheme("dialog-warning");
+	warningPixmap = warningIcon.pixmap(QSize(fontHeight, fontHeight));
+}
+
+ChartListModel::~ChartListModel()
+{
+}
+
+int ChartListModel::rowCount(const QModelIndex &parent) const
+{
+	return parent.isValid() ? 0 : (int)items.size();
+}
+
+Qt::ItemFlags ChartListModel::flags(const QModelIndex &index) const
+{
+	int row = index.row();
+	if (index.parent().isValid() || row < 0 || row >= (int)items.size())
+		return Qt::NoItemFlags;
+	return items[row].isHeader ? Qt::ItemIsEnabled
+				   : Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+}
+
+QVariant ChartListModel::data(const QModelIndex &index, int role) const
+{
+	int row = index.row();
+	if (index.parent().isValid() || row < 0 || row >= (int)items.size())
+		return QVariant();
+
+	switch (role) {
+	case Qt::FontRole:
+		return items[row].isHeader ? headerFont : itemFont;
+	case Qt::DisplayRole:
+		return items[row].fullName;
+	case Qt::DecorationRole:
+		return items[row].warning ? QVariant::fromValue(warningIcon)
+					  : QVariant();
+	case PixmapRole:
+		return items[row].warning ? QVariant::fromValue(warningPixmap)
+					  : QVariant();
+	case ChartNameRole:
+		return items[row].name;
+	case IsHeaderRole:
+		return items[row].isHeader;
+	case Qt::UserRole:
+		return items[row].id;
+	}
+	return QVariant();
+}
+
+int ChartListModel::update(const StatsState::ChartList &charts)
+{
+	// Sort non-recommended entries to the back
+	std::vector<StatsState::Chart> sorted;
+	sorted.reserve(charts.charts.size());
+	std::copy_if(charts.charts.begin(), charts.charts.end(), std::back_inserter(sorted),
+		     [] (const StatsState::Chart &chart) { return !chart.warning; });
+	std::copy_if(charts.charts.begin(), charts.charts.end(), std::back_inserter(sorted),
+		     [] (const StatsState::Chart &chart) { return chart.warning; });
+
+	beginResetModel();
+	items.clear();
+	QString act;
+	int res = -1;
+	for (const StatsState::Chart &chart: sorted) {
+		if (act != chart.name) {
+			items.push_back({ true, chart.name, QString(), -1, false });
+			act = chart.name;
+		}
+		if (charts.selected == chart.id)
+			res = (int)items.size();
+		QString fullName = QString("%1 / %2").arg(chart.name, chart.subtypeName);
+		items.push_back({ false, chart.subtypeName, fullName, chart.id, chart.warning });
+	}
+	endResetModel();
+	return res;
+}

--- a/stats/chartlistmodel.h
+++ b/stats/chartlistmodel.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0
+// A model to feed to the chart-selection combobox
+#ifndef CHART_LIST_MODEL_H
+#define CHART_LIST_MODEL_H
+
+#include "statsstate.h" // Argh. Can't forward declare StatsState::ChartList. :-/
+#include <vector>
+#include <QAbstractListModel>
+#include <QString>
+#include <QFont>
+#include <QIcon>
+#include <QPixmap>
+
+class ChartListModel : public QAbstractListModel {
+	Q_OBJECT
+public:
+	ChartListModel();
+	~ChartListModel();
+
+	// Returns index of selected item
+	int update(const StatsState::ChartList &charts);
+
+	static const constexpr int ChartNameRole = Qt::UserRole + 1;
+	static const constexpr int IsHeaderRole = Qt::UserRole + 2;
+	static const constexpr int PixmapRole = Qt::UserRole + 3;
+private:
+	struct Item {
+		bool isHeader;
+		QString name;
+		QString fullName;
+		int id;
+		bool warning;
+	};
+	QFont itemFont;
+	QFont headerFont;
+	QIcon warningIcon;
+	QPixmap warningPixmap;
+	std::vector<Item> items;
+	int rowCount(const QModelIndex &parent) const override;
+	QVariant data(const QModelIndex &index, int role) const override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+};
+
+#endif

--- a/stats/chartlistmodel.h
+++ b/stats/chartlistmodel.h
@@ -3,7 +3,7 @@
 #ifndef CHART_LIST_MODEL_H
 #define CHART_LIST_MODEL_H
 
-#include "statsstate.h" // Argh. Can't forward declare StatsState::ChartList. :-/
+#include "statsstate.h"
 #include <vector>
 #include <QAbstractListModel>
 #include <QString>
@@ -22,23 +22,33 @@ public:
 
 	static const constexpr int ChartNameRole = Qt::UserRole + 1;
 	static const constexpr int IsHeaderRole = Qt::UserRole + 2;
-	static const constexpr int PixmapRole = Qt::UserRole + 3;
+	static const constexpr int IconRole = Qt::UserRole + 3;
+	static const constexpr int IconSizeRole = Qt::UserRole + 4;
 private:
 	struct Item {
 		bool isHeader;
 		QString name;
 		QString fullName;
+		ChartSubType subtype;
 		int id;
 		bool warning;
 	};
+
+	struct SubTypeIcons {
+		QPixmap normal;
+		QPixmap warning;
+	};
+	QPixmap warningPixmap;
+	SubTypeIcons subTypeIcons[(size_t)ChartSubType::Count];
+
 	QFont itemFont;
 	QFont headerFont;
-	QIcon warningIcon;
-	QPixmap warningPixmap;
 	std::vector<Item> items;
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	void initIcon(ChartSubType type, const char *name, int iconSize);
+	const QPixmap &getIcon(ChartSubType type, bool warning) const;
 };
 
 #endif

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -12,7 +12,7 @@ InformationBox::InformationBox(QtCharts::QChart *chart) : QGraphicsRectItem(char
 	setBrush(informationColor);
 }
 
-void InformationBox::setText(std::vector<QString> text, QPointF pos)
+void InformationBox::setText(const std::vector<QString> &text, QPointF pos)
 {
 	width = height = 0.0;
 	textItems.clear();

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -1,4 +1,5 @@
 #include "informationbox.h"
+#include "statscolors.h"
 #include <QChart>
 
 static const QColor informationBorderColor(Qt::black);
@@ -53,6 +54,7 @@ void InformationBox::addLine(const QString &s)
 {
 	textItems.emplace_back(new QGraphicsSimpleTextItem(s, this));
 	QGraphicsSimpleTextItem &item = *textItems.back();
+	item.setBrush(QBrush(labelColor));
 	item.setPos(QPointF(0.0, height));
 	QRectF rect = item.boundingRect();
 	width = std::max(width, rect.width());

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -1,0 +1,60 @@
+#include "informationbox.h"
+#include <QChart>
+
+static const QColor informationBorderColor(Qt::black);
+static const QColor informationColor(0xff, 0xff, 0x00, 192); // Note: fourth argument is opacity
+static const int informationBorder = 2;
+static const int distanceFromPointer = 10; // Distance to place box from mouse pointer or scatter item
+
+InformationBox::InformationBox(QtCharts::QChart *chart) : QGraphicsRectItem(chart), chart(chart)
+{
+	setPen(QPen(informationBorderColor, informationBorder));
+	setBrush(informationColor);
+}
+
+void InformationBox::setText(std::vector<QString> text, QPointF pos)
+{
+	width = height = 0.0;
+	textItems.clear();
+
+	for (const QString &s: text) {
+		if (!s.isEmpty())
+			addLine(s);
+	}
+
+	width += 4.0 * informationBorder;
+	height += 4.0 * informationBorder;
+
+	// Setting the position will also set the proper size
+	setPos(pos);
+}
+
+void InformationBox::setPos(QPointF pos)
+{
+	QRectF plotArea = chart->plotArea();
+
+	double x = pos.x() + distanceFromPointer;
+	if (x + width >= plotArea.right() && pos.x() - width >= plotArea.x())
+		x = pos.x() - width;
+	double y = pos.y() + distanceFromPointer;
+	if (y + height >= plotArea.bottom() && pos.y() - height >= plotArea.y())
+		y = pos.y() - height;
+
+	setRect(x, y, width, height);
+	double actY = y + 2.0 * informationBorder;
+	for (auto &item: textItems) {
+		item->setPos(QPointF(x + 2.0 * informationBorder, actY));
+		actY += item->boundingRect().height();
+	}
+	setZValue(20.0); // What would a proper value be here?
+}
+
+void InformationBox::addLine(const QString &s)
+{
+	textItems.emplace_back(new QGraphicsSimpleTextItem(s, this));
+	QGraphicsSimpleTextItem &item = *textItems.back();
+	item.setPos(QPointF(0.0, height));
+	QRectF rect = item.boundingRect();
+	width = std::max(width, rect.width());
+	height += rect.height();
+}

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -54,7 +54,7 @@ void InformationBox::addLine(const QString &s)
 {
 	textItems.emplace_back(new QGraphicsSimpleTextItem(s, this));
 	QGraphicsSimpleTextItem &item = *textItems.back();
-	item.setBrush(QBrush(labelColor));
+	item.setBrush(QBrush(darkLabelColor));
 	item.setPos(QPointF(0.0, height));
 	QRectF rect = item.boundingRect();
 	width = std::max(width, rect.width());

--- a/stats/informationbox.h
+++ b/stats/informationbox.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0
+// A small box displaying statistics information, notably
+// for a scatter-plot item or a bar in a bar chart.
+#ifndef INFORMATION_BOX_H
+#define INFORMATION_BOX_H
+
+#include <vector>
+#include <memory>
+#include <QGraphicsRectItem>
+
+namespace QtCharts {
+	class QChart;
+}
+struct dive;
+
+// Information window showing data of highlighted dive
+struct InformationBox : QGraphicsRectItem {
+	InformationBox(QtCharts::QChart *chart);
+	void setText(std::vector<QString> text, QPointF pos);
+	void setPos(QPointF pos);
+private:
+	QtCharts::QChart *chart;
+	double width, height;
+	void addLine(const QString &s);
+	std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> textItems;
+};
+
+#endif

--- a/stats/informationbox.h
+++ b/stats/informationbox.h
@@ -16,7 +16,7 @@ struct dive;
 // Information window showing data of highlighted dive
 struct InformationBox : QGraphicsRectItem {
 	InformationBox(QtCharts::QChart *chart);
-	void setText(std::vector<QString> text, QPointF pos);
+	void setText(const std::vector<QString> &text, QPointF pos);
 	void setPos(QPointF pos);
 private:
 	QtCharts::QChart *chart;

--- a/stats/legend.cpp
+++ b/stats/legend.cpp
@@ -46,7 +46,7 @@ Legend::Entry::Entry(const QString &name, int idx, int numBins, QGraphicsItem *p
 	rect->setPen(QPen(legendBorderColor, legendBoxBorderSize));
 	rect->setBrush(QBrush(binColor(idx, numBins)));
 	text->setZValue(30.0);
-	text->setBrush(QBrush(labelColor));
+	text->setBrush(QBrush(darkLabelColor));
 }
 
 void Legend::hide()

--- a/stats/legend.cpp
+++ b/stats/legend.cpp
@@ -20,7 +20,7 @@ Legend::Legend(QGraphicsWidget *chart, const std::vector<QString> &names) :
 	entries.reserve(names.size());
 	int idx = 0;
 	for (const QString &name: names)
-		entries.emplace_back(name, idx++, this);
+		entries.emplace_back(name, idx++, (int)names.size(), this);
 
 	// Calculate the height and width of the elements
 	if (!entries.empty()) {
@@ -38,13 +38,13 @@ Legend::Legend(QGraphicsWidget *chart, const std::vector<QString> &names) :
 	resize(); // Draw initial legend
 }
 
-Legend::Entry::Entry(const QString &name, int idx, QGraphicsItem *parent) :
+Legend::Entry::Entry(const QString &name, int idx, int numBins, QGraphicsItem *parent) :
 	rect(new QGraphicsRectItem(parent)),
 	text(new QGraphicsSimpleTextItem(name, parent))
 {
 	rect->setZValue(30.0);
 	rect->setPen(QPen(legendBorderColor, legendBoxBorderSize));
-	rect->setBrush(QBrush(binColor(idx)));
+	rect->setBrush(QBrush(binColor(idx, numBins)));
 	text->setZValue(30.0);
 	text->setBrush(QBrush(labelColor));
 }

--- a/stats/legend.cpp
+++ b/stats/legend.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "legend.h"
+#include "statscolors.h"
+#include <QFontMetrics>
+#include <QGraphicsSceneMouseEvent>
+#include <QGraphicsWidget>
+#include <QPen>
+
+static const double legendBorderSize = 2.0;
+static const double legendBoxBorderSize = 1.0;
+static const double legendBoxScale = 0.8;		// 1.0: text-height of the used font
+static const double legendInternalBorderSize = 2.0;
+static const QColor legendColor(0x00, 0x8e, 0xcc, 192); // Note: fourth argument is opacity
+static const QColor legendBorderColor(Qt::black);
+
+Legend::Legend(QGraphicsWidget *chart, const std::vector<QString> &names) :
+	QGraphicsRectItem(chart), chart(chart), displayedItems(0), width(0.0), height(0.0)
+{
+	setZValue(30.0); // On top of everything else.
+	entries.reserve(names.size());
+	int idx = 0;
+	for (const QString &name: names)
+		entries.emplace_back(name, idx++, this);
+
+	// Calculate the height and width of the elements
+	if (!entries.empty()) {
+		QFontMetrics fm(entries[0].text->font());
+		fontHeight = fm.height();
+		for (Entry &e: entries)
+			e.width = fontHeight + 2.0 * legendBoxBorderSize +
+				  fm.size(Qt::TextSingleLine, e.text->text()).width();
+	} else {
+		fontHeight = 0.0;
+	}
+	setPen(QPen(legendBorderColor, legendBorderSize));
+	setBrush(QBrush(legendColor));
+
+	resize(); // Draw initial legend
+}
+
+Legend::Entry::Entry(const QString &name, int idx, QGraphicsItem *parent) :
+	rect(new QGraphicsRectItem(parent)),
+	text(new QGraphicsSimpleTextItem(name, parent))
+{
+	rect->setZValue(30.0);
+	rect->setPen(QPen(legendBorderColor, legendBoxBorderSize));
+	rect->setBrush(QBrush(binColor(idx)));
+	text->setZValue(30.0);
+	text->setBrush(QBrush(labelColor));
+}
+
+void Legend::hide()
+{
+	for (Entry &e: entries) {
+		e.rect->hide();
+		e.text->hide();
+	}
+	QGraphicsRectItem::hide();
+}
+
+void Legend::resize()
+{
+	if (entries.empty())
+		return hide();
+
+	QSizeF size = chart->size();
+
+	// Silly heuristics: make the legend at most half as high and half as wide as the chart.
+	// Not sure if that makes sense - this might need some optimization.
+	int maxRows = static_cast<int>(size.height() / 2.0 - 2.0 * legendInternalBorderSize) / fontHeight;
+	if (maxRows <= 0)
+		return hide();
+	int numColumns = ((int)entries.size() - 1) / maxRows + 1;
+	int numRows = ((int)entries.size() - 1) / numColumns + 1;
+
+	double x = legendInternalBorderSize;
+	displayedItems = 0;
+	for (int col = 0; col < numColumns; ++col) {
+		double y = legendInternalBorderSize;
+		double nextX = x;
+
+		for (int row = 0; row < numRows; ++row) {
+			int idx = col * numRows + row;
+			if (idx >= (int)entries.size())
+				break;
+			entries[idx].pos = QPointF(x, y);
+			nextX = std::max(nextX, x + entries[idx].width);
+			y += fontHeight;
+			++displayedItems;
+		}
+		x += nextX;
+		width = nextX;
+		if (width >= size.width() / 2.0) // More than half the chart-width -> give up
+			break;
+	}
+	width += legendInternalBorderSize;
+	height = 2 * legendInternalBorderSize + numRows * fontHeight;
+	updatePosition();
+}
+
+void Legend::updatePosition()
+{
+	if (displayedItems <= 0)
+		return hide();
+	// For now, place the legend in the top right corner.
+	QPointF pos(chart->size().width() - width - 10.0, 10.0);
+	setRect(QRectF(pos, QSizeF(width, height)));
+	for (int i = 0; i < displayedItems; ++i) {
+		QPointF itemPos = pos + entries[i].pos;
+		QRectF rect(itemPos, QSizeF(fontHeight, fontHeight));
+		// Decrease box size by legendBoxScale factor
+		double delta = fontHeight * (1.0 - legendBoxScale) / 2.0;
+		rect = rect.adjusted(delta, delta, -delta, -delta);
+		entries[i].rect->setRect(rect);
+		itemPos.rx() += fontHeight + 2.0 * legendBoxBorderSize;
+		entries[i].text->setPos(itemPos);
+		entries[i].rect->show();
+		entries[i].text->show();
+	}
+	for (int i = displayedItems; i < (int)entries.size(); ++i) {
+		entries[i].rect->hide();
+		entries[i].text->hide();
+	}
+	show();
+}

--- a/stats/legend.h
+++ b/stats/legend.h
@@ -21,7 +21,7 @@ private:
 		std::unique_ptr<QGraphicsSimpleTextItem> text;
 		QPointF pos;
 		double width;
-		Entry(const QString &name, int idx, QGraphicsItem *parent);
+		Entry(const QString &name, int idx, int numBins, QGraphicsItem *parent);
 	};
 	QGraphicsWidget *chart;
 	int displayedItems;

--- a/stats/legend.h
+++ b/stats/legend.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+// A legend box, which is shown on the chart.
+#ifndef STATS_LEGEND_H
+#define STATS_LEGEND_H
+
+#include <memory>
+#include <vector>
+#include <QGraphicsRectItem>
+
+class QGraphicsSceneMouseEvent;
+
+class Legend : public QGraphicsRectItem {
+public:
+	Legend(QGraphicsWidget *chart, const std::vector<QString> &names);
+	void hover(QPointF pos);
+	void resize(); // called when the chart size changes.
+private:
+	// Each entry is a text besides a rectangle showing the color
+	struct Entry {
+		std::unique_ptr<QGraphicsRectItem> rect;
+		std::unique_ptr<QGraphicsSimpleTextItem> text;
+		QPointF pos;
+		double width;
+		Entry(const QString &name, int idx, QGraphicsItem *parent);
+	};
+	QGraphicsWidget *chart;
+	int displayedItems;
+	double width;
+	double height;
+	int fontHeight;
+	std::vector<Entry> entries;
+	void updatePosition();
+	void hide();
+};
+
+#endif

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -37,11 +37,11 @@ PieSeries::Item::Item(QtCharts::QChart *chart, const QString &name, int from, in
 		double percentage = count * 100.0 / totalCount;
 		QString innerLabelText = QStringLiteral("%1\%").arg(loc.toString(percentage, 'f', 1));
 		innerLabel.reset(new QGraphicsSimpleTextItem(innerLabelText, chart));
-		innerLabel->setBrush(QBrush(labelColor));
+		innerLabel->setBrush(QBrush(labelColor(bin_nr, numBins)));
 		innerLabel->setZValue(10.0); // ? What is a sensible value here ?
 
 		outerLabel.reset(new QGraphicsSimpleTextItem(name, chart));
-		innerLabel->setBrush(QBrush(labelColor));
+		innerLabel->setBrush(QBrush(labelColor(bin_nr, numBins)));
 		innerLabel->setZValue(10.0); // ? What is a sensible value here ?
 	}
 
@@ -109,7 +109,7 @@ PieSeries::PieSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis
 	std::sort(sorted.begin(), sorted.end(),
 		  [&data](int idx1, int idx2)
 		  { return std::make_tuple(-data[idx1].second, idx1) <
-		  	   std::make_tuple(-data[idx2].second, idx2); });
+			   std::make_tuple(-data[idx2].second, idx2); });
 	auto it = std::find_if(sorted.begin(), sorted.end(),
 			       [count=totalCount, &data, smallest_slice_percentage](int idx)
 			       { return data[idx].second * 100 / count < smallest_slice_percentage; });

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "pieseries.h"
+#include "informationbox.h"
+#include "statscolors.h"
+#include "statstranslations.h"
+
+#include <numeric>
+#include <math.h>
+#include <QChart>
+#include <QGraphicsEllipseItem>
+#include <QLocale>
+
+static const double pieSize = 0.9; // 1.0 = occupy full width of chart
+static const double pieBorderWidth = 1.0;
+static const double innerLabelRadius = 0.75; // 1.0 = at outer border of pie
+static const double outerLabelRadius = 1.01; // 1.0 = at outer border of pie
+
+PieSeries::Item::Item(QtCharts::QChart *chart, const QString &name, int from, int count, int totalCount, int bin_nr, bool labels) :
+	item(new QGraphicsEllipseItem(chart)),
+	name(name),
+	count(count)
+{
+	QLocale loc;
+	// For whatever obscure reason, angles in QGraphicsEllipseItem are given as 16th of a degree...?
+	// Angles increase CCW, whereas pie charts usually are read CW.
+	item->setStartAngle(90 * 16 - (from + count) * 360 * 16 / totalCount);
+	item->setSpanAngle(count * 360 * 16 / totalCount);
+	item->setPen(QPen(::borderColor));
+
+	angleTo = static_cast<double>(from + count) / totalCount;
+	double meanAngle = M_PI / 2.0 - (from + count / 2.0) / totalCount * M_PI * 2.0; // Note: "-" because we go CW.
+	innerLabelPos = QPointF(cos(meanAngle) * innerLabelRadius, -sin(meanAngle) * innerLabelRadius);
+	outerLabelPos = QPointF(cos(meanAngle) * outerLabelRadius, -sin(meanAngle) * outerLabelRadius);
+
+	if (labels) {
+		double percentage = count * 100.0 / totalCount;
+		QString innerLabelText = QStringLiteral("%1\%").arg(loc.toString(percentage, 'f', 1));
+		innerLabel.reset(new QGraphicsSimpleTextItem(innerLabelText, chart));
+		innerLabel->setBrush(QBrush(labelColor));
+		innerLabel->setZValue(10.0); // ? What is a sensible value here ?
+
+		outerLabel.reset(new QGraphicsSimpleTextItem(name, chart));
+		innerLabel->setBrush(QBrush(labelColor));
+		innerLabel->setZValue(10.0); // ? What is a sensible value here ?
+	}
+
+	highlight(bin_nr, false);
+}
+
+void PieSeries::Item::updatePositions(const QRectF &rect, const QPointF &center, double radius)
+{
+	item->setRect(rect);
+	if (innerLabel) {
+		QRectF labelRect = innerLabel->boundingRect();
+		innerLabel->setPos(center.x() + innerLabelPos.x() * radius - labelRect.width() / 2.0,
+				   center.y() + innerLabelPos.y() * radius - labelRect.height() / 2.0);
+	}
+	if (outerLabel) {
+		QRectF labelRect = outerLabel->boundingRect();
+		QPointF pos(center.x() + outerLabelPos.x() * radius, center.y() + outerLabelPos.y() * radius);
+		if (outerLabelPos.x() < 0.0) {
+			if (outerLabelPos.y() < 0.0)
+				pos -= QPointF(labelRect.width(), labelRect.height());
+			else
+				pos.rx() -= labelRect.width();
+		} else if (outerLabelPos.y() < 0.0) {
+			pos.ry() -= labelRect.height();
+		}
+
+		outerLabel->setPos(pos);
+	}
+}
+
+void PieSeries::Item::highlight(int bin_nr, bool highlight)
+{
+	QBrush brush = highlight ? QBrush(highlightedColor) : QBrush(binColor(bin_nr));
+	QPen pen = highlight ? QPen(highlightedBorderColor, pieBorderWidth) : QPen(::borderColor, pieBorderWidth);
+	item->setBrush(brush);
+	item->setPen(pen);
+}
+
+PieSeries::PieSeries(QtCharts::QChart *chart, const QString &categoryName,
+		     const std::vector<std::pair<QString, int>> &data, bool keepOrder, bool labels) :
+	categoryName(categoryName),
+	highlighted(invalidIndex())
+{
+	// Pie charts with many slices are unreadable. Therefore, subsume slices under
+	// a certain percentage as "other". But draw a minimum number of slices
+	// until we reach 50% so that we never get a pie only of "other".
+	// This is heuristics, which might have to be optimized.
+	const int smallest_slice_percentage = 5; // Smaller than 5% = others. That makes at most 20 slices.
+	const int min_slices = 5; // Try to draw at least 5 slices until we reach 50%
+
+	// Easier to read than std::accumulate
+	totalCount = 0;
+	for (const auto &[name, count]: data)
+		totalCount += count;
+
+	// First of all, sort from largest to smalles slice. Instead
+	// of sorting the initial array, sort a list of indices, so that
+	// the original order can be easily reconstructed later.
+	std::vector<int> sorted(data.size());
+	std::iota(sorted.begin(), sorted.end(), 0); // Fill with 0..size-1.
+	// Two notes:
+	//  - by negating the counts in the sort below, count is sorted descending.
+	//  - do a lexicographic sort by (count, idx) so that for equal counts the order is preserved.
+	std::sort(sorted.begin(), sorted.end(),
+		  [&data](int idx1, int idx2)
+		  { return std::make_tuple(-data[idx1].second, idx1) <
+		  	   std::make_tuple(-data[idx2].second, idx2); });
+	auto it = std::find_if(sorted.begin(), sorted.end(),
+			       [count=totalCount, &data, smallest_slice_percentage](int idx)
+			       { return data[idx].second * 100 / count < smallest_slice_percentage; });
+	if (it - sorted.begin() < min_slices) {
+		// Take minimum amount of slices below 50%...
+		int sum = 0;
+		for (auto it2 = sorted.begin(); it2 != it; ++it2)
+			sum += data[*it2].second;
+
+		while(it != sorted.end() && sum * 2 < totalCount && it - sorted.begin() < min_slices) {
+			sum += data[*it].second;
+			++it;
+		}
+	}
+
+	// Don't do a single "other" group
+	if (sorted.end() - it == 1)
+		++it;
+
+	// Sort the main groups and the other groups back, if requested
+	if (keepOrder) {
+		std::sort(sorted.begin(), it);
+		std::sort(it, sorted.end());
+	}
+
+	items.reserve(it - sorted.begin() + 1); // +1 in case that there is an "other" group.
+	int act = 0;
+	for (auto it2 = sorted.begin(); it2 != it; ++it2) {
+		int count = data[*it2].second;
+		items.emplace_back(chart, data[*it2].first, act, count, totalCount, (int)items.size(), labels);
+		act += count;
+	}
+
+	// Register the items of the "other" group.
+	if (it != sorted.end()) {
+		other.reserve(sorted.end() - it);
+		for (auto it2 = it; it2 != sorted.end(); ++it2)
+			other.push_back({ data[*it2].first, data[*it2].second });
+		QString name = StatsTranslations::tr("other (%1 items)").arg(other.size());
+		items.emplace_back(chart, name, act, totalCount - act, totalCount, (int)items.size(), labels);
+	}
+}
+
+PieSeries::~PieSeries()
+{
+}
+
+void PieSeries::updatePositions()
+{
+	QtCharts::QChart *c = chart();
+	QRectF plotRect = c->plotArea();
+	center = plotRect.center();
+	radius = std::min(plotRect.width(), plotRect.height()) * pieSize / 2.0;
+	QRectF rect(center.x() - radius, center.y() - radius, 2.0 * radius, 2.0 * radius);
+	for (Item &item: items)
+		item.updatePositions(rect, center, radius);
+}
+
+std::vector<QString> PieSeries::binNames()
+{
+	std::vector<QString> res;
+	res.reserve(items.size());
+	for (Item &item: items)
+		res.push_back(item.name);
+	return res;
+}
+
+int PieSeries::getItemUnderMouse(const QPointF &f) const
+{
+	QPointF delta = f - center;
+	double len = sqrt(QPointF::dotProduct(delta, delta));
+	if (len > radius)
+		return invalidIndex();
+	delta /= len;
+	double angle = 0.25 - atan2(-delta.y(), delta.x()) / 2.0 / M_PI;
+	while (angle < 0.0)
+		angle += 1.0;
+	auto it = std::lower_bound(items.begin(), items.end(), angle,
+				   [](const Item &item, double angle) { return item.angleTo < angle; });
+	if (it == items.end())
+		return invalidIndex(); // Floating point rounding issues?
+	return it - items.begin();
+}
+
+int PieSeries::invalidIndex()
+{
+	return -1;
+}
+
+bool PieSeries::isValidIndex(int idx)
+{
+	return idx >= 0;
+}
+
+static QString makePercentageLine(int count, int total)
+{
+	double percentage = count * 100.0 / total;
+	QString countString = QString("%L1").arg(count);
+	QString percentageString = QString("%L1%").arg(percentage, 0, 'f', 1);
+	QString totalString = QString("%L1").arg(total);
+	return StatsTranslations::tr("%1 (%2 of %3) dives").arg(countString, percentageString, totalString);
+}
+
+std::vector<QString> PieSeries::makeInfo(int idx) const
+{
+	std::vector<QString> res;
+	if (idx + 1 == (int)items.size() && !other.empty()) {
+		// This is the "other" bin. Format all these items and an overview item.
+		res.reserve(other.size() + 1);
+		res.push_back(QString("%1: %2").arg(StatsTranslations::tr("other"),
+						    makePercentageLine(items[idx].count, totalCount)));
+		for (const OtherItem &item: other)
+			res.push_back(QString("%1: %2").arg(item.name,
+							    makePercentageLine(item.count, totalCount)));
+	} else {
+		// A "normal" item.
+		res.reserve(2);
+		res.push_back(QStringLiteral("%1: %2").arg(categoryName, items[idx].name));
+		res.push_back(makePercentageLine(items[idx].count, totalCount));
+	}
+	return res;
+}
+
+void PieSeries::highlight(int index, QPointF pos)
+{
+	if (index == highlighted) {
+		if (information)
+			information->setPos(pos);
+		return;
+	}
+
+	// Unhighlight old highlighted item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted].highlight(highlighted, false);
+	highlighted = index;
+
+	// Highlight new item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size()) {
+		items[highlighted].highlight(highlighted, true);
+		if (!information)
+			information.reset(new InformationBox(chart()));
+		information->setText(makeInfo(highlighted), pos);
+	} else {
+		information.reset();
+	}
+}

--- a/stats/pieseries.h
+++ b/stats/pieseries.h
@@ -3,41 +3,35 @@
 #ifndef PIE_SERIES_H
 #define PIE_SERIES_H
 
+#include "statsseries.h"
+
 #include <memory>
 #include <vector>
 #include <QString>
-#include <QScatterSeries>
 
-namespace QtCharts {
-	class QChart;
-}
 class InformationBox;
 class QGraphicsEllipseItem;
 class QGraphicsSimpleTextItem;
 
-// For historical reasons, we currently have to derive from a series.
-// TODO: Remove in due course.
-class PieSeries : public QtCharts::QScatterSeries {
+class PieSeries : public StatsSeries {
 public:
 	// The pie series is initialized with (name, count) pairs.
 	// If keepOrder is false, bins will be sorted by size, otherwise the sorting
 	// of the shown bins will be retained. Small bins are omitted for clarity.
-	PieSeries(QtCharts::QChart *chart, const QString &categoryName,
+	PieSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis, const QString &categoryName,
 		  const std::vector<std::pair<QString, int>> &data, bool keepOrder, bool labels);
 	~PieSeries();
 
-	// Call if chart geometry changed
-	void updatePositions();
+	void updatePositions() override;
+	bool hover(QPointF pos) override;
+	void unhighlight() override;
 
 	std::vector<QString> binNames();
 
-	int getItemUnderMouse(const QPointF &f) const;
-	static int invalidIndex();
-	static bool isValidIndex(int);
-
-	// Highlight item when hovering over item
-	void highlight(int index, QPointF pos);
 private:
+	// Get item under mouse pointer, or -1 if none
+	int getItemUnderMouse(const QPointF &f) const;
+
 	QString categoryName;
 	std::vector<QString> makeInfo(int idx) const;
 

--- a/stats/pieseries.h
+++ b/stats/pieseries.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0
+// A pie chart series, which displays percentual information.
+#ifndef PIE_SERIES_H
+#define PIE_SERIES_H
+
+#include <memory>
+#include <vector>
+#include <QString>
+#include <QScatterSeries>
+
+namespace QtCharts {
+	class QChart;
+}
+class InformationBox;
+class QGraphicsEllipseItem;
+class QGraphicsSimpleTextItem;
+
+// For historical reasons, we currently have to derive from a series.
+// TODO: Remove in due course.
+class PieSeries : public QtCharts::QScatterSeries {
+public:
+	// The pie series is initialized with (name, count) pairs.
+	// If keepOrder is false, bins will be sorted by size, otherwise the sorting
+	// of the shown bins will be retained. Small bins are omitted for clarity.
+	PieSeries(QtCharts::QChart *chart, const QString &categoryName,
+		  const std::vector<std::pair<QString, int>> &data, bool keepOrder, bool labels);
+	~PieSeries();
+
+	// Call if chart geometry changed
+	void updatePositions();
+
+	std::vector<QString> binNames();
+
+	int getItemUnderMouse(const QPointF &f) const;
+	static int invalidIndex();
+	static bool isValidIndex(int);
+
+	// Highlight item when hovering over item
+	void highlight(int index, QPointF pos);
+private:
+	QString categoryName;
+	std::vector<QString> makeInfo(int idx) const;
+
+	struct Item {
+		std::unique_ptr<QGraphicsEllipseItem> item;
+		std::unique_ptr<QGraphicsSimpleTextItem> innerLabel, outerLabel;
+		QString name;
+		double angleTo; // In fraction of total
+		int count;
+		QPointF innerLabelPos, outerLabelPos; // With respect to a (-1, -1)-(1, 1) rectangle.
+		Item(QtCharts::QChart *chart, const QString &name, int from, int count, int totalCount, int bin_nr, bool labels);
+		void updatePositions(const QRectF &rect, const QPointF &center, double radius);
+		void highlight(int bin_nr, bool highlight);
+	};
+	std::vector<Item> items;
+	int totalCount;
+
+	// Entries in the "other" group. If empty, there is no "other" group.
+	struct OtherItem {
+		QString name;
+		int count;
+	};
+	std::vector<OtherItem> other;
+
+	std::unique_ptr<InformationBox> information;
+	QPointF center; // center of drawing area
+	double radius; // radius of pie
+	int highlighted;
+};
+
+#endif

--- a/stats/pieseries.h
+++ b/stats/pieseries.h
@@ -42,9 +42,10 @@ private:
 		double angleTo; // In fraction of total
 		int count;
 		QPointF innerLabelPos, outerLabelPos; // With respect to a (-1, -1)-(1, 1) rectangle.
-		Item(QtCharts::QChart *chart, const QString &name, int from, int count, int totalCount, int bin_nr, bool labels);
+		Item(QtCharts::QChart *chart, const QString &name, int from, int count, int totalCount,
+		     int bin_nr, int numBins, bool labels);
 		void updatePositions(const QRectF &rect, const QPointF &center, double radius);
-		void highlight(int bin_nr, bool highlight);
+		void highlight(int bin_nr, bool highlight, int numBins);
 	};
 	std::vector<Item> items;
 	int totalCount;

--- a/stats/qml/statsview.qml
+++ b/stats/qml/statsview.qml
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.0
+import QtCharts 2.0
+
+ChartView {
+    antialiasing: true
+    localizeNumbers: true
+}

--- a/stats/qml/statsview.qrc
+++ b/stats/qml/statsview.qrc
@@ -1,0 +1,5 @@
+<RCC>
+	<qresource prefix="/qml">
+		<file>statsview.qml</file>
+	</qresource>
+</RCC>

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -7,18 +7,26 @@
 
 static const QColor scatterItemColor(0x66, 0xb2, 0xff);
 static const QColor scatterItemBorderColor(Qt::blue);
+static const QColor scatterItemHighlightedColor(Qt::yellow);
+static const QColor scatterItemHighlightedBorderColor(0xaa, 0xaa, 0x22);
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
 
-static QPixmap createScatterPixmap()
+ScatterSeries::ScatterSeries()
+	: highlighted(-1)
+{
+}
+
+static QPixmap createScatterPixmap(const QColor &color, const QColor &borderColor)
 {
 	QPixmap res(scatterItemDiameter, scatterItemDiameter);
 	res.fill(Qt::transparent);
 	QPainter painter(&res);
+	painter.setPen(Qt::NoPen);
 	painter.setRenderHint(QPainter::Antialiasing);
-	painter.setBrush(scatterItemBorderColor);
+	painter.setBrush(borderColor);
 	painter.drawEllipse(0, 0, scatterItemDiameter, scatterItemDiameter);
-	painter.setBrush(scatterItemColor);
+	painter.setBrush(color);
 	painter.drawEllipse(scatterItemBorder, scatterItemBorder,
 			    scatterItemDiameter - 2 * scatterItemBorder,
 			    scatterItemDiameter - 2 * scatterItemBorder);
@@ -29,16 +37,21 @@ static QPixmap createScatterPixmap()
 // Therefore, do this as a on-demand initialized pointer. A function local static
 // variable does unnecesssary (in this case) thread synchronization.
 static std::unique_ptr<QPixmap> scatterPixmapPtr;
+static std::unique_ptr<QPixmap> scatterPixmapHighlightedPtr;
 
-static const QPixmap &scatterPixmap()
+static const QPixmap &scatterPixmap(bool highlight)
 {
-	if (!scatterPixmapPtr)
-		scatterPixmapPtr.reset(new QPixmap(createScatterPixmap()));
-	return *scatterPixmapPtr;
+	if (!scatterPixmapPtr) {
+		scatterPixmapPtr.reset(new QPixmap(createScatterPixmap(scatterItemColor,
+								       scatterItemBorderColor)));
+		scatterPixmapHighlightedPtr.reset(new QPixmap(createScatterPixmap(scatterItemHighlightedColor,
+										  scatterItemHighlightedBorderColor)));
+	}
+	return highlight ? *scatterPixmapHighlightedPtr : *scatterPixmapPtr;
 }
 
 ScatterSeries::Item::Item(QtCharts::QChart *chart, ScatterSeries *series, double pos, double value) :
-	item(new QGraphicsPixmapItem(scatterPixmap(), chart)),
+	item(new QGraphicsPixmapItem(scatterPixmap(false), chart)),
 	pos(pos),
 	value(value)
 {
@@ -53,6 +66,11 @@ void ScatterSeries::Item::updatePosition(QtCharts::QChart *chart, ScatterSeries 
 		     center.y() - scatterItemDiameter / 2.0);
 }
 
+void ScatterSeries::Item::highlight(bool highlight)
+{
+	item->setPixmap(scatterPixmap(highlight));
+}
+
 void ScatterSeries::append(double pos, double value)
 {
 	items.emplace_back(chart(), this, pos, value);
@@ -63,4 +81,54 @@ void ScatterSeries::updatePositions()
 	QtCharts::QChart *c = chart();
 	for (Item &item: items)
 		item.updatePosition(c, this);
+}
+
+static double sq(double f)
+{
+	return f * f;
+}
+
+static double squareDist(const QPointF &p1, const QPointF &p2)
+{
+	return sq(p1.x() - p2.x()) + sq(p1.y() - p2.y());
+}
+
+// Attention: this supposes that items are sorted by x-position!
+std::pair<double, int> ScatterSeries::getClosest(const QPointF &point)
+{
+	double x = point.x();
+
+	auto low = std::lower_bound(items.begin(), items.end(), x - scatterItemDiameter,
+				    [] (const Item &item, double x) { return item.item->pos().x() < x; });
+	auto high = std::upper_bound(low, items.end(), x + scatterItemDiameter,
+				    [] (double x, const Item &item) { return x < item.item->pos().x(); });
+	// Hopefully that narrows it down enough. For discrete scatter plots, we could also partition
+	// by equal x and do a binary search in these partitions. But that's probably not worth it.
+	double minSquare = sq(scatterItemDiameter); // Only consider items within twice the radius
+	int index = -1;
+	for (auto it = low; it < high; ++it) {
+		QPointF pos = it->item->pos();
+		pos.rx() += scatterItemDiameter / 2.0;
+		pos.ry() += scatterItemDiameter / 2.0;
+		double square = squareDist(pos, point);
+		if (square <= minSquare) {
+			index = it - items.begin();
+			minSquare = square;
+		}
+	}
+	return { minSquare, index };
+}
+
+// Highlight item when hovering over item
+void ScatterSeries::highlight(int index)
+{
+	if (index == highlighted)
+		return;
+	// Unhighlight old highlighted item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted].highlight(false);
+	highlighted = index;
+	// Highlight new item (if any)
+	if (highlighted >= 0 && highlighted < (int)items.size())
+		items[highlighted].highlight(true);
 }

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "scatterseries.h"
+#include "statstranslations.h"
+#include "statstypes.h"
+#include "core/dive.h"
+#include "core/divelist.h"
+#include "core/qthelper.h"
 
 #include <QChart>
 #include <QGraphicsPixmapItem>
@@ -11,9 +16,12 @@ static const QColor scatterItemHighlightedColor(Qt::yellow);
 static const QColor scatterItemHighlightedBorderColor(0xaa, 0xaa, 0x22);
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
+static const QColor informationBorderColor(Qt::black);
+static const QColor informationColor(0xff, 0xff, 0x00, 192); // Note: fourth argument is opacity
+static const int informationBorder = 2;
 
-ScatterSeries::ScatterSeries()
-	: highlighted(-1)
+ScatterSeries::ScatterSeries(const StatsType &typeX, const StatsType &typeY)
+	: highlighted(-1), typeX(typeX), typeY(typeY)
 {
 }
 
@@ -50,8 +58,9 @@ static const QPixmap &scatterPixmap(bool highlight)
 	return highlight ? *scatterPixmapHighlightedPtr : *scatterPixmapPtr;
 }
 
-ScatterSeries::Item::Item(QtCharts::QChart *chart, ScatterSeries *series, double pos, double value) :
+ScatterSeries::Item::Item(QtCharts::QChart *chart, ScatterSeries *series, dive *d, double pos, double value) :
 	item(new QGraphicsPixmapItem(scatterPixmap(false), chart)),
+	d(d),
 	pos(pos),
 	value(value)
 {
@@ -71,9 +80,9 @@ void ScatterSeries::Item::highlight(bool highlight)
 	item->setPixmap(scatterPixmap(highlight));
 }
 
-void ScatterSeries::append(double pos, double value)
+void ScatterSeries::append(dive *d, double pos, double value)
 {
-	items.emplace_back(chart(), this, pos, value);
+	items.emplace_back(chart(), this, d, pos, value);
 }
 
 void ScatterSeries::updatePositions()
@@ -128,7 +137,91 @@ void ScatterSeries::highlight(int index)
 	if (highlighted >= 0 && highlighted < (int)items.size())
 		items[highlighted].highlight(false);
 	highlighted = index;
+
 	// Highlight new item (if any)
-	if (highlighted >= 0 && highlighted < (int)items.size())
-		items[highlighted].highlight(true);
+	if (highlighted >= 0 && highlighted < (int)items.size()) {
+		Item &item = items[highlighted];
+		item.highlight(true);
+		QPointF pos = item.item->pos();
+		if (!information)
+			information.reset(new Information(chart()));
+		information->set(items[highlighted].d, pos, typeX, typeY);
+	} else {
+		information.reset();
+	}
+}
+
+ScatterSeries::Information::Information(QtCharts::QChart *chart) : QGraphicsRectItem(chart)
+{
+	setPen(QPen(informationBorderColor, informationBorder));
+	setBrush(informationColor);
+}
+
+void ScatterSeries::Information::set(const dive *d, QPointF pos, const StatsType &typeX, const StatsType &typeY)
+{
+	width = height = 0.0;
+	textItems.clear();
+
+	// We don't listen to undo-command signals, therefore we have to check whether that dive actually exists!
+	// TODO: fix this.
+	if (get_divenr(d) < 0) {
+		addLine(StatsTranslations::tr("Removed dive"));
+	} else {
+		addLine(StatsTranslations::tr("Dive #%1").arg(d->number));
+		addLine(get_dive_date_string(d->when));
+		addDataLine(typeX, d);
+		addDataLine(typeY, d);
+	}
+
+	width += 4.0 * informationBorder;
+	height += 4.0 * informationBorder;
+
+	QRectF parentRect = parentItem()->boundingRect();
+
+	double x = pos.x() + scatterItemDiameter;
+	if (x + width >= parentRect.right() && pos.x() - width >= parentRect.x())
+		x = pos.x() - width;
+	double y = pos.y() + scatterItemDiameter;
+	if (y + height >= parentRect.bottom() && pos.y() - height >= parentRect.y())
+		y = pos.y() - height;
+
+
+	setRect(x, y, width, height);
+	double actY = y + 2.0 * informationBorder;
+	for (auto &item: textItems) {
+		item->setPos(QPointF(x + 2.0 * informationBorder, actY));
+		actY += item->boundingRect().height();
+	}
+	setZValue(20.0); // What would a proper value be here?
+}
+
+void ScatterSeries::Information::addLine(const QString &s)
+{
+	textItems.emplace_back(new QGraphicsSimpleTextItem(s, this));
+	QGraphicsSimpleTextItem &item = *textItems.back();
+	item.setPos(QPointF(0.0, height));
+	QRectF rect = item.boundingRect();
+	width = std::max(width, rect.width());
+	height += rect.height();
+}
+
+void ScatterSeries::Information::addDataLine(const StatsType &type, const dive *d)
+{
+	// For "numeric" types, we display value and unit.
+	// For "discrete" types, we display all categories the dive belongs to.
+	// There is only one "continuous" type, the date, for which we don't display anything,
+	// because the date is displayed anyway.
+	QString val;
+	switch (type.type()) {
+	case StatsType::Type::Numeric:
+		val = type.valueWithUnit(d);
+		break;
+	case StatsType::Type::Discrete:
+		val = type.diveCategories(d);
+		break;
+	default:
+		return;
+	}
+
+	addLine(QString("%1: %2").arg(type.name(), val));
 }

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "scatterseries.h"
+
+#include <QChart>
+#include <QGraphicsPixmapItem>
+#include <QPainter>
+
+static const QColor scatterItemColor(0x66, 0xb2, 0xff);
+static const QColor scatterItemBorderColor(Qt::blue);
+static const int scatterItemDiameter = 10;
+static const int scatterItemBorder = 1;
+
+static QPixmap createScatterPixmap()
+{
+	QPixmap res(scatterItemDiameter, scatterItemDiameter);
+	res.fill(Qt::transparent);
+	QPainter painter(&res);
+	painter.setRenderHint(QPainter::Antialiasing);
+	painter.setBrush(scatterItemBorderColor);
+	painter.drawEllipse(0, 0, scatterItemDiameter, scatterItemDiameter);
+	painter.setBrush(scatterItemColor);
+	painter.drawEllipse(scatterItemBorder, scatterItemBorder,
+			    scatterItemDiameter - 2 * scatterItemBorder,
+			    scatterItemDiameter - 2 * scatterItemBorder);
+	return res;
+}
+
+// Annoying: we can create a QPixmap only after the application was initialized.
+// Therefore, do this as a on-demand initialized pointer. A function local static
+// variable does unnecesssary (in this case) thread synchronization.
+static std::unique_ptr<QPixmap> scatterPixmapPtr;
+
+static const QPixmap &scatterPixmap()
+{
+	if (!scatterPixmapPtr)
+		scatterPixmapPtr.reset(new QPixmap(createScatterPixmap()));
+	return *scatterPixmapPtr;
+}
+
+ScatterSeries::Item::Item(QtCharts::QChart *chart, ScatterSeries *series, double pos, double value) :
+	item(new QGraphicsPixmapItem(scatterPixmap(), chart)),
+	pos(pos),
+	value(value)
+{
+	item->setZValue(5.0); // ? What is a sensible value here ?
+	updatePosition(chart, series);
+}
+
+void ScatterSeries::Item::updatePosition(QtCharts::QChart *chart, ScatterSeries *series)
+{
+	QPointF center = chart->mapToPosition(QPointF(pos, value), series);
+	item->setPos(center.x() - scatterItemDiameter / 2.0,
+		     center.y() - scatterItemDiameter / 2.0);
+}
+
+void ScatterSeries::append(double pos, double value)
+{
+	items.emplace_back(chart(), this, pos, value);
+}
+
+void ScatterSeries::updatePositions()
+{
+	QtCharts::QChart *c = chart();
+	for (Item &item: items)
+		item.updatePosition(c, this);
+}

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -179,7 +179,7 @@ void ScatterSeries::highlight(int index)
 			text.push_back(dataInfo(typeX, item.d));
 			text.push_back(dataInfo(typeY, item.d));
 		}
-		information->setText(std::move(text), pos);
+		information->setText(text, pos);
 	} else {
 		information.reset();
 	}

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "scatterseries.h"
+#include "informationbox.h"
 #include "statstranslations.h"
 #include "statstypes.h"
 #include "core/dive.h"
@@ -16,12 +17,13 @@ static const QColor scatterItemHighlightedColor(Qt::yellow);
 static const QColor scatterItemHighlightedBorderColor(0xaa, 0xaa, 0x22);
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
-static const QColor informationBorderColor(Qt::black);
-static const QColor informationColor(0xff, 0xff, 0x00, 192); // Note: fourth argument is opacity
-static const int informationBorder = 2;
 
 ScatterSeries::ScatterSeries(const StatsType &typeX, const StatsType &typeY)
 	: highlighted(-1), typeX(typeX), typeY(typeY)
+{
+}
+
+ScatterSeries::~ScatterSeries()
 {
 }
 
@@ -128,6 +130,26 @@ std::pair<double, int> ScatterSeries::getClosest(const QPointF &point)
 	return { minSquare, index };
 }
 
+static QString dataInfo(const StatsType &type, const dive *d)
+{
+	// For "numeric" types, we display value and unit.
+	// For "discrete" types, we display all categories the dive belongs to.
+	// There is only one "continuous" type, the date, for which we don't display anything,
+	// because the date is displayed anyway.
+	QString val;
+	switch (type.type()) {
+	case StatsType::Type::Numeric:
+		val = type.valueWithUnit(d);
+		break;
+	case StatsType::Type::Discrete:
+		val = type.diveCategories(d);
+		break;
+	default:
+		return QString();
+	}
+
+	return QString("%1: %2").arg(type.name(), val);
+}
 // Highlight item when hovering over item
 void ScatterSeries::highlight(int index)
 {
@@ -144,84 +166,21 @@ void ScatterSeries::highlight(int index)
 		item.highlight(true);
 		QPointF pos = item.item->pos();
 		if (!information)
-			information.reset(new Information(chart()));
-		information->set(items[highlighted].d, pos, typeX, typeY);
+			information.reset(new InformationBox(chart()));
+
+		// We don't listen to undo-command signals, therefore we have to check whether that dive actually exists!
+		// TODO: fix this.
+		std::vector<QString> text;
+		if (get_divenr(item.d) < 0) {
+			text.push_back(StatsTranslations::tr("Removed dive"));
+		} else {
+			text.push_back(StatsTranslations::tr("Dive #%1").arg(item.d->number));
+			text.push_back(get_dive_date_string(item.d->when));
+			text.push_back(dataInfo(typeX, item.d));
+			text.push_back(dataInfo(typeY, item.d));
+		}
+		information->setText(std::move(text), pos);
 	} else {
 		information.reset();
 	}
-}
-
-ScatterSeries::Information::Information(QtCharts::QChart *chart) : QGraphicsRectItem(chart)
-{
-	setPen(QPen(informationBorderColor, informationBorder));
-	setBrush(informationColor);
-}
-
-void ScatterSeries::Information::set(const dive *d, QPointF pos, const StatsType &typeX, const StatsType &typeY)
-{
-	width = height = 0.0;
-	textItems.clear();
-
-	// We don't listen to undo-command signals, therefore we have to check whether that dive actually exists!
-	// TODO: fix this.
-	if (get_divenr(d) < 0) {
-		addLine(StatsTranslations::tr("Removed dive"));
-	} else {
-		addLine(StatsTranslations::tr("Dive #%1").arg(d->number));
-		addLine(get_dive_date_string(d->when));
-		addDataLine(typeX, d);
-		addDataLine(typeY, d);
-	}
-
-	width += 4.0 * informationBorder;
-	height += 4.0 * informationBorder;
-
-	QRectF parentRect = parentItem()->boundingRect();
-
-	double x = pos.x() + scatterItemDiameter;
-	if (x + width >= parentRect.right() && pos.x() - width >= parentRect.x())
-		x = pos.x() - width;
-	double y = pos.y() + scatterItemDiameter;
-	if (y + height >= parentRect.bottom() && pos.y() - height >= parentRect.y())
-		y = pos.y() - height;
-
-
-	setRect(x, y, width, height);
-	double actY = y + 2.0 * informationBorder;
-	for (auto &item: textItems) {
-		item->setPos(QPointF(x + 2.0 * informationBorder, actY));
-		actY += item->boundingRect().height();
-	}
-	setZValue(20.0); // What would a proper value be here?
-}
-
-void ScatterSeries::Information::addLine(const QString &s)
-{
-	textItems.emplace_back(new QGraphicsSimpleTextItem(s, this));
-	QGraphicsSimpleTextItem &item = *textItems.back();
-	item.setPos(QPointF(0.0, height));
-	QRectF rect = item.boundingRect();
-	width = std::max(width, rect.width());
-	height += rect.height();
-}
-
-void ScatterSeries::Information::addDataLine(const StatsType &type, const dive *d)
-{
-	// For "numeric" types, we display value and unit.
-	// For "discrete" types, we display all categories the dive belongs to.
-	// There is only one "continuous" type, the date, for which we don't display anything,
-	// because the date is displayed anyway.
-	QString val;
-	switch (type.type()) {
-	case StatsType::Type::Numeric:
-		val = type.valueWithUnit(d);
-		break;
-	case StatsType::Type::Discrete:
-		val = type.diveCategories(d);
-		break;
-	default:
-		return;
-	}
-
-	addLine(QString("%1: %2").arg(type.name(), val));
 }

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "scatterseries.h"
 #include "informationbox.h"
+#include "statscolors.h"
 #include "statstranslations.h"
 #include "statstypes.h"
 #include "core/dive.h"
@@ -11,10 +12,6 @@
 #include <QGraphicsPixmapItem>
 #include <QPainter>
 
-static const QColor scatterItemColor(0x66, 0xb2, 0xff);
-static const QColor scatterItemBorderColor(Qt::blue);
-static const QColor scatterItemHighlightedColor(Qt::yellow);
-static const QColor scatterItemHighlightedBorderColor(0xaa, 0xaa, 0x22);
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
 
@@ -52,10 +49,8 @@ static std::unique_ptr<QPixmap> scatterPixmapHighlightedPtr;
 static const QPixmap &scatterPixmap(bool highlight)
 {
 	if (!scatterPixmapPtr) {
-		scatterPixmapPtr.reset(new QPixmap(createScatterPixmap(scatterItemColor,
-								       scatterItemBorderColor)));
-		scatterPixmapHighlightedPtr.reset(new QPixmap(createScatterPixmap(scatterItemHighlightedColor,
-										  scatterItemHighlightedBorderColor)));
+		scatterPixmapPtr.reset(new QPixmap(createScatterPixmap(fillColor, ::borderColor)));
+		scatterPixmapHighlightedPtr.reset(new QPixmap(createScatterPixmap(highlightedColor, highlightedBorderColor)));
 	}
 	return highlight ? *scatterPixmapHighlightedPtr : *scatterPixmapPtr;
 }

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -15,6 +15,16 @@
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
 
+int ScatterSeries::invalidIndex()
+{
+	return -1;
+}
+
+bool ScatterSeries::isValidIndex(int idx)
+{
+	return idx >= 0;
+}
+
 ScatterSeries::ScatterSeries(const StatsType &typeX, const StatsType &typeY)
 	: highlighted(-1), typeX(typeX), typeY(typeY)
 {

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+// A small custom scatter series, where every item represents a dive
+// The original QScatterSeries was buggy and distinctly slower
+#ifndef SCATTER_SERIES_H
+#define SCATTER_SERIES_H
+
+#include <memory>
+#include <vector>
+#include <QScatterSeries>
+
+namespace QtCharts {
+	class QAbstractAxis;
+	class QChart;
+}
+class QGraphicsPixmapItem;
+
+// We derive from a proper scatter series to get access to the map-to
+// and map-from coordinates calls. But we don't use any of its functionality.
+// Can we avoid that?
+
+class ScatterSeries : public QtCharts::QScatterSeries {
+public:
+	// A short line used to mark quartiles
+	struct Item {
+		std::unique_ptr<QGraphicsPixmapItem> item;
+		double pos, value;
+		Item(QtCharts::QChart *chart, ScatterSeries *series, double pos, double value);
+		void updatePosition(QtCharts::QChart *chart, ScatterSeries *series);
+	};
+
+	// Call if chart geometry changed
+	void updatePositions();
+
+	// Note: this expects that all items are added with increasing pos!
+	void append(double pos, double value);
+private:
+	std::vector<Item> items;
+};
+
+#endif

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -20,12 +20,15 @@ class QGraphicsPixmapItem;
 
 class ScatterSeries : public QtCharts::QScatterSeries {
 public:
+	ScatterSeries();
+
 	// A short line used to mark quartiles
 	struct Item {
 		std::unique_ptr<QGraphicsPixmapItem> item;
 		double pos, value;
 		Item(QtCharts::QChart *chart, ScatterSeries *series, double pos, double value);
 		void updatePosition(QtCharts::QChart *chart, ScatterSeries *series);
+		void highlight(bool highlight);
 	};
 
 	// Call if chart geometry changed
@@ -33,8 +36,18 @@ public:
 
 	// Note: this expects that all items are added with increasing pos!
 	void append(double pos, double value);
+
+	// Get closest item. Returns square of distance as double and item index.
+	// If the index is -1, no item is inside the range.
+	// Super weird: this function can't be const, because QChart::mapToValue takes
+	// a non-const reference!?
+	std::pair<double, int> getClosest(const QPointF &f);
+
+	// Highlight item when hovering over item
+	void highlight(int index);
 private:
 	std::vector<Item> items;
+	int highlighted; // -1: no item highlighted
 };
 
 #endif

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -14,7 +14,8 @@ namespace QtCharts {
 	class QChart;
 }
 class QGraphicsPixmapItem;
-class StatsType;
+class InformationBox;
+struct StatsType;
 struct dive;
 
 // We derive from a proper scatter series to get access to the map-to
@@ -24,6 +25,7 @@ struct dive;
 class ScatterSeries : public QtCharts::QScatterSeries {
 public:
 	ScatterSeries(const StatsType &typeX, const StatsType &typeY);
+	~ScatterSeries();
 
 	// Call if chart geometry changed
 	void updatePositions();
@@ -49,18 +51,7 @@ private:
 		void highlight(bool highlight);
 	};
 
-	// Information window showing data of highlighted dive
-	struct Information : QGraphicsRectItem {
-		Information(QtCharts::QChart *chart);
-		void set(const dive *d, QPointF pos, const StatsType &typeX, const StatsType &typeY);
-	private:
-		double width, height;
-		void addLine(const QString &s);
-		void addDataLine(const StatsType &type, const dive *d);
-		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> textItems;
-	};
-
-	std::unique_ptr<Information> information;
+	std::unique_ptr<InformationBox> information;
 	std::vector<Item> items;
 	int highlighted; // -1: no item highlighted
 	const StatsType &typeX;

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -4,46 +4,36 @@
 #ifndef SCATTER_SERIES_H
 #define SCATTER_SERIES_H
 
+#include "statsseries.h"
+
 #include <memory>
 #include <vector>
 #include <QGraphicsRectItem>
-#include <QScatterSeries>
 
-namespace QtCharts {
-	class QAbstractAxis;
-	class QChart;
-}
 class QGraphicsPixmapItem;
 class InformationBox;
 struct StatsType;
 struct dive;
 
-// We derive from a proper scatter series to get access to the map-to
-// and map-from coordinates calls. But we don't use any of its functionality.
-// Can we avoid that?
-
-class ScatterSeries : public QtCharts::QScatterSeries {
+class ScatterSeries : public StatsSeries {
 public:
-	ScatterSeries(const StatsType &typeX, const StatsType &typeY);
+	ScatterSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis,
+		      const StatsType &typeX, const StatsType &typeY);
 	~ScatterSeries();
 
-	// Call if chart geometry changed
-	void updatePositions();
+	void updatePositions() override;
+	bool hover(QPointF pos) override;
+	void unhighlight() override;
 
 	// Note: this expects that all items are added with increasing pos!
 	void append(dive *d, double pos, double value);
 
-	// Get closest item. Returns square of distance as double and item index.
-	// If the index is -1, no item is inside the range.
+private:
+	// Get closest item. If the return value is -1, no item is inside the range.
 	// Super weird: this function can't be const, because QChart::mapToValue takes
 	// a non-const reference!?
-	std::pair<double, int> getClosest(const QPointF &f);
+	int getItemUnderMouse(const QPointF &f);
 
-	// Highlight item when hovering over item
-	void highlight(int index);
-	static int invalidIndex();
-	static bool isValidIndex(int);
-private:
 	struct Item {
 		std::unique_ptr<QGraphicsPixmapItem> item;
 		dive *d;

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -41,6 +41,8 @@ public:
 
 	// Highlight item when hovering over item
 	void highlight(int index);
+	static int invalidIndex();
+	static bool isValidIndex(int);
 private:
 	struct Item {
 		std::unique_ptr<QGraphicsPixmapItem> item;

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsaxis.h"
+#include "statstypes.h"
 #include "statstranslations.h"
+#include "core/pref.h"
+#include "core/subsurface-time.h"
 #include <math.h> // for lrint
 #include <QChart>
 #include <QFontMetrics>
@@ -12,6 +15,11 @@ StatsAxis::StatsAxis(bool horizontal) : horizontal(horizontal)
 
 StatsAxis::~StatsAxis()
 {
+}
+
+std::pair<double, double> StatsAxis::minMax() const
+{
+	return { 0.0, 1.0 };
 }
 
 // Guess the number of tick marks based on example strings.
@@ -45,6 +53,11 @@ int StatsAxis::guessNumTicks(const QtCharts::QChart *chart, const QtCharts::QAbs
 ValueAxis::ValueAxis(double min, double max, int decimals, bool horizontal) : StatsAxisTemplate(horizontal),
 	min(min), max(max), decimals(decimals)
 {
+}
+
+std::pair<double, double> ValueAxis::minMax() const
+{
+	return { QValueAxis::min(), QValueAxis::max() };
 }
 
 static QString makeFormatString(int decimals)
@@ -91,7 +104,8 @@ void ValueAxis::updateLabels(const QtCharts::QChart *chart)
 	setTickCount(num + 1);
 }
 
-CountAxis::CountAxis(int count, bool horizontal) : StatsAxisTemplate(horizontal), count(count)
+CountAxis::CountAxis(int count, bool horizontal) : ValueAxis(0.0, (double)count, 0, horizontal),
+	count(count)
 {
 }
 
@@ -146,15 +160,52 @@ void CategoryAxis::updateLabels(const QtCharts::QChart *)
 {
 }
 
-HistogramAxis::HistogramAxis(std::vector<HistogramAxisEntry> bin_values, bool horizontal) : StatsAxisTemplate(horizontal),
-	bin_values(bin_values)
+// A small helper class that makes strings unique. We need this,
+// because QCategoryAxis can only handle unique category names.
+// Disambiguate strings by adding unicode zero-width spaces.
+// Keep track of a list of strings and how many spaces have to
+// be added.
+class LabelDisambiguator {
+	using Pair = std::pair<QString, int>;
+	std::vector<Pair> entries;
+public:
+	QString transmogrify(const QString &s);
+};
+
+QString LabelDisambiguator::transmogrify(const QString &s)
+{
+	auto it = std::find_if(entries.begin(), entries.end(),
+			       [&s](const Pair &p) { return p.first == s; });
+	if (it == entries.end()) {
+		entries.emplace_back(s, 0);
+		return s;
+	}  else {
+		++(it->second);
+		return s + QString(it->second, QChar(0x200b));
+	}
+}
+
+HistogramAxis::HistogramAxis(std::vector<HistogramAxisEntry> bins, bool horizontal) : StatsAxisTemplate(horizontal),
+	bin_values(bins)
 {
 	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
 		return;
+
+	LabelDisambiguator labeler;
+	for (HistogramAxisEntry &entry: bin_values)
+		entry.name = labeler.transmogrify(entry.name);
+
 	setMin(bin_values.front().value);
 	setMax(bin_values.back().value);
 	setStartValue(bin_values.front().value);
 	setLabelsPosition(QCategoryAxis::AxisLabelsPositionOnValue);
+}
+
+std::pair<double, double> HistogramAxis::minMax() const
+{
+	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
+		return { 0.0, 1.0 };
+	return { QValueAxis::min(), QValueAxis::max() };
 }
 
 // Initialize a histogram axis with the given labels. Labels are specified as (name, value, recommended) triplets.
@@ -193,4 +244,127 @@ void HistogramAxis::updateLabels(const QtCharts::QChart *chart)
 		const auto &[name, value, recommended] = bin_values[i];
 		append(name, value);
 	}
+}
+
+// Helper function to turn days since "Unix epoch" into a timestamp_t
+static const double seconds_in_day = 86400.0;
+static timestamp_t double_to_timestamp(double d)
+{
+	return timestamp_t{ lrint(d * seconds_in_day) };
+}
+
+// Turn double to (year, month) pair
+static std::pair<int, int> double_to_month(double d)
+{
+	struct tm tm;
+	utc_mkdate(double_to_timestamp(d), &tm);
+	return { tm.tm_year, tm.tm_mon };
+}
+
+// Increase (year, month) pair by one month
+static void inc(std::pair<int, int> &ym)
+{
+	if (++ym.second >= 12) {
+		++ym.first;
+		ym.second = 0;
+	}
+}
+
+static std::array<int, 3> double_to_day(double d)
+{
+	struct tm tm;
+	utc_mkdate(double_to_timestamp(d), &tm);
+	return { tm.tm_year, tm.tm_mon, tm.tm_mday };
+}
+
+// This is trashy: to increase a day, turn into timestamp and back.
+// This surely can be done better.
+static void inc(std::array<int, 3> &ymd)
+{
+	struct tm tm = { 0 };
+	tm.tm_year = ymd[0];
+	tm.tm_mon = ymd[1];
+	tm.tm_mday = ymd[2] + 1;
+	timestamp_t t = utc_mktime(&tm);
+	utc_mkdate(t, &tm);
+	ymd = { tm.tm_year, tm.tm_mon, tm.tm_mday };
+}
+
+// Use heuristics to determine the preferred day/month format:
+// Try to see whether day or month comes first and try to extract
+// the separator character. Returns a (day_first, separator) pair.
+static std::pair<bool, char> day_format()
+{
+	const char *fmt = prefs.date_format;
+	const char *d, *m, *sep;
+	for (d = fmt; *d && *d != 'd' && *d != 'D'; ++d)
+		;
+	for (m = fmt; *m && *m != 'm' && *m != 'M'; ++m)
+		;
+	for(sep = std::min(m, d); *sep == 'm' || *sep == 'M' || *sep == 'd' || *sep == 'D'; ++sep)
+		;
+	return { d < m, *sep ? *sep : '.' };
+}
+
+// For now, misuse the histogram axis for creating a time axis. Depending on the range,
+// create year, month or day-based bins. This is certainly not efficient and may need
+// some tuning. However, it should ensure that no crazy number of bins is generated.
+// Ultimately, this should be replaced by a better and dynamic scheme
+// From and to are given in seconds since "epoch".
+static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
+{
+	// from and two are given in days since the "Unix epoch".
+	// The lowest precision we do is two days.
+	if (to - from < 2.0) {
+		double center = (from + to) / 2.0;
+		from = center + 1.0;
+		to = center - 1.0;
+	}
+
+	std::vector<HistogramAxisEntry> res;
+	if (to - from > 2.0 * 356.0) {
+		// For two years or more, do year based bins
+		int year_from = utc_year(double_to_timestamp(from));
+		int year_to = utc_year(double_to_timestamp(to)) + 1;
+		for (int year = year_from; year <= year_to; ++year)
+			res.push_back({ QString::number(year), date_to_double(year, 0, 0), true });
+	} else if (to - from > 2.0 * 30.0) {
+		// For two months or more, do month based bins
+		auto year_month_from = double_to_month(from);
+		auto year_month_to = double_to_month(to);
+		inc(year_month_to);
+		for (auto act = year_month_from; act <= year_month_to; inc(act)) {
+			double val = date_to_double(act.first, act.second, 0);
+			if (act.second == 0)
+				res.push_back({ QString::number(act.first), val, true });
+			else
+				res.push_back({ monthname(act.second), val, false });
+		}
+	} else {
+		// For less than two months, do date based bins
+		auto day_from = double_to_day(from);
+		auto day_to = double_to_day(to);
+		inc(day_to);
+		auto [day_before_month, separator] = day_format();
+		QString format = day_before_month ? QStringLiteral("%1%2%3")
+						  : QStringLiteral("%3%2%1");
+		QString sep = QString(separator);
+		for (auto act = day_from; act < day_to; inc(act)) {
+			double val = date_to_double(act[0], act[1], act[2]);
+			if (act[1] == 0) {
+				res.push_back({ QString::number(act[0]), val, true });
+			} else if (act[2] == 0) {
+				res.push_back({ monthname(act[1]), val, true });
+			} else {
+				QString s = format.arg(QString::number(act[2]), sep, QString::number(act[1]));
+				res.push_back({s, val, true });
+			}
+		}
+	}
+	return res;
+}
+
+DateAxis::DateAxis(double from, double to, bool horizontal) :
+	HistogramAxis(timeRangeToBins(from, to), horizontal)
+{
 }

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statsaxis.h"
+#include "statstranslations.h"
+#include <math.h> // for lrint
+#include <QChart>
+#include <QFontMetrics>
+#include <QLocale>
+
+StatsAxis::StatsAxis(bool horizontal) : horizontal(horizontal)
+{
+}
+
+StatsAxis::~StatsAxis()
+{
+}
+
+// Guess the number of tick marks based on example strings.
+// We will use minimum and maximum values, which are not necessarily the
+// maximum-size strings especially, when using proportional fonts or for
+// categorical data. Therefore, try to err on the safe side by adding enough
+// margins.
+int StatsAxis::guessNumTicks(const QtCharts::QChart *chart, const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const
+{
+	QFont font = axis->labelsFont();
+	QFontMetrics fm(font);
+	int minSize = fm.height();
+	for (const QString &s: strings) {
+		QSize size = fm.size(Qt::TextSingleLine, s);
+		int needed = horizontal ? size.width() : size.height();
+		if (needed > minSize)
+			minSize = needed;
+	}
+
+	// Add space between labels
+	if (horizontal)
+		minSize = minSize * 3 / 2;
+	else
+		minSize *= 2;
+	QRectF chartSize = chart->plotArea();
+	double availableSpace = horizontal ? chartSize.width() : chartSize.height();
+	int numTicks = lrint(availableSpace / minSize);
+	return std::max(numTicks, 2);
+}
+
+ValueAxis::ValueAxis(double min, double max, int decimals, bool horizontal) : StatsAxisTemplate(horizontal),
+	min(min), max(max), decimals(decimals)
+{
+}
+
+static QString makeFormatString(int decimals)
+{
+	return QStringLiteral("%.%1f").arg(decimals < 0 ? 0 : decimals);
+}
+
+void ValueAxis::updateLabels(const QtCharts::QChart *chart)
+{
+	using QtCharts::QValueAxis;
+
+	// Avoid degenerate cases
+	if (max - min < 0.0001) {
+		max = 0.5;
+		min = -0.5;
+	}
+
+	QLocale loc;
+	QString minString = loc.toString(min, 'f', decimals);
+	QString maxString = loc.toString(max, 'f', decimals);
+	int numTicks = guessNumTicks(chart, this, { minString, maxString});
+
+	// Use full decimal increments
+	double height = max - min;
+	double inc = height / numTicks;
+	double digits = floor(log10(inc));
+	int digits_int = lrint(digits);
+	double digits_factor = pow(10.0, digits);
+	int inc_int = std::max((int)ceil(inc / digits_factor), 1);
+	// Do "nice" increments: 1, 2, 4, 5.
+	if (inc_int > 5)
+		inc_int = 10;
+	if (inc_int == 3)
+		inc_int = 5;
+	inc = inc_int * digits_factor;
+	if (-digits_int > decimals)
+		decimals = -digits_int;
+
+	setLabelFormat(makeFormatString(decimals));
+	double actMin = floor(min /  inc) * inc;
+	double actMax = ceil(max /  inc) * inc;
+	int num = lrint((actMax - actMin) / inc);
+	setRange(actMin, actMax);
+	setTickCount(num + 1);
+}
+
+CountAxis::CountAxis(int count, bool horizontal) : StatsAxisTemplate(horizontal), count(count)
+{
+}
+
+void CountAxis::updateLabels(const QtCharts::QChart *chart)
+{
+	QLocale loc;
+	QString countString = loc.toString(count);
+	int numTicks = guessNumTicks(chart, this, { countString });
+
+	// Get estimate of step size
+	if (count <= 0)
+		count = 1;
+	// When determining the step size, make sure to round up
+	int step = (count + numTicks - 1) / numTicks;
+	if (step <= 0)
+		step = 1;
+
+	// Get the significant first or first two digits
+	int scale = 1;
+	int significant = step;
+	while (significant > 25) {
+		significant /= 10;
+		scale *= 10;
+	}
+
+	for (int increment: { 1, 2, 4, 5, 10, 15, 20, 25 }) {
+		if (increment >= significant) {
+			significant = increment;
+			break;
+		}
+	}
+	step = significant * scale;
+
+	// Make maximum an integer number of steps, equal or greater than the needed counts
+	int num = (count - 1) / step + 1;
+	int max = num * step;
+	numTicks = num + 1; // There is one more tick than steps
+
+	setLabelFormat("%.0f");
+	setTitleText(StatsTranslations::tr("No. dives"));
+	setRange(0, max);
+	setTickCount(numTicks);
+}
+
+CategoryAxis::CategoryAxis(const std::vector<QString> &labels, bool horizontal) : StatsAxisTemplate(horizontal)
+{
+	for (const QString &s: labels)
+		append(s);
+}
+
+void CategoryAxis::updateLabels(const QtCharts::QChart *)
+{
+}
+
+HistogramAxis::HistogramAxis(std::vector<HistogramAxisEntry> bin_values, bool horizontal) : StatsAxisTemplate(horizontal),
+	bin_values(bin_values)
+{
+	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
+		return;
+	setMin(bin_values.front().value);
+	setMax(bin_values.back().value);
+	setStartValue(bin_values.front().value);
+	setLabelsPosition(QCategoryAxis::AxisLabelsPositionOnValue);
+}
+
+// Initialize a histogram axis with the given labels. Labels are specified as (name, value, recommended) triplets.
+// If labels are skipped, try to skip it in such a way that a recommended label is shown.
+// The one example where this is relevant is the quarterly bins, which are formated as (2019, q1, q2, q3, 2020, ...).
+// There, we obviously want to show the years and not the quarters.
+void HistogramAxis::updateLabels(const QtCharts::QChart *chart)
+{
+	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
+		return;
+
+	// There is no clear all labels function in QCategoryAxis!? You must be kidding.
+	for (const QString &label: categoriesLabels())
+		remove(label);
+	if (count() > 0)
+		qWarning("HistogramAxis::updateLabels(): labels left after clearing!?");
+
+	std::vector<QString> strings;
+	strings.reserve(bin_values.size());
+	for (auto &[name, value, recommended]: bin_values)
+		strings.push_back(name);
+	int maxLabels = guessNumTicks(chart, this, strings);
+
+	int step = ((int)bin_values.size() - 1) / maxLabels + 1;
+	int first = 0;
+	if (step > 1) {
+		for (int i = 0; i < (int)bin_values.size(); ++i) {
+			const auto &[name, value, recommended] = bin_values[i];
+			if (recommended) {
+				first = i % step;
+				break;
+			}
+		}
+	}
+	for (int i = first; i < (int)bin_values.size(); i += step) {
+		const auto &[name, value, recommended] = bin_values[i];
+		append(name, value);
+	}
+}

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -145,7 +145,6 @@ void CountAxis::updateLabels(const QtCharts::QChart *chart)
 	numTicks = num + 1; // There is one more tick than steps
 
 	setLabelFormat("%.0f");
-	setTitleText(StatsTranslations::tr("No. dives"));
 	setRange(0, max);
 	setTickCount(numTicks);
 }

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0
+// Supported chart axes
+#ifndef STATS_AXIS_H
+#define STATS_AXIS_H
+
+#include <vector>
+#include <QBarCategoryAxis>
+#include <QCategoryAxis>
+#include <QValueAxis>
+
+namespace QtCharts {
+	class QChart;
+}
+
+class StatsAxis {
+public:
+	virtual ~StatsAxis();
+	virtual void updateLabels(const QtCharts::QChart *chart) = 0;
+	virtual QtCharts::QAbstractAxis *qaxis() = 0;
+protected:
+	StatsAxis(bool horizontal);
+	int guessNumTicks(const QtCharts::QChart *chart, const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const;
+	bool horizontal;
+};
+
+// Small template that derives from a QChart-axis and defines
+// the corresponding virtual axis() accessor.
+template<typename QAxis>
+class StatsAxisTemplate : public StatsAxis, public QAxis
+{
+	using StatsAxis::StatsAxis;
+	QtCharts::QAbstractAxis *qaxis() override final {
+		return this;
+	}
+};
+
+class ValueAxis : public StatsAxisTemplate<QtCharts::QValueAxis> {
+public:
+	ValueAxis(double min, double max, int decimals, bool horizontal);
+private:
+	double min, max;
+	int decimals;
+	void updateLabels(const QtCharts::QChart *chart) override;
+};
+
+class CountAxis : public StatsAxisTemplate<QtCharts::QValueAxis> {
+public:
+	CountAxis(int count, bool horizontal);
+private:
+	int count;
+	void updateLabels(const QtCharts::QChart *chart) override;
+};
+
+class CategoryAxis : public StatsAxisTemplate<QtCharts::QBarCategoryAxis> {
+public:
+	CategoryAxis(const std::vector<QString> &labels, bool horizontal);
+private:
+	void updateLabels(const QtCharts::QChart *chart);
+};
+
+struct HistogramAxisEntry {
+	QString name;
+	double value;
+	bool recommended;
+};
+
+class HistogramAxis : public StatsAxisTemplate<QtCharts::QCategoryAxis> {
+public:
+	HistogramAxis(std::vector<HistogramAxisEntry> bin_values, bool horizontal);
+private:
+	void updateLabels(const QtCharts::QChart *chart) override;
+	std::vector<HistogramAxisEntry> bin_values;
+};
+
+#endif

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -74,6 +74,7 @@ private:
 	void updateLabels(const QtCharts::QChart *chart) override;
 	std::pair<double, double> minMax() const override;
 	std::vector<HistogramAxisEntry> bin_values;
+	int preferred_step;
 };
 
 class DateAxis : public HistogramAxis {

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -17,6 +17,8 @@ public:
 	virtual ~StatsAxis();
 	virtual void updateLabels(const QtCharts::QChart *chart) = 0;
 	virtual QtCharts::QAbstractAxis *qaxis() = 0;
+	// Returns minimum and maximum of shown range, not of data points.
+	virtual std::pair<double, double> minMax() const;
 protected:
 	StatsAxis(bool horizontal);
 	int guessNumTicks(const QtCharts::QChart *chart, const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const;
@@ -41,9 +43,10 @@ private:
 	double min, max;
 	int decimals;
 	void updateLabels(const QtCharts::QChart *chart) override;
+	std::pair<double, double> minMax() const override;
 };
 
-class CountAxis : public StatsAxisTemplate<QtCharts::QValueAxis> {
+class CountAxis : public ValueAxis {
 public:
 	CountAxis(int count, bool horizontal);
 private:
@@ -69,7 +72,13 @@ public:
 	HistogramAxis(std::vector<HistogramAxisEntry> bin_values, bool horizontal);
 private:
 	void updateLabels(const QtCharts::QChart *chart) override;
+	std::pair<double, double> minMax() const override;
 	std::vector<HistogramAxisEntry> bin_values;
+};
+
+class DateAxis : public HistogramAxis {
+public:
+	DateAxis(double from, double to, bool horizontal);
 };
 
 #endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+// Color constants for the various series
+#ifndef STATSCOLORS_H
+#define STATSCOLORS_H
+
+#include <QColor>
+
+static const QColor fillColor(0x44, 0x76, 0xaa);
+static const QColor borderColor(0x66, 0xb2, 0xff);
+static const QColor highlightedColor(Qt::yellow);
+static const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
+
+#endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -17,9 +17,12 @@ inline const QColor binColors[] = {
 	QRgb(0x00108c), QRgb(0x2737a0), QRgb(0x3f59b4), QRgb(0x567bc6), QRgb(0x719ed5), QRgb(0x93c0e1), QRgb(0xbfe2e7),
 	QRgb(0xffdac4), QRgb(0xffb2a6), QRgb(0xf68d8b), QRgb(0xe26c72), QRgb(0xc74f5c), QRgb(0xa33c47), QRgb(0x743535)
 };
-inline QColor binColor(int bin)
+inline QColor binColor(int bin, int numBins)
 {
-	return bin < 0 ? binColors[0] : binColors[bin % std::size(binColors)];
+	if (numBins == 1 || bin < 0 || bin >= numBins)
+		return fillColor;
+	else
+		return binColors[bin % std::size(binColors)];
 }
 
 #endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -5,10 +5,10 @@
 
 #include <QColor>
 
-static const QColor fillColor(0x44, 0x76, 0xaa);
-static const QColor borderColor(0x66, 0xb2, 0xff);
-static const QColor highlightedColor(Qt::yellow);
-static const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
+inline const QColor fillColor(0x44, 0x76, 0xaa);
+inline const QColor borderColor(0x66, 0xb2, 0xff);
+inline const QColor highlightedColor(Qt::yellow);
+inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
 
 // Colors created using the Chroma.js Color Palette Helper
 // https://vis4.net/palettes/#/14|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -10,4 +10,15 @@ static const QColor borderColor(0x66, 0xb2, 0xff);
 static const QColor highlightedColor(Qt::yellow);
 static const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
 
+// Colors created using the Chroma.js Color Palette Helper
+// https://vis4.net/palettes/#/14|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1
+inline const QColor binColors[] = {
+	QRgb(0x00108c), QRgb(0x2737a0), QRgb(0x3f59b4), QRgb(0x567bc6), QRgb(0x719ed5), QRgb(0x93c0e1), QRgb(0xbfe2e7),
+	QRgb(0xffdac4), QRgb(0xffb2a6), QRgb(0xf68d8b), QRgb(0xe26c72), QRgb(0xc74f5c), QRgb(0xa33c47), QRgb(0x743535)
+};
+inline QColor binColor(int bin)
+{
+	return bin < 0 ? binColors[0] : binColors[bin % std::size(binColors)];
+}
+
 #endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -9,6 +9,7 @@ inline const QColor fillColor(0x44, 0x76, 0xaa);
 inline const QColor borderColor(0x66, 0xb2, 0xff);
 inline const QColor highlightedColor(Qt::yellow);
 inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
+inline const QColor labelColor(Qt::black);
 
 // Colors created using the Chroma.js Color Palette Helper
 // https://vis4.net/palettes/#/14|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -9,20 +9,42 @@ inline const QColor fillColor(0x44, 0x76, 0xaa);
 inline const QColor borderColor(0x66, 0xb2, 0xff);
 inline const QColor highlightedColor(Qt::yellow);
 inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
-inline const QColor labelColor(Qt::black);
+inline const QColor darkLabelColor(Qt::black);
+inline const QColor lightLabelColor(Qt::white);
 
 // Colors created using the Chroma.js Color Palette Helper
-// https://vis4.net/palettes/#/14|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1
+// https://vis4.net/palettes/#/50|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1
 inline const QColor binColors[] = {
-	QRgb(0x00108c), QRgb(0x2737a0), QRgb(0x3f59b4), QRgb(0x567bc6), QRgb(0x719ed5), QRgb(0x93c0e1), QRgb(0xbfe2e7),
-	QRgb(0xffdac4), QRgb(0xffb2a6), QRgb(0xf68d8b), QRgb(0xe26c72), QRgb(0xc74f5c), QRgb(0xa33c47), QRgb(0x743535)
+	QRgb(0x00108c), QRgb(0x0f1c92), QRgb(0x1a2798), QRgb(0x23319d), QRgb(0x2a3ba3),
+	QRgb(0x3144a8), QRgb(0x374eae), QRgb(0x3e58b3), QRgb(0x4461b8), QRgb(0x4b6bbd),
+	QRgb(0x5274c2), QRgb(0x587ec7), QRgb(0x6088cc), QRgb(0x6791d0), QRgb(0x6f9bd4),
+	QRgb(0x78a5d8), QRgb(0x81aedb), QRgb(0x8ab8df), QRgb(0x95c2e2), QRgb(0xa0cbe4),
+	QRgb(0xacd5e6), QRgb(0xb9dee7), QRgb(0xc7e7e7), QRgb(0xd7efe7), QRgb(0xeaf8e4),
+	QRgb(0xfff5d8), QRgb(0xffead0), QRgb(0xffe0c8), QRgb(0xffd5c0), QRgb(0xffcab8),
+	QRgb(0xffbfb0), QRgb(0xffb4a8), QRgb(0xffa99f), QRgb(0xfc9e98), QRgb(0xf99490),
+	QRgb(0xf48b89), QRgb(0xf08182), QRgb(0xea787b), QRgb(0xe46f74), QRgb(0xde666e),
+	QRgb(0xd75e67), QRgb(0xcf5661), QRgb(0xc64f5b), QRgb(0xbd4855), QRgb(0xb3434f),
+	QRgb(0xa83e49), QRgb(0x9d3a44), QRgb(0x90383f), QRgb(0x83363a), QRgb(0x743535)
 };
+
+// Pick roughly equidistant colors out of the color set above
+// if we need more bins than we have colors (what chart is THAT?) simply loop
 inline QColor binColor(int bin, int numBins)
 {
 	if (numBins == 1 || bin < 0 || bin >= numBins)
 		return fillColor;
-	else
+	if (numBins > (int)std::size(binColors))
 		return binColors[bin % std::size(binColors)];
+
+	// use integer math to spread out the indices
+	int idx = bin * (std::size(binColors) - 1) / (numBins - 1);
+	return binColors[idx];
+}
+
+// Figure out if we want a light or a dark label
+inline QColor labelColor(int bin, size_t numBins)
+{
+	return (binColor(bin, numBins).lightness() < 150) ? lightLabelColor : darkLabelColor;
 }
 
 #endif

--- a/stats/statsseries.cpp
+++ b/stats/statsseries.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statsseries.h"
+#include "statsaxis.h"
+
+#include <QChart>
+
+StatsSeries::StatsSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis)
+{
+	chart->addSeries(this);
+	if (xAxis && yAxis) {
+		attachAxis(xAxis->qaxis());
+		attachAxis(yAxis->qaxis());
+	}
+}
+
+StatsSeries::~StatsSeries()
+{
+}

--- a/stats/statsseries.h
+++ b/stats/statsseries.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+// Base class for all series. Defines a small virtual interface
+// concerning highlighting of series items.
+#ifndef STATS_SERIES_H
+#define STATS_SERIES_H
+
+#include <QScatterSeries>
+
+namespace QtCharts {
+	class QChart;
+}
+class StatsAxis;
+
+// We derive from a proper scatter series to get access to the map-to
+// and map-from coordinates calls. But we don't use any of its functionality.
+// This should be removed in due course.
+
+class StatsSeries : public QtCharts::QScatterSeries {
+public:
+	StatsSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
+	virtual ~StatsSeries();
+	virtual void updatePositions() = 0;	// Called if chart geometry changes.
+	virtual bool hover(QPointF pos) = 0;	// Called on mouse movement. Return true if an item of this series is highlighted.
+	virtual void unhighlight() = 0;		// Unhighlight any highlighted item.
+};
+
+#endif

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statsstate.h"
+#include "statstypes.h"
+#include "statstranslations.h"
+
+// Attn: The order must correspond to the enum above
+static const char *chart_subtype_names[] = {
+	QT_TRANSLATE_NOOP("StatsTranslations", "Vertical"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Vertical stacked"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal stacked"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Pie")
+};
+
+enum class SupportedVariable {
+	Count,
+	Categorical,		// Implies that the variable is binned
+	Continuous,		// Implies that the variable is binned
+	Numeric
+};
+
+static const int ChartFeatureMedian = 1 << 0;
+static const int ChartFeatureMean =   1 << 1;
+
+static const struct ChartTypeDesc {
+	ChartType id;
+	const char *name;
+	SupportedVariable var1;
+	SupportedVariable var2;
+	bool var2HasOperations;
+	const std::vector<ChartSubType> subtypes;
+	int features;
+} chart_types[] = {
+	{
+		ChartType::ScatterPlot,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Scatter"),
+		SupportedVariable::Numeric,
+		SupportedVariable::Numeric,
+		false,
+		{ },
+		0
+	},
+	{
+		ChartType::HistogramCount,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Histogram"),
+		SupportedVariable::Continuous,
+		SupportedVariable::Count,
+		false,
+		{ ChartSubType::Vertical, ChartSubType::Horizontal },
+		ChartFeatureMedian | ChartFeatureMean
+	},
+	{
+		ChartType::HistogramBar,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Histogram"),
+		SupportedVariable::Continuous,
+		SupportedVariable::Numeric,
+		true,
+		{ ChartSubType::Vertical, ChartSubType::Horizontal },
+		0
+	},
+	{
+		ChartType::DiscreteScatter,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical scatter"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Numeric,
+		false,
+		{ },
+		0
+	},
+	{
+		ChartType::DiscreteBar,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Bar"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Categorical,
+		false,
+		{ ChartSubType::Vertical, ChartSubType::VerticalStacked, ChartSubType::Horizontal, ChartSubType::HorizontalStacked },
+		0
+	},
+	{
+		ChartType::DiscreteValue,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Numeric,
+		true,
+		{ ChartSubType::Vertical, ChartSubType::Horizontal },
+		0
+	},
+	{
+		ChartType::DiscreteCount,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Count,
+		false,
+		{ ChartSubType::Pie, ChartSubType::Vertical, ChartSubType::Horizontal },
+		0
+	},
+	{
+		ChartType::DiscreteBox,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical box"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Numeric,
+		false,
+		{ },
+		0
+	}
+};
+
+// Some charts are valid, but not preferrable. For example a numeric variable
+// is better plotted in a histogram than in a categorical bar chart. To
+// describe this use an enum: good, bad, invalid. Default to "good" charts
+// first, but ultimately let the user decide.
+enum ChartValidity {
+	Good,
+	Undesired,
+	Invalid
+};
+
+static const int count_idx = -1; // Special index for the count variable
+
+StatsState::StatsState() :
+	var1(stats_types[0]),
+	var2(nullptr),
+	type(ChartType::DiscreteBar),
+	subtype(ChartSubType::Pie),
+	median(false),
+	mean(false),
+	var1Binner(nullptr),
+	var2Binner(nullptr),
+	var2Operation(StatsOperation::Invalid),
+	var1Binned(false),
+	var2Binned(false),
+	var2HasOperations(false)
+{
+	validate(true);
+}
+
+static StatsState::VariableList createVariableList(const StatsType *selected, bool addCount, const StatsType *omit)
+{
+	StatsState::VariableList res;
+	res.variables.reserve(stats_types.size() + addCount);
+	res.selected = -1;
+	if (addCount) {
+		if (selected == nullptr)
+			res.selected = (int)res.variables.size();
+		res.variables.push_back({ StatsTranslations::tr("Count"), count_idx });
+	}
+	for (int i = 0; i < (int)stats_types.size(); ++i) {
+		const StatsType *variable = stats_types[i];
+		if (variable == omit)
+			continue;
+		if (variable == selected)
+			res.selected = (int)res.variables.size();
+		res.variables.push_back({ variable->name(), i });
+	}
+	return res;
+}
+
+// This is a bit lame: we pass Chart/SubChart as an integer to the UI,
+// by placing one in the lower and one in the upper 16 bit of a 32 bit integer.
+static int toInt(ChartType type)
+{
+	return (int)type << 16;
+}
+
+static int toInt(ChartType type, ChartSubType subtype)
+{
+	return ((int)type << 16) | (int)subtype;
+}
+
+static std::pair<ChartType, ChartSubType> fromInt(int id)
+{
+	return { (ChartType)(id >> 16), (ChartSubType)(id & 0xff) };
+}
+
+static ChartValidity variableValidity(StatsType::Type type, SupportedVariable var)
+{
+	switch (var) {
+	default:
+	case SupportedVariable::Count:
+		return ChartValidity::Invalid;	// Count has been special cased outside of this function
+	case SupportedVariable::Categorical:
+		return type == StatsType::Type::Continuous || type == StatsType::Type::Numeric ?
+			ChartValidity::Undesired : ChartValidity::Good;
+	case SupportedVariable::Continuous:
+		return type == StatsType::Type::Discrete ? ChartValidity::Invalid : ChartValidity::Good;
+	case SupportedVariable::Numeric:
+		return type != StatsType::Type::Numeric ? ChartValidity::Invalid : ChartValidity::Good;
+	}
+}
+
+static ChartValidity chartValidity(const ChartTypeDesc &desc, const StatsType *var1, const StatsType *var2)
+{
+	if (!var1)
+		return ChartValidity::Invalid; // Huh? We don't support count as independent variable
+
+	// Check the first variable
+	ChartValidity valid1 = variableValidity(var1->type(), desc.var1);
+	if (valid1 == ChartValidity::Invalid)
+		return ChartValidity::Invalid;
+
+	// Then, check the second variable
+	if (var2 == nullptr) // Our special marker for "count"
+		return desc.var2 == SupportedVariable::Count ? valid1 : ChartValidity::Invalid;
+
+	ChartValidity valid2 = variableValidity(var2->type(), desc.var2);
+	if (valid2 == ChartValidity::Invalid)
+		return ChartValidity::Invalid;
+
+	return valid1 == ChartValidity::Undesired || valid2 == ChartValidity::Undesired ? 
+		ChartValidity::Undesired : ChartValidity::Good;
+}
+
+// Returns a list of (chart-type, warning) pairs
+const std::vector<std::pair<const ChartTypeDesc &, bool>> validCharts(const StatsType *var1, const StatsType *var2)
+{
+	std::vector<std::pair<const ChartTypeDesc &, bool>> res;
+	res.reserve(std::size(chart_types));
+	for (const ChartTypeDesc &desc: chart_types) {
+		ChartValidity valid = chartValidity(desc, var1, var2);
+		if (valid == ChartValidity::Invalid)
+			continue;
+		res.emplace_back(desc, valid == ChartValidity::Undesired);
+	}
+
+	return res;
+}
+
+static StatsState::ChartList createChartList(const StatsType *var1, const StatsType *var2, ChartType selectedType, ChartSubType selectedSubType)
+{
+	StatsState::ChartList res;
+	res.selected = -1;
+	for (auto [desc, warn]: validCharts(var1, var2)) {
+		QString name = StatsTranslations::tr(desc.name);
+		if (desc.subtypes.empty()) {
+			if (selectedType == desc.id)
+				res.selected = (int)res.charts.size();
+			res.charts.push_back({ name, toInt(desc.id), warn });
+		} else {
+			for (ChartSubType subtype: desc.subtypes) {
+				if (selectedType == desc.id && selectedSubType == subtype)
+					res.selected = (int)res.charts.size();
+				QString fullname = QString("%1 %2").arg(name,
+									StatsTranslations::tr(chart_subtype_names[(int)subtype]));
+				res.charts.push_back({ fullname , toInt(desc.id, subtype), warn });
+			}
+		}
+	}
+
+	// If none of the charts are recommended - remove the warning flag.
+	// This can happen if if first variable is numerical, but the second is categorical.
+	if (std::all_of(res.charts.begin(), res.charts.end(), [] (const StatsState::Chart &c) { return c.warning; })) {
+		for (StatsState::Chart &c: res.charts)
+			c.warning = false;
+	}
+
+	return res;
+}
+
+static StatsState::BinnerList createBinnerList(bool binned, const StatsType *var, const StatsBinner *binner)
+{
+	StatsState::BinnerList res;
+	res.selected = -1;
+	if (!binned || !var)
+		return res;
+	std::vector<const StatsBinner *> binners = var->binners();
+	if (binners.size() <= 1)
+		return res; // Don't show combo boxes for single binners
+	res.binners.reserve(binners.size());
+	for (const StatsBinner *bin: binners) {
+		if (bin == binner)
+			res.selected = (int)res.binners.size();
+		res.binners.push_back(bin->name());
+	}
+	return res;
+}
+
+static StatsState::VariableList createOperationsList(bool hasOperations, const StatsType *var, StatsOperation operation)
+{
+	StatsState::VariableList res;
+	res.selected = -1;
+	if (!hasOperations || !var)
+		return res;
+	std::vector<StatsOperation> operations = var->supportedOperations();
+	res.variables.reserve(operations.size());
+	for (StatsOperation op: operations) {
+		if (op == operation)
+			res.selected = (int)res.variables.size();
+		res.variables.push_back({ StatsType::operationName(op), (int)op });
+	}
+	return res;
+}
+
+std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool median, bool mean)
+{
+	std::vector<StatsState::Feature> res;
+	if (chartFeatures & ChartFeatureMedian)
+		res.push_back({ StatsTranslations::tr("median"), ChartFeatureMedian, median });
+	if (chartFeatures & ChartFeatureMean)
+		res.push_back({ StatsTranslations::tr("mean"), ChartFeatureMean, mean });
+	return res;
+}
+
+StatsState::UIState StatsState::getUIState() const
+{
+	UIState res;
+	res.var1 = createVariableList(var1, false, nullptr);
+	res.var2 = createVariableList(var2, true, var1);
+	res.var1Name = var1 ? var1->name() : QString();
+	res.var2Name = var2 ? var2->name() : QString();
+	res.charts = createChartList(var1, var2, type, subtype);
+	res.binners1 = createBinnerList(var1Binned, var1, var1Binner);
+	res.binners2 = createBinnerList(var2Binned, var2, var2Binner);
+	res.operations2 = createOperationsList(var2HasOperations, var2, var2Operation);
+	res.features = createFeaturesList(chartFeatures, median, mean);
+	return res;
+}
+
+static const StatsBinner *idxToBinner(const StatsType *t, int idx)
+{
+	if (!t)
+		return nullptr;
+	auto binners = t->binners();
+	return idx >= 0 && idx < (int)binners.size() ? binners[idx] : 0;
+}
+
+void StatsState::var1Changed(int id)
+{
+	var1 = stats_types[std::clamp(id, 0, (int)stats_types.size())];
+	validate(true);
+}
+
+void StatsState::binner1Changed(int idx)
+{
+	var1Binner = idxToBinner(var1, idx);
+	validate(false);
+}
+
+void StatsState::var2Changed(int id)
+{
+	// The "count" variable is represented by a nullptr
+	var2 = id == count_idx ? nullptr
+			       : stats_types[std::clamp(id, 0, (int)stats_types.size())];
+	validate(true);
+}
+
+void StatsState::binner2Changed(int idx)
+{
+	var2Binner = idxToBinner(var2, idx);
+	validate(false);
+}
+
+void StatsState::var2OperationChanged(int id)
+{
+	var2Operation = (StatsOperation)id;
+	validate(false);
+}
+
+void StatsState::chartChanged(int id)
+{
+	std::tie(type, subtype) = fromInt(id); // use std::tie to assign two values at once
+	validate(false);
+}
+
+void StatsState::featureChanged(int id, bool state)
+{
+	if (id == ChartFeatureMedian)
+		median = state;
+	else if (id == ChartFeatureMean)
+		mean = state;
+}
+
+// Creates the new chart-type from the current chart-type and a list of possible chart types.
+// If the flag "varChanged" is true, the current chart-type will be changed if the
+// current chart-type is undesired.
+const ChartTypeDesc &newChartType(ChartType type, std::vector<std::pair<const ChartTypeDesc &, bool>> charts,
+			      bool varChanged)
+{
+	for (auto [desc, warn]: charts) {
+		// Found it, but if the axis was changed, we change anyway if the chart is "undesired"
+		if (type == desc.id) {
+			if (!varChanged || !warn)
+				return desc;
+			break;
+		}
+	}
+
+	// Find the first non-undesired chart
+	for (auto [desc, warn]: charts) {
+		if (!warn)
+			return desc;
+	}
+
+	return charts.empty() ? chart_types[0] : charts[0].first;
+}
+
+static void validateBinner(const StatsBinner *&binner, const StatsType *var, bool isBinned)
+{
+	if (!var || !isBinned) {
+		binner = nullptr;
+		return;
+	}
+	auto binners = var->binners();
+	if (std::find(binners.begin(), binners.end(), binner) != binners.end())
+		return;
+
+	// For now choose the first binner. However, we might try to be smarter here
+	// and adapt to the given screen size and the estimated number of bins.
+	binner = binners.empty() ? nullptr : binners[0];
+}
+
+static void validateOperation(StatsOperation &operation, const StatsType *var, bool hasOperation)
+{
+	if (!hasOperation) {
+		operation = StatsOperation::Invalid;
+		return;
+	}
+	std::vector<StatsOperation> ops = var->supportedOperations();
+	if (std::find(ops.begin(), ops.end(), operation) != ops.end())
+		return;
+
+	operation = ops.empty() ? StatsOperation::Invalid : ops[0];
+}
+
+// The var changed variable indicates whether this function is called
+// after a variable change or a change of the chart type. In the
+// former case, the chart type is switched, if it is not recommended.
+// In the latter case, the user explicitly chose a non-recommended type,
+// so let's use that.
+void StatsState::validate(bool varChanged)
+{
+	// Take care that we don't plot a variable against itself.
+	// By default plot the count of the first variable. Is that sensible?
+	if (var1 == var2)
+		var2 = nullptr;
+
+	// Let's see if the currently selected chart is one of the valid charts
+	auto charts = validCharts(var1, var2);
+	const ChartTypeDesc &desc = newChartType(type, charts, varChanged);
+	type = desc.id;
+
+	// Check if the current subtype is supported by the chart
+	if (std::find(desc.subtypes.begin(), desc.subtypes.end(), subtype) == desc.subtypes.end())
+		subtype = desc.subtypes.empty() ? ChartSubType::Pie : desc.subtypes[0];
+
+	var1Binned = desc.var1 == SupportedVariable::Categorical || desc.var1 == SupportedVariable::Continuous;
+	var2Binned = desc.var2 == SupportedVariable::Categorical || desc.var2 == SupportedVariable::Continuous;
+	var2HasOperations = desc.var2HasOperations;
+
+	chartFeatures = desc.features;
+	// Median and mean currently only if first variable is numeric
+	if (!var1 || var1->type() != StatsType::Type::Numeric)
+		chartFeatures = false;
+
+	// Check that the binners and operation are valid
+	validateBinner(var1Binner, var1, var1Binned);
+	validateBinner(var2Binner, var2, var2Binned);
+	validateOperation(var2Operation, var2, var2HasOperations);
+}

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -9,7 +9,6 @@ static const char *chart_subtype_names[] = {
 	QT_TRANSLATE_NOOP("StatsTranslations", "Vertical stacked"),
 	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal"),
 	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal stacked"),
-	QT_TRANSLATE_NOOP("StatsTranslations", "Pie")
 };
 
 enum class SupportedVariable {
@@ -92,7 +91,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Categorical,
 		SupportedVariable::Count,
 		false,
-		{ ChartSubType::Pie, ChartSubType::Vertical, ChartSubType::Horizontal },
+		{ ChartSubType::Vertical, ChartSubType::Horizontal },
 		ChartFeatureLabels
 	},
 	{
@@ -100,6 +99,15 @@ static const struct ChartTypeDesc {
 		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical box"),
 		SupportedVariable::Categorical,
 		SupportedVariable::Numeric,
+		false,
+		{ },
+		0
+	},
+	{
+		ChartType::Pie,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Pie"),
+		SupportedVariable::Categorical,
+		SupportedVariable::Count,
 		false,
 		{ },
 		0
@@ -122,7 +130,7 @@ StatsState::StatsState() :
 	var1(stats_types[0]),
 	var2(nullptr),
 	type(ChartType::DiscreteBar),
-	subtype(ChartSubType::Pie),
+	subtype(ChartSubType::Vertical),
 	labels(true),
 	median(false),
 	mean(false),
@@ -446,7 +454,7 @@ void StatsState::validate(bool varChanged)
 
 	// Check if the current subtype is supported by the chart
 	if (std::find(desc.subtypes.begin(), desc.subtypes.end(), subtype) == desc.subtypes.end())
-		subtype = desc.subtypes.empty() ? ChartSubType::Pie : desc.subtypes[0];
+		subtype = desc.subtypes.empty() ? ChartSubType::Horizontal : desc.subtypes[0];
 
 	var1Binned = desc.var1 == SupportedVariable::Categorical || desc.var1 == SupportedVariable::Continuous;
 	var2Binned = desc.var2 == SupportedVariable::Categorical || desc.var2 == SupportedVariable::Continuous;

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -34,7 +34,7 @@ static const struct ChartTypeDesc {
 	{
 		ChartType::ScatterPlot,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Scatter"),
-		SupportedVariable::Numeric,
+		SupportedVariable::Continuous,
 		SupportedVariable::Numeric,
 		false,
 		{ },
@@ -465,7 +465,7 @@ void StatsState::validate(bool varChanged)
 	if (std::find(desc.subtypes.begin(), desc.subtypes.end(), subtype) == desc.subtypes.end())
 		subtype = desc.subtypes.empty() ? ChartSubType::Horizontal : desc.subtypes[0];
 
-	var1Binned = desc.var1 == SupportedVariable::Categorical || desc.var1 == SupportedVariable::Continuous;
+	var1Binned = type != ChartType::ScatterPlot;
 	var2Binned = desc.var2 == SupportedVariable::Categorical || desc.var2 == SupportedVariable::Continuous;
 	var2HasOperations = desc.var2HasOperations;
 

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -59,6 +59,15 @@ static const struct ChartTypeDesc {
 		ChartFeatureLabels
 	},
 	{
+		ChartType::HistogramBox,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Box"),
+		SupportedVariable::Continuous,
+		SupportedVariable::Numeric,
+		false,
+		{ },
+		0
+	},
+	{
 		ChartType::DiscreteScatter,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Categorical scatter"),
 		SupportedVariable::Categorical,

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -18,9 +18,10 @@ enum class SupportedVariable {
 	Numeric
 };
 
-static const int ChartFeatureLabels = 1 << 0;
-static const int ChartFeatureMedian = 1 << 1;
-static const int ChartFeatureMean =   1 << 2;
+static const int ChartFeatureLabels =	 1 << 0;
+static const int ChartFeatureMedian =	 1 << 1;
+static const int ChartFeatureMean =	 1 << 2;
+static const int ChartFeatureQuartiles = 1 << 3;
 
 static const struct ChartTypeDesc {
 	ChartType id;
@@ -74,7 +75,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Numeric,
 		false,
 		{ },
-		0
+		ChartFeatureQuartiles
 	},
 	{
 		ChartType::DiscreteBar,
@@ -143,6 +144,7 @@ StatsState::StatsState() :
 	labels(true),
 	median(false),
 	mean(false),
+	quartiles(true),
 	var1Binner(nullptr),
 	var2Binner(nullptr),
 	var2Operation(StatsOperation::Invalid),
@@ -309,7 +311,7 @@ static StatsState::VariableList createOperationsList(bool hasOperations, const S
 	return res;
 }
 
-std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool labels, bool median, bool mean)
+static std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool labels, bool median, bool mean, bool quartiles)
 {
 	std::vector<StatsState::Feature> res;
 	if (chartFeatures & ChartFeatureLabels)
@@ -318,6 +320,8 @@ std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool labe
 		res.push_back({ StatsTranslations::tr("median"), ChartFeatureMedian, median });
 	if (chartFeatures & ChartFeatureMean)
 		res.push_back({ StatsTranslations::tr("mean"), ChartFeatureMean, mean });
+	if (chartFeatures & ChartFeatureQuartiles)
+		res.push_back({ StatsTranslations::tr("quartiles"), ChartFeatureQuartiles, quartiles });
 	return res;
 }
 
@@ -332,7 +336,7 @@ StatsState::UIState StatsState::getUIState() const
 	res.binners1 = createBinnerList(var1Binned, var1, var1Binner);
 	res.binners2 = createBinnerList(var2Binned, var2, var2Binner);
 	res.operations2 = createOperationsList(var2HasOperations, var2, var2Operation);
-	res.features = createFeaturesList(chartFeatures, labels, median, mean);
+	res.features = createFeaturesList(chartFeatures, labels, median, mean, quartiles);
 	return res;
 }
 
@@ -390,6 +394,8 @@ void StatsState::featureChanged(int id, bool state)
 		median = state;
 	else if (id == ChartFeatureMean)
 		mean = state;
+	else if (id == ChartFeatureQuartiles)
+		quartiles = state;
 }
 
 // Creates the new chart-type from the current chart-type and a list of possible chart types.

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -268,7 +268,7 @@ static StatsState::ChartList createChartList(const StatsType *var1, const StatsT
 			if (selectedType == desc.id && selectedSubType == subtype)
 				res.selected = id;
 			QString subtypeName = StatsTranslations::tr(chart_subtype_names[(int)subtype]);
-			res.charts.push_back({ name, subtypeName, toInt(desc.id, subtype), warn });
+			res.charts.push_back({ name, subtypeName, subtype, toInt(desc.id, subtype), warn });
 		}
 	}
 

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -126,7 +126,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Count,
 		false,
 		{ ChartSubType::Pie },
-		ChartFeatureLegend
+		ChartFeatureLabels | ChartFeatureLegend
 	},
 	{
 		ChartType::DiscreteBar,

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -24,9 +24,10 @@ enum class SupportedVariable {
 };
 
 static const int ChartFeatureLabels =	 1 << 0;
-static const int ChartFeatureMedian =	 1 << 1;
-static const int ChartFeatureMean =	 1 << 2;
-static const int ChartFeatureQuartiles = 1 << 3;
+static const int ChartFeatureLegend =	 1 << 1;
+static const int ChartFeatureMedian =	 1 << 2;
+static const int ChartFeatureMean =	 1 << 3;
+static const int ChartFeatureQuartiles = 1 << 4;
 
 static const struct ChartTypeDesc {
 	ChartType id;
@@ -80,7 +81,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Categorical,
 		false,
 		{ ChartSubType::VerticalStacked, ChartSubType::HorizontalStacked },
-		ChartFeatureLabels
+		ChartFeatureLabels | ChartFeatureLegend
 	},
 	{
 		ChartType::DiscreteScatter,
@@ -125,7 +126,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Count,
 		false,
 		{ ChartSubType::Pie },
-		0
+		ChartFeatureLegend
 	},
 	{
 		ChartType::DiscreteBar,
@@ -134,7 +135,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Categorical,
 		false,
 		{ ChartSubType::VerticalGrouped, ChartSubType::VerticalStacked, ChartSubType::HorizontalGrouped, ChartSubType::HorizontalStacked },
-		ChartFeatureLabels
+		ChartFeatureLabels | ChartFeatureLegend
 	}
 };
 
@@ -156,6 +157,7 @@ StatsState::StatsState() :
 	type(ChartType::DiscreteBar),
 	subtype(ChartSubType::Vertical),
 	labels(true),
+	legend(true),
 	median(false),
 	mean(false),
 	quartiles(true),
@@ -314,11 +316,13 @@ static StatsState::VariableList createOperationsList(bool hasOperations, const S
 	return res;
 }
 
-static std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool labels, bool median, bool mean, bool quartiles)
+static std::vector<StatsState::Feature> createFeaturesList(int chartFeatures, bool labels, bool legend, bool median, bool mean, bool quartiles)
 {
 	std::vector<StatsState::Feature> res;
 	if (chartFeatures & ChartFeatureLabels)
 		res.push_back({ StatsTranslations::tr("labels"), ChartFeatureLabels, labels });
+	if (chartFeatures & ChartFeatureLegend)
+		res.push_back({ StatsTranslations::tr("legend"), ChartFeatureLegend, legend });
 	if (chartFeatures & ChartFeatureMedian)
 		res.push_back({ StatsTranslations::tr("median"), ChartFeatureMedian, median });
 	if (chartFeatures & ChartFeatureMean)
@@ -339,7 +343,7 @@ StatsState::UIState StatsState::getUIState() const
 	res.binners1 = createBinnerList(var1Binned, var1, var1Binner);
 	res.binners2 = createBinnerList(var2Binned, var2, var2Binner);
 	res.operations2 = createOperationsList(var2HasOperations, var2, var2Operation);
-	res.features = createFeaturesList(chartFeatures, labels, median, mean, quartiles);
+	res.features = createFeaturesList(chartFeatures, labels, legend, median, mean, quartiles);
 	return res;
 }
 
@@ -393,6 +397,8 @@ void StatsState::featureChanged(int id, bool state)
 {
 	if (id == ChartFeatureLabels)
 		labels = state;
+	else if (id == ChartFeatureLegend)
+		legend = state;
 	else if (id == ChartFeatureMedian)
 		median = state;
 	else if (id == ChartFeatureMean)

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -56,7 +56,7 @@ static const struct ChartTypeDesc {
 		ChartFeatureLabels | ChartFeatureMedian | ChartFeatureMean
 	},
 	{
-		ChartType::HistogramBar,
+		ChartType::HistogramValue,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Histogram"),
 		SupportedVariable::Continuous,
 		SupportedVariable::Numeric,
@@ -72,6 +72,15 @@ static const struct ChartTypeDesc {
 		false,
 		{ ChartSubType::Box },
 		0
+	},
+	{
+		ChartType::HistogramStacked,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Histogram"),
+		SupportedVariable::Continuous,
+		SupportedVariable::Categorical,
+		false,
+		{ ChartSubType::VerticalStacked, ChartSubType::HorizontalStacked },
+		ChartFeatureLabels
 	},
 	{
 		ChartType::DiscreteScatter,
@@ -125,7 +134,7 @@ static const struct ChartTypeDesc {
 		SupportedVariable::Categorical,
 		false,
 		{ ChartSubType::VerticalGrouped, ChartSubType::VerticalStacked, ChartSubType::HorizontalGrouped, ChartSubType::HorizontalStacked },
-		0
+		ChartFeatureLabels
 	}
 };
 

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -14,6 +14,7 @@ enum class ChartType {
 	DiscreteCount,
 	DiscreteBox,
 	DiscreteScatter,
+	Pie,
 	HistogramCount,
 	HistogramBar,
 	ScatterPlot
@@ -23,8 +24,7 @@ enum class ChartSubType {
 	Vertical = 0,
 	VerticalStacked,
 	Horizontal,
-	HorizontalStacked,
-	Pie
+	HorizontalStacked
 };
 
 struct StatsType;

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -17,6 +17,7 @@ enum class ChartType {
 	Pie,
 	HistogramCount,
 	HistogramBar,
+	HistogramBox,
 	ScatterPlot
 };
 

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -91,6 +91,7 @@ public:
 	const StatsType *var2;		// Dependent variable (nullptr: count)
 	ChartType type;
 	ChartSubType subtype;
+	bool labels;
 	bool median;
 	bool mean;
 	const StatsBinner *var1Binner;	// nullptr: undefined

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0
+// Describes the current state of the statistics widget
+// (selected variables, chart type, etc.) and is the
+// interface between UI and plotting code.
+#ifndef STATS_STATE_H
+#define STATS_STATE_H
+
+#include <vector>
+#include <QString>
+
+enum class ChartType {
+	DiscreteBar,
+	DiscreteValue,
+	DiscreteCount,
+	DiscreteBox,
+	DiscreteScatter,
+	HistogramCount,
+	HistogramBar,
+	ScatterPlot
+};
+
+enum class ChartSubType {
+	Vertical = 0,
+	VerticalStacked,
+	Horizontal,
+	HorizontalStacked,
+	Pie
+};
+
+struct StatsType;
+struct StatsBinner;
+enum class StatsOperation : int;
+
+struct StatsState {
+public:
+	StatsState();
+	int setFirstAxis();
+	int setSecondAxis();
+
+	struct Variable {
+		QString name;
+		int id;
+	};
+	struct VariableList {
+		std::vector<Variable> variables;
+		int selected;
+	};
+	struct Chart {
+		QString name;
+		int id;
+		bool warning;		// Not recommended for that combination
+	};
+	struct ChartList {
+		std::vector<Chart> charts;
+		int selected;
+	};
+	struct BinnerList {
+		std::vector<QString> binners;
+		int selected;
+	};
+	struct Feature {
+		QString name;
+		int id;
+		bool selected;
+	};
+	struct UIState {
+		VariableList var1;
+		VariableList var2;
+		QString var1Name;
+		QString var2Name;
+		ChartList charts;
+		std::vector<Feature> features;
+		BinnerList binners1;
+		BinnerList binners2;
+		// Currently, operations are only supported on the second variable
+		// This reuses the variable list - not very nice.
+		VariableList operations2;
+	};
+	UIState getUIState() const;
+
+	// State changers
+	void var1Changed(int id);
+	void var2Changed(int id);
+	void chartChanged(int id);
+	void binner1Changed(int id);
+	void binner2Changed(int id);
+	void var2OperationChanged(int id);
+	void featureChanged(int id, bool state);
+
+	const StatsType *var1;		// Independent variable
+	const StatsType *var2;		// Dependent variable (nullptr: count)
+	ChartType type;
+	ChartSubType subtype;
+	bool median;
+	bool mean;
+	const StatsBinner *var1Binner;	// nullptr: undefined
+	const StatsBinner *var2Binner;	// nullptr: undefined
+	StatsOperation var2Operation;
+private:
+	void validate(bool varChanged);
+	bool var1Binned;
+	bool var2Binned;
+	bool var2HasOperations;
+	int chartFeatures;
+};
+
+#endif

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -95,6 +95,7 @@ public:
 	bool labels;
 	bool median;
 	bool mean;
+	bool quartiles;
 	const StatsBinner *var1Binner;	// nullptr: undefined
 	const StatsBinner *var2Binner;	// nullptr: undefined
 	StatsOperation var2Operation;

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -23,9 +23,14 @@ enum class ChartType {
 
 enum class ChartSubType {
 	Vertical = 0,
+	VerticalGrouped,
 	VerticalStacked,
 	Horizontal,
-	HorizontalStacked
+	HorizontalGrouped,
+	HorizontalStacked,
+	Dots,
+	Box,
+	Pie
 };
 
 struct StatsType;
@@ -48,6 +53,7 @@ public:
 	};
 	struct Chart {
 		QString name;
+		QString subtypeName;
 		int id;
 		bool warning;		// Not recommended for that combination
 	};

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -16,8 +16,9 @@ enum class ChartType {
 	DiscreteScatter,
 	Pie,
 	HistogramCount,
-	HistogramBar,
+	HistogramValue,
 	HistogramBox,
+	HistogramStacked,
 	ScatterPlot
 };
 

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -31,7 +31,8 @@ enum class ChartSubType {
 	HorizontalStacked,
 	Dots,
 	Box,
-	Pie
+	Pie,
+	Count
 };
 
 struct StatsType;
@@ -55,6 +56,7 @@ public:
 	struct Chart {
 		QString name;
 		QString subtypeName;
+		ChartSubType subtype;
 		int id;
 		bool warning;		// Not recommended for that combination
 	};

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -100,6 +100,7 @@ public:
 	ChartType type;
 	ChartSubType subtype;
 	bool labels;
+	bool legend;
 	bool median;
 	bool mean;
 	bool quartiles;

--- a/stats/statstranslations.h
+++ b/stats/statstranslations.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0
+// Dummy object for stats-module related translations
+
+#ifndef STATS_TRANSLATIONS_H
+#define STATS_TRANSLATIONS_H
+
+#include <QObject>
+
+class StatsTranslations : public QObject
+{
+	Q_OBJECT
+};
+
+#endif

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -858,7 +858,7 @@ struct DateMonthBinner : public SimpleContinuousBinner<DateMonthBinner, DateMont
 static DateYearBinner date_year_binner;
 static DateQuarterBinner date_quarter_binner;
 static DateMonthBinner date_month_binner;
-struct DateType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+struct DateType : public StatsTypeTemplate<StatsType::Type::Continuous> {
 	QString name() const {
 		return StatsTranslations::tr("Date");
 	}
@@ -1503,16 +1503,4 @@ const std::vector<const StatsType *> stats_types = {
 	&water_temperature_type, &air_temperature_type,
 	&gas_content_o2_type, &gas_content_o2_he_max_type, &gas_content_he_type,
 	&dive_mode_type, &buddy_type, &gas_type_type, &suit_type, &location_type
-};
-
-const std::vector<const StatsType *> stats_continuous_types = {
-	&date_type, &depth_type, &duration_type, &sac_type,
-	&water_temperature_type, &air_temperature_type,
-	&gas_content_o2_he_max_type, &gas_content_o2_he_max_type, &gas_content_he_type
-};
-
-const std::vector<const StatsType *> stats_numeric_types = {
-	&depth_type, &duration_type, &sac_type,
-	&water_temperature_type, &air_temperature_type,
-	&gas_content_o2_type, &gas_content_o2_he_max_type, &gas_content_he_type
 };

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -170,6 +170,13 @@ QString StatsBinner::name() const
 	return QStringLiteral("N/A"); // Some dummy string that should never reach the UI
 }
 
+QString StatsBinner::formatWithUnit(const StatsBin &bin) const
+{
+	QString unit = unitSymbol();
+	QString name = format(bin);
+	return unit.isEmpty() ? name : QStringLiteral("%1 %2").arg(name, unit);
+}
+
 QString StatsBinner::formatLowerBound(const StatsBin &bin) const
 {
 	return QStringLiteral("N/A"); // Some dummy string that should never reach the UI

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -910,6 +910,9 @@ struct DateType : public StatsTypeTemplate<StatsType::Type::Continuous> {
 	QString name() const {
 		return StatsTranslations::tr("Date");
 	}
+	double toFloat(const dive *d) const override {
+		return d->when / 86400.0;
+	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &date_year_binner, &date_quarter_binner, &date_month_binner };
 	}

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -1,0 +1,981 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statstypes.h"
+#include "core/dive.h"
+#include "core/divemode.h"
+#include "core/divesite.h"
+#include "core/pref.h"
+#include "core/qthelper.h" // for get_depth_unit() et al.
+#include "core/subsurface-time.h"
+#include <limits>
+#include <QLocale>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#define SKIP_EMPTY Qt::SkipEmptyParts
+#else
+#define SKIP_EMPTY QString::SkipEmptyParts
+#endif
+
+static const constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+// Typedefs for year / quarter or month binners
+using year_quarter = std::pair<unsigned short, unsigned short>;
+using year_month = std::pair<unsigned short, unsigned short>;
+
+// Note: usually I dislike functions defined inside class/struct
+// declarations ("Java style"). However, for brevity this is done
+// in this rather template-heavy source file more or less consistently.
+
+// Templates to define invalid values for types and test for said values.
+// This is used by the binners: returning such a value means "ignore this dive".
+template<typename T> T invalid_value();
+template<> int invalid_value<int>()
+{
+	return std::numeric_limits<int>::max();
+}
+template<> double invalid_value<double>()
+{
+	return std::numeric_limits<double>::quiet_NaN();
+}
+template<> QString invalid_value<QString>()
+{
+	return QString();
+}
+
+static bool is_invalid_value(int i)
+{
+	return i == std::numeric_limits<int>::max();
+}
+
+static bool is_invalid_value(double d)
+{
+	return std::isnan(d);
+}
+
+static bool is_invalid_value(const QString &s)
+{
+	return s.isEmpty();
+}
+
+// Currently, we don't support invalid dates - should we?
+static bool is_invalid_value(const year_quarter &)
+{
+	return false;
+}
+
+static bool is_invalid_value(const dive_site *d)
+{
+	return !d;
+}
+
+// First, let's define the virtual destructors of our base classes
+StatsBin::~StatsBin()
+{
+}
+
+StatsBinner::~StatsBinner()
+{
+}
+
+QString StatsBinner::unitSymbol() const
+{
+	return QString();
+}
+
+StatsType::~StatsType()
+{
+}
+
+QString StatsBinner::name() const
+{
+	return QStringLiteral("N/A"); // Some dummy string that should never reach the UI
+}
+
+QString StatsBinner::formatLowerBound(const StatsBin &bin) const
+{
+	return QStringLiteral("N/A"); // Some dummy string that should never reach the UI
+}
+
+QString StatsBinner::formatUpperBound(const StatsBin &bin) const
+{
+	return QStringLiteral("N/A"); // Some dummy string that should never reach the UI
+}
+
+double StatsBinner::lowerBoundToFloat(const StatsBin &bin) const
+{
+	return 0.0;
+}
+
+double StatsBinner::upperBoundToFloat(const StatsBin &bin) const
+{
+	return 0.0;
+}
+
+// Default implementation for discrete types: there are no bins between discrete bins.
+std::vector<StatsBinPtr> StatsBinner::bins_between(const StatsBin &bin1, const StatsBin &bin2) const
+{
+	return {};
+}
+
+QString StatsType::unitSymbol() const
+{
+	return {};
+}
+
+int StatsType::decimals() const
+{
+	return 0;
+}
+
+double StatsType::toFloat(const dive *d) const
+{
+	return invalid_value<double>();
+}
+
+QString StatsType::nameWithUnit() const
+{
+	QString s = name();
+	QString symb = unitSymbol();
+	return symb.isEmpty() ? s : QStringLiteral("%1 [%2]").arg(s, symb);
+}
+
+QString StatsType::nameWithBinnerUnit(const StatsBinner &binner) const
+{
+	QString s = name();
+	QString symb = binner.unitSymbol();
+	return symb.isEmpty() ? s : QStringLiteral("%1 [%2]").arg(s, symb);
+}
+
+const StatsBinner *StatsType::getBinner(int idx) const
+{
+	std::vector<const StatsBinner *> b = binners();
+	if (b.empty())
+		return nullptr;
+	return idx >= 0 && idx < (int)b.size() ? b[idx] : b[0];
+}
+
+std::vector<StatsOperation> StatsType::supportedOperations() const
+{
+	return {};
+}
+
+// Attn: The order must correspond to the StatsOperation enum
+static const char *operation_names[] = {
+	QT_TRANSLATE_NOOP("StatsTranslations", "Median"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Average"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Time-weighted Avg."),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Sum")
+};
+
+QStringList StatsType::supportedOperationNames() const
+{
+	std::vector<StatsOperation> ops = supportedOperations();
+	QStringList res;
+	res.reserve(ops.size());
+	for (StatsOperation op: ops)
+		res.push_back(operationName(op));
+	return res;
+}
+
+StatsOperation StatsType::idxToOperation(int idx) const
+{
+	std::vector<StatsOperation> ops = supportedOperations();
+	if (ops.empty()) {
+		qWarning("Stats type %s does not support operations", qPrintable(name()));
+		return StatsOperation::Median; // oops!
+	}
+	return idx < 0 || idx >= (int)ops.size() ? ops[0] : ops[idx];
+}
+
+QString StatsType::operationName(StatsOperation op)
+{
+	int idx = (int)op;
+	return idx < 0 || idx >= (int)std::size(operation_names) ? QString()
+								 : operation_names[(int)op];
+}
+
+double StatsType::average(const std::vector<dive *> &dives) const
+{
+	double sum = 0.0;
+	double count = 0.0;
+	for (const dive *d: dives) {
+		double v = toFloat(d);
+		if (is_invalid_value(v))
+			continue;
+		sum += v;
+		count += 1.0;
+	}
+	return count > 0.0 ? sum / count : 0.0;
+}
+
+double StatsType::averageTimeWeighted(const std::vector<dive *> &dives) const
+{
+	double sum = 0.0;
+	double weight_count = 0.0;
+	for (const dive *d: dives) {
+		double v = toFloat(d);
+		if (is_invalid_value(v))
+			continue;
+		sum += v * d->duration.seconds;
+		weight_count += d->duration.seconds;
+	}
+	return weight_count > 0.0 ? sum / weight_count : 0.0;
+}
+
+double StatsType::median(const std::vector<dive *> &dives) const
+{
+	if (dives.empty())
+		return 0.0;
+	std::vector<double> vec;
+	vec.reserve(dives.size());
+	for (const dive *d: dives) {
+		double v = toFloat(d);
+		if (is_invalid_value(v))
+			continue;
+		vec.push_back(v);
+	}
+	std::sort(vec.begin(), vec.end());
+	size_t s = vec.size();
+	return s % 2 == 0 ? (vec[s/2 - 1] + vec[s/2]) / 2.0
+			  : vec[s/2];
+}
+
+double StatsType::sum(const std::vector<dive *> &dives) const
+{
+	double res = 0.0;
+	for (const dive *d: dives) {
+		double v = toFloat(d);
+		if (!is_invalid_value(v))
+			res += v;
+	}
+	return res;
+}
+
+double StatsType::applyOperation(const std::vector<dive *> &dives, StatsOperation op) const
+{
+	switch (op) {
+	case StatsOperation::Median:
+		return median(dives);
+	case StatsOperation::Average:
+		return average(dives);
+	case StatsOperation::TimeWeightedAverage:
+		return averageTimeWeighted(dives);
+	case StatsOperation::Sum:
+		return sum(dives);
+	default: return 0.0;
+	}
+}
+
+// Silly template, which spares us defining type() member functions.
+template<StatsType::Type t>
+struct StatsTypeTemplate : public StatsType {
+	Type type() const override { return t; }
+};
+
+// A simple bin that is based on copyable value and can be initialized from
+// that value. This template spares us from writing one-line constructors.
+template<typename Type>
+struct SimpleBin : public StatsBin {
+	Type value;
+	SimpleBin(const Type &v) : value(v) { }
+
+	// This must not be called for different types. It will crash with an exception.
+	bool operator<(StatsBin &b) const {
+		return value < dynamic_cast<SimpleBin &>(b).value;
+	}
+
+	bool operator==(StatsBin &b) const {
+		return value == dynamic_cast<SimpleBin &>(b).value;
+	}
+};
+using IntBin = SimpleBin<int>;
+using StringBin = SimpleBin<QString>;
+
+// A general binner template that works on trivial bins that are based
+// on a type that is equality and less-than comparable. The derived class
+// must possess:
+//  - A to_bin_value() function that turns a dive into a value from
+//    which the bins can be constructed.
+//  - A lowerBoundToFloatBase() function that turns the value form
+//    into a double which is understood by the StatsType.
+// The bins must possess:
+//  - A member variable "value" of the type it is constructed with.
+// Note: this uses the curiously recurring template pattern, which I
+// dislike, but it is the easiest thing for now.
+template<typename Binner, typename Bin>
+struct SimpleBinner : public StatsBinner {
+public:
+	using Type = decltype(Bin::value);
+	std::vector<StatsBinDives> bin_dives(const std::vector<dive *> &dives, bool fill_empty) const override;
+	std::vector<StatsBinCount> count_dives(const std::vector<dive *> &dives, bool fill_empty) const override;
+	const Binner &derived() const {
+		return static_cast<const Binner &>(*this);
+	}
+	const Bin &derived_bin(const StatsBin &bin) const {
+		return dynamic_cast<const Bin &>(bin);
+	}
+};
+
+// Wrapper around std::lower_bound that searches for a value in a
+// vector of pairs. Comparison is made with the first element of the pair.
+// std::lower_bound does a binary search and this is used to keep a
+// vector in ascending order.
+template<typename T1, typename T2>
+auto pair_lower_bound(std::vector<std::pair<T1, T2>> &v, const T1 &value)
+{
+	return std::lower_bound(v.begin(), v.end(), value,
+	       			[] (const std::pair<T1, T2> &entry, const T1 &value) {
+					return entry.first < value;
+				});
+}
+
+// Add a dive to a vector of (value, dive_list) pairs. If the value doesn't yet
+// exist, create a new entry in the vector.
+template<typename T>
+using ValueDiveListPair = std::pair<T, std::vector<dive *>>;
+template<typename T>
+void add_dive_to_value_bin(std::vector<ValueDiveListPair<T>> &v, const T &value, dive *d)
+{
+	// Does that value already exist?
+	auto it = pair_lower_bound(v, value);
+	if (it != v.end() && it->first == value)
+		it->second.push_back(d);	// Bin exists -> add dive!
+	else
+		v.insert(it, { value, { d }});	// Bin does not exist -> insert at proper location.
+}
+
+// Increase count in a vector of (value, count) pairs. If the value doesn't yet
+// exist, create a new entry in the vector.
+template<typename T>
+using ValueCountPair = std::pair<T, int>;
+template<typename T>
+void increment_count_bin(std::vector<ValueCountPair<T>> &v, const T &value)
+{
+	// Does that value already exist?
+	auto it = pair_lower_bound(v, value);
+	if (it != v.end() && it->first == value)
+		++it->second;			// Bin exists -> increment count!
+	else
+		v.insert(it, { value, 1 });	// Bin does not exist -> insert at proper location.
+}
+
+template<typename Binner, typename Bin>
+std::vector<StatsBinDives> SimpleBinner<Binner, Bin>::bin_dives(const std::vector<dive *> &dives, bool fill_empty) const
+{
+	// First, collect a value / dives vector and then produce the final vector
+	// out of that. I wonder if that is permature optimization?
+	using Pair = ValueDiveListPair<Type>;
+	std::vector<Pair> value_bins;
+	for (dive *d: dives) {
+		Type value = derived().to_bin_value(d);
+		if (is_invalid_value(value))
+			continue;
+		add_dive_to_value_bin(value_bins, value, d);
+	}
+
+	// Now, turn that into our result array with allocated bin objects.
+	std::vector<StatsBinDives> res;
+	res.reserve(value_bins.size());
+	for (const Pair &pair: value_bins) {
+		StatsBinPtr b = std::make_unique<Bin>(pair.first);
+		if (fill_empty && !res.empty()) {
+			// Add empty bins, if any
+			for (StatsBinPtr &bin: bins_between(*res.back().bin, *b))
+				res.push_back({ std::move(bin), {}});
+		}
+		res.push_back({ std::move(b), std::move(pair.second)});
+	}
+	return res;
+}
+
+template<typename Binner, typename Bin>
+std::vector<StatsBinCount> SimpleBinner<Binner, Bin>::count_dives(const std::vector<dive *> &dives, bool fill_empty) const
+{
+	// First, collect a value / counts vector and then produce the final vector
+	// out of that. I wonder if that is permature optimization?
+	using Pair = std::pair<Type, int>;
+	std::vector<Pair> value_bins;
+	for (const dive *d: dives) {
+		Type value = derived().to_bin_value(d);
+		if (is_invalid_value(value))
+			continue;
+		increment_count_bin(value_bins, value);
+	}
+
+	// Now, turn that into our result array with allocated bin objects.
+	std::vector<StatsBinCount> res;
+	res.reserve(value_bins.size());
+	for (const Pair &pair: value_bins) {
+		StatsBinPtr b = std::make_unique<Bin>(pair.first);
+		if (fill_empty && !res.empty()) {
+			// Add empty bins, if any
+			for (StatsBinPtr &bin: bins_between(*res.back().bin, *b))
+				res.push_back({ std::move(bin), 0});
+		}
+		res.push_back({ std::move(b), pair.second});
+	}
+	return res;
+}
+
+// A simple binner (see above) that works on continuous (or numeric) types
+// and can return bin-ranges. The binner must implement an inc() function
+// that turns a bin into the next-higher bin.
+template<typename Binner, typename Bin>
+struct SimpleContinuousBinner : public SimpleBinner<Binner, Bin>
+{
+	using SimpleBinner<Binner, Bin>::derived;
+	std::vector<StatsBinPtr> bins_between(const StatsBin &bin1, const StatsBin &bin2) const override;
+
+	// By default the value gives the lower bound, so the format is the same
+	QString formatLowerBound(const StatsBin &bin) const override {
+		return derived().format(bin);
+	}
+
+	// For the upper bound, simply go to the next bin
+	QString formatUpperBound(const StatsBin &bin) const override {
+		Bin b = SimpleBinner<Binner,Bin>::derived_bin(bin);
+		derived().inc(b);
+		return formatLowerBound(b);
+	}
+
+	// Cast to base value type so that the derived class doesn't have to do it
+	double lowerBoundToFloat(const StatsBin &bin) const override {
+		const Bin &b = SimpleBinner<Binner,Bin>::derived_bin(bin);
+		return derived().lowerBoundToFloatBase(b.value);
+	}
+
+	// For the upper bound, simply go to the next bin
+	double upperBoundToFloat(const StatsBin &bin) const override {
+		Bin b = SimpleBinner<Binner,Bin>::derived_bin(bin);
+		derived().inc(b);
+		return derived().lowerBoundToFloatBase(b.value);
+	}
+};
+
+// A continuous binner, where the bin is based on an integer value
+// and subsequent bins are adjacent integers.
+template<typename Binner, typename Bin>
+struct IntBinner : public SimpleContinuousBinner<Binner, Bin>
+{
+	void inc(Bin &bin) const {
+		++bin.value;
+	}
+};
+
+// An integer based binner, where each bin represents an integer
+// range with a fixed size.
+template<typename Binner, typename Bin>
+struct IntRangeBinner : public IntBinner<Binner, Bin> {
+	int bin_size;
+	IntRangeBinner(int size)
+		: bin_size(size)
+	{
+	}
+	QString format(const StatsBin &bin) const override {
+		int value = IntBinner<Binner, Bin>::derived_bin(bin).value;
+		QLocale loc;
+		return StatsTranslations::tr("%1–%2").arg(loc.toString(value * bin_size),
+							  loc.toString((value + 1) * bin_size));
+	}
+	QString formatLowerBound(const StatsBin &bin) const override {
+		int value = IntBinner<Binner, Bin>::derived_bin(bin).value;
+		return QStringLiteral("%L1").arg(value * bin_size);
+	}
+	double lowerBoundToFloatBase(int value) const {
+		return static_cast<double>(value * bin_size);
+	}
+};
+
+template<typename Binner, typename Bin>
+std::vector<StatsBinPtr> SimpleContinuousBinner<Binner, Bin>::bins_between(const StatsBin &bin1, const StatsBin &bin2) const
+{
+	const Bin &b1 = SimpleBinner<Binner,Bin>::derived_bin(bin1);
+	const Bin &b2 = SimpleBinner<Binner,Bin>::derived_bin(bin2);
+	std::vector<StatsBinPtr> res;
+	Bin act = b1;
+	derived().inc(act);
+	while (act.value < b2.value) {
+		res.push_back(std::make_unique<Bin>(act));
+		derived().inc(act);
+	}
+	return res;
+}
+
+// A binner that works on string-based bins whereby each dive can
+// produce multiple strings (e.g. dive buddies). The binner must
+// feature a to_string_list() function that produces a vector of
+// QStrings and bins that can be constructed from QStrings.
+// Other than that, see SimpleBinner.
+template<typename Binner, typename Bin>
+struct StringBinner : public StatsBinner {
+public:
+	std::vector<StatsBinDives> bin_dives(const std::vector<dive *> &dives, bool fill_empty) const override;
+	std::vector<StatsBinCount> count_dives(const std::vector<dive *> &dives, bool fill_empty) const override;
+	const Binner &derived() const {
+		return static_cast<const Binner &>(*this);
+	}
+	QString format(const StatsBin &bin) const override {
+		return dynamic_cast<const Bin &>(bin).value;
+	}
+};
+
+template<typename Binner, typename Bin>
+std::vector<StatsBinDives> StringBinner<Binner, Bin>::bin_dives(const std::vector<dive *> &dives, bool) const
+{
+	// First, collect a value / dives vector and then produce the final vector
+	// out of that. I wonder if that is permature optimization?
+	using Pair = ValueDiveListPair<QString>;
+	std::vector<Pair> value_bins;
+	for (dive *d: dives) {
+		for (const QString &s: derived().to_string_list(d)) {
+			if (is_invalid_value(s))
+				continue;
+			add_dive_to_value_bin(value_bins, s, d);
+		}
+	}
+
+	// Now, turn that into our result array with allocated bin objects.
+	std::vector<StatsBinDives> res;
+	res.reserve(value_bins.size());
+	for (const Pair &pair: value_bins)
+		res.push_back({ std::make_unique<Bin>(pair.first), std::move(pair.second)});
+	return res;
+}
+
+template<typename Binner, typename Bin>
+std::vector<StatsBinCount> StringBinner<Binner, Bin>::count_dives(const std::vector<dive *> &dives, bool) const
+{
+	// First, collect a value / counts vector and then produce the final vector
+	// out of that. I wonder if that is permature optimization?
+	using Pair = std::pair<QString, int>;
+	std::vector<Pair> value_bins;
+	for (const dive *d: dives) {
+		for (const QString &s: derived().to_string_list(d)) {
+			if (is_invalid_value(s))
+				continue;
+			increment_count_bin(value_bins, s);
+		}
+	}
+
+	// Now, turn that into our result array with allocated bin objects.
+	std::vector<StatsBinCount> res;
+	res.reserve(value_bins.size());
+	for (const Pair &pair: value_bins)
+		res.push_back({ std::make_unique<Bin>(pair.first), pair.second});
+	return res;
+}
+
+// ============ The date of the dive by year, quarter or month ============
+// (Note that calendar week is defined differently in different parts of the world and therefore omitted for now)
+
+double date_to_double(int year, int month, int day)
+{
+	struct tm tm = { 0 };
+	tm.tm_year = year;
+	tm.tm_mon = month;
+	tm.tm_mday = day;
+	timestamp_t t = utc_mktime(&tm);
+	return t / 86400.0; // Turn seconds since 1970 to days since 1970, if that makes sense...?
+}
+
+struct DateYearBinner : public IntBinner<DateYearBinner, IntBin> {
+	QString name() const override {
+		return StatsTranslations::tr("Yearly");
+	}
+	QString format(const StatsBin &bin) const override {
+		return QString::number(derived_bin(bin).value);
+	}
+	int to_bin_value(const dive *d) const {
+		return utc_year(d->when);
+	}
+	double lowerBoundToFloatBase(int year) const {
+		return date_to_double(year, 0, 0);
+	}
+};
+
+using DateQuarterBin = SimpleBin<year_quarter>;
+
+struct DateQuarterBinner : public SimpleContinuousBinner<DateQuarterBinner, DateQuarterBin> {
+	QString name() const override {
+		return StatsTranslations::tr("Quarterly");
+	}
+	QString format(const StatsBin &bin) const override {
+		year_quarter value = derived_bin(bin).value;
+		return StatsTranslations::tr("%1 Q%2").arg(QString::number(value.first),
+							   QString::number(value.second));
+	}
+	// As histogram axis: show full year for new years and then Q2, Q3, Q4.
+	QString formatLowerBound(const StatsBin &bin) const override {
+		year_quarter value = derived_bin(bin).value;
+		return value.second == 1
+			? QString::number(value.first)
+			: StatsTranslations::tr("Q%1").arg(QString::number(value.second));
+	}
+	double lowerBoundToFloatBase(year_quarter value) const {
+		return date_to_double(value.first, (value.second - 1) * 3, 0);
+	}
+	year_quarter to_bin_value(const dive *d) const {
+		struct tm tm;
+		utc_mkdate(d->when, &tm);
+
+		int year = tm.tm_year;
+		switch (tm.tm_mon) {
+		case 0 ... 2: return { year, 1 };
+		case 3 ... 5: return { year, 2 };
+		case 6 ... 8: return { year, 3 };
+		default:      return { year, 4 };
+		}
+	}
+	void inc(DateQuarterBin &bin) const {
+		if (++bin.value.second > 4) {
+			bin.value.second = 1;
+			++bin.value.first;
+		}
+	}
+};
+
+using DateMonthBin = SimpleBin<year_month>;
+
+struct DateMonthBinner : public SimpleContinuousBinner<DateMonthBinner, DateMonthBin> {
+	QString name() const override {
+		return StatsTranslations::tr("Monthly");
+	}
+	QString format(const StatsBin &bin) const override {
+		year_month value = derived_bin(bin).value;
+		return StatsTranslations::tr("%1 %2").arg(QString(monthname(value.second)),
+							  QString::number(value.first));
+	}
+	double lowerBoundToFloatBase(year_quarter value) const {
+		return date_to_double(value.first, value.second, 0);
+	}
+	year_month to_bin_value(const dive *d) const {
+		struct tm tm;
+		utc_mkdate(d->when, &tm);
+		return { tm.tm_year, tm.tm_mon };
+	}
+	void inc(DateMonthBin &bin) const {
+		if (++bin.value.second > 11) {
+			bin.value.second = 0;
+			++bin.value.first;
+		}
+	}
+};
+
+static DateYearBinner date_year_binner;
+static DateQuarterBinner date_quarter_binner;
+static DateMonthBinner date_month_binner;
+struct DateType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+	QString name() const {
+		return StatsTranslations::tr("Date");
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &date_year_binner, &date_quarter_binner, &date_month_binner };
+	}
+};
+
+// ============ Dive depth, binned in 5, 10, 20 m or 15, 30, 60 ft bins ============
+
+struct DepthBinner : public IntRangeBinner<DepthBinner, IntBin> {
+	bool metric;
+	DepthBinner(int bin_size, bool metric) : IntRangeBinner(bin_size), metric(metric)
+	{
+	}
+	QString name() const override {
+		QLocale loc;
+		return StatsTranslations::tr("in %1 %2 steps").arg(loc.toString(bin_size),
+								   get_depth_unit());
+	}
+	QString unitSymbol() const override {
+		return get_depth_unit();
+	}
+	int to_bin_value(const dive *d) const {
+		return metric ? d->maxdepth.mm / 1000 / bin_size
+			      : lrint(mm_to_feet(d->maxdepth.mm)) / bin_size;
+	}
+};
+
+static DepthBinner meter_binner5(5, true);
+static DepthBinner meter_binner10(10, true);
+static DepthBinner meter_binner20(20, true);
+static DepthBinner feet_binner15(15, false);
+static DepthBinner feet_binner30(30, false);
+static DepthBinner feet_binner60(60, false);
+struct DepthType : public StatsTypeTemplate<StatsType::Type::Numeric> {
+	QString name() const override {
+		return StatsTranslations::tr("Max. Depth");
+	}
+	QString unitSymbol() const override {
+		return get_depth_unit();
+	}
+	int decimals() const override {
+		return 1;
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		if (prefs.units.length == units::METERS)
+			return { &meter_binner5, &meter_binner10, &meter_binner20 };
+		else
+			return { &feet_binner15, &feet_binner30, &feet_binner60 };
+	}
+	double toFloat(const dive *d) const override {
+		return prefs.units.length == units::METERS ? d->maxdepth.mm / 1000.0
+							   : mm_to_feet(d->maxdepth.mm);
+	}
+	std::vector<StatsOperation> supportedOperations() const override {
+		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::Sum };
+	}
+};
+
+// ============ Bottom time, binned in 5, 10, 30 min or 1 h bins ============
+
+struct MinuteBinner : public IntRangeBinner<MinuteBinner, IntBin> {
+	using IntRangeBinner::IntRangeBinner;
+	QString name() const override {
+		return StatsTranslations::tr("in %1 min steps").arg(bin_size);
+	}
+	QString unitSymbol() const override {
+		return StatsTranslations::tr("min");
+	}
+	int to_bin_value(const dive *d) const {
+		return d->duration.seconds / 60 / bin_size;
+	}
+};
+
+struct HourBinner : public IntBinner<HourBinner, IntBin> {
+	QString name() const override {
+		return StatsTranslations::tr("in hours");
+	}
+	QString format(const StatsBin &bin) const override {
+		return QString::number(derived_bin(bin).value);
+	}
+	QString unitSymbol() const override {
+		return StatsTranslations::tr("h");
+	}
+	int to_bin_value(const dive *d) const {
+		return d->duration.seconds / 3600;
+	}
+	double lowerBoundToFloatBase(int hour) const {
+		return static_cast<double>(hour);
+	}
+};
+
+static MinuteBinner minute_binner5(5);
+static MinuteBinner minute_binner10(10);
+static MinuteBinner minute_binner30(30);
+static HourBinner hour_binner;
+struct DurationType : public StatsTypeTemplate<StatsType::Type::Numeric> {
+	QString name() const override {
+		return StatsTranslations::tr("Duration");
+	}
+	QString unitSymbol() const override {
+		return StatsTranslations::tr("min");
+	}
+	int decimals() const override {
+		return 0;
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &minute_binner5, &minute_binner10, &minute_binner30, &hour_binner };
+	}
+	double toFloat(const dive *d) const override {
+		return d->duration.seconds / 60.0;
+	}
+	std::vector<StatsOperation> supportedOperations() const override {
+		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::Sum };
+	}
+};
+
+// ============ SAC, binned in 2, 5, 10 l/min or 0.1, 0.2, 0.4, 0.8 cuft/min bins ============
+
+struct MetricSACBinner : public IntRangeBinner<MetricSACBinner, IntBin> {
+	using IntRangeBinner::IntRangeBinner;
+	QString name() const override {
+		QLocale loc;
+		return StatsTranslations::tr("in %1 %2/min steps").arg(loc.toString(bin_size),
+								       get_volume_unit());
+	}
+	QString unitSymbol() const override {
+		return get_volume_unit() + StatsTranslations::tr("/min");
+	}
+	int to_bin_value(const dive *d) const {
+		if (d->sac <= 0)
+			return invalid_value<int>();
+		return d->sac / 1000 / bin_size;
+	}
+};
+
+// "Imperial" SACs are annoying, since we have to bin to sub-integer precision.
+// We store cuft * 100 as an integer, to avoid troubles with floating point semantics.
+
+struct ImperialSACBinner : public IntBinner<ImperialSACBinner, IntBin> {
+	int bin_size;
+	ImperialSACBinner(double size)
+		: bin_size(lrint(size * 100.0))
+	{
+	}
+	QString name() const override {
+		QLocale loc;
+		return StatsTranslations::tr("in %1 %2/min steps").arg(loc.toString(bin_size / 100.0, 'f', 2),
+								       get_volume_unit());
+	}
+	QString format(const StatsBin &bin) const override {
+		int value = derived_bin(bin).value;
+		QLocale loc;
+		return StatsTranslations::tr("%1–%2").arg(loc.toString((value * bin_size) / 100.0, 'f', 2),
+							  loc.toString(((value + 1) * bin_size) / 100.0, 'f', 2));
+	}
+	QString unitSymbol() const override {
+		return get_volume_unit() + StatsTranslations::tr("/min");
+	}
+	QString formatLowerBound(const StatsBin &bin) const override {
+		int value = derived_bin(bin).value;
+		return QStringLiteral("%L1").arg((value * bin_size) / 100.0, 0, 'f', 2);
+	}
+	double lowerBoundToFloatBase(int value) const {
+		return static_cast<double>((value * bin_size) / 100.0);
+	}
+	int to_bin_value(const dive *d) const {
+		if (d->sac <= 0)
+			return invalid_value<int>();
+		return lrint(ml_to_cuft(d->sac) * 100.0) / bin_size;
+	}
+};
+
+MetricSACBinner metric_sac_binner2(2);
+MetricSACBinner metric_sac_binner5(5);
+MetricSACBinner metric_sac_binner10(10);
+ImperialSACBinner imperial_sac_binner1(0.1);
+ImperialSACBinner imperial_sac_binner2(0.2);
+ImperialSACBinner imperial_sac_binner4(0.4);
+ImperialSACBinner imperial_sac_binner8(0.8);
+
+struct SACType : public StatsTypeTemplate<StatsType::Type::Numeric> {
+	QString name() const override {
+		return StatsTranslations::tr("SAC");
+	}
+	QString unitSymbol() const override {
+		return get_volume_unit() + StatsTranslations::tr("/min");
+	}
+	int decimals() const override {
+		return prefs.units.volume == units::LITER ? 0 : 2;
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		if (prefs.units.volume == units::LITER)
+			return { &metric_sac_binner2, &metric_sac_binner5, &metric_sac_binner10 };
+		else
+			return { &imperial_sac_binner1, &imperial_sac_binner2, &imperial_sac_binner4, &imperial_sac_binner8 };
+	}
+	double toFloat(const dive *d) const override {
+		if (d->sac <= 0)
+			return invalid_value<double>();
+		return prefs.units.volume == units::LITER ? d->sac / 1000.0 :
+							    ml_to_cuft(d->sac);
+	}
+	std::vector<StatsOperation> supportedOperations() const override {
+		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::TimeWeightedAverage };
+	}
+};
+
+// ============ Dive mode ============
+
+struct DiveModeBinner : public SimpleBinner<DiveModeBinner, IntBin> {
+	QString format(const StatsBin &bin) const override {
+		return QString(divemode_text_ui[derived_bin(bin).value]);
+	}
+	int to_bin_value(const dive *d) const {
+		int res = (int)d->dc.divemode;
+		return res >= 0 && res < NUM_DIVEMODE ? res : OC;
+	}
+};
+
+static DiveModeBinner dive_mode_binner;
+struct DiveModeType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+	QString name() const override {
+		return StatsTranslations::tr("Dive mode");
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &dive_mode_binner };
+	}
+};
+
+// ============ Buddy (including dive guides) ============
+
+struct BuddyBinner : public StringBinner<BuddyBinner, StringBin> {
+	std::vector<QString> to_string_list(const dive *d) const {
+		std::vector<QString> dive_people;
+		for (const QString &s: QString(d->buddy).split(",", SKIP_EMPTY))
+			dive_people.push_back(s.trimmed());
+		for (const QString &s: QString(d->divemaster).split(",", SKIP_EMPTY))
+			dive_people.push_back(s.trimmed());
+		return dive_people;
+	}
+};
+
+static BuddyBinner buddy_binner;
+struct BuddyType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+	QString name() const override {
+		return StatsTranslations::tr("Buddies");
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &buddy_binner };
+	}
+};
+
+// ============ Suit  ============
+
+struct SuitBinner : public StringBinner<SuitBinner, StringBin> {
+	std::vector<QString> to_string_list(const dive *d) const {
+		return { QString(d->suit) };
+	}
+};
+
+static SuitBinner suit_binner;
+struct SuitType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+	QString name() const override {
+		return StatsTranslations::tr("Suit type");
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &suit_binner };
+	}
+};
+
+// ============ Location (including trip location)  ============
+
+using LocationBin = SimpleBin<const dive_site *>;
+
+struct LocationBinner : public SimpleBinner<LocationBinner, LocationBin> {
+	QString format(const StatsBin &bin) const override {
+		const dive_site *ds = derived_bin(bin).value;
+		return QString(ds ? ds->name : "-");
+	}
+	const dive_site *to_bin_value(const dive *d) const {
+		return d->dive_site;
+	}
+};
+
+static LocationBinner location_binner;
+struct LocationType : public StatsTypeTemplate<StatsType::Type::Discrete> {
+	QString name() const override {
+		return StatsTranslations::tr("Dive site");
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &location_binner };
+	}
+};
+
+static DateType date_type;
+static DepthType depth_type;
+static DurationType duration_type;
+static SACType sac_type;
+static DiveModeType dive_mode_type;
+static BuddyType buddy_type;
+static SuitType suit_type;
+static LocationType location_type;
+const std::vector<const StatsType *> stats_types = {
+	&date_type, &depth_type, &duration_type, &sac_type, &dive_mode_type, &buddy_type, &suit_type, &location_type
+};
+
+const std::vector<const StatsType *> stats_continuous_types = {
+	&date_type, &depth_type, &duration_type, &sac_type
+};
+
+const std::vector<const StatsType *> stats_numeric_types = {
+	&depth_type, &duration_type, &sac_type
+};

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -304,6 +304,21 @@ double StatsType::applyOperation(const std::vector<dive *> &dives, StatsOperatio
 	}
 }
 
+std::vector<std::pair<double,double>> StatsType::scatter(const StatsType &t2, const std::vector<dive *> &dives) const
+{
+	std::vector<std::pair<double,double>> res;
+	res.reserve(dives.size());
+	for (const dive *d: dives) {
+		double v1 = toFloat(d);
+		double v2 = t2.toFloat(d);
+		if (is_invalid_value(v1) || is_invalid_value(v2))
+			continue;
+		res.emplace_back(v1, v2);
+	}
+	std::sort(res.begin(), res.end());
+	return res;
+}
+
 // Silly template, which spares us defining type() member functions.
 template<StatsType::Type t>
 struct StatsTypeTemplate : public StatsType {

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statstypes.h"
+#include "statstranslations.h"
 #include "core/dive.h"
 #include "core/divemode.h"
 #include "core/divesite.h"

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -844,8 +844,12 @@ struct DateMonthBinner : public SimpleContinuousBinner<DateMonthBinner, DateMont
 	QString name() const override {
 		return StatsTranslations::tr("Monthly");
 	}
-	// Output year for fill years, month otherwise
 	QString format(const StatsBin &bin) const override {
+		year_month value = derived_bin(bin).value;
+		return QString("%1 %2").arg(monthname(value.second), QString::number(value.first));
+	}
+	// In histograms, output year for fill years, month otherwise
+	QString formatLowerBound(const StatsBin &bin) const override {
 		year_month value = derived_bin(bin).value;
 		return value.second == 0 ? QString::number(value.first)
 					 : QString(monthname(value.second));

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -73,6 +73,11 @@ static bool is_invalid_value(const dive_site *d)
 	return !d;
 }
 
+static bool is_invalid_value(const std::vector<StatsValue> &v)
+{
+	return v.empty();
+}
+
 static bool is_invalid_value(const StatsQuartiles &q)
 {
 	return std::isnan(q.min);
@@ -390,6 +395,12 @@ std::vector<StatsBinVal> StatsType::bin_value(const StatsBinner &binner, const s
 {
 	return bin_convert<double>(*this, binner, dives, fill_empty,
 				   [this, op](const std::vector<dive *> &d) { return applyOperation(d, op); });
+}
+
+std::vector<StatsBinValues> StatsType::bin_values(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const
+{
+	return bin_convert<std::vector<StatsValue>>(*this, binner, dives, fill_empty,
+						    [this](const std::vector<dive *> &d) { return values(d); });
 }
 
 // Silly template, which spares us defining type() member functions.

--- a/stats/statstypes.cpp
+++ b/stats/statstypes.cpp
@@ -161,8 +161,8 @@ std::vector<StatsOperation> StatsType::supportedOperations() const
 // Attn: The order must correspond to the StatsOperation enum
 static const char *operation_names[] = {
 	QT_TRANSLATE_NOOP("StatsTranslations", "Median"),
-	QT_TRANSLATE_NOOP("StatsTranslations", "Average"),
-	QT_TRANSLATE_NOOP("StatsTranslations", "Time-weighted Avg."),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Mean"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Time-weighted mean"),
 	QT_TRANSLATE_NOOP("StatsTranslations", "Sum")
 };
 
@@ -193,7 +193,7 @@ QString StatsType::operationName(StatsOperation op)
 								 : operation_names[(int)op];
 }
 
-double StatsType::average(const std::vector<dive *> &dives) const
+double StatsType::mean(const std::vector<dive *> &dives) const
 {
 	double sum = 0.0;
 	double count = 0.0;
@@ -207,7 +207,7 @@ double StatsType::average(const std::vector<dive *> &dives) const
 	return count > 0.0 ? sum / count : 0.0;
 }
 
-double StatsType::averageTimeWeighted(const std::vector<dive *> &dives) const
+double StatsType::meanTimeWeighted(const std::vector<dive *> &dives) const
 {
 	double sum = 0.0;
 	double weight_count = 0.0;
@@ -294,10 +294,10 @@ double StatsType::applyOperation(const std::vector<dive *> &dives, StatsOperatio
 	switch (op) {
 	case StatsOperation::Median:
 		return quartiles(dives).q2;
-	case StatsOperation::Average:
-		return average(dives);
-	case StatsOperation::TimeWeightedAverage:
-		return averageTimeWeighted(dives);
+	case StatsOperation::Mean:
+		return mean(dives);
+	case StatsOperation::TimeWeightedMean:
+		return meanTimeWeighted(dives);
 	case StatsOperation::Sum:
 		return sum(dives);
 	default: return 0.0;
@@ -774,7 +774,7 @@ struct DepthType : public StatsTypeTemplate<StatsType::Type::Numeric> {
 							   : mm_to_feet(d->maxdepth.mm);
 	}
 	std::vector<StatsOperation> supportedOperations() const override {
-		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::Sum };
+		return { StatsOperation::Median, StatsOperation::Mean, StatsOperation::Sum };
 	}
 };
 
@@ -832,7 +832,7 @@ struct DurationType : public StatsTypeTemplate<StatsType::Type::Numeric> {
 		return d->duration.seconds / 60.0;
 	}
 	std::vector<StatsOperation> supportedOperations() const override {
-		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::Sum };
+		return { StatsOperation::Median, StatsOperation::Mean, StatsOperation::Sum };
 	}
 };
 
@@ -923,7 +923,7 @@ struct SACType : public StatsTypeTemplate<StatsType::Type::Numeric> {
 							    ml_to_cuft(d->sac);
 	}
 	std::vector<StatsOperation> supportedOperations() const override {
-		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::TimeWeightedAverage };
+		return { StatsOperation::Median, StatsOperation::Mean, StatsOperation::TimeWeightedMean };
 	}
 };
 
@@ -987,7 +987,7 @@ struct TemperatureType : public StatsTypeTemplate<StatsType::Type::Numeric> {
 		return { &b2, &b5, &b10, &b20 };
 	}
 	std::vector<StatsOperation> supportedOperations() const override {
-		return { StatsOperation::Median, StatsOperation::Average, StatsOperation::TimeWeightedAverage };
+		return { StatsOperation::Median, StatsOperation::Mean, StatsOperation::TimeWeightedMean };
 	}
 };
 

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -101,6 +101,7 @@ struct StatsType {
 	static StatsQuartiles quartiles(const std::vector<double> &values);
 	StatsQuartiles quartiles(const std::vector<dive *> &dives) const;
 	std::vector<double> values(const std::vector<dive *> &dives) const;
+	std::vector<std::pair<double,double>> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
 	double sum(const std::vector<dive *> &dives) const;
 	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
 private:

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -116,10 +116,4 @@ extern const std::vector<const StatsType *> stats_types;
 extern const std::vector<const StatsType *> stats_continuous_types; // includes numeric types
 extern const std::vector<const StatsType *> stats_numeric_types; // types that support averaging, etc
 
-// Dummy object for our translations
-class StatsTranslations : public QObject
-{
-	Q_OBJECT
-};
-
 #endif

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -143,4 +143,7 @@ private:
 
 extern const std::vector<const StatsType *> stats_types;
 
+// Helper function for date-based variables
+extern double date_to_double(int year, int month, int day);
+
 #endif

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -54,6 +54,7 @@ struct StatsBinValue {
 using StatsBinDives = StatsBinValue<std::vector<dive *>>;
 using StatsBinCount = StatsBinValue<int>;
 using StatsBinQuartiles = StatsBinValue<StatsQuartiles>;
+using StatsBinVal = StatsBinValue<double>;
 
 struct StatsBinner {
 	virtual ~StatsBinner();
@@ -91,6 +92,7 @@ struct StatsType {
 	virtual int decimals() const; // For numeric types: numbers of decimals to display on axes. Defaults to 0.
 	virtual std::vector<const StatsBinner *> binners() const = 0; // Note: may depend on current locale!
 	std::vector<StatsBinQuartiles> bin_quartiles(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
+	std::vector<StatsBinVal> bin_value(const StatsBinner &binner, const std::vector<dive *> &dives, StatsOperation op, bool fill_empty) const;
 	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
 	QString nameWithUnit() const;
 	QString nameWithBinnerUnit(const StatsBinner &) const;
@@ -98,16 +100,16 @@ struct StatsType {
 	QStringList supportedOperationNames() const; // Only for numeric types
 	StatsOperation idxToOperation(int idx) const;
 	static QString operationName(StatsOperation);
-	double mean(const std::vector<dive *> &dives) const;
-	double meanTimeWeighted(const std::vector<dive *> &dives) const;
-	static StatsQuartiles quartiles(const std::vector<double> &values);
+	double mean(const std::vector<dive *> &dives) const; // Returns NaN for empty list
+	double meanTimeWeighted(const std::vector<dive *> &dives) const; // Returns NaN for empty list
+	static StatsQuartiles quartiles(const std::vector<double> &values); // Returns invalid quartiles for empty list
 	StatsQuartiles quartiles(const std::vector<dive *> &dives) const;
 	std::vector<double> values(const std::vector<dive *> &dives) const;
 	std::vector<std::pair<double,double>> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
-	double sum(const std::vector<dive *> &dives) const;
-	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
+	double sum(const std::vector<dive *> &dives) const; // Returns 0.0 for empty list
 private:
 	virtual double toFloat(const struct dive *d) const; // For numeric types - if dive doesn't have that value, returns NaN
+	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
 };
 
 extern const std::vector<const StatsType *> stats_types;

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -33,6 +33,7 @@ struct StatsQuartiles {
 	double min;
 	double q1, q2, q3;
 	double max;
+	bool isValid() const;
 };
 
 struct StatsBin {
@@ -52,6 +53,7 @@ struct StatsBinValue {
 };
 using StatsBinDives = StatsBinValue<std::vector<dive *>>;
 using StatsBinCount = StatsBinValue<int>;
+using StatsBinQuartiles = StatsBinValue<StatsQuartiles>;
 
 struct StatsBinner {
 	virtual ~StatsBinner();
@@ -88,6 +90,7 @@ struct StatsType {
 	virtual QString unitSymbol() const; // For numeric types - by default returns empty string
 	virtual int decimals() const; // For numeric types: numbers of decimals to display on axes. Defaults to 0.
 	virtual std::vector<const StatsBinner *> binners() const = 0; // Note: may depend on current locale!
+	std::vector<StatsBinQuartiles> bin_quartiles(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
 	QString nameWithUnit() const;
 	QString nameWithBinnerUnit(const StatsBinner &) const;

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -28,6 +28,13 @@ enum class StatsOperation : int {
 	Sum
 };
 
+// For median and quartiles.
+struct StatsQuartiles {
+	double min;
+	double q1, q2, q3;
+	double max;
+};
+
 struct StatsBin {
 	virtual ~StatsBin();
 	virtual bool operator<(StatsBin &) const = 0;
@@ -91,7 +98,9 @@ struct StatsType {
 	static QString operationName(StatsOperation);
 	double average(const std::vector<dive *> &dives) const;
 	double averageTimeWeighted(const std::vector<dive *> &dives) const;
-	double median(const std::vector<dive *> &dives) const;
+	static StatsQuartiles quartiles(const std::vector<double> &values);
+	StatsQuartiles quartiles(const std::vector<dive *> &dives) const;
+	std::vector<double> values(const std::vector<dive *> &dives) const;
 	double sum(const std::vector<dive *> &dives) const;
 	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
 private:

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -29,6 +29,18 @@ enum class StatsOperation : int {
 	Invalid
 };
 
+// Results of the above operations
+struct StatsOperationResults {
+	int count;
+	double median;
+	double mean;
+	double timeWeightedMean;
+	double sum;
+	StatsOperationResults(); // Initialize to invalid (e.g. no dives)
+	bool isValid() const;
+	double get(StatsOperation op) const;
+};
+
 // For median and quartiles.
 struct StatsQuartiles {
 	double min;
@@ -62,7 +74,7 @@ using StatsBinDives = StatsBinValue<std::vector<dive *>>;
 using StatsBinValues = StatsBinValue<std::vector<StatsValue>>;
 using StatsBinCount = StatsBinValue<int>;
 using StatsBinQuartiles = StatsBinValue<StatsQuartiles>;
-using StatsBinVal = StatsBinValue<double>;
+using StatsBinOp = StatsBinValue<StatsOperationResults>;
 
 struct StatsBinner {
 	virtual ~StatsBinner();
@@ -109,7 +121,7 @@ struct StatsType {
 	virtual std::vector<const StatsBinner *> binners() const = 0; // Note: may depend on current locale!
 	virtual QString diveCategories(const dive *d) const; // Only for discrete types
 	std::vector<StatsBinQuartiles> bin_quartiles(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
-	std::vector<StatsBinVal> bin_value(const StatsBinner &binner, const std::vector<dive *> &dives, StatsOperation op, bool fill_empty) const;
+	std::vector<StatsBinOp> bin_operations(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	std::vector<StatsBinValues> bin_values(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
 	QString nameWithUnit() const;
@@ -119,16 +131,14 @@ struct StatsType {
 	StatsOperation idxToOperation(int idx) const;
 	static QString operationName(StatsOperation);
 	double mean(const std::vector<dive *> &dives) const; // Returns NaN for empty list
-	double meanTimeWeighted(const std::vector<dive *> &dives) const; // Returns NaN for empty list
 	static StatsQuartiles quartiles(const std::vector<StatsValue> &values); // Returns invalid quartiles for empty list
 	StatsQuartiles quartiles(const std::vector<dive *> &dives) const; // Only for numeric types
 	std::vector<StatsValue> values(const std::vector<dive *> &dives) const; // Only for numeric types
 	QString valueWithUnit(const dive *d) const; // Only for numeric types
 	std::vector<StatsScatterItem> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
-	double sum(const std::vector<dive *> &dives) const; // Returns 0.0 for empty list
 private:
 	virtual double toFloat(const struct dive *d) const; // For numeric types - if dive doesn't have that value, returns NaN
-	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
+	StatsOperationResults applyOperations(const std::vector<dive *> &dives) const;
 };
 
 extern const std::vector<const StatsType *> stats_types;

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -44,15 +44,14 @@ struct StatsBin {
 
 using StatsBinPtr = std::unique_ptr<StatsBin>;
 
-struct StatsBinDives {
+// A bin and an arbitrarily associated value, e.g. a count or a list of dives.
+template<typename T>
+struct StatsBinValue {
 	StatsBinPtr bin;
-	std::vector<dive *> dives;
+	T value;
 };
-
-struct StatsBinCount {
-	StatsBinPtr bin;
-	int count;
-};
+using StatsBinDives = StatsBinValue<std::vector<dive *>>;
+using StatsBinCount = StatsBinValue<int>;
 
 struct StatsBinner {
 	virtual ~StatsBinner();

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -45,6 +45,12 @@ struct StatsBin {
 
 using StatsBinPtr = std::unique_ptr<StatsBin>;
 
+// A value and a dive
+struct StatsValue {
+	double v;
+	dive *d;
+};
+
 // A bin and an arbitrarily associated value, e.g. a count or a list of dives.
 template<typename T>
 struct StatsBinValue {
@@ -52,6 +58,7 @@ struct StatsBinValue {
 	T value;
 };
 using StatsBinDives = StatsBinValue<std::vector<dive *>>;
+using StatsBinValues = StatsBinValue<std::vector<StatsValue>>;
 using StatsBinCount = StatsBinValue<int>;
 using StatsBinQuartiles = StatsBinValue<StatsQuartiles>;
 using StatsBinVal = StatsBinValue<double>;
@@ -84,12 +91,6 @@ struct StatsScatterItem {
 	dive *d;
 };
 
-// A value and a dive
-struct StatsValue {
-	double v;
-	dive *d;
-};
-
 struct StatsType {
 	enum class Type {
 		Discrete,
@@ -106,6 +107,7 @@ struct StatsType {
 	virtual QString diveCategories(const dive *d) const; // Only for discrete types
 	std::vector<StatsBinQuartiles> bin_quartiles(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	std::vector<StatsBinVal> bin_value(const StatsBinner &binner, const std::vector<dive *> &dives, StatsOperation op, bool fill_empty) const;
+	std::vector<StatsBinValues> bin_values(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
 	QString nameWithUnit() const;
 	QString nameWithBinnerUnit(const StatsBinner &) const;

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -76,6 +76,7 @@ struct StatsBinner {
 
 	// Note: these functions will crash with an exception if passed incompatible bins!
 	virtual QString format(const StatsBin &bin) const = 0;
+	QString formatWithUnit(const StatsBin &bin) const;
 	virtual QString formatLowerBound(const StatsBin &bin) const; // Only for continuous types
 	virtual QString formatUpperBound(const StatsBin &bin) const; // Only for continuous types
 	virtual double lowerBoundToFloat(const StatsBin &bin) const; // Only for continuous types

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0
+// Types used for the statistic widgets. There are three kinds of types:
+// 1) Discrete types can only adopt discrete values.
+//    Examples are dive-type or dive buddy.
+//    Note that for example dive buddy means that a dive can have
+//    multiple values.
+// 2) Continuous types have a notion of a linear distance and can be
+//    plotted on a linear axis.
+//    An Example is the dive-date.
+// 3) Numeric types are continuous types that support operations
+//    such as averaging.
+// Not every type makes sense in every type of graph.
+#ifndef STATS_TYPES_H
+#define STATS_TYPES_H
+
+#include <vector>
+#include <memory>
+#include <QString>
+#include <QObject>
+
+struct dive;
+
+// Operations that can be performed on numeric types
+enum class StatsOperation : int {
+	Median = 0,
+	Average,
+	TimeWeightedAverage,
+	Sum
+};
+
+struct StatsBin {
+	virtual ~StatsBin();
+	virtual bool operator<(StatsBin &) const = 0;
+	virtual bool operator==(StatsBin &) const = 0;
+	bool operator!=(StatsBin &b) const { return !(*this == b); }
+};
+
+using StatsBinPtr = std::unique_ptr<StatsBin>;
+
+struct StatsBinDives {
+	StatsBinPtr bin;
+	std::vector<dive *> dives;
+};
+
+struct StatsBinCount {
+	StatsBinPtr bin;
+	int count;
+};
+
+struct StatsBinner {
+	virtual ~StatsBinner();
+	virtual QString name() const; // Only needed if there are multiple binners for a type
+	virtual QString unitSymbol() const; // For numeric types - by default returns empty string
+
+	// The binning functions have a parameter "fill_empty". If true, missing
+	// bins in the range will be filled with empty bins. This only works for continuous types.
+	virtual std::vector<StatsBinDives> bin_dives(const std::vector<dive *> &dives, bool fill_empty) const = 0;
+	virtual std::vector<StatsBinCount> count_dives(const std::vector<dive *> &dives, bool fill_empty) const = 0;
+
+	// Note: these functions will crash with an exception if passed incompatible bins!
+	virtual QString format(const StatsBin &bin) const = 0;
+	virtual QString formatLowerBound(const StatsBin &bin) const; // Only for continuous types
+	virtual QString formatUpperBound(const StatsBin &bin) const; // Only for continuous types
+	virtual double lowerBoundToFloat(const StatsBin &bin) const; // Only for continuous types
+	virtual double upperBoundToFloat(const StatsBin &bin) const; // Only for continuous types
+
+	// Only for continuous and numeric types
+	// Note: this will crash with an exception if passed incompatible bins!
+	virtual std::vector<StatsBinPtr> bins_between(const StatsBin &bin1, const StatsBin &bin2) const;
+};
+
+struct StatsType {
+	enum class Type {
+		Discrete,
+		Continuous,
+		Numeric
+	};
+
+	virtual ~StatsType();
+	virtual Type type() const = 0;
+	virtual QString name() const = 0;
+	virtual QString unitSymbol() const; // For numeric types - by default returns empty string
+	virtual int decimals() const; // For numeric types: numbers of decimals to display on axes. Defaults to 0.
+	virtual std::vector<const StatsBinner *> binners() const = 0; // Note: may depend on current locale!
+	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
+	QString nameWithUnit() const;
+	QString nameWithBinnerUnit(const StatsBinner &) const;
+	virtual std::vector<StatsOperation> supportedOperations() const; // Only for numeric types
+	QStringList supportedOperationNames() const; // Only for numeric types
+	StatsOperation idxToOperation(int idx) const;
+	static QString operationName(StatsOperation);
+	double average(const std::vector<dive *> &dives) const;
+	double averageTimeWeighted(const std::vector<dive *> &dives) const;
+	double median(const std::vector<dive *> &dives) const;
+	double sum(const std::vector<dive *> &dives) const;
+	double applyOperation(const std::vector<dive *> &dives, StatsOperation op) const;
+private:
+	virtual double toFloat(const struct dive *d) const; // For numeric types - if dive doesn't have that value, returns NaN
+};
+
+extern const std::vector<const StatsType *> stats_types;
+extern const std::vector<const StatsType *> stats_continuous_types; // includes numeric types
+extern const std::vector<const StatsType *> stats_numeric_types; // types that support averaging, etc
+
+// Dummy object for our translations
+class StatsTranslations : public QObject
+{
+	Q_OBJECT
+};
+
+#endif

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -78,6 +78,12 @@ struct StatsBinner {
 	virtual std::vector<StatsBinPtr> bins_between(const StatsBin &bin1, const StatsBin &bin2) const;
 };
 
+// A scatter item is two values and a dive
+struct StatsScatterItem {
+	double x, y;
+	dive *d;
+};
+
 struct StatsType {
 	enum class Type {
 		Discrete,
@@ -103,9 +109,10 @@ struct StatsType {
 	double mean(const std::vector<dive *> &dives) const; // Returns NaN for empty list
 	double meanTimeWeighted(const std::vector<dive *> &dives) const; // Returns NaN for empty list
 	static StatsQuartiles quartiles(const std::vector<double> &values); // Returns invalid quartiles for empty list
-	StatsQuartiles quartiles(const std::vector<dive *> &dives) const;
-	std::vector<double> values(const std::vector<dive *> &dives) const;
-	std::vector<std::pair<double,double>> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
+	StatsQuartiles quartiles(const std::vector<dive *> &dives) const; // Only for numeric types
+	std::vector<double> values(const std::vector<dive *> &dives) const; // Only for numeric types
+	QString valueWithUnit(const dive *d) const; // Only for numeric types
+	std::vector<StatsScatterItem> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
 	double sum(const std::vector<dive *> &dives) const; // Returns 0.0 for empty list
 private:
 	virtual double toFloat(const struct dive *d) const; // For numeric types - if dive doesn't have that value, returns NaN

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -23,8 +23,8 @@ struct dive;
 // Operations that can be performed on numeric types
 enum class StatsOperation : int {
 	Median = 0,
-	Average,
-	TimeWeightedAverage,
+	Mean,
+	TimeWeightedMean,
 	Sum
 };
 
@@ -96,8 +96,8 @@ struct StatsType {
 	QStringList supportedOperationNames() const; // Only for numeric types
 	StatsOperation idxToOperation(int idx) const;
 	static QString operationName(StatsOperation);
-	double average(const std::vector<dive *> &dives) const;
-	double averageTimeWeighted(const std::vector<dive *> &dives) const;
+	double mean(const std::vector<dive *> &dives) const;
+	double meanTimeWeighted(const std::vector<dive *> &dives) const;
 	static StatsQuartiles quartiles(const std::vector<double> &values);
 	StatsQuartiles quartiles(const std::vector<dive *> &dives) const;
 	std::vector<double> values(const std::vector<dive *> &dives) const;

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -80,6 +80,7 @@ struct StatsBinner {
 	virtual QString formatUpperBound(const StatsBin &bin) const; // Only for continuous types
 	virtual double lowerBoundToFloat(const StatsBin &bin) const; // Only for continuous types
 	virtual double upperBoundToFloat(const StatsBin &bin) const; // Only for continuous types
+	virtual bool preferBin(const StatsBin &bin) const; // Prefer to show this bins tick if bins are omitted. Default to true.
 
 	// Only for continuous and numeric types
 	// Note: this will crash with an exception if passed incompatible bins!

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -84,6 +84,12 @@ struct StatsScatterItem {
 	dive *d;
 };
 
+// A value and a dive
+struct StatsValue {
+	double v;
+	dive *d;
+};
+
 struct StatsType {
 	enum class Type {
 		Discrete,
@@ -97,6 +103,7 @@ struct StatsType {
 	virtual QString unitSymbol() const; // For numeric types - by default returns empty string
 	virtual int decimals() const; // For numeric types: numbers of decimals to display on axes. Defaults to 0.
 	virtual std::vector<const StatsBinner *> binners() const = 0; // Note: may depend on current locale!
+	virtual QString diveCategories(const dive *d) const; // Only for discrete types
 	std::vector<StatsBinQuartiles> bin_quartiles(const StatsBinner &binner, const std::vector<dive *> &dives, bool fill_empty) const;
 	std::vector<StatsBinVal> bin_value(const StatsBinner &binner, const std::vector<dive *> &dives, StatsOperation op, bool fill_empty) const;
 	const StatsBinner *getBinner(int idx) const; // Handles out of bounds gracefully (returns first binner)
@@ -108,9 +115,9 @@ struct StatsType {
 	static QString operationName(StatsOperation);
 	double mean(const std::vector<dive *> &dives) const; // Returns NaN for empty list
 	double meanTimeWeighted(const std::vector<dive *> &dives) const; // Returns NaN for empty list
-	static StatsQuartiles quartiles(const std::vector<double> &values); // Returns invalid quartiles for empty list
+	static StatsQuartiles quartiles(const std::vector<StatsValue> &values); // Returns invalid quartiles for empty list
 	StatsQuartiles quartiles(const std::vector<dive *> &dives) const; // Only for numeric types
-	std::vector<double> values(const std::vector<dive *> &dives) const; // Only for numeric types
+	std::vector<StatsValue> values(const std::vector<dive *> &dives) const; // Only for numeric types
 	QString valueWithUnit(const dive *d) const; // Only for numeric types
 	std::vector<StatsScatterItem> scatter(const StatsType &t2, const std::vector<dive *> &dives) const;
 	double sum(const std::vector<dive *> &dives) const; // Returns 0.0 for empty list

--- a/stats/statstypes.h
+++ b/stats/statstypes.h
@@ -25,7 +25,8 @@ enum class StatsOperation : int {
 	Median = 0,
 	Mean,
 	TimeWeightedMean,
-	Sum
+	Sum,
+	Invalid
 };
 
 // For median and quartiles.
@@ -129,7 +130,5 @@ private:
 };
 
 extern const std::vector<const StatsType *> stats_types;
-extern const std::vector<const StatsType *> stats_continuous_types; // includes numeric types
-extern const std::vector<const StatsType *> stats_numeric_types; // types that support averaging, etc
 
 #endif

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statsview.h"
+#include <QQuickItem>
+#include <QChart>
+#include <QBarSet>
+#include <QBarSeries>
+#include <QBarCategoryAxis>
+#include <QValueAxis>
+
+static const QUrl urlStatsView = QUrl(QStringLiteral("qrc:/qml/statsview.qml"));
+
+StatsView::StatsView(QWidget *parent) : QQuickWidget(parent)
+{
+	setResizeMode(QQuickWidget::SizeRootObjectToView);
+	setSource(urlStatsView);
+}
+
+StatsView::~StatsView()
+{
+}
+
+// Convenience templates that turn a series-type into a series-id.
+// TODO: Qt should provide that, no? Let's inspect the docs more closely...
+template<typename Series> constexpr int series_type_id();
+template<> constexpr int series_type_id<QtCharts::QBarSeries>()
+{ return QtCharts::QAbstractSeries::SeriesTypeBar; }
+
+// Helper function to add a series to a QML ChartView.
+// Sadly, accessing QML from C++ is maliciously cumbersome.
+template<typename Type>
+Type *StatsView::addSeries(const QString &name, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis)
+{
+	QtCharts::QAbstractSeries *abstract_series = addSeriesHelper(name, series_type_id<Type>(), xAxis, yAxis);
+	Type *res = qobject_cast<Type *>(abstract_series);
+	if (!res)
+		qWarning("Couldn't cast abstract series to %s", typeid(Type).name());
+
+	return res;
+}
+
+QtCharts::QAbstractSeries *StatsView::addSeriesHelper(const QString &name, int type, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis)
+{
+	using QtCharts::QAbstractSeries;
+	using QtCharts::QAbstractAxis;
+
+	QQuickItem *chart = rootObject();
+	QAbstractSeries *abstract_series;
+	if (!QMetaObject::invokeMethod(chart, "createSeries", Qt::AutoConnection,
+				       Q_RETURN_ARG(QAbstractSeries *, abstract_series),
+				       Q_ARG(int, type),
+				       Q_ARG(QString, name),
+				       Q_ARG(QAbstractAxis *, xAxis),
+				       Q_ARG(QAbstractAxis *, yAxis))) {
+		qWarning("Couldn't call createSeries()");
+		return nullptr;
+	}
+
+	return abstract_series;
+}
+
+template <typename T>
+T *StatsView::makeAxis()
+{
+	T *res = new T;
+	axes.emplace_back(res);
+	return res;
+}
+
+void StatsView::reset()
+{
+	QQuickItem *chart = rootObject();
+	QMetaObject::invokeMethod(chart, "removeAllSeries", Qt::AutoConnection);
+	axes.clear();
+}
+
+void StatsView::plot()
+{
+	reset();
+}

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -966,6 +966,7 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 	QScatterSeries *quartileSeries = addSeries<QScatterSeries>(valueType->name());
 	quartileSeries->setMarkerShape(QScatterSeries::MarkerShapeRectangle);
 	quartileSeries->setColor(Qt::red);
+	series->setBorderColor(Qt::blue);
 
 	double x = 0.0;
 	for (const std::vector<double> &array: values) {
@@ -1359,6 +1360,8 @@ void StatsView::plotScatter(const std::vector<dive *> &dives, const StatsType *c
 
 	addAxes(axisX, axisY);
 	QScatterSeries *series = addSeries<QScatterSeries>(valueType->name());
+	series->setMarkerSize(10);
+	series->setBorderColor(Qt::blue);
 
 	for (auto [x, y]: points)
 		series->append(x, y);

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -985,7 +985,7 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 
 	setTitle(valueType->name());
 
-	std::vector<StatsBinDives> categoryBins = categoryBinner->bin_dives(dives, false);
+	std::vector<StatsBinValues> categoryBins = valueType->bin_values(*categoryBinner, dives, false);
 
 	// If there is nothing to display, quit
 	if (categoryBins.empty())
@@ -994,12 +994,7 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 	QBarCategoryAxis *catAxis = createCategoryAxis(*categoryBinner, categoryBins);
 	catAxis->setTitleText(categoryType->nameWithBinnerUnit(*categoryBinner));
 
-	std::vector<std::vector<StatsValue>> values;
-	values.reserve(categoryBins.size());
-	for (const auto &[dummy, dives]: categoryBins)
-		values.push_back(valueType->values(dives));
-
-	auto [minValue, maxValue] = getMinMaxValue(values);
+	auto [minValue, maxValue] = getMinMaxValue(categoryBins);
 
 	QValueAxis *valAxis = createValueAxis(minValue, maxValue, valueType->decimals(), false);
 	valAxis->setTitleText(valueType->nameWithUnit());
@@ -1008,7 +1003,7 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 	ScatterSeries *series = addScatterSeries(valueType->name(), *categoryType, *valueType);
 
 	double x = 0.0;
-	for (const std::vector<StatsValue> &array: values) {
+	for (const auto &[bin, array]: categoryBins) {
 		for (auto [v, d]: array)
 			series->append(d, x, v);
 		StatsQuartiles quartiles = StatsType::quartiles(array);

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -12,6 +12,7 @@
 #include <QHorizontalBarSeries>
 #include <QHorizontalStackedBarSeries>
 #include <QLineSeries>
+#include <QLocale>
 #include <QPieSeries>
 #include <QScatterSeries>
 #include <QStackedBarSeries>
@@ -695,10 +696,20 @@ void StatsView::plotDiscreteCountChart(const std::vector<dive *> &dives,
 	if (categoryBins.empty())
 		return;
 
+	int total = 0;
+	for (const auto &[bin, count]: categoryBins)
+		total += count;
+
 	if (subType == ChartSubType::Pie) {
 		QPieSeries *series = addSeries<QtCharts::QPieSeries>(categoryType->name(), nullptr, nullptr);
+		QLocale loc;
 		for (auto const &[bin, count]: categoryBins) {
-			QPieSlice *slice = new QPieSlice(categoryBinner->format(*bin), count);
+			double percentage = count * 100.0 / total;
+			QString label = QString("%1 (%2: %3\%)").arg(
+						categoryBinner->format(*bin),
+						loc.toString(count),
+						loc.toString(percentage, 'f', 1));
+			QPieSlice *slice = new QPieSlice(label, count);
 			slice->setLabelVisible(true);
 			series->append(slice);
 		}

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -29,6 +29,7 @@ static constexpr size_t array_size(const T (&)[N])
 
 // Constants that control the graph layouts
 static const double histogramBarWidth = 0.8; // 1.0 = full width of category
+static const QColor barColor(0x66, 0xb2, 0xff);
 
 enum class ChartSubType {
 	Vertical = 0,
@@ -691,6 +692,7 @@ void StatsView::plotValueChart(const std::vector<dive *> &dives,
 	}
 
 	QBarSet *set = new QBarSet(QString());
+	set->setColor(barColor);
 	double pos = 0.0;
 	for (double value: values) {
 		*set << value;
@@ -716,7 +718,7 @@ static std::vector<QString> makePercentageLabels(int count, int total, bool isHo
 {
 	double percentage = count * 100.0 / total;
 	QString countString = QString("%L1").arg(count);
-	QString percentageString = QString("(%L1%)").arg(percentage, 0, 'f', 1);
+	QString percentageString = QString("%L1%").arg(percentage, 0, 'f', 1);
 	if (isHorizontal)
 		return { QString("%1 %2").arg(countString, percentageString) };
 	else
@@ -828,6 +830,8 @@ void StatsView::plotDiscreteCountChart(const std::vector<dive *> &dives,
 			return;
 
 		QBarSet *set = new QBarSet(QString());
+		set->setColor(barColor);
+
 		double pos = 0.0;
 		for (auto const &[bin, count]: categoryBins) {
 			*set << count;
@@ -1033,7 +1037,7 @@ void StatsView::addBar(double lowerBound, double upperBound, double height, bool
 	using QtCharts::QAreaSeries;
 	using QtCharts::QLineSeries;
 
-	QBrush brush(Qt::blue);
+	QBrush brush("#66B2FF");
 	QPen pen(Qt::white);
 
 	QAreaSeries *series = addSeries<QAreaSeries>(QString());

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -652,8 +652,6 @@ void StatsView::plotValueChart(const std::vector<dive *> &dives,
 			       const StatsType *categoryType, const StatsBinner *categoryBinner,
 			       const StatsType *valueType, StatsOperation valueAxisOperation)
 {
-	using QtCharts::QBarSet;
-	using QtCharts::QAbstractBarSeries;
 	using QtCharts::QBarCategoryAxis;
 	using QtCharts::QValueAxis;
 
@@ -682,25 +680,17 @@ void StatsView::plotValueChart(const std::vector<dive *> &dives,
 	QValueAxis *valAxis = createValueAxis(0.0, maxValue, valueType->decimals(), isHorizontal);
 	valAxis->setTitleText(valueType->nameWithUnit());
 
-	QAbstractBarSeries *series;
-	if (isHorizontal) {
+	if (isHorizontal)
 		addAxes(valAxis, catAxis);
-		series = addSeries<QtCharts::QHorizontalBarSeries>(valueType->name());
-	} else {
+	else
 		addAxes(catAxis, valAxis);
-		series = addSeries<QtCharts::QBarSeries>(valueType->name());
-	}
 
-	QBarSet *set = new QBarSet(QString());
-	set->setColor(barColor);
 	double pos = 0.0;
 	for (double value: values) {
-		*set << value;
 		std::vector<QString> label = { QString("%L1").arg(value, 0, 'f', decimals) };
-		barLabels.emplace_back(label, pos, value, isHorizontal, series);
+		addBar(pos - 0.5, pos + 0.5, value, isHorizontal, label);
 		pos += 1.0;
 	}
-	series->append(set);
 
 	hideLegend();
 }
@@ -750,9 +740,7 @@ void StatsView::plotDiscreteCountChart(const std::vector<dive *> &dives,
 				      ChartSubType subType,
 				      const StatsType *categoryType, const StatsBinner *categoryBinner)
 {
-	using QtCharts::QAbstractBarSeries;
 	using QtCharts::QBarCategoryAxis;
-	using QtCharts::QBarSet;
 	using QtCharts::QPieSeries;
 	using QtCharts::QPieSlice;
 	using QtCharts::QValueAxis;
@@ -818,29 +806,18 @@ void StatsView::plotDiscreteCountChart(const std::vector<dive *> &dives,
 		int maxCount = getMaxCount(categoryBins);
 		QValueAxis *valAxis = createCountAxis(maxCount, isHorizontal);
 
-		QAbstractBarSeries *series;
-		if (isHorizontal) {
+		if (isHorizontal)
 			addAxes(valAxis, catAxis);
-			series = addSeries<QtCharts::QHorizontalBarSeries>(categoryType->name());
-		} else {
+		else
 			addAxes(catAxis, valAxis);
-			series = addSeries<QtCharts::QBarSeries>(categoryType->name());
-		}
-		if (!series)
-			return;
-
-		QBarSet *set = new QBarSet(QString());
-		set->setColor(barColor);
 
 		double pos = 0.0;
 		for (auto const &[bin, count]: categoryBins) {
-			*set << count;
 			std::vector<QString> label = makePercentageLabels(count, total, isHorizontal);
-			barLabels.emplace_back(label, pos, count, isHorizontal, series);
+			addBar(pos - 0.5, pos + 0.5, (double)count, isHorizontal, label);
 			pos += 1.0;
 		}
 
-		series->append(set);
 		hideLegend();
 	}
 }

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -785,7 +785,7 @@ void StatsView::plotHistogramCountChart(const std::vector<dive *> &dives,
 
 	if (categoryType->type() == StatsType::Type::Numeric) {
 		double average = categoryType->average(dives);
-		double median = categoryType->median(dives);
+		double median = categoryType->quartiles(dives).q2;
 		QPen averagePen(Qt::green);
 		averagePen.setWidth(2);
 		QPen medianPen(Qt::black);

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -1368,6 +1368,9 @@ void StatsView::plotScatter(const std::vector<dive *> &dives, const StatsType *c
 	QScatterSeries *series = addSeries<QScatterSeries>(valueType->name());
 	series->setMarkerSize(10);
 	series->setBorderColor(Qt::blue);
+	QPen dotpen(Qt::blue);
+	dotpen.setWidth(0);
+	series->setPen(dotpen);
 
 	for (auto [x, y]: points)
 		series->append(x, y);

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -965,11 +965,14 @@ void StatsView::addLineMarker(double pos, double low, double high, const QPen &p
 }
 
 
-void StatsView::addBar(double lowerBound, double upperBound, double height, const QBrush &brush, const QPen &pen, bool isHorizontal,
+void StatsView::addBar(double lowerBound, double upperBound, double height, bool isHorizontal,
 		       const std::vector<QString> &label)
 {
 	using QtCharts::QAreaSeries;
 	using QtCharts::QLineSeries;
+
+	QBrush brush(Qt::blue);
+	QPen pen(Qt::white);
 
 	QAreaSeries *series = addSeries<QAreaSeries>(QString());
 	QLineSeries *lower = new QLineSeries;
@@ -1159,7 +1162,7 @@ void StatsView::plotHistogramCountChart(const std::vector<dive *> &dives,
 		double upperBound = categoryBinner->upperBoundToFloat(*bin);
 		std::vector<QString> label = makePercentageLabels(count, total, isHorizontal);
 
-		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::white), isHorizontal, label);
+		addBar(lowerBound, upperBound, height, isHorizontal, label);
 	}
 
 	if (categoryType->type() == StatsType::Type::Numeric) {
@@ -1224,7 +1227,7 @@ void StatsView::plotHistogramBarChart(const std::vector<dive *> &dives,
 		double lowerBound = categoryBinner->lowerBoundToFloat(*bin);
 		double upperBound = categoryBinner->upperBoundToFloat(*bin);
 		QString label = QString("%L1").arg(height, 0, 'f', decimals);
-		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::white), isHorizontal, {label});
+		addBar(lowerBound, upperBound, height, isHorizontal, {label});
 	}
 
 	hideLegend();

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -967,6 +967,8 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 	quartileSeries->setMarkerShape(QScatterSeries::MarkerShapeRectangle);
 	quartileSeries->setColor(Qt::red);
 	series->setBorderColor(Qt::blue);
+	series->setMarkerSize(10);
+	quartileSeries->setMarkerSize(10);
 
 	double x = 0.0;
 	for (const std::vector<double> &array: values) {

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -770,17 +770,17 @@ void StatsView::plotDiscreteCountChart(const std::vector<dive *> &dives,
 		const int min_slices = 10; // Try to draw at least 10 slices.
 		std::sort(categoryBins.begin(), categoryBins.end(),
 			  [](const StatsBinCount &item1, const StatsBinCount &item2)
-			  { return item1.count > item2.count; }); // Note: reverse sort.
+			  { return item1.value > item2.value; }); // Note: reverse sort.
 		auto it = std::find_if(categoryBins.begin(), categoryBins.end(),
 				       [total, smallest_slice_percentage](const StatsBinCount &item)
-				       { return item.count * 100 / total < smallest_slice_percentage; });
+				       { return item.value * 100 / total < smallest_slice_percentage; });
 		if (it - categoryBins.begin() < min_slices)
 			it = categoryBins.begin() + std::min(min_slices, (int)categoryBins.size());
 
 		// Sum counts of "other" bins.
 		int otherCount = 0;
 		for (auto it2 = it; it2 != categoryBins.end(); ++it2)
-			otherCount += it2->count;
+			otherCount += it2->value;
 
 		categoryBins.erase(it, categoryBins.end()); // Delete "other" bins
 

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -985,7 +985,7 @@ void StatsView::plotHistogramCountChart(const std::vector<dive *> &dives,
 		double height = count;
 		double lowerBound = categoryBinner->lowerBoundToFloat(*bin);
 		double upperBound = categoryBinner->upperBoundToFloat(*bin);
-		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::red), xAxis, yAxis, isHorizontal);
+		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::white), xAxis, yAxis, isHorizontal);
 	}
 
 	if (categoryType->type() == StatsType::Type::Numeric) {
@@ -993,7 +993,7 @@ void StatsView::plotHistogramCountChart(const std::vector<dive *> &dives,
 		double median = categoryType->quartiles(dives).q2;
 		QPen averagePen(Qt::green);
 		averagePen.setWidth(2);
-		QPen medianPen(Qt::black);
+		QPen medianPen(Qt::red);
 		medianPen.setWidth(2);
 		addLineMarker(average, 0.0, chartHeight, averagePen, xAxis, yAxis, isHorizontal);
 		addLineMarker(median, 0.0, chartHeight, medianPen, xAxis, yAxis, isHorizontal);
@@ -1046,7 +1046,7 @@ void StatsView::plotHistogramBarChart(const std::vector<dive *> &dives,
 		double height = values[i++];
 		double lowerBound = categoryBinner->lowerBoundToFloat(*bin);
 		double upperBound = categoryBinner->upperBoundToFloat(*bin);
-		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::red), xAxis, yAxis, isHorizontal);
+		addBar(lowerBound, upperBound, height, QBrush(Qt::blue), QPen(Qt::white), xAxis, yAxis, isHorizontal);
 	}
 
 	hideLegend();

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -85,7 +85,7 @@ static const struct ChartType {
 		ChartTypeId::DiscreteValue,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Discrete value"),
 		stats_types,		// supports all types as first axis
-		stats_numeric_types,	// supports numeric types as second axis, since we want to average, etc
+		stats_numeric_types,	// supports numeric types as second axis, since we want to calculate the mean, etc
 		true,
 		false,
 		false,
@@ -118,7 +118,7 @@ static const struct ChartType {
 		ChartTypeId::DiscreteScatter,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Discrete scatter"),
 		stats_types,	// supports all types as first axis
-		stats_numeric_types,	// supports numeric types as second axis, since we want to average, etc
+		stats_numeric_types,	// supports numeric types as second axis, since we want to calculate the mean, etc
 		true,
 		false,
 		false,
@@ -140,7 +140,7 @@ static const struct ChartType {
 		ChartTypeId::HistogramBar,
 		QT_TRANSLATE_NOOP("StatsTranslations", "Histogram bar"),
 		stats_continuous_types,	// supports continuous types as first axis
-		stats_numeric_types,	// supports numeric types as second axis, since we want to average, etc
+		stats_numeric_types,	// supports numeric types as second axis, since we want to calculate the mean, etc
 		true,
 		false,
 		false,
@@ -1163,13 +1163,13 @@ void StatsView::plotHistogramCountChart(const std::vector<dive *> &dives,
 	}
 
 	if (categoryType->type() == StatsType::Type::Numeric) {
-		double average = categoryType->average(dives);
+		double mean = categoryType->mean(dives);
 		double median = categoryType->quartiles(dives).q2;
-		QPen averagePen(Qt::green);
-		averagePen.setWidth(2);
+		QPen meanPen(Qt::green);
+		meanPen.setWidth(2);
 		QPen medianPen(Qt::red);
 		medianPen.setWidth(2);
-		addLineMarker(average, 0.0, chartHeight, averagePen, isHorizontal);
+		addLineMarker(mean, 0.0, chartHeight, meanPen, isHorizontal);
 		addLineMarker(median, 0.0, chartHeight, medianPen, isHorizontal);
 	}
 

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsview.h"
+#include "statstranslations.h"
 #include "statstypes.h"
 #include "scatterseries.h"
 #include "core/divefilter.h"

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -1,11 +1,177 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsview.h"
+#include "statstypes.h"
+#include "core/divefilter.h"
 #include <QQuickItem>
 #include <QChart>
 #include <QBarSet>
 #include <QBarSeries>
+#include <QStackedBarSeries>
+#include <QHorizontalBarSeries>
+#include <QHorizontalStackedBarSeries>
 #include <QBarCategoryAxis>
 #include <QValueAxis>
+
+// Some of our compilers do not support std::size(). Roll our own for now.
+template <typename T, size_t N>
+static constexpr size_t array_size(const T (&)[N])
+{
+	return N;
+}
+
+enum class ChartSubType {
+	Vertical = 0,
+	VerticalStacked,
+	Horizontal,
+	HorizontalStacked
+};
+
+// Attn: The order must correspond to the enum above
+static const char *chart_subtype_names[] = {
+	QT_TRANSLATE_NOOP("StatsTranslations", "Vertical"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Vertical stacked"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal"),
+	QT_TRANSLATE_NOOP("StatsTranslations", "Horizontal stacked")
+};
+
+enum class ChartTypeId {
+	DiscreteBar
+};
+
+static const struct ChartType {
+	ChartTypeId id;
+	const char *name;
+	const std::vector<const StatsType *> &firstAxisTypes;
+	const std::vector<const StatsType *> &secondAxisTypes;
+	bool firstAxisBinned;
+	bool secondAxisBinned;
+	const std::vector<ChartSubType> subtypes;
+} chart_types[] = {
+	{
+		ChartTypeId::DiscreteBar,
+		QT_TRANSLATE_NOOP("StatsTranslations", "Discrete Bar"),
+		stats_types,	// supports all types as first axis
+		stats_types,	// supports all types as second axis
+		true,
+		true,
+		{ ChartSubType::Vertical, ChartSubType::VerticalStacked, ChartSubType::Horizontal, ChartSubType::HorizontalStacked }
+	}
+};
+
+// returns null on out-of-bound
+static const ChartType *idxToChartType(int idx)
+{
+	return idx < 0 || idx >= (int)array_size(chart_types) ?
+		nullptr : &chart_types[idx];
+}
+
+// returns null on out-of-bound
+static const StatsType *idxToFirstAxisType(int chartType, int firstAxis)
+{
+	const ChartType *t = idxToChartType(chartType);
+	return !t || firstAxis < 0 || firstAxis >= (int)t->firstAxisTypes.size() ?
+		nullptr : t->firstAxisTypes[firstAxis];
+}
+
+QStringList StatsView::getChartTypes()
+{
+	QStringList res;
+	res.reserve(array_size(chart_types));
+	for (const ChartType &t: chart_types)
+		res.push_back(StatsTranslations::tr(t.name));
+	return res;
+}
+
+QStringList StatsView::getChartSubTypes(int chartType)
+{
+	const ChartType *t = idxToChartType(chartType);
+	if (!t)
+		return {};
+
+	QStringList res;
+	res.reserve(t->subtypes.size());
+	for (ChartSubType subtype: t->subtypes)
+		res.push_back(StatsTranslations::tr(chart_subtype_names[(int)subtype]));
+	return res;
+}
+
+QStringList StatsView::getFirstAxisTypes(int chartType)
+{
+	const ChartType *t = idxToChartType(chartType);
+	if (!t)
+		return {};
+
+	QStringList res;
+	res.reserve(t->firstAxisTypes.size());
+	for (const StatsType *type: t->firstAxisTypes)
+		res.push_back(type->name());
+	return res;
+}
+
+static QStringList statsTypeToBinnerNames(const StatsType *t)
+{
+	if (!t)
+		return {};
+	std::vector<const StatsBinner *> binners = t->binners();
+	QStringList res;
+	res.reserve(binners.size());
+	for (const StatsBinner *binner: binners)
+		res.push_back(binner->name());
+	return res;
+}
+
+QStringList StatsView::getFirstAxisBins(int chartType, int firstAxis)
+{
+	const ChartType *t = idxToChartType(chartType);
+	if (!t || !t->firstAxisBinned)
+		return {};
+	return statsTypeToBinnerNames(idxToFirstAxisType(chartType, firstAxis));
+}
+
+// Getting the second axis is a bit special: it removes the first axis
+// from the list, as plotting the same value against itself makes no sense.
+static std::vector<const StatsType *> calcSecondAxisTypes(int chartType, int firstAxis)
+{
+	const ChartType *t = idxToChartType(chartType);
+	const StatsType *first = idxToFirstAxisType(chartType, firstAxis);
+	if (!t || !first)
+		return {};
+	const std::vector<const StatsType *> &types = t->secondAxisTypes;
+	std::vector<const StatsType *> res;
+	res.reserve(types.size());
+	for (const StatsType *t: types) {
+		if (t != first)
+			res.push_back(t);
+	}
+	return res;
+}
+
+// returns null on out-of-bound
+static const StatsType *idxToSecondAxisType(int chartType, int firstAxis, int secondAxis)
+{
+	std::vector<const StatsType *> secondAxisTypes = calcSecondAxisTypes(chartType, firstAxis);
+	return secondAxis < 0 || secondAxis >= (int)secondAxisTypes.size() ?
+		nullptr : secondAxisTypes[secondAxis];
+}
+
+QStringList StatsView::getSecondAxisTypes(int chartType, int firstAxis)
+{
+	std::vector<const StatsType *> types = calcSecondAxisTypes(chartType, firstAxis);
+	QStringList res;
+	res.reserve(types.size());
+	for (const StatsType *t: types)
+		res.push_back(t->name());
+
+	return res;
+}
+
+QStringList StatsView::getSecondAxisBins(int chartType, int firstAxis, int secondAxis)
+{
+	const ChartType *t = idxToChartType(chartType);
+	if (!t || !t->secondAxisBinned)
+		return {};
+	return statsTypeToBinnerNames(idxToSecondAxisType(chartType, firstAxis, secondAxis));
+}
 
 static const QUrl urlStatsView = QUrl(QStringLiteral("qrc:/qml/statsview.qml"));
 
@@ -24,6 +190,12 @@ StatsView::~StatsView()
 template<typename Series> constexpr int series_type_id();
 template<> constexpr int series_type_id<QtCharts::QBarSeries>()
 { return QtCharts::QAbstractSeries::SeriesTypeBar; }
+template<> constexpr int series_type_id<QtCharts::QStackedBarSeries>()
+{ return QtCharts::QAbstractSeries::SeriesTypeStackedBar; }
+template<> constexpr int series_type_id<QtCharts::QHorizontalBarSeries>()
+{ return QtCharts::QAbstractSeries::SeriesTypeHorizontalBar; }
+template<> constexpr int series_type_id<QtCharts::QHorizontalStackedBarSeries>()
+{ return QtCharts::QAbstractSeries::SeriesTypeHorizontalStackedBar; }
 
 // Helper function to add a series to a QML ChartView.
 // Sadly, accessing QML from C++ is maliciously cumbersome.
@@ -58,6 +230,26 @@ QtCharts::QAbstractSeries *StatsView::addSeriesHelper(const QString &name, int t
 	return abstract_series;
 }
 
+void StatsView::showLegend()
+{
+	using QtCharts::QLegend;
+	QQuickItem *chart = rootObject();
+	QVariant v = chart->property("legend");
+	QLegend *legend = v.value<QLegend *>();
+	if (!legend) {
+		qWarning("Couldn't get legend");
+		return;
+	}
+	legend->setVisible(true);
+	legend->setAlignment(Qt::AlignBottom);
+}
+
+void StatsView::setTitle(const QString &s)
+{
+	QQuickItem *chart = rootObject();
+	chart->setProperty("title", s);
+}
+
 template <typename T>
 T *StatsView::makeAxis()
 {
@@ -73,7 +265,119 @@ void StatsView::reset()
 	axes.clear();
 }
 
-void StatsView::plot()
+void StatsView::plot(int type, int subTypeIdx, int firstAxis, int firstAxisBin, int secondAxis, int secondAxisBin)
 {
 	reset();
+
+	const ChartType *t = idxToChartType(type);
+	const StatsType *firstAxisType = idxToFirstAxisType(type, firstAxis);
+	const StatsType *secondAxisType = idxToSecondAxisType(type, firstAxis, secondAxis);
+	if (!t || !firstAxisType || !secondAxisType)
+		return;
+
+	ChartSubType subType = subTypeIdx >= 0 && subTypeIdx < (int)t->subtypes.size() ?
+		t->subtypes[subTypeIdx] : ChartSubType::Vertical;
+	const StatsBinner *firstAxisBinner = t->firstAxisBinned ? firstAxisType->getBinner(firstAxisBin) : nullptr;
+	const StatsBinner *secondAxisBinner = t->secondAxisBinned ? secondAxisType->getBinner(secondAxisBin) : nullptr;
+
+	const std::vector<dive *> dives = DiveFilter::instance()->visibleDives();
+	switch (t->id) {
+	case ChartTypeId::DiscreteBar:
+		return plotBarChart(dives, subType, firstAxisType, firstAxisBinner, secondAxisType, secondAxisBinner);
+	default:
+		qWarning("Unknown chart type");
+		return;
+	}
+}
+
+void StatsView::plotBarChart(const std::vector<dive *> &dives,
+			     ChartSubType subType,
+			     const StatsType *categoryType, const StatsBinner *categoryBinner,
+			     const StatsType *valueType, const StatsBinner *valueBinner)
+{
+	using QtCharts::QBarSet;
+	using QtCharts::QAbstractBarSeries;
+	using QtCharts::QBarCategoryAxis;
+	using QtCharts::QValueAxis;
+
+	if (!categoryBinner || !valueBinner)
+		return;
+
+	setTitle(valueType->name());
+
+	QStringList categoryNames;
+	std::vector<StatsBinDives> categoryBins = categoryBinner->bin_dives(dives);
+
+	// The problem here is that for different dive sets of the category
+	// bins, we might get different value bins. So we have to keep track
+	// of our counts and adjust accordingly. That's a bit annoying.
+	// Perhaps we should determine the bins of all dives first and then
+	// query the counts for precisely those bins?
+	using BinCountsPair = std::pair<StatsBinPtr, std::vector<int>>;
+	std::vector<BinCountsPair> vbin_counts;
+	int catBinNr = 0;
+	int maxCount = 0;
+	int maxCategoryCount = 0;
+	for (const auto &[bin, dives]: categoryBins) {
+		categoryNames.push_back(bin->format());
+
+		int categoryCount = 0;
+		for (auto &[vbin, count]: valueBinner->count_dives(dives)) {
+			// Note: we assume that the bins are sorted!
+			auto it = std::lower_bound(vbin_counts.begin(), vbin_counts.end(), vbin,
+						   [] (const BinCountsPair &p, const StatsBinPtr &bin)
+						   { return *p.first < *bin; });
+			if (it == vbin_counts.end() || *it->first != *vbin) {
+				// Add a new value bin.
+				// Attn: this invalidate "vbin", which must not be used henceforth!
+				it = vbin_counts.insert(it, { std::move(vbin), std::vector<int>(categoryBins.size()) });
+			}
+			it->second[catBinNr] = count;
+			categoryCount += count;
+			if (count > maxCount)
+				maxCount = count;
+		}
+		if (categoryCount > maxCategoryCount)
+			maxCategoryCount = categoryCount;
+		++catBinNr;
+	}
+
+	bool isStacked = subType == ChartSubType::VerticalStacked || subType == ChartSubType::HorizontalStacked;
+
+	QBarCategoryAxis *catAxis = makeAxis<QBarCategoryAxis>();
+	catAxis->append(categoryNames);
+	catAxis->setTitleText(categoryType->name());
+
+	QValueAxis *valAxis = makeAxis<QValueAxis>();
+	valAxis->setRange(0, isStacked ? maxCategoryCount : maxCount);
+	valAxis->setLabelFormat(QStringLiteral("%d"));
+	valAxis->setTitleText(tr("No. dives"));
+
+	QAbstractBarSeries *series;
+	switch (subType) {
+	default:
+	case ChartSubType::Vertical:
+		series = addSeries<QtCharts::QBarSeries>(valueType->name(), catAxis, valAxis);
+		break;
+	case ChartSubType::VerticalStacked:
+		series = addSeries<QtCharts::QStackedBarSeries>(valueType->name(), catAxis, valAxis);
+		break;
+	case ChartSubType::Horizontal:
+		series = addSeries<QtCharts::QHorizontalBarSeries>(valueType->name(), valAxis, catAxis);
+		break;
+	case ChartSubType::HorizontalStacked:
+		series = addSeries<QtCharts::QHorizontalStackedBarSeries>(valueType->name(), valAxis, catAxis);
+		break;
+	}
+	if (!series)
+		return;
+
+	for (auto &[vbin, counts]: vbin_counts) {
+		QBarSet *set = new QBarSet(vbin->format());
+		for (int count: counts)
+			*set << count;
+		series->append(set);
+	}
+
+	showLegend();
 }

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -351,7 +351,7 @@ void StatsView::plotBarChart(const std::vector<dive *> &dives,
 	}
 
 	bool isStacked = subType == ChartSubType::VerticalStacked || subType == ChartSubType::HorizontalStacked;
-	bool isHorizontal = subType == ChartSubType::Horizontal || subType == ChartSubType::HorizontalStacked;
+	bool isHorizontal = subType == ChartSubType::HorizontalGrouped || subType == ChartSubType::HorizontalStacked;
 
 	CategoryAxis *catAxis = createCategoryAxis(categoryType->nameWithBinnerUnit(*categoryBinner),
 						   *categoryBinner, categoryBins, !isHorizontal);
@@ -366,13 +366,13 @@ void StatsView::plotBarChart(const std::vector<dive *> &dives,
 	QAbstractBarSeries *series;
 	switch (subType) {
 	default:
-	case ChartSubType::Vertical:
+	case ChartSubType::VerticalGrouped:
 		series = addSeries<QtCharts::QBarSeries>(valueType->name());
 		break;
 	case ChartSubType::VerticalStacked:
 		series = addSeries<QtCharts::QStackedBarSeries>(valueType->name());
 		break;
-	case ChartSubType::Horizontal:
+	case ChartSubType::HorizontalGrouped:
 		series = addSeries<QtCharts::QHorizontalBarSeries>(valueType->name());
 		break;
 	case ChartSubType::HorizontalStacked:

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -270,7 +270,7 @@ void StatsView::plot(const StatsState &stateIn)
 	case ChartType::DiscreteBox:
 		return plotDiscreteBoxChart(dives, state.var1, state.var1Binner, state.var2);
 	case ChartType::DiscreteScatter:
-		return plotDiscreteScatter(dives, state.var1, state.var1Binner, state.var2);
+		return plotDiscreteScatter(dives, state.var1, state.var1Binner, state.var2, state.quartiles);
 	case ChartType::HistogramCount:
 		return plotHistogramCountChart(dives, state.subtype, state.var1, state.var1Binner,
 					       state.labels, state.median, state.mean);
@@ -696,7 +696,7 @@ void StatsView::plotDiscreteBoxChart(const std::vector<dive *> &dives,
 
 void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner,
-				    const StatsType *valueType)
+				    const StatsType *valueType, bool quartiles)
 {
 	if (!categoryBinner)
 		return;
@@ -724,11 +724,13 @@ void StatsView::plotDiscreteScatter(const std::vector<dive *> &dives,
 	for (const auto &[bin, array]: categoryBins) {
 		for (auto [v, d]: array)
 			series->append(d, x, v);
-		StatsQuartiles quartiles = StatsType::quartiles(array);
-		if (quartiles.isValid()) {
-			quartileMarkers.emplace_back(x, quartiles.q1, series);
-			quartileMarkers.emplace_back(x, quartiles.q2, series);
-			quartileMarkers.emplace_back(x, quartiles.q3, series);
+		if (quartiles) {
+			StatsQuartiles quartiles = StatsType::quartiles(array);
+			if (quartiles.isValid()) {
+				quartileMarkers.emplace_back(x, quartiles.q1, series);
+				quartileMarkers.emplace_back(x, quartiles.q2, series);
+				quartileMarkers.emplace_back(x, quartiles.q3, series);
+			}
 		}
 		x += 1.0;
 	}

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -19,7 +19,10 @@ namespace QtCharts {
 	class QLegend;
 	class QValueAxis;
 }
+class QGraphicsLineItem;
+class QGraphicsPixmapItem;
 class QGraphicsSimpleTextItem;
+class ScatterSeries;
 
 enum class ChartSubType : int;
 enum class StatsOperation : int;
@@ -82,6 +85,7 @@ private:
 
 	template <typename T>
 	T *addSeries(const QString &name);
+	ScatterSeries *addScatterSeries(const QString &name);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
@@ -109,9 +113,20 @@ private:
 		void updatePosition();
 	};
 
+	// A short line used to mark quartiles
+	struct QuartileMarker {
+		std::unique_ptr<QGraphicsLineItem> item;
+		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
+		double pos, value;
+		QuartileMarker(double pos, double value, QtCharts::QAbstractSeries *series);
+		void updatePosition();
+	};
+
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
 	std::vector<BarLabel> barLabels;
+	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
+	std::vector<QuartileMarker> quartileMarkers;
 };
 
 #endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -94,7 +94,7 @@ private:
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
-	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen, bool isHorizontal,
+	void addBar(double from, double to, double height, bool isHorizontal,
 		    const std::vector<QString> &label);
 
 	// A label that is composed of multiple lines

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -8,11 +8,15 @@
 struct dive;
 struct StatsType;
 struct StatsBinner;
+struct StatsBin;
 
 namespace QtCharts {
 	class QAbstractAxis;
 	class QAbstractSeries;
+	class QBarCategoryAxis;
+	class QCategoryAxis;
 	class QLegend;
+	class QValueAxis;
 }
 
 enum class ChartSubType : int;
@@ -51,13 +55,17 @@ private:
 	void plotDiscreteCountChart(const std::vector<dive *> &dives,
 				    ChartSubType subType,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner);
+	void plotDiscreteScatter(const std::vector<dive *> &dives,
+				 const StatsType *categoryType, const StatsBinner *categoryBinner,
+				 const StatsType *valueType);
 	void plotHistogramCountChart(const std::vector<dive *> &dives,
 				     ChartSubType subType,
 				     const StatsType *categoryType, const StatsBinner *categoryBinner);
-	void plotHistogramChart(const std::vector<dive *> &dives,
-				ChartSubType subType,
-				const StatsType *categoryType, const StatsBinner *categoryBinner,
-				const StatsType *valueType, StatsOperation valueAxisOperation);
+	void plotHistogramBarChart(const std::vector<dive *> &dives,
+				   ChartSubType subType,
+				   const StatsType *categoryType, const StatsBinner *categoryBinner,
+				   const StatsType *valueType, StatsOperation valueAxisOperation);
+	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
 	void setTitle(const QString &);
 	QtCharts::QLegend *getLegend();
 	void showLegend();
@@ -69,6 +77,14 @@ private:
 	template <typename T>
 	T *addSeries(const QString &name, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
 	QtCharts::QAbstractSeries *addSeriesHelper(const QString &name, int type, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
+
+	template<typename T>
+	QtCharts::QBarCategoryAxis *createCategoryAxis(const StatsBinner &binner, const std::vector<T> &bins);
+	template<typename T>
+	QtCharts::QCategoryAxis *createHistogramAxis(const StatsBinner &binner,
+						     const std::vector<T> &bins,
+						     bool isHorizontal);
+	QtCharts::QValueAxis *createValueAxis(double min, double max, int decimals, bool isHorizontal);
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen,

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -19,6 +19,7 @@ namespace QtCharts {
 	class QLegend;
 	class QValueAxis;
 }
+class QGraphicsSimpleTextItem;
 
 enum class ChartSubType : int;
 enum class StatsOperation : int;
@@ -43,6 +44,8 @@ public:
 	static QStringList getSecondAxisTypes(int chartType, int firstAxis);
 	static QStringList getSecondAxisBins(int chartType, int firstAxis, int secondAxis);
 	static QStringList getSecondAxisOperations(int chartType, int firstAxis, int secondAxis);
+private slots:
+	void plotAreaChanged(const QRectF &plotArea);
 private:
 	void reset(); // clears all series and axes
 	void addAxes(QtCharts::QAbstractAxis *x, QtCharts::QAbstractAxis *y); // Add new x- and y-axis
@@ -91,10 +94,23 @@ private:
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
-	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen, bool isHorizontal);
+	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen, bool isHorizontal,
+		    const std::vector<QString> &label);
+
+	// A label that is composed of multiple lines
+	struct BarLabel {
+		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
+		double value, height; // Position and size of bar in graph
+		double totalWidth, totalHeight; // Size of the item
+		bool isHorizontal;
+		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
+		BarLabel(const std::vector<QString> &labels, double value, double height, bool isHorizontal, QtCharts::QAbstractSeries *series);
+		void updatePosition();
+	};
 
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
+	std::vector<BarLabel> barLabels;
 };
 
 #endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -12,9 +12,11 @@ struct StatsBinner;
 namespace QtCharts {
 	class QAbstractAxis;
 	class QAbstractSeries;
+	class QLegend;
 }
 
 enum class ChartSubType : int;
+enum class StatsOperation : int;
 
 class StatsView : public QQuickWidget {
 	Q_OBJECT
@@ -23,23 +25,43 @@ public:
 	~StatsView();
 
 	// Integers are indexes of the combobox entries retrieved with the functions below
-	void plot(int type, int subType, int firstAxis, int firstAxisBin, int secondAxis, int secondAxisBin);
+	void plot(int type, int subType,
+		  int firstAxis, int firstAxisBin, int firstAxisOperation,
+		  int secondAxis, int secondAxisBin, int secondAxisOperation);
 
 	// Functions to construct the UI comboboxes
 	static QStringList getChartTypes();
 	static QStringList getChartSubTypes(int chartType);
 	static QStringList getFirstAxisTypes(int chartType);
 	static QStringList getFirstAxisBins(int chartType, int firstAxis);
+	static QStringList getFirstAxisOperations(int chartType, int secondAxis);
 	static QStringList getSecondAxisTypes(int chartType, int firstAxis);
 	static QStringList getSecondAxisBins(int chartType, int firstAxis, int secondAxis);
+	static QStringList getSecondAxisOperations(int chartType, int firstAxis, int secondAxis);
 private:
 	void reset(); // clears all series and axes
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsType *categoryType, const StatsBinner *categoryBinner,
 			  const StatsType *valueType, const StatsBinner *valueBinner);
+	void plotValueChart(const std::vector<dive *> &dives,
+			    ChartSubType subType,
+			    const StatsType *categoryType, const StatsBinner *categoryBinner,
+			    const StatsType *valueType, StatsOperation valueAxisOperation);
+	void plotDiscreteCountChart(const std::vector<dive *> &dives,
+				    ChartSubType subType,
+				    const StatsType *categoryType, const StatsBinner *categoryBinner);
+	void plotHistogramCountChart(const std::vector<dive *> &dives,
+				     ChartSubType subType,
+				     const StatsType *categoryType, const StatsBinner *categoryBinner);
+	void plotHistogramChart(const std::vector<dive *> &dives,
+				ChartSubType subType,
+				const StatsType *categoryType, const StatsBinner *categoryBinner,
+				const StatsType *valueType, StatsOperation valueAxisOperation);
 	void setTitle(const QString &);
+	QtCharts::QLegend *getLegend();
 	void showLegend();
+	void hideLegend();
 
 	template <typename T>
 	T *makeAxis();
@@ -47,6 +69,13 @@ private:
 	template <typename T>
 	T *addSeries(const QString &name, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
 	QtCharts::QAbstractSeries *addSeriesHelper(const QString &name, int type, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
+
+	// Helper functions to add feature to the chart
+	void addLineMarker(double pos, double low, double high, const QPen &pen,
+			   QtCharts::QAbstractAxis *axisX, QtCharts::QAbstractAxis *axisY,
+			   bool isHorizontal);
+	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen,
+		    QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis, bool isHorizontal);
 
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
 };

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -15,6 +15,7 @@ namespace QtCharts {
 	class QAbstractSeries;
 	class QBarCategoryAxis;
 	class QCategoryAxis;
+	class QChart;
 	class QLegend;
 	class QValueAxis;
 }
@@ -44,6 +45,7 @@ public:
 	static QStringList getSecondAxisOperations(int chartType, int firstAxis, int secondAxis);
 private:
 	void reset(); // clears all series and axes
+	void addAxes(QtCharts::QAbstractAxis *x, QtCharts::QAbstractAxis *y); // Add new x- and y-axis
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsType *categoryType, const StatsBinner *categoryBinner,
@@ -67,7 +69,6 @@ private:
 				   const StatsType *valueType, StatsOperation valueAxisOperation);
 	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
 	void setTitle(const QString &);
-	QtCharts::QLegend *getLegend();
 	void showLegend();
 	void hideLegend();
 
@@ -75,8 +76,8 @@ private:
 	T *makeAxis();
 
 	template <typename T>
-	T *addSeries(const QString &name, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
-	QtCharts::QAbstractSeries *addSeriesHelper(const QString &name, int type, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
+	T *addSeries(const QString &name);
+	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
 	QtCharts::QBarCategoryAxis *createCategoryAxis(const StatsBinner &binner, const std::vector<T> &bins);
@@ -87,12 +88,10 @@ private:
 	QtCharts::QValueAxis *createValueAxis(double min, double max, int decimals, bool isHorizontal);
 
 	// Helper functions to add feature to the chart
-	void addLineMarker(double pos, double low, double high, const QPen &pen,
-			   QtCharts::QAbstractAxis *axisX, QtCharts::QAbstractAxis *axisY,
-			   bool isHorizontal);
-	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen,
-		    QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis, bool isHorizontal);
+	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
+	void addBar(double from, double to, double height, const QBrush &brush, const QPen &pen, bool isHorizontal);
 
+	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
 };
 

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -85,7 +85,7 @@ private:
 
 	template <typename T>
 	T *addSeries(const QString &name);
-	ScatterSeries *addScatterSeries(const QString &name);
+	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -57,6 +57,8 @@ private:
 	void plotDiscreteCountChart(const std::vector<dive *> &dives,
 				    ChartSubType subType,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner);
+	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
+				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,
 				 const StatsType *categoryType, const StatsBinner *categoryBinner,
 				 const StatsType *valueType);

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -91,6 +91,7 @@ private:
 						     const std::vector<T> &bins,
 						     bool isHorizontal);
 	QtCharts::QValueAxis *createValueAxis(double min, double max, int decimals, bool isHorizontal);
+	QtCharts::QValueAxis *createCountAxis(int count, bool isHorizontal);
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -5,19 +5,41 @@
 #include <memory>
 #include <QQuickWidget>
 
+struct dive;
+struct StatsType;
+struct StatsBinner;
+
 namespace QtCharts {
 	class QAbstractAxis;
 	class QAbstractSeries;
 }
+
+enum class ChartSubType : int;
 
 class StatsView : public QQuickWidget {
 	Q_OBJECT
 public:
 	StatsView(QWidget *parent = NULL);
 	~StatsView();
-	void plot();
+
+	// Integers are indexes of the combobox entries retrieved with the functions below
+	void plot(int type, int subType, int firstAxis, int firstAxisBin, int secondAxis, int secondAxisBin);
+
+	// Functions to construct the UI comboboxes
+	static QStringList getChartTypes();
+	static QStringList getChartSubTypes(int chartType);
+	static QStringList getFirstAxisTypes(int chartType);
+	static QStringList getFirstAxisBins(int chartType, int firstAxis);
+	static QStringList getSecondAxisTypes(int chartType, int firstAxis);
+	static QStringList getSecondAxisBins(int chartType, int firstAxis, int secondAxis);
 private:
 	void reset(); // clears all series and axes
+	void plotBarChart(const std::vector<dive *> &dives,
+			  ChartSubType subType,
+			  const StatsType *categoryType, const StatsBinner *categoryBinner,
+			  const StatsType *valueType, const StatsBinner *valueBinner);
+	void setTitle(const QString &);
+	void showLegend();
 
 	template <typename T>
 	T *makeAxis();

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -127,6 +127,19 @@ private:
 	std::vector<BarLabel> barLabels;
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
 	std::vector<QuartileMarker> quartileMarkers;
+	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
+
+	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
+	// Therefore, we have to listen to hover events using an events-filter.
+	// Probably we should try to get rid of the QML ChartView.
+	struct EventFilter : public QObject {
+		StatsView *view;
+		EventFilter(StatsView *view) : view(view) {}
+	private:
+		bool eventFilter(QObject *o, QEvent *event);
+	} eventFilter;
+	friend EventFilter;
+	void hover(QPointF pos);
 };
 
 #endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef STATS_VIEW_H
+#define STATS_VIEW_H
+
+#include <memory>
+#include <QQuickWidget>
+
+namespace QtCharts {
+	class QAbstractAxis;
+	class QAbstractSeries;
+}
+
+class StatsView : public QQuickWidget {
+	Q_OBJECT
+public:
+	StatsView(QWidget *parent = NULL);
+	~StatsView();
+	void plot();
+private:
+	void reset(); // clears all series and axes
+
+	template <typename T>
+	T *makeAxis();
+
+	template <typename T>
+	T *addSeries(const QString &name, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
+	QtCharts::QAbstractSeries *addSeriesHelper(const QString &name, int type, QtCharts::QAbstractAxis *xAxis, QtCharts::QAbstractAxis *yAxis);
+
+	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
+};
+
+#endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -23,6 +23,7 @@ namespace QtCharts {
 class QGraphicsLineItem;
 class QGraphicsPixmapItem;
 class QGraphicsSimpleTextItem;
+class BarSeries;
 class ScatterSeries;
 
 enum class ChartSubType : int;
@@ -75,6 +76,7 @@ private:
 	template <typename T>
 	T *addSeries(const QString &name);
 	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
+	BarSeries *addBarSeries(const QString &name, bool horizontal);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
@@ -88,19 +90,6 @@ private:
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
-	void addBar(double from, double to, double height, bool isHorizontal,
-		    const std::vector<QString> &label);
-
-	// A label that is composed of multiple lines
-	struct BarLabel {
-		std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> items;
-		double value, height; // Position and size of bar in graph
-		double totalWidth, totalHeight; // Size of the item
-		bool isHorizontal;
-		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
-		BarLabel(const std::vector<QString> &labels, double value, double height, bool isHorizontal, QtCharts::QAbstractSeries *series);
-		void updatePosition();
-	};
 
 	// A short line used to mark quartiles
 	struct QuartileMarker {
@@ -113,10 +102,11 @@ private:
 
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
-	std::vector<BarLabel> barLabels;
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
+	std::vector<std::unique_ptr<BarSeries>> barSeries;
 	std::vector<QuartileMarker> quartileMarkers;
 	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
+	BarSeries *highlightedBarSeries;		// bar series with highlighted element
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
 	// Therefore, we have to listen to hover events using an events-filter.

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -24,6 +24,7 @@ class QGraphicsLineItem;
 class QGraphicsPixmapItem;
 class QGraphicsSimpleTextItem;
 class BarSeries;
+class BoxSeries;
 class ScatterSeries;
 
 enum class ChartSubType : int;
@@ -79,6 +80,7 @@ private:
 	T *addSeries(const QString &name);
 	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
 	BarSeries *addBarSeries(const QString &name, bool horizontal);
+	BoxSeries *addBoxSeries(const QString &name, const QString &unit, int decimals);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
@@ -106,9 +108,11 @@ private:
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
 	std::vector<std::unique_ptr<BarSeries>> barSeries;
+	std::vector<std::unique_ptr<BoxSeries>> boxSeries;
 	std::vector<QuartileMarker> quartileMarkers;
 	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
 	BarSeries *highlightedBarSeries;		// bar series with highlighted element
+	BoxSeries *highlightedBoxSeries;		// box series with highlighted element
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
 	// Therefore, we have to listen to hover events using an events-filter.
@@ -121,6 +125,9 @@ private:
 	} eventFilter;
 	friend EventFilter;
 	void hover(QPointF pos);
+	// Generic code to handle the highlighting of a series element
+	template<typename Series>
+	void handleHover(const std::vector<std::unique_ptr<Series>> &series, Series *&highlighted, QPointF pos);
 };
 
 #endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -13,15 +13,16 @@ struct StatsState;
 struct StatsType;
 
 namespace QtCharts {
-	class QAbstractAxis;
 	class QAbstractSeries;
-	class QBarCategoryAxis;
 	class QChart;
 }
 class QGraphicsLineItem;
 class BarSeries;
 class BoxSeries;
 class ScatterSeries;
+class CategoryAxis;
+class CountAxis;
+class HistogramAxis;
 class StatsAxis;
 
 enum class ChartSubType : int;
@@ -39,7 +40,7 @@ private slots:
 	void replotIfVisible();
 private:
 	void reset(); // clears all series and axes
-	void addAxes(QtCharts::QAbstractAxis *x, QtCharts::QAbstractAxis *y); // Add new x- and y-axis
+	void addAxes(StatsAxis *x, StatsAxis *y); // Add new x- and y-axis
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsType *categoryType, const StatsBinner *categoryBinner,
@@ -74,7 +75,7 @@ private:
 	void hideLegend();
 
 	template <typename T, class... Args>
-	T *createAxis(Args&&... args);
+	T *createAxis(const QString &title, Args&&... args);
 
 	template <typename T>
 	T *addSeries(const QString &name);
@@ -85,11 +86,12 @@ private:
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
-	QtCharts::QBarCategoryAxis *createCategoryAxis(const StatsBinner &binner, const std::vector<T> &bins, bool isHorizontal);
+	CategoryAxis *createCategoryAxis(const QString &title, const StatsBinner &binner,
+					 const std::vector<T> &bins, bool isHorizontal);
 	template<typename T>
-	QtCharts::QAbstractAxis *createHistogramAxis(const StatsBinner &binner,
-						     const std::vector<T> &bins,
-						     bool isHorizontal);
+	HistogramAxis *createHistogramAxis(const QString &title, const StatsBinner &binner,
+					   const std::vector<T> &bins, bool isHorizontal);
+	CountAxis *createCountAxis(int maxVal, bool isHorizontal);
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -9,6 +9,7 @@ struct dive;
 struct StatsType;
 struct StatsBinner;
 struct StatsBin;
+struct StatsState;
 
 namespace QtCharts {
 	class QAbstractAxis;
@@ -33,20 +34,7 @@ public:
 	StatsView(QWidget *parent = NULL);
 	~StatsView();
 
-	// Integers are indexes of the combobox entries retrieved with the functions below
-	void plot(int type, int subType,
-		  int firstAxis, int firstAxisBin, int firstAxisOperation,
-		  int secondAxis, int secondAxisBin, int secondAxisOperation);
-
-	// Functions to construct the UI comboboxes
-	static QStringList getChartTypes();
-	static QStringList getChartSubTypes(int chartType);
-	static QStringList getFirstAxisTypes(int chartType);
-	static QStringList getFirstAxisBins(int chartType, int firstAxis);
-	static QStringList getFirstAxisOperations(int chartType, int secondAxis);
-	static QStringList getSecondAxisTypes(int chartType, int firstAxis);
-	static QStringList getSecondAxisBins(int chartType, int firstAxis, int secondAxis);
-	static QStringList getSecondAxisOperations(int chartType, int firstAxis, int secondAxis);
+	void plot(const StatsState &state);
 private slots:
 	void plotAreaChanged(const QRectF &plotArea);
 private:
@@ -70,7 +58,8 @@ private:
 				 const StatsType *valueType);
 	void plotHistogramCountChart(const std::vector<dive *> &dives,
 				     ChartSubType subType,
-				     const StatsType *categoryType, const StatsBinner *categoryBinner);
+				     const StatsType *categoryType, const StatsBinner *categoryBinner,
+				     bool showMedian, bool showMean);
 	void plotHistogramBarChart(const std::vector<dive *> &dives,
 				   ChartSubType subType,
 				   const StatsType *categoryType, const StatsBinner *categoryBinner,

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -24,6 +24,7 @@ class CategoryAxis;
 class CountAxis;
 class HistogramAxis;
 class StatsAxis;
+class Legend;
 
 enum class ChartSubType : int;
 enum class StatsOperation : int;
@@ -44,7 +45,7 @@ private:
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsType *categoryType, const StatsBinner *categoryBinner,
-			  const StatsType *valueType, const StatsBinner *valueBinner, bool labels);
+			  const StatsType *valueType, const StatsBinner *valueBinner, bool labels, bool legend);
 	void plotValueChart(const std::vector<dive *> &dives,
 			    ChartSubType subType,
 			    const StatsType *categoryType, const StatsBinner *categoryBinner,
@@ -53,7 +54,7 @@ private:
 				    ChartSubType subType,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner, bool labels);
 	void plotPieChart(const std::vector<dive *> &dives,
-			  const StatsType *categoryType, const StatsBinner *categoryBinner);
+			  const StatsType *categoryType, const StatsBinner *categoryBinner, bool legend);
 	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
 				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,
@@ -70,13 +71,11 @@ private:
 	void plotHistogramStackedChart(const std::vector<dive *> &dives,
 				       ChartSubType subType,
 				       const StatsType *categoryType, const StatsBinner *categoryBinner,
-				       const StatsType *valueType, const StatsBinner *valueBinner, bool labels);
+				       const StatsType *valueType, const StatsBinner *valueBinner, bool labels, bool legend);
 	void plotHistogramBoxChart(const std::vector<dive *> &dives,
 				   const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
 	void setTitle(const QString &);
-	void showLegend();
-	void hideLegend();
 
 	template <typename T, class... Args>
 	T *createAxis(const QString &title, Args&&... args);
@@ -116,6 +115,7 @@ private:
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
 	std::vector<std::unique_ptr<BarSeries>> barSeries;
 	std::vector<std::unique_ptr<BoxSeries>> boxSeries;
+	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
 	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
 	BarSeries *highlightedBarSeries;		// bar series with highlighted element

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -19,6 +19,7 @@ namespace QtCharts {
 class QGraphicsLineItem;
 class BarSeries;
 class BoxSeries;
+class PieSeries;
 class ScatterSeries;
 class CategoryAxis;
 class CountAxis;
@@ -54,7 +55,7 @@ private:
 				    ChartSubType subType,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner, bool labels);
 	void plotPieChart(const std::vector<dive *> &dives,
-			  const StatsType *categoryType, const StatsBinner *categoryBinner, bool legend);
+			  const StatsType *categoryType, const StatsBinner *categoryBinner, bool labels, bool legend);
 	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
 				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,
@@ -87,6 +88,7 @@ private:
 				const QString &categoryName, const StatsType *valueType,
 				std::vector<QString> valueBinNames);
 	BoxSeries *addBoxSeries(const QString &name, const QString &unit, int decimals);
+	PieSeries *addPieSeries(const QString &name, const std::vector<std::pair<QString, int>> &data, bool keepOrder, bool labels);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
@@ -127,12 +129,14 @@ private:
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
 	std::vector<std::unique_ptr<BarSeries>> barSeries;
 	std::vector<std::unique_ptr<BoxSeries>> boxSeries;
+	std::vector<std::unique_ptr<PieSeries>> pieSeries;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
 	std::vector<LineMarker> lineMarkers;
 	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
 	BarSeries *highlightedBarSeries;		// bar series with highlighted element
 	BoxSeries *highlightedBoxSeries;		// box series with highlighted element
+	PieSeries *highlightedPieSeries;		// pie series with highlighted element
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
 	// Therefore, we have to listen to hover events using an events-filter.

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -47,10 +47,10 @@ private:
 	void plotValueChart(const std::vector<dive *> &dives,
 			    ChartSubType subType,
 			    const StatsType *categoryType, const StatsBinner *categoryBinner,
-			    const StatsType *valueType, StatsOperation valueAxisOperation);
+			    const StatsType *valueType, StatsOperation valueAxisOperation, bool labels);
 	void plotDiscreteCountChart(const std::vector<dive *> &dives,
 				    ChartSubType subType,
-				    const StatsType *categoryType, const StatsBinner *categoryBinner);
+				    const StatsType *categoryType, const StatsBinner *categoryBinner, bool labels);
 	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
 				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,
@@ -59,11 +59,11 @@ private:
 	void plotHistogramCountChart(const std::vector<dive *> &dives,
 				     ChartSubType subType,
 				     const StatsType *categoryType, const StatsBinner *categoryBinner,
-				     bool showMedian, bool showMean);
+				     bool labels, bool showMedian, bool showMean);
 	void plotHistogramBarChart(const std::vector<dive *> &dives,
 				   ChartSubType subType,
 				   const StatsType *categoryType, const StatsBinner *categoryBinner,
-				   const StatsType *valueType, StatsOperation valueAxisOperation);
+				   const StatsType *valueType, StatsOperation valueAxisOperation, bool labels);
 	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
 	void setTitle(const QString &);
 	void showLegend();

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -68,6 +68,8 @@ private:
 				   ChartSubType subType,
 				   const StatsType *categoryType, const StatsBinner *categoryBinner,
 				   const StatsType *valueType, StatsOperation valueAxisOperation, bool labels);
+	void plotHistogramBoxChart(const std::vector<dive *> &dives,
+				   const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
 	void setTitle(const QString &);
 	void showLegend();

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -109,6 +109,18 @@ private:
 		void updatePosition();
 	};
 
+	// A general line marker
+	struct LineMarker {
+		std::unique_ptr<QGraphicsLineItem> item;
+		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
+		QPointF from, to; // In local coordinates
+		void updatePosition();
+		LineMarker(QPointF from, QPointF to, QPen pen, QtCharts::QAbstractSeries *series);
+	};
+
+	void addLinearRegression(double a, double b, double minX, double maxX, QtCharts::QAbstractSeries *series);
+	void addHistogramMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal, QtCharts::QAbstractSeries *series);
+
 	StatsState state;
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<StatsAxis>> axes;
@@ -117,6 +129,7 @@ private:
 	std::vector<std::unique_ptr<BoxSeries>> boxSeries;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
+	std::vector<LineMarker> lineMarkers;
 	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
 	BarSeries *highlightedBarSeries;		// bar series with highlighted element
 	BoxSeries *highlightedBoxSeries;		// box series with highlighted element

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -7,26 +7,22 @@
 #include <QQuickWidget>
 
 struct dive;
-struct StatsType;
 struct StatsBinner;
 struct StatsBin;
 struct StatsState;
+struct StatsType;
 
 namespace QtCharts {
 	class QAbstractAxis;
 	class QAbstractSeries;
 	class QBarCategoryAxis;
-	class QCategoryAxis;
 	class QChart;
-	class QLegend;
-	class QValueAxis;
 }
 class QGraphicsLineItem;
-class QGraphicsPixmapItem;
-class QGraphicsSimpleTextItem;
 class BarSeries;
 class BoxSeries;
 class ScatterSeries;
+class StatsAxis;
 
 enum class ChartSubType : int;
 enum class StatsOperation : int;
@@ -77,8 +73,8 @@ private:
 	void showLegend();
 	void hideLegend();
 
-	template <typename T>
-	T *makeAxis();
+	template <typename T, class... Args>
+	T *createAxis(Args&&... args);
 
 	template <typename T>
 	T *addSeries(const QString &name);
@@ -89,15 +85,11 @@ private:
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 
 	template<typename T>
-	QtCharts::QBarCategoryAxis *createCategoryAxis(const StatsBinner &binner, const std::vector<T> &bins);
+	QtCharts::QBarCategoryAxis *createCategoryAxis(const StatsBinner &binner, const std::vector<T> &bins, bool isHorizontal);
 	template<typename T>
-	QtCharts::QCategoryAxis *createHistogramAxis(const StatsBinner &binner,
+	QtCharts::QAbstractAxis *createHistogramAxis(const StatsBinner &binner,
 						     const std::vector<T> &bins,
 						     bool isHorizontal);
-	QtCharts::QValueAxis *createValueAxis(double min, double max, int decimals, bool isHorizontal);
-	QtCharts::QValueAxis *createCountAxis(int count, bool isHorizontal);
-	void initHistogramAxis(QtCharts::QCategoryAxis *axis, const std::vector<std::tuple<QString, double, bool>> &labels, bool isHorizontal) const;
-	int guessNumTicks(const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings, bool isHorizontal) const;
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
@@ -113,7 +105,7 @@ private:
 
 	StatsState state;
 	QtCharts::QChart *chart;
-	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
+	std::vector<std::unique_ptr<StatsAxis>> axes;
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
 	std::vector<std::unique_ptr<BarSeries>> barSeries;
 	std::vector<std::unique_ptr<BoxSeries>> boxSeries;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -2,6 +2,7 @@
 #ifndef STATS_VIEW_H
 #define STATS_VIEW_H
 
+#include "statsstate.h"
 #include <memory>
 #include <QQuickWidget>
 
@@ -39,6 +40,7 @@ public:
 	void plot(const StatsState &state);
 private slots:
 	void plotAreaChanged(const QRectF &plotArea);
+	void replotIfVisible();
 private:
 	void reset(); // clears all series and axes
 	void addAxes(QtCharts::QAbstractAxis *x, QtCharts::QAbstractAxis *y); // Add new x- and y-axis
@@ -106,6 +108,7 @@ private:
 		void updatePosition();
 	};
 
+	StatsState state;
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<QtCharts::QAbstractAxis>> axes;
 	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -52,6 +52,8 @@ private:
 	void plotDiscreteCountChart(const std::vector<dive *> &dives,
 				    ChartSubType subType,
 				    const StatsType *categoryType, const StatsBinner *categoryBinner, bool labels);
+	void plotPieChart(const std::vector<dive *> &dives,
+			  const StatsType *categoryType, const StatsBinner *categoryBinner);
 	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
 				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -83,7 +83,8 @@ private:
 	template <typename T>
 	T *addSeries(const QString &name);
 	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
-	BarSeries *addBarSeries(const QString &name, bool horizontal);
+	BarSeries *addBarSeries(const QString &name, bool horizontal, const QString &categoryName,
+				const StatsType *valueType);
 	BoxSeries *addBoxSeries(const QString &name, const QString &unit, int decimals);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -58,7 +58,7 @@ private:
 				  const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotDiscreteScatter(const std::vector<dive *> &dives,
 				 const StatsType *categoryType, const StatsBinner *categoryBinner,
-				 const StatsType *valueType);
+				 const StatsType *valueType, bool quartiles);
 	void plotHistogramCountChart(const std::vector<dive *> &dives,
 				     ChartSubType subType,
 				     const StatsType *categoryType, const StatsBinner *categoryBinner,

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -44,7 +44,7 @@ private:
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsType *categoryType, const StatsBinner *categoryBinner,
-			  const StatsType *valueType, const StatsBinner *valueBinner);
+			  const StatsType *valueType, const StatsBinner *valueBinner, bool labels);
 	void plotValueChart(const std::vector<dive *> &dives,
 			    ChartSubType subType,
 			    const StatsType *categoryType, const StatsBinner *categoryBinner,
@@ -63,10 +63,14 @@ private:
 				     ChartSubType subType,
 				     const StatsType *categoryType, const StatsBinner *categoryBinner,
 				     bool labels, bool showMedian, bool showMean);
-	void plotHistogramBarChart(const std::vector<dive *> &dives,
-				   ChartSubType subType,
-				   const StatsType *categoryType, const StatsBinner *categoryBinner,
-				   const StatsType *valueType, StatsOperation valueAxisOperation, bool labels);
+	void plotHistogramValueChart(const std::vector<dive *> &dives,
+				     ChartSubType subType,
+				     const StatsType *categoryType, const StatsBinner *categoryBinner,
+				     const StatsType *valueType, StatsOperation valueAxisOperation, bool labels);
+	void plotHistogramStackedChart(const std::vector<dive *> &dives,
+				       ChartSubType subType,
+				       const StatsType *categoryType, const StatsBinner *categoryBinner,
+				       const StatsType *valueType, const StatsBinner *valueBinner, bool labels);
 	void plotHistogramBoxChart(const std::vector<dive *> &dives,
 				   const StatsType *categoryType, const StatsBinner *categoryBinner, const StatsType *valueType);
 	void plotScatter(const std::vector<dive *> &dives, const StatsType *categoryType, const StatsType *valueType);
@@ -80,8 +84,9 @@ private:
 	template <typename T>
 	T *addSeries(const QString &name);
 	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
-	BarSeries *addBarSeries(const QString &name, bool horizontal, const QString &categoryName,
-				const StatsType *valueType);
+	BarSeries *addBarSeries(const QString &name, bool horizontal, bool stacked,
+				const QString &categoryName, const StatsType *valueType,
+				std::vector<QString> valueBinNames);
 	BoxSeries *addBoxSeries(const QString &name, const QString &unit, int decimals);
 	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
 

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -17,10 +17,7 @@ namespace QtCharts {
 	class QChart;
 }
 class QGraphicsLineItem;
-class BarSeries;
-class BoxSeries;
-class PieSeries;
-class ScatterSeries;
+class StatsSeries;
 class CategoryAxis;
 class CountAxis;
 class HistogramAxis;
@@ -79,17 +76,10 @@ private:
 	void setTitle(const QString &);
 
 	template <typename T, class... Args>
-	T *createAxis(const QString &title, Args&&... args);
+	T *createSeries(Args&&... args);
 
-	template <typename T>
-	T *addSeries(const QString &name);
-	ScatterSeries *addScatterSeries(const QString &name, const StatsType &typeX, const StatsType &typeY);
-	BarSeries *addBarSeries(const QString &name, bool horizontal, bool stacked,
-				const QString &categoryName, const StatsType *valueType,
-				std::vector<QString> valueBinNames);
-	BoxSeries *addBoxSeries(const QString &name, const QString &unit, int decimals);
-	PieSeries *addPieSeries(const QString &name, const std::vector<std::pair<QString, int>> &data, bool keepOrder, bool labels);
-	void initSeries(QtCharts::QAbstractSeries *series, const QString &name);
+	template <typename T, class... Args>
+	T *createAxis(const QString &title, Args&&... args);
 
 	template<typename T>
 	CategoryAxis *createCategoryAxis(const QString &title, const StatsBinner &binner,
@@ -126,17 +116,11 @@ private:
 	StatsState state;
 	QtCharts::QChart *chart;
 	std::vector<std::unique_ptr<StatsAxis>> axes;
-	std::vector<std::unique_ptr<ScatterSeries>> scatterSeries;
-	std::vector<std::unique_ptr<BarSeries>> barSeries;
-	std::vector<std::unique_ptr<BoxSeries>> boxSeries;
-	std::vector<std::unique_ptr<PieSeries>> pieSeries;
+	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
 	std::vector<LineMarker> lineMarkers;
-	ScatterSeries *highlightedScatterSeries;	// scatter series with highlighted element
-	BarSeries *highlightedBarSeries;		// bar series with highlighted element
-	BoxSeries *highlightedBoxSeries;		// box series with highlighted element
-	PieSeries *highlightedPieSeries;		// pie series with highlighted element
+	StatsSeries *highlightedSeries;
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
 	// Therefore, we have to listen to hover events using an events-filter.
@@ -149,9 +133,6 @@ private:
 	} eventFilter;
 	friend EventFilter;
 	void hover(QPointF pos);
-	// Generic code to handle the highlighting of a series element
-	template<typename Series>
-	void handleHover(const std::vector<std::unique_ptr<Series>> &series, Series *&highlighted, QPointF pos);
 };
 
 #endif

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -96,6 +96,8 @@ private:
 						     bool isHorizontal);
 	QtCharts::QValueAxis *createValueAxis(double min, double max, int decimals, bool isHorizontal);
 	QtCharts::QValueAxis *createCountAxis(int count, bool isHorizontal);
+	void initHistogramAxis(QtCharts::QCategoryAxis *axis, const std::vector<std::tuple<QString, double, bool>> &labels, bool isHorizontal) const;
+	int guessNumTicks(const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings, bool isHorizontal) const;
 
 	// Helper functions to add feature to the chart
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -100,5 +100,15 @@
         <file alias="gps_good_result-icon">icons/resultgreen.png</file>
         <file alias="gps_warning_result-icon">icons/resultyellow.png</file>
         <file alias="gps_bad_result-icon">icons/resultred.png</file>
+        <file alias="chart-bar-grouped-horizontal-icon">icons/chart_bar_grouped_horizontal.svg</file>
+        <file alias="chart-bar-grouped-vertical-icon">icons/chart_bar_grouped_vertical.svg</file>
+        <file alias="chart-bar-stacked-horizontal-icon">icons/chart_bar_stacked_horizontal.svg</file>
+        <file alias="chart-bar-stacked-vertical-icon">icons/chart_bar_stacked_vertical.svg</file>
+        <file alias="chart-bar-horizontal-icon">icons/chart_bar_horizontal.svg</file>
+        <file alias="chart-bar-vertical-icon">icons/chart_bar_vertical.svg</file>
+        <file alias="chart-box-icon">icons/chart_box.svg</file>
+        <file alias="chart-pie-icon">icons/chart_pie.svg</file>
+        <file alias="chart-points-icon">icons/chart_points.svg</file>
+        <file alias="chart-warning-icon">icons/warning-icon.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is an idea how a new statistics widget could be implemented in the desktop application. Note: this does nothing at all currently. The shown stats are hardcoded as a proof of concept (code by @willemferguson).

The idea here is to discuss the way the users switches into the statistics tab / how the code is organized. Please speak up now, before I commit too much energy into this.

I think on desktop it makes sense to show the statistics and the filter widget at the same time.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add a statistics applications state.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson @dirkhh