### PR TITLE
statistics: replace QChart::*Axis

### DIFF
--- a/stats/CMakeLists.txt
+++ b/stats/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SUBSURFACE_STATS_SRCS
 	statsaxis.cpp
 	statscolors.h
 	statscolors.cpp
+	statsgrid.h
+	statsgrid.cpp
 	statsseries.h
 	statsseries.cpp
 	statsstate.h

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -188,7 +188,7 @@ BarSeries::Item::Item(QtCharts::QChart *chart, BarSeries *series, double lowerBo
 	total(total)
 {
 	for (SubItem &item: subitems) {
-		item.item->setZValue(ZValues::seriesLabels);
+		item.item->setZValue(ZValues::series);
 		item.highlight(false, binCount);
 	}
 	updatePosition(chart, series, horizontal, stacked, binCount);

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -87,8 +87,7 @@ private:
 		bool isOutside; // Is shown outside of bar
 		BarLabel(QtCharts::QChart *chart, const std::vector<QString> &labels, int bin_nr, int binCount);
 		void setVisible(bool visible);
-		void updatePosition(QtCharts::QChart *chart, QtCharts::QAbstractSeries *series,
-				    bool horizontal, bool center, const QRectF &rect, int bin_nr, int binCount);
+		void updatePosition(bool horizontal, bool center, const QRectF &rect, int bin_nr, int binCount);
 		void highlight(bool highlight, int bin_nr, int binCount);
 	};
 
@@ -98,7 +97,7 @@ private:
 		double value_from;
 		double value_to;
 		int bin_nr;
-		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked,
+		void updatePosition(BarSeries *series, bool horizontal, bool stacked,
 				    double from, double to, int binCount);
 		void highlight(bool highlight, int binCount);
 	};
@@ -114,7 +113,7 @@ private:
 		     std::vector<SubItem> subitems,
 		     const QString &binName, const StatsOperationResults &res, int total, bool horizontal,
 		     bool stacked, int binCount);
-		void updatePosition(QtCharts::QChart *chart, BarSeries *series, bool horizontal, bool stacked, int binCount);
+		void updatePosition(BarSeries *series, bool horizontal, bool stacked, int binCount);
 		void highlight(int subitem, bool highlight, int binCount);
 		int getSubItemUnderMouse(const QPointF &f, bool horizontal, bool stacked) const;
 	};

--- a/stats/boxseries.h
+++ b/stats/boxseries.h
@@ -45,7 +45,7 @@ private:
 		StatsQuartiles q;
 		QString binName;
 		Item(QtCharts::QChart *chart, BoxSeries *series, double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName);
-		void updatePosition(QtCharts::QChart *chart, BoxSeries *series);
+		void updatePosition(BoxSeries *series);
 		void highlight(bool highlight);
 	};
 

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -40,11 +40,19 @@ void InformationBox::setPos(QPointF pos)
 	QRectF plotArea = chart->plotArea();
 
 	double x = pos.x() + distanceFromPointer;
-	if (x + width >= plotArea.right() && pos.x() - width >= plotArea.x())
-		x = pos.x() - width;
+	if (x + width >= plotArea.right()) {
+		if (pos.x() - width >= plotArea.x())
+			x = pos.x() - width;
+		else
+			x = pos.x() - width / 2.0;
+	}
 	double y = pos.y() + distanceFromPointer;
