### PR TITLE
Header style - alternative to #3060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- desktop: improve the appearance in dark mode
 - add Garmin Descent Mk2/Mk2i support for Linux, macOS, and 64bit Windows
 - desktop: add 64bit Windows build
 - desktop: make device management undoable

--- a/core/pref.h
+++ b/core/pref.h
@@ -87,7 +87,7 @@ struct preferences {
 	int animation_speed;
 
 	// ********** CloudStorage **********
-	bool       cloud_auto_sync;
+	bool        cloud_auto_sync;
 	const char *cloud_base_url;
 	const char *cloud_git_url;
 	const char *cloud_storage_email;
@@ -135,11 +135,11 @@ struct preferences {
 	geocoding_prefs_t geocoding;
 
 	// ********** Language **********
-	const char *    date_format;
+	const char     *date_format;
 	bool            date_format_override;
-	const char *    date_format_short;
+	const char     *date_format_short;
 	locale_prefs_t  locale; //: TODO: move the rest of locale based info here.
-	const char *    time_format;
+	const char     *time_format;
 	bool            time_format_override;
 
 	// ********** LocationService **********

--- a/core/pref.h
+++ b/core/pref.h
@@ -66,6 +66,12 @@ enum unit_system_values {
 	PERSONALIZE
 };
 
+enum headerstyle_color_values {
+	MEDIUMBLUE,
+	LIGHTBLUE,
+	BLACK
+};
+
 // ********** PREFERENCES **********
 // This struct is kept global for all of ssrf
 // most of the fields are loaded from git as
@@ -100,11 +106,12 @@ struct preferences {
 	dive_computer_prefs_t dive_computer4;
 
 	// ********** Display *************
-	bool        display_invalid_dives;
-	const char *divelist_font;
-	double      font_size;
-	double      mobile_scale;
-	bool        show_developer;
+	bool                          display_invalid_dives;
+	const char                   *divelist_font;
+	double                        font_size;
+	double                        mobile_scale;
+	bool                          show_developer;
+	enum headerstyle_color_values headerstyle_color;
 
 	// ********** Equipment tab *******
 	const char *default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -55,6 +55,7 @@ void qPrefDisplay::loadSync(bool doSync)
 	disk_mobile_scale(doSync);
 	disk_display_invalid_dives(doSync);
 	disk_show_developer(doSync);
+	disk_headerstyle_color(doSync);
 	if (!doSync) {
 		load_tooltip_position();
 		load_theme();
@@ -174,6 +175,29 @@ void qPrefDisplay::setCorrectFont()
 	qApp->setFont(defaultFont);
 
 	prefs.display_invalid_dives = qPrefPrivate::propValue(keyFromGroupAndName(group, "displayinvalid"), default_prefs.display_invalid_dives).toBool();
+}
+
+void qPrefDisplay::set_headerstyle_color(enum headerstyle_color_values value)
+{
+	if (value != prefs.headerstyle_color) {
+		prefs.headerstyle_color = value;
+		disk_headerstyle_color(true);
+		emit instance()->headerstyle_colorChanged(value);
+	}
+}
+
+void qPrefDisplay::disk_headerstyle_color(bool doSync)
+{
+	static enum headerstyle_color_values current_state;
+	if (doSync) {
+		if (current_state != prefs.headerstyle_color) {
+			current_state = prefs.headerstyle_color;
+			qPrefPrivate::propSetValue(keyFromGroupAndName(group, "headerstyle_color"), prefs.headerstyle_color, default_prefs.headerstyle_color);
+		}
+	} else {
+		prefs.headerstyle_color = (enum headerstyle_color_values)qPrefPrivate::propValue(keyFromGroupAndName(group, "headerstyle_color"), default_prefs.headerstyle_color).toInt();
+		current_state = prefs.headerstyle_color;
+	}
 }
 
 HANDLE_PROP_QSTRING(Display, "FileDialog/LastDir", lastDir);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -8,6 +8,7 @@
 
 class qPrefDisplay : public QObject {
 	Q_OBJECT
+	Q_PROPERTY(enum headerstyle_color_values headerstyle_color READ headerstyle_color WRITE set_headerstyle_color NOTIFY headerstyle_colorChanged)
 	Q_PROPERTY(int animation_speed READ animation_speed WRITE set_animation_speed NOTIFY animation_speedChanged)
 	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_fontChanged)
 	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_sizeChanged)
@@ -35,6 +36,7 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
+	static enum headerstyle_color_values headerstyle_color() { return prefs.headerstyle_color; }
 	static int animation_speed() { return prefs.animation_speed; }
 	static QString divelist_font() { return prefs.divelist_font; }
 	static double font_size() { return prefs.font_size; }
@@ -54,6 +56,7 @@ public:
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 
 public slots:
+	static void set_headerstyle_color(enum headerstyle_color_values value);
 	static void set_animation_speed(int value);
 	static void set_divelist_font(const QString &value);
 	static void set_font_size(double value);
@@ -73,6 +76,7 @@ public slots:
 	static void set_singleColumnPortrait(bool value);
 
 signals:
+	void headerstyle_colorChanged(enum headerstyle_color_values value);
 	void animation_speedChanged(int value);
 	void divelist_fontChanged(const QString &value);
 	void font_sizeChanged(double value);
@@ -95,6 +99,7 @@ private:
 	qPrefDisplay() {}
 
 	// functions to load/sync variable with disk
+	static void disk_headerstyle_color(bool doSync);
 	static void disk_animation_speed(bool doSync);
 	static void disk_divelist_font(bool doSync);
 	static void disk_font_size(bool doSync);

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -24,6 +24,7 @@ PreferencesDefaults::~PreferencesDefaults()
 
 void PreferencesDefaults::refreshSettings()
 {
+	prefs.headerstyle_color == BLACK ? ui->black_text->setChecked(true) : (prefs.headerstyle_color == LIGHTBLUE ? ui->lightblue_text->setChecked(true) : ui->mediumblue_text->setChecked(true));
 	ui->font->setCurrentFont(qPrefDisplay::divelist_font());
 	ui->fontsize->setValue(qPrefDisplay::font_size());
 	ui->velocitySlider->setValue(qPrefDisplay::animation_speed());
@@ -35,4 +36,6 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_divelist_font(ui->font->currentFont().toString());
 	qPrefDisplay::set_font_size(ui->fontsize->value());
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
+	qPrefDisplay::set_headerstyle_color(ui->black_text->isChecked() ? BLACK : (ui->lightblue_text->isChecked() ? LIGHTBLUE : MEDIUMBLUE));
+
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -120,6 +120,77 @@
    </item>
 
    <item>
+    <widget class="QGroupBox" name="groupBox_headerstyle">
+     <property name="title">
+      <string>Header text colors</string>
+     </property>
+     <layout class="QVBoxLayout" name="headerModeLayout_4">
+      <property name="margin">
+       <number>5</number>
+      </property>
+
+      <item>
+       <widget class="QLabel" name="label_help_header">
+        <property name="toolTip">
+         <string extracomment="Help info header"/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Depending on the display mode, sometimes the blue text used in headers in the various information panes is not clearly visible. Select a color that fits the current theme of your computer. For dark mode, select either Light Blue or Black (rendered white using a dark theme). The default is Medium Blue.</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>  
+       <layout class="QHBoxLayout" name="darkmodeLayout_5">
+
+         <item>
+          <widget class="QRadioButton" name="mediumblue_text">
+           <property name="text">
+            <string>Medium Blue</string>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QRadioButton" name="lightblue_text">
+           <property name="text">
+            <string>Light Blue</string>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QRadioButton" name="black_text">
+           <property name="text">
+            <string>Black</string>
+           </property>
+          </widget>
+         </item>
+
+        </layout>
+      </item>
+
+      </layout>
+    </widget>
+   </item>
+
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>195</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+      <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -132,8 +203,10 @@
      </property>
     </spacer>
    </item>
+
   </layout>
  </widget>
+
  <resources/>
  <connections>
   <connection>

--- a/desktop-widgets/tab-widgets/TabBase.cpp
+++ b/desktop-widgets/tab-widgets/TabBase.cpp
@@ -4,3 +4,7 @@
 TabBase::TabBase(QWidget *parent) : QWidget(parent)
 {
 }
+
+void TabBase::updateUi()
+{
+}

--- a/desktop-widgets/tab-widgets/TabBase.h
+++ b/desktop-widgets/tab-widgets/TabBase.h
@@ -13,6 +13,7 @@ public:
 	TabBase(QWidget *parent = 0);
 	virtual void updateData() = 0;
 	virtual void clear() = 0;
+	virtual void updateUi();
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.ui
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.ui
@@ -73,6 +73,9 @@
              <property name="text">
               <string>Suit</string>
              </property>
+             <property name="isHeader" stdset="0">
+              <bool>true</bool>
+             </property>
             </widget>
             <widget class="QLineEdit" name="suit">
              <property name="readOnly">

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -23,7 +23,18 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &TabDiveInformation::cylinderChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveInformation::cylinderChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveInformation::cylinderChanged);
+
+	// Put together appropriate CSS stylesheets: NB: Colors below in same order as the enum in prefs.h
+	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
+	QString colorText = colors[prefs.headerstyle_color];
+
+	QString lastpart = colorText + " ;}";
+	QString CSSLabelColor = "QLabel { color: " + lastpart;
+	QString CSSTitleColor = "QGroupBox::title { color: " + lastpart ;
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
+	QString CSSSetSmallLabel = "QLabel { color: ";
+	CSSSetSmallLabel.append(colorText + "; font-size: ");
+	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
 	ui->waterTypeCombo->insertItems(0, getWaterTypesAsString());
@@ -34,8 +45,10 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 		types.append(gettextFromC::tr(divemode_text_ui[i]));
 	ui->diveType->insertItems(0, types);
 	connect(ui->diveType, SIGNAL(currentIndexChanged(int)), this, SLOT(diveModeChanged(int)));
-	QString CSSSetSmallLabel = "QLabel { font-size: " +                           // Using label height
-		QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}"; // .. set CSS font size of star widget subscripts
+	ui->scrollAreaWidgetContents_3->setStyleSheet(CSSTitleColor);
+	ui->diveHeadingLabel->setStyleSheet(CSSLabelColor);
+	ui->gasHeadingLabel->setStyleSheet(CSSLabelColor);
+	ui->environmentHeadingLabel->setStyleSheet(CSSLabelColor);
 	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
 	ui->groupBox_current->setStyleSheet(CSSSetSmallLabel);
 	ui->groupBox_wavesize->setStyleSheet(CSSSetSmallLabel);
@@ -55,7 +68,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	updateWaterTypeWidget();
 	QPixmap warning (":salinity-warning-icon");
 	ui->salinityOverWrittenIcon->setPixmap(warning);
-	ui->salinityOverWrittenIcon->setToolTip("Water type differs from that of dc");
+	ui->salinityOverWrittenIcon->setToolTip(CSSSetSmallLabel);
 	ui->salinityOverWrittenIcon->setToolTipDuration(2500);
 	ui->salinityOverWrittenIcon->setVisible(false);
 }

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -24,17 +24,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveInformation::cylinderChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveInformation::cylinderChanged);
 
