### PR TITLE
[cleanup] some profile code straightening

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -256,7 +256,6 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 		updateNotes(current_dive);
 	if (field.datetime) {
 		updateDateTime(current_dive);
-		MainWindow::instance()->graphics->dateTimeChanged();
 		DivePlannerPointsModel::instance()->getDiveplan().when = current_dive->when;
 	}
 	if (field.divesite)

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -9,7 +9,7 @@
 #include "profile-widget/divelineitem.h"
 #include "profile-widget/profilewidget2.h"
 
-QPen DiveCartesianAxis::gridPen()
+QPen DiveCartesianAxis::gridPen() const
 {
 	QPen pen;
 	pen.setColor(getColor(TIME_GRID));
@@ -96,7 +96,7 @@ void DiveCartesianAxis::setOrientation(Orientation o)
 	changed = true;
 }
 
-QColor DiveCartesianAxis::colorForValue(double)
+QColor DiveCartesianAxis::colorForValue(double) const
 {
 	return QColor(Qt::black);
 }
@@ -265,7 +265,7 @@ void DiveCartesianAxis::animateChangeLine(const QLineF &newLine)
 	sizeChanged();
 }
 
-QString DiveCartesianAxis::textForValue(double value)
+QString DiveCartesianAxis::textForValue(double value) const
 {
 	return QString("%L1").arg(value, 0, 'g', 4);
 }
@@ -297,7 +297,7 @@ qreal DiveCartesianAxis::valueAt(const QPointF &p) const
 	return fraction * (max - min) + min;
 }
 
-qreal DiveCartesianAxis::posAtValue(qreal value)
+qreal DiveCartesianAxis::posAtValue(qreal value) const
 {
 	QLineF m = line();
 	QPointF p = pos();
@@ -349,14 +349,14 @@ void DiveCartesianAxis::setColor(const QColor &color)
 	setPen(defaultPen);
 }
 
-QString DepthAxis::textForValue(double value)
+QString DepthAxis::textForValue(double value) const
 {
 	if (value == 0)
 		return QString();
 	return get_depth_string(lrint(value), false, false);
 }
 
-QColor DepthAxis::colorForValue(double)
+QColor DepthAxis::colorForValue(double) const
 {
 	return QColor(Qt::red);
 }
@@ -382,12 +382,12 @@ TimeAxis::TimeAxis(ProfileWidget2 *widget) : DiveCartesianAxis(widget)
 {
 }
 
-QColor TimeAxis::colorForValue(double)
+QColor TimeAxis::colorForValue(double) const
 {
 	return QColor(Qt::blue);
 }
 
-QString TimeAxis::textForValue(double value)
+QString TimeAxis::textForValue(double value) const
 {
 	int nr = lrint(value) / 60;
 	if (maximum() < 600)
@@ -409,7 +409,7 @@ TemperatureAxis::TemperatureAxis(ProfileWidget2 *widget) : DiveCartesianAxis(wid
 {
 }
 
-QString TemperatureAxis::textForValue(double value)
+QString TemperatureAxis::textForValue(double value) const
 {
 	return QString::number(mkelvin_to_C((int)value));
 }

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -361,17 +361,16 @@ QColor DepthAxis::colorForValue(double) const
 	return QColor(Qt::red);
 }
 
-DepthAxis::DepthAxis(ProfileWidget2 *widget) : DiveCartesianAxis(widget)
+DepthAxis::DepthAxis(ProfileWidget2 *widget) : DiveCartesianAxis(widget),
+	unitSystem(prefs.units.length)
 {
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DepthAxis::settingsChanged);
 	changed = true;
-	settingsChanged();
 }
 
 void DepthAxis::settingsChanged()
 {
-	static int unitSystem = prefs.units.length;
-	if ( unitSystem == prefs.units.length )
+	if (unitSystem == prefs.units.length)
 		return;
 	changed = true;
 	updateTicks();

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -413,34 +413,27 @@ QString TemperatureAxis::textForValue(double value) const
 	return QString::number(mkelvin_to_C((int)value));
 }
 
-PartialGasPressureAxis::PartialGasPressureAxis(ProfileWidget2 *widget) :
+PartialGasPressureAxis::PartialGasPressureAxis(const DivePlotDataModel &model, ProfileWidget2 *widget) :
 	DiveCartesianAxis(widget),
-	model(NULL)
+	model(model)
 {
-	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &PartialGasPressureAxis::settingsChanged);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &PartialGasPressureAxis::update);
 }
 
