### PR TITLE
Statistics: Two small but important improvements to axis rendering

### DIFF
--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -16,6 +16,7 @@ public:
 	// Returns minimum and maximum of shown range, not of data points.
 	std::pair<double, double> minMax() const;
 	std::pair<double, double> minMaxScreen() const; // minimum and maximum in screen coordinates
+	std::pair<double, double> horizontalOverhang() const; // space that labels peak out in horizontal axes
 
 	double width() const;		// Only supported by vertical axes. Only valid after setSize().
 	double height() const;		// Only supported for horizontal axes. Always valid.
@@ -39,6 +40,7 @@ protected:
 	std::vector<Label> labels;
 	void addLabel(const QString &label, double pos);
 	virtual void updateLabels() = 0;
+	virtual std::pair<QString, QString> getFirstLastLabel() const = 0;
 
 	struct Tick {
 		std::unique_ptr<QGraphicsLineItem> item;
@@ -69,6 +71,7 @@ private:
 	double min, max;
 	int decimals;
 	void updateLabels() override;
+	std::pair<QString, QString> getFirstLastLabel() const override;
 };
 
 class CountAxis : public ValueAxis {
@@ -77,6 +80,7 @@ public:
 private:
 	int count;
 	void updateLabels() override;
+	std::pair<QString, QString> getFirstLastLabel() const override;
 };
 
 class CategoryAxis : public StatsAxis {
@@ -85,6 +89,7 @@ public:
 private:
 	std::vector<QString> labelsText;
 	void updateLabels();
+	std::pair<QString, QString> getFirstLastLabel() const override;
 };
 
 struct HistogramAxisEntry {
@@ -98,6 +103,7 @@ public:
 	HistogramAxis(const QString &title, std::vector<HistogramAxisEntry> bin_values, bool horizontal);
 private:
 	void updateLabels() override;
+	std::pair<QString, QString> getFirstLastLabel() const override;
 	std::vector<HistogramAxisEntry> bin_values;
 	int preferred_step;
 };

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -97,15 +97,21 @@ void StatsView::plotAreaChanged(const QSizeF &s)
 	if (title)
 		top += title->boundingRect().height() + titleBorder;
 	// Currently, we only have either none, or an x- and a y-axis
-	if (xAxis)
+	std::pair<double,double> horizontalSpace{ 0.0, 0.0 };
+	if (xAxis) {
 		bottom -= xAxis->height();
+		horizontalSpace = xAxis->horizontalOverhang();
+	}
 	if (bottom - top < minSize)
 		return;
 	if (yAxis) {
 		yAxis->setSize(bottom - top);
-		left += yAxis->width();
-		yAxis->setPos(QPointF(left, bottom));
+		horizontalSpace.first = std::max(horizontalSpace.first, yAxis->width());
 	}
+	left += horizontalSpace.first;
+	right -= horizontalSpace.second;
+	if (yAxis)
+		yAxis->setPos(QPointF(left, bottom));
 	if (right - left < minSize)
 		return;
 	if (xAxis) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Consider overhang of labels in horizontal axes when calculating the size.
2) Replace too wide labels by an ellipsis in the case of categorical axes.
