### PR TITLE
btdiscovery - Add second matcher for Ratio iX3M

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -116,6 +116,11 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		// but that seems to be just happenstance.
 		vendor = "Ratio";
 		product = "iX3M GPS Easy"; // we don't know which of the GPS models, so set one
+	} else if (btName.contains(QRegularExpression("^IX5M\\d{6}"))) {
+		// The 2021 iX3M models (square buttons) report as iX5M,
+		// eventhough the physical model states iX3M.
+		vendor = "Ratio";
+		product = "iX3M GPS Easy"; // we don't know which of the GPS models, so set one
 	} else if (btName == "COSMIQ") {
 		vendor = "Deepblu";
 		product = "Cosmiq+";


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
New (late 2020) iX3M hardware (referred to as 'iX3m with Squared Buttons' in the Ratio support section) appears to identify as iX5M, both in the Bluetooth name and reported version.

Add a second Bluetooth name matcher for this variation, returning the same (generic) model as is currently used.

### Changes made:
1) Additional name matcher added to btdiscovery's `getDeviceType` logic

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:

Tooling reports iX5M;
```
$ ./ratio-toolbox-x86_64.AppImage info | head -n2
Model: Ratio® iX5M GPS TECH+
Firmware version: 4.1.26/016 (English)
```

Physical device stamped as iX3M;
![20210110_214341](https://user-images.githubusercontent.com/142120/104134927-10115e80-538d-11eb-9d0c-7941e52c0c4d.jpg)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
