### PR TITLE
desktop UI updates

### DIFF
--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -740,7 +740,6 @@
  </customwidgets>
  <resources>
   <include location="../subsurface.qrc"/>
-  <include location="../subsurface.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -97,7 +97,6 @@
     <addaction name="actionAutoGroup"/>
     <addaction name="separator"/>
     <addaction name="actionFilterTags"/>
-    <addaction name="actionStats"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -108,8 +107,8 @@
     <addaction name="actionViewProfile"/>
     <addaction name="actionViewInfo"/>
     <addaction name="actionViewMap"/>
-    <addaction name="actionViewStats"/>
     <addaction name="separator"/>
+    <addaction name="actionStats"/>
     <addaction name="actionYearlyStatistics"/>
     <addaction name="actionPreviousDC"/>
     <addaction name="actionNextDC"/>

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -687,6 +687,9 @@
    <property name="text">
     <string>Open c&amp;loud storage</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+O</string>
+   </property>
   </action>
   <action name="actionCloudstoragesave">
    <property name="text">


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
The first commit adds a useful shortcut that I have often missed.
The next simply removes redundant resource references that QtCreator appears to add when one isn't looking.
The third is interesting as it moves the new menu entry for the statistics into the View menu from the Log menu. Something that @bstoeger clearly considered at some point.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
maybe the Ctrl-Shift-O... but that's too subtle to mention, I think

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I need to check in how much detail we talk about the shortcuts. The opening of the statistics isn't in the user manual, yet.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @willemferguson I'm curious of your thought about the change in menu structure