### PR TITLE
Fix mobile profile redraw

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -411,6 +411,7 @@ Kirigami.Page {
 				DiveDetailsView {
 					id: diveDetails
 					width: internalScrollView.width
+					myId: model.id
 				}
 				ScrollBar.vertical: ScrollBar { }
 			}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -115,9 +115,6 @@ Item {
 				      endpressure, usedGas, usedCyl,
 				      detailsEdit.rating,
 				      detailsEdit.visibility, state)
-		// trigger the profile to be redrawn
-		QMLProfile.diveId = dive_id
-
 		Qt.inputMethod.hide()
 		// now make sure we directly show the saved dive (this may be a new dive, or it may have moved)
 		clearDetailsEdit()

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -12,6 +12,7 @@ Item {
 	property real col1Width: gridWidth * 0.40
 	property real col2Width: gridWidth * 0.30
 	property real col3Width: gridWidth * 0.30
+	property int myId: -1
 
 	width: diveDetailsPage.width - diveDetailsPage.leftPadding - diveDetailsPage.rightPadding
 	height: divePlate.implicitHeight + bottomLayout.implicitHeight + Kirigami.Units.iconSizes.large
@@ -229,6 +230,7 @@ Item {
 				anchors.fill: parent
 				clip: true
 				property real lastScale: 1.0 // final scale at the end of previous pinch
+				diveId: detailsView.myId
 				Rectangle {
 					color: "transparent"
 					opacity: 0.6
@@ -572,11 +574,6 @@ Item {
 			Layout.columnSpan: 3
 			Layout.fillWidth: true
 			Layout.minimumHeight: Kirigami.Units.gridUnit * 6
-		}
-		Component.onCompleted: {
-			qmlProfile.setMargin(Kirigami.Units.smallSpacing)
-			qmlProfile.diveId = model.id;
-			qmlProfile.update();
 		}
 	}
 }

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -25,6 +25,7 @@ QMLProfile::QMLProfile(QQuickItem *parent) :
 	m_profileWidget->setFontPrintScale(fontScale);
 	connect(QMLManager::instance(), &QMLManager::sendScreenChanged, this, &QMLProfile::screenChanged);
 	connect(this, &QMLProfile::scaleChanged, this, &QMLProfile::triggerUpdate);
+	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &QMLProfile::divesChanged);
 	setDevicePixelRatio(QMLManager::instance()->lastDevicePixelRatio());
 }
 
@@ -181,4 +182,17 @@ void QMLProfile::setYOffset(qreal value)
 void QMLProfile::screenChanged(QScreen *screen)
 {
 	setDevicePixelRatio(screen->devicePixelRatio());
+}
+
+void QMLProfile::divesChanged(const QVector<dive *> &dives, DiveField)
+{
+	for (struct dive *d: dives) {
+		if (d->id == m_diveId) {
+			qDebug() << "dive #" << d->number << "changed, trigger profile update";
+			m_profileWidget->plotDive(d, true);
+			triggerUpdate();
+			return;
+		}
+	}
+
 }

--- a/profile-widget/qmlprofile.h
+++ b/profile-widget/qmlprofile.h
@@ -3,6 +3,7 @@
 #define QMLPROFILE_H
 
 #include "profilewidget2.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 #include <QQuickPaintedItem>
 
 class QMLProfile : public QQuickPaintedItem
@@ -37,6 +38,9 @@ private:
 	qreal m_xOffset, m_yOffset;
 	QScopedPointer<ProfileWidget2> m_profileWidget;
 	void updateProfile();
+
+private slots:
+	void divesChanged(const QVector<dive *> &dives, DiveField);
 
 signals:
 	void rightAlignedChanged();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
If the user edits a dive in a way that changes the profile (things like duration, depth, or gas mix), the mobile app actually didn't redraw the profile until the dive view got invalidated (so scroll forward a couple of dives and then scroll back). That's because the way we tried to do that was completely bogus, fundamentally misunderstanding how delegates work. I'm kinda surprised that this didn't get us at least a QML warning

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- clean up the way we set the dive id for the profile: the existing code kinda worked but also was odd
- update the rendering of the profile if the underlying dive was changed

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
missing - again, mobile changes are very poorly tracked in that file

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger the second commit is one where I'd love to get your feedback. I think I am connecting things correctly (and in my testing this works fine), but this code is really strange. I tried to check if any of the relevant fields were changed, but couldn't figure out how to check the fields argument for a specific set of bits.