-void PartialGasPressureAxis::setModel(DivePlotDataModel *m)
-{
-	model = m;
-	connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(settingsChanged()));
-	settingsChanged();
-}
-
-void PartialGasPressureAxis::settingsChanged()
+void PartialGasPressureAxis::update()
 {
 	bool showPhe = prefs.pp_graphs.phe;
 	bool showPn2 = prefs.pp_graphs.pn2;
 	bool showPo2 = prefs.pp_graphs.po2;
 	setVisible(showPhe || showPn2 || showPo2);
-	if (!model->rowCount())
+	if (!model.rowCount())
 		return;
 
-	double max = showPhe ? model->pheMax() : -1;
-	if (showPn2 && model->pn2Max() > max)
-		max = model->pn2Max();
-	if (showPo2 && model->po2Max() > max)
-		max = model->po2Max();
+	double max = showPhe ? model.pheMax() : -1;
+	if (showPn2 && model.pn2Max() > max)
+		max = model.pn2Max();
+	if (showPo2 && model.po2Max() > max)
+		max = model.po2Max();
 
 	qreal pp = floor(max * 10.0) / 10.0 + 0.2;
 	if (IS_FP_SAME(maximum(), pp))

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -20,7 +20,7 @@ class DiveCartesianAxis : public QObject, public QGraphicsLineItem {
 	Q_PROPERTY(qreal y WRITE setY READ y)
 private:
 	bool printMode;
-	QPen gridPen();
+	QPen gridPen() const;
 public:
 	enum Orientation {
 		TopToBottom,
@@ -41,7 +41,7 @@ public:
 	double maximum() const;
 	double fontLabelScale() const;
 	qreal valueAt(const QPointF &p) const;
-	qreal posAtValue(qreal value);
+	qreal posAtValue(qreal value) const;
 	void setColor(const QColor &color);
 	void setTextColor(const QColor &color);
 	void animateChangeLine(const QLineF &newLine);
@@ -60,8 +60,8 @@ signals:
 
 protected:
 	ProfileWidget2 *profileWidget;
-	virtual QString textForValue(double value);
-	virtual QColor colorForValue(double value);
+	virtual QString textForValue(double value) const;
+	virtual QColor colorForValue(double value) const;
 	Orientation orientation;
 	QList<DiveTextItem *> labels;
 	QList<DiveLineItem *> lines;
@@ -82,8 +82,8 @@ class DepthAxis : public DiveCartesianAxis {
 public:
 	DepthAxis(ProfileWidget2 *widget);
 private:
-	QString textForValue(double value);
-	QColor colorForValue(double value);
+	QString textForValue(double value) const override;
+	QColor colorForValue(double value) const override;
 private
 slots:
 	void settingsChanged();
@@ -95,8 +95,8 @@ public:
 	TimeAxis(ProfileWidget2 *widget);
 	void updateTicks(color_index_t color = TIME_GRID);
 private:
-	QString textForValue(double value);
-	QColor colorForValue(double value);
+	QString textForValue(double value) const override;
+	QColor colorForValue(double value) const override;
 };
 
 class TemperatureAxis : public DiveCartesianAxis {
@@ -104,7 +104,7 @@ class TemperatureAxis : public DiveCartesianAxis {
 public:
 	TemperatureAxis(ProfileWidget2 *widget);
 private:
-	QString textForValue(double value);
+	QString textForValue(double value) const override;
 };
 
 class PartialGasPressureAxis : public DiveCartesianAxis {

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -84,6 +84,7 @@ public:
 private:
 	QString textForValue(double value) const override;
 	QColor colorForValue(double value) const override;
+	int unitSystem;
 private
 slots:
 	void settingsChanged();

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -50,8 +50,6 @@ public:
 	void setLineSize(qreal lineSize);
 	void setLine(const QLineF& line);
 	int unitSystem;
-public
-slots:
 	virtual void updateTicks(color_index_t color = TIME_GRID);
 
 signals:
@@ -94,7 +92,7 @@ class TimeAxis : public DiveCartesianAxis {
 	Q_OBJECT
 public:
 	TimeAxis(ProfileWidget2 *widget);
-	void updateTicks(color_index_t color = TIME_GRID);
+	void updateTicks(color_index_t color = TIME_GRID) override;
 private:
 	QString textForValue(double value) const override;
 	QColor colorForValue(double value) const override;

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -109,13 +109,12 @@ private:
 class PartialGasPressureAxis : public DiveCartesianAxis {
 	Q_OBJECT
 public:
-	PartialGasPressureAxis(ProfileWidget2 *widget);
-	void setModel(DivePlotDataModel *model);
+	PartialGasPressureAxis(const DivePlotDataModel &model, ProfileWidget2 *widget);
 public
 slots:
-	void settingsChanged();
+	void update();
 private:
-	DivePlotDataModel *model;
+	const DivePlotDataModel &model;
 };
 
 #endif // DIVECARTESIANAXIS_H

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -19,32 +19,12 @@ AbstractProfilePolygonItem::AbstractProfilePolygonItem(const DivePlotDataModel &
 	setCacheMode(DeviceCoordinateCache);
 }
 
-void AbstractProfilePolygonItem::replot()
-{
-	modelDataChanged();
-}
-
 void AbstractProfilePolygonItem::setVisible(bool visible)
 {
 	QGraphicsPolygonItem::setVisible(visible);
 }
 
-bool AbstractProfilePolygonItem::shouldCalculateStuff(const QModelIndex &topLeft, const QModelIndex &bottomRight)
-{
-	if (dataModel.rowCount() == 0)
-		return false;
-	if (hDataColumn == -1 || vDataColumn == -1)
-		return false;
-	if (topLeft.isValid() && bottomRight.isValid()) {
-		if ((topLeft.column() >= vDataColumn || topLeft.column() >= hDataColumn) &&
-		    (bottomRight.column() <= vDataColumn || topLeft.column() <= hDataColumn)) {
-			return true;
-		}
-	}
-	return true;
-}
-
-void AbstractProfilePolygonItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
+void AbstractProfilePolygonItem::replot()
 {
 	// Calculate the polygon. This is the polygon that will be painted on screen
 	// on the ::paint method. Here we calculate the correct position of the points
@@ -116,13 +96,11 @@ int DiveProfileItem::maxCeiling(int row)
 	return max;
 }
 
-void DiveProfileItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveProfileItem::replot()
 {
 	bool eventAdded = false;
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
-	AbstractProfilePolygonItem::modelDataChanged(topLeft, bottomRight);
+	AbstractProfilePolygonItem::replot();
 	if (polygon().isEmpty())
 		return;
 
@@ -219,17 +197,13 @@ DiveHeartrateItem::DiveHeartrateItem(const DivePlotDataModel &model, const DiveC
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::hrgraphChanged, this, &DiveHeartrateItem::setVisible);
 }
 
-void DiveHeartrateItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveHeartrateItem::replot()
 {
 	int last = -300, last_printed_hr = 0, sec = 0;
 	struct {
 		int sec;
 		int hr;
 	} hist[3] = {};
-
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	qDeleteAll(texts);
 	texts.clear();
@@ -302,13 +276,9 @@ DivePercentageItem::DivePercentageItem(const DivePlotDataModel &model, const Div
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::percentagegraphChanged, this, &DivePercentageItem::setVisible);
 }
 
-void DivePercentageItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DivePercentageItem::replot()
 {
 	int sec = 0;
-
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
@@ -382,13 +352,9 @@ DiveAmbPressureItem::DiveAmbPressureItem(const DivePlotDataModel &model, const D
 	setPen(pen);
 }
 
-void DiveAmbPressureItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveAmbPressureItem::replot()
 {
 	int sec = 0;
-
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
@@ -427,13 +393,9 @@ DiveGFLineItem::DiveGFLineItem(const DivePlotDataModel &model, const DiveCartesi
 	setPen(pen);
 }
 
-void DiveGFLineItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveGFLineItem::replot()
 {
 	int sec = 0;
-
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	// Ignore empty values. a heart rate of 0 would be a bad sign.
 	QPolygonF poly;
@@ -472,12 +434,9 @@ DiveTemperatureItem::DiveTemperatureItem(const DivePlotDataModel &model, const D
 	setPen(pen);
 }
 
-void DiveTemperatureItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveTemperatureItem::replot()
 {
 	int last = -300, last_printed_temp = 0, sec = 0, last_valid_temp = 0;
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	qDeleteAll(texts);
 	texts.clear();
@@ -553,12 +512,9 @@ DiveMeanDepthItem::DiveMeanDepthItem(const DivePlotDataModel &model, const DiveC
 	lastRunningSum = 0.0;
 }
 
-void DiveMeanDepthItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveMeanDepthItem::replot()
 {
 	double meandepthvalue = 0.0;
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
 
 	QPolygonF poly;
 	plot_data *entry = dataModel.data().entry;
@@ -603,12 +559,8 @@ void DiveMeanDepthItem::createTextItem()
 	texts.append(text);
 }
 
-void DiveGasPressureItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveGasPressureItem::replot()
 {
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
-
 	const struct plot_info *pInfo = &dataModel.data();
 	std::vector<int> plotted_cyl(pInfo->nr_cylinders, false);
 	std::vector<int> last_plotted(pInfo->nr_cylinders, 0);
@@ -780,12 +732,9 @@ DiveCalculatedCeiling::DiveCalculatedCeiling(const DivePlotDataModel &model, con
 	setVisible(prefs.calcceiling);
 }
 
-void DiveCalculatedCeiling::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveCalculatedCeiling::replot()
 {
-	// We don't have enougth data to calculate things, quit.
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
-	AbstractProfilePolygonItem::modelDataChanged(topLeft, bottomRight);
+	AbstractProfilePolygonItem::replot();
 	// Add 2 points to close the polygon.
 	QPolygonF poly = polygon();
 	if (poly.isEmpty())
@@ -831,11 +780,8 @@ DiveReportedCeiling::DiveReportedCeiling(const DivePlotDataModel &model, const D
 	setVisible(prefs.dcceiling);
 }
 
-void DiveReportedCeiling::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void DiveReportedCeiling::replot()
 {
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
-
 	QPolygonF p;
 	p.append(QPointF(hAxis.posAtValue(0), vAxis.posAtValue(0)));
 	plot_data *entry = dataModel.data().entry;
@@ -867,11 +813,8 @@ void DiveReportedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	QGraphicsPolygonItem::paint(painter, option, widget);
 }
 
-void PartialPressureGasItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+void PartialPressureGasItem::replot()
 {
-	if (!shouldCalculateStuff(topLeft, bottomRight))
-		return;
-
 	plot_data *entry = dataModel.data().entry;
 	QPolygonF poly;
 	QPolygonF alertpoly;

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -48,13 +48,6 @@ DiveProfileItem::DiveProfileItem(const DivePlotDataModel &model, const DiveCarte
 	AbstractProfilePolygonItem(model, hAxis, hColumn, vAxis, vColumn),
 	show_reported_ceiling(0), reported_ceiling_in_red(0)
 {
-	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::dcceilingChanged, this, &DiveProfileItem::settingsToggled);
-	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::redceilingChanged, this, &DiveProfileItem::settingsToggled);
-}
-
-void DiveProfileItem::settingsToggled(bool)
-{
-	replot();
 }
 
 void DiveProfileItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -17,10 +17,6 @@ AbstractProfilePolygonItem::AbstractProfilePolygonItem(const DivePlotDataModel &
 	hAxis(horizontal), vAxis(vertical), dataModel(model), hDataColumn(hColumn), vDataColumn(vColumn)
 {
 	setCacheMode(DeviceCoordinateCache);
-	connect(&dataModel, &DivePlotDataModel::dataChanged, this, &AbstractProfilePolygonItem::modelDataChanged);
-	connect(&hAxis, &DiveCartesianAxis::sizeChanged, this, &AbstractProfilePolygonItem::replot);
-	connect(&vAxis, &DiveCartesianAxis::sizeChanged, this, &AbstractProfilePolygonItem::replot);
-	connect(&vAxis, &DiveCartesianAxis::maxChanged, this, &AbstractProfilePolygonItem::replot);
 }
 
 void AbstractProfilePolygonItem::replot()
@@ -873,7 +869,6 @@ void DiveReportedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsIte
 
 void PartialPressureGasItem::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
-	//AbstractProfilePolygonItem::modelDataChanged();
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
 

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -562,7 +562,7 @@ void DiveGasPressureItem::replot()
 	const struct plot_info *pInfo = &dataModel.data();
 	std::vector<int> plotted_cyl(pInfo->nr_cylinders, false);
 	std::vector<int> last_plotted(pInfo->nr_cylinders, 0);
-	std::vector<QPolygonF> poly(pInfo->nr_cylinders);
+	std::vector<std::vector<Entry>> poly(pInfo->nr_cylinders);
 	QPolygonF boundingPoly;
 	polygons.clear();
 
@@ -579,29 +579,42 @@ void DiveGasPressureItem::replot()
 			QPointF point(hAxis.posAtValue(time), vAxis.posAtValue(mbar));
 			boundingPoly.push_back(point);
 
+			QColor color;
+			if (!in_planner()) {
+				if (entry->sac)
+					color = getSacColor(entry->sac, displayed_dive.sac);
+				else
+					color = MED_GRAY_HIGH_TRANS;
+			} else {
+				if (mbar < 0)
+					color = MAGENTA;
+				else
+					color = getPressureColor(entry->density);
+			}
+
 			if (plotted_cyl[cyl]) {
-				/* Have we used this culinder in the last two minutes? Continue */
+				/* Have we used this cylinder in the last two minutes? Continue */
 				if (time - last_plotted[cyl] <= 2*60) {
-					poly[cyl].push_back(point);
+					poly[cyl].push_back({ point, color });
 					last_plotted[cyl] = time;
 					continue;
 				}
 
 				/* Finish the previous one, start a new one */
-				polygons.append(poly[cyl]);
-				poly[cyl] = QPolygonF();
+				polygons.push_back(std::move(poly[cyl]));
+				poly[cyl].clear();
 			}
 
 			plotted_cyl[cyl] = true;
 			last_plotted[cyl] = time;
-			poly[cyl].push_back(point);
+			poly[cyl].push_back({ point, color });
 		}
 	}
 
 	for (int cyl = 0; cyl < pInfo->nr_cylinders; cyl++) {
 		if (!plotted_cyl[cyl])
 			continue;
-		polygons.append(poly[cyl]);
+		polygons.push_back(poly[cyl]);
 	}
 
 	setPolygon(boundingPoly);
@@ -700,23 +713,11 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	pen.setCosmetic(true);
 	pen.setWidth(2);
 	painter->save();
-	struct plot_data *entry;
-	Q_FOREACH (const QPolygonF &poly, polygons) {
-		entry = dataModel.data().entry;
-		for (int i = 1, count = poly.count(); i < count; i++, entry++) {
-			if (!in_planner()) {
-				if (entry->sac)
-					pen.setBrush(getSacColor(entry->sac, displayed_dive.sac));
-				else
-					pen.setBrush(MED_GRAY_HIGH_TRANS);
-			} else {
-				if (vAxis.valueAt(poly[i]) < 0)
-					pen.setBrush(MAGENTA);
-				else
-					pen.setBrush(getPressureColor(entry->density));
-			}
+	for (const std::vector<Entry> &poly: polygons) {
+		for (size_t i = 1; i < poly.size(); i++) {
+			pen.setBrush(poly[i].col);
 			painter->setPen(pen);
-			painter->drawLine(poly[i - 1], poly[i]);
+			painter->drawLine(poly[i - 1].pos, poly[i].pos);
 		}
 	}
 	painter->restore();

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -18,7 +18,6 @@ AbstractProfilePolygonItem::AbstractProfilePolygonItem(const DivePlotDataModel &
 {
 	setCacheMode(DeviceCoordinateCache);
 	connect(&dataModel, &DivePlotDataModel::dataChanged, this, &AbstractProfilePolygonItem::modelDataChanged);
-	connect(&dataModel, &DivePlotDataModel::rowsAboutToBeRemoved, this, &AbstractProfilePolygonItem::modelDataRemoved);
 	connect(&hAxis, &DiveCartesianAxis::sizeChanged, this, &AbstractProfilePolygonItem::replot);
 	connect(&vAxis, &DiveCartesianAxis::sizeChanged, this, &AbstractProfilePolygonItem::replot);
 	connect(&vAxis, &DiveCartesianAxis::maxChanged, this, &AbstractProfilePolygonItem::replot);
@@ -32,13 +31,6 @@ void AbstractProfilePolygonItem::replot()
 void AbstractProfilePolygonItem::setVisible(bool visible)
 {
 	QGraphicsPolygonItem::setVisible(visible);
-}
-
-void AbstractProfilePolygonItem::modelDataRemoved(const QModelIndex&, int, int)
-{
-	setPolygon(QPolygonF());
-	qDeleteAll(texts);
-	texts.clear();
 }
 
 bool AbstractProfilePolygonItem::shouldCalculateStuff(const QModelIndex &topLeft, const QModelIndex &bottomRight)

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -820,8 +820,7 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 }
 
 DiveCalculatedCeiling::DiveCalculatedCeiling(ProfileWidget2 *widget) :
-	profileWidget(widget),
-	is3mIncrement(false)
+	profileWidget(widget)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::calcceilingChanged, this, &DiveCalculatedCeiling::setVisible);
 	setVisible(prefs.calcceiling);
@@ -830,8 +829,6 @@ DiveCalculatedCeiling::DiveCalculatedCeiling(ProfileWidget2 *widget) :
 
 void DiveCalculatedCeiling::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
-	connect(profileWidget, SIGNAL(dateTimeChangedItems()), this, SLOT(recalc()), Qt::UniqueConnection);
-
 	// We don't have enougth data to calculate things, quit.
 	if (!shouldCalculateStuff(topLeft, bottomRight))
 		return;
@@ -912,22 +909,6 @@ void DiveReportedCeiling::modelDataChanged(const QModelIndex &topLeft, const QMo
 	}
 	setPen(QPen(QBrush(Qt::NoBrush), 0));
 	setBrush(pat);
-}
-
-void DiveCalculatedCeiling::recalc()
-{
-#ifndef SUBSURFACE_MOBILE
-	dataModel->calculateDecompression();
-#endif
-}
-
-void DiveCalculatedCeiling::settingsChanged()
-{
-	if (dataModel && is3mIncrement != prefs.calcceiling3m) {
-		// recalculate that part.
-		recalc();
-	}
-	is3mIncrement = prefs.calcceiling3m;
 }
 
 void DiveReportedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -67,7 +67,6 @@ public:
 	DiveProfileItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void replot() override;
-	void settingsToggled(bool toggled);
 	void plot_depth_sample(struct plot_data *entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color);
 	int maxCeiling(int row);
 

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -11,7 +11,7 @@
 /* This is the Profile Item, it should be used for quite a lot of things
  on the profile view. The usage should be pretty simple:
 
- DiveProfileItem *profile = new DiveProfileItem();
+ DiveProfileItem *profile = new DiveProfileItem( DiveDataModel );
  profile->setVerticalAxis( profileYAxis );
  profile->setHorizontalAxis( timeAxis );
  profile->setModel( DiveDataModel );
@@ -35,10 +35,9 @@ class AbstractProfilePolygonItem : public QObject, public QGraphicsPolygonItem {
 	Q_PROPERTY(qreal x WRITE setX READ x)
 	Q_PROPERTY(qreal y WRITE setY READ y)
 public:
-	AbstractProfilePolygonItem();
+	AbstractProfilePolygonItem(const DivePlotDataModel &model);
 	void setVerticalAxis(DiveCartesianAxis *vertical);
 	void setHorizontalAxis(DiveCartesianAxis *horizontal);
-	void setModel(DivePlotDataModel *model);
 	void setHorizontalDataColumn(int column);
 	void setVerticalDataColumn(int column);
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
@@ -61,7 +60,7 @@ protected:
 
 	DiveCartesianAxis *hAxis;
 	DiveCartesianAxis *vAxis;
-	DivePlotDataModel *dataModel;
+	const DivePlotDataModel &dataModel;
 	int hDataColumn;
 	int vDataColumn;
 	QList<DiveTextItem *> texts;
@@ -71,7 +70,7 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveProfileItem();
+	DiveProfileItem(const DivePlotDataModel &model);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void settingsToggled(bool toggled);
@@ -88,7 +87,7 @@ private:
 class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveMeanDepthItem();
+	DiveMeanDepthItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -101,7 +100,7 @@ private:
 class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveTemperatureItem();
+	DiveTemperatureItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -112,7 +111,7 @@ private:
 class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveHeartrateItem();
+	DiveHeartrateItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -124,7 +123,7 @@ private:
 class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DivePercentageItem(int i);
+	DivePercentageItem(const DivePlotDataModel &model, int i);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -138,7 +137,7 @@ private:
 class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveAmbPressureItem();
+	DiveAmbPressureItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -149,7 +148,7 @@ private:
 class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveGFLineItem();
+	DiveGFLineItem(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -161,6 +160,7 @@ class DiveGasPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
+	using AbstractProfilePolygonItem::AbstractProfilePolygonItem;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -174,7 +174,7 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveCalculatedCeiling(ProfileWidget2 *profileWidget);
+	DiveCalculatedCeiling(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -186,7 +186,7 @@ class DiveReportedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveReportedCeiling();
+	DiveReportedCeiling(const DivePlotDataModel &model);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 };
@@ -194,7 +194,7 @@ public:
 class DiveCalculatedTissue : public DiveCalculatedCeiling {
 	Q_OBJECT
 public:
-	DiveCalculatedTissue(ProfileWidget2 *profileWidget);
+	DiveCalculatedTissue(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
 	void settingsChanged() override;
 };
@@ -202,7 +202,7 @@ public:
 class PartialPressureGasItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	PartialPressureGasItem();
+	PartialPressureGasItem(const DivePlotDataModel &model);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax);

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -35,17 +35,14 @@ class AbstractProfilePolygonItem : public QObject, public QGraphicsPolygonItem {
 	Q_PROPERTY(qreal x WRITE setX READ x)
 	Q_PROPERTY(qreal y WRITE setY READ y)
 public:
-	AbstractProfilePolygonItem(const DivePlotDataModel &model);
-	void setVerticalAxis(DiveCartesianAxis *vertical);
-	void setHorizontalAxis(DiveCartesianAxis *horizontal);
-	void setHorizontalDataColumn(int column);
-	void setVerticalDataColumn(int column);
+	AbstractProfilePolygonItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
 public
 slots:
 	virtual void settingsChanged();
 	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 	virtual void modelDataRemoved(const QModelIndex &parent, int from, int to);
+	void replot();
 	void setVisible(bool visible);
 
 protected:
@@ -58,8 +55,8 @@ protected:
 	 */
 	bool shouldCalculateStuff(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
-	DiveCartesianAxis *hAxis;
-	DiveCartesianAxis *vAxis;
+	const DiveCartesianAxis &hAxis;
+	const DiveCartesianAxis &vAxis;
 	const DivePlotDataModel &dataModel;
 	int hDataColumn;
 	int vDataColumn;
@@ -70,7 +67,7 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveProfileItem(const DivePlotDataModel &model);
+	DiveProfileItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void settingsToggled(bool toggled);
@@ -87,7 +84,7 @@ private:
 class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveMeanDepthItem(const DivePlotDataModel &model);
+	DiveMeanDepthItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -100,7 +97,7 @@ private:
 class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveTemperatureItem(const DivePlotDataModel &model);
+	DiveTemperatureItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -111,7 +108,7 @@ private:
 class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveHeartrateItem(const DivePlotDataModel &model);
+	DiveHeartrateItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -123,7 +120,7 @@ private:
 class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DivePercentageItem(const DivePlotDataModel &model, int i);
+	DivePercentageItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn, int i);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -137,7 +134,7 @@ private:
 class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveAmbPressureItem(const DivePlotDataModel &model);
+	DiveAmbPressureItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -148,7 +145,7 @@ private:
 class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	DiveGFLineItem(const DivePlotDataModel &model);
+	DiveGFLineItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
@@ -174,7 +171,8 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveCalculatedCeiling(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
+	DiveCalculatedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
+			      const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
@@ -186,7 +184,7 @@ class DiveReportedCeiling : public AbstractProfilePolygonItem {
 	Q_OBJECT
 
 public:
-	DiveReportedCeiling(const DivePlotDataModel &model);
+	DiveReportedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 };
@@ -194,7 +192,8 @@ public:
 class DiveCalculatedTissue : public DiveCalculatedCeiling {
 	Q_OBJECT
 public:
-	DiveCalculatedTissue(const DivePlotDataModel &model, ProfileWidget2 *profileWidget);
+	DiveCalculatedTissue(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
+			     const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
 	void settingsChanged() override;
 };
@@ -202,7 +201,7 @@ public:
 class PartialPressureGasItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
-	PartialPressureGasItem(const DivePlotDataModel &model);
+	PartialPressureGasItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax);

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -161,7 +161,11 @@ public:
 private:
 	void plotPressureValue(int mbar, int sec, QFlags<Qt::AlignmentFlag> align, double offset);
 	void plotGasValue(int mbar, int sec, struct gasmix gasmix, QFlags<Qt::AlignmentFlag> align, double offset);
-	QVector<QPolygonF> polygons;
+	struct Entry {
+		QPointF pos;
+		QColor col;
+	};
+	std::vector<std::vector<Entry>> polygons;
 };
 
 class DiveCalculatedCeiling : public AbstractProfilePolygonItem {

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -39,7 +39,6 @@ public:
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
 public
 slots:
-	virtual void settingsChanged();
 	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
 	virtual void modelDataRemoved(const QModelIndex &parent, int from, int to);
 	void replot();
@@ -71,7 +70,6 @@ public:
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void settingsToggled(bool toggled);
-	void settingsChanged() override;
 	void plot_depth_sample(struct plot_data *entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color);
 	int maxCeiling(int row);
 
@@ -195,7 +193,6 @@ public:
 	DiveCalculatedTissue(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
 			     const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
 	void setVisible(bool visible);
-	void settingsChanged() override;
 };
 
 class PartialPressureGasItem : public AbstractProfilePolygonItem {

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -121,6 +121,7 @@ public:
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
+	std::vector<QColor> colors;	// Must have same number of elements as the polygon
 	QString visibilityKey;
 	int tissueIndex;
 	QColor ColorScale(double value, int inert);

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -40,7 +40,6 @@ public:
 public
 slots:
 	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	virtual void modelDataRemoved(const QModelIndex &parent, int from, int to);
 	void replot();
 	void setVisible(bool visible);
 

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -37,10 +37,9 @@ class AbstractProfilePolygonItem : public QObject, public QGraphicsPolygonItem {
 public:
 	AbstractProfilePolygonItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) = 0;
+	virtual void replot();
 public
 slots:
-	virtual void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
-	void replot();
 	void setVisible(bool visible);
 
 protected:
@@ -67,7 +66,7 @@ class DiveProfileItem : public AbstractProfilePolygonItem {
 public:
 	DiveProfileItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void settingsToggled(bool toggled);
 	void plot_depth_sample(struct plot_data *entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color);
 	int maxCeiling(int row);
@@ -82,7 +81,7 @@ class DiveMeanDepthItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveMeanDepthItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
@@ -95,7 +94,7 @@ class DiveTemperatureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveTemperatureItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
@@ -106,7 +105,7 @@ class DiveHeartrateItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveHeartrateItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
@@ -118,7 +117,7 @@ class DivePercentageItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DivePercentageItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn, int i);
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
@@ -132,7 +131,7 @@ class DiveAmbPressureItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveAmbPressureItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
@@ -143,7 +142,7 @@ class DiveGFLineItem : public AbstractProfilePolygonItem {
 	Q_OBJECT
 public:
 	DiveGFLineItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 private:
@@ -155,7 +154,7 @@ class DiveGasPressureItem : public AbstractProfilePolygonItem {
 
 public:
 	using AbstractProfilePolygonItem::AbstractProfilePolygonItem;
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
@@ -170,7 +169,7 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 public:
 	DiveCalculatedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
 			      const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
@@ -182,7 +181,7 @@ class DiveReportedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveReportedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 };
 
@@ -199,7 +198,7 @@ class PartialPressureGasItem : public AbstractProfilePolygonItem {
 public:
 	PartialPressureGasItem(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn);
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
+	void replot() override;
 	void setThresholdSettingsKey(const double *prefPointerMin, const double *prefPointerMax);
 	void setVisibilitySettingsKey(const QString &setVisibilitySettingsKey);
 	void setColors(const QColor &normalColor, const QColor &alertColor);

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -177,15 +177,9 @@ public:
 	DiveCalculatedCeiling(ProfileWidget2 *profileWidget);
 	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex()) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-	void settingsChanged() override;
-
-public
-slots:
-	void recalc();
 
 private:
 	ProfileWidget2 *profileWidget;
-	bool is3mIncrement;
 };
 
 class DiveReportedCeiling : public AbstractProfilePolygonItem {

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -150,7 +150,7 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	mouseFollowerHorizontal(new DiveLineItem()),
 	rulerItem(new RulerItem2()),
 #endif
-	tankItem(new TankItem()),
+	tankItem(new TankItem(*timeAxis)),
 	shouldCalculateMaxTime(true),
 	shouldCalculateMaxDepth(true),
 	fontPrintScale(1.0)
@@ -317,8 +317,6 @@ void ProfileWidget2::setupItemOnScene()
 
 	diveComputerText->setAlignment(Qt::AlignRight | Qt::AlignTop);
 	diveComputerText->setBrush(getColor(TIME_TEXT, isGrayscale));
-
-	tankItem->setHorizontalAxis(timeAxis);
 
 #ifndef SUBSURFACE_MOBILE
 	rulerItem->setAxis(timeAxis, profileYAxis);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -357,7 +357,6 @@ void ProfileWidget2::setupItemOnScene()
 	}
 #endif
 
-#undef CREATE_PP_GAS
 #ifndef SUBSURFACE_MOBILE
 
 	// Visibility Connections

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -120,7 +120,7 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 #endif
 	isPlotZoomed(prefs.zoomed_plot),// no! bad use of prefs. 'PreferencesDialog::loadSettings' NOT CALLED yet.
 	profileYAxis(new DepthAxis(this)),
-	gasYAxis(new PartialGasPressureAxis(this)),
+	gasYAxis(new PartialGasPressureAxis(*dataModel, this)),
 	temperatureAxis(new TemperatureAxis(this)),
 	timeAxis(new TimeAxis(this)),
 	diveProfileItem(createItem<DiveProfileItem>(*profileYAxis, DivePlotDataModel::DEPTH, 0)),
@@ -288,7 +288,6 @@ void ProfileWidget2::setupItemOnScene()
 	gasYAxis->setTickInterval(1);
 	gasYAxis->setTickSize(1);
 	gasYAxis->setMinimum(0);
-	gasYAxis->setModel(dataModel);
 	gasYAxis->setFontLabelScale(0.7);
 	gasYAxis->setLineSize(96);
 
@@ -735,6 +734,7 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 #endif
 	tankItem->setData(&plotInfo, &displayed_dive);
 
+	gasYAxis->update();
 	dataModel->emitDataChanged();
 	// The event items are a bit special since we don't know how many events are going to
 	// exist on a dive, so I cant create cache items for that. that's why they are here
@@ -837,7 +837,7 @@ void ProfileWidget2::settingsChanged()
 	else
 		needReplot = prefs.calcceiling;
 #ifndef SUBSURFACE_MOBILE
-	gasYAxis->settingsChanged();	// Initialize ticks of partial pressure graph
+	gasYAxis->update();	// Initialize ticks of partial pressure graph
 	if ((prefs.percentagegraph||prefs.hrgraph) && PP_GRAPHS_ENABLED) {
 		profileYAxis->animateChangeLine(itemPos.depth.shrinked);
 		temperatureAxis->setPos(itemPos.temperatureAll.pos.on);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -865,11 +865,6 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 #endif
 }
 
-void ProfileWidget2::dateTimeChanged()
-{
-	emit dateTimeChangedItems();
-}
-
 void ProfileWidget2::actionRequestedReplot(bool)
 {
 	settingsChanged();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -96,6 +96,14 @@ static struct _ItemPos {
 static const double thumbnailBaseZValue = 100.0;
 #endif
 
+template<typename T, class... Args>
+T *ProfileWidget2::createItem(const DiveCartesianAxis &vAxis, int vColumn, Args&&... args)
+{
+	T *res = new T(*dataModel, *timeAxis, DivePlotDataModel::TIME, vAxis, vColumn,
+		       std::forward<Args>(args)...);
+	return res;
+}
+
 ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	currentState(INVALID),
 	dataModel(new DivePlotDataModel(this)),
@@ -111,29 +119,29 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	gasYAxis(new PartialGasPressureAxis(this)),
 	temperatureAxis(new TemperatureAxis(this)),
 	timeAxis(new TimeAxis(this)),
-	diveProfileItem(new DiveProfileItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::DEPTH)),
-	temperatureItem(new DiveTemperatureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *temperatureAxis, DivePlotDataModel::TEMPERATURE)),
-	meanDepthItem(new DiveMeanDepthItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::INSTANT_MEANDEPTH)),
+	diveProfileItem(createItem<DiveProfileItem>(*profileYAxis, DivePlotDataModel::DEPTH)),
+	temperatureItem(createItem<DiveTemperatureItem>(*temperatureAxis, DivePlotDataModel::TEMPERATURE)),
+	meanDepthItem(createItem<DiveMeanDepthItem>(*profileYAxis, DivePlotDataModel::INSTANT_MEANDEPTH)),
 	cylinderPressureAxis(new DiveCartesianAxis(this)),
-	gasPressureItem(new DiveGasPressureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *cylinderPressureAxis, DivePlotDataModel::TEMPERATURE)),
+	gasPressureItem(createItem<DiveGasPressureItem>(*cylinderPressureAxis, DivePlotDataModel::TEMPERATURE)),
 	diveComputerText(new DiveTextItem()),
-	reportedCeiling(new DiveReportedCeiling(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::CEILING)),
-	pn2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PN2)),
-	pheGasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PHE)),
-	po2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PO2)),
-	o2SetpointGasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::O2SETPOINT)),
-	ccrsensor1GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR1)),
-	ccrsensor2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR2)),
-	ccrsensor3GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR3)),
-	ocpo2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::SCR_OC_PO2)),
+	reportedCeiling(createItem<DiveReportedCeiling>(*profileYAxis, DivePlotDataModel::CEILING)),
+	pn2GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::PN2)),
+	pheGasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::PHE)),
+	po2GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::PO2)),
+	o2SetpointGasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::O2SETPOINT)),
+	ccrsensor1GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::CCRSENSOR1)),
+	ccrsensor2GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::CCRSENSOR2)),
+	ccrsensor3GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::CCRSENSOR3)),
+	ocpo2GasItem(createItem<PartialPressureGasItem>(*gasYAxis, DivePlotDataModel::SCR_OC_PO2)),
 #ifndef SUBSURFACE_MOBILE