-	// Put together appropriate CSS stylesheets: NB: Colors below in same order as the enum in prefs.h
-	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
-	QString colorText = colors[prefs.headerstyle_color];
-
-	QString lastpart = colorText + " ;}";
-	QString CSSLabelColor = "QLabel { color: " + lastpart;
-	QString CSSTitleColor = "QGroupBox::title { color: " + lastpart ;
 	QStringList atmPressTypes { "mbar", get_depth_unit() ,tr("Use DC")};
-	QString CSSSetSmallLabel = "QLabel { color: ";
-	CSSSetSmallLabel.append(colorText + "; font-size: ");
-	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
 	ui->atmPressType->insertItems(0, atmPressTypes);
 	pressTypeIndex = 0;
 	ui->waterTypeCombo->insertItems(0, getWaterTypesAsString());
@@ -45,15 +35,6 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 		types.append(gettextFromC::tr(divemode_text_ui[i]));
 	ui->diveType->insertItems(0, types);
 	connect(ui->diveType, SIGNAL(currentIndexChanged(int)), this, SLOT(diveModeChanged(int)));
-	ui->scrollAreaWidgetContents_3->setStyleSheet(CSSTitleColor);
-	ui->diveHeadingLabel->setStyleSheet(CSSLabelColor);
-	ui->gasHeadingLabel->setStyleSheet(CSSLabelColor);
-	ui->environmentHeadingLabel->setStyleSheet(CSSLabelColor);
-	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_current->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_wavesize->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_surge->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_chill->setStyleSheet(CSSSetSmallLabel);
 	if (!prefs.extraEnvironmentalDefault) // if extraEnvironmental preference is turned off
 		showCurrentWidget(false, 0);  // Show current star widget at lefthand side
 	QAction *action = new QAction(tr("OK"), this);
