### PR TITLE
desktop/filter: show '&' in dropdown for loading saved filters

### DIFF
--- a/desktop-widgets/filterwidget.cpp
+++ b/desktop-widgets/filterwidget.cpp
@@ -77,6 +77,10 @@ void FilterWidget::updatePresetMenu()
 	for (int i = 0; i < count; ++i) {
 		QModelIndex idx = model->index(i, FilterPresetModel::NAME);
 		QString name = model->data(idx, Qt::DisplayRole).value<QString>();
+		// QAction constructor tries to be clever and interprets an ampersand
+		// in the text as a shortcut indicator; manually work around that in order to
+		// have labels like "Amy & Bob" work
+		name.replace("&", "&&");
 		loadFilterPresetMenu->addAction(name, [this,i]() { selectPreset(i); });
 	}
 	ui.loadSetButton->setMenu(loadFilterPresetMenu.get());


### PR DESCRIPTION
Apparently this is mis-interpreted as a shortcut key unless the ampersand is
doubled.  The documentation is frustratingly quiet about this.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
maybe?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger