### PR TITLE
core: exclude filtered dives from statistics

### DIFF
--- a/core/statistics.c
+++ b/core/statistics.c
@@ -172,6 +172,8 @@ void calculate_stats_summary(struct stats_summary *out, bool selected_only)
 			continue;
 		if (dp->invalid)
 			continue;
+		if (dp->hidden_by_filter)
+			continue;
 		process_dive(dp, &stats);
 
 		/* yearly statistics */


### PR DESCRIPTION
This allows computing statistics for specific dives based on filter rules
e.g. statistics for dives with "deco" tag only.

Signed-off-by: Jeremie Guichard <djeBrest@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I make heavy use of tags for the different type of diving I'm doing, for example on what CCR unit the dive was made. It would be useful to be able to get statistics total dive time, amount of dives, etc. based on the tags. This is what this small change allows.

With the change when dives are filtered via the  "Filter divelist" functionality, when opening the Yearly statistics, then only statistics for the filtered dives are computed. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Simply skip the dive if it is "hidden_by_filter"
   I did not find tests about statistics, but maybe I have not looked long enough. It could be good to have a test suite for stats, but adding this I guess would rather be part of a separate change. I may have some time in the next days to look into that.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
There is not much documentation about yearly statistics, but could be worth adding a note to explain that behavior.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