@@ -68,7 +49,6 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	updateWaterTypeWidget();
 	QPixmap warning (":salinity-warning-icon");
 	ui->salinityOverWrittenIcon->setPixmap(warning);
-	ui->salinityOverWrittenIcon->setToolTip(CSSSetSmallLabel);
 	ui->salinityOverWrittenIcon->setToolTipDuration(2500);
 	ui->salinityOverWrittenIcon->setVisible(false);
 }
@@ -241,7 +221,7 @@ void TabDiveInformation::updateData()
 		if (prefs.salinityEditDefault) {   //If edit-salinity is enabled then set correct water type in combobox:
 			ui->waterTypeCombo->setCurrentIndex(updateSalinityComboIndex(salinity_value));
 		} else {         // If water salinity is not editable: show water type as a text label
-                        ui->waterTypeText->setText(get_water_type_string(salinity_value));
+			ui->waterTypeText->setText(get_water_type_string(salinity_value));
 		}
 		ui->salinityText->setText(get_salinity_string(salinity_value));
 	} else {
@@ -261,6 +241,31 @@ void TabDiveInformation::updateData()
 		showCurrentWidget(true, 2);   // Show current star widget at 3rd position
 	else
 		showCurrentWidget(false, 0);  // Show current star widget at lefthand side
+}
+
+void TabDiveInformation::updateUi()
+{
+	// Put together appropriate CSS stylesheets: NB: colors below in same order as the enum in prefs.h
+	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
+	QString colorText = colors[prefs.headerstyle_color];
+
+	QString lastpart = colorText + " ;}";
+	QString CSSLabelcolor = "QLabel { color: " + lastpart;
+	QString CSSTitlecolor = "QGroupBox::title { color: " + lastpart ;
+	QString CSSSetSmallLabel = "QLabel { color: ";
+	CSSSetSmallLabel.append(colorText + "; font-size: ");
+	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
+	ui->scrollAreaWidgetContents_3->setStyleSheet(CSSTitlecolor);
+	ui->diveHeadingLabel->setStyleSheet(CSSLabelcolor);
+	ui->gasHeadingLabel->setStyleSheet(CSSLabelcolor);
+	ui->environmentHeadingLabel->setStyleSheet(CSSLabelcolor);
+	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
+	ui->groupBox_current->setStyleSheet(CSSSetSmallLabel);
+	ui->groupBox_wavesize->setStyleSheet(CSSSetSmallLabel);
+	ui->groupBox_surge->setStyleSheet(CSSSetSmallLabel);
+	ui->groupBox_chill->setStyleSheet(CSSSetSmallLabel);
+	ui->salinityOverWrittenIcon->setToolTip(CSSSetSmallLabel);
+
 }
 
 // From the index of the water type combo box, set the dive->salinity to an appropriate value

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -249,23 +249,15 @@ void TabDiveInformation::updateUi()
 	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
 	QString colorText = colors[prefs.headerstyle_color];
 
