### PR TITLE
filter: don't escape '&' in filter-preset menu

### DIFF
--- a/desktop-widgets/filterwidget.cpp
+++ b/desktop-widgets/filterwidget.cpp
@@ -77,7 +77,10 @@ void FilterWidget::updatePresetMenu()
 	for (int i = 0; i < count; ++i) {
 		QModelIndex idx = model->index(i, FilterPresetModel::NAME);
 		QString name = model->data(idx, Qt::DisplayRole).value<QString>();
-		loadFilterPresetMenu->addAction(name, [this,i]() { selectPreset(i); });
+		QAction *action = new QAction(loadFilterPresetMenu.get());
+		action->setIconText(name);
+		connect(action, &QAction::triggered, [this,i]() { selectPreset(i); });
+		loadFilterPresetMenu->addAction(action);
 	}
 	ui.loadSetButton->setMenu(loadFilterPresetMenu.get());
 }


### PR DESCRIPTION
When constructing an action, '&' is used as the keyboard shortcut
marker. Since this mangles preset names, use the setIconText()
function of the action instead.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes the bug reported on the ML. I totally forgot about that menu - maybe we should remove it?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Don't escape ampersands in filter-preset menu.