### PR TITLE
Some desktop code reshuffling and cleanups

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -157,6 +157,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	profile-widget/divepixmapitem.cpp \
 	profile-widget/divetooltipitem.cpp \
 	profile-widget/tankitem.cpp \
+	profile-widget/divehandler.cpp \
 	profile-widget/divelineitem.cpp \
 	profile-widget/diverectitem.cpp \
 	profile-widget/divetextitem.cpp
@@ -292,6 +293,7 @@ HEADERS += \
 	profile-widget/tankitem.h \
 	profile-widget/animationfunctions.h \
 	profile-widget/divecartesianaxis.h \
+	profile-widget/divehandler.h \
 	profile-widget/divelineitem.h \
 	profile-widget/divepixmapitem.h \
 	profile-widget/diverectitem.h \

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -740,8 +740,14 @@ void TripBase::undoit()
 	redoit();
 }
 
-RemoveDivesFromTrip::RemoveDivesFromTrip(const QVector<dive *> &divesToRemove)
+RemoveDivesFromTrip::RemoveDivesFromTrip(const QVector<dive *> &divesToRemoveIn)
 {
+	// Filter out dives outside of trip. Note: This is in a separate loop to get the command-description right.
+	QVector<dive *> divesToRemove;
+	for (dive *d: divesToRemoveIn) {
+		if (d->divetrip)
+			divesToRemove.push_back(d);
+	}
 	setText(QStringLiteral("%1 [%2]").arg(Command::Base::tr("remove %n dive(s) from trip", "", divesToRemove.size())).arg(getListOfDives(divesToRemove)));
 	divesToMove.divesToMove.reserve(divesToRemove.size());
 	for (dive *d: divesToRemove) {

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -83,6 +83,9 @@ signals:
 	// The core structures were completely reset. Repopulate all models.
 	void dataReset();
 
+	// The settings changed. Repopulate / rerender unit-dependent data, etc.
+	void settingsChanged();
+
 	// Note that there are no signals for trips being added and created
 	// because these events never happen without a dive being added, removed or moved.
 	// The dives are always sorted according to the dives_less_than() function of the core.

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -679,15 +679,7 @@ void DiveListView::mergeTripBelow()
 
 void DiveListView::removeFromTrip()
 {
-	//TODO: move this to C-code.
-	int i;
-	struct dive *d;
-	QVector<dive *> divesToRemove;
-	for_each_dive (i, d) {
-		if (d->selected && d->divetrip)
-			divesToRemove.append(d);
-	}
-	Command::removeDivesFromTrip(divesToRemove);
+	Command::removeDivesFromTrip(stdToQt(getDiveSelection()));
 }
 
 void DiveListView::newTripAbove()
@@ -695,14 +687,7 @@ void DiveListView::newTripAbove()
 	struct dive *d = contextMenuIndex.data(DiveTripModelBase::DIVE_ROLE).value<struct dive *>();
 	if (!d) // shouldn't happen as we only are setting up this action if this is a dive
 		return;
-	//TODO: port to c-code.
-	int idx;
-	QVector<dive *> dives;
-	for_each_dive (idx, d) {
-		if (d->selected)
-			dives.append(d);
-	}
-	Command::createTrip(dives);
+	Command::createTrip(stdToQt(getDiveSelection()));
 }
 
 void DiveListView::addToTripBelow()

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -9,6 +9,7 @@
 #include "desktop-widgets/modeldelegates.h"
 #include "desktop-widgets/mainwindow.h"
 #include "core/selection.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #include <unistd.h>
 #include <QSettings>
 #include <QKeyEvent>
@@ -39,6 +40,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	setModel(m);
 	connect(m, &MultiFilterSortModel::selectionChanged, this, &DiveListView::diveSelectionChanged);
 	connect(m, &MultiFilterSortModel::currentDiveChanged, this, &DiveListView::currentDiveChanged);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DiveListView::settingsChanged);
 
 	setSortingEnabled(true);
 	setContextMenuPolicy(Qt::DefaultContextMenu);
@@ -346,6 +348,12 @@ void DiveListView::reload()
 			setAnimated(true);
 		}
 	}
+}
+
+void DiveListView::settingsChanged()
+{
+	update();
+	reloadHeaderActions();
 }
 
 void DiveListView::reloadHeaderActions()

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -34,7 +34,6 @@ signals:
 public
 slots:
 	void settingsChanged();
-	void reloadHeaderActions();
 private
 slots:
 	void toggleColumnVisibilityByIndex();

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -33,6 +33,7 @@ signals:
 	void divesSelected();
 public
 slots:
+	void settingsChanged();
 	void reloadHeaderActions();
 private
 slots:

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -15,97 +15,12 @@
 #include "profile-widget/profilewidget2.h"
 #include "qt-models/diveplannermodel.h"
 
-#include <QGraphicsSceneMouseEvent>
-#include <QSettings>
 #include <QShortcut>
 #ifndef NO_PRINTING
 #include <QPrintDialog>
 #include <QPrinter>
 #include <QBuffer>
 #endif