-	QString lastpart = colorText + " ;}";
-	QString CSSLabelcolor = "QLabel { color: " + lastpart;
-	QString CSSTitlecolor = "QGroupBox::title { color: " + lastpart ;
-	QString CSSSetSmallLabel = "QLabel { color: ";
+	QString CSSSetSmallLabel = "QLabel:enabled { color: ";
 	CSSSetSmallLabel.append(colorText + "; font-size: ");
 	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
-	ui->scrollAreaWidgetContents_3->setStyleSheet(CSSTitlecolor);
-	ui->diveHeadingLabel->setStyleSheet(CSSLabelcolor);
-	ui->gasHeadingLabel->setStyleSheet(CSSLabelcolor);
-	ui->environmentHeadingLabel->setStyleSheet(CSSLabelcolor);
-	ui->groupBox_visibility->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_current->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_wavesize->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_surge->setStyleSheet(CSSSetSmallLabel);
-	ui->groupBox_chill->setStyleSheet(CSSSetSmallLabel);
-	ui->salinityOverWrittenIcon->setToolTip(CSSSetSmallLabel);
-
+	ui->groupBox_visibility->setStyleSheet(ui->groupBox_visibility->styleSheet() + CSSSetSmallLabel);
+	ui->groupBox_current->setStyleSheet(ui->groupBox_current->styleSheet() + CSSSetSmallLabel);
+	ui->groupBox_wavesize->setStyleSheet(ui->groupBox_wavesize->styleSheet() + CSSSetSmallLabel);
+	ui->groupBox_surge->setStyleSheet(ui->groupBox_surge->styleSheet() + CSSSetSmallLabel);
+	ui->groupBox_chill->setStyleSheet(ui->groupBox_chill->styleSheet() + CSSSetSmallLabel);
+	ui->salinityOverWrittenIcon->setToolTip(ui->salinityOverWrittenIcon->styleSheet() + CSSSetSmallLabel);
 }
 
 // From the index of the water type combo box, set the dive->salinity to an appropriate value

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -16,6 +16,7 @@ public:
 	~TabDiveInformation();
 	void updateData() override;
 	void clear() override;
