### PR TITLE
core: correct AL* tankinfo sizes.

### DIFF
--- a/core/equipment.c
+++ b/core/equipment.c
@@ -253,12 +253,12 @@ static void add_default_tank_infos(struct tank_info_table *table)
 	add_tank_info_metric(table, "11.1ℓ", 11100, 0);
 
 	/* Most common AL cylinders */
-	add_tank_info_metric(table, "AL40", 40, 3000);
-	add_tank_info_metric(table, "AL50", 50, 3000);
-	add_tank_info_metric(table, "AL63", 63, 3000);
-	add_tank_info_metric(table, "AL72", 72, 3000);
-	add_tank_info_metric(table, "AL80", 80, 3000);
-	add_tank_info_metric(table, "AL100", 100, 3300);
+	add_tank_info_imperial(table, "AL40", 40, 3000);
+	add_tank_info_imperial(table, "AL50", 50, 3000);
+	add_tank_info_imperial(table, "AL63", 63, 3000);
+	add_tank_info_imperial(table, "AL72", 72, 3000);
+	add_tank_info_imperial(table, "AL80", 80, 3000);
+	add_tank_info_imperial(table, "AL100", 100, 3300);
 
 	/* Metric AL cylinders */
 	add_tank_info_metric(table, "ALU7", 7000, 200);


### PR DESCRIPTION
Recently (d16a9f118a) the tankinfo table was made dynamic, which
means that the default tankinfos are added programatically.
Thereby, the wrong function was used for AL* type of cylinders:
metric instead of imperial. Fix those.

Reported-by: Michael Andreen <harv@ruin.nu>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix tank sizes of AL* tanks - see commit description.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes bug introduced in #3101.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@michaelandreen