### PR TITLE
filter: avoid Windows crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Windows: avoid crash when setting filter values for tag-style fields
 - mobile: add location service warning as required by Google Play
 - mobile: fix manually adding dives in the past [#2971]
 

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -686,8 +686,8 @@ void filter_constraint_set_stringlist(filter_constraint &c, const QString &s)
 		return;
 	}
 	c.data.string_list->clear();
-	for (const QString &s: s.split(",", SKIP_EMPTY))
-		c.data.string_list->push_back(s.trimmed());
+	for (const QString &part: s.split(",", SKIP_EMPTY))
+		c.data.string_list->push_back(part.trimmed());
 }
 
 void filter_constraint_set_timestamp_from(filter_constraint &c, timestamp_t from)


### PR DESCRIPTION
The scope confusion between s (the for loop variable) and s (the function
argument) caused a crash in the s.split() on Windows.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
interesting to see this work on all platforms except Windows

### Release notes
added

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 