+	void updateUi() override;
 private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void cylinderChanged(dive *d);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -62,6 +62,9 @@
          <property name="text">
           <string>DIVE</string>
          </property>
+         <property name="isHeader" stdset="0">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
 
@@ -207,6 +210,9 @@
         <widget class="QLabel" name="gasHeadingLabel">
          <property name="text">
           <string>GAS</string>
+         </property>
+         <property name="isHeader" stdset="0">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -362,6 +368,9 @@
         <widget class="QLabel" name="environmentHeadingLabel">
          <property name="text">
           <string>ENVIRONMENT</string>
+         </property>
+         <property name="isHeader" stdset="0">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/desktop-widgets/tab-widgets/TabDiveSite.ui
+++ b/desktop-widgets/tab-widgets/TabDiveSite.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Filter</string>
        </property>
+       <property name="isHeader" stdset="0">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -112,7 +112,7 @@ void TabDiveStatistics::updateData()
 	bool is_freedive = current_dive && current_dive->dc.divemode == FREEDIVE;
 	ui->divesAllText->setText(QString::number(stats_selection.selection_size));
 	ui->totalTimeAllText->setText(get_dive_duration_string(stats_selection.total_time.seconds, tr("h"), tr("min"), tr("sec"), " ", is_freedive));
-	
+
 	int seconds = stats_selection.total_time.seconds;
 	if (stats_selection.selection_size)
 		seconds /= stats_selection.selection_size;

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -72,6 +72,9 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	extraWidgets << new TabDiveComputer(this);
 	ui.tabWidget->addTab(extraWidgets.last(), tr("Device names"));
 
+	// call colorsChanged() for the initial setup now that the extraWidgets are loaded
+	colorsChanged();
+
 	updateDateTimeFields();
 
 	closeMessage();
@@ -701,8 +704,32 @@ void MainTab::clearTabs()
 		widget->clear();
 }
 
+// setup the colors of 'header' elements in the tab widget
 void MainTab::colorsChanged()
 {
+	// Put together appropriate CSS stylesheets: NB: colors below in same order as the enum in prefs.h
+	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
+	QString colorText = colors[prefs.headerstyle_color];
+
+	QString lastpart = colorText + " ;}";
+
+	// only set the color if the widget is enabled
+	QString CSSLabelcolor = "QLabel:enabled { color: " + lastpart;
+	QString CSSTitlecolor = "QGroupBox::title:enabled { color: " + lastpart ;
+
+	// apply to all the group boxes
+	QList<QGroupBox *>groupBoxes = this->findChildren<QGroupBox *>();
+	for (QGroupBox *gb: groupBoxes)
+		gb->setStyleSheet(QString(CSSTitlecolor));
+
+	// apply to all labels that are marked as headers in the .ui file
+	QList<QLabel *>labels = this->findChildren<QLabel *>();
+	for (QLabel *ql: labels) {
+		if (ql->property("isHeader").toBool())
+			ql->setStyleSheet(QString(CSSLabelcolor));
+	}
+
+	// finally call the individual updateUi() functions so they can overwrite these style sheets
 	for (TabBase *widget: extraWidgets)
 		widget->updateUi();
 }

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -34,6 +34,7 @@
 #include "TabDiveStatistics.h"
 #include "TabDiveSite.h"
 #include "TabDiveComputer.h"
+#include "core/settings/qPrefDisplay.h"
 
 #include <QCompleter>
 #include <QScrollBar>
