### PR TITLE
mobile/GPS: fix two errors in the GPS handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - undo: reset dive-mode on undo of set-point addition
 - desktop: complete rewrite of the statistics code, significantly expanding capabilities
 - desktop: add preferences option to disable default cylinder types
+- mobile: fix broken 'use current location' in dive edit
 - mobile: add ability to show fundamentally the same statistics as on the desktop
 - mobile: add settings for DC and calculated ceilings and show calculated ceilings
 - mobile: switch to newer version of Kirigami

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -126,7 +126,7 @@ QString GpsLocation::currentPosition()
 	if (!hasLocationsSource())
 		return tr("Unknown GPS location (no GPS source)");
 	if (m_trackers.count()) {
-		QDateTime lastFixTime =	timestampToDateTime(m_trackers.lastKey() + gettimezoneoffset());
+		QDateTime lastFixTime =	timestampToDateTime(m_trackers.lastKey() - gettimezoneoffset());
 		QDateTime now = QDateTime::currentDateTime();
 		int delta = lastFixTime.secsTo(now);
 		qDebug() << "lastFixTime" << lastFixTime.toString() << "now" << now.toString() << "delta" << delta;
@@ -168,14 +168,13 @@ void GpsLocation::newPosition(QGeoPositionInfo pos)
 	    lastCoord.distanceTo(pos.coordinate()) > prefs.distance_threshold) {
 		QString msg = QStringLiteral("received new position %1 after delta %2 threshold %3 (now %4 last %5)");
 		status(qPrintable(msg.arg(pos.coordinate().toString()).arg(delta).arg(prefs.time_threshold).arg(pos.timestamp().toString()).arg(timestampToDateTime(lastTime).toString())));
-		waitingForPosition = false;
-		acquiredPosition();
 		gpsTracker gt;
 		gt.when = thisTime;
 		gt.location = create_location(pos.coordinate().latitude(), pos.coordinate().longitude());
 		addFixToStorage(gt);
 		gpsTracker gtNew = m_trackers.last();
-		qDebug() << "newest fix is now at" << timestampToDateTime(gtNew.when - gettimezoneoffset()).toString();
+		waitingForPosition = false;
+		acquiredPosition();
 	}
 }
 

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -204,6 +204,7 @@ Item {
 				target: manager
 				onWaitingForPositionChanged: {
 					gpsText = manager.getCurrentPosition()
+					manager.appendTextToLog("received updated position info " + gpsText)
 				}
 			}
 


### PR DESCRIPTION
First, the time zone adjustment was wrong - this as written could only
ever have worked in UTC or by pure chance.

Second, the order of alerting the UI of the availability of a GPS fix
was also incorrect creating a race between the UI and our data
structures.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'm doing a much larger rewrite of the mobile dive edit, and while playing with that I noticed that the 'use current location' thing was completely broken and cannot possibly have worked.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- fix timezone calculation
- don't notify of new GPS fix until it has been added to the data structure where the UI code will look for it

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
included

