### PR TITLE
Cleanup gps location code

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -15,17 +15,12 @@
 #include <QApplication>
 #include <QTimer>
 
-GpsLocation *GpsLocation::m_Instance = NULL;
-
-GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
-	QObject(parent),
+GpsLocation::GpsLocation() :
 	m_GpsSource(0),
+	showMessageCB(0),
 	waitingForPosition(false),
 	haveSource(UNKNOWN)
 {
-	Q_ASSERT_X(m_Instance == NULL, "GpsLocation", "GpsLocation recreated");
-	m_Instance = this;
-	showMessageCB = showMsgCB;
 	// create a QSettings object that's separate from the main application settings
 	geoSettings = new QSettings(QSettings::NativeFormat, QSettings::UserScope,
 				    QStringLiteral("org.subsurfacedivelog"), QStringLiteral("subsurfacelocation"), this);
@@ -39,19 +34,17 @@ GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 
 GpsLocation *GpsLocation::instance()
 {
-	Q_ASSERT(m_Instance != NULL);
-
-	return m_Instance;
-}
-
-bool GpsLocation::hasInstance()
-{
-	return m_Instance != NULL;
+	static GpsLocation self;
+	return &self;
 }
 
 GpsLocation::~GpsLocation()
 {
-	m_Instance = NULL;
+}
+
+void GpsLocation::setLogCallBack(void (*showMsgCB)(const char *))
+{
+	showMessageCB = showMsgCB;
 }
 
 void GpsLocation::setGpsTimeThreshold(int seconds)

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -29,14 +29,14 @@ struct DiveAndLocation {
 class GpsLocation : public QObject {
 	Q_OBJECT
 public:
-	GpsLocation(void (*showMsgCB)(const char *msg), QObject *parent);
+	GpsLocation();
 	~GpsLocation();
 	static GpsLocation *instance();
-	static bool hasInstance();
 	std::vector<DiveAndLocation> getLocations();
 	int getGpsNum() const;
 	bool hasLocationsSource();
 	QString currentPosition();
+	void setLogCallBack(void (*showMsgCB)(const char *msg));
 
 	QMap<qint64, gpsTracker> currentGPSInfo() const;
 
@@ -49,7 +49,6 @@ private:
 	QNetworkReply *reply;
 	QString userAgent;
 	void (*showMessageCB)(const char *msg);
-	static GpsLocation *m_Instance;
 	bool waitingForPosition;
 	QMap<qint64, gpsTracker> m_trackers;
 	QList<gpsTracker> m_deletedTrackers;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -290,7 +290,8 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 			this, &QMLManager::btHostModeChange);
 	}
 	// create location manager service
-	locationProvider = new GpsLocation(&appendTextToLogStandalone, this);
+	locationProvider = GpsLocation::instance();
+	locationProvider->setLogCallBack(&appendTextToLogStandalone);
 	progress_callback = &progressCallback;
 	connect(locationProvider, SIGNAL(haveSourceChanged()), this, SLOT(hasLocationSourceChanged()));
 	setLocationServiceAvailable(locationProvider->hasLocationsSource());

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -209,7 +209,6 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	m_instance = this;
 	m_lastDevicePixelRatio = qApp->devicePixelRatio();
 	timer.start();
-	connect(qobject_cast<QApplication *>(QApplication::instance()), &QApplication::applicationStateChanged, this, &QMLManager::applicationStateChanged);
 
 	// make upload signals available in QML
 	// Remark: signal - signal connect
@@ -323,6 +322,9 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 	// get updates to the undo/redo texts
 	connect(Command::getUndoStack(), &QUndoStack::undoTextChanged, this, &QMLManager::undoTextChanged);
 	connect(Command::getUndoStack(), &QUndoStack::redoTextChanged, this, &QMLManager::redoTextChanged);
+
+	// now that everything is setup, connect the application changed signal
+	connect(qobject_cast<QApplication *>(QApplication::instance()), &QApplication::applicationStateChanged, this, &QMLManager::applicationStateChanged);
 
 	// we start out with clean data
 	updateHaveLocalChanges(false);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -254,7 +254,6 @@ private:
 	bool m_verboseEnabled;
 	bool m_diveListProcessing;
 	bool m_initialized;
-	GpsLocation *locationProvider;
 	bool m_loadFromCloud;
 	static QMLManager *m_instance;
 	QString m_notificationText;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was much easier than I thought - but then maybe I didn't go as 'deep' fixing it as you likely expected me to :-)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) move the connect for the applicationStateChanged signal to the very end of the `QMLManager` constructor to ensure that the object is fully set up before that slot can be called
2) change the GpsLocation class to a more typical singleton with a static variable in the constructor
3) instead of completely redoing the log logic, simply add another method to set up the callback function

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger -- good enough?