### PR TITLE
Manipulate text colour to accomodate dark mode displays

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -66,6 +66,12 @@ enum unit_system_values {
 	PERSONALIZE
 };
 
+enum darkmode_colour_values {
+	MEDIUMBLUE,
+	LIGHTBLUE,
+	BLACK
+};
+
 // ********** PREFERENCES **********
 // This struct is kept global for all of ssrf
 // most of the fields are loaded from git as
@@ -105,6 +111,7 @@ struct preferences {
 	double      font_size;
 	double      mobile_scale;
 	bool        show_developer;
+	enum darkmode_colour_values darkmode_colour;
 
 	// ********** Equipment tab *******
 	const char *default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -55,6 +55,7 @@ void qPrefDisplay::loadSync(bool doSync)
 	disk_mobile_scale(doSync);
 	disk_display_invalid_dives(doSync);
 	disk_show_developer(doSync);
+	disk_darkmode_colour(doSync);
 	if (!doSync) {
 		load_tooltip_position();
 		load_theme();
@@ -174,6 +175,29 @@ void qPrefDisplay::setCorrectFont()
 	qApp->setFont(defaultFont);
 
 	prefs.display_invalid_dives = qPrefPrivate::propValue(keyFromGroupAndName(group, "displayinvalid"), default_prefs.display_invalid_dives).toBool();
+}
+
+void qPrefDisplay::set_darkmode_colour(enum darkmode_colour_values value)
+{
+	if (value != prefs.darkmode_colour) {
+		prefs.darkmode_colour = value;
+		disk_darkmode_colour(true);
+		emit instance()->darkmode_colourChanged(value);
+	}
+}
+
+void qPrefDisplay::disk_darkmode_colour(bool doSync) \
+{ 
+	static enum darkmode_colour_values current_state; 
+	if (doSync) { 
+		if (current_state != prefs.darkmode_colour) { 
+			current_state = prefs.darkmode_colour; 
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, "darkmode_colour"), prefs.darkmode_colour, default_prefs.darkmode_colour); 
+		} 
+	} else { 
+		prefs.darkmode_colour = (enum darkmode_colour_values)qPrefPrivate::propValue(keyFromGroupAndName(group, "darkmode_colour"), default_prefs.darkmode_colour).toInt(); 
+		current_state = prefs.darkmode_colour; 
+	} 
 }
 
 HANDLE_PROP_QSTRING(Display, "FileDialog/LastDir", lastDir);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -8,6 +8,7 @@
 
 class qPrefDisplay : public QObject {
 	Q_OBJECT
+	Q_PROPERTY(enum darkmode_colour_values darkmode_colour READ darkmode_colour WRITE set_darkmode_colour NOTIFY darkmode_colourChanged)
 	Q_PROPERTY(int animation_speed READ animation_speed WRITE set_animation_speed NOTIFY animation_speedChanged)
 	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_fontChanged)
 	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_sizeChanged)
@@ -35,6 +36,7 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
+	static enum darkmode_colour_values darkmode_colour() { return prefs.darkmode_colour; }
 	static int animation_speed() { return prefs.animation_speed; }
 	static QString divelist_font() { return prefs.divelist_font; }
 	static double font_size() { return prefs.font_size; }
@@ -54,6 +56,7 @@ public:
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 
 public slots:
+	static void set_darkmode_colour(enum darkmode_colour_values value);
 	static void set_animation_speed(int value);
 	static void set_divelist_font(const QString &value);
 	static void set_font_size(double value);
@@ -73,6 +76,7 @@ public slots:
 	static void set_singleColumnPortrait(bool value);
 
 signals:
+	void darkmode_colourChanged(enum darkmode_colour_values value);
 	void animation_speedChanged(int value);
 	void divelist_fontChanged(const QString &value);
 	void font_sizeChanged(double value);
@@ -95,6 +99,7 @@ private:
 	qPrefDisplay() {}
 
 	// functions to load/sync variable with disk