-
-DiveHandler::DiveHandler() : QGraphicsEllipseItem()
-{
-	setRect(-5, -5, 10, 10);
-	setFlags(ItemIgnoresTransformations | ItemIsSelectable | ItemIsMovable | ItemSendsGeometryChanges);
-	setBrush(Qt::white);
-	setZValue(2);
-	t.start();
-}
-
-int DiveHandler::parentIndex()
-{
-	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
-	return view->handles.indexOf(this);
-}
-
-void DiveHandler::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
-{
-	QMenu m;
-	// Don't have a gas selection for the last point
-	emit released();
-	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
-	if (index.sibling(index.row() + 1, index.column()).isValid()) {
-		GasSelectionModel *model = GasSelectionModel::instance();
-		model->repopulate();
-		int rowCount = model->rowCount();
-		for (int i = 0; i < rowCount; i++) {
-			QAction *action = new QAction(&m);
-			action->setText(model->data(model->index(i, 0), Qt::DisplayRole).toString());
-			action->setData(i);
-			connect(action, &QAction::triggered, this, &DiveHandler::changeGas);
-			m.addAction(action);
-		}
-	}
-	// don't allow removing the last point
-	if (plannerModel->rowCount() > 1) {
-		m.addSeparator();
-		m.addAction(gettextFromC::tr("Remove this point"), this, &DiveHandler::selfRemove);
-		m.exec(event->screenPos());
-	}
-}
-
-void DiveHandler::selfRemove()
-{
-	setSelected(true);
-	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
-	view->keyDeleteAction();
-}
-
-void DiveHandler::changeGas()
-{
-	QAction *action = qobject_cast<QAction *>(sender());
-	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
-	plannerModel->gasChange(index.sibling(index.row() + 1, index.column()), action->data().toInt());
-}
-
-void DiveHandler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
-{
-	if (t.elapsed() < 40)
-		return;
-	t.start();
-
-	ProfileWidget2 *view = qobject_cast<ProfileWidget2*>(scene()->views().first());
-	if(view->isPointOutOfBoundaries(event->scenePos()))
-		return;
-
-	QGraphicsEllipseItem::mouseMoveEvent(event);
-	emit moved();
-}
-
-void DiveHandler::mousePressEvent(QGraphicsSceneMouseEvent *event)
-{
-	QGraphicsItem::mousePressEvent(event);
-	emit clicked();
-}
-
-void DiveHandler::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
-{
-	QGraphicsItem::mouseReleaseEvent(event);
-	emit released();
-}
 
 DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0))
 {

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -663,7 +663,6 @@ void PlannerWidgets::replanDive()
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
 	MainWindow::instance()->graphics->setPlanState();
-	MainWindow::instance()->graphics->clearHandlers();
 
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(current_dive->when));

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -19,6 +19,11 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QShortcut>
+#ifndef NO_PRINTING
+#include <QPrintDialog>
+#include <QPrinter>
+#include <QBuffer>
+#endif
 
 #define TIME_INITIAL_MAX 30
 
@@ -149,7 +154,6 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(cylinders, &CylindersModel::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(cylinders, &CylindersModel::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-	connect(plannerModel, &DivePlannerPointsModel::calculatedPlanNotes, MainWindow::instance(), &MainWindow::setPlanNotes);
 
 
 	ui.tableWidget->setBtnToolTip(tr("Add dive data point"));
@@ -181,6 +185,8 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	/* set defaults. */
 	ui.ATMPressure->setValue(1013);
 	ui.atmHeight->setValue(0);
+
+	settingsChanged();
 
 	setMinimumWidth(0);
 	setMinimumHeight(0);
@@ -423,11 +429,6 @@ void PlannerSettingsWidget::disableBackgasBreaks(bool enabled)
 	}
 }
 
-void DivePlannerWidget::printDecoPlan()
-{
-	MainWindow::instance()->printPlan();
-}
-
 PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent) : QWidget(parent, QFlag(0))
 {
 	ui.setupUi(this);
@@ -603,10 +604,6 @@ void PlannerSettingsWidget::settingsChanged()
 	ui.descRate->setSuffix(vs);
 }
 
