### PR TITLE
Mobile chart selection

### DIFF
--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -135,7 +135,7 @@ Kirigami.Page {
 			Layout.column: wide ? 1 : 0
 			Layout.row: wide ? 0 : 3
 			Layout.columnSpan: wide ? 1 : 3
-			Layout.rowSpan: wide ? 5 : 1
+			Layout.rowSpan: wide ? 6 : 1
 			id: statsView
 			Layout.margins: Kirigami.Units.smallSpacing
 			Layout.fillWidth: true

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -20,14 +20,11 @@ Kirigami.Page {
 		id: statsManager
 	}
 	onVisibleChanged: {
-	       manager.appendTextToLog("StatisticsPage visible changed with width " + width + " with height " + rootItem.height + " we are " + (statisticsPage.wide ? "in" : "not in") + " wide mode")
 		if (visible)
 			statsManager.doit()
 	}
 	onWidthChanged: {
 		if (visible) {
-			manager.appendTextToLog("StatisticsPage width changed to " + width + " with height " + height + " we are " +
-						 (statisticsPage.wide ? "in" : "not in") + " wide mode - screen " + Screen.width + " x " + Screen.height )
 			statsManager.doit()
 		}
 	}

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -19,6 +19,9 @@ Kirigami.Page {
 	StatsManager {
 		id: statsManager
 	}
+	ChartListModel {
+		id: chartListModel
+	}
 	onVisibleChanged: {
 		if (visible)
 			statsManager.doit()
@@ -26,6 +29,53 @@ Kirigami.Page {
 	onWidthChanged: {
 		if (visible) {
 			statsManager.doit()
+		}
+	}
+
+	Component {
+		id: chartListDelegate
+		Kirigami.AbstractListItem {
+			id: chartListDelegateItem
+			height: isHeader ? 1 + 8 * Kirigami.Units.smallSpacing : 11 * Kirigami.Units.smallSpacing // delegateInnerItem.height
+			onClicked: {
+				if (!isHeader) {
+					chartTypePopup.close()
+					statsManager.setChart(id)
+				}
+			}
+			Item {
+				id: chartListDelegateInnerItem
+				Row {
+					height: childrenRect.height
+					spacing: Kirigami.Units.smallSpacing
+					Kirigami.Icon {
+						id: chartIcon
+						source: icon
+						width: iconSize !== undefined ? iconSize.width : 0
+					}
+					Label {
+						text: chartName
+						font.bold: isHeader
+					}
+				}
+			}
+		}
+	}
+	Popup {
+		id: chartTypePopup
+		x: Kirigami.Units.gridUnit * 2
+		y: Kirigami.Units.gridUnit
+		width: Math.min(Kirigami.Units.gridUnit * 12, statisticsPage.width * 0.6)
+		height: Math.min(statisticsPage.height - 3 * Kirigami.Units.gridUnit, chartListModel.count * Kirigami.Units.gridUnit * 2.75)
+		modal: true
+		focus: true
+		clip: true
+		closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+		ListView {
+			id: chartTypes
+			model: chartListModel
+			anchors.fill: parent
+			delegate: chartListDelegate
 		}
 	}
 
@@ -120,19 +170,40 @@ Kirigami.Page {
 				}
 			}
 		}
-		Item {
+		Button {
+			id: chartTypeButton
 			Layout.column: wide ? 0 : 1
 			Layout.row: wide ? 5 : 2
+			Layout.leftMargin: Kirigami.Units.smallSpacing
+			Layout.topMargin: Kirigami.Units.largeSpacing
+			Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+			Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+			background: Rectangle {
+				color: chartTypeButton.pressed ? subsurfaceTheme.darkerPrimaryColor : subsurfaceTheme.primaryColor
+				antialiasing: true
+				radius: Kirigami.Units.smallSpacing * 2
+				height: Kirigami.Units.gridUnit * 2
+			}
+			contentItem: Text {
+				verticalAlignment: Qt.AlignVCenter
+				horizontalAlignment: Qt.AlignHCenter
+				color: subsurfaceTheme.primaryTextColor
+				text: qsTr("Chart type")
+			}
+			onClicked: chartTypePopup.open()
+		}
+		Item {
+			Layout.column: wide ? 0 : 1
+			Layout.row: wide ? 6 : 2
 			Layout.preferredHeight: wide ? parent.height - Kirigami.Units.gridUnit * 16 : Kirigami.Units.gridUnit
 			Layout.preferredWidth: wide ? parent.width - i1.implicitWidt - i2.implicitWidt - i3.implicitWidt - i4.implicitWidth : Kirigami.Units.gridUnit
 			// just used for spacing
 		}
-
 		StatsView {
 			Layout.column: wide ? 1 : 0
 			Layout.row: wide ? 0 : 3
 			Layout.columnSpan: wide ? 1 : 3
-			Layout.rowSpan: wide ? 6 : 1
+			Layout.rowSpan: wide ? 7 : 1
 			id: statsView
 			Layout.margins: Kirigami.Units.smallSpacing
 			Layout.fillWidth: true
@@ -148,7 +219,7 @@ Kirigami.Page {
 		}
 	}
 	Component.onCompleted: {
-		statsManager.init(statsView, var1)
+		statsManager.init(statsView, chartListModel)
 		console.log("Statistics widget loaded")
 	}
 }

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -3,10 +3,6 @@
 
 StatsManager::StatsManager() : view(nullptr)
 {
-	// Test: show some random data. Let's see what happens.
-	state.var1Changed(2);
-	state.var2Changed(3);
-	state.binner2Changed(2);
 	updateUi();
 }
 

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsmanager.h"
+#include "stats/chartlistmodel.h"
 
-StatsManager::StatsManager() : view(nullptr)
+StatsManager::StatsManager() : view(nullptr), charts(nullptr)
 {
 	updateUi();
 }
@@ -10,18 +11,19 @@ StatsManager::~StatsManager()
 {
 }
 
-void StatsManager::init(StatsView *v, QObject *o)
+void StatsManager::init(StatsView *v, ChartListModel *m)
 {
 	if (!v)
 		fprintf(stderr, "StatsManager::init(): no StatsView - statistics will not work.\n");
+	if (!m)
+		fprintf(stderr, "StatsManager::init(): no ChartListModel - statistics will not work.\n");
 	view = v;
+	charts = m;
 }
 
 void StatsManager::doit()
 {
-	if (!view)
-		return;
-	view->plot(state);
+	updateUi();
 }
 
 static void setVariableList(const StatsState::VariableList &list, QStringList &stringList, int &idx)
@@ -59,6 +61,8 @@ void StatsManager::updateUi()
 	binner2IndexChanged();
 	operation2IndexChanged();
 
+	if (charts)
+		charts->update(uiState.charts);
 	if (view)
 		view->plot(state);
 }
@@ -99,5 +103,11 @@ void StatsManager::var2OperationChanged(int idx)
 		return;
 	idx = std::clamp(idx, 0, (int)uiState.operations2.variables.size());
 	state.var2OperationChanged(uiState.operations2.variables[idx].id);
+	updateUi();
+}
+
+void StatsManager::setChart(int idx)
+{
+	state.chartChanged(idx);
 	updateUi();
 }

