### PR TITLE
cleanup: don't save PASCAL pressure units to git

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -46,6 +46,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/file.c \
 	core/fulltext.cpp \
 	core/subsurfacestartup.c \
+	core/pref.c \
 	core/profile.c \
 	core/device.cpp \
 	core/dive.c \

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -143,6 +143,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	planner.h
 	plannernotes.c
 	pref.h
+	pref.c
 	profile.c
 	profile.h
 	qt-gui.h

--- a/core/dive.c
+++ b/core/dive.c
@@ -2972,8 +2972,6 @@ void set_informational_units(const char *units)
 			git_prefs.units.pressure = BAR;
 		if (strstr(units, "PSI"))
 			git_prefs.units.pressure = PSI;
-		if (strstr(units, "PASCAL"))
-			git_prefs.units.pressure = PASCALS;
 		if (strstr(units, "CELSIUS"))
 			git_prefs.units.temperature = CELSIUS;
 		if (strstr(units, "FAHRENHEIT"))

--- a/core/pref.c
+++ b/core/pref.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "pref.h"
+#include "subsurface-string.h"
+
+struct preferences prefs, git_prefs;
+struct preferences default_prefs = {
+	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
+	.units = SI_UNITS,
+	.unit_system = METRIC,
+	.coordinates_traditional = true,
+	.pp_graphs = {
+		.po2 = false,
+		.pn2 = false,
+		.phe = false,
+		.po2_threshold_min = 0.16,
+		.po2_threshold_max = 1.6,
+		.pn2_threshold = 4.0,
+		.phe_threshold = 13.0,
+	},
+	.mod = false,
+	.modpO2 = 1.6,
+	.ead = false,
+	.hrgraph = false,
+	.percentagegraph = false,
+	.dcceiling = true,
+	.redceiling = false,
+	.calcceiling = false,
+	.calcceiling3m = false,
+	.calcndltts = false,
+	.decoinfo = true,
+	.gflow = 30,
+	.gfhigh = 75,
+	.animation_speed = 500,
+	.gf_low_at_maxdepth = false,
+	.show_ccr_setpoint = false,
+	.show_ccr_sensors = false,
+	.show_scr_ocpo2 = false,
+	.font_size = -1,
+	.mobile_scale = 1.0,
+	.display_invalid_dives = false,
+	.show_sac = false,
+	.display_unused_tanks = false,
+	.display_default_tank_infos = true,
+	.show_average_depth = true,
+	.show_icd = false,
+	.ascrate75 = 9000 / 60,
+	.ascrate50 = 9000 / 60,
+	.ascratestops = 9000 / 60,
+	.ascratelast6m = 9000 / 60,
+	.descrate = 18000 / 60,
+	.sacfactor = 400,
+	.problemsolvingtime = 4,
+	.bottompo2 = 1400,
+	.decopo2 = 1600,
+	.bestmixend.mm = 30000,
+	.doo2breaks = false,
+	.dobailout = false,
+	.drop_stone_mode = false,
+	.switch_at_req_stop = false,
+	.min_switch_duration = 60,
+	.surface_segment = 0,
+	.last_stop = false,
+	.verbatim_plan = false,
+	.display_runtime = true,
+	.display_duration = true,
+	.display_transitions = true,
+	.display_variations = false,
+	.o2narcotic = true,
+	.safetystop = true,
+	.bottomsac = 20000,
+	.decosac = 17000,
+	.reserve_gas=40000,
+	.o2consumption = 720,
+	.pscr_ratio = 100,
+	.show_pictures_in_profile = true,
+	.tankbar = false,
+	.defaultsetpoint = 1100,
+	.geocoding = {
+		.category = { 0 }
+	},
+	.locale = {
+		.use_system_language = true,
+	},
+	.planner_deco_mode = BUEHLMANN,
+	.vpmb_conservatism = 3,
+	.distance_threshold = 100,
+	.time_threshold = 300,
+#if defined(SUBSURFACE_MOBILE)
+	.cloud_timeout = 10,
+#else
+	.cloud_timeout = 5,
+#endif
+	.auto_recalculate_thumbnails = true,
+	.extract_video_thumbnails = true,
+	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
+};
+
+/* copy a preferences block, including making copies of all included strings */
+void copy_prefs(struct preferences *src, struct preferences *dest)
+{
+	*dest = *src;
+	dest->divelist_font = copy_string(src->divelist_font);
+	dest->default_filename = copy_string(src->default_filename);
+	dest->default_cylinder = copy_string(src->default_cylinder);
+	dest->cloud_base_url = copy_string(src->cloud_base_url);
+	dest->cloud_git_url = copy_string(src->cloud_git_url);
+	dest->proxy_host = copy_string(src->proxy_host);
+	dest->proxy_user = copy_string(src->proxy_user);
+	dest->proxy_pass = copy_string(src->proxy_pass);
+	dest->time_format = copy_string(src->time_format);
+	dest->date_format = copy_string(src->date_format);
+	dest->date_format_short = copy_string(src->date_format_short);
+	dest->cloud_storage_password = copy_string(src->cloud_storage_password);
+	dest->cloud_storage_email = copy_string(src->cloud_storage_email);
+	dest->cloud_storage_email_encoded = copy_string(src->cloud_storage_email_encoded);
+	dest->ffmpeg_executable = copy_string(src->ffmpeg_executable);
+}
+
+/*
+ * Free strduped prefs before exit.
+ *
+ * These are not real leaks but they plug the holes found by eg.
+ * valgrind so you can find the real leaks.
+ */
+void free_prefs(void)
+{
+	// nop
+}

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -842,7 +842,7 @@ static void save_units(void *_b)
 		put_format(b, "units PERSONALIZE %s %s %s %s %s %s\n",
 			   prefs.units.length == METERS ? "METERS" : "FEET",
 			   prefs.units.volume == LITER ? "LITER" : "CUFT",
-			   prefs.units.pressure == BAR ? "BAR" : prefs.units.pressure == PSI ? "PSI" : "PASCAL",
+			   prefs.units.pressure == BAR ? "BAR" : "PSI",
 			   prefs.units.temperature == CELSIUS ? "CELSIUS" : prefs.units.temperature == FAHRENHEIT ? "FAHRENHEIT" : "KELVIN",
 			   prefs.units.weight == KG ? "KG" : "LBS",
 			   prefs.units.vertical_speed_time == SECONDS ? "SECONDS" : "MINUTES");

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -110,11 +110,6 @@ int quit, force_root, ignore_bt;
 char *testqml = NULL;
 #endif
 
