### PR TITLE
undo: set dive mode to CCR in undo command, not profile code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- undo: reset dive-mode on undo of set-point addition
 - desktop: complete rewrite of the statistics code, significantly expanding capabilities
 - desktop: add preferences option to disable default cylinder types
 - mobile: add ability to show fundamentally the same statistics as on the desktop

--- a/commands/command_event.cpp
+++ b/commands/command_event.cpp
@@ -74,9 +74,22 @@ AddEventDivemodeSwitch::AddEventDivemodeSwitch(struct dive *d, int dcNr, int sec
 }
 
 AddEventSetpointChange::AddEventSetpointChange(struct dive *d, int dcNr, int seconds, pressure_t pO2) :
-	AddEventBase(d, dcNr, create_event(seconds, SAMPLE_EVENT_PO2, 0, pO2.mbar, QT_TRANSLATE_NOOP("gettextFromC", "SP change")))
+	AddEventBase(d, dcNr, create_event(seconds, SAMPLE_EVENT_PO2, 0, pO2.mbar, QT_TRANSLATE_NOOP("gettextFromC", "SP change"))),
+	divemode(CCR)
 {
 	setText(Command::Base::tr("Add set point change")); // TODO: format pO2 value in bar or psi.
+}
+
+void AddEventSetpointChange::undoit()
+{
+	AddEventBase::undoit();
+	std::swap(get_dive_dc(d, dcNr)->divemode, divemode);
+}
+
+void AddEventSetpointChange::redoit()
+{
+	AddEventBase::redoit();
+	std::swap(get_dive_dc(d, dcNr)->divemode, divemode);
 }
 
 RenameEvent::RenameEvent(struct dive *d, int dcNr, struct event *ev, const char *name) : EventBase(d, dcNr),

--- a/commands/command_event.h
+++ b/commands/command_event.h
@@ -5,6 +5,7 @@
 #define COMMAND_EVENT_H
 
 #include "command_base.h"
+#include "core/divemode.h"
 
 // We put everything in a namespace, so that we can shorten names without polluting the global namespace
 namespace Command {
@@ -35,10 +36,11 @@ private:
 class AddEventBase : public EventBase {
 public:
 	AddEventBase(struct dive *d, int dcNr, struct event *ev); // Takes ownership of event!
-private:
-	bool workToBeDone() override;
+protected:
 	void undoit() override;
 	void redoit() override;
+private:
+	bool workToBeDone() override;
 
 	OwningEventPtr eventToAdd;	// for redo
 	event *eventToRemove;		// for undo
@@ -57,6 +59,10 @@ public:
 class AddEventSetpointChange : public AddEventBase {
 public:
 	AddEventSetpointChange(struct dive *d, int dcNr, int seconds, pressure_t pO2);
+private:
+	divemode_t divemode;	// Wonderful: this may change the divemode of the dive to CCR
+	void undoit() override;
+	void redoit() override;
 };
 
 class RenameEvent : public EventBase {

--- a/core/profile.c
+++ b/core/profile.c
@@ -345,8 +345,6 @@ static void check_setpoint_events(const struct dive *dive, struct divecomputer *
 	do {
 		i = set_setpoint(pi, i, setpoint.mbar, ev->time.seconds);
 		setpoint.mbar = ev->value;
-		if (setpoint.mbar)
-			dc->divemode = CCR;
 		ev = get_next_event(ev->next, "SP change");
 	} while (ev);
 	set_setpoint(pi, i, setpoint.mbar, INT_MAX);


### PR DESCRIPTION
When setting a CCR setpoint, the profile code(!) would turn
the dive into a CCR dive. Not only should the display layer
not alter dives, this also means that the action is not
undoable.

Move that to the appropriate undo command, where it makes
more sense, but obviously also makes things more complicated.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The divemode was not reset on undo of a setpoint addition, because the divemode was changed in the profile code of all things. This moves this to the undo code which, of course, makes things more complicated.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
FWIW, it worked in my limited testing, though I'm not even totally sure, what this should do.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Obscure, but added.
