### PR TITLE
statistics: don't reset binner if binner is set

### DIFF
--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -557,9 +557,11 @@ void StatsState::validate(bool varChanged)
 	if (var1 == var2)
 		var2 = nullptr;
 
+	validateBinner(var1Binner, var1, false);
+
 	// If there is no second variable or the second variable is not
 	// "numeric", the first variable must be binned.
-	if (!var2 || var2->type() != StatsVariable::Type::Numeric)
+	if ((!var2 || var2->type() != StatsVariable::Type::Numeric) && !var1Binner)
 		var1Binner = getFirstBinner(var1);
 
 	// Check that the binners and operation are valid
@@ -567,7 +569,6 @@ void StatsState::validate(bool varChanged)
 		var2Binner = nullptr;	// Second variable can only be binned if first variable is binned.
 		var2Operation = StatsOperation::Invalid;
 	}
-	validateBinner(var1Binner, var1, false);
 	validateBinner(var2Binner, var2, true);
 	validateOperation(var2Operation, var2, var1Binner);
 


### PR DESCRIPTION
Recently code was added to reset variable 1 binner if the second
variable does not support an unbinned first variable.

It forgot to check whether a binner was already set. Do this.
But validate the old binner first!

This code is extremely fragile and will have to be redone.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix for bug reported on the ML. The code must be redone - the old way is not compatible with the new way.
