### PR TITLE
[RFC] Remove unused/redundant code in profile

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -256,7 +256,6 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 		updateNotes(current_dive);
 	if (field.datetime) {
 		updateDateTime(current_dive);
-		MainWindow::instance()->graphics->dateTimeChanged();
 		DivePlannerPointsModel::instance()->getDiveplan().when = current_dive->when;
 	}
 	if (field.divesite)

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -9,7 +9,7 @@
 #include "profile-widget/divelineitem.h"
 #include "profile-widget/profilewidget2.h"
 
-QPen DiveCartesianAxis::gridPen()
+QPen DiveCartesianAxis::gridPen() const
 {
 	QPen pen;
 	pen.setColor(getColor(TIME_GRID));
@@ -96,7 +96,7 @@ void DiveCartesianAxis::setOrientation(Orientation o)
 	changed = true;
 }
 
-QColor DiveCartesianAxis::colorForValue(double)
+QColor DiveCartesianAxis::colorForValue(double) const
 {
 	return QColor(Qt::black);
 }
@@ -265,7 +265,7 @@ void DiveCartesianAxis::animateChangeLine(const QLineF &newLine)
 	sizeChanged();
 }
 
-QString DiveCartesianAxis::textForValue(double value)
+QString DiveCartesianAxis::textForValue(double value) const
 {
 	return QString("%L1").arg(value, 0, 'g', 4);
 }
@@ -297,7 +297,7 @@ qreal DiveCartesianAxis::valueAt(const QPointF &p) const
 	return fraction * (max - min) + min;
 }
 
-qreal DiveCartesianAxis::posAtValue(qreal value)
+qreal DiveCartesianAxis::posAtValue(qreal value) const
 {
 	QLineF m = line();
 	QPointF p = pos();
@@ -349,14 +349,14 @@ void DiveCartesianAxis::setColor(const QColor &color)
 	setPen(defaultPen);
 }
 
-QString DepthAxis::textForValue(double value)
+QString DepthAxis::textForValue(double value) const
 {
 	if (value == 0)
 		return QString();
 	return get_depth_string(lrint(value), false, false);
 }
 
-QColor DepthAxis::colorForValue(double)
+QColor DepthAxis::colorForValue(double) const
 {
 	return QColor(Qt::red);
 }
@@ -382,12 +382,12 @@ TimeAxis::TimeAxis(ProfileWidget2 *widget) : DiveCartesianAxis(widget)
 {
 }
 
-QColor TimeAxis::colorForValue(double)
+QColor TimeAxis::colorForValue(double) const
 {
 	return QColor(Qt::blue);
 }
 
