### PR TITLE
call invalidate_dive_cache() when editing weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- undo: save to git after editing weights [#3159]
 - desktop: complete rewrite of the statistics code, significantly expanding capabilities
 - desktop: add preferences option to disable default cylinder types
 - mobile: add ability to show fundamentally the same statistics as on the desktop

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -838,6 +838,7 @@ void ReplanDive::undo()
 	std::swap(d->duration, duration);
 	std::swap(d->salinity, salinity);
 	fixup_dive(d);
+	invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 
 	QVector<dive *> divesToNotify = { d };
 	// Note that we have to emit cylindersReset before divesChanged, because the divesChanged
@@ -875,6 +876,7 @@ void AddWeight::undo()
 			continue;
 		remove_weightsystem(d, d->weightsystems.nr - 1);
 		emit diveListNotifier.weightRemoved(d, d->weightsystems.nr);
+		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
 }
 
@@ -883,6 +885,7 @@ void AddWeight::redo()
 	for (dive *d: dives) {
 		add_cloned_weightsystem(&d->weightsystems, empty_weightsystem);
 		emit diveListNotifier.weightAdded(d, d->weightsystems.nr - 1);
+		invalidate_dive_cache(d); // Ensure that dive is written in git_save()
 	}
 }
 
@@ -954,6 +957,7 @@ void RemoveWeight::undo()
 	for (size_t i = 0; i < dives.size(); ++i) {
 		add_to_weightsystem_table(&dives[i]->weightsystems, indices[i], clone_weightsystem(ws));
 		emit diveListNotifier.weightAdded(dives[i], indices[i]);
+		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}
 }
 
@@ -962,6 +966,7 @@ void RemoveWeight::redo()
 	for (size_t i = 0; i < dives.size(); ++i) {
 		remove_weightsystem(dives[i], indices[i]);
 		emit diveListNotifier.weightRemoved(dives[i], indices[i]);
+		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}
 }
 
@@ -1012,6 +1017,7 @@ void EditWeight::redo()
 	for (size_t i = 0; i < dives.size(); ++i) {
 		set_weightsystem(dives[i], indices[i], new_ws);
 		emit diveListNotifier.weightEdited(dives[i], indices[i]);
+		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()
 	}
 	std::swap(ws, new_ws);
 }

--- a/core/dive.c
+++ b/core/dive.c
@@ -3014,7 +3014,6 @@ struct dive *make_first_dc(const struct dive *d, int dc_number)
 
 	/* make a new unique id, since we still can't handle two equal ids */
 	res->id = dive_getUniqID();
-	invalidate_dive_cache(res);
 
 	if (dc_number == 0)
 		return res;

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -34,10 +34,8 @@ void RenumberDialog::buttonClicked(QAbstractButton *button)
 		int newNr = ui.spinBox->value();
 		struct dive *d;
 		for_each_dive (i, d) {
-			if (!selectedOnly || d->selected) {
-				invalidate_dive_cache(d);
+			if (!selectedOnly || d->selected)
 				renumberedDives.append({ d, newNr++ });
-			}
 		}
 		Command::renumberDives(renumberedDives);
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Bug fix for #3150: call invalidate_dive_cache() at the appropriate places.

This also removes redundant invalidate_dive_cache() calls outside of the undo command. By moving them all to the undo machinery, the problem becomes more localized making it easier to come up with a general solution: Only ever store / pass around const-pointers to dives. To write to a dive, force a call to `get_mutable_dive`, which invalidates the dive cache.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add invalidate_dive_cache() where needed.
2) Remove invalidate_dive_cache() where redundant.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3150.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.