### PR TITLE
stats: fix line segment intersection math

### DIFF
--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -686,9 +686,9 @@ void StatsView::addLinearRegression(double a, double b, double minX, double maxX
 	// but owing to floating point imprecision, let's test again.
 	if ((y1 < minY || y1 > maxY || y2 < minY || y2 > maxY) && fabs(a) > 0.0001) {
 		// Intersections with y = minY and y = maxY lines
-		double intersect_x1 = minY / a - b;
-		double intersect_x2 = maxY / a - b;
-		if (intersect_x1 < intersect_x2)
+		double intersect_x1 = (minY - b) / a;
+		double intersect_x2 = (maxY - b) / a;
+		if (intersect_x1 > intersect_x2)
 			std::swap(intersect_x1, intersect_x2);
 		minX = std::max(minX, intersect_x1);
 		maxX = std::min(maxX, intersect_x2);


### PR DESCRIPTION
Linear algebra class was a while ago, but somehow this does look more
logical to me.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'll have the actual scientists review my math... but what was there was quite clearly not right.
What I changed it to makes sense to me and creates correct regression lines for me in all cases.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 