### PR TITLE
build-systsem: hack around Xcode 12 issue

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,8 +9,10 @@ on:
 
 jobs:
   mobileBuild:
-    runs-on: macOS-latest
+    runs-on: macOS-10.15
     steps:
+    - name: switch to Xcode 11
+      run: sudo xcode-select -s "/Applications/Xcode_11.7.app"
     - name: checkout sources
       uses: actions/checkout@v1
     - name: setup Homebrew


### PR DESCRIPTION
It appears that Xcode 12 applies some rather self defeating logic when picking
build architectures in release builds for the simulator. It adds aarch64 by
default and I can't find a way to turn that off from the command line. At the
same time, you can't link against the simulator if you have build with aarch64
as the aarch64 simulator doesn't exist, yet.

Some people claim that building in debug mode fixes this. Let's see if that
works.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
simply try to build in debug mode for iOS
