### PR TITLE
parser: don't crash when parsing <weight> tags [Alternative 2]

### DIFF
--- a/core/equipment.c
+++ b/core/equipment.c
@@ -317,6 +317,19 @@ void set_weightsystem(struct dive *dive, int idx, weightsystem_t ws)
 	dive->weightsystems.weightsystems[idx] = clone_weightsystem(ws);
 }
 
+weightsystem_t *get_or_create_weightsystem(struct dive *d, int idx)
+{
+	if (idx < 0) {
+		fprintf(stderr, "Warning: accessing invalid weightsystem %d\n", idx);
+		return NULL;
+	}
+	while (idx >= d->weightsystems.nr) {
+		weightsystem_t ws = empty_weightsystem;
+		add_cloned_weightsystem(&d->weightsystems, ws);
+	}
+	return &d->weightsystems.weightsystems[idx];
+}
+
 /* when planning a dive we need to make sure that all cylinders have a sane depth assigned
  * and if we are tracking gas consumption the pressures need to be reset to start = end = workingpressure */
 void reset_cylinders(struct dive *dive, bool track_gas)

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -78,6 +78,7 @@ extern weightsystem_t clone_weightsystem(weightsystem_t ws);
 extern void free_weightsystem(weightsystem_t ws);
 extern void copy_cylinder_types(const struct dive *s, struct dive *d);
 extern void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws);
+extern weightsystem_t *get_or_create_weightsystem(struct dive *d, int idx);
 extern cylinder_t clone_cylinder(cylinder_t cyl);
 extern void free_cylinder(cylinder_t cyl);
 extern cylinder_t *add_empty_cylinder(struct cylinder_table *t);

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1223,7 +1223,10 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 {
 	char *hash = NULL;
 	cylinder_t *cyl = dive->cylinders.nr > 0 ? get_cylinder(dive, dive->cylinders.nr - 1) : NULL;
+	weightsystem_t *ws = dive->weightsystems.nr > 0 ?
+		&dive->weightsystems.weightsystems[dive->weightsystems.nr - 1] : NULL;
 	pressure_t p;
+	weight_t w;
 	start_match("dive", name, buf);
 
 	switch (state->import_source) {
@@ -1326,12 +1329,17 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH_STATE("airpressure.dive", pressure, &dive->surface_pressure))
 		return;
-	if (MATCH("description.weightsystem", utf8_string, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].description))
+	if (ws) {
+		if (MATCH("description.weightsystem", utf8_string, &ws->description))
+			return;
+		if (MATCH_STATE("weight.weightsystem", weight, &ws->weight))
+			return;
+	}
+	if (MATCH_STATE("weight", weight, &w)) {
+		weightsystem_t *ws = get_or_create_weightsystem(dive, 0);
+		ws->weight.grams += w.grams;
 		return;
-	if (MATCH_STATE("weight.weightsystem", weight, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].weight))
-		return;
-	if (MATCH_STATE("weight", weight, &dive->weightsystems.weightsystems[dive->weightsystems.nr - 1].weight))
-		return;
+	}
 	if (cyl) {
 		if (MATCH("size.cylinder", cylindersize, &cyl->type.size))
 			return;


### PR DESCRIPTION
When encountering a <weight> tag, we would parse into the last
weightsystem. However, we only create weightsystems when
encountering <weightsystem> tag. Therefore, this code would
either crash or overwrite the previous weightsystem.

Instead, add the weight to the first weightsystem. Create that
if it doesn't exist using the new get_or_create_weightsystem()
function, which works like its cylinder-analogue.

Moreover, make sure that inside a <weightsystem> tag a
weightsystem actually exists. This should be the case,
but who knows...?

Reported-by: Nihal Gabr <gabr.nihal@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Fixes a crash on parsing XMLs with <weight> tags - see commit description.