### PR TITLE
core: on import remove merged dives from trip/divesite

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -857,6 +857,10 @@ static void merge_imported_dives(struct dive_table *table)
 			merged->dive_site = NULL;
 			add_dive_to_dive_site(merged, ds);
 		}
+		unregister_dive_from_dive_site(prev);
+		unregister_dive_from_dive_site(dive);
+		unregister_dive_from_trip(prev);
+		unregister_dive_from_trip(dive);
 
 		/* Overwrite the first of the two dives and remove the second */
 		free_dive(prev);


### PR DESCRIPTION
When dives were merged on import, they were not unregistered
from their dive site and trip before being deleted. Thus, these
tables had stale pointers, which would ultimate lead to crashes.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a crash on dive import. The code is incredibly fragile - we have to do something about this. And we also have to improve our testing of this part of the code! 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove merged dives from trip and divesite tables before deleting them.