-void PlannerSettingsWidget::printDecoPlan()
-{
-}
-
 void PlannerSettingsWidget::setBackgasBreaks(bool dobreaks)
 {
 	PlannerShared::set_doo2breaks(dobreaks);
@@ -621,4 +618,111 @@ void PlannerSettingsWidget::setBailoutVisibility(int mode)
 PlannerDetails::PlannerDetails(QWidget *parent) : QWidget(parent)
 {
 	ui.setupUi(this);
+#ifdef NO_PRINTING
+	ui.printPlan->hide();
+#endif
+}
+
+void PlannerDetails::setPlanNotes(QString plan)
+{
+	ui.divePlanOutput->setHtml(plan);
+}
+
+PlannerWidgets::PlannerWidgets()
+{
+	connect(plannerDetails.printPlan(), &QPushButton::pressed, this, &PlannerWidgets::printDecoPlan);
+	connect(DivePlannerPointsModel::instance(), &DivePlannerPointsModel::calculatedPlanNotes,
+		&plannerDetails, &PlannerDetails::setPlanNotes);
+}
+
+void PlannerWidgets::planDive()
+{
+	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
+
+	MainWindow::instance()->graphics->setPlanState();
+	dc_number = 0;
+
+	// create a simple starting dive, using the first gas from the just copied cylinders
+	DivePlannerPointsModel::instance()->createSimpleDive();
+
+	// plan the dive in the same mode as the currently selected one
+	if (current_dive) {
+		plannerSettingsWidget.setDiveMode(current_dive->dc.divemode);
+		plannerSettingsWidget.setBailoutVisibility(current_dive->dc.divemode);
+		if (current_dive->salinity)
+			plannerWidget.setSalinity(current_dive->salinity);
+		else	// No salinity means salt water
+			plannerWidget.setSalinity(SEAWATER_SALINITY);
+	}
+	plannerWidget.setReplanButton(false);
+}
+
+void PlannerWidgets::replanDive()
+{
+	DivePlannerPointsModel::instance()->clear();
+	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
+
+	MainWindow::instance()->graphics->setPlanState();
+	MainWindow::instance()->graphics->clearHandlers();
+
+	plannerWidget.setReplanButton(true);
+	plannerWidget.setupStartTime(timestampToDateTime(current_dive->when));
+	if (current_dive->surface_pressure.mbar)
+		plannerWidget.setSurfacePressure(current_dive->surface_pressure.mbar);
+	if (current_dive->salinity)
+		plannerWidget.setSalinity(current_dive->salinity);
+	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
+	reset_cylinders(&displayed_dive, true);
+	DivePlannerPointsModel::instance()->cylindersModel()->updateDive(&displayed_dive);
+}
+
+void PlannerWidgets::printDecoPlan()
+{
+#ifndef NO_PRINTING
+	char *disclaimer = get_planner_disclaimer_formatted();
+	// Prepend a logo and a disclaimer to the plan.
+	// Save the old plan so that it can be restored at the end of the function.
+	QString origPlan = plannerDetails.divePlanOutput()->toHtml();
+	QString diveplan = QStringLiteral("<img height=50 src=\":subsurface-icon\"> ") +
+			   QString(disclaimer) + origPlan;
+	free(disclaimer);
+
+	QPrinter printer;
+	QPrintDialog *dialog = new QPrintDialog(&printer, MainWindow::instance());
+	dialog->setWindowTitle(tr("Print runtime table"));
+	if (dialog->exec() != QDialog::Accepted)
+		return;
+
+	/* render the profile as a pixmap that is inserted as base64 data into a HTML <img> tag
+	 * make it fit a page width defined by 2 cm margins via QTextDocument->print() (cannot be changed?)
+	 * the height of the profile is 40% of the page height.
+	 */
+	QSizeF renderSize = printer.pageRect(QPrinter::Inch).size();
+	const qreal marginsInch = 1.57480315; // = (2 x 2cm) / 2.45cm/inch
+	renderSize.setWidth((renderSize.width() - marginsInch) * printer.resolution());
+	renderSize.setHeight(((renderSize.height() - marginsInch) * printer.resolution()) / 2.5);
+
+	QPixmap pixmap(renderSize.toSize());
+	QPainter painter(&pixmap);
+	painter.setRenderHint(QPainter::Antialiasing);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform);
+
+	ProfileWidget2 *profile = MainWindow::instance()->graphics;
+	QSize origSize = profile->size();
+	profile->resize(renderSize.toSize());
+	profile->setPrintMode(true);
+	profile->render(&painter);
+	profile->resize(origSize);
+	profile->setPrintMode(false);
+
+	QByteArray byteArray;
+	QBuffer buffer(&byteArray);
+	pixmap.save(&buffer, "PNG");
+	QString profileImage = QString("<img src=\"data:image/png;base64,") + byteArray.toBase64() + "\"/><br><br>";
+	diveplan = profileImage + diveplan;
+
+	plannerDetails.divePlanOutput()->setHtml(diveplan);
+	plannerDetails.divePlanOutput()->print(&printer);
+	plannerDetails.divePlanOutput()->setHtml(origPlan); // restore original plan
+#endif
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -16,7 +16,6 @@
 #include "qt-models/diveplannermodel.h"
 
 #include <QGraphicsSceneMouseEvent>
-#include <QMessageBox>
 #include <QSettings>
 #include <QShortcut>
 #ifndef NO_PRINTING
@@ -24,11 +23,6 @@
 #include <QPrinter>
 #include <QBuffer>
 #endif
-
-#define TIME_INITIAL_MAX 30
-
-#define MAX_DEPTH M_OR_FT(150, 450)
-#define MIN_DEPTH M_OR_FT(20, 60)
 
 DiveHandler::DiveHandler() : QGraphicsEllipseItem()
 {

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -6,6 +6,7 @@
 #include "core/qthelper.h"
 #include "core/units.h"
 #include "core/settings/qPrefDivePlanner.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #include "core/gettextfromc.h"
 #include "backend-shared/plannershared.h"
 
@@ -174,6 +175,8 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::RUNTIME, new SpinBoxDelegate(0, INT_MAX, 1, this));
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DURATION, new SpinBoxDelegate(0, 6000, 1, this));
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::CCSETPOINT, new DoubleSpinBoxDelegate(0, 2, 0.1, this));
+
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DivePlannerWidget::settingsChanged);
 
 	/* set defaults. */
 	ui.ATMPressure->setValue(1013);
@@ -506,6 +509,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(QWidget *parent) : QWidget(parent, 
 	connect(ui.bestmixEND, QOverload<int>::of(&QSpinBox::valueChanged), &PlannerShared::set_bestmixend);
 	connect(ui.bottomSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &PlannerShared::set_bottomsac);
 	connect(ui.decoStopSAC, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &PlannerShared::set_decosac);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &PlannerSettingsWidget::settingsChanged);
 
 	settingsChanged();
 	ui.gflow->setValue(prefs.gflow);

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -2,40 +2,13 @@
 #ifndef DIVEPLANNER_H
 #define DIVEPLANNER_H
 
-#include <QGraphicsPathItem>
 #include <QAbstractTableModel>
 #include <QAbstractButton>
 #include <QDateTime>
-#include <QSignalMapper>
-#include <QElapsedTimer>
 
 class QListView;
 class QModelIndex;
 class DivePlannerPointsModel;
-
-class DiveHandler : public QObject, public QGraphicsEllipseItem {
-	Q_OBJECT
-public:
-	DiveHandler();
-
-protected:
-	void contextMenuEvent(QGraphicsSceneContextMenuEvent *event);
-	void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
-	void mousePressEvent(QGraphicsSceneMouseEvent *event);
-	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-signals:
-	void moved();
-	void clicked();
-	void released();
-private:
-	int parentIndex();
-public
-slots:
-	void selfRemove();
-	void changeGas();
-private:
-	QElapsedTimer t;
-};
 
 #include "ui_diveplanner.h"
 

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -9,7 +9,6 @@
 #include <QSignalMapper>
 #include <QElapsedTimer>
 
-
 class QListView;
 class QModelIndex;
 class DivePlannerPointsModel;

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -53,7 +53,6 @@ slots:
 	void heightChanged(const int height);
 	void waterTypeChanged(const int index);
 	void customSalinityChanged(double density);
-	void printDecoPlan();
 	void setSurfacePressure(int surface_pressure);
 	void setSalinity(int salinity);
 private:
@@ -72,7 +71,6 @@ public:
 public
 slots:
 	void settingsChanged();
-	void printDecoPlan();
 	void setBackgasBreaks(bool dobreaks);
 	void disableDecoElements(int mode);
 	void disableBackgasBreaks(bool enabled);
@@ -92,10 +90,28 @@ public:
 	explicit PlannerDetails(QWidget *parent = 0);
 	QPushButton *printPlan() const { return ui.printPlan; }
 	QTextEdit *divePlanOutput() const { return ui.divePlanOutput; }
-	QLabel *divePlannerOutputLabel() const { return ui.divePlanOutputLabel; }
+public
+slots:
+	void setPlanNotes(QString plan);
 
 private:
 	Ui::plannerDetails ui;