-	diveCeiling(new DiveCalculatedCeiling(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::CEILING, this)),
+	diveCeiling(createItem<DiveCalculatedCeiling>(*profileYAxis, DivePlotDataModel::CEILING, this)),
 	decoModelParameters(new DiveTextItem()),
 	heartBeatAxis(new DiveCartesianAxis(this)),
-	heartBeatItem(new DiveHeartrateItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *heartBeatAxis, DivePlotDataModel::HEARTBEAT)),
+	heartBeatItem(createItem<DiveHeartrateItem>(*heartBeatAxis, DivePlotDataModel::HEARTBEAT)),
 	percentageAxis(new DiveCartesianAxis(this)),
-	ambPressureItem(new DiveAmbPressureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::AMBPRESSURE)),
-	gflineItem(new DiveGFLineItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::GFLINE)),
+	ambPressureItem(createItem<DiveAmbPressureItem>(*percentageAxis, DivePlotDataModel::AMBPRESSURE)),
+	gflineItem(createItem<DiveGFLineItem>(*percentageAxis, DivePlotDataModel::GFLINE)),
 	mouseFollowerVertical(new DiveLineItem()),
 	mouseFollowerHorizontal(new DiveLineItem()),
 	rulerItem(new RulerItem2()),
@@ -342,10 +350,10 @@ void ProfileWidget2::setupItemOnScene()
 	decoModelParameters->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
 	setupItem(diveCeiling, 1);
 	for (int i = 0; i < 16; i++) {
-		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::TISSUE_1 + i, this);
+		DiveCalculatedTissue *tissueItem = createItem<DiveCalculatedTissue>(*profileYAxis, DivePlotDataModel::TISSUE_1 + i, this);
 		setupItem(tissueItem, 1 + i);
 		allTissues.append(tissueItem);
