### PR TITLE
[WIP] Mobile stats

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -302,7 +302,8 @@ HEADERS += \
 
 RESOURCES += mobile-widgets/qml/mobile-resources.qrc \
 		mobile-widgets/3rdparty/icons.qrc \
-		map-widget/qml/map-widget.qrc
+		map-widget/qml/map-widget.qrc \
+		stats/qml/statsview.qrc
 
 android {
 	SOURCES += core/android.cpp \

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.6
+import org.subsurfacedivelog.mobile 1.0
+import org.kde.kirigami 2.4 as Kirigami
+
+Kirigami.Page {
+	id: statisticsPagge
+	objectName: "StatisticsPage"
+	title: qsTr("Statistics")
+	leftPadding: 0
+	topPadding: 0
+	rightPadding: 0
+	bottomPadding: 0
+	width: rootItem.colWidth
+	StatsView {
+		id: statisticsWidget
+		anchors.fill: parent
+		Component.onCompleted: {
+			console.log("Statistics widget loaded")
+		}
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -441,6 +441,12 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				}
 			},
 			Kirigami.Action {
+				text: qsTr("Statistics")
+				onTriggered: {
+					showPage(statistics)
+				}
+			},
+			Kirigami.Action {
 				icon {
 					name: ":/icons/ic_settings.svg"
 				}
@@ -857,6 +863,10 @@ if you have network connectivity and want to sync your data to cloud storage."),
 	DiveList {
 		id: diveList
 		visible: false
+	}
+
+	StatisticsPage {
+		id: statistics
 	}
 
 	Settings {

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -37,6 +37,7 @@
 		<file>Log.qml</file>
 		<file>main.qml</file>
 		<file>MapPage.qml</file>
+		<file>StatisticsPage.qml</file>
 		<file>Settings.qml</file>
 		<file>CopySettings.qml</file>
 		<file>ThemeTest.qml</file>

--- a/mobile-widgets/qml/qmldir
+++ b/mobile-widgets/qml/qmldir
@@ -9,3 +9,4 @@
 MapWidget ../../map-widget/qml/MapWidget.qml
 MapWidgetContextMenu ../../map-widget/qml/MapWidgetContextMenu.qml
 MapWidgetError ../../map-widget/qml/MapWidgetError.qml
+StatisticsWidget ../../stats/qml/statsview.qml

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2316,3 +2316,14 @@ QString QMLManager::getSyncState() const
 		return tr("(changes synced locally)");
 	return tr("(synced with cloud)");
 }
+
+void QMLManager::accessChart()
+{
+	QObject *chartView = qmlWindow->findChild<QObject *>("qmlChartView");
+	if (chartView != nullptr) {
+		qDebug() << "found the chartview";
+	} else {
+		qDebug() << "didn't find the chartview";
+	}
+
+}

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -176,6 +176,7 @@ public:
 	void rememberOldStatus();
 
 	QString getSyncState() const;
+	void accessChart();
 
 public slots:
 	void appInitialized();

--- a/stats/qml/statsview.qml
+++ b/stats/qml/statsview.qml
@@ -3,6 +3,7 @@ import QtQuick 2.0
 import QtCharts 2.0
 
 ChartView {
-    antialiasing: true
-    localizeNumbers: true
+	objectName: "qmlChartView"
+	antialiasing: true
+	localizeNumbers: true
 }

--- a/stats/qml/statsview.qrc
+++ b/stats/qml/statsview.qrc
@@ -1,5 +1,5 @@
 <RCC>
 	<qresource prefix="/qml">
-		<file>statsview.qml</file>
+		<file alias="StatsView.qml">statsview.qml</file>
 	</qresource>
 </RCC>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] non working playground

### Pull request long description:
<!-- Describe your pull request in detail. -->
This doesn’t do anything useful.
It shows how I think we can load the statsview QtChart from QML.
Now the question becomes: how do I talk to this? I guess I need to reimplement something like the `statsview.cpp`?

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger before I spend too much time on this, I wanted to run this by you in case it turns out this is completely the wrong way to go about this. My assumption was that I’d create a QML UI that feeds a C++ class that is analogous to `StatsView` with more or less the same information which will then result in the same time of statistics being show...???