### PR TITLE
automatically pick a good title color for light and dark mode

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -66,12 +66,6 @@ enum unit_system_values {
 	PERSONALIZE
 };
 
-enum headerstyle_color_values {
-	MEDIUMBLUE,
-	LIGHTBLUE,
-	BLACK
-};
-
 // ********** PREFERENCES **********
 // This struct is kept global for all of ssrf
 // most of the fields are loaded from git as
@@ -106,12 +100,11 @@ struct preferences {
 	dive_computer_prefs_t dive_computer4;
 
 	// ********** Display *************
-	bool                          display_invalid_dives;
-	const char                   *divelist_font;
-	double                        font_size;
-	double                        mobile_scale;
-	bool                          show_developer;
-	enum headerstyle_color_values headerstyle_color;
+	bool        display_invalid_dives;
+	const char *divelist_font;
+	double      font_size;
+	double      mobile_scale;
+	bool        show_developer;
 
 	// ********** Equipment tab *******
 	const char *default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -55,7 +55,6 @@ void qPrefDisplay::loadSync(bool doSync)
 	disk_mobile_scale(doSync);
 	disk_display_invalid_dives(doSync);
 	disk_show_developer(doSync);
-	disk_headerstyle_color(doSync);
 	if (!doSync) {
 		load_tooltip_position();
 		load_theme();
@@ -175,29 +174,6 @@ void qPrefDisplay::setCorrectFont()
 	qApp->setFont(defaultFont);
 
 	prefs.display_invalid_dives = qPrefPrivate::propValue(keyFromGroupAndName(group, "displayinvalid"), default_prefs.display_invalid_dives).toBool();
-}
-
-void qPrefDisplay::set_headerstyle_color(enum headerstyle_color_values value)
-{
-	if (value != prefs.headerstyle_color) {
-		prefs.headerstyle_color = value;
-		disk_headerstyle_color(true);
-		emit instance()->headerstyle_colorChanged(value);
-	}
-}
-
-void qPrefDisplay::disk_headerstyle_color(bool doSync)
-{
-	static enum headerstyle_color_values current_state;
-	if (doSync) {
-		if (current_state != prefs.headerstyle_color) {
-			current_state = prefs.headerstyle_color;
-			qPrefPrivate::propSetValue(keyFromGroupAndName(group, "headerstyle_color"), prefs.headerstyle_color, default_prefs.headerstyle_color);
-		}
-	} else {
-		prefs.headerstyle_color = (enum headerstyle_color_values)qPrefPrivate::propValue(keyFromGroupAndName(group, "headerstyle_color"), default_prefs.headerstyle_color).toInt();
-		current_state = prefs.headerstyle_color;
-	}
 }
 
 HANDLE_PROP_QSTRING(Display, "FileDialog/LastDir", lastDir);

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -8,7 +8,6 @@
 
 class qPrefDisplay : public QObject {
 	Q_OBJECT
-	Q_PROPERTY(enum headerstyle_color_values headerstyle_color READ headerstyle_color WRITE set_headerstyle_color NOTIFY headerstyle_colorChanged)
 	Q_PROPERTY(int animation_speed READ animation_speed WRITE set_animation_speed NOTIFY animation_speedChanged)
 	Q_PROPERTY(QString divelist_font READ divelist_font WRITE set_divelist_font NOTIFY divelist_fontChanged)
 	Q_PROPERTY(double font_size READ font_size WRITE set_font_size NOTIFY font_sizeChanged)
@@ -36,7 +35,6 @@ public:
 	static void sync() { loadSync(true); }
 
 public:
-	static enum headerstyle_color_values headerstyle_color() { return prefs.headerstyle_color; }
 	static int animation_speed() { return prefs.animation_speed; }
 	static QString divelist_font() { return prefs.divelist_font; }
 	static double font_size() { return prefs.font_size; }
@@ -56,7 +54,6 @@ public:
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 
 public slots:
-	static void set_headerstyle_color(enum headerstyle_color_values value);
 	static void set_animation_speed(int value);
 	static void set_divelist_font(const QString &value);
 	static void set_font_size(double value);
@@ -76,7 +73,6 @@ public slots:
 	static void set_singleColumnPortrait(bool value);
 
 signals:
-	void headerstyle_colorChanged(enum headerstyle_color_values value);
 	void animation_speedChanged(int value);
 	void divelist_fontChanged(const QString &value);
 	void font_sizeChanged(double value);
@@ -99,7 +95,6 @@ private:
 	qPrefDisplay() {}
 
 	// functions to load/sync variable with disk
-	static void disk_headerstyle_color(bool doSync);
 	static void disk_animation_speed(bool doSync);
 	static void disk_divelist_font(bool doSync);
 	static void disk_font_size(bool doSync);

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -24,7 +24,6 @@ PreferencesDefaults::~PreferencesDefaults()
 
 void PreferencesDefaults::refreshSettings()
 {
-	prefs.headerstyle_color == BLACK ? ui->black_text->setChecked(true) : (prefs.headerstyle_color == LIGHTBLUE ? ui->lightblue_text->setChecked(true) : ui->mediumblue_text->setChecked(true));
 	ui->font->setCurrentFont(qPrefDisplay::divelist_font());
 	ui->fontsize->setValue(qPrefDisplay::font_size());
 	ui->velocitySlider->setValue(qPrefDisplay::animation_speed());
@@ -36,6 +35,4 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_divelist_font(ui->font->currentFont().toString());
 	qPrefDisplay::set_font_size(ui->fontsize->value());
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
-	qPrefDisplay::set_headerstyle_color(ui->black_text->isChecked() ? BLACK : (ui->lightblue_text->isChecked() ? LIGHTBLUE : MEDIUMBLUE));
-
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -120,77 +120,6 @@
    </item>
 
    <item>
-    <widget class="QGroupBox" name="groupBox_headerstyle">
-     <property name="title">
-      <string>Header text colors</string>
-     </property>
-     <layout class="QVBoxLayout" name="headerModeLayout_4">
-      <property name="margin">
-       <number>5</number>
-      </property>
-
-      <item>
-       <widget class="QLabel" name="label_help_header">
-        <property name="toolTip">
-         <string extracomment="Help info header"/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Depending on the display mode, sometimes the blue text used in headers in the various information panes is not clearly visible. Select a color that fits the current theme of your computer. For dark mode, select either Light Blue or Black (rendered white using a dark theme). The default is Medium Blue.</string>
-        </property>
-       </widget>
-      </item>
-
-      <item>  
-       <layout class="QHBoxLayout" name="darkmodeLayout_5">
-
-         <item>
-          <widget class="QRadioButton" name="mediumblue_text">
-           <property name="text">
-            <string>Medium Blue</string>
-           </property>
-          </widget>
-         </item>
-
-         <item>
-          <widget class="QRadioButton" name="lightblue_text">
-           <property name="text">
-            <string>Light Blue</string>
-           </property>
-          </widget>
-         </item>
-
-         <item>
-          <widget class="QRadioButton" name="black_text">
-           <property name="text">
-            <string>Black</string>
-           </property>
-          </widget>
-         </item>
-
-        </layout>
-      </item>
-
-      </layout>
-    </widget>
-   </item>
-
-   <item>
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>195</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-      <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -203,10 +132,8 @@
      </property>
     </spacer>
    </item>
-
   </layout>
  </widget>
-
  <resources/>
  <connections>
   <connection>

--- a/desktop-widgets/tab-widgets/TabBase.cpp
+++ b/desktop-widgets/tab-widgets/TabBase.cpp
@@ -5,6 +5,7 @@ TabBase::TabBase(QWidget *parent) : QWidget(parent)
 {
 }
 
-void TabBase::updateUi()
+void TabBase::updateUi(QString titleColor)
 {
+	Q_UNUSED(titleColor)
 }

--- a/desktop-widgets/tab-widgets/TabBase.h
+++ b/desktop-widgets/tab-widgets/TabBase.h
@@ -13,7 +13,7 @@ public:
 	TabBase(QWidget *parent = 0);
 	virtual void updateData() = 0;
 	virtual void clear() = 0;
-	virtual void updateUi();
+	virtual void updateUi(QString titleColor);
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -243,14 +243,10 @@ void TabDiveInformation::updateData()
 		showCurrentWidget(false, 0);  // Show current star widget at lefthand side
 }
 
-void TabDiveInformation::updateUi()
+void TabDiveInformation::updateUi(QString titleColor)
 {
-	// Put together appropriate CSS stylesheets: NB: colors below in same order as the enum in prefs.h
-	QStringList colors = { "mediumblue", "lightblue", "black" };	// If using dark theme, set color appropriately
-	QString colorText = colors[prefs.headerstyle_color];
-
 	QString CSSSetSmallLabel = "QLabel:enabled { color: ";
-	CSSSetSmallLabel.append(colorText + "; font-size: ");
+	CSSSetSmallLabel.append(titleColor + "; font-size: ");
 	CSSSetSmallLabel.append(QString::number((int)(0.5 + ui->diveHeadingLabel->geometry().height() * 0.66)) + "px;}");
 	ui->groupBox_visibility->setStyleSheet(ui->groupBox_visibility->styleSheet() + CSSSetSmallLabel);
 	ui->groupBox_current->setStyleSheet(ui->groupBox_current->styleSheet() + CSSSetSmallLabel);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -49,6 +49,7 @@ TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(ne
 	updateWaterTypeWidget();
 	QPixmap warning (":salinity-warning-icon");
 	ui->salinityOverWrittenIcon->setPixmap(warning);
+	ui->salinityOverWrittenIcon->setToolTip("Water type differs from that of dc");
 	ui->salinityOverWrittenIcon->setToolTipDuration(2500);
 	ui->salinityOverWrittenIcon->setVisible(false);
 }

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -16,7 +16,7 @@ public:
 	~TabDiveInformation();
 	void updateData() override;
 	void clear() override;
-	void updateUi() override;
+	void updateUi(QString titleColor) override;
 private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void cylinderChanged(dive *d);

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -34,7 +34,6 @@
 #include "TabDiveStatistics.h"
 #include "TabDiveSite.h"
 #include "TabDiveComputer.h"
-#include "core/settings/qPrefDisplay.h"
 
 #include <QCompleter>
 #include <QScrollBar>
@@ -102,7 +101,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	// Alas, this is not the case. When the user switches to system-format, the preferences sends the according
 	// signal. However, the correct date and time format is set by the preferences dialog later. This should be fixed.
 	connect(PreferencesDialog::instance(), &PreferencesDialog::settingsChanged, this, &MainTab::updateDateTimeFields);
-	connect(qPrefDisplay::instance(), &qPrefDisplay::headerstyle_colorChanged, this, &MainTab::colorsChanged);
+
 	QAction *action = new QAction(tr("Apply changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(acceptChanges()));
 	ui.diveNotesMessage->addAction(action);

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -78,6 +78,8 @@ private:
 	dive_trip *currentTrip;
 	QList<TabBase*> extraWidgets;
 	void divesEdited(int num); // Opens a warning window if more than one dive was edited
+	void changeEvent(QEvent *ev) override;
+	bool isDark;
 };
 
 #endif // MAINTAB_H


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a much better replacement for #3063 -- which really shouldn't have been merged :-(

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
rip out the preferences to pick this one color. that was just so user unfriendly
instead figure out if we are in a light or dark color and pick a reasonable title color.
and notice if the theme changes and update this choice if necessary

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3060 #3063 #3053 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@djunkins @bstoeger @willemferguson 