-		DivePercentageItem *percentageItem = new DivePercentageItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, i);
+		DivePercentageItem *percentageItem = createItem<DivePercentageItem>(*percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, i);
 		setupItem(percentageItem, 1 + i);
 		allPercentages.append(percentageItem);
 	}

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -735,7 +735,11 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 	tankItem->setData(&plotInfo, &displayed_dive);
 
 	gasYAxis->update();
-	dataModel->emitDataChanged();
+
+	// Replot dive items
+	for (AbstractProfilePolygonItem *item: profileItems)
+		item->replot();
+
 	// The event items are a bit special since we don't know how many events are going to
 	// exist on a dive, so I cant create cache items for that. that's why they are here
 	// while all other items are up there on the constructor.

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -111,29 +111,29 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	gasYAxis(new PartialGasPressureAxis(this)),
 	temperatureAxis(new TemperatureAxis(this)),
 	timeAxis(new TimeAxis(this)),
-	diveProfileItem(new DiveProfileItem(*dataModel)),
-	temperatureItem(new DiveTemperatureItem(*dataModel)),
-	meanDepthItem(new DiveMeanDepthItem(*dataModel)),
+	diveProfileItem(new DiveProfileItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::DEPTH)),
+	temperatureItem(new DiveTemperatureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *temperatureAxis, DivePlotDataModel::TEMPERATURE)),
+	meanDepthItem(new DiveMeanDepthItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::INSTANT_MEANDEPTH)),
 	cylinderPressureAxis(new DiveCartesianAxis(this)),
