### PR TITLE
build.sh: recreate previous behavior with no args

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -133,6 +133,11 @@ while [[ $# -gt 0 ]] ; do
 	shift
 done
 
+# recreate the old default behavior - no flag set implies build desktop
+if [ "$BUILD_MOBILE$BUILD_DOWNLOADER" = "" ] ; then
+	BUILD_DESKTOP="1"
+fi
+
 if [ "$BUILD_DEPS" = "1" ] && [ "$QUICK" = "1" ] ; then
 	echo "Conflicting options; cannot request combine -build-deps and -quick"
 	exit 1;


### PR DESCRIPTION
When calling build.sh with no args asking for a specific build type, that
should be equivalent with calling it with the -desktop arg.

Reported-by: Salvador Cuñat <salvador.cunat@gmail.com>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
restore the previous behavior by ensuring at least one of the `BUILD_XXX` variables is set, and if none are set, assume `BUILD_DESKTOP`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3143 

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
