### PR TITLE
profile: remove clearHandlers function (fixes crash)

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1318,17 +1318,6 @@ void ProfileWidget2::setProfileState()
 }
 
 #ifndef SUBSURFACE_MOBILE
-void ProfileWidget2::clearHandlers()
-{
-	if (handles.count()) {
-		foreach (DiveHandler *handle, handles) {
-			scene()->removeItem(handle);
-			delete handle;
-		}
-		handles.clear();
-	}
-}
-
 void ProfileWidget2::setToolTipVisibile(bool visible)
 {
 	toolTipItem->setVisible(visible);
@@ -1339,7 +1328,6 @@ void ProfileWidget2::setAddState()
 	if (currentState == ADD)
 		return;
 
-	clearHandlers();
 	setProfileState();
 	mouseFollowerHorizontal->setVisible(true);
 	mouseFollowerVertical->setVisible(true);
@@ -1373,7 +1361,6 @@ void ProfileWidget2::setPlanState()
 	if (currentState == PLAN)
 		return;
 
-	clearHandlers();
 	setProfileState();
 	mouseFollowerHorizontal->setVisible(true);
 	mouseFollowerVertical->setVisible(true);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -162,9 +162,6 @@ private:
 	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
 			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
-#ifndef SUBSURFACE_MOBILE
-	void clearHandlers();
-#endif
 	void plotPicturesInternal(const struct dive *d, bool synchronous);
 	void addDivemodeSwitch(int seconds, int divemode);
 	void addBookmark(int seconds);


### PR DESCRIPTION
Recently (674c20227b2), the call to ProfileWidget::clearHandlers()
was moved from PlannerWidgets::replanDive() to ProfileWidget2.
This cause a crash, because the code assumes that the number
of elements in the handles-vector the divepointplanner model
is the same.

Clearing the handles violates this assumption. It turns out
that the clearHandlers() function is broken anyway: it clear
the handles-vector, but not the gases-vector, which should
likewise have the same number of elements. It appears that
the clearHandlers() function is an artifact and it is
mysterious how this has worked so far. Remove.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a crash in current master, which can be triggered by entering the planner twice.

This part of the code really needs a refactor.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove the `clearHandlers` function, as it appears to have bit-rotted.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - crash recently introduced.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh @atdotde