### PR TITLE
core: fix incorrect QString::asprintf usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: fix missing GPS coordinate strings in the UI
 - core: Gracefully handle infinte MND for oxygen
 - mobile: add location service warning as required by Google Play
 - mobile: fix manually adding dives in the past [#2971]

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -18,7 +18,7 @@ static QString str_error(const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-	const QString str = QString().vasprintf(fmt, args);
+	const QString str = QString::vasprintf(fmt, args);
 	va_end(args);
 
 	return str;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -107,11 +107,11 @@ QString printGPSCoords(const location_t *location)
 		lonmin = (lon % 1000000U) * 60U;
 		latsec = (latmin % 1000000) * 60;
 		lonsec = (lonmin % 1000000) * 60;
-		result.asprintf("%u°%02d\'%06.3f\"%s %u°%02d\'%06.3f\"%s",
+		result = QString::asprintf("%u°%02d\'%06.3f\"%s %u°%02d\'%06.3f\"%s",
 			       latdeg, latmin / 1000000, latsec / 1000000, qPrintable(lath),
 			       londeg, lonmin / 1000000, lonsec / 1000000, qPrintable(lonh));
 	} else {
-		result.asprintf("%f %f", (double) lat / 1000000.0, (double) lon / 1000000.0);
+		result = QString::asprintf("%f %f", (double) lat / 1000000.0, (double) lon / 1000000.0);
 	}
 	return result;
 }


### PR DESCRIPTION
This is a static function, it cannot be used as a method on an object to
construct that object.

This caused us to not print GPS coordinates in the UI.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
that's what happens when I 'fix' warnings and don't carefully test the resulting code because it's "obviously right". :-(

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