+};
+
+// The planner widgets make up three quadrants
+class PlannerWidgets : public QObject {
+	Q_OBJECT
+public:
+	PlannerWidgets();
+	void planDive();
+	void replanDive();
+public
+slots:
+	void printDecoPlan();
+public:
+	DivePlannerWidget plannerWidget;
+	PlannerSettingsWidget plannerSettingsWidget;
+	PlannerDetails plannerDetails;
 };
 
 #endif // DIVEPLANNER_H

--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -2,7 +2,7 @@
 #include "filterconstraintwidget.h"
 #include "starwidget.h"
 #include "core/pref.h"
-#include "desktop-widgets/preferences/preferencesdialog.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #include "qt-models/cleanertablemodel.h" // for trashIcon()
 #include "qt-models/filterconstraintmodel.h"
 
@@ -225,7 +225,7 @@ FilterConstraintWidget::FilterConstraintWidget(FilterConstraintModel *modelIn, c
 	rangeLayout->addStretch();
 
 	// Update the widget if the settings changed to reflect new units.
-	connect(PreferencesDialog::instance(), &PreferencesDialog::settingsChanged, this, &FilterConstraintWidget::update);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &FilterConstraintWidget::update);
 
 	addToLayout();
 	update();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -284,25 +284,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(ui.profPn2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_pn2);
 	connect(ui.profPO2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_po2);
 
-	connect(tec, &qPrefTechnicalDetails::calcalltissuesChanged        , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcceilingChanged           , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::dcceilingChanged             , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::eadChanged                   , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcceiling3mChanged         , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::modChanged                   , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::calcndlttsChanged            , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::hrgraphChanged               , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::rulergraphChanged            , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::show_sacChanged              , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::zoomed_plotChanged           , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::show_pictures_in_profileChanged , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::tankbarChanged               , graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(tec, &qPrefTechnicalDetails::percentagegraphChanged       , graphics, &ProfileWidget2::actionRequestedReplot);
-
-	connect(pp_gas, &qPrefPartialPressureGas::pheChanged, graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(pp_gas, &qPrefPartialPressureGas::pn2Changed, graphics, &ProfileWidget2::actionRequestedReplot);
-	connect(pp_gas, &qPrefPartialPressureGas::po2Changed, graphics, &ProfileWidget2::actionRequestedReplot);
-
 	// now let's set up some connections
 	connect(graphics, &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
 	connect(graphics, &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -308,7 +308,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(graphics, &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);
 	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
-	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab.get(), &MainTab::updateDiveInfo);
 
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, graphics, &ProfileWidget2::settingsChanged);
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1552,9 +1552,6 @@ void MainWindow::turnOffNdlTts()
 	qPrefTechnicalDetails::set_calcndltts(false);
 }
 
-#undef TOOLBOX_PREF_PROFILE
-#undef PERF_PROFILE
-
 void MainWindow::on_actionExport_triggered()
 {
 	DiveLogExportDialog diveLogExport;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -189,13 +189,7 @@ MainWindow::MainWindow() : QMainWindow(),
 		QIcon::setThemeName("subsurface");
 	}
 	connect(diveList, &DiveListView::divesSelected, this, &MainWindow::selectionChanged);
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(readSettings()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(update()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), diveList, SLOT(reloadHeaderActions()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), mainTab.get(), SLOT(updateDiveInfo()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerWidget, SLOT(settingsChanged()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), divePlannerSettingsWidget, SLOT(settingsChanged()));
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), TankInfoModel::instance(), SLOT(update()));
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainWindow::readSettings);
 	for (int i = 0; i < NUM_RECENT_FILES; i++) {
 		actionsRecent[i] = new QAction(this);
 		actionsRecent[i]->setData(i);
@@ -324,7 +318,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
 	connect(graphics, &ProfileWidget2::updateDiveInfo, mainTab.get(), &MainTab::updateDiveInfo);
 
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), graphics, SLOT(settingsChanged()));
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, graphics, &ProfileWidget2::settingsChanged);
 
 	ui.profCalcAllTissues->setChecked(qPrefTechnicalDetails::calcalltissues());
 	ui.profCalcCeiling->setChecked(qPrefTechnicalDetails::calcceiling());

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -219,8 +219,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	graphics->setEmptyState();
 	initialUiSetup();
 	readSettings();
-	diveList->reload();
-	diveList->reloadHeaderActions();
 	diveList->setFocus();
 	MapWidget::instance()->reload();
 	diveList->expand(diveList->model()->index(0, 0));

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -35,10 +35,8 @@ class QWebView;
 class QSettings;
 class UpdateManager;
 class UserManual;
-class DivePlannerWidget;
+class PlannerWidgets;
 class ProfileWidget2;
-class PlannerDetails;
-class PlannerSettingsWidget;
 class LocationInformationWidget;
 
 typedef std::pair<QByteArray, QVariant> WidgetProperty;
@@ -73,7 +71,6 @@ public:
 	void loadFiles(const QStringList files);
 	void importFiles(const QStringList importFiles);
 	void setToolButtonsEnabled(bool enabled);
-	void printPlan();
 	void setApplicationState(ApplicationState state);
 	bool inPlanner();
 	NotificationWidget *getNotificationWidget();
@@ -82,10 +79,8 @@ public:
 	void editDiveSite(dive_site *ds);
 
 	std::unique_ptr<MainTab> mainTab;
-	PlannerDetails *plannerDetails;
-	PlannerSettingsWidget *divePlannerSettingsWidget;
+	std::unique_ptr<PlannerWidgets> plannerWidgets;
 	ProfileWidget2 *graphics;
-	DivePlannerWidget *divePlannerWidget;
 	DiveListView *diveList;
 private
 slots:
@@ -164,7 +159,6 @@ slots:
 	void planCanceled();
 	void planCreated();
 	void setEnabledToolbar(bool arg1);
-	void setPlanNotes(QString plan);
 	// Some shortcuts like "change DC" or "copy/paste dive components"
 	// should only be enabled when the profile's visible.
 	void disableShortcuts(bool disablePaste = true);

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -31,11 +31,6 @@ PreferencesDialog* PreferencesDialog::instance()
 	return self;
 }
 
