### PR TITLE
[TRIVIAL] cleanup: remove unnecessary includes from divepicturewidget.cpp

### DIFF
--- a/desktop-widgets/divepicturewidget.cpp
+++ b/desktop-widgets/divepicturewidget.cpp
@@ -1,19 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "desktop-widgets/divepicturewidget.h"
-#include "qt-models/divepicturemodel.h"
 #include "core/metrics.h"
-#include "core/dive.h"
-#include "core/divelist.h"
-#include <unistd.h>
-#include <QFuture>
-#include <QDir>
-#include <QCryptographicHash>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include "desktop-widgets/mainwindow.h"
 #include "core/qthelper.h"
-#include <QStandardPaths>
-#include <QtWidgets>
+#include <QDrag>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPixmap>
 
 DivePictureWidget::DivePictureWidget(QWidget *parent) : QListView(parent)
 {


### PR DESCRIPTION
Also, use finer-grained Qt includes instead of the full QtWidgets
include.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove include artifacts in divepicturewidget.cpp. Let's see if it works on all supported Qt version.