-const struct units *get_units()
-{
-	return &prefs.units;
-}
-
 /*
  * track whether we switched to importing dives
  */

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -2,108 +2,17 @@
 #include "subsurfacestartup.h"
 #include "subsurface-string.h"
 #include "version.h"
-#include <stdbool.h>
-#include <string.h>
 #include "errorhelper.h"
 #include "gettext.h"
 #include "qthelper.h"
 #include "git-access.h"
+#include "pref.h"
 #include "libdivecomputer/version.h"
 
-extern void show_computer_list();
+#include <stdbool.h>
+#include <string.h>
 
-struct preferences prefs, git_prefs;
-struct preferences default_prefs = {
-	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
-	.units = SI_UNITS,
-	.unit_system = METRIC,
-	.coordinates_traditional = true,
-	.pp_graphs = {
-		.po2 = false,
-		.pn2 = false,
-		.phe = false,
-		.po2_threshold_min = 0.16,
-		.po2_threshold_max = 1.6,
-		.pn2_threshold = 4.0,
-		.phe_threshold = 13.0,
-	},
-	.mod = false,
-	.modpO2 = 1.6,
-	.ead = false,
-	.hrgraph = false,
-	.percentagegraph = false,
-	.dcceiling = true,
-	.redceiling = false,
-	.calcceiling = false,
-	.calcceiling3m = false,
-	.calcndltts = false,
-	.decoinfo = true,
-	.gflow = 30,
-	.gfhigh = 75,
-	.animation_speed = 500,
-	.gf_low_at_maxdepth = false,
-	.show_ccr_setpoint = false,
-	.show_ccr_sensors = false,
-	.show_scr_ocpo2 = false,
-	.font_size = -1,
-	.mobile_scale = 1.0,
-	.display_invalid_dives = false,
-	.show_sac = false,
-	.display_unused_tanks = false,
-	.display_default_tank_infos = true,
-	.show_average_depth = true,
-	.show_icd = false,
-	.ascrate75 = 9000 / 60,
-	.ascrate50 = 9000 / 60,
-	.ascratestops = 9000 / 60,
-	.ascratelast6m = 9000 / 60,
-	.descrate = 18000 / 60,
-	.sacfactor = 400,
-	.problemsolvingtime = 4,
-	.bottompo2 = 1400,
-	.decopo2 = 1600,
-	.bestmixend.mm = 30000,
-	.doo2breaks = false,
-	.dobailout = false,
-	.drop_stone_mode = false,
-	.switch_at_req_stop = false,
-	.min_switch_duration = 60,
-	.surface_segment = 0,
-	.last_stop = false,
-	.verbatim_plan = false,
-	.display_runtime = true,
-	.display_duration = true,
-	.display_transitions = true,
-	.display_variations = false,
-	.o2narcotic = true,
-	.safetystop = true,
-	.bottomsac = 20000,
-	.decosac = 17000,
-	.reserve_gas=40000,
-	.o2consumption = 720,
-	.pscr_ratio = 100,
-	.show_pictures_in_profile = true,
-	.tankbar = false,
-	.defaultsetpoint = 1100,
-	.geocoding = {
-		.category = { 0 }
-	},
-	.locale = {
-		.use_system_language = true,
-	},
-	.planner_deco_mode = BUEHLMANN,
-	.vpmb_conservatism = 3,
-	.distance_threshold = 100,
-	.time_threshold = 300,
-#if defined(SUBSURFACE_MOBILE)
-	.cloud_timeout = 10,
-#else
-	.cloud_timeout = 5,
-#endif
-	.auto_recalculate_thumbnails = true,
-	.extract_video_thumbnails = true,
-	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
-};
+extern void show_computer_list();
 
 int quit, force_root, ignore_bt;
 #ifdef SUBSURFACE_MOBILE_DESKTOP