-void PreferencesDialog::emitSettingsChanged()
-{
-	emit settingsChanged();
-}
-
 PreferencesDialog::PreferencesDialog()
 {
 	//FIXME: This looks wrong.

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -32,6 +32,11 @@ PreferencesDialog *PreferencesDialog::instance()
 	return self;
 }
 
+static bool abstractpreferenceswidget_lessthan(const AbstractPreferencesWidget *p1, const AbstractPreferencesWidget *p2)
+{
+	return p1->positionHeight() < p2->positionHeight();
+}
+
 PreferencesDialog::PreferencesDialog()
 {
 	//FIXME: This looks wrong.
@@ -61,18 +66,19 @@ PreferencesDialog::PreferencesDialog()
 
 	setLayout(v);
 
-	addPreferencePage(new PreferencesLanguage());
-	addPreferencePage(new PreferencesGeoreference());
-	addPreferencePage(new PreferencesDefaults());
-	addPreferencePage(new PreferencesUnits());
-	addPreferencePage(new PreferencesGraph());
-	addPreferencePage(new PreferencesNetwork());
-	addPreferencePage(new PreferencesCloud());
-	addPreferencePage(new PreferencesEquipment());
-	addPreferencePage(new PreferencesMedia());
-	addPreferencePage(new PreferencesDc());
-	addPreferencePage(new PreferencesLog());
-	addPreferencePage(new PreferencesReset());
+	pages.push_back(new PreferencesLanguage);
+	pages.push_back(new PreferencesGeoreference);
+	pages.push_back(new PreferencesDefaults);
+	pages.push_back(new PreferencesUnits);
+	pages.push_back(new PreferencesGraph);
+	pages.push_back(new PreferencesNetwork);
+	pages.push_back(new PreferencesCloud);
+	pages.push_back(new PreferencesEquipment);
+	pages.push_back(new PreferencesMedia);
+	pages.push_back(new PreferencesDc);
+	pages.push_back(new PreferencesLog);
+	pages.push_back(new PreferencesReset);
+	std::sort(pages.begin(), pages.end(), abstractpreferenceswidget_lessthan);
 
 	refreshPages();
 
@@ -96,17 +102,6 @@ void PreferencesDialog::buttonClicked(QAbstractButton* btn)
 	case QDialogButtonBox::ResetRole : defaultsRequested(); return;
 	default: return;
 	}
-}
-
-bool abstractpreferenceswidget_lessthan(AbstractPreferencesWidget *p1, AbstractPreferencesWidget *p2)
-{
-	return p1->positionHeight() < p2->positionHeight();
-}
-
-void PreferencesDialog::addPreferencePage(AbstractPreferencesWidget *page)
-{
-	pages.push_back(page);
-	std::sort(pages.begin(), pages.end(), abstractpreferenceswidget_lessthan);
 }
 
 void PreferencesDialog::refreshPages()

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -16,6 +16,7 @@
 #include "preferences_reset.h"
 
 #include "core/qthelper.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -25,7 +26,7 @@
 #include <QAbstractButton>
 #include <QDebug>
 
-PreferencesDialog* PreferencesDialog::instance()
+PreferencesDialog *PreferencesDialog::instance()
 {
 	static PreferencesDialog *self = new PreferencesDialog();
 	return self;
@@ -130,10 +131,10 @@ void PreferencesDialog::refreshPages()
 void PreferencesDialog::applyRequested(bool closeIt)
 {
 	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
-		connect(page, &AbstractPreferencesWidget::settingsChanged, this, &PreferencesDialog::settingsChanged, Qt::UniqueConnection);
+		connect(page, &AbstractPreferencesWidget::settingsChanged, &diveListNotifier, &DiveListNotifier::settingsChanged, Qt::UniqueConnection);
 		page->syncSettings();
 	}
-	emit settingsChanged();
+	emit diveListNotifier.settingsChanged();
 	if (closeIt)
 		accept();
 }
@@ -152,6 +153,6 @@ void PreferencesDialog::defaultsRequested()
 	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
 		page->refreshSettings();
 	}
-	emit settingsChanged();
+	emit diveListNotifier.settingsChanged();
 	accept();
 }

--- a/desktop-widgets/preferences/preferencesdialog.cpp
+++ b/desktop-widgets/preferences/preferencesdialog.cpp
@@ -84,6 +84,7 @@ PreferencesDialog::PreferencesDialog()
 		pagesList->addItem(item);
 		pagesStack->addWidget(page);
 		page->refreshSettings();
