### PR TITLE
OnePlus crash

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -306,6 +306,7 @@ android {
 	SOURCES += core/android.cpp \
 		core/serial_usb_android.cpp
 	RESOURCES += packaging/android/translations.qrc
+	RESOURCES += android-mobile/font.qrc
 	QT += androidextras
 	ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android-mobile
 	ANDROID_VERSION_CODE = $$BUILD_NR

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -67,13 +67,18 @@ void run_ui()
 	if (getAndroidHWInfo().contains("/OnePlus/")) {
 		QFontDatabase db;
 		int id = QFontDatabase::addApplicationFont(":/fonts/Roboto-Regular.ttf");
-		QString family = QFontDatabase::applicationFontFamilies(id).at(0);
-		QFont newDefaultFont;
-		newDefaultFont.setFamily(family);
-		(static_cast<QApplication *>(QCoreApplication::instance()))->setFont(newDefaultFont);
-		qDebug() << "Detected OnePlus device, trying to force bundled font" << family;
-		QFont defaultFont = (static_cast<QApplication *>(QCoreApplication::instance()))->font();
-		qDebug() << "Qt reports default font is set as" << defaultFont.family();
+		QStringList fontFamilies = QFontDatabase::applicationFontFamilies(id);
+		if (fontFamilies.count() > 0) {
+			QString family = fontFamilies.at(0);
+			QFont newDefaultFont;
+			newDefaultFont.setFamily(family);
+			(static_cast<QApplication *>(QCoreApplication::instance()))->setFont(newDefaultFont);
+			qDebug() << "Detected OnePlus device, trying to force bundled font" << family;
+			QFont defaultFont = (static_cast<QApplication *>(QCoreApplication::instance()))->font();
+			qDebug() << "Qt reports default font is set as" << defaultFont.family();
+		} else {
+			qDebug() << "Detected OnePlus device, but can't determine font family used";
+		}
 	}
 #endif
 	QScreen *appScreen = QApplication::screens().at(0);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
forgot to bundle the default font needed for OnePlus devices when switching to qmake
as a result noticed bad code that crashed when the bundled font was missing

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
since this was only ever in a closed limited pre-beta release, no

