### PR TITLE
desktop: update completion models if dive was edited

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -261,12 +261,18 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 	}
 	if (field.divesite)
 		updateDiveSite(current_dive);
-	if (field.tags)
+	if (field.tags) {
+		tagModel.updateModel(); // TODO: Don't do this here
 		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
-	if (field.buddy)
+	}
+	if (field.buddy) {
+		buddyModel.updateModel(); // TODO: Don't do this here
 		ui.buddy->setText(current_dive->buddy);
-	if (field.divemaster)
+	}
+	if (field.divemaster) {
+		diveMasterModel.updateModel(); // TODO: Don't do this here
 		ui.divemaster->setText(current_dive->divemaster);
+	}
 
 	// If duration or depth changed, the profile needs to be replotted
 	if (field.duration || field.depth)


### PR DESCRIPTION
In the main-tab, when changing tag, buddy or divemaster,
update the corresponding completion model.
This is a quick-fix and the wrong thing to do. It works only
if the currently shown dive is changed, which is not a given.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Update auto-complete models, quickfix. See commit description.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3077.