+		connect(page, &AbstractPreferencesWidget::settingsChanged, &diveListNotifier, &DiveListNotifier::settingsChanged);
 	}
 
 	connect(pagesList, &QListWidget::currentRowChanged,
@@ -116,10 +117,8 @@ void PreferencesDialog::refreshPages()
 
 void PreferencesDialog::applyRequested(bool closeIt)
 {
-	Q_FOREACH(AbstractPreferencesWidget *page, pages) {
-		connect(page, &AbstractPreferencesWidget::settingsChanged, &diveListNotifier, &DiveListNotifier::settingsChanged, Qt::UniqueConnection);
+	for (AbstractPreferencesWidget *page: pages)
 		page->syncSettings();
-	}
 	emit diveListNotifier.settingsChanged();
 	if (closeIt)
 		accept();

--- a/desktop-widgets/preferences/preferencesdialog.h
+++ b/desktop-widgets/preferences/preferencesdialog.h
@@ -3,7 +3,6 @@
 #define PREFERENCES_WIDGET_H
 
 #include <QDialog>
-#include "core/pref.h"
 
 class AbstractPreferencesWidget;
 class QListWidget;
@@ -14,7 +13,7 @@ class QAbstractButton;
 class PreferencesDialog : public QDialog {
 	Q_OBJECT
 public:
-	static PreferencesDialog* instance();
+	static PreferencesDialog *instance();
 	~PreferencesDialog();
 	void refreshPages();
 	void defaultsRequested();

--- a/desktop-widgets/preferences/preferencesdialog.h
+++ b/desktop-widgets/preferences/preferencesdialog.h
@@ -19,8 +19,6 @@ public:
 	void addPreferencePage(AbstractPreferencesWidget *page);
 	void refreshPages();
 	void defaultsRequested();
-signals:
-	void settingsChanged();
 private:
 	PreferencesDialog();
 	void cancelRequested();

--- a/desktop-widgets/preferences/preferencesdialog.h
+++ b/desktop-widgets/preferences/preferencesdialog.h
@@ -18,7 +18,6 @@ public:
 	~PreferencesDialog();
 	void addPreferencePage(AbstractPreferencesWidget *page);
 	void refreshPages();
-	void emitSettingsChanged();
 	void defaultsRequested();
 signals:
 	void settingsChanged();

--- a/desktop-widgets/preferences/preferencesdialog.h
+++ b/desktop-widgets/preferences/preferencesdialog.h
@@ -16,7 +16,6 @@ class PreferencesDialog : public QDialog {
 public:
 	static PreferencesDialog* instance();
 	~PreferencesDialog();
-	void addPreferencePage(AbstractPreferencesWidget *page);
 	void refreshPages();
 	void defaultsRequested();
 private:

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -8,7 +8,6 @@
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "desktop-widgets/mainwindow.h"
 #include "desktop-widgets/mapwidget.h"
-#include "desktop-widgets/preferences/preferencesdialog.h"
 #include "core/qthelper.h"
 #include "core/trip.h"
 #include "qt-models/diveplannermodel.h"
@@ -91,6 +90,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &MainTab::tripChanged);
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &MainTab::diveSiteEdited);
 	connect(&diveListNotifier, &DiveListNotifier::commandExecuted, this, &MainTab::closeWarning);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainTab::updateDiveInfo);
 
 	connect(ui.editDiveSiteButton, &QToolButton::clicked, MainWindow::instance(), &MainWindow::startDiveSiteEdit);
 	connect(ui.location, &DiveLocationLineEdit::entered, MapWidget::instance(), &MapWidget::centerOnIndex);
@@ -100,7 +100,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	// One might think that we could listen to the precise property-changed signals of the preferences system.
 	// Alas, this is not the case. When the user switches to system-format, the preferences sends the according
 	// signal. However, the correct date and time format is set by the preferences dialog later. This should be fixed.
-	connect(PreferencesDialog::instance(), &PreferencesDialog::settingsChanged, this, &MainTab::updateDateTimeFields);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainTab::updateDateTimeFields);
 
 	QAction *action = new QAction(tr("Apply changes"), this);
 	connect(action, SIGNAL(triggered(bool)), this, SLOT(acceptChanges()));

--- a/packaging/ios/Subsurface-mobile.pro
+++ b/packaging/ios/Subsurface-mobile.pro
@@ -163,6 +163,7 @@ SOURCES += ../../subsurface-mobile-main.cpp \
 	../../profile-widget/divepixmapitem.cpp \
 	../../profile-widget/divetooltipitem.cpp \
 	../../profile-widget/tankitem.cpp \
+	../../profile-widget/divehandler.cpp \
 	../../profile-widget/divelineitem.cpp \
 	../../profile-widget/diverectitem.cpp \
 	../../profile-widget/divetextitem.cpp
@@ -322,6 +323,7 @@ HEADERS += \
 	../../profile-widget/tankitem.h \
 	../../profile-widget/animationfunctions.h \
 	../../profile-widget/divecartesianaxis.h \
+	../../profile-widget/divehandler.h \
 	../../profile-widget/divelineitem.h \
 	../../profile-widget/divepixmapitem.h \
 	../../profile-widget/diverectitem.h \

--- a/profile-widget/CMakeLists.txt
+++ b/profile-widget/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SUBSURFACE_PROFILE_LIB_SRCS
 	divecartesianaxis.h
 	diveeventitem.cpp
 	diveeventitem.h
+	divehandler.cpp
+	divehandler.h
 	divelineitem.cpp
 	divelineitem.h
 	divepixmapitem.cpp

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -3,9 +3,7 @@
 #include "profile-widget/divetextitem.h"
 #include "core/qthelper.h"
 #include "core/subsurface-string.h"
-#ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/preferences/preferencesdialog.h"
-#endif
+#include "core/subsurface-qt/divelistnotifier.h"
 #include "qt-models/diveplotdatamodel.h"
 #include "profile-widget/animationfunctions.h"
 #include "profile-widget/divelineitem.h"
@@ -365,9 +363,7 @@ QColor DepthAxis::colorForValue(double)
 
 DepthAxis::DepthAxis(ProfileWidget2 *widget) : DiveCartesianAxis(widget)
 {
-#ifndef SUBSURFACE_MOBILE
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
-#endif
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DepthAxis::settingsChanged);
 	changed = true;
 	settingsChanged();
 }
@@ -422,9 +418,7 @@ PartialGasPressureAxis::PartialGasPressureAxis(ProfileWidget2 *widget) :
 	DiveCartesianAxis(widget),
 	model(NULL)
 {
-#ifndef SUBSURFACE_MOBILE
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
-#endif
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &PartialGasPressureAxis::settingsChanged);
 }
 
 void PartialGasPressureAxis::setModel(DivePlotDataModel *m)