-	gasPressureItem(new DiveGasPressureItem(*dataModel)),
+	gasPressureItem(new DiveGasPressureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *cylinderPressureAxis, DivePlotDataModel::TEMPERATURE)),
 	diveComputerText(new DiveTextItem()),
-	reportedCeiling(new DiveReportedCeiling(*dataModel)),
-	pn2GasItem(new PartialPressureGasItem(*dataModel)),
-	pheGasItem(new PartialPressureGasItem(*dataModel)),
-	po2GasItem(new PartialPressureGasItem(*dataModel)),
-	o2SetpointGasItem(new PartialPressureGasItem(*dataModel)),
-	ccrsensor1GasItem(new PartialPressureGasItem(*dataModel)),
-	ccrsensor2GasItem(new PartialPressureGasItem(*dataModel)),
-	ccrsensor3GasItem(new PartialPressureGasItem(*dataModel)),
-	ocpo2GasItem(new PartialPressureGasItem(*dataModel)),
+	reportedCeiling(new DiveReportedCeiling(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::CEILING)),
+	pn2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PN2)),
+	pheGasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PHE)),
+	po2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::PO2)),
+	o2SetpointGasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::O2SETPOINT)),
+	ccrsensor1GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR1)),
+	ccrsensor2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR2)),
+	ccrsensor3GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::CCRSENSOR3)),
+	ocpo2GasItem(new PartialPressureGasItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *gasYAxis, DivePlotDataModel::SCR_OC_PO2)),
 #ifndef SUBSURFACE_MOBILE
-	diveCeiling(new DiveCalculatedCeiling(*dataModel, this)),
+	diveCeiling(new DiveCalculatedCeiling(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::CEILING, this)),
 	decoModelParameters(new DiveTextItem()),
 	heartBeatAxis(new DiveCartesianAxis(this)),
-	heartBeatItem(new DiveHeartrateItem(*dataModel)),
+	heartBeatItem(new DiveHeartrateItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *heartBeatAxis, DivePlotDataModel::HEARTBEAT)),
 	percentageAxis(new DiveCartesianAxis(this)),
-	ambPressureItem(new DiveAmbPressureItem(*dataModel)),
-	gflineItem(new DiveGFLineItem(*dataModel)),
+	ambPressureItem(new DiveAmbPressureItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::AMBPRESSURE)),
+	gflineItem(new DiveGFLineItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::GFLINE)),
 	mouseFollowerVertical(new DiveLineItem()),
 	mouseFollowerHorizontal(new DiveLineItem()),
 	rulerItem(new RulerItem2()),
@@ -340,33 +340,33 @@ void ProfileWidget2::setupItemOnScene()
 	decoModelParameters->setX(50);
 	decoModelParameters->setBrush(getColor(PRESSURE_TEXT));
 	decoModelParameters->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
-	setupItem(diveCeiling, profileYAxis, DivePlotDataModel::CEILING, DivePlotDataModel::TIME, 1);
+	setupItem(diveCeiling, 1);
 	for (int i = 0; i < 16; i++) {
-		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(*dataModel, this);
-		setupItem(tissueItem, profileYAxis, DivePlotDataModel::TISSUE_1 + i, DivePlotDataModel::TIME, 1 + i);
+		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(*dataModel, *timeAxis, DivePlotDataModel::TIME, *profileYAxis, DivePlotDataModel::TISSUE_1 + i, this);
+		setupItem(tissueItem, 1 + i);
 		allTissues.append(tissueItem);
-		DivePercentageItem *percentageItem = new DivePercentageItem(*dataModel, i);
-		setupItem(percentageItem, percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, DivePlotDataModel::TIME, 1 + i);
+		DivePercentageItem *percentageItem = new DivePercentageItem(*dataModel, *timeAxis, DivePlotDataModel::TIME, *percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, i);
+		setupItem(percentageItem, 1 + i);
 		allPercentages.append(percentageItem);
 	}
-	setupItem(heartBeatItem, heartBeatAxis, DivePlotDataModel::HEARTBEAT, DivePlotDataModel::TIME, 1);
-	setupItem(ambPressureItem, percentageAxis, DivePlotDataModel::AMBPRESSURE, DivePlotDataModel::TIME, 1);
-	setupItem(gflineItem, percentageAxis, DivePlotDataModel::GFLINE, DivePlotDataModel::TIME, 1);
+	setupItem(heartBeatItem, 1);
+	setupItem(ambPressureItem, 1);
+	setupItem(gflineItem, 1);
 #endif
-	setupItem(reportedCeiling, profileYAxis, DivePlotDataModel::CEILING, DivePlotDataModel::TIME, 1);
-	setupItem(gasPressureItem, cylinderPressureAxis, DivePlotDataModel::TEMPERATURE, DivePlotDataModel::TIME, 1);
-	setupItem(temperatureItem, temperatureAxis, DivePlotDataModel::TEMPERATURE, DivePlotDataModel::TIME, 1);
-	setupItem(diveProfileItem, profileYAxis, DivePlotDataModel::DEPTH, DivePlotDataModel::TIME, 0);
-	setupItem(meanDepthItem, profileYAxis, DivePlotDataModel::INSTANT_MEANDEPTH, DivePlotDataModel::TIME, 1);
+	setupItem(reportedCeiling, 1);
+	setupItem(gasPressureItem, 1);
+	setupItem(temperatureItem, 1);
+	setupItem(diveProfileItem, 0);
+	setupItem(meanDepthItem, 1);
 
