### PR TITLE
statistics: add ticks at beginning and end of the axis

### DIFF
--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -411,11 +411,20 @@ void HistogramAxis::updateLabels()
 		}
 	}
 	labels.reserve((bin_values.size() - first) / step + 1);
+	// Always add a tick at the beginning of the axis - this is
+	// important for the grid, which uses the ticks.
+	if (first != 0)
+		addTick(bin_values.front().value);
+	int last = first;
 	for (int i = first; i < (int)bin_values.size(); i += step) {
 		const auto &[name, value, recommended] = bin_values[i];
 		addLabel(name, value);
 		addTick(value);
+		last = i;
 	}
+	// Always add a tick at the end of the axis (see above).
+	if (last != (int)bin_values.size() - 1)
+		addTick(bin_values.back().value);
 }
 
 // Helper function to turn days since "Unix epoch" into a timestamp_t


### PR DESCRIPTION
The grid is based on the axis ticks. If labels in histogram
axes were skipped (because there are too many bins), it could
happen that the grid was incomplete, because the first and/or
last tick were missing. Add these explicitly.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes an ugly rendering error when labels were skipped in a histogram plot.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Explicitly add ticks at the beginning and end of histogram axes.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh