### PR TITLE
printing: properly initialize DPI value

### DIFF
--- a/desktop-widgets/printdialog.cpp
+++ b/desktop-widgets/printdialog.cpp
@@ -50,6 +50,7 @@ PrintDialog::PrintDialog(QWidget *parent) :
 	printOptions.color_selected = s.value("color_selected", true).toBool();
 	printOptions.landscape = s.value("landscape", false).toBool();
 	printOptions.p_template = s.value("template_selected", "one_dive.html").toString();
+	printOptions.resolution = s.value("resolution", 600).toInt();
 	templateOptions.font_index = s.value("font", 0).toInt();
 	templateOptions.font_size = s.value("font_size", 9).toDouble();
 	templateOptions.color_palette_index = s.value("color_palette", SSRF_COLORS).toInt();
@@ -150,6 +151,7 @@ void PrintDialog::onFinished()
 	s.setValue("print_selected", printOptions.print_selected);
 	s.setValue("color_selected", printOptions.color_selected);
 	s.setValue("template_selected", printOptions.p_template);
+	s.setValue("resolution", printOptions.resolution);
 
 	// save template settings
 	s.setValue("font", templateOptions.font_index);

--- a/desktop-widgets/printoptions.cpp
+++ b/desktop-widgets/printoptions.cpp
@@ -38,6 +38,9 @@ void PrintOptions::setup()
 	ui.printInColor->setChecked(printOptions->color_selected);
 	ui.printSelected->setChecked(printOptions->print_selected);
 
+	// resolution
+	ui.resolution->setValue(printOptions->resolution);
+
 	// connect slots only once
 	if (hasSetupSlots)
 		return;


### PR DESCRIPTION
The DPI value in the print_options structure was never initialized.
This could lead to random DPI values and crashes. How this ever
worked is a mystery.

Therefore, read and write the DPI value from the settings just
as the other print-options. And initialize the corresponding dialog
widget to this value.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes print-preview (and perhaps printing), see commit description. It's remains a mystery how this ever worked.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Initialize DPI from settings.
2) Save DPI to settings.
3) Initialize dialog DPI field.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Could perhaps fix #3076 - at least printing preview works for me now.