-	if (y + height >= plotArea.bottom() && pos.y() - height >= plotArea.y())
-		y = pos.y() - height;
+	if (y + height >= plotArea.bottom()) {
+		if (pos.y() - height >= plotArea.y())
+			y = pos.y() - height;
+		else
+			y = pos.y() - height / 2.0;
+	}
 
 	setRect(x, y, width, height);
 	double actY = y + 2.0 * informationBorder;

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -167,8 +167,7 @@ PieSeries::~PieSeries()
 
 void PieSeries::updatePositions()
 {
-	QtCharts::QChart *c = chart();
-	QRectF plotRect = c->plotArea();
+	QRectF plotRect = chart->plotArea();
 	center = plotRect.center();
 	radius = std::min(plotRect.width(), plotRect.height()) * pieSize / 2.0;
 	QRectF rect(center.x() - radius, center.y() - radius, 2.0 * radius, 2.0 * radius);
@@ -247,7 +246,7 @@ bool PieSeries::hover(QPointF pos)
 	if (highlighted >= 0 && highlighted < (int)items.size()) {
 		items[highlighted].highlight(highlighted, true, (int)items.size());
 		if (!information)
-			information.reset(new InformationBox(chart()));
+			information.reset(new InformationBox(chart));
 		information->setText(makeInfo(highlighted), pos);
 	} else {
 		information.reset();

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -65,12 +65,12 @@ ScatterSeries::Item::Item(QtCharts::QChart *chart, ScatterSeries *series, dive *
 	value(value)
 {
 	item->setZValue(ZValues::series);
-	updatePosition(chart, series);
+	updatePosition(series);
 }
 
-void ScatterSeries::Item::updatePosition(QtCharts::QChart *chart, ScatterSeries *series)
+void ScatterSeries::Item::updatePosition(ScatterSeries *series)
 {
-	QPointF center = chart->mapToPosition(QPointF(pos, value), series);
+	QPointF center = series->toScreen(QPointF(pos, value));
 	item->setPos(center.x() - scatterItemDiameter / 2.0,
 		     center.y() - scatterItemDiameter / 2.0);
 }
@@ -82,14 +82,13 @@ void ScatterSeries::Item::highlight(bool highlight)
 
 void ScatterSeries::append(dive *d, double pos, double value)
 {
-	items.emplace_back(chart(), this, d, pos, value);
+	items.emplace_back(chart, this, d, pos, value);
 }
 
 void ScatterSeries::updatePositions()
 {
-	QtCharts::QChart *c = chart();
 	for (Item &item: items)
-		item.updatePosition(c, this);
+		item.updatePosition(this);
 }
 
 static double sq(double f)
@@ -103,7 +102,7 @@ static double squareDist(const QPointF &p1, const QPointF &p2)
 	return QPointF::dotProduct(diff, diff);
 }
 
-std::vector<int> ScatterSeries::getItemsUnderMouse(const QPointF &point)
+std::vector<int> ScatterSeries::getItemsUnderMouse(const QPointF &point) const
 {
 	std::vector<int> res;
 	double x = point.x();
@@ -174,7 +173,7 @@ bool ScatterSeries::hover(QPointF pos)
 		return false;
 	} else {
 		if (!information)
-			information.reset(new InformationBox(chart()));
+			information.reset(new InformationBox(chart));
 
 		std::vector<QString> text;
 		text.reserve(highlighted.size() * 5);

--- a/stats/scatterseries.h
+++ b/stats/scatterseries.h
@@ -30,16 +30,14 @@ public:
 
 private:
 	// Get items under mouse.
-	// Super weird: this function can't be const, because QChart::mapToValue takes
-	// a non-const reference!?
-	std::vector<int> getItemsUnderMouse(const QPointF &f);
+	std::vector<int> getItemsUnderMouse(const QPointF &f) const;
 
 	struct Item {
 		std::unique_ptr<QGraphicsPixmapItem> item;
 		dive *d;
 		double pos, value;
 		Item(QtCharts::QChart *chart, ScatterSeries *series, dive *d, double pos, double value);
-		void updatePosition(QtCharts::QChart *chart, ScatterSeries *series);
+		void updatePosition(ScatterSeries *series);
 		void highlight(bool highlight);
 	};
 

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -133,6 +133,15 @@ void StatsAxis::addTick(double pos)
 	ticks.emplace_back(pos, chart);
 }
 
+std::vector<double> StatsAxis::ticksPositions() const
+{
+	std::vector<double> res;
+	res.reserve(ticks.size());
+	for (const Tick &tick: ticks)
+		res.push_back(toScreen(tick.pos));
+	return res;
+}
+
 // Map x (horizontal) or y (vertical) coordinate to or from screen coordinate
 double StatsAxis::toScreen(double pos) const
 {

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -14,8 +14,8 @@
 
 // Define most constants for horizontal and vertical axes for more flexibility.
 // Note: *Horizontal means that this is for the horizontal axis, so a vertical space.
-static const double axisWidth = 1.0;
-static const double axisTickWidth = 1.0;
+static const double axisWidth = 0.5;
+static const double axisTickWidth = 0.3;
 static const double axisTickSizeHorizontal = 6.0;
 static const double axisTickSizeVertical = 6.0;
 static const double axisLabelSpaceHorizontal = 2.0;	// Space between axis or ticks and labels
@@ -26,10 +26,12 @@ static const double axisTitleSpaceVertical = 2.0;	// Space between labels and ti
 StatsAxis::StatsAxis(QtCharts::QChart *chart, const QString &titleIn, bool horizontal, bool labelsBetweenTicks) :
 	QGraphicsLineItem(chart),
 	chart(chart), horizontal(horizontal), labelsBetweenTicks(labelsBetweenTicks),
-	labelFont(QFont()),	// make this configurable
-	titleFont(QFont(labelFont.family(), labelFont.pointSize(), QFont::Bold, false)), // same as label, but bold
 	size(1.0), zeroOnScreen(0.0), min(0.0), max(1.0), labelWidth(0.0)
 {
+	// use a Light version of the application fond for both labels and title
+	labelFont = QFont();
+	labelFont.setWeight(QFont::Light);
+	titleFont = labelFont;
 	setPen(QPen(axisColor, axisWidth));
 	setZValue(ZValues::axes);
 	if (!titleIn.isEmpty()) {

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -23,15 +23,22 @@ static const double axisLabelSpaceVertical = 2.0;	// Space between axis or ticks
 static const double axisTitleSpaceHorizontal = 2.0;	// Space between labels and title
 static const double axisTitleSpaceVertical = 2.0;	// Space between labels and title
 
-StatsAxis::StatsAxis(QtCharts::QChart *chart, bool horizontal, bool labelsBetweenTicks) :
+StatsAxis::StatsAxis(QtCharts::QChart *chart, const QString &titleIn, bool horizontal, bool labelsBetweenTicks) :
 	QGraphicsLineItem(chart),
 	chart(chart), horizontal(horizontal), labelsBetweenTicks(labelsBetweenTicks),
 	labelFont(QFont()),	// make this configurable
 	titleFont(QFont(labelFont.family(), labelFont.pointSize(), QFont::Bold, false)), // same as label, but bold
-	size(1.0), zeroOnScreen(0.0), min(0.0), max(1.0)
+	size(1.0), zeroOnScreen(0.0), min(0.0), max(1.0), labelWidth(0.0)
 {
 	setPen(QPen(axisColor, axisWidth));
 	setZValue(ZValues::axes);
+	if (!titleIn.isEmpty()) {
+		title = std::make_unique<QGraphicsSimpleTextItem>(titleIn, chart);
+		title->setFont(titleFont);
+		title->setBrush(darkLabelColor);
+		if (!horizontal)
+			title->setRotation(-90.0);
+	}
 }
 
 StatsAxis::~StatsAxis()
@@ -74,18 +81,19 @@ int StatsAxis::guessNumTicks(const std::vector<QString> &strings) const
 	return std::max(numTicks, 2);
 }
 
+double StatsAxis::titleSpace() const
+{
+	if (!title)
+		return 0.0;
+	return horizontal ? QFontMetrics(titleFont).height() + axisTitleSpaceHorizontal
+			  : QFontMetrics(titleFont).height() + axisTitleSpaceVertical;
+}
+
 double StatsAxis::width() const
 {
 	if (horizontal)
 		return 0.0;	// Only supported for vertical axes
-	double labelWidth = 0.0;
-	for (const Label &label: labels) {
-		double w = label.label->boundingRect().width();
-		if (w > labelWidth)
-			labelWidth = w;
-	}
-	return labelWidth + axisLabelSpaceVertical +
-	       QFontMetrics(titleFont).height() + axisTitleSpaceVertical +
+	return labelWidth + axisLabelSpaceVertical + titleSpace() +
 	       (labelsBetweenTicks ? 0.0 : axisTickSizeVertical);
 }
 
@@ -94,7 +102,7 @@ double StatsAxis::height() const
 	if (!horizontal)
 		return 0.0;	// Only supported for horizontal axes
 	return QFontMetrics(labelFont).height() + axisLabelSpaceHorizontal +
-	       QFontMetrics(titleFont).height() + axisTitleSpaceHorizontal +
+	       titleSpace() +
 	       (labelsBetweenTicks ? 0.0 : axisTickSizeHorizontal);
 }
 
@@ -144,6 +152,12 @@ void StatsAxis::setSize(double sizeIn)
 {
 	size = sizeIn;
 	updateLabels();
+	labelWidth = 0.0;
+	for (const Label &label: labels) {
+		double w = label.label->boundingRect().width();
+		if (w > labelWidth)
+			labelWidth = w;
+	}
 }
 
 void StatsAxis::setPos(QPointF pos)
@@ -162,6 +176,9 @@ void StatsAxis::setPos(QPointF pos)
 			tick.item->setLine(x, y, x, y + axisTickSizeHorizontal);
 		}
 		setLine(zeroOnScreen, y, zeroOnScreen + size, y);
+		if (title)
+			title->setPos(zeroOnScreen + (size - title->boundingRect().width()) / 2.0,
+				      labelY + QFontMetrics(labelFont).height() + axisTitleSpaceHorizontal);
 	} else {
 		double fontHeight = QFontMetrics(labelFont).height();
 		zeroOnScreen = pos.y();
@@ -176,12 +193,18 @@ void StatsAxis::setPos(QPointF pos)
 			double y = toScreen(tick.pos);
 			tick.item->setLine(x, y, x - axisTickSizeVertical, y);
 		}
+		// This is very confusing: even though we need the height of the title, the correct
+		// size is stored in boundingRect().width(). Presumably because the item is rotated
+		// by -90°. Apparently, the boundingRect is in item-local coordinates?
+		if (title)
+			title->setPos(labelX - labelWidth - QFontMetrics(labelFont).height() - axisTitleSpaceVertical,
+				      zeroOnScreen - (size - title->boundingRect().width()) / 2.0);
 		setLine(x, zeroOnScreen, x, zeroOnScreen - size);
 	}
 }
 