-QString TimeAxis::textForValue(double value)
+QString TimeAxis::textForValue(double value) const
 {
 	int nr = lrint(value) / 60;
 	if (maximum() < 600)
@@ -409,7 +409,7 @@ TemperatureAxis::TemperatureAxis(ProfileWidget2 *widget) : DiveCartesianAxis(wid
 {
 }
 
-QString TemperatureAxis::textForValue(double value)
+QString TemperatureAxis::textForValue(double value) const
 {
 	return QString::number(mkelvin_to_C((int)value));
 }

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -20,7 +20,7 @@ class DiveCartesianAxis : public QObject, public QGraphicsLineItem {
 	Q_PROPERTY(qreal y WRITE setY READ y)
 private:
 	bool printMode;
-	QPen gridPen();
+	QPen gridPen() const;
 public:
 	enum Orientation {
 		TopToBottom,
@@ -41,7 +41,7 @@ public:
 	double maximum() const;
 	double fontLabelScale() const;
 	qreal valueAt(const QPointF &p) const;
-	qreal posAtValue(qreal value);
+	qreal posAtValue(qreal value) const;
 	void setColor(const QColor &color);
 	void setTextColor(const QColor &color);
 	void animateChangeLine(const QLineF &newLine);
@@ -60,8 +60,8 @@ signals:
 
 protected:
 	ProfileWidget2 *profileWidget;
-	virtual QString textForValue(double value);
-	virtual QColor colorForValue(double value);
+	virtual QString textForValue(double value) const;
+	virtual QColor colorForValue(double value) const;
 	Orientation orientation;
 	QList<DiveTextItem *> labels;
 	QList<DiveLineItem *> lines;
@@ -82,8 +82,8 @@ class DepthAxis : public DiveCartesianAxis {
 public:
 	DepthAxis(ProfileWidget2 *widget);
 private:
-	QString textForValue(double value);
-	QColor colorForValue(double value);
+	QString textForValue(double value) const override;
+	QColor colorForValue(double value) const override;
 private
 slots:
 	void settingsChanged();
@@ -95,8 +95,8 @@ public:
 	TimeAxis(ProfileWidget2 *widget);
 	void updateTicks(color_index_t color = TIME_GRID);
 private:
-	QString textForValue(double value);
-	QColor colorForValue(double value);
+	QString textForValue(double value) const override;
+	QColor colorForValue(double value) const override;
 };
 
 class TemperatureAxis : public DiveCartesianAxis {
@@ -104,7 +104,7 @@ class TemperatureAxis : public DiveCartesianAxis {
 public:
 	TemperatureAxis(ProfileWidget2 *widget);
 private:
-	QString textForValue(double value);
+	QString textForValue(double value) const;
 };
 
 class PartialGasPressureAxis : public DiveCartesianAxis {

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -13,10 +13,13 @@
 #include "libdivecomputer/parser.h"
 #include "profile-widget/profilewidget2.h"
 
-AbstractProfilePolygonItem::AbstractProfilePolygonItem() : QObject(), QGraphicsPolygonItem(), hAxis(NULL), vAxis(NULL), dataModel(NULL), hDataColumn(-1), vDataColumn(-1)
+AbstractProfilePolygonItem::AbstractProfilePolygonItem(const DivePlotDataModel &model) :
+	hAxis(NULL), vAxis(NULL), dataModel(model), hDataColumn(-1), vDataColumn(-1)
 {
 	setCacheMode(DeviceCoordinateCache);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &AbstractProfilePolygonItem::settingsChanged);
+	connect(&dataModel, &DivePlotDataModel::dataChanged, this, &AbstractProfilePolygonItem::modelDataChanged);
+	connect(&dataModel, &DivePlotDataModel::rowsAboutToBeRemoved, this, &AbstractProfilePolygonItem::modelDataRemoved);
 }
 
 void AbstractProfilePolygonItem::settingsChanged()
@@ -38,14 +41,6 @@ void AbstractProfilePolygonItem::setHorizontalAxis(DiveCartesianAxis *horizontal
 void AbstractProfilePolygonItem::setHorizontalDataColumn(int column)
 {
 	hDataColumn = column;
-	modelDataChanged();
-}
-
-void AbstractProfilePolygonItem::setModel(DivePlotDataModel *model)
-{
-	dataModel = model;
-	connect(dataModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(modelDataChanged(QModelIndex, QModelIndex)));
-	connect(dataModel, SIGNAL(rowsAboutToBeRemoved(QModelIndex, int, int)), this, SLOT(modelDataRemoved(QModelIndex, int, int)));
 	modelDataChanged();
 }
 
@@ -74,7 +69,7 @@ bool AbstractProfilePolygonItem::shouldCalculateStuff(const QModelIndex &topLeft
 {
 	if (!hAxis || !vAxis)
 		return false;
-	if (!dataModel || dataModel->rowCount() == 0)
+	if (dataModel.rowCount() == 0)
 		return false;
 	if (hDataColumn == -1 || vDataColumn == -1)
 		return false;
@@ -95,9 +90,9 @@ void AbstractProfilePolygonItem::modelDataChanged(const QModelIndex&, const QMod
 	// is an array of QPointF's, so we basically get the point from the model, convert
 	// to our coordinates, store. no painting is done here.
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		qreal horizontalValue = dataModel->index(i, hDataColumn).data().toReal();
-		qreal verticalValue = dataModel->index(i, vDataColumn).data().toReal();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		qreal horizontalValue = dataModel.index(i, hDataColumn).data().toReal();
+		qreal verticalValue = dataModel.index(i, vDataColumn).data().toReal();
 		QPointF point(hAxis->posAtValue(horizontalValue), vAxis->posAtValue(verticalValue));
 		poly.append(point);
 	}
@@ -107,7 +102,8 @@ void AbstractProfilePolygonItem::modelDataChanged(const QModelIndex&, const QMod
 	texts.clear();
 }
 
-DiveProfileItem::DiveProfileItem() : show_reported_ceiling(0), reported_ceiling_in_red(0)
+DiveProfileItem::DiveProfileItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model),
+	show_reported_ceiling(0), reported_ceiling_in_red(0)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::dcceilingChanged, this, &DiveProfileItem::settingsToggled);
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::redceilingChanged, this, &DiveProfileItem::settingsToggled);
@@ -136,8 +132,8 @@ void DiveProfileItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
 	pen.setWidth(2);
 	QPolygonF poly = polygon();
 	// This paints the colors of the velocities.
-	for (int i = 1, count = dataModel->rowCount(); i < count; i++) {
-		QModelIndex colorIndex = dataModel->index(i, DivePlotDataModel::COLOR);
+	for (int i = 1, count = dataModel.rowCount(); i < count; i++) {
+		QModelIndex colorIndex = dataModel.index(i, DivePlotDataModel::COLOR);
 		pen.setBrush(QBrush(colorIndex.data(Qt::BackgroundRole).value<QColor>()));
 		painter->setPen(pen);
 		if (i < poly.count())
@@ -149,7 +145,7 @@ void DiveProfileItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
 int DiveProfileItem::maxCeiling(int row)
 {
 	int max = -1;
-	plot_data *entry = dataModel->data().entry + row;
+	plot_data *entry = dataModel.data().entry + row;
 	for (int tissue = 0; tissue < 16; tissue++) {
 		if (max < entry->ceilings[tissue])
 			max = entry->ceilings[tissue];
@@ -176,8 +172,8 @@ void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelI
 #else
 	int currState = qobject_cast<ProfileWidget2 *>(scene()->views().first())->currentState;
 	if (currState == ProfileWidget2::PLAN) {
-		plot_data *entry = dataModel->data().entry;
-		for (int i = 0; i < dataModel->rowCount(); i++, entry++) {
+		plot_data *entry = dataModel.data().entry;
+		for (int i = 0; i < dataModel.rowCount(); i++, entry++) {
 			int max = maxCeiling(i);
 			// Don't scream if we violate the ceiling by a few cm
 			if (entry->depth < max - 100 && entry->sec > 0) {
@@ -194,8 +190,8 @@ void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelI
 	/* Show any ceiling we may have encountered */
 	if (prefs.dcceiling && !prefs.redceiling) {
 		QPolygonF p = polygon();
-		plot_data *entry = dataModel->data().entry + dataModel->rowCount() - 1;
-		for (int i = dataModel->rowCount() - 1; i >= 0; i--, entry--) {
+		plot_data *entry = dataModel.data().entry + dataModel.rowCount() - 1;
+		for (int i = dataModel.rowCount() - 1; i >= 0; i--, entry--) {
 			if (!entry->in_deco) {
 				/* not in deco implies this is a safety stop, no ceiling */
 				p.append(QPointF(hAxis->posAtValue(entry->sec), vAxis->posAtValue(0)));
@@ -214,8 +210,8 @@ void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelI
 	setBrush(QBrush(pat));
 
 	int last = -1;
-	for (int i = 0, count = dataModel->rowCount(); i < count; i++) {
-		struct plot_data *pd = dataModel->data().entry;
+	for (int i = 0, count = dataModel.rowCount(); i < count; i++) {
+		struct plot_data *pd = dataModel.data().entry;
 		struct plot_data *entry =  pd + i;
 		// "min/max" are the 9-minute window min/max indices
 		struct plot_data *min_entry = pd + entry->min;
@@ -257,7 +253,7 @@ void DiveProfileItem::plot_depth_sample(struct plot_data *entry, QFlags<Qt::Alig
 	texts.append(item);
 }
 
-DiveHeartrateItem::DiveHeartrateItem()
+DiveHeartrateItem::DiveHeartrateItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	QPen pen;
 	pen.setBrush(QBrush(getColor(::HR_PLOT)));
@@ -283,11 +279,11 @@ void DiveHeartrateItem::modelDataChanged(const QModelIndex &topLeft, const QMode
 	texts.clear();
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		int hr = dataModel->index(i, vDataColumn).data().toInt();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		int hr = dataModel.index(i, vDataColumn).data().toInt();
 		if (!hr)
 			continue;
-		sec = dataModel->index(i, hDataColumn).data().toInt();
+		sec = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(sec), vAxis->posAtValue(hr));
 		poly.append(point);
 		if (hr == hist[2].hr)
@@ -343,7 +339,7 @@ void DiveHeartrateItem::paint(QPainter *painter, const QStyleOptionGraphicsItem*
 	painter->restore();
 }
 
-DivePercentageItem::DivePercentageItem(int i)
+DivePercentageItem::DivePercentageItem(const DivePlotDataModel &model, int i) : AbstractProfilePolygonItem(model)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::percentagegraphChanged, this, &DivePercentageItem::setVisible);
 	tissueIndex = i;
@@ -360,8 +356,8 @@ void DivePercentageItem::modelDataChanged(const QModelIndex &topLeft, const QMod
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		sec = dataModel->index(i, hDataColumn).data().toInt();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		sec = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(sec), vAxis->posAtValue(64 - 4 * tissueIndex));
 		poly.append(point);
 	}
@@ -404,12 +400,12 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 	mypen.setCapStyle(Qt::FlatCap);
 	mypen.setCosmetic(false);
 	QPolygonF poly = polygon();
-	for (int i = 1, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
+	for (int i = 1, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
 		if (i < poly.count()) {
-			double value = dataModel->index(i, vDataColumn).data().toDouble();
+			double value = dataModel.index(i, vDataColumn).data().toDouble();
 			struct gasmix gasmix = gasmix_air;
 			const struct event *ev = NULL;
-			int sec = dataModel->index(i, DivePlotDataModel::TIME).data().toInt();
+			int sec = dataModel.index(i, DivePlotDataModel::TIME).data().toInt();
 			gasmix = get_gasmix(&displayed_dive, displayed_dc, sec, &ev, gasmix);
 			int inert = get_n2(gasmix) + get_he(gasmix);
 			mypen.setBrush(QBrush(ColorScale(value, inert)));
@@ -420,7 +416,7 @@ void DivePercentageItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
 	painter->restore();
 }
 
-DiveAmbPressureItem::DiveAmbPressureItem()
+DiveAmbPressureItem::DiveAmbPressureItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	QPen pen;
 	pen.setBrush(QBrush(getColor(::AMB_PRESSURE_LINE)));
@@ -440,11 +436,11 @@ void DiveAmbPressureItem::modelDataChanged(const QModelIndex &topLeft, const QMo
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		int hr = dataModel->index(i, vDataColumn).data().toInt();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		int hr = dataModel.index(i, vDataColumn).data().toInt();
 		if (!hr)
 			continue;
-		sec = dataModel->index(i, hDataColumn).data().toInt();
+		sec = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(sec), vAxis->posAtValue(hr));
 		poly.append(point);
 	}
@@ -465,7 +461,7 @@ void DiveAmbPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::percentagegraphChanged, this, &DiveAmbPressureItem::setVisible);
 }
 
-DiveGFLineItem::DiveGFLineItem()
+DiveGFLineItem::DiveGFLineItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	QPen pen;
 	pen.setBrush(QBrush(getColor(::GF_LINE)));
@@ -485,11 +481,11 @@ void DiveGFLineItem::modelDataChanged(const QModelIndex &topLeft, const QModelIn
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		int hr = dataModel->index(i, vDataColumn).data().toInt();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		int hr = dataModel.index(i, vDataColumn).data().toInt();
 		if (!hr)
 			continue;
-		sec = dataModel->index(i, hDataColumn).data().toInt();
+		sec = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(sec), vAxis->posAtValue(hr));
 		poly.append(point);
 	}
@@ -510,7 +506,7 @@ void DiveGFLineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem*, Q
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::percentagegraphChanged, this, &DiveAmbPressureItem::setVisible);
 }
 
-DiveTemperatureItem::DiveTemperatureItem()
+DiveTemperatureItem::DiveTemperatureItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	QPen pen;
 	pen.setBrush(QBrush(getColor(::TEMP_PLOT)));
@@ -530,12 +526,12 @@ void DiveTemperatureItem::modelDataChanged(const QModelIndex &topLeft, const QMo
 	texts.clear();
 	// Ignore empty values. things do not look good with '0' as temperature in kelvin...
 	QPolygonF poly;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++) {
-		int mkelvin = dataModel->index(i, vDataColumn).data().toInt();
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++) {
+		int mkelvin = dataModel.index(i, vDataColumn).data().toInt();
 		if (!mkelvin)
 			continue;
 		last_valid_temp = mkelvin;
-		sec = dataModel->index(i, hDataColumn).data().toInt();
+		sec = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(sec), vAxis->posAtValue(mkelvin));
 		poly.append(point);
 
@@ -589,7 +585,7 @@ void DiveTemperatureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	painter->restore();
 }
 
-DiveMeanDepthItem::DiveMeanDepthItem()
+DiveMeanDepthItem::DiveMeanDepthItem(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	QPen pen;
 	pen.setBrush(QBrush(getColor(::HR_AXIS)));
@@ -608,8 +604,8 @@ void DiveMeanDepthItem::modelDataChanged(const QModelIndex &topLeft, const QMode
 		return;
 
 	QPolygonF poly;
-	plot_data *entry = dataModel->data().entry;
-	for (int i = 0, modelDataCount = dataModel->rowCount(); i < modelDataCount; i++, entry++) {
+	plot_data *entry = dataModel.data().entry;
+	for (int i = 0, modelDataCount = dataModel.rowCount(); i < modelDataCount; i++, entry++) {
 		// Ignore empty values
 		if (entry->running_sum == 0 || entry->sec == 0)
 			continue;
@@ -637,8 +633,8 @@ void DiveMeanDepthItem::paint(QPainter *painter, const QStyleOptionGraphicsItem*
 
 void DiveMeanDepthItem::createTextItem()
 {
-	plot_data *entry = dataModel->data().entry;
-	int sec = entry[dataModel->rowCount()-1].sec;
+	plot_data *entry = dataModel.data().entry;
+	int sec = entry[dataModel.rowCount()-1].sec;
 	qDeleteAll(texts);
 	texts.clear();
 	DiveTextItem *text = new DiveTextItem(this);
@@ -656,14 +652,14 @@ void DiveGasPressureItem::modelDataChanged(const QModelIndex &topLeft, const QMo
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
 
-	const struct plot_info *pInfo = &dataModel->data();
+	const struct plot_info *pInfo = &dataModel.data();
 	std::vector<int> plotted_cyl(pInfo->nr_cylinders, false);
 	std::vector<int> last_plotted(pInfo->nr_cylinders, 0);
 	std::vector<QPolygonF> poly(pInfo->nr_cylinders);
 	QPolygonF boundingPoly;
 	polygons.clear();
 
-	for (int i = 0, count = dataModel->rowCount(); i < count; i++) {
+	for (int i = 0, count = dataModel.rowCount(); i < count; i++) {
 		const struct plot_data *entry = pInfo->entry + i;
 
 		for (int cyl = 0; cyl < pInfo->nr_cylinders; cyl++) {
@@ -723,7 +719,7 @@ void DiveGasPressureItem::modelDataChanged(const QModelIndex &topLeft, const QMo
 	double axisRange = (vAxis->maximum() - vAxis->minimum())/1000;	// Convert axis pressure range to bar
 	double axisLog = log10(log10(axisRange));
 
-	for (int i = 0, count = dataModel->rowCount(); i < count; i++) {
+	for (int i = 0, count = dataModel.rowCount(); i < count; i++) {
 		const struct plot_data *entry = pInfo->entry + i;
 
 		for (int cyl = 0; cyl < pInfo->nr_cylinders; cyl++) {
@@ -799,7 +795,7 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	painter->save();
 	struct plot_data *entry;
 	Q_FOREACH (const QPolygonF &poly, polygons) {
-		entry = dataModel->data().entry;
+		entry = dataModel.data().entry;
 		for (int i = 1, count = poly.count(); i < count; i++, entry++) {
 			if (!in_planner()) {
 				if (entry->sac)
@@ -819,19 +815,16 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	painter->restore();
 }
 
-DiveCalculatedCeiling::DiveCalculatedCeiling(ProfileWidget2 *widget) :
-	profileWidget(widget),
-	is3mIncrement(false)
+DiveCalculatedCeiling::DiveCalculatedCeiling(const DivePlotDataModel &model, ProfileWidget2 *widget) :
+	AbstractProfilePolygonItem(model),
+	profileWidget(widget)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::calcceilingChanged, this, &DiveCalculatedCeiling::setVisible);
 	setVisible(prefs.calcceiling);
-	DiveCalculatedCeiling::settingsChanged();
 }
 
 void DiveCalculatedCeiling::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
-	connect(profileWidget, SIGNAL(dateTimeChangedItems()), this, SLOT(recalc()), Qt::UniqueConnection);
-
 	// We don't have enougth data to calculate things, quit.
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
@@ -861,7 +854,8 @@ void DiveCalculatedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsI
 	QGraphicsPolygonItem::paint(painter, option, widget);
 }
 
-DiveCalculatedTissue::DiveCalculatedTissue(ProfileWidget2 *widget) : DiveCalculatedCeiling(widget)
+DiveCalculatedTissue::DiveCalculatedTissue(const DivePlotDataModel &model, ProfileWidget2 *widget) :
+	DiveCalculatedCeiling(model, widget)
 {
 	settingsChanged();
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::calcalltissuesChanged, this, &DiveCalculatedTissue::setVisible);
@@ -878,7 +872,7 @@ void DiveCalculatedTissue::settingsChanged()
 	DiveCalculatedCeiling::setVisible(prefs.calcalltissues && prefs.calcceiling);
 }
 
-DiveReportedCeiling::DiveReportedCeiling()
+DiveReportedCeiling::DiveReportedCeiling(const DivePlotDataModel &model) : AbstractProfilePolygonItem(model)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::dcceilingChanged, this, &DiveReportedCeiling::setVisible);
 	setVisible(prefs.dcceiling);
@@ -892,8 +886,8 @@ void DiveReportedCeiling::modelDataChanged(const QModelIndex &topLeft, const QMo
 
 	QPolygonF p;
 	p.append(QPointF(hAxis->posAtValue(0), vAxis->posAtValue(0)));
-	plot_data *entry = dataModel->data().entry;
-	for (int i = 0, count = dataModel->rowCount(); i < count; i++, entry++) {
+	plot_data *entry = dataModel.data().entry;
+	for (int i = 0, count = dataModel.rowCount(); i < count; i++, entry++) {
 		if (entry->in_deco && entry->stopdepth) {
 			p.append(QPointF(hAxis->posAtValue(entry->sec), vAxis->posAtValue(qMin(entry->stopdepth, entry->depth))));
 		} else {
@@ -914,22 +908,6 @@ void DiveReportedCeiling::modelDataChanged(const QModelIndex &topLeft, const QMo
 	setBrush(pat);
 }
 
-void DiveCalculatedCeiling::recalc()
-{
-#ifndef SUBSURFACE_MOBILE
-	dataModel->calculateDecompression();
-#endif
-}
-
-void DiveCalculatedCeiling::settingsChanged()
-{
-	if (dataModel && is3mIncrement != prefs.calcceiling3m) {
-		// recalculate that part.
-		recalc();
-	}
-	is3mIncrement = prefs.calcceiling3m;
-}
-
 void DiveReportedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
 	if (polygon().isEmpty())
@@ -943,7 +921,7 @@ void PartialPressureGasItem::modelDataChanged(const QModelIndex &topLeft, const 
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
 
-	plot_data *entry = dataModel->data().entry;
+	plot_data *entry = dataModel.data().entry;
 	QPolygonF poly;
 	QPolygonF alertpoly;
 	alertPolygons.clear();
@@ -954,9 +932,9 @@ void PartialPressureGasItem::modelDataChanged(const QModelIndex &topLeft, const 
 	if (thresholdPtrMin)
 		threshold_min = *thresholdPtrMin;
 	bool inAlertFragment = false;
-	for (int i = 0; i < dataModel->rowCount(); i++, entry++) {
-		double value = dataModel->index(i, vDataColumn).data().toDouble();
-		int time = dataModel->index(i, hDataColumn).data().toInt();
+	for (int i = 0; i < dataModel.rowCount(); i++, entry++) {
+		double value = dataModel.index(i, vDataColumn).data().toDouble();
+		int time = dataModel.index(i, hDataColumn).data().toInt();
 		QPointF point(hAxis->posAtValue(time), vAxis->posAtValue(value));
 		poly.push_back(point);
 		if (thresholdPtrMax && value >= threshold_max) {
@@ -1007,7 +985,8 @@ void PartialPressureGasItem::setThresholdSettingsKey(const double *prefPointerMi
 	thresholdPtrMax = prefPointerMax;
 }
 
-PartialPressureGasItem::PartialPressureGasItem() :
+PartialPressureGasItem::PartialPressureGasItem(const DivePlotDataModel &model) :
+	AbstractProfilePolygonItem(model),
 	thresholdPtrMin(NULL),
 	thresholdPtrMax(NULL)
 {

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -11,7 +11,7 @@
 /* This is the Profile Item, it should be used for quite a lot of things
  on the profile view. The usage should be pretty simple:
 
- DiveProfileItem *profile = new DiveProfileItem();
+ DiveProfileItem *profile = new DiveProfileItem( DiveDataModel );
  profile->setVerticalAxis( profileYAxis );
  profile->setHorizontalAxis( timeAxis );
  profile->setModel( DiveDataModel );
@@ -35,10 +35,9 @@ class AbstractProfilePolygonItem : public QObject, public QGraphicsPolygonItem {
 	Q_PROPERTY(qreal x WRITE setX READ x)
 	Q_PROPERTY(qreal y WRITE setY READ y)
 public:
-	AbstractProfilePolygonItem();
+	AbstractProfilePolygonItem(const DivePlotDataModel &model);
 	void setVerticalAxis(DiveCartesianAxis *vertical);
 	void setHorizontalAxis(DiveCartesianAxis *horizontal);
-	void setModel(DivePlotDataModel *model);
 	void setHorizontalDataColumn(int column);
 	void setVerticalDataColumn(int column);
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
@@ -61,7 +60,7 @@ protected:
 
 	DiveCartesianAxis *hAxis;
 	DiveCartesianAxis *vAxis;
-	DivePlotDataModel *dataModel;
+	const DivePlotDataModel &dataModel;
 	int hDataColumn;
 	int vDataColumn;
 	QList<DiveTextItem *> texts;
@@ -71,7 +70,7 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveProfileItem();
+	DiveProfileItem(const DivePlotDataModel &model);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void settingsToggled(bool toggled);
@@ -88,7 +87,7 @@ private:
 class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveMeanDepthItem();
+	DiveMeanDepthItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -101,7 +100,7 @@ private:
 class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveTemperatureItem();
+	DiveTemperatureItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -112,7 +111,7 @@ private:
 class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveHeartrateItem();
+	DiveHeartrateItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -124,7 +123,7 @@ private:
 class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DivePercentageItem(int i);
+	DivePercentageItem(const DivePlotDataModel &model, int i);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -138,7 +137,7 @@ private:
 class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveAmbPressureItem();
+	DiveAmbPressureItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -149,7 +148,7 @@ private:
 class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveGFLineItem();
+	DiveGFLineItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -161,6 +160,7 @@ class DiveGasPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
+	using AbstractProfilePolygonItem::AbstractProfilePolygonItem;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -174,25 +174,19 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveCalculatedCeiling(ProfileWidget2 *profileWidget);
+	DiveCalculatedCeiling(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void settingsChanged() override;
-
-public
-slots:
-	void recalc();
 
 private:
 	ProfileWidget2 *profileWidget;
-	bool is3mIncrement;
 };
 
 class DiveReportedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveReportedCeiling();
+	DiveReportedCeiling(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 };
@@ -200,7 +194,7 @@ public:
 class DiveCalculatedTissue : public DiveCalculatedCeiling {
 	Q_OBJECT
 public:
-	DiveCalculatedTissue(ProfileWidget2 *profileWidget);
+	DiveCalculatedTissue(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
 	void settingsChanged() override;
 };
@@ -208,7 +202,7 @@ public:
 class PartialPressureGasItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	PartialPressureGasItem();
+	PartialPressureGasItem(const DivePlotDataModel &model);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -865,11 +865,6 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 #endif
 }
 
-void ProfileWidget2::dateTimeChanged()
-{
-	emit dateTimeChangedItems();
-}
-
 void ProfileWidget2::actionRequestedReplot(bool)
 {
 	settingsChanged();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -111,29 +111,29 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	gasYAxis(new PartialGasPressureAxis(this)),
 	temperatureAxis(new TemperatureAxis(this)),
 	timeAxis(new TimeAxis(this)),
-	diveProfileItem(new DiveProfileItem()),
-	temperatureItem(new DiveTemperatureItem()),
-	meanDepthItem(new DiveMeanDepthItem()),
+	diveProfileItem(new DiveProfileItem(*dataModel)),
+	temperatureItem(new DiveTemperatureItem(*dataModel)),
+	meanDepthItem(new DiveMeanDepthItem(*dataModel)),
 	cylinderPressureAxis(new DiveCartesianAxis(this)),
-	gasPressureItem(new DiveGasPressureItem()),
+	gasPressureItem(new DiveGasPressureItem(*dataModel)),
 	diveComputerText(new DiveTextItem()),
-	reportedCeiling(new DiveReportedCeiling()),
-	pn2GasItem(new PartialPressureGasItem()),
-	pheGasItem(new PartialPressureGasItem()),
-	po2GasItem(new PartialPressureGasItem()),
-	o2SetpointGasItem(new PartialPressureGasItem()),
-	ccrsensor1GasItem(new PartialPressureGasItem()),
-	ccrsensor2GasItem(new PartialPressureGasItem()),
-	ccrsensor3GasItem(new PartialPressureGasItem()),
-	ocpo2GasItem(new PartialPressureGasItem()),
+	reportedCeiling(new DiveReportedCeiling(*dataModel)),
+	pn2GasItem(new PartialPressureGasItem(*dataModel)),
+	pheGasItem(new PartialPressureGasItem(*dataModel)),
+	po2GasItem(new PartialPressureGasItem(*dataModel)),
+	o2SetpointGasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor1GasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor2GasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor3GasItem(new PartialPressureGasItem(*dataModel)),
+	ocpo2GasItem(new PartialPressureGasItem(*dataModel)),
 #ifndef SUBSURFACE_MOBILE
-	diveCeiling(new DiveCalculatedCeiling(this)),
+	diveCeiling(new DiveCalculatedCeiling(*dataModel, this)),
 	decoModelParameters(new DiveTextItem()),
 	heartBeatAxis(new DiveCartesianAxis(this)),
-	heartBeatItem(new DiveHeartrateItem()),
+	heartBeatItem(new DiveHeartrateItem(*dataModel)),
 	percentageAxis(new DiveCartesianAxis(this)),
-	ambPressureItem(new DiveAmbPressureItem()),
-	gflineItem(new DiveGFLineItem()),
+	ambPressureItem(new DiveAmbPressureItem(*dataModel)),
+	gflineItem(new DiveGFLineItem(*dataModel)),
 	mouseFollowerVertical(new DiveLineItem()),
 	mouseFollowerHorizontal(new DiveLineItem()),
 	rulerItem(new RulerItem2()),
@@ -342,10 +342,10 @@ void ProfileWidget2::setupItemOnScene()
 	decoModelParameters->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
 	setupItem(diveCeiling, profileYAxis, DivePlotDataModel::CEILING, DivePlotDataModel::TIME, 1);
 	for (int i = 0; i < 16; i++) {
-		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(this);
+		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(*dataModel, this);
 		setupItem(tissueItem, profileYAxis, DivePlotDataModel::TISSUE_1 + i, DivePlotDataModel::TIME, 1 + i);
 		allTissues.append(tissueItem);
-		DivePercentageItem *percentageItem = new DivePercentageItem(i);
+		DivePercentageItem *percentageItem = new DivePercentageItem(*dataModel, i);
 		setupItem(percentageItem, percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, DivePlotDataModel::TIME, 1 + i);
 		allPercentages.append(percentageItem);
 	}
@@ -542,7 +542,6 @@ void ProfileWidget2::setupItem(AbstractProfilePolygonItem *item, DiveCartesianAx
 {
 	item->setHorizontalAxis(timeAxis);
 	item->setVerticalAxis(vAxis);
-	item->setModel(dataModel);
 	item->setVerticalDataColumn(vData);
 	item->setHorizontalDataColumn(hData);
 	item->setZValue(zValue);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -98,11 +98,9 @@ signals:
 	void enableShortcuts();
 	void disableShortcuts(bool paste);
 	void editCurrentDive();
-	void dateTimeChangedItems();
 
 public
 slots: // Necessary to call from QAction's signals.
-	void dateTimeChanged();
 	void settingsChanged();
 	void actionRequestedReplot(bool triggered);
 	void setEmptyState();

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -218,13 +218,3 @@ void DivePlotDataModel::emitDataChanged()
 {
 	emit dataChanged(QModelIndex(), QModelIndex());
 }
-
-#ifndef SUBSURFACE_MOBILE
-void DivePlotDataModel::calculateDecompression()
-{
-	struct divecomputer *dc = select_dc(&displayed_dive);
-	init_decompression(&plot_deco_state, &displayed_dive);
-	calculate_deco_information(&plot_deco_state, &(DivePlannerPointsModel::instance()->final_deco_state), &displayed_dive, dc, &pInfo, false);
-	dataChanged(index(0, CEILING), index(pInfo.nr - 1, TISSUE_16));
-}
-#endif

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -86,9 +86,6 @@ public:
 	double pn2Max();
 	double po2Max();
 	void emitDataChanged();
-#ifndef SUBSURFACE_MOBILE
-	void calculateDecompression();
-#endif
 
 private:
 	struct plot_info pInfo;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The control flow in the profile code is a complete mess. For example, in my testing, every call to plotDive() replots the profile items thrice(!). The code tries to be smart and fails horribly. Fixing this will take a long time and I start with a rather simple thing: There seems to be obsolete calls to deco-recalculation, since the deco-info is recalculated for every call to plotDive() anyway. This removes on of those cases. In my tests, this all appeared to work properly, but of course I might have missed something. Please check it out.