@@ -316,36 +225,4 @@ void setup_system_prefs(void)
 		return;
 
 	default_prefs.units = IMPERIAL_units;
-}
-
-/* copy a preferences block, including making copies of all included strings */
-void copy_prefs(struct preferences *src, struct preferences *dest)
-{
-	*dest = *src;
-	dest->divelist_font = copy_string(src->divelist_font);
-	dest->default_filename = copy_string(src->default_filename);
-	dest->default_cylinder = copy_string(src->default_cylinder);
-	dest->cloud_base_url = copy_string(src->cloud_base_url);
-	dest->cloud_git_url = copy_string(src->cloud_git_url);
-	dest->proxy_host = copy_string(src->proxy_host);
-	dest->proxy_user = copy_string(src->proxy_user);
-	dest->proxy_pass = copy_string(src->proxy_pass);
-	dest->time_format = copy_string(src->time_format);
-	dest->date_format = copy_string(src->date_format);
-	dest->date_format_short = copy_string(src->date_format_short);
-	dest->cloud_storage_password = copy_string(src->cloud_storage_password);
-	dest->cloud_storage_email = copy_string(src->cloud_storage_email);
-	dest->cloud_storage_email_encoded = copy_string(src->cloud_storage_email_encoded);
-	dest->ffmpeg_executable = copy_string(src->ffmpeg_executable);
-}
-
-/*
- * Free strduped prefs before exit.
- *
- * These are not real leaks but they plug the holes found by eg.
- * valgrind so you can find the real leaks.
- */
-void free_prefs(void)
-{
-	// nop
 }

--- a/core/units.c
+++ b/core/units.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "units.h"
 #include "gettext.h"
+#include "pref.h"
 
 int get_pressure_units(int mb, const char **units)
 {
@@ -167,4 +168,9 @@ double get_weight_units(unsigned int grams, int *frac, const char **units)
 	if (units)
 		*units = unit;
 	return value;
+}
+
+const struct units *get_units()
+{
+	return &prefs.units;
 }

--- a/core/units.c
+++ b/core/units.c
@@ -9,10 +9,6 @@ int get_pressure_units(int mb, const char **units)
 	const struct units *units_p = get_units();
 
 	switch (units_p->pressure) {
-	case PASCALS:
-		pressure = mb * 100;
-		unit = translate("gettextFromC", "pascal");
-		break;
 	case BAR:
 	default:
 		pressure = (mb + 500) / 1000;


### PR DESCRIPTION
The way I understand, the PASCAL pressure unit is used to parse
obscure dive logs. However, there is no support in the UI for
using Pa as pressure unit. Therefore remove reading / writing
this unit to git divelogs.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Pa pressures are not supported by the UI(?) - don't write to / read from git logs.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - shouldn't be user visible.