@@ -89,7 +90,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	// Alas, this is not the case. When the user switches to system-format, the preferences sends the according
 	// signal. However, the correct date and time format is set by the preferences dialog later. This should be fixed.
 	connect(PreferencesDialog::instance(), &PreferencesDialog::settingsChanged, this, &MainTab::updateDateTimeFields);
-
+	connect(qPrefDisplay::instance(), &qPrefDisplay::headerstyle_colorChanged, this, &MainTab::colorsChanged);
 	QAction *action = new QAction(tr("Apply changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(acceptChanges()));
 	ui.diveNotesMessage->addAction(action);
@@ -698,4 +699,10 @@ void MainTab::clearTabs()
 {
 	for (auto widget: extraWidgets)
 		widget->clear();
+}
+
+void MainTab::colorsChanged()
+{
+	for (TabBase *widget: extraWidgets)
+		widget->updateUi();
 }

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -64,6 +64,7 @@ slots:
 	void enableEdition();
 	void escDetected(void);
 	void updateDateTimeFields();
+	void colorsChanged();
 private:
 	Ui::MainTab ui;
 	bool editMode;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -82,6 +82,10 @@
               <property name="text">
                 <string>Date</string>
               </property>
+              <property name="isHeader" stdset="0">
+               <bool>true</bool>
+              </property>
+
               <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                  <horstretch>1</horstretch>
@@ -98,6 +102,9 @@
                <property name="text">
                 <string>Time</string>
                </property>
+              <property name="isHeader" stdset="0">
+               <bool>true</bool>
+              </property>
                <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                   <horstretch>1</horstretch>
@@ -133,6 +140,9 @@
                <property name="text">
                 <string>Depth</string>
                </property>
+              <property name="isHeader" stdset="0">
+               <bool>true</bool>
+              </property>
               </widget>
              </item>
              <item row="0" column="3">
@@ -146,6 +156,9 @@
                <property name="text">
                 <string>Duration (h:mm)</string>
                </property>
+              <property name="isHeader" stdset="0">
+               <bool>true</bool>
+              </property>
               </widget>
              </item>
              <item row="1" column="0">
@@ -230,6 +243,9 @@
                  <property name="text">
                   <string>Location</string>
                  </property>
+                 <property name="isHeader" stdset="0">
+                  <bool>true</bool>
+                 </property>
                  <property name="alignment">
                   <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
                  </property>
@@ -302,6 +318,9 @@
                <property name="text">
                 <string>Divemaster</string>
                </property>
+               <property name="isHeader" stdset="0">
+                <bool>true</bool>
+               </property>
                <property name="alignment">
                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
                </property>
@@ -311,6 +330,9 @@
               <widget class="QLabel" name="BuddyLabel">
                <property name="text">
                 <string>Buddy</string>
+               </property>
+               <property name="isHeader" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="alignment">
                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -347,6 +369,9 @@
               <widget class="QLabel" name="TagLabel">
                <property name="text">
                 <string>Tags</string>
+               </property>
+               <property name="isHeader" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="alignment">
                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -396,6 +421,9 @@
                <property name="text">
                 <string>Rating</string>
                </property>
+               <property name="isHeader" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="1" column="1" alignment="Qt::AlignVCenter">
@@ -424,6 +452,9 @@
               <widget class="QLabel" name="NotesLabel">
                <property name="text">
                 <string>Notes</string>
+               </property>
+               <property name="isHeader" stdset="0">
+                <bool>true</bool>
                </property>
                <property name="alignment">
                 <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
Allow customization of the color of header elements in the tab widget
This significantly changes and generalizes the work done by @willemferguson in #3060 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- change the language to be about header style and not dark mode. Dark mode is the use case, but this isn't about dark mode.
- added the ability to update the colors at run time
- added a reasonably generic way to do this for all the tabs and kept just a small amount of code specific for the Info Tab to deal with the smaller fonts needed for the star widgets

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
maybe, but not urgent

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger just for my sanity :-)
I wonder if I did the right thing with the virtual functions. I added those when I still expected that I would need custom code for every page. Now that it seems that isn't needed, maybe I should just make the Information tab the special case?

@willemferguson this is a pretty massive rewrite of what you did. I kept a highly edited version of your commit in #3060 to make sure you get credit for the initial idea - but the end result is rather different :-)