### PR TITLE
core: don't construct std::string from null in device.cpp

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -37,7 +37,7 @@ bool device::operator<(const device &a) const
 extern "C" const struct device *get_device_for_dc(const struct device_table *table, const struct divecomputer *dc)
 {
 	const std::vector<device> &dcs = table->devices;
-	device dev { dc->model, dc->deviceid, {}, {}, {} };
+	device dev { dc->model ?: "", dc->deviceid, {}, {}, {} };
 	auto it = std::lower_bound(dcs.begin(), dcs.end(), dev);
 	return it != dcs.end() && same_device(*it, dev) ? &*it : NULL;
 }
@@ -60,7 +60,7 @@ extern "C" void set_dc_deviceid(struct divecomputer *dc, unsigned int deviceid, 
 	dc->deviceid = deviceid;
 
 	// Serial and firmware can only be deduced if we know the model
-	if (!dc->model)
+	if (empty_string(dc->model))
 		return;
 
 	const device *node = get_device_for_dc(device_table, dc);


### PR DESCRIPTION
Recently the QStrings were replaced by std::strings in device.cpp
so that they can be accessed from C-code. However, libstd being
modelled after C, constructing a std::string from a NULL pointer
leads to a crash.

Fix one case were this was overlooked.

Moreover, replace a null-pointer check by empty_string(), to
treat NULL and "" equally.

Reported-by: Salvador Cuñat <salvador.cunat@gmail.com>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes the null-pointer dereference described in #3005.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix null pointer dereference
2) Replace null pointer check by empty_string()

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3005 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@salvadorcunat 