-	createPPGas(pn2GasItem, DivePlotDataModel::PN2, PN2, PN2_ALERT, NULL, &prefs.pp_graphs.pn2_threshold);
-	createPPGas(pheGasItem, DivePlotDataModel::PHE, PHE, PHE_ALERT, NULL, &prefs.pp_graphs.phe_threshold);
-	createPPGas(po2GasItem, DivePlotDataModel::PO2, PO2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
-	createPPGas(o2SetpointGasItem, DivePlotDataModel::O2SETPOINT, O2SETPOINT, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
-	createPPGas(ccrsensor1GasItem, DivePlotDataModel::CCRSENSOR1, CCRSENSOR1, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
-	createPPGas(ccrsensor2GasItem, DivePlotDataModel::CCRSENSOR2, CCRSENSOR2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
-	createPPGas(ccrsensor3GasItem, DivePlotDataModel::CCRSENSOR3, CCRSENSOR3, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
-	createPPGas(ocpo2GasItem, DivePlotDataModel::SCR_OC_PO2, SCR_OCPO2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(pn2GasItem, PN2, PN2_ALERT, NULL, &prefs.pp_graphs.pn2_threshold);
+	createPPGas(pheGasItem, PHE, PHE_ALERT, NULL, &prefs.pp_graphs.phe_threshold);
+	createPPGas(po2GasItem, PO2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(o2SetpointGasItem, O2SETPOINT, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(ccrsensor1GasItem, CCRSENSOR1, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(ccrsensor2GasItem, CCRSENSOR2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(ccrsensor3GasItem, CCRSENSOR3, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
+	createPPGas(ocpo2GasItem, SCR_OCPO2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max);
 
 #undef CREATE_PP_GAS
 #ifndef SUBSURFACE_MOBILE
@@ -402,10 +402,10 @@ void ProfileWidget2::replot()
 	plotDive(current_dive, true, false);
 }
 
-void ProfileWidget2::createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
+void ProfileWidget2::createPPGas(PartialPressureGasItem *item, color_index_t color, color_index_t colorAlert,
 				 const double *thresholdSettingsMin, const double *thresholdSettingsMax)
 {
-	setupItem(item, gasYAxis, verticalColumn, DivePlotDataModel::TIME, 0);
+	setupItem(item, 0);
 	item->setThresholdSettingsKey(thresholdSettingsMin, thresholdSettingsMax);
 	item->setColors(getColor(color, isGrayscale), getColor(colorAlert, isGrayscale));
 	item->settingsChanged();
@@ -537,13 +537,8 @@ void ProfileWidget2::setupItemSizes()
 #endif
 }
 
-void ProfileWidget2::setupItem(AbstractProfilePolygonItem *item, DiveCartesianAxis *vAxis,
-			       int vData, int hData, int zValue)
+void ProfileWidget2::setupItem(AbstractProfilePolygonItem *item, int zValue)
 {
-	item->setHorizontalAxis(timeAxis);
-	item->setVerticalAxis(vAxis);
-	item->setVerticalDataColumn(vData);
-	item->setHorizontalDataColumn(hData);
 	item->setZValue(zValue);
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -102,6 +102,7 @@ T *ProfileWidget2::createItem(const DiveCartesianAxis &vAxis, int vColumn, int z
 	T *res = new T(*dataModel, *timeAxis, DivePlotDataModel::TIME, vAxis, vColumn,
 		       std::forward<Args>(args)...);
 	res->setZValue(static_cast<double>(z));
+	profileItems.push_back(res);
 	return res;
 }
 
@@ -237,34 +238,19 @@ void ProfileWidget2::addItemsToScene()
 	scene()->addItem(gasYAxis);
 	scene()->addItem(temperatureAxis);
 	scene()->addItem(timeAxis);
-	scene()->addItem(diveProfileItem);
 	scene()->addItem(cylinderPressureAxis);
-	scene()->addItem(temperatureItem);
-	scene()->addItem(meanDepthItem);
-	scene()->addItem(gasPressureItem);
 	// I cannot seem to figure out if an object that I find with itemAt() on the scene
 	// is the object I am looking for - my guess is there's a simple way in Qt to do that
 	// but nothing I tried worked.
 	// so instead this adds a special magic key/value pair to the object to mark it
 	diveComputerText->setData(SUBSURFACE_OBJ_DATA, SUBSURFACE_OBJ_DC_TEXT);
 	scene()->addItem(diveComputerText);
-	scene()->addItem(reportedCeiling);
 	scene()->addItem(tankItem);
-	scene()->addItem(pn2GasItem);
-	scene()->addItem(pheGasItem);
-	scene()->addItem(po2GasItem);
-	scene()->addItem(o2SetpointGasItem);
-	scene()->addItem(ccrsensor1GasItem);
-	scene()->addItem(ccrsensor2GasItem);
-	scene()->addItem(ccrsensor3GasItem);
-	scene()->addItem(ocpo2GasItem);
 #ifndef SUBSURFACE_MOBILE
 	scene()->addItem(toolTipItem);
-	scene()->addItem(diveCeiling);
 	scene()->addItem(decoModelParameters);
 	scene()->addItem(percentageAxis);
 	scene()->addItem(heartBeatAxis);
-	scene()->addItem(heartBeatItem);
 	scene()->addItem(rulerItem);
 	scene()->addItem(rulerItem->sourceNode());
 	scene()->addItem(rulerItem->destNode());
@@ -274,16 +260,9 @@ void ProfileWidget2::addItemsToScene()
 	pen.setWidth(0);
 	mouseFollowerHorizontal->setPen(pen);
 	mouseFollowerVertical->setPen(pen);
-
-	Q_FOREACH (DiveCalculatedTissue *tissue, allTissues) {
-		scene()->addItem(tissue);
-	}
-	Q_FOREACH (DivePercentageItem *percentage, allPercentages) {
-		scene()->addItem(percentage);
-	}
-	scene()->addItem(ambPressureItem);
-	scene()->addItem(gflineItem);
 #endif
+	for (AbstractProfilePolygonItem *item: profileItems)
+		scene()->addItem(item);
 }
 
 void ProfileWidget2::setupItemOnScene()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -735,7 +735,7 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 		ocpo2GasItem->setVisible(false);
 	}
 #endif
-	tankItem->setData(dataModel, &plotInfo, &displayed_dive);
+	tankItem->setData(&plotInfo, &displayed_dive);
 
 	dataModel->emitDataChanged();
 	// The event items are a bit special since we don't know how many events are going to

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -375,7 +375,6 @@ PartialPressureGasItem *ProfileWidget2::createPPGas(int column, color_index_t co
 	PartialPressureGasItem *item = createItem<PartialPressureGasItem>(*gasYAxis, column, 99);
 	item->setThresholdSettingsKey(thresholdSettingsMin, thresholdSettingsMax);
 	item->setColors(getColor(color, isGrayscale), getColor(colorAlert, isGrayscale));
-	item->settingsChanged();
 	return item;
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -111,29 +111,29 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	gasYAxis(new PartialGasPressureAxis(this)),
 	temperatureAxis(new TemperatureAxis(this)),
 	timeAxis(new TimeAxis(this)),
-	diveProfileItem(new DiveProfileItem()),
-	temperatureItem(new DiveTemperatureItem()),
-	meanDepthItem(new DiveMeanDepthItem()),
+	diveProfileItem(new DiveProfileItem(*dataModel)),
+	temperatureItem(new DiveTemperatureItem(*dataModel)),
+	meanDepthItem(new DiveMeanDepthItem(*dataModel)),
 	cylinderPressureAxis(new DiveCartesianAxis(this)),
-	gasPressureItem(new DiveGasPressureItem()),
+	gasPressureItem(new DiveGasPressureItem(*dataModel)),
 	diveComputerText(new DiveTextItem()),
-	reportedCeiling(new DiveReportedCeiling()),
-	pn2GasItem(new PartialPressureGasItem()),
-	pheGasItem(new PartialPressureGasItem()),
-	po2GasItem(new PartialPressureGasItem()),
-	o2SetpointGasItem(new PartialPressureGasItem()),
-	ccrsensor1GasItem(new PartialPressureGasItem()),
-	ccrsensor2GasItem(new PartialPressureGasItem()),
-	ccrsensor3GasItem(new PartialPressureGasItem()),
-	ocpo2GasItem(new PartialPressureGasItem()),
+	reportedCeiling(new DiveReportedCeiling(*dataModel)),
+	pn2GasItem(new PartialPressureGasItem(*dataModel)),
+	pheGasItem(new PartialPressureGasItem(*dataModel)),
+	po2GasItem(new PartialPressureGasItem(*dataModel)),
+	o2SetpointGasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor1GasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor2GasItem(new PartialPressureGasItem(*dataModel)),
+	ccrsensor3GasItem(new PartialPressureGasItem(*dataModel)),
+	ocpo2GasItem(new PartialPressureGasItem(*dataModel)),
 #ifndef SUBSURFACE_MOBILE
-	diveCeiling(new DiveCalculatedCeiling(this)),
+	diveCeiling(new DiveCalculatedCeiling(*dataModel, this)),
 	decoModelParameters(new DiveTextItem()),
 	heartBeatAxis(new DiveCartesianAxis(this)),
-	heartBeatItem(new DiveHeartrateItem()),
+	heartBeatItem(new DiveHeartrateItem(*dataModel)),
 	percentageAxis(new DiveCartesianAxis(this)),
-	ambPressureItem(new DiveAmbPressureItem()),
-	gflineItem(new DiveGFLineItem()),
+	ambPressureItem(new DiveAmbPressureItem(*dataModel)),
+	gflineItem(new DiveGFLineItem(*dataModel)),
 	mouseFollowerVertical(new DiveLineItem()),
 	mouseFollowerHorizontal(new DiveLineItem()),
 	rulerItem(new RulerItem2()),
@@ -342,10 +342,10 @@ void ProfileWidget2::setupItemOnScene()
 	decoModelParameters->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
 	setupItem(diveCeiling, profileYAxis, DivePlotDataModel::CEILING, DivePlotDataModel::TIME, 1);
 	for (int i = 0; i < 16; i++) {
-		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(this);
+		DiveCalculatedTissue *tissueItem = new DiveCalculatedTissue(*dataModel, this);
 		setupItem(tissueItem, profileYAxis, DivePlotDataModel::TISSUE_1 + i, DivePlotDataModel::TIME, 1 + i);
 		allTissues.append(tissueItem);
-		DivePercentageItem *percentageItem = new DivePercentageItem(i);
+		DivePercentageItem *percentageItem = new DivePercentageItem(*dataModel, i);
 		setupItem(percentageItem, percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, DivePlotDataModel::TIME, 1 + i);
 		allPercentages.append(percentageItem);
 	}
@@ -542,7 +542,6 @@ void ProfileWidget2::setupItem(AbstractProfilePolygonItem *item, DiveCartesianAx
 {
 	item->setHorizontalAxis(timeAxis);
 	item->setVerticalAxis(vAxis);
-	item->setModel(dataModel);
 	item->setVerticalDataColumn(vData);
 	item->setHorizontalDataColumn(hData);
 	item->setZValue(zValue);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -118,7 +118,6 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 #ifndef SUBSURFACE_MOBILE
 	toolTipItem(new ToolTipItem()),
 #endif
-	isPlotZoomed(prefs.zoomed_plot),// no! bad use of prefs. 'PreferencesDialog::loadSettings' NOT CALLED yet.
 	profileYAxis(new DepthAxis(this)),
 	gasYAxis(new PartialGasPressureAxis(*dataModel, this)),
 	temperatureAxis(new TemperatureAxis(this)),
@@ -155,9 +154,6 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	shouldCalculateMaxDepth(true),
 	fontPrintScale(1.0)
 {
-	// would like to be able to ASSERT here that PreferencesDialog::loadSettings has been called.
-	isPlotZoomed = prefs.zoomed_plot; // now it seems that 'prefs' has loaded our preferences
-
 	init_plot_info(&plotInfo);
 
 	setupSceneAndFlags();
@@ -830,16 +826,6 @@ void ProfileWidget2::actionRequestedReplot(bool)
 
 void ProfileWidget2::settingsChanged()
 {
-	// if we are showing calculated ceilings then we have to replot()
-	// because the GF could have changed; otherwise we try to avoid replot()
-	// but always replot in PLAN/ADD/EDIT mode to avoid a bug of DiveHandlers not
-	// being redrawn on setting changes, causing them to become unattached
-	// to the profile
-	bool needReplot;
-	if (currentState == ADD || currentState == PLAN || currentState ==  EDIT)
-		needReplot = true;
-	else
-		needReplot = prefs.calcceiling;
 #ifndef SUBSURFACE_MOBILE
 	gasYAxis->update();	// Initialize ticks of partial pressure graph
 	if ((prefs.percentagegraph||prefs.hrgraph) && PP_GRAPHS_ENABLED) {
@@ -896,12 +882,7 @@ void ProfileWidget2::settingsChanged()
 	}
 
 	tankItem->setVisible(prefs.tankbar);
-	if (prefs.zoomed_plot != isPlotZoomed) {
-		isPlotZoomed = prefs.zoomed_plot;
-		needReplot = true;
-	}
-	if (needReplot)
-		replot();
+	replot();
 }
 
 void ProfileWidget2::resizeEvent(QResizeEvent *event)

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -184,7 +184,6 @@ private:
 #ifndef SUBSURFACE_MOBILE
 	ToolTipItem *toolTipItem;
 #endif
-	bool isPlotZoomed;
 	// All those here should probably be merged into one structure,
 	// So it's esyer to replicate for more dives later.
 	// In the meantime, keep it here.

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -193,6 +193,7 @@ private:
 	PartialGasPressureAxis *gasYAxis;
 	TemperatureAxis *temperatureAxis;
 	TimeAxis *timeAxis;
+	std::vector<AbstractProfilePolygonItem *> profileItems;
 	DiveProfileItem *diveProfileItem;
 	DiveTemperatureItem *temperatureItem;
 	DiveMeanDepthItem *meanDepthItem;

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -159,8 +159,8 @@ private:
 	void disconnectTemporaryConnections();
 	struct plot_data *getEntryFromPos(QPointF pos);
 	void addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)());
-	void createPPGas(PartialPressureGasItem *item, color_index_t color, color_index_t colorAlert,
-			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
+	PartialPressureGasItem *createPPGas(int column, color_index_t color, color_index_t colorAlert,
+					    const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
 	void plotPicturesInternal(const struct dive *d, bool synchronous);
 	void addDivemodeSwitch(int seconds, int divemode);
@@ -178,6 +178,8 @@ private:
 	DivePlotDataModel *dataModel;
 	int zoomLevel;
 	qreal zoomFactor;
+	bool isGrayscale;
+	bool printMode;
 	DivePixmapItem *background;
 	QString backgroundFile;
 #ifndef SUBSURFACE_MOBILE
@@ -223,8 +225,6 @@ private:
 	RulerItem2 *rulerItem;
 #endif
 	TankItem *tankItem;
-	bool isGrayscale;
-	bool printMode;
 
 	QList<QGraphicsSimpleTextItem *> gases;
 

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -98,11 +98,9 @@ signals:
 	void enableShortcuts();
 	void disableShortcuts(bool paste);
 	void editCurrentDive();
-	void dateTimeChangedItems();
 
 public
 slots: // Necessary to call from QAction's signals.
-	void dateTimeChanged();
 	void settingsChanged();
 	void actionRequestedReplot(bool triggered);
 	void setEmptyState();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -152,6 +152,7 @@ private:
 	void fixBackgroundPos();
 	void scrollViewTo(const QPoint &pos);
 	void setupSceneAndFlags();
+	template<typename T, class... Args> T *createItem(const DiveCartesianAxis &vAxis, int vColumn, Args&&... args);
 	void setupItemSizes();
 	void addItemsToScene();
 	void setupItemOnScene();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -78,7 +78,6 @@ public:
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
 	void plotDive(const struct dive *d, bool force = false, bool clearPictures = false, bool instant = false);
-	void setupItem(AbstractProfilePolygonItem *item, int zValue);
 	void setPrintMode(bool mode, bool grayscale = false);
 	bool getPrintMode();
 	bool isPointOutOfBoundaries(const QPointF &point) const;
@@ -152,7 +151,7 @@ private:
 	void fixBackgroundPos();
 	void scrollViewTo(const QPoint &pos);
 	void setupSceneAndFlags();
-	template<typename T, class... Args> T *createItem(const DiveCartesianAxis &vAxis, int vColumn, Args&&... args);
+	template<typename T, class... Args> T *createItem(const DiveCartesianAxis &vAxis, int vColumn, int z, Args&&... args);
 	void setupItemSizes();
 	void addItemsToScene();
 	void setupItemOnScene();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -78,7 +78,7 @@ public:
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
 	void plotDive(const struct dive *d, bool force = false, bool clearPictures = false, bool instant = false);
-	void setupItem(AbstractProfilePolygonItem *item, DiveCartesianAxis *vAxis, int vData, int hData, int zValue);
+	void setupItem(AbstractProfilePolygonItem *item, int zValue);
 	void setPrintMode(bool mode, bool grayscale = false);
 	bool getPrintMode();
 	bool isPointOutOfBoundaries(const QPointF &point) const;
@@ -158,7 +158,7 @@ private:
 	void disconnectTemporaryConnections();
 	struct plot_data *getEntryFromPos(QPointF pos);
 	void addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)());
-	void createPPGas(PartialPressureGasItem *item, int verticalColumn, color_index_t color, color_index_t colorAlert,
+	void createPPGas(PartialPressureGasItem *item, color_index_t color, color_index_t colorAlert,
 			 const double *thresholdSettingsMin, const double *thresholdSettingsMax);
 	void clearPictures();
 	void plotPicturesInternal(const struct dive *d, bool synchronous);

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "profile-widget/tankitem.h"
+#include "profile-widget/divecartesianaxis.h"
 #include "profile-widget/divetextitem.h"
+#include "core/dive.h"
 #include "core/event.h"
 #include "core/profile.h"
 #include <QPen>

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "profile-widget/tankitem.h"
-#include "qt-models/diveplotdatamodel.h"
 #include "profile-widget/divetextitem.h"
 #include "core/event.h"
 #include "core/profile.h"
@@ -33,7 +32,7 @@ TankItem::TankItem(QObject *parent) :
 	hAxis = nullptr;
 }
 
-void TankItem::setData(DivePlotDataModel *model, struct plot_info *plotInfo, struct dive *d)
+void TankItem::setData(struct plot_info *plotInfo, struct dive *d)
 {
 	// If there is nothing to plot, quit early.
 	if (plotInfo->nr <= 0) {
@@ -45,10 +44,7 @@ void TankItem::setData(DivePlotDataModel *model, struct plot_info *plotInfo, str
 	struct plot_data *last_entry = &plotInfo->entry[plotInfo->nr - 1];
 	plotEndTime = last_entry->sec;
 
-	// Stay informed of changes to the tanks.
-	connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(modelDataChanged(QModelIndex, QModelIndex)), Qt::UniqueConnection);
-
-	modelDataChanged();
+	replot();
 }
 
 void TankItem::createBar(int startTime, int stopTime, struct gasmix gas)
@@ -79,7 +75,7 @@ void TankItem::createBar(int startTime, int stopTime, struct gasmix gas)
 	label->setZValue(101);
 }
 
-void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
+void TankItem::replot()
 {
 	// We don't have enougth data to calculate things, quit.
 	if (plotEndTime < 0)
@@ -115,6 +111,6 @@ void TankItem::modelDataChanged(const QModelIndex&, const QModelIndex&)
 void TankItem::setHorizontalAxis(DiveCartesianAxis *horizontal)
 {
 	hAxis = horizontal;
-	connect(hAxis, SIGNAL(sizeChanged()), this, SLOT(modelDataChanged()));
-	modelDataChanged();
+	connect(hAxis, SIGNAL(sizeChanged()), this, SLOT(replot()));
+	replot();
 }

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -7,7 +7,8 @@
 
 static const qreal height = 3.0;
 
-TankItem::TankItem() :
+TankItem::TankItem(const DiveCartesianAxis &axis) :
+	hAxis(axis),
 	plotEndTime(-1)
 {
 	QColor red(PERSIANRED1);
@@ -28,7 +29,6 @@ TankItem::TankItem() :
 	trimixGradient.setColorAt(1.0, red);
 	trimix = trimixGradient;
 	air = blue;
-	hAxis = nullptr;
 }
 
 void TankItem::setData(struct plot_info *plotInfo, struct dive *d)
@@ -48,8 +48,8 @@ void TankItem::setData(struct plot_info *plotInfo, struct dive *d)
 
 void TankItem::createBar(int startTime, int stopTime, struct gasmix gas)
 {
-	qreal x = hAxis->posAtValue(startTime);
-	qreal w = hAxis->posAtValue(stopTime) - hAxis->posAtValue(startTime);
+	qreal x = hAxis.posAtValue(startTime);
+	qreal w = hAxis.posAtValue(stopTime) - hAxis.posAtValue(startTime);
 
 	// pick the right gradient, size, position and text
 	QGraphicsRectItem *rect = new QGraphicsRectItem(x, 0, w, height, this);
@@ -105,9 +105,4 @@ void TankItem::replot()
 		ev = get_next_event(ev->next, "gaschange");
 	}
 	createBar(startTime, plotEndTime, gasmix);
-}
-
-void TankItem::setHorizontalAxis(DiveCartesianAxis *horizontal)
-{
-	hAxis = horizontal;
 }

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -7,8 +7,7 @@
 
 static const qreal height = 3.0;
 
-TankItem::TankItem(QObject *parent) :
-	QObject(parent),
+TankItem::TankItem() :
 	plotEndTime(-1)
 {
 	QColor red(PERSIANRED1);
@@ -111,6 +110,4 @@ void TankItem::replot()
 void TankItem::setHorizontalAxis(DiveCartesianAxis *horizontal)
 {
 	hAxis = horizontal;
-	connect(hAxis, SIGNAL(sizeChanged()), this, SLOT(replot()));
-	replot();
 }

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -18,7 +18,6 @@ public:
 
 private:
 	void createBar(int startTime, int stopTime, struct gasmix gas);
-	void replot();
 	const DiveCartesianAxis &hAxis;
 	int plotEndTime;
 	QBrush air, nitrox, oxygen, trimix;

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -2,11 +2,13 @@
 #ifndef TANKITEM_H
 #define TANKITEM_H
 
-#include <QGraphicsItem>
-#include <QBrush>
 #include "profile-widget/divelineitem.h"
-#include "profile-widget/divecartesianaxis.h"
-#include "core/dive.h"
+#include "core/gas.h"
+#include <QGraphicsRectItem>
+#include <QBrush>
+
+struct dive;
+class DiveCartesianAxis;
 
 class TankItem : public QGraphicsRectItem
 {

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -11,14 +11,13 @@
 class TankItem : public QGraphicsRectItem
 {
 public:
-	explicit TankItem();
-	void setHorizontalAxis(DiveCartesianAxis *horizontal);
+	explicit TankItem(const DiveCartesianAxis &axis);
 	void setData(struct plot_info *plotInfo, struct dive *d);
 
 private:
 	void createBar(int startTime, int stopTime, struct gasmix gas);
 	void replot();
-	DiveCartesianAxis *hAxis;
+	const DiveCartesianAxis &hAxis;
 	int plotEndTime;
 	QBrush air, nitrox, oxygen, trimix;
 	QList<QGraphicsRectItem *> rects;

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -8,20 +8,16 @@
 #include "profile-widget/divecartesianaxis.h"
 #include "core/dive.h"
 
-class TankItem : public QObject, public QGraphicsRectItem
+class TankItem : public QGraphicsRectItem
 {
-	Q_OBJECT
-
 public:
-	explicit TankItem(QObject *parent = 0);
+	explicit TankItem();
 	void setHorizontalAxis(DiveCartesianAxis *horizontal);
 	void setData(struct plot_info *plotInfo, struct dive *d);
 
-public slots:
-	void replot();
-
 private:
 	void createBar(int startTime, int stopTime, struct gasmix gas);
+	void replot();
 	DiveCartesianAxis *hAxis;
 	int plotEndTime;
 	QBrush air, nitrox, oxygen, trimix;

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -3,7 +3,6 @@
 #define TANKITEM_H
 
 #include <QGraphicsItem>
-#include <QModelIndex>
 #include <QBrush>
 #include "profile-widget/divelineitem.h"
 #include "profile-widget/divecartesianaxis.h"
@@ -16,12 +15,10 @@ class TankItem : public QObject, public QGraphicsRectItem
 public:
 	explicit TankItem(QObject *parent = 0);
 	void setHorizontalAxis(DiveCartesianAxis *horizontal);
-	void setData(DivePlotDataModel *model, struct plot_info *plotInfo, struct dive *d);
-
-signals:
+	void setData(struct plot_info *plotInfo, struct dive *d);
 
 public slots:
-	void modelDataChanged(const QModelIndex &topLeft = QModelIndex(), const QModelIndex &bottomRight = QModelIndex());
+	void replot();
 
 private:
 	void createBar(int startTime, int stopTime, struct gasmix gas);

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -218,13 +218,3 @@ void DivePlotDataModel::emitDataChanged()
 {
 	emit dataChanged(QModelIndex(), QModelIndex());
 }
-
-#ifndef SUBSURFACE_MOBILE
-void DivePlotDataModel::calculateDecompression()
-{
-	struct divecomputer *dc = select_dc(&displayed_dive);
-	init_decompression(&plot_deco_state, &displayed_dive);
-	calculate_deco_information(&plot_deco_state, &(DivePlannerPointsModel::instance()->final_deco_state), &displayed_dive, dc, &pInfo, false);
-	dataChanged(index(0, CEILING), index(pInfo.nr - 1, TISSUE_16));
-}
-#endif

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -199,20 +199,30 @@ unsigned int DivePlotDataModel::dcShown() const
 	return dcNr;
 }
 
-#define MAX_PPGAS_FUNC(GAS, GASFUNC)                                  \
-	double DivePlotDataModel::GASFUNC()                           \
-	{                                                             \
-		double ret = -1;                                      \
-		for (int i = 0, count = rowCount(); i < count; i++) { \
-			if (pInfo.entry[i].pressures.GAS > ret)       \
-				ret = pInfo.entry[i].pressures.GAS;   \
-		}                                                     \
-		return ret;                                           \
+static double max_gas(const plot_info &pi, double gas_pressures::*gas)
+{
+	double ret = -1;
+	for (int i = 0; i < pi.nr; ++i) {
+		if (pi.entry[i].pressures.*gas > ret)
+			ret = pi.entry[i].pressures.*gas;
 	}
+	return ret;
+}
 
-MAX_PPGAS_FUNC(he, pheMax);
-MAX_PPGAS_FUNC(n2, pn2Max);
-MAX_PPGAS_FUNC(o2, po2Max);
+double DivePlotDataModel::pheMax() const
+{
+	return max_gas(pInfo, &gas_pressures::he);
+}
+
+double DivePlotDataModel::pn2Max() const
+{
+	return max_gas(pInfo, &gas_pressures::n2);
+}
+
+double DivePlotDataModel::po2Max() const
+{
+	return max_gas(pInfo, &gas_pressures::o2);
+}
 
 void DivePlotDataModel::emitDataChanged()
 {

--- a/qt-models/diveplotdatamodel.cpp
+++ b/qt-models/diveplotdatamodel.cpp
@@ -223,8 +223,3 @@ double DivePlotDataModel::po2Max() const
 {
 	return max_gas(pInfo, &gas_pressures::o2);
 }
-
-void DivePlotDataModel::emitDataChanged()
-{
-	emit dataChanged(QModelIndex(), QModelIndex());
-}

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -86,9 +86,6 @@ public:
 	double pn2Max();
 	double po2Max();
 	void emitDataChanged();
-#ifndef SUBSURFACE_MOBILE
-	void calculateDecompression();
-#endif
 
 private:
 	struct plot_info pInfo;

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -85,7 +85,6 @@ public:
 	double pheMax() const;
 	double pn2Max() const;
 	double po2Max() const;
-	void emitDataChanged();
 
 private:
 	struct plot_info pInfo;

--- a/qt-models/diveplotdatamodel.h
+++ b/qt-models/diveplotdatamodel.h
@@ -82,9 +82,9 @@ public:
 	void setDive(struct dive *d, const plot_info &pInfo);
 	const plot_info &data() const;
 	unsigned int dcShown() const;
-	double pheMax();
-	double pn2Max();
-	double po2Max();
+	double pheMax() const;
+	double pn2Max() const;
+	double po2Max() const;
 	void emitDataChanged();
 
 private:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
These are the first steps in making the profile widget reentrant, so that we can e.g. print without these weird ramifications, but also implement a life chart-widget in mobile. So far, this is mostly bike-shedding so that I can wrap my head around the control flow, which happens to be quite ... convoluted. We should really refrain from doing control flow via signals.

But it also improves the code in the sense that it halves the repainting of the profile items: They were painted twice per `plot()` call. In my tests I noticed that there is a rendering bug in the planner, but that exists at least since May 2020. It also removes some pointless optimizations: if the settings change there is no point in trying to be smart about when to replot the chart. The chart plotting must be instantaneous anyway if it should be useable in the planner.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Numerous small cleanups.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This needs some testing.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - purely preparatory and internal stuff.
