### PR TITLE
Mobile UI tuning

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -386,17 +386,15 @@ Kirigami.ScrollablePage {
 			anchors.right: parent.right
 			anchors.leftMargin: Kirigami.Units.gridUnit / 2
 			anchors.rightMargin: Kirigami.Units.gridUnit / 2
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				visible: filterBar.height === sitefilter.implicitHeight
 				id: sitefilterMode
-				editable: false
 				model: ListModel {
 					ListElement {text: qsTr("Fulltext")}
 					ListElement {text: qsTr("People")}
 					ListElement {text: qsTr("Tags")}
 				}
 				font.pointSize: subsurfaceTheme.smallPointSize
-				Layout.preferredWidth: parent.width * 0.2
 				Layout.maximumWidth: parent.width * 0.3
 				onActivated:  {
 					manager.setFilter(sitefilter.text, currentIndex)

--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -12,7 +12,7 @@ Kirigami.ScrollablePage {
 	DiveSummaryModel { id: summaryModel }
 	property string firstDive: ""
 	property string lastDive: ""
-	property int headerColumnWidth: Math.floor(width / 3)
+	property int headerColumnWidth: Math.floor((width - Kirigami.Units.gridUnit) / 3)
 
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 	title: qsTr("Dive summary")
@@ -83,12 +83,13 @@ Kirigami.ScrollablePage {
 		TemplateButton {
 			/* Replace by signals from the core in due course. */
 			text: qsTr("Refresh")
-			implicitWidth: headerColumnWidth
+			implicitWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			onClicked: reload()
 		}
-		TemplateComboBox {
+		TemplateSlimComboBox {
 			id: selectionPrimary
-			editable: false
+			Layout.maximumWidth: headerColumnWidth - Kirigami.Units.largeSpacing
+			Layout.preferredWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			currentIndex: 0
 			model: monthModel
 			font.pointSize: subsurfaceTheme.smallPointSize
@@ -96,9 +97,10 @@ Kirigami.ScrollablePage {
 				summaryModel.calc(0, currentIndex)
 			}
 		}
-		TemplateComboBox {
+		TemplateSlimComboBox {
 			id: selectionSecondary
-			editable: false
+			Layout.maximumWidth: headerColumnWidth - Kirigami.Units.largeSpacing
+			Layout.preferredWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			currentIndex: 3
 			model: monthModel
 			font.pointSize: subsurfaceTheme.smallPointSize
@@ -110,6 +112,7 @@ Kirigami.ScrollablePage {
 		Component {
 			id: rowDelegate
 			Row {
+				Layout.leftMargin: 0
 				height: headerLabel.height + Kirigami.Units.largeSpacing
 				Rectangle {
 					width: Kirigami.Units.gridUnit
@@ -131,7 +134,7 @@ Kirigami.ScrollablePage {
 				}
 				Rectangle {
 					color: index & 1 ? subsurfaceTheme.backgroundColor : subsurfaceTheme.lightPrimaryColor
-					width: headerColumnWidth - 2 * Kirigami.Units.gridUnit
+					width: headerColumnWidth - 1.5 * Kirigami.Units.gridUnit
 					height: headerLabel.height + Kirigami.Units.largeSpacing
 					Label {
 						color: subsurfaceTheme.textColor
@@ -141,7 +144,7 @@ Kirigami.ScrollablePage {
 				}
 				Rectangle {
 					color: index & 1 ? subsurfaceTheme.backgroundColor : subsurfaceTheme.lightPrimaryColor
-					width: headerColumnWidth - 2 * Kirigami.Units.gridUnit
+					width: headerColumnWidth - 1.5 * Kirigami.Units.gridUnit
 					height: headerLabel.height + Kirigami.Units.largeSpacing
 					Label {
 						color: subsurfaceTheme.textColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -81,7 +81,7 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Cylinder:")
 				}
-				TemplateComboBox {
+				TemplateSlimComboBox {
 					id: defaultCylinderBox
 					Layout.fillWidth: true
 					onActivated: {
@@ -145,7 +145,7 @@ TemplatePage {
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 					Layout.columnSpan: 2
 				}
-				TemplateComboBox {
+				TemplateSlimComboBox {
 					editable: false
 					Layout.columnSpan: 2
 					currentIndex: (subsurfaceTheme.currentTheme === "Blue") ? 0 :

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -43,11 +43,10 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Base variable")
 			}
-			TemplateComboBox  {
+			TemplateSlimComboBox  {
 				id: var1
 				model: statsManager.var1List
 				currentIndex: statsManager.var1Index;
-				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var1Changed(currentIndex)
 				}
@@ -61,11 +60,10 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Binning")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var1Binner
 				model: statsManager.binner1List
 				currentIndex: statsManager.binner1Index;
-				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var1BinnerChanged(currentIndex)
 				}
@@ -79,7 +77,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Data")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2
 				model: statsManager.var2List
 				currentIndex: statsManager.var2Index;
@@ -97,7 +95,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Binning")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2Binner
 				model: statsManager.binner2List
 				currentIndex: statsManager.binner2Index;
@@ -115,7 +113,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Operation")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2Operation
 				model: statsManager.operation2List
 				currentIndex: statsManager.operation2Index;

--- a/mobile-widgets/qml/TemplateComboBox.qml
+++ b/mobile-widgets/qml/TemplateComboBox.qml
@@ -27,7 +27,7 @@ ComboBox {
 		id: canvas
 		x: cb.width - width - cb.rightPadding
 		y: cb.topPadding + (cb.availableHeight - height) / 2
-		width: Kirigami.Units.gridUnit
+		width: Kirigami.Units.gridUnit * 0.8
 		height: width * 0.66
 		contextType: "2d"
 		Connections {
@@ -74,7 +74,7 @@ ComboBox {
 		border.color: cb.focus ? subsurfaceTheme.darkerPrimaryColor : subsurfaceTheme.backgroundColor
 		border.width: cb.visualFocus ? 2 : 1
 		color: Qt.darker(subsurfaceTheme.backgroundColor, 1.1)
-		radius: 2
+		radius: Kirigami.Units.smallSpacing
 	}
 
 	popup: Popup {
@@ -95,7 +95,7 @@ ComboBox {
 		background: Rectangle {
 			border.color: subsurfaceTheme.darkerPrimaryColor
 			color: subsurfaceTheme.backgroundColor
-			radius: 2
+			radius: Kirigami.Units.smallSpacing
 		}
 	}
 }

--- a/mobile-widgets/qml/TemplateSlimComboBox.qml
+++ b/mobile-widgets/qml/TemplateSlimComboBox.qml
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+import org.kde.kirigami 2.4 as Kirigami
+
+TemplateComboBox {
+	id: cb
+	Layout.fillWidth: false
+	Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+	Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+	contentItem: Text {
+		text: cb.displayText
+		font.pointSize: subsurfaceTheme.regularPointSize
+		anchors.right: indicator.left
+		anchors.left: cb.left
+		color: subsurfaceTheme.textColor
+		leftPadding: Kirigami.Units.smallSpacing * 0.5
+		rightPadding: Kirigami.Units.smallSpacing * 0.5
+		verticalAlignment: Text.AlignVCenter
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -194,16 +194,19 @@ Kirigami.ApplicationWindow {
 				  Backend.cloud_verification_status === Enums.CS_VERIFIED)
 		topContent: Image {
 			source: "qrc:/qml/icons/dive.jpg"
+			// it's a 4x3 image, but clip if it takes too much space (making sure the text fits)
+			property int myHeight: Math.min(Math.max(rootItem.height * 0.3, textblock.height + Kirigami.Units.largeSpacing), parent.width * 0.75)
 			Layout.fillWidth: true
+			Layout.maximumHeight: myHeight
 			sourceSize.width: parent.width
-			fillMode: Image.PreserveAspectFit
+			fillMode: Image.PreserveAspectCrop
 			LinearGradient {
 				anchors {
 					left: parent.left
 					right: parent.right
 					top: parent.top
 				}
-				height: textblock.height * 2
+				height: Math.min(textblock.height * 2, parent.myHeight)
 				start: Qt.point(0, 0)
 				end: Qt.point(0, height)
 				gradient: Gradient {

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -4,6 +4,7 @@
 		<file>TemplateButton.qml</file>
 		<file>TemplateCheckBox.qml</file>
 		<file>TemplateComboBox.qml</file>
+		<file>TemplateSlimComboBox.qml</file>
 		<file>TemplateEditComboBox.qml</file>
 		<file>TemplateLabel.qml</file>
 		<file>TemplateLabelSmall.qml</file>

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -99,7 +99,7 @@ void StatsManager::var2BinnerChanged(int idx)
 
 void StatsManager::var2OperationChanged(int idx)
 {
-	if (uiState.var2.variables.empty())
+	if (uiState.operations2.variables.empty())
 		return;
 	idx = std::clamp(idx, 0, (int)uiState.operations2.variables.size());
 	state.var2OperationChanged(uiState.operations2.variables[idx].id);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
- fixes a crash in the mobile statistics code
- changes most of the drop down combo boxes to be "more modern looking"
- various small layout fixes to make better use of the space that's available
- crops the header image in the global drawer on small displays in landscape mode (which I think more people will be using for the statistics)
 
