### PR TITLE
statistics: fix range in categorical axes

### DIFF
--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -340,7 +340,7 @@ CategoryAxis::CategoryAxis(QtCharts::QChart *chart, const QString &title, const 
 		addTick(pos + 0.5);
 		pos += 1.0;
 	}
-	setRange(-0.5, static_cast<double>(labelsIn.size()) + 0.5);
+	setRange(-0.5, static_cast<double>(labelsIn.size()) - 0.5);
 }
 
 void CategoryAxis::updateLabels()


### PR DESCRIPTION
The range for a one-bin chart is [-0.5,0.5], thus the range
in an n-bin chart is [-0.5,n-0.5], not [-0.5,n+0.5].

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes a stupid bug - see commit message.