--- a/profile-widget/divehandler.cpp
+++ b/profile-widget/divehandler.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "divehandler.h"
+#include "profilewidget2.h"
+#include "core/gettextfromc.h"
+#include "qt-models/diveplannermodel.h"
+#include "qt-models/models.h"
+
+#include <QMenu>
+#include <QGraphicsSceneMouseEvent>
+#include <QSettings>
+
+DiveHandler::DiveHandler() : QGraphicsEllipseItem()
+{
+	setRect(-5, -5, 10, 10);
+	setFlags(ItemIgnoresTransformations | ItemIsSelectable | ItemIsMovable | ItemSendsGeometryChanges);
+	setBrush(Qt::white);
+	setZValue(2);
+	t.start();
+}
+
+int DiveHandler::parentIndex()
+{
+	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
+	return view->handles.indexOf(this);
+}
+
+void DiveHandler::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
+{
+	QMenu m;
+	// Don't have a gas selection for the last point
+	emit released();
+	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
+	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
+	if (index.sibling(index.row() + 1, index.column()).isValid()) {
+		GasSelectionModel *model = GasSelectionModel::instance();
+		model->repopulate();
+		int rowCount = model->rowCount();
+		for (int i = 0; i < rowCount; i++) {
+			QAction *action = new QAction(&m);
+			action->setText(model->data(model->index(i, 0), Qt::DisplayRole).toString());
+			action->setData(i);
+			connect(action, &QAction::triggered, this, &DiveHandler::changeGas);
+			m.addAction(action);
+		}
+	}
+	// don't allow removing the last point
+	if (plannerModel->rowCount() > 1) {
+		m.addSeparator();
+		m.addAction(gettextFromC::tr("Remove this point"), this, &DiveHandler::selfRemove);
+		m.exec(event->screenPos());
+	}
+}
+
+void DiveHandler::selfRemove()
+{
+#ifndef SUBSURFACE_MOBILE
+	setSelected(true);
+	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
+	view->keyDeleteAction();
+#endif
+}
+
+void DiveHandler::changeGas()
+{
+	QAction *action = qobject_cast<QAction *>(sender());
+	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
+	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
+	plannerModel->gasChange(index.sibling(index.row() + 1, index.column()), action->data().toInt());
+}
+
+void DiveHandler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
+{
+	if (t.elapsed() < 40)
+		return;
+	t.start();
+
+	ProfileWidget2 *view = qobject_cast<ProfileWidget2*>(scene()->views().first());
+	if(view->isPointOutOfBoundaries(event->scenePos()))
+		return;
+
+	QGraphicsEllipseItem::mouseMoveEvent(event);
+	emit moved();
+}
+
+void DiveHandler::mousePressEvent(QGraphicsSceneMouseEvent *event)
+{
+	QGraphicsItem::mousePressEvent(event);
+	emit clicked();
+}
+
+void DiveHandler::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
+{
+	QGraphicsItem::mouseReleaseEvent(event);
+	emit released();
+}

--- a/profile-widget/divehandler.h
+++ b/profile-widget/divehandler.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef DIVEHANDLER_HPP
+#define DIVEHANDLER_HPP
+
+#include <QGraphicsPathItem>
+#include <QElapsedTimer>
+
+class DiveHandler : public QObject, public QGraphicsEllipseItem {
+	Q_OBJECT
+public:
+	DiveHandler();
+
+protected:
+	void contextMenuEvent(QGraphicsSceneContextMenuEvent *event);
+	void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
+	void mousePressEvent(QGraphicsSceneMouseEvent *event);
+	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
+signals:
+	void moved();
+	void clicked();
+	void released();
+private:
+	int parentIndex();
+public
+slots:
+	void selfRemove();
+	void changeGas();
+private:
+	QElapsedTimer t;
+};
+
+#endif

--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -4,8 +4,8 @@
 #include "core/pref.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefDisplay.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/preferences/preferencesdialog.h"
 #include "core/dive.h" // for displayed_dive
 #include "commands/command.h"
 #endif
@@ -50,9 +50,7 @@ DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
 	setFlag(ItemIgnoresTransformations);
 	setAcceptHoverEvents(true);
 	setScale(0.2);
-#ifndef SUBSURFACE_MOBILE
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
-#endif
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DivePictureItem::settingsChanged);
 
 	canvas->setPen(Qt::NoPen);
 	canvas->setBrush(QColor(Qt::white));

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -5,22 +5,18 @@
 #include "profile-widget/divetextitem.h"
 #include "profile-widget/animationfunctions.h"
 #include "core/profile.h"
-#ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/preferences/preferencesdialog.h"
-#endif
 #include "qt-models/diveplannermodel.h"
 #include "core/qthelper.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "core/settings/qPrefLog.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #include "libdivecomputer/parser.h"
 #include "profile-widget/profilewidget2.h"
 
 AbstractProfilePolygonItem::AbstractProfilePolygonItem() : QObject(), QGraphicsPolygonItem(), hAxis(NULL), vAxis(NULL), dataModel(NULL), hDataColumn(-1), vDataColumn(-1)
 {
 	setCacheMode(DeviceCoordinateCache);
-#ifndef SUBSURFACE_MOBILE
-	connect(PreferencesDialog::instance(), SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
-#endif
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &AbstractProfilePolygonItem::settingsChanged);
 }
 
 void AbstractProfilePolygonItem::settingsChanged()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1352,6 +1352,7 @@ void ProfileWidget2::setPlanState()
 	if (currentState == PLAN)
 		return;
 
+	clearHandlers();
 	setProfileState();
 	mouseFollowerHorizontal->setVisible(true);
 	mouseFollowerVertical->setVisible(true);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -12,6 +12,7 @@
 #include "profile-widget/diveeventitem.h"
 #include "profile-widget/divetextitem.h"
 #include "profile-widget/divetooltipitem.h"
+#include "profile-widget/divehandler.h"
 #include "core/planner.h"
 #include "core/device.h"
 #include "profile-widget/ruleritem.h"
@@ -23,7 +24,6 @@
 #include "core/divelist.h"
 #include "core/errorhelper.h"
 #ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/diveplanner.h"
 #include "desktop-widgets/simplewidgets.h"
 #include "desktop-widgets/divepicturewidget.h"
 #include "desktop-widgets/mainwindow.h"
@@ -1003,6 +1003,16 @@ void ProfileWidget2::scale(qreal sx, qreal sy)
 #endif
 }
 
+bool ProfileWidget2::isPointOutOfBoundaries(const QPointF &point) const
+{
+	double xpos = timeAxis->valueAt(point);
+	double ypos = profileYAxis->valueAt(point);
+	return xpos > timeAxis->maximum() ||
+	       xpos < timeAxis->minimum() ||
+	       ypos > profileYAxis->maximum() ||
+	       ypos < profileYAxis->minimum();
+}
+
 #ifndef SUBSURFACE_MOBILE
 void ProfileWidget2::wheelEvent(QWheelEvent *event)
 {
@@ -1039,16 +1049,6 @@ void ProfileWidget2::mouseDoubleClickEvent(QMouseEvent *event)
 		int milimeters = lrint(profileYAxis->valueAt(mappedPos) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
 		plannerModel->addStop(milimeters, minutes * 60, -1, 0, true, UNDEF_COMP_TYPE);
 	}
-}
-
-bool ProfileWidget2::isPointOutOfBoundaries(const QPointF &point) const
-{
-	double xpos = timeAxis->valueAt(point);
-	double ypos = profileYAxis->valueAt(point);
-	return xpos > timeAxis->maximum() ||
-	       xpos < timeAxis->minimum() ||
-	       ypos > profileYAxis->maximum() ||
-	       ypos < profileYAxis->minimum();
 }
 
 void ProfileWidget2::scrollViewTo(const QPoint &pos)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -178,6 +178,27 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	diveDepthTableView->setModel(dataModel);
 	diveDepthTableView->show();
 #endif
+
+	auto tec = qPrefTechnicalDetails::instance();
+	connect(tec, &qPrefTechnicalDetails::calcalltissuesChanged           , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcceilingChanged              , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::dcceilingChanged                , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::eadChanged                      , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcceiling3mChanged            , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::modChanged                      , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::calcndlttsChanged               , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::hrgraphChanged                  , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::rulergraphChanged               , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::show_sacChanged                 , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::zoomed_plotChanged              , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::show_pictures_in_profileChanged , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::tankbarChanged                  , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::percentagegraphChanged          , this, &ProfileWidget2::actionRequestedReplot);
+
+	auto pp_gas = qPrefPartialPressureGas::instance();
+	connect(pp_gas, &qPrefPartialPressureGas::pheChanged, this, &ProfileWidget2::actionRequestedReplot);
+	connect(pp_gas, &qPrefPartialPressureGas::pn2Changed, this, &ProfileWidget2::actionRequestedReplot);
+	connect(pp_gas, &qPrefPartialPressureGas::po2Changed, this, &ProfileWidget2::actionRequestedReplot);
 }
 
 ProfileWidget2::~ProfileWidget2()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -31,8 +31,8 @@
 #include "core/qthelper.h"
 #include "core/gettextfromc.h"
 #include "core/imagedownloader.h"
-#include "core/subsurface-qt/divelistnotifier.h"
 #endif
+#include "core/subsurface-qt/divelistnotifier.h"
 
 #include <libdivecomputer/parser.h>
 #include <QScrollBar>
@@ -46,9 +46,6 @@
 
 #ifndef QT_NO_DEBUG
 #include <QTableView>
-#endif
-#ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/preferences/preferencesdialog.h"
 #endif
 #include <QtWidgets>
 

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -87,7 +87,6 @@ public:
 	void setFontPrintScale(double scale);
 #ifndef SUBSURFACE_MOBILE
 	bool eventFilter(QObject *, QEvent *) override;
-	void clearHandlers();
 #endif
 	void setToolTipVisibile(bool visible);
 	State currentState;
@@ -164,6 +163,9 @@ private:
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
+#ifndef SUBSURFACE_MOBILE
+	void clearHandlers();
+#endif
 	void plotPicturesInternal(const struct dive *d, bool synchronous);
 	void addDivemodeSwitch(int seconds, int divemode);
 	void addBookmark(int seconds);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -97,7 +97,6 @@ signals:
 	void enableToolbar(bool enable);
 	void enableShortcuts();
 	void disableShortcuts(bool paste);
-	void updateDiveInfo();
 	void editCurrentDive();
 	void dateTimeChangedItems();
 

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -252,12 +252,14 @@ private:
 	void calculatePictureYPositions();
 	void updateDurationLine(PictureEntry &e);
 	void updateThumbnailPaintOrder();
+#endif
 
 	QList<DiveHandler *> handles;
+#ifndef SUBSURFACE_MOBILE
 	void repositionDiveHandlers();
 	int fixHandlerIndex(DiveHandler *activeHandler);
-	friend class DiveHandler;
 #endif
+	friend class DiveHandler;
 	QHash<Qt::Key, QAction *> actionsForKeys;
 	bool shouldCalculateMaxTime;
 	bool shouldCalculateMaxDepth;

--- a/profile-widget/ruleritem.cpp
+++ b/profile-widget/ruleritem.cpp
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "profile-widget/ruleritem.h"
-#ifndef SUBSURFACE_MOBILE
-#include "desktop-widgets/preferences/preferencesdialog.h"
-#endif
 #include "profile-widget/profilewidget2.h"
 #include "core/display.h"
 #include "core/settings/qPrefTechnicalDetails.h"

--- a/qt-models/tankinfomodel.cpp
+++ b/qt-models/tankinfomodel.cpp
@@ -87,6 +87,7 @@ TankInfoModel::TankInfoModel()
 {
 	setHeaderDataStrings(QStringList() << tr("Description") << tr("ml") << tr("bar"));
 	connect(&diveListNotifier, &DiveListNotifier::dataReset, this, &TankInfoModel::update);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &TankInfoModel::update);
 	update();
 }
 

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <time.h>
 
-#include "core/color.h"
 #include "core/downloadfromdcthread.h" // for fill_computer_list
 #include "core/errorhelper.h"
 #include "core/parse.h"
@@ -15,11 +14,7 @@
 #include "core/subsurfacestartup.h"
 #include "core/settings/qPref.h"
 #include "core/tag.h"
-#include "desktop-widgets/diveplanner.h"
 #include "desktop-widgets/mainwindow.h"
-#include "desktop-widgets/preferences/preferencesdialog.h"
-#include "desktop-widgets/tab-widgets/maintab.h"
-#include "profile-widget/profilewidget2.h"
 
 #include <QApplication>
 #include <QLoggingCategory>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are small steps towards better encapsulation and less inter-dependencies. It is mostly moving code around, notably out of the MainWindow. More to come.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create a global settings-changed signal and connect in the appropriate classes.
2) Simplify the preferences-widget code.
3) Move planner-code from MainWindow to diveplanner.cpp. Collect the three widgets in a new class.
4) Move DiveHandler to profilewidget folder. If we want to have a planner on mobile, this must be generally accessible.
5) Some dead code removal.