### PR TITLE
Mobile chart selection

### DIFF
--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -386,17 +386,15 @@ Kirigami.ScrollablePage {
 			anchors.right: parent.right
 			anchors.leftMargin: Kirigami.Units.gridUnit / 2
 			anchors.rightMargin: Kirigami.Units.gridUnit / 2
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				visible: filterBar.height === sitefilter.implicitHeight
 				id: sitefilterMode
-				editable: false
 				model: ListModel {
 					ListElement {text: qsTr("Fulltext")}
 					ListElement {text: qsTr("People")}
 					ListElement {text: qsTr("Tags")}
 				}
 				font.pointSize: subsurfaceTheme.smallPointSize
-				Layout.preferredWidth: parent.width * 0.2
 				Layout.maximumWidth: parent.width * 0.3
 				onActivated:  {
 					manager.setFilter(sitefilter.text, currentIndex)

--- a/mobile-widgets/qml/DiveSummary.qml
+++ b/mobile-widgets/qml/DiveSummary.qml
@@ -12,7 +12,7 @@ Kirigami.ScrollablePage {
 	DiveSummaryModel { id: summaryModel }
 	property string firstDive: ""
 	property string lastDive: ""
-	property int headerColumnWidth: Math.floor(width / 3)
+	property int headerColumnWidth: Math.floor((width - Kirigami.Units.gridUnit) / 3)
 
 	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 	title: qsTr("Dive summary")
@@ -83,12 +83,13 @@ Kirigami.ScrollablePage {
 		TemplateButton {
 			/* Replace by signals from the core in due course. */
 			text: qsTr("Refresh")
-			implicitWidth: headerColumnWidth
+			implicitWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			onClicked: reload()
 		}
-		TemplateComboBox {
+		TemplateSlimComboBox {
 			id: selectionPrimary
-			editable: false
+			Layout.maximumWidth: headerColumnWidth - Kirigami.Units.largeSpacing
+			Layout.preferredWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			currentIndex: 0
 			model: monthModel
 			font.pointSize: subsurfaceTheme.smallPointSize
@@ -96,9 +97,10 @@ Kirigami.ScrollablePage {
 				summaryModel.calc(0, currentIndex)
 			}
 		}
-		TemplateComboBox {
+		TemplateSlimComboBox {
 			id: selectionSecondary
-			editable: false
+			Layout.maximumWidth: headerColumnWidth - Kirigami.Units.largeSpacing
+			Layout.preferredWidth: headerColumnWidth - Kirigami.Units.largeSpacing
 			currentIndex: 3
 			model: monthModel
 			font.pointSize: subsurfaceTheme.smallPointSize
@@ -110,6 +112,7 @@ Kirigami.ScrollablePage {
 		Component {
 			id: rowDelegate
 			Row {
+				Layout.leftMargin: 0
 				height: headerLabel.height + Kirigami.Units.largeSpacing
 				Rectangle {
 					width: Kirigami.Units.gridUnit
@@ -131,7 +134,7 @@ Kirigami.ScrollablePage {
 				}
 				Rectangle {
 					color: index & 1 ? subsurfaceTheme.backgroundColor : subsurfaceTheme.lightPrimaryColor
-					width: headerColumnWidth - 2 * Kirigami.Units.gridUnit
+					width: headerColumnWidth - 1.5 * Kirigami.Units.gridUnit
 					height: headerLabel.height + Kirigami.Units.largeSpacing
 					Label {
 						color: subsurfaceTheme.textColor
@@ -141,7 +144,7 @@ Kirigami.ScrollablePage {
 				}
 				Rectangle {
 					color: index & 1 ? subsurfaceTheme.backgroundColor : subsurfaceTheme.lightPrimaryColor
-					width: headerColumnWidth - 2 * Kirigami.Units.gridUnit
+					width: headerColumnWidth - 1.5 * Kirigami.Units.gridUnit
 					height: headerLabel.height + Kirigami.Units.largeSpacing
 					Label {
 						color: subsurfaceTheme.textColor

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -81,7 +81,7 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Cylinder:")
 				}
-				TemplateComboBox {
+				TemplateSlimComboBox {
 					id: defaultCylinderBox
 					Layout.fillWidth: true
 					onActivated: {
@@ -145,7 +145,7 @@ TemplatePage {
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 					Layout.columnSpan: 2
 				}
-				TemplateComboBox {
+				TemplateSlimComboBox {
 					editable: false
 					Layout.columnSpan: 2
 					currentIndex: (subsurfaceTheme.currentTheme === "Blue") ? 0 :

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -159,7 +159,7 @@ Kirigami.Page {
 			Layout.column: wide ? 1 : 0
 			Layout.row: wide ? 0 : 3
 			Layout.columnSpan: wide ? 1 : 3
-			Layout.rowSpan: wide ? 5 : 1
+			Layout.rowSpan: wide ? 6 : 1
 			id: statsView
 			Layout.margins: Kirigami.Units.smallSpacing
 			Layout.fillWidth: true

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -43,11 +43,10 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Base variable")
 			}
-			TemplateComboBox  {
+			TemplateSlimComboBox  {
 				id: var1
 				model: statsManager.var1List
 				currentIndex: statsManager.var1Index;
-				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var1Changed(currentIndex)
 				}
@@ -61,11 +60,10 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Binning")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var1Binner
 				model: statsManager.binner1List
 				currentIndex: statsManager.binner1Index;
-				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var1BinnerChanged(currentIndex)
 				}
@@ -79,7 +77,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Data")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2
 				model: statsManager.var2List
 				currentIndex: statsManager.var2Index;
@@ -97,7 +95,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Binning")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2Binner
 				model: statsManager.binner2List
 				currentIndex: statsManager.binner2Index;
@@ -115,7 +113,7 @@ Kirigami.Page {
 			TemplateLabelSmall {
 				text: qsTr("Operation")
 			}
-			TemplateComboBox {
+			TemplateSlimComboBox {
 				id: var2Operation
 				model: statsManager.operation2List
 				currentIndex: statsManager.operation2Index;

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -21,8 +21,10 @@ Kirigami.Page {
 	}
 	onVisibleChanged: {
 	       manager.appendTextToLog("StatisticsPage visible changed with width " + width + " with height " + rootItem.height + " we are " + (statisticsPage.wide ? "in" : "not in") + " wide mode")
-		if (visible)
+		if (visible) {
+			updateCharts()
 			statsManager.doit()
+		}
 	}
 	onWidthChanged: {
 		if (visible) {
@@ -30,6 +32,28 @@ Kirigami.Page {
 						 (statisticsPage.wide ? "in" : "not in") + " wide mode - screen " + Screen.width + " x " + Screen.height )
 			statsManager.doit()
 		}
+	}
+	function executeAction(actionText) {
+		statsManager.setChart(actionText)
+	}
+	function updateCharts() {
+		var charts = []
+		for(var chart in chartList) {
+			var chartKey = chartList[chart]
+			var keyParts = chartKey.split(':')
+			var newAction = Qt.createQmlObject('import QtQuick 2.6; import org.kde.kirigami 2.4 as Kirigami;' +
+							   'Kirigami.Action { text: "' + keyParts[0] + '"; onTriggered: { executeAction(' + keyParts[1] + ') }}',
+							   statisticsPage,
+							   "dynamicAction");
+			charts.push(newAction)
+		}
+		statisticsPage.contextualActions = charts
+	}
+
+	property var chartList: statsManager.chartList
+
+	onChartListChanged: {
+		updateCharts()
 	}
 
 	GridLayout {

--- a/mobile-widgets/qml/TemplateComboBox.qml
+++ b/mobile-widgets/qml/TemplateComboBox.qml
@@ -27,7 +27,7 @@ ComboBox {
 		id: canvas
 		x: cb.width - width - cb.rightPadding
 		y: cb.topPadding + (cb.availableHeight - height) / 2
-		width: Kirigami.Units.gridUnit
+		width: Kirigami.Units.gridUnit * 0.8
 		height: width * 0.66
 		contextType: "2d"
 		Connections {
@@ -74,7 +74,7 @@ ComboBox {
 		border.color: cb.focus ? subsurfaceTheme.darkerPrimaryColor : subsurfaceTheme.backgroundColor
 		border.width: cb.visualFocus ? 2 : 1
 		color: Qt.darker(subsurfaceTheme.backgroundColor, 1.1)
-		radius: 2
+		radius: Kirigami.Units.smallSpacing
 	}
 
 	popup: Popup {
@@ -95,7 +95,7 @@ ComboBox {
 		background: Rectangle {
 			border.color: subsurfaceTheme.darkerPrimaryColor
 			color: subsurfaceTheme.backgroundColor
-			radius: 2
+			radius: Kirigami.Units.smallSpacing
 		}
 	}
 }

--- a/mobile-widgets/qml/TemplateSlimComboBox.qml
+++ b/mobile-widgets/qml/TemplateSlimComboBox.qml
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+import org.kde.kirigami 2.4 as Kirigami
+
+TemplateComboBox {
+	id: cb
+	Layout.fillWidth: false
+	Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+	Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+	contentItem: Text {
+		text: cb.displayText
+		font.pointSize: subsurfaceTheme.regularPointSize
+		anchors.right: indicator.left
+		anchors.left: cb.left
+		color: subsurfaceTheme.textColor
+		leftPadding: Kirigami.Units.smallSpacing * 0.5
+		rightPadding: Kirigami.Units.smallSpacing * 0.5
+		verticalAlignment: Text.AlignVCenter
+	}
+}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -194,16 +194,19 @@ Kirigami.ApplicationWindow {
 				  Backend.cloud_verification_status === Enums.CS_VERIFIED)
 		topContent: Image {
 			source: "qrc:/qml/icons/dive.jpg"
+			// it's a 4x3 image, but clip if it takes too much space (making sure the text fits)
+			property int myHeight: Math.min(Math.max(rootItem.height * 0.3, textblock.height + Kirigami.Units.largeSpacing), parent.width * 0.75)
 			Layout.fillWidth: true
+			Layout.maximumHeight: myHeight
 			sourceSize.width: parent.width
-			fillMode: Image.PreserveAspectFit
+			fillMode: Image.PreserveAspectCrop
 			LinearGradient {
 				anchors {
 					left: parent.left
 					right: parent.right
 					top: parent.top
 				}
-				height: textblock.height * 2
+				height: Math.min(textblock.height * 2, parent.myHeight)
 				start: Qt.point(0, 0)
 				end: Qt.point(0, height)
 				gradient: Gradient {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -109,10 +109,12 @@ Kirigami.ApplicationWindow {
 		if (page === statistics) {
 			manager.appendTextToLog("switching to statistics page, clearing out stack")
 			pageStack.clear()
+			contextDrawer.title = qsTr("Chart type")
 		}
 		if (pageStack.currentItem === statistics) {
 			manager.appendTextToLog("switching away from statistics page, clearing out stack")
 			pageStack.clear()
+			contextDrawer.title = qsTr("Actions")
 		}
 
 		if (page !== mapPage)

--- a/mobile-widgets/qml/mobile-resources.qrc
+++ b/mobile-widgets/qml/mobile-resources.qrc
@@ -4,6 +4,7 @@
 		<file>TemplateButton.qml</file>
 		<file>TemplateCheckBox.qml</file>
 		<file>TemplateComboBox.qml</file>
+		<file>TemplateSlimComboBox.qml</file>
 		<file>TemplateEditComboBox.qml</file>
 		<file>TemplateLabel.qml</file>
 		<file>TemplateLabelSmall.qml</file>

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -99,7 +99,7 @@ void StatsManager::var2BinnerChanged(int idx)
 
 void StatsManager::var2OperationChanged(int idx)
 {
-	if (uiState.var2.variables.empty())
+	if (uiState.operations2.variables.empty())
 		return;
 	idx = std::clamp(idx, 0, (int)uiState.operations2.variables.size());
 	state.var2OperationChanged(uiState.operations2.variables[idx].id);

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -52,6 +52,7 @@ void StatsManager::updateUi()
 	setVariableList(uiState.var2, var2List, var2Index);
 	setBinnerList(uiState.binners2, binner2List, binner2Index);
 	setVariableList(uiState.operations2, operation2List, operation2Index);
+	chartList = state.usableCharts();
 	var1ListChanged();
 	binner1ListChanged();
 	var2ListChanged();
@@ -62,6 +63,7 @@ void StatsManager::updateUi()
 	var2IndexChanged();
 	binner2IndexChanged();
 	operation2IndexChanged();
+	chartListChanged();
 
 	if (view)
 		view->plot(state);
@@ -103,5 +105,11 @@ void StatsManager::var2OperationChanged(int idx)
 		return;
 	idx = std::clamp(idx, 0, (int)uiState.operations2.variables.size());
 	state.var2OperationChanged(uiState.operations2.variables[idx].id);
+	updateUi();
+}
+
+void StatsManager::setChart(int id)
+{
+	state.chartChanged(id);
 	updateUi();
 }

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -3,10 +3,10 @@
 
 StatsManager::StatsManager() : view(nullptr)
 {
-	// Test: show some random data. Let's see what happens.
-	state.var1Changed(2);
-	state.var2Changed(3);
-	state.binner2Changed(2);
+	// Default chart is dives per year
+	state.var1Changed(0);
+	state.var2Changed(0);
+	state.binner2Changed(0);
 	updateUi();
 }
 

--- a/mobile-widgets/statsmanager.h
+++ b/mobile-widgets/statsmanager.h
@@ -15,6 +15,7 @@ public:
 	Q_PROPERTY(QStringList var2List MEMBER var2List NOTIFY var2ListChanged)
 	Q_PROPERTY(QStringList binner2List MEMBER binner2List NOTIFY binner2ListChanged)
 	Q_PROPERTY(QStringList operation2List MEMBER operation2List NOTIFY operation2ListChanged)
+	Q_PROPERTY(QStringList chartList MEMBER chartList NOTIFY chartListChanged)
 	Q_PROPERTY(int var1Index MEMBER var1Index NOTIFY var1IndexChanged)
 	Q_PROPERTY(int binner1Index MEMBER binner1Index NOTIFY binner1IndexChanged)
 	Q_PROPERTY(int var2Index MEMBER var2Index NOTIFY var2IndexChanged)
@@ -30,12 +31,14 @@ public:
 	Q_INVOKABLE void var2Changed(int idx);
 	Q_INVOKABLE void var2BinnerChanged(int idx);
 	Q_INVOKABLE void var2OperationChanged(int idx);
+	Q_INVOKABLE void setChart(int i);
 signals:
 	void var1ListChanged();
 	void binner1ListChanged();
 	void var2ListChanged();
 	void binner2ListChanged();
 	void operation2ListChanged();
+	void chartListChanged();
 	void var1IndexChanged();
 	void binner1IndexChanged();
 	void var2IndexChanged();
@@ -49,6 +52,7 @@ private:
 	QStringList var2List;
 	QStringList binner2List;
 	QStringList operation2List;
+	QStringList chartList;
 	int var1Index;
 	int binner1Index;
 	int var2Index;
@@ -56,7 +60,6 @@ private:
 	int operation2Index;
 	StatsState::UIState uiState;	// Remember UI state so that we can interpret indexes
 	void updateUi();
-
 };
 
 #endif

--- a/stats/statsstate.cpp
+++ b/stats/statsstate.cpp
@@ -265,6 +265,27 @@ const std::vector<std::pair<const ChartTypeDesc &, bool>> validCharts(const Stat
 	return res;
 }
 
+// provide list of usable charts - if there are 'good' ones, then only those, otherwise 'undesired' ones
+// this is returned as QStringList as it is used as in the mobile UI
+QStringList StatsState::usableCharts()
+{
+	QStringList resGood, resOK;
+	for (const ChartTypeDesc &desc: chart_types) {
+		ChartValidity valid = chartValidity(desc, var1, var2, var1Binner, var2Binner, var2Operation);
+		if (valid == ChartValidity::Invalid)
+			continue;
+		for (ChartSubType subtype: desc.subtypes) {
+			int key = toInt(desc.id, subtype);
+			QString chartDesc = QString("%1/%2:%3").arg(desc.name).arg(chart_subtype_names[(int)subtype]).arg(key);
+			if (valid == ChartValidity::Good)
+				resGood.append(chartDesc);
+			else
+				resOK.append(chartDesc);
+		}
+	}
+	return resGood.isEmpty() ? resOK : resGood;
+}
+
 static StatsState::ChartList createChartList(const StatsVariable *var1, const StatsVariable *var2,
 					     const StatsBinner *binner1, const StatsBinner *binner2,
 					     StatsOperation operation,

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -111,6 +111,8 @@ public:
 	const StatsBinner *var1Binner;	// nullptr: undefined
 	const StatsBinner *var2Binner;	// nullptr: undefined
 	StatsOperation var2Operation;
+	QStringList usableCharts();
+
 private:
 	void validate(bool varChanged);
 	int chartFeatures;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add the ability to pick the chart used to the mobile UI

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) create a helper in the `StatsState` to get a list of usable charts - prefer `Good`, use `Undesirable` if there are none
2) encode the magic chart ID in that list
3) make all this available to the QML code via the `StatsManager` and allow the selection of the chart via magic ID
4) dynamically create a list of actions at run time that are shown in the context menu of the stats page and allow the user to switch charts

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
This includes #3159 almost by mistake - but the UI looks like crap without that one

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
clearly this need to be captured in the as yet to be written manual

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger can I get you to definitely take a look at the two C++ helpers?