+	static void disk_darkmode_colour(bool doSync);
 	static void disk_animation_speed(bool doSync);
 	static void disk_divelist_font(bool doSync);
 	static void disk_font_size(bool doSync);

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -24,6 +24,7 @@ PreferencesDefaults::~PreferencesDefaults()
 
 void PreferencesDefaults::refreshSettings()
 {
+	prefs.darkmode_colour == BLACK ? ui->black_text->setChecked(true) : (prefs.darkmode_colour == LIGHTBLUE ? ui->lightblue_text->setChecked(true) : ui->mediumblue_text->setChecked(true));
 	ui->font->setCurrentFont(qPrefDisplay::divelist_font());
 	ui->fontsize->setValue(qPrefDisplay::font_size());
 	ui->velocitySlider->setValue(qPrefDisplay::animation_speed());
@@ -35,4 +36,6 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_divelist_font(ui->font->currentFont().toString());
 	qPrefDisplay::set_font_size(ui->fontsize->value());
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
+	qPrefDisplay::set_darkmode_colour(ui->black_text->isChecked() ? BLACK : (ui->lightblue_text->isChecked() ? LIGHTBLUE : MEDIUMBLUE));
+
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -120,6 +120,77 @@
    </item>
 
    <item>
+    <widget class="QGroupBox" name="groupBox_dark">
+     <property name="title">
+      <string>Dark theme text colours</string>
+     </property>
+     <layout class="QVBoxLayout" name="darkModeLayout_4">
+      <property name="margin">
+       <number>5</number>
+      </property>
+
+      <item>
+       <widget class="QLabel" name="label_help_dark">
+        <property name="toolTip">
+         <string extracomment="Help info dark"/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>With some computers, when a dark theme is chosen, some of the blue text in Subsurface is not clearly visible. Select a colour that fits the current theme of your computer. For dark mode, select either Light Blue or Black (rendered white using a dark theme). The default is Medium Blue.  IMPORTANT: You need to restart Subsurface for this change to take effect.</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>  
+       <layout class="QHBoxLayout" name="darkmodeLayout_5">
+
+         <item>
+          <widget class="QRadioButton" name="mediumblue_text">
+           <property name="text">
+            <string>Medium Blue</string>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QRadioButton" name="lightblue_text">
+           <property name="text">
+            <string>Light Blue</string>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QRadioButton" name="black_text">
+           <property name="text">
+            <string>Black</string>
+           </property>
+          </widget>
+         </item>
+
+        </layout>
+      </item>
+
+      </layout>
+    </widget>
+   </item>
+
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>195</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+      <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -132,8 +203,10 @@
      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
+
  <resources/>
  <connections>
   <connection>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -23,7 +23,18 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &TabDiveInformation::cylinderChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveInformation::cylinderChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveInformation::cylinderChanged);
+
+	// Put together appropriate CSS stylesheets: NB: Colours below in same order as the enum in prefs.h
+	QStringList colours = { "mediumblue", "lightblue", "black" };	// If using dark theme, set colour appropriately
+	QString colourText = colours[prefs.darkmode_colour];
+
+	QString lastpart = colourText + " ;}";
+	QString CSSLabelColour = "QLabel { color: " + lastpart;
+	QString CSSTitleColour = "QGroupBox::title { color: " + lastpart ;
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
+	QString CSSSetSmallLabel = "QLabel { color: ";
+	CSSSetSmallLabel.append(colourText + "; font-size: ");
+	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
 	ui->waterTypeCombo->insertItems(0, getWaterTypesAsString());
@@ -34,8 +45,10 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 		types.append(gettextFromC::tr(divemode_text_ui[i]));
 	ui->diveType->insertItems(0, types);
 	connect(ui->diveType, SIGNAL(currentIndexChanged(int)), this, SLOT(diveModeChanged(int)));
-	QString CSSSetSmallLabel = "QLabel { font-size: " +                           // Using label height
-		QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}"; // .. set CSS font size of star widget subscripts
+	ui->scrollAreaWidgetContents_3->setStyleSheet(CSSTitleColour);
+	ui->diveHeadingLabel->setStyleSheet(CSSLabelColour);
+	ui->gasHeadingLabel->setStyleSheet(CSSLabelColour);
+	ui->environmentHeadingLabel->setStyleSheet(CSSLabelColour);
 	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
 	ui->groupBox_current->setStyleSheet(CSSSetSmallLabel);
 	ui->groupBox_wavesize->setStyleSheet(CSSSetSmallLabel);
@@ -55,7 +68,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	updateWaterTypeWidget();
 	QPixmap warning (":salinity-warning-icon");
 	ui->salinityOverWrittenIcon->setPixmap(warning);
-	ui->salinityOverWrittenIcon->setToolTip("Water type differs from that of dc");
+	ui->salinityOverWrittenIcon->setToolTip(CSSSetSmallLabel);
 	ui->salinityOverWrittenIcon->setToolTipDuration(2500);
 	ui->salinityOverWrittenIcon->setVisible(false);
 }


### PR DESCRIPTION
The Preferences has an option to set the colour of the text on the
Information tab to either MediumBlue, LightBlue or Black. The last two of these
colours are meant to enable areadable font contrast on displays with dark mode.
The choice is saved with the other preferences.

Important. Subsurface needs to be restarted for the change to take effect. This
is because the text colour is part of the initialisation of the TabDiveInformation
object. To redo text colour on the fly would require destructing the object and
creating a new TabDiveInformation object.

Signed-off-by: willemferguson <willemferguson@zoology.up.ac.za>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @bstoeger 