-ValueAxis::ValueAxis(QtCharts::QChart *chart, double min, double max, int decimals, bool horizontal) :
-	StatsAxis(chart, horizontal, false),
+ValueAxis::ValueAxis(QtCharts::QChart *chart, const QString &title, double min, double max, int decimals, bool horizontal) :
+	StatsAxis(chart, title, horizontal, false),
 	min(min), max(max), decimals(decimals)
 {
 }
@@ -235,8 +258,8 @@ void ValueAxis::updateLabels()
 	}
 }
 
-CountAxis::CountAxis(QtCharts::QChart *chart, int count, bool horizontal) :
-	ValueAxis(chart, 0.0, (double)count, 0, horizontal),
+CountAxis::CountAxis(QtCharts::QChart *chart, const QString &title, int count, bool horizontal) :
+	ValueAxis(chart, title, 0.0, (double)count, 0, horizontal),
 	count(count)
 {
 }
@@ -288,8 +311,8 @@ void CountAxis::updateLabels()
 	}
 }
 
-CategoryAxis::CategoryAxis(QtCharts::QChart *chart, const std::vector<QString> &labelsIn, bool horizontal) :
-	StatsAxis(chart, horizontal, true)
+CategoryAxis::CategoryAxis(QtCharts::QChart *chart, const QString &title, const std::vector<QString> &labelsIn, bool horizontal) :
+	StatsAxis(chart, title, horizontal, true)
 {
 	labels.reserve(labelsIn.size());
 	ticks.reserve(labelsIn.size() + 1);
@@ -307,8 +330,8 @@ void CategoryAxis::updateLabels()
 {
 }
 
-HistogramAxis::HistogramAxis(QtCharts::QChart *chart, std::vector<HistogramAxisEntry> bins, bool horizontal) :
-	StatsAxis(chart, horizontal, false),
+HistogramAxis::HistogramAxis(QtCharts::QChart *chart, const QString &title, std::vector<HistogramAxisEntry> bins, bool horizontal) :
+	StatsAxis(chart, title, horizontal, false),
 	bin_values(std::move(bins))
 {
 	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
@@ -496,7 +519,7 @@ static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
 	return res;
 }
 
-DateAxis::DateAxis(QtCharts::QChart *chart, double from, double to, bool horizontal) :
-	HistogramAxis(chart, timeRangeToBins(from, to), horizontal)
+DateAxis::DateAxis(QtCharts::QChart *chart, const QString &title, double from, double to, bool horizontal) :
+	HistogramAxis(chart, title, timeRangeToBins(from, to), horizontal)
 {
 }

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsaxis.h"
+#include "statscolors.h"
 #include "statstranslations.h"
 #include "statsvariables.h"
+#include "zvalues.h"
 #include "core/pref.h"
 #include "core/subsurface-time.h"
 #include <math.h> // for lrint
@@ -10,8 +12,26 @@
 #include <QFontMetrics>
 #include <QLocale>
 
-StatsAxis::StatsAxis(QtCharts::QChart *chart, bool horizontal) : chart(chart), horizontal(horizontal)
+// Define most constants for horizontal and vertical axes for more flexibility.
+// Note: *Horizontal means that this is for the horizontal axis, so a vertical space.
+static const double axisWidth = 1.0;
+static const double axisTickWidth = 1.0;
+static const double axisTickSizeHorizontal = 6.0;
+static const double axisTickSizeVertical = 6.0;
+static const double axisLabelSpaceHorizontal = 2.0;	// Space between axis or ticks and labels
+static const double axisLabelSpaceVertical = 2.0;	// Space between axis or ticks and labels
+static const double axisTitleSpaceHorizontal = 2.0;	// Space between labels and title
+static const double axisTitleSpaceVertical = 2.0;	// Space between labels and title
+
+StatsAxis::StatsAxis(QtCharts::QChart *chart, bool horizontal, bool labelsBetweenTicks) :
+	QGraphicsLineItem(chart),
+	chart(chart), horizontal(horizontal), labelsBetweenTicks(labelsBetweenTicks),
+	labelFont(QFont()),	// make this configurable
+	titleFont(QFont(labelFont.family(), labelFont.pointSize(), QFont::Bold, false)), // same as label, but bold
+	size(1.0), zeroOnScreen(0.0), min(0.0), max(1.0)
 {
+	setPen(QPen(axisColor, axisWidth));
+	setZValue(ZValues::axes);
 }
 
 StatsAxis::~StatsAxis()
@@ -20,7 +40,13 @@ StatsAxis::~StatsAxis()
 
 std::pair<double, double> StatsAxis::minMax() const
 {
-	return { 0.0, 1.0 };
+	return { min, max };
+}
+
+void StatsAxis::setRange(double minIn, double maxIn)
+{
+	min = minIn;
+	max = maxIn;
 }
 
 // Guess the number of tick marks based on example strings.
@@ -28,14 +54,13 @@ std::pair<double, double> StatsAxis::minMax() const
 // maximum-size strings especially, when using proportional fonts or for
 // categorical data. Therefore, try to err on the safe side by adding enough
 // margins.
-int StatsAxis::guessNumTicks(const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const
+int StatsAxis::guessNumTicks(const std::vector<QString> &strings) const
 {
-	QFont font = axis->labelsFont();
-	QFontMetrics fm(font);
+	QFontMetrics fm(labelFont);
 	int minSize = fm.height();
 	for (const QString &s: strings) {
-		QSize size = fm.size(Qt::TextSingleLine, s);
-		int needed = horizontal ? size.width() : size.height();
+		QSize labelSize = fm.size(Qt::TextSingleLine, s);
+		int needed = horizontal ? labelSize.width() : labelSize.height();
 		if (needed > minSize)
 			minSize = needed;
 	}
@@ -45,31 +70,127 @@ int StatsAxis::guessNumTicks(const QtCharts::QAbstractAxis *axis, const std::vec
 		minSize = minSize * 3 / 2;
 	else
 		minSize *= 2;
-	QRectF chartSize = chart->plotArea();
-	double availableSpace = horizontal ? chartSize.width() : chartSize.height();
-	int numTicks = lrint(availableSpace / minSize);
+	int numTicks = lrint(size / minSize);
 	return std::max(numTicks, 2);
 }
 
+double StatsAxis::width() const
+{
+	if (horizontal)
+		return 0.0;	// Only supported for vertical axes
+	double labelWidth = 0.0;
+	for (const Label &label: labels) {
+		double w = label.label->boundingRect().width();
+		if (w > labelWidth)
+			labelWidth = w;
+	}
+	return labelWidth + axisLabelSpaceVertical +
+	       QFontMetrics(titleFont).height() + axisTitleSpaceVertical +
+	       (labelsBetweenTicks ? 0.0 : axisTickSizeVertical);
+}
+
+double StatsAxis::height() const
+{
+	if (!horizontal)
+		return 0.0;	// Only supported for horizontal axes
+	return QFontMetrics(labelFont).height() + axisLabelSpaceHorizontal +
+	       QFontMetrics(titleFont).height() + axisTitleSpaceHorizontal +
+	       (labelsBetweenTicks ? 0.0 : axisTickSizeHorizontal);
+}
+
+StatsAxis::Label::Label(const QString &name, double pos, QtCharts::QChart *chart, const QFont &font) :
+	label(new QGraphicsSimpleTextItem(name, chart)),
+	pos(pos)
+{
+	label->setBrush(QBrush(darkLabelColor));
+	label->setFont(font);
+	label->setZValue(ZValues::axes);
+}
+
+void StatsAxis::addLabel(const QString &label, double pos)
+{
+	labels.emplace_back(label, pos, chart, labelFont);
+}
+
+StatsAxis::Tick::Tick(double pos, QtCharts::QChart *chart) :
+	item(new QGraphicsLineItem(chart)),
+	pos(pos)
+{
+	item->setPen(QPen(axisColor, axisTickWidth));
+	item->setZValue(ZValues::axes);
+}
+
+void StatsAxis::addTick(double pos)
+{
+	ticks.emplace_back(pos, chart);
+}
+
+// Map x (horizontal) or y (vertical) coordinate to or from screen coordinate
+double StatsAxis::toScreen(double pos) const
+{
+	// Vertical is bottom-up
+	return horizontal ? (pos - min) / (max - min) * size + zeroOnScreen
+			  : (min - pos) / (max - min) * size + zeroOnScreen;
+}
+
+double StatsAxis::toValue(double pos) const
+{
+	// Vertical is bottom-up
+	return horizontal ? (pos - zeroOnScreen) / size * (max - min) + min
+			  : (zeroOnScreen - pos) / size * (max - min) + zeroOnScreen;
+}
+
+void StatsAxis::setSize(double sizeIn)
+{
+	size = sizeIn;
+	updateLabels();
+}
+
+void StatsAxis::setPos(QPointF pos)
+{
+	if (horizontal) {
+		zeroOnScreen = pos.x();
+		double labelY = pos.y() + axisLabelSpaceHorizontal +
+				(labelsBetweenTicks ? 0.0 : axisTickSizeHorizontal);
+		double y = pos.y();
+		for (Label &label: labels) {
+			double x = toScreen(label.pos) - label.label->boundingRect().width() / 2.0;
+			label.label->setPos(QPointF(x, labelY));
+		}
+		for (Tick &tick: ticks) {
+			double x = toScreen(tick.pos);
+			tick.item->setLine(x, y, x, y + axisTickSizeHorizontal);
+		}
+		setLine(zeroOnScreen, y, zeroOnScreen + size, y);
+	} else {
+		double fontHeight = QFontMetrics(labelFont).height();
+		zeroOnScreen = pos.y();
+		double x = pos.x();
+		double labelX = x - axisLabelSpaceVertical -
+				(labelsBetweenTicks ? 0.0 : axisTickSizeVertical);
+		for (Label &label: labels) {
+			double y = toScreen(label.pos) - fontHeight / 2.0;
+			label.label->setPos(QPointF(labelX - label.label->boundingRect().width(), y));
+		}
+		for (Tick &tick: ticks) {
+			double y = toScreen(tick.pos);
+			tick.item->setLine(x, y, x - axisTickSizeVertical, y);
+		}
+		setLine(x, zeroOnScreen, x, zeroOnScreen - size);
+	}
+}
+
 ValueAxis::ValueAxis(QtCharts::QChart *chart, double min, double max, int decimals, bool horizontal) :
-	StatsAxisTemplate(chart, horizontal),
+	StatsAxis(chart, horizontal, false),
 	min(min), max(max), decimals(decimals)
 {
-}
-
-std::pair<double, double> ValueAxis::minMax() const
-{
-	return { QValueAxis::min(), QValueAxis::max() };
-}
-
-static QString makeFormatString(int decimals)
-{
-	return QStringLiteral("%.%1f").arg(decimals < 0 ? 0 : decimals);
 }
 
 void ValueAxis::updateLabels()
 {
 	using QtCharts::QValueAxis;
+	labels.clear();
+	ticks.clear();
 
 	// Avoid degenerate cases
 	if (max - min < 0.0001) {
@@ -80,7 +201,7 @@ void ValueAxis::updateLabels()
 	QLocale loc;
 	QString minString = loc.toString(min, 'f', decimals);
 	QString maxString = loc.toString(max, 'f', decimals);
-	int numTicks = guessNumTicks(this, { minString, maxString});
+	int numTicks = guessNumTicks({ minString, maxString});
 
 	// Use full decimal increments
 	double height = max - min;
@@ -98,12 +219,20 @@ void ValueAxis::updateLabels()
 	if (-digits_int > decimals)
 		decimals = -digits_int;
 
-	setLabelFormat(makeFormatString(decimals));
 	double actMin = floor(min /  inc) * inc;
 	double actMax = ceil(max /  inc) * inc;
 	int num = lrint((actMax - actMin) / inc);
 	setRange(actMin, actMax);
-	setTickCount(num + 1);
+
+	double actStep = (actMax - actMin) / static_cast<double>(num);
+	double act = actMin;
+	labels.reserve(num + 1);
+	ticks.reserve(num + 1);
+	for (int i = 0; i <= num; ++i) {
+		addLabel(loc.toString(act, 'f', decimals), act);
+		addTick(act);
+		act += actStep;
+	}
 }
 
 CountAxis::CountAxis(QtCharts::QChart *chart, int count, bool horizontal) :
@@ -114,9 +243,12 @@ CountAxis::CountAxis(QtCharts::QChart *chart, int count, bool horizontal) :
 
 void CountAxis::updateLabels()
 {
+	labels.clear();
+	ticks.clear();
+
 	QLocale loc;
 	QString countString = loc.toString(count);
-	int numTicks = guessNumTicks(this, { countString });
+	int numTicks = guessNumTicks({ countString });
 
 	// Get estimate of step size
 	if (count <= 0)
@@ -145,59 +277,42 @@ void CountAxis::updateLabels()
 	// Make maximum an integer number of steps, equal or greater than the needed counts
 	int num = (count - 1) / step + 1;
 	int max = num * step;
-	numTicks = num + 1; // There is one more tick than steps
 
-	setLabelFormat("%.0f");
 	setRange(0, max);
-	setTickCount(numTicks);
+
+	labels.reserve(max + 1);
+	ticks.reserve(max + 1);
+	for (int i = 0; i <= max; i += step) {
+		addLabel(loc.toString(i), static_cast<double>(i));
+		addTick(static_cast<double>(i));
+	}
 }
 
-CategoryAxis::CategoryAxis(QtCharts::QChart *chart, const std::vector<QString> &labels, bool horizontal) :
-	StatsAxisTemplate(chart, horizontal)
+CategoryAxis::CategoryAxis(QtCharts::QChart *chart, const std::vector<QString> &labelsIn, bool horizontal) :
+	StatsAxis(chart, horizontal, true)
 {
-	for (const QString &s: labels)
-		append(s);
+	labels.reserve(labelsIn.size());
+	ticks.reserve(labelsIn.size() + 1);
+	double pos = 0.0;
+	addTick(-0.5);
+	for (const QString &s: labelsIn) {
+		addLabel(s, pos);
+		addTick(pos + 0.5);
+		pos += 1.0;
+	}
+	setRange(-0.5, static_cast<double>(labelsIn.size()) + 0.5);
 }
 
 void CategoryAxis::updateLabels()
 {
 }
 
-// A small helper class that makes strings unique. We need this,
-// because QCategoryAxis can only handle unique category names.
-// Disambiguate strings by adding unicode zero-width spaces.
-// Keep track of a list of strings and how many spaces have to
-// be added.
-class LabelDisambiguator {
-	using Pair = std::pair<QString, int>;
-	std::vector<Pair> entries;
-public:
-	QString transmogrify(const QString &s);
-};
-
-QString LabelDisambiguator::transmogrify(const QString &s)
-{
-	auto it = std::find_if(entries.begin(), entries.end(),
-			       [&s](const Pair &p) { return p.first == s; });
-	if (it == entries.end()) {
-		entries.emplace_back(s, 0);
-		return s;
-	}  else {
-		++(it->second);
-		return s + QString(it->second, QChar(0x200b));
-	}
-}
-
 HistogramAxis::HistogramAxis(QtCharts::QChart *chart, std::vector<HistogramAxisEntry> bins, bool horizontal) :
-	StatsAxisTemplate(chart, horizontal),
+	StatsAxis(chart, horizontal, false),
 	bin_values(std::move(bins))
 {
 	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
 		return;
-
-	LabelDisambiguator labeler;
-	for (HistogramAxisEntry &entry: bin_values)
-		entry.name = labeler.transmogrify(entry.name);
 
 	// The caller can declare some bin labels as preferred, when there are
 	// too many labels to show all. Try to infer the preferred step size
@@ -210,17 +325,7 @@ HistogramAxis::HistogramAxis(QtCharts::QChart *chart, std::vector<HistogramAxisE
 	auto it2 = std::find_if(next_it, bin_values.end(),
 				[](const HistogramAxisEntry &e) { return e.recommended; });
 	preferred_step = it2 == bin_values.end() ? 1 : it2 - it1;
-	setMin(bin_values.front().value);
-	setMax(bin_values.back().value);
-	setStartValue(bin_values.front().value);
-	setLabelsPosition(QCategoryAxis::AxisLabelsPositionOnValue);
-}
-
-std::pair<double, double> HistogramAxis::minMax() const
-{
-	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
-		return { 0.0, 1.0 };
-	return { QValueAxis::min(), QValueAxis::max() };
+	setRange(bin_values.front().value, bin_values.back().value);
 }
 
 // Initialize a histogram axis with the given labels. Labels are specified as (name, value, recommended) triplets.
@@ -229,20 +334,17 @@ std::pair<double, double> HistogramAxis::minMax() const
 // There, we obviously want to show the years and not the quarters.
 void HistogramAxis::updateLabels()
 {
+	labels.clear();
+	ticks.clear();
+
 	if (bin_values.size() < 2) // Less than two makes no sense -> there must be at least one category
 		return;
-
-	// There is no clear all labels function in QCategoryAxis!? You must be kidding.
-	for (const QString &label: categoriesLabels())
-		remove(label);
-	if (count() > 0)
-		qWarning("HistogramAxis::updateLabels(): labels left after clearing!?");
 
 	std::vector<QString> strings;
 	strings.reserve(bin_values.size());
 	for (auto &[name, value, recommended]: bin_values)
 		strings.push_back(name);
-	int maxLabels = guessNumTicks(this, strings);
+	int maxLabels = guessNumTicks(strings);
 
 	int step = ((int)bin_values.size() - 1) / maxLabels + 1;
 	if (step < preferred_step) {
@@ -268,9 +370,11 @@ void HistogramAxis::updateLabels()
 			}
 		}
 	}
+	labels.reserve((bin_values.size() - first) / step + 1);
 	for (int i = first; i < (int)bin_values.size(); i += step) {
 		const auto &[name, value, recommended] = bin_values[i];
-		append(name, value);
+		addLabel(name, value);
+		addTick(value);
 	}
 }
 

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -50,6 +50,12 @@ std::pair<double, double> StatsAxis::minMax() const
 	return { min, max };
 }
 
+std::pair<double, double> StatsAxis::minMaxScreen() const
+{
+	return horizontal ? std::make_pair(zeroOnScreen, zeroOnScreen + size)
+			  : std::make_pair(zeroOnScreen, zeroOnScreen - size);
+}
+
 void StatsAxis::setRange(double minIn, double maxIn)
 {
 	min = minIn;

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -31,7 +31,7 @@ public:
 	double toScreen(double) const;
 	double toValue(double) const;
 protected:
-	StatsAxis(QtCharts::QChart *chart, bool horizontal, bool labelsBetweenTicks);
+	StatsAxis(QtCharts::QChart *chart, const QString &title, bool horizontal, bool labelsBetweenTicks);
 	QtCharts::QChart *chart;
 
 	struct Label {
@@ -56,14 +56,18 @@ protected:
 	bool labelsBetweenTicks;	// When labels are between ticks, they can be moved closer to the axis
 
 	QFont labelFont, titleFont;
+	std::unique_ptr<QGraphicsSimpleTextItem> title;
 	double size;			// width for horizontal, height for vertical
 	double zeroOnScreen;
 	double min, max;
+	double labelWidth;		// Maximum width of labels
+private:
+	double titleSpace() const;	// Space needed for title
 };
 
 class ValueAxis : public StatsAxis {
 public:
-	ValueAxis(QtCharts::QChart *chart, double min, double max, int decimals, bool horizontal);
+	ValueAxis(QtCharts::QChart *chart, const QString &title, double min, double max, int decimals, bool horizontal);
 private:
 	double min, max;
 	int decimals;
@@ -72,7 +76,7 @@ private:
 
 class CountAxis : public ValueAxis {
 public:
-	CountAxis(QtCharts::QChart *chart, int count, bool horizontal);
+	CountAxis(QtCharts::QChart *chart, const QString &title, int count, bool horizontal);
 private:
 	int count;
 	void updateLabels() override;
@@ -80,7 +84,7 @@ private:
 
 class CategoryAxis : public StatsAxis {
 public:
-	CategoryAxis(QtCharts::QChart *chart, const std::vector<QString> &labels, bool horizontal);
+	CategoryAxis(QtCharts::QChart *chart, const QString &title, const std::vector<QString> &labels, bool horizontal);
 private:
 	void updateLabels();
 };
@@ -93,7 +97,7 @@ struct HistogramAxisEntry {
 
 class HistogramAxis : public StatsAxis {
 public:
-	HistogramAxis(QtCharts::QChart *chart, std::vector<HistogramAxisEntry> bin_values, bool horizontal);
+	HistogramAxis(QtCharts::QChart *chart, const QString &title, std::vector<HistogramAxisEntry> bin_values, bool horizontal);
 private:
 	void updateLabels() override;
 	std::vector<HistogramAxisEntry> bin_values;
@@ -102,7 +106,7 @@ private:
 
 class DateAxis : public HistogramAxis {
 public:
-	DateAxis(QtCharts::QChart *chart, double from, double to, bool horizontal);
+	DateAxis(QtCharts::QChart *chart, const QString &title, double from, double to, bool horizontal);
 };
 
 #endif

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -30,6 +30,8 @@ public:
 	// Map x (horizontal) or y (vertical) coordinate to or from screen coordinate
 	double toScreen(double) const;
 	double toValue(double) const;
+
+	std::vector<double> ticksPositions() const; // Positions in screen coordinates
 protected:
 	StatsAxis(QtCharts::QChart *chart, const QString &title, bool horizontal, bool labelsBetweenTicks);
 	QtCharts::QChart *chart;

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -15,13 +15,14 @@ namespace QtCharts {
 class StatsAxis {
 public:
 	virtual ~StatsAxis();
-	virtual void updateLabels(const QtCharts::QChart *chart) = 0;
+	virtual void updateLabels() = 0;
 	virtual QtCharts::QAbstractAxis *qaxis() = 0;
 	// Returns minimum and maximum of shown range, not of data points.
 	virtual std::pair<double, double> minMax() const;
 protected:
-	StatsAxis(bool horizontal);
-	int guessNumTicks(const QtCharts::QChart *chart, const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const;
+	QtCharts::QChart *chart;
+	StatsAxis(QtCharts::QChart *chart, bool horizontal);
+	int guessNumTicks(const QtCharts::QAbstractAxis *axis, const std::vector<QString> &strings) const;
 	bool horizontal;
 };
 
@@ -38,27 +39,27 @@ class StatsAxisTemplate : public StatsAxis, public QAxis
 
 class ValueAxis : public StatsAxisTemplate<QtCharts::QValueAxis> {
 public:
-	ValueAxis(double min, double max, int decimals, bool horizontal);
+	ValueAxis(QtCharts::QChart *chart, double min, double max, int decimals, bool horizontal);
 private:
 	double min, max;
 	int decimals;
-	void updateLabels(const QtCharts::QChart *chart) override;
+	void updateLabels() override;
 	std::pair<double, double> minMax() const override;
 };
 
 class CountAxis : public ValueAxis {
 public:
-	CountAxis(int count, bool horizontal);
+	CountAxis(QtCharts::QChart *chart, int count, bool horizontal);
 private:
 	int count;
-	void updateLabels(const QtCharts::QChart *chart) override;
+	void updateLabels() override;
 };
 
 class CategoryAxis : public StatsAxisTemplate<QtCharts::QBarCategoryAxis> {
 public:
-	CategoryAxis(const std::vector<QString> &labels, bool horizontal);
+	CategoryAxis(QtCharts::QChart *chart, const std::vector<QString> &labels, bool horizontal);
 private:
-	void updateLabels(const QtCharts::QChart *chart);
+	void updateLabels();
 };
 
 struct HistogramAxisEntry {
@@ -69,9 +70,9 @@ struct HistogramAxisEntry {
 
 class HistogramAxis : public StatsAxisTemplate<QtCharts::QCategoryAxis> {
 public:
-	HistogramAxis(std::vector<HistogramAxisEntry> bin_values, bool horizontal);
+	HistogramAxis(QtCharts::QChart *chart, std::vector<HistogramAxisEntry> bin_values, bool horizontal);
 private:
-	void updateLabels(const QtCharts::QChart *chart) override;
+	void updateLabels() override;
 	std::pair<double, double> minMax() const override;
 	std::vector<HistogramAxisEntry> bin_values;
 	int preferred_step;
@@ -79,7 +80,7 @@ private:
 
 class DateAxis : public HistogramAxis {
 public:
-	DateAxis(double from, double to, bool horizontal);
+	DateAxis(QtCharts::QChart *chart, double from, double to, bool horizontal);
 };
 
 #endif

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -20,6 +20,7 @@ public:
 	virtual ~StatsAxis();
 	// Returns minimum and maximum of shown range, not of data points.
 	std::pair<double, double> minMax() const;
+	std::pair<double, double> minMaxScreen() const; // minimum and maximum in screen coordinates
 
 	double width() const;		// Only supported by vertical axes. Only valid after setSize().
 	double height() const;		// Only supported for horizontal axes. Always valid.

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -12,6 +12,7 @@ inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
 inline const QColor darkLabelColor(Qt::black);
 inline const QColor lightLabelColor(Qt::white);
 inline const QColor axisColor(Qt::black);
+inline const QColor gridColor(0xcc, 0xcc, 0xcc);
 
 QColor binColor(int bin, int numBins);
 QColor labelColor(int bin, size_t numBins);

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -11,6 +11,7 @@ inline const QColor highlightedColor(Qt::yellow);
 inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
 inline const QColor darkLabelColor(Qt::black);
 inline const QColor lightLabelColor(Qt::white);
+inline const QColor axisColor(Qt::black);
 
 QColor binColor(int bin, int numBins);
 QColor labelColor(int bin, size_t numBins);

--- a/stats/statsgrid.cpp
+++ b/stats/statsgrid.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "statsgrid.h"
+#include "statsaxis.h"
+#include "statscolors.h"
+#include "zvalues.h"
+
+#include <QChart>
+#include <QGraphicsLineItem>
+
+static const double gridWidth = 1.0;
+static const Qt::PenStyle gridStyle = Qt::SolidLine;
+
+StatsGrid::StatsGrid(QtCharts::QChart *chart, const StatsAxis &xAxis, const StatsAxis &yAxis)
+	: chart(chart), xAxis(xAxis), yAxis(yAxis)
+{
+}
+
+void StatsGrid::updatePositions()
+{
+	std::vector<double> xtics = xAxis.ticksPositions();
+	std::vector<double> ytics = yAxis.ticksPositions();
+	lines.clear();
+	if (xtics.empty() || ytics.empty())
+		return;
+
+	for (double x: xtics) {
+		lines.emplace_back(new QGraphicsLineItem(x, ytics.front(), x, ytics.back(), chart));
+		lines.back()->setPen(QPen(gridColor, gridWidth, gridStyle));
+		lines.back()->setZValue(ZValues::grid);
+	}
+	for (double y: ytics) {
+		lines.emplace_back(new QGraphicsLineItem(xtics.front(), y, xtics.back(), y, chart));
+		lines.back()->setPen(QPen(gridColor, gridWidth, gridStyle));
+		lines.back()->setZValue(ZValues::grid);
+	}
+}

--- a/stats/statsgrid.h
+++ b/stats/statsgrid.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+// The background grid of a chart
+
+#include <memory>
+#include <vector>
+#include <QVector>
+#include <QGraphicsLineItem>
+
+class StatsAxis;
+namespace QtCharts {
+	class QChart;
+};
+
+class StatsGrid  {
+public:
+	StatsGrid(QtCharts::QChart *chart, const StatsAxis &xAxis, const StatsAxis &yAxis);
+	void updatePositions();
+private:
+	QtCharts::QChart *chart;
+	const StatsAxis &xAxis, &yAxis;
+	std::vector<std::unique_ptr<QGraphicsLineItem>> lines;
+};

--- a/stats/statsseries.cpp
+++ b/stats/statsseries.cpp
@@ -2,18 +2,17 @@
 #include "statsseries.h"
 #include "statsaxis.h"
 
-#include <QChart>
-
 StatsSeries::StatsSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis) :
-	xAxis(xAxis), yAxis(yAxis)
+	chart(chart), xAxis(xAxis), yAxis(yAxis)
 {
-	chart->addSeries(this);
-	if (xAxis && yAxis) {
-		attachAxis(xAxis->qaxis());
-		attachAxis(yAxis->qaxis());
-	}
 }
 
 StatsSeries::~StatsSeries()
 {
+}
+
+QPointF StatsSeries::toScreen(QPointF p)
+{
+	return xAxis && yAxis ? QPointF(xAxis->toScreen(p.x()), yAxis->toScreen(p.y()))
+			      : QPointF(0.0, 0.0);
 }

--- a/stats/statsseries.cpp
+++ b/stats/statsseries.cpp
@@ -4,7 +4,8 @@
 
 #include <QChart>
 
-StatsSeries::StatsSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis)
+StatsSeries::StatsSeries(QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis) :
+	xAxis(xAxis), yAxis(yAxis)
 {
 	chart->addSeries(this);
 	if (xAxis && yAxis) {

--- a/stats/statsseries.h
+++ b/stats/statsseries.h
@@ -23,7 +23,9 @@ public:
 	virtual bool hover(QPointF pos) = 0;	// Called on mouse movement. Return true if an item of this series is highlighted.
 	virtual void unhighlight() = 0;		// Unhighlight any highlighted item.
 protected:
+	QtCharts::QChart *chart;
 	StatsAxis *xAxis, *yAxis;		// May be zero for charts without axes (pie charts).
+	QPointF toScreen(QPointF p);
 };
 
 #endif

--- a/stats/statsseries.h
+++ b/stats/statsseries.h
@@ -22,6 +22,8 @@ public:
 	virtual void updatePositions() = 0;	// Called if chart geometry changes.
 	virtual bool hover(QPointF pos) = 0;	// Called on mouse movement. Return true if an item of this series is highlighted.
 	virtual void unhighlight() = 0;		// Unhighlight any highlighted item.
+protected:
+	StatsAxis *xAxis, *yAxis;		// May be zero for charts without axes (pie charts).
 };
 
 #endif

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -86,7 +86,7 @@ StatsView::~StatsView()
 void StatsView::plotAreaChanged(const QRectF &)
 {
 	for (auto &axis: axes)
-		axis->updateLabels(chart);
+		axis->updateLabels();
 	for (auto &series: series)
 		series->updatePositions();
 	for (QuartileMarker &marker: quartileMarkers)
@@ -142,9 +142,9 @@ void StatsView::setTitle(const QString &s)
 template <typename T, class... Args>
 T *StatsView::createAxis(const QString &title, Args&&... args)
 {
-	T *res = new T(std::forward<Args>(args)...);
+	T *res = new T(chart, std::forward<Args>(args)...);
 	axes.emplace_back(res);
-	axes.back()->updateLabels(chart);
+	axes.back()->updateLabels();
 	axes.back()->qaxis()->setTitleText(title);
 	return res;
 }

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -6,6 +6,7 @@
 #include "pieseries.h"
 #include "scatterseries.h"
 #include "statsaxis.h"
+#include "statsgrid.h"
 #include "statsstate.h"
 #include "statstranslations.h"
 #include "statsvariables.h"
@@ -118,6 +119,8 @@ void StatsView::plotAreaChanged(const QRectF &r)
 		xAxis->setPos(QPointF(left, bottom));
 	}
 
+	if (grid)
+		grid->updatePositions();
 	for (auto &series: series)
 		series->updatePositions();
 	for (QuartileMarker &marker: quartileMarkers)
@@ -195,6 +198,8 @@ void StatsView::setAxes(StatsAxis *x, StatsAxis *y)
 {
 	xAxis = x;
 	yAxis = y;
+	if (x && y)
+		grid = std::make_unique<StatsGrid>(chart, *x, *y);
 }
 
 void StatsView::reset()
@@ -208,6 +213,7 @@ void StatsView::reset()
 	quartileMarkers.clear();
 	lineMarkers.clear();
 	chart->removeAllSeries();
+	grid.reset();
 	axes.clear();
 	title.reset();
 }

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -186,8 +186,7 @@ void StatsView::updateTitlePos()
 template <typename T, class... Args>
 T *StatsView::createAxis(const QString &title, Args&&... args)
 {
-	// TODO: set title
-	T *res = new T(chart, std::forward<Args>(args)...);
+	T *res = new T(chart, title, std::forward<Args>(args)...);
 	axes.emplace_back(res);
 	return res;
 }

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -18,11 +18,14 @@
 #include <QAbstractSeries>
 #include <QChart>
 #include <QGraphicsSceneHoverEvent>
+#include <QGraphicsSimpleTextItem>
 #include <QLocale>
 
 // Constants that control the graph layouts
 static const QColor quartileMarkerColor(Qt::red);
-static const double quartileMarkerSize = 15;
+static const double quartileMarkerSize = 15.0;
+static const double sceneBorder = 5.0;			// Border between scene edges and statitistics view
+static const double titleBorder = 2.0;			// Border between title and chart
 
 static const QUrl urlStatsView = QUrl(QStringLiteral("qrc:/qml/statsview.qml"));
 
@@ -77,6 +80,9 @@ StatsView::StatsView(QWidget *parent) : QQuickWidget(parent),
 		chart->setAcceptHoverEvents(true);
 		chart->legend()->setVisible(false);
 	}
+
+	QFont font;
+	titleFont = QFont(font.family(), font.pointSize(), QFont::Bold);	// Make configurable
 }
 
 StatsView::~StatsView()
@@ -95,6 +101,7 @@ void StatsView::plotAreaChanged(const QRectF &)
 		marker.updatePosition();
 	if (legend)
 		legend->resize();
+	updateTitlePos();
 }
 
 void StatsView::replotIfVisible()
@@ -136,7 +143,21 @@ T *StatsView::createSeries(Args&&... args)
 
 void StatsView::setTitle(const QString &s)
 {
-	chart->setTitle(s);
+	if (s.isEmpty()) {
+		title.reset();
+		return;
+	}
+	title = std::make_unique<QGraphicsSimpleTextItem>(s, chart);
+	title->setFont(titleFont);
+}
+
+void StatsView::updateTitlePos()
+{
+	if (!title)
+		return;
+	QRectF rect = chart->plotArea();
+	title->setPos((rect.width() - title->boundingRect().width()) / 2.0,
+		      sceneBorder);
 }
 
 template <typename T, class... Args>
@@ -166,11 +187,18 @@ void StatsView::reset()
 	lineMarkers.clear();
 	chart->removeAllSeries();
 	axes.clear();
+	title.reset();
 }
 
 void StatsView::plot(const StatsState &stateIn)
 {
 	state = stateIn;
+	plotChart();
+	plotAreaChanged(chart->plotArea());
+}
+
+void StatsView::plotChart()
+{
 	if (!chart || !state.var1)
 		return;
 	reset();

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -85,7 +85,7 @@ StatsView::StatsView(QWidget *parent) : QQuickWidget(parent),
 	}
 
 	QFont font;
-	titleFont = QFont(font.family(), font.pointSize(), QFont::Bold);	// Make configurable
+	titleFont = QFont(font.family(), font.pointSize(), QFont::Light);	// Make configurable
 }
 
 StatsView::~StatsView()

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -106,17 +106,27 @@ private:
 		void updatePosition();
 	};
 
-	// A general line marker
-	struct LineMarker {
+	// A regression line
+	struct RegressionLine {
 		std::unique_ptr<QGraphicsLineItem> item;
 		StatsAxis *xAxis, *yAxis;
-		QPointF from, to; // In local coordinates
+		double a, b;			// y = ax + b
 		void updatePosition();
-		LineMarker(QPointF from, QPointF to, QPen pen, QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
+		RegressionLine(double a, double b, QPen pen, QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
+	};
+
+	// A line marking median or mean in histograms
+	struct HistogramMarker {
+		std::unique_ptr<QGraphicsLineItem> item;
+		StatsAxis *xAxis, *yAxis;
+		double val;
+		bool horizontal;
+		void updatePosition();
+		HistogramMarker(double val, bool horizontal, QPen pen, QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
 	};
 
 	void addLinearRegression(double a, double b, double minX, double maxX, double minY, double maxY, StatsAxis *xAxis, StatsAxis *yAxis);
-	void addHistogramMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal, StatsAxis *xAxis, StatsAxis *yAxis);
+	void addHistogramMarker(double pos, const QPen &pen, bool isHorizontal, StatsAxis *xAxis, StatsAxis *yAxis);
 
 	StatsState state;
 	QtCharts::QChart *chart;
@@ -126,7 +136,8 @@ private:
 	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
-	std::vector<LineMarker> lineMarkers;
+	std::vector<RegressionLine> regressionLines;
+	std::vector<HistogramMarker> histogramMarkers;
 	std::unique_ptr<QGraphicsSimpleTextItem> title;
 	StatsSeries *highlightedSeries;
 	StatsAxis *xAxis, *yAxis;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -41,7 +41,7 @@ private slots:
 	void replotIfVisible();
 private:
 	void reset(); // clears all series and axes
-	void addAxes(StatsAxis *x, StatsAxis *y); // Add new x- and y-axis
+	void setAxes(StatsAxis *x, StatsAxis *y);
 	void plotBarChart(const std::vector<dive *> &dives,
 			  ChartSubType subType,
 			  const StatsVariable *categoryVariable, const StatsBinner *categoryBinner,
@@ -99,23 +99,23 @@ private:
 	// A short line used to mark quartiles
 	struct QuartileMarker {
 		std::unique_ptr<QGraphicsLineItem> item;
-		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
+		StatsAxis *xAxis, *yAxis;
 		double pos, value;
-		QuartileMarker(double pos, double value, QtCharts::QAbstractSeries *series);
+		QuartileMarker(double pos, double value, QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
 		void updatePosition();
 	};
 
 	// A general line marker
 	struct LineMarker {
 		std::unique_ptr<QGraphicsLineItem> item;
-		QtCharts::QAbstractSeries *series; // In case we ever support charts with multiple axes
+		StatsAxis *xAxis, *yAxis;
 		QPointF from, to; // In local coordinates
 		void updatePosition();
-		LineMarker(QPointF from, QPointF to, QPen pen, QtCharts::QAbstractSeries *series);
+		LineMarker(QPointF from, QPointF to, QPen pen, QtCharts::QChart *chart, StatsAxis *xAxis, StatsAxis *yAxis);
 	};
 
-	void addLinearRegression(double a, double b, double minX, double maxX, double minY, double maxY, QtCharts::QAbstractSeries *series);
-	void addHistogramMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal, QtCharts::QAbstractSeries *series);
+	void addLinearRegression(double a, double b, double minX, double maxX, double minY, double maxY, StatsAxis *xAxis, StatsAxis *yAxis);
+	void addHistogramMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal, StatsAxis *xAxis, StatsAxis *yAxis);
 
 	StatsState state;
 	QtCharts::QChart *chart;
@@ -127,6 +127,7 @@ private:
 	std::vector<LineMarker> lineMarkers;
 	std::unique_ptr<QGraphicsSimpleTextItem> title;
 	StatsSeries *highlightedSeries;
+	StatsAxis *xAxis, *yAxis;
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.
 	// Therefore, we have to listen to hover events using an events-filter.

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -24,6 +24,7 @@ class CategoryAxis;
 class CountAxis;
 class HistogramAxis;
 class StatsAxis;
+class StatsGrid;
 class Legend;
 
 enum class ChartSubType : int;
@@ -121,6 +122,7 @@ private:
 	QtCharts::QChart *chart;
 	QFont titleFont;
 	std::vector<std::unique_ptr<StatsAxis>> axes;
+	std::unique_ptr<StatsGrid> grid;
 	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -4,6 +4,7 @@
 
 #include "statsstate.h"
 #include <memory>
+#include <QFont>
 #include <QQuickWidget>
 
 struct dive;
@@ -17,6 +18,7 @@ namespace QtCharts {
 	class QChart;
 }
 class QGraphicsLineItem;
+class QGraphicsSimpleTextItem;
 class StatsSeries;
 class CategoryAxis;
 class CountAxis;
@@ -74,6 +76,8 @@ private:
 				   const StatsVariable *categoryVariable, const StatsBinner *categoryBinner, const StatsVariable *valueVariable);
 	void plotScatter(const std::vector<dive *> &dives, const StatsVariable *categoryVariable, const StatsVariable *valueVariable);
 	void setTitle(const QString &);
+	void updateTitlePos(); // After resizing, set title to correct position
+	void plotChart();
 
 	template <typename T, class... Args>
 	T *createSeries(Args&&... args);
@@ -115,11 +119,13 @@ private:
 
 	StatsState state;
 	QtCharts::QChart *chart;
+	QFont titleFont;
 	std::vector<std::unique_ptr<StatsAxis>> axes;
 	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<Legend> legend;
 	std::vector<QuartileMarker> quartileMarkers;
 	std::vector<LineMarker> lineMarkers;
+	std::unique_ptr<QGraphicsSimpleTextItem> title;
 	StatsSeries *highlightedSeries;
 
 	// This is unfortunate: we can't derive from QChart, because the chart is allocated by QML.

--- a/stats/zvalues.h
+++ b/stats/zvalues.h
@@ -6,12 +6,12 @@
 #ifndef ZVALUES_H
 
 struct ZValues {
-	static constexpr double axes = 0.0;
-	static constexpr double series = 11.0;
-	static constexpr double seriesLabels = 12.0;
-	static constexpr double chartFeatures = 13.0;	// quartile markers and regression lines
-	static constexpr double informationBox = 14.0;
-	static constexpr double legend = 15.0;
+	static constexpr double series = 0.0;
+	static constexpr double axes = 1.0;
+	static constexpr double seriesLabels = 2.0;
+	static constexpr double chartFeatures = 3.0;	// quartile markers and regression lines
+	static constexpr double informationBox = 4.0;
+	static constexpr double legend = 5.0;
 };
 
 #endif

--- a/stats/zvalues.h
+++ b/stats/zvalues.h
@@ -6,6 +6,7 @@
 #ifndef ZVALUES_H
 
 struct ZValues {
+	static constexpr double grid = -1.0;
 	static constexpr double series = 0.0;
 	static constexpr double axes = 1.0;
 	static constexpr double seriesLabels = 2.0;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The easy step in removal of the QtCharts module: render our own axes. It's a bit ugly, but I tried to make it full configurable with constants in the various source files. It still needs some optimization concerning label sizes - it doesn't yet recognize when category labels are too large and should be replaced by ellipsis.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Render custom axes
2) Render custom grid

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh: This is only very lightly tested, but I don't think any fundamental problems will show up. Certainly a few things to optimize though.