--- a/mobile-widgets/statsmanager.h
+++ b/mobile-widgets/statsmanager.h
@@ -7,6 +7,8 @@
 
 #include <QStringList>
 
+class ChartListModel;
+
 class StatsManager : public QObject {
 	Q_OBJECT
 public:
@@ -23,13 +25,14 @@ public:
 
 	StatsManager();
 	~StatsManager();
-	Q_INVOKABLE void init(StatsView *v, QObject *o);
+	Q_INVOKABLE void init(StatsView *v, ChartListModel *charts);
 	Q_INVOKABLE void doit();
 	Q_INVOKABLE void var1Changed(int idx);
 	Q_INVOKABLE void var1BinnerChanged(int idx);
 	Q_INVOKABLE void var2Changed(int idx);
 	Q_INVOKABLE void var2BinnerChanged(int idx);
 	Q_INVOKABLE void var2OperationChanged(int idx);
+	Q_INVOKABLE void setChart(int idx);
 signals:
 	void var1ListChanged();
 	void binner1ListChanged();
@@ -43,6 +46,7 @@ signals:
 	void operation2IndexChanged();
 private:
 	StatsView *view;
+	ChartListModel *charts;
 	StatsState state;
 	QStringList var1List;
 	QStringList binner1List;

--- a/stats/chartlistmodel.cpp
+++ b/stats/chartlistmodel.cpp
@@ -7,7 +7,7 @@
 #include <QPainter>
 
 ChartListModel::ChartListModel() :
-	itemFont(defaultModelFont()), 
+	itemFont(defaultModelFont()),
 	headerFont(itemFont.family(), itemFont.pointSize(), itemFont.weight(), true)
 {
 	QFontMetrics fm(itemFont);
@@ -127,5 +127,6 @@ int ChartListModel::update(const StatsState::ChartList &charts)
 		items.push_back({ false, chart.subtypeName, fullName, chart.subtype, chart.id, chart.warning });
 	}
 	endResetModel();
+	emit countChanged();
 	return res;
 }

--- a/stats/chartlistmodel.cpp
+++ b/stats/chartlistmodel.cpp
@@ -60,6 +60,18 @@ Qt::ItemFlags ChartListModel::flags(const QModelIndex &index) const
 				   : Qt::ItemIsSelectable | Qt::ItemIsEnabled;
 }
 
+QHash<int, QByteArray> ChartListModel::roleNames() const
+{
+	QHash<int, QByteArray> roles;
+	roles[Qt::DisplayRole] = "display";
+	roles[IconRole] = "icon";
+	roles[IconSizeRole] = "iconSize";
+	roles[ChartNameRole] = "chartName";
+	roles[IsHeaderRole] = "isHeader";
+	roles[Qt::UserRole] = "id";
+	return roles;
+}
+
 QVariant ChartListModel::data(const QModelIndex &index, int role) const
 {
 	int row = index.row();

--- a/stats/chartlistmodel.h
+++ b/stats/chartlistmodel.h
@@ -24,6 +24,12 @@ public:
 	static const constexpr int IsHeaderRole = Qt::UserRole + 2;
 	static const constexpr int IconRole = Qt::UserRole + 3;
 	static const constexpr int IconSizeRole = Qt::UserRole + 4;
+
+	Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+
+signals:
+	void countChanged();
+
 private:
 	struct Item {
 		bool isHeader;
@@ -45,7 +51,7 @@ private:
 	QFont headerFont;
 	std::vector<Item> items;
 	QHash<int, QByteArray> roleNames() const override;
-	int rowCount(const QModelIndex &parent) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	void initIcon(ChartSubType type, const char *name, int iconSize);

--- a/stats/chartlistmodel.h
+++ b/stats/chartlistmodel.h
@@ -44,6 +44,7 @@ private:
 	QFont itemFont;
 	QFont headerFont;
 	std::vector<Item> items;
+	QHash<int, QByteArray> roleNames() const override;
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex &index, int role) const override;
 	Qt::ItemFlags flags(const QModelIndex &index) const override;

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -17,6 +17,7 @@
 #include "mobile-widgets/qmlmanager.h"
 #include "mobile-widgets/qmlinterface.h"
 #include "mobile-widgets/statsmanager.h"
+#include "stats/chartlistmodel.h"
 #include "qt-models/divesummarymodel.h"
 #include "qt-models/gpslistmodel.h"
 #include "qt-models/messagehandlermodel.h"
@@ -212,6 +213,7 @@ static void register_qml_types(QQmlEngine *engine)
 	register_qml_type<QMLProfile>("QMLProfile");
 	register_qml_type<DiveImportedModel>("DCImportModel");
 	register_qml_type<DiveSummaryModel>("DiveSummaryModel");
+	register_qml_type<ChartListModel>("ChartListModel");
 #endif // not SUBSURFACE_MOBILE
 
 	register_qml_type<MapWidgetHelper>("MapWidgetHelper");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
With all due respect to @bstoeger and #3162 - I think this is maybe slightly more reasonable

I gave up on doing this in the context drawer since Berthold thought this was a terrible idea, instead I took some liberty with his idea of a popup driven by a button, including actually showing the icons that he so carefully exported, styling the whole thing, placing it in the right spot in the layout, etc...
