### PR TITLE
mobile/UI: update dive edit layout and other UI updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - undo: reset dive-mode on undo of set-point addition
 - desktop: complete rewrite of the statistics code, significantly expanding capabilities
 - desktop: add preferences option to disable default cylinder types
+- mobile: redesigned dive edit experience
 - mobile: fix broken 'use current location' in dive edit
 - mobile: add ability to show fundamentally the same statistics as on the desktop
 - mobile: add settings for DC and calculated ceilings and show calculated ceilings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ endif()
 #set up the subsurface_link_libraries variable
 set(SUBSURFACE_LINK_LIBRARIES ${SUBSURFACE_LINK_LIBRARIES} ${LIBDIVECOMPUTER_LIBRARIES} ${LIBGIT2_LIBRARIES} ${LIBUSB_LIBRARIES} ${LIBMTP_LIBRARIES})
 if (NOT SUBSURFACE_TARGET_EXECUTABLE MATCHES "DownloaderExecutable")
-	qt5_add_resources(SUBSURFACE_RESOURCES subsurface.qrc map-widget/qml/map-widget.qrc desktop-widgets/qml/statsview2.qrc)
+	qt5_add_resources(SUBSURFACE_RESOURCES subsurface.qrc stats/statsicons.qrc map-widget/qml/map-widget.qrc desktop-widgets/qml/statsview2.qrc)
 endif()
 
 # hack to build successfully on LGTM

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -334,7 +334,8 @@ HEADERS += \
 
 RESOURCES += mobile-widgets/qml/mobile-resources.qrc \
 		mobile-widgets/3rdparty/icons.qrc \
-		map-widget/qml/map-widget.qrc
+		map-widget/qml/map-widget.qrc \
+		stats/statsicons.qrc
 
 android {
 	SOURCES += core/android.cpp \

--- a/core/metrics.cpp
+++ b/core/metrics.cpp
@@ -24,7 +24,6 @@ IconMetrics::IconMetrics() :
 QFont defaultModelFont()
 {
 	QFont font;
-//	font.setPointSizeF(font.pointSizeF() * 0.8);
 	return font;
 }
 

--- a/core/qt-gui.h
+++ b/core/qt-gui.h
@@ -10,7 +10,7 @@ void set_non_bt_addresses();
 
 #if defined(SUBSURFACE_MOBILE)
 #include <QQuickWindow>
-void run_mobile_ui();
+void run_mobile_ui(double initial_font_size);
 #else
 void run_ui();
 #endif

--- a/core/qt-gui.h
+++ b/core/qt-gui.h
@@ -5,12 +5,14 @@
 void init_qt_late();
 void init_ui();
 
-void run_ui();
 void exit_ui();
 void set_non_bt_addresses();
 
 #if defined(SUBSURFACE_MOBILE)
 #include <QQuickWindow>
+void run_mobile_ui();
+#else
+void run_ui();
 #endif
 
 #endif // QT_GUI_H

--- a/mobile-widgets/3rdparty/0005-breadcrumbs-get-better-font-size.patch
+++ b/mobile-widgets/3rdparty/0005-breadcrumbs-get-better-font-size.patch
@@ -5,26 +5,9 @@ Subject: [PATCH 05/11] breadcrumbs: get better font size
 
 Signed-off-by: Dirk Hohndel <dirk@hohndel.org>
 ---
- src/controls/Units.qml                                   | 5 +++++
  src/controls/private/globaltoolbar/BreadcrumbControl.qml | 1 +
- 2 files changed, 6 insertions(+)
+ 1 file changed, 1 insertion(+)
 
-diff --git a/src/controls/Units.qml b/src/controls/Units.qml
-index 615228a2..f957046f 100644
---- a/src/controls/Units.qml
-+++ b/src/controls/Units.qml
-@@ -105,6 +105,11 @@ QtObject {
-      */
-     readonly property int wheelScrollLines: 3
- 
-+    /**
-+     * Use this to hardcode the font size of the global toolbar that Kirigami gets wrong
-+     */
-+    property double defaultFontSize: fontMetrics.font.pixelSize
-+
-     /**
-      * metrics used by the default font
-      */
 diff --git a/src/controls/private/globaltoolbar/BreadcrumbControl.qml b/src/controls/private/globaltoolbar/BreadcrumbControl.qml
 index ad80d222..c45db280 100644
 --- a/src/controls/private/globaltoolbar/BreadcrumbControl.qml
@@ -33,7 +16,7 @@ index ad80d222..c45db280 100644
                      }
                      Kirigami.Heading {
                          Layout.leftMargin: Kirigami.Units.largeSpacing
-+                        font.pixelSize: Math.max(1, Kirigami.Units.defaultFontSize)
++                        font: Kirigami.Theme.defaultFont
                          color: Kirigami.Theme.textColor
                          verticalAlignment: Text.AlignVCenter
                          wrapMode: Text.NoWrap

--- a/mobile-widgets/3rdparty/0017-make-space-for-button-in-passive-notification.patch
+++ b/mobile-widgets/3rdparty/0017-make-space-for-button-in-passive-notification.patch
@@ -1,0 +1,28 @@
+From a0532ed879b5068ce64a9d5e5464d36507a9a92a Mon Sep 17 00:00:00 2001
+From: Dirk Hohndel <dirk@hohndel.org>
+Date: Sun, 17 Jan 2021 17:31:22 -0800
+Subject: [PATCH 17/17] make space for button in passive notification
+
+Not sure how this is supposed to work otherwise.
+
+Signed-off-by: Dirk Hohndel <dirk@hohndel.org>
+---
+ src/controls/templates/private/PassiveNotification.qml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/controls/templates/private/PassiveNotification.qml b/src/controls/templates/private/PassiveNotification.qml
+index ceb57aca..aaa438ae 100644
+--- a/src/controls/templates/private/PassiveNotification.qml
++++ b/src/controls/templates/private/PassiveNotification.qml
+@@ -172,7 +172,7 @@ Controls.Popup {
+                 Controls.Label {
+                     id: label
+                     color: subsurfaceTheme.primaryTextColor
+-                    Layout.maximumWidth: Math.min(root.parent.width - Kirigami.Units.largeSpacing * 4, implicitWidth)
++                    Layout.maximumWidth: Math.min(root.parent.width - actionButton.implicitWidth - Kirigami.Units.largeSpacing * 4, implicitWidth)
+                     elide: Text.ElideRight
+                     wrapMode: Text.WordWrap
+                     maximumLineCount: 4
+-- 
+2.29.2
+

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -115,7 +115,7 @@ Kirigami.Page {
 		enabled: manager.redoText !== ""
 		onTriggered: manager.redo()
 	}
-	property variant contextactions: [ removeDiveFromTripAction, addDiveToTripAboveAction, addDiveToTripBelowAction, undoAction, redoAction ]
+	property variant contextactions: [ removeDiveFromTripAction, addDiveToTripAboveAction, addDiveToTripBelowAction, deleteAction, undoAction, redoAction ]
 
 	states: [
 		State {
@@ -123,7 +123,7 @@ Kirigami.Page {
 			PropertyChanges {
 				target: diveDetailsPage;
 				actions {
-					right: deleteAction
+					right: null
 					left: currentItem ? (currentItem.modelData && currentItem.modelData.gps !== "" ? mapAction : null) : null
 				}
 				contextualActions: contextactions

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -788,21 +788,26 @@ Item {
 					selectByMouse: true
 					wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 					property bool firstTime: true
-					property int visibleTop: detailsEditFlickable.contentY
-					property int visibleBottom: visibleTop + detailsEditFlickable.height - 4 * Kirigami.Units.gridUnit
 					onPressed: waitForKeyboard.start()
 					onCursorRectangleChanged: {
-						ensureVisible(y + cursorRectangle.y)
+						ensureVisible()
 					}
-
 					// ensure that the y coordinate is inside the visible part of the detailsEditFlickable (our flickable)
-					function ensureVisible(yDest) {
-						if (yDest > visibleBottom)
-							detailsEditFlickable.contentY += yDest - visibleBottom
-						if (yDest < visibleTop)
-							detailsEditFlickable.contentY -= visibleTop - yDest
+					function ensureVisible() {
+						// make sure there's enough space for the TextArea above the keyboard and action button
+						// and that it's not too far up, either
+						var flickable = detailsEditFlickable
+						var positionInFlickable = txtNotes.mapToItem(flickable.contentItem, 0, 0)
+						var taY = positionInFlickable.y + cursorRectangle.y
+						if (manager.verboseEnabled)
+							manager.appendTextToLog("position check: lower edge of view is " +
+										    (0 + flickable.contentY + flickable.height) +
+										    " and text area is at " + taY)
+						if (taY > flickable.contentY + flickable.height - 4 * Kirigami.Units.gridUnit)
+							flickable.contentY = Math.max(0, 4 * Kirigami.Units.gridUnit + taY - flickable.height)
+						while (taY < flickable.contentY)
+							flickable.contentY -= 2 * Kirigami.Units.gridUnit
 					}
-
 					// give the OS enough time to actually resize the flickable
 					Timer {
 						id: waitForKeyboard
@@ -816,7 +821,7 @@ Item {
 								return
 							}
 							// make sure at least half the Notes field is visible
-							txtNotes.ensureVisible(txtNotes.y + txtNotes.cursorRectangle.y)
+							txtNotes.ensureVisible()
 						}
 					}
 				}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -84,31 +84,31 @@ Item {
 		var state =  diveDetailsPage.state
 		diveDetailsPage.state = "view" // run the transition
 		// join cylinder info from separate string into a list.
-		if (usedCyl[0] != null) {
+		if (usedCyl[0] !== undefined) {
 			usedCyl[0] = cylinderBox0.currentText
 			usedGas[0] = txtGasMix0.text
 			startpressure[0] = txtStartPressure0.text
 			endpressure[0] = txtEndPressure0.text
 		}
-		if (usedCyl[1] != null) {
+		if (usedCyl[1] !== undefined) {
 			usedCyl[1] = cylinderBox1.currentText
 			usedGas[1] = txtGasMix1.text
 			startpressure[1] = txtStartPressure1.text
 			endpressure[1] = txtEndPressure1.text
 		}
-		if (usedCyl[2] != null) {
+		if (usedCyl[2] !== undefined) {
 			usedCyl[2] = cylinderBox2.currentText
 			usedGas[2] = txtGasMix2.text
 			startpressure[2] = txtStartPressure2.text
 			endpressure[2] = txtEndPressure2.text
 		}
-		if (usedCyl[3] != null) {
+		if (usedCyl[3] !== undefined) {
 			usedCyl[3] = cylinderBox3.currentText
 			usedGas[3] = txtGasMix3.text
 			startpressure[3] = txtStartPressure3.text
 			endpressure[3] = txtEndPressure3.text
 		}
-		if (usedCyl[4] != null) {
+		if (usedCyl[4] !== undefined) {
 			usedCyl[4] = cylinderBox4.currentText
 			usedGas[4] = txtGasMix4.text
 			startpressure[4] = txtStartPressure4.text
@@ -352,12 +352,9 @@ Item {
 			// first cylinder
 			Flow {
 				width: parent.width
-
-
 				RowLayout {
 					width: Kirigami.Units.gridUnit * 12
 					id: cb1
-
 					TemplateLabelSmall {
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
@@ -382,7 +379,7 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix0
-						text: usedGas[0] != null ? usedGas[0] : null
+						text: usedGas[0] !== undefined ? usedGas[0] : null
 						Layout.fillWidth: true
 						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
@@ -398,7 +395,7 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure0
-						text: startpressure[0] != null ? startpressure[0] : null
+						text: startpressure[0] !== undefined ? startpressure[0] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -413,7 +410,7 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure0
-						text: endpressure[0] != null ? endpressure[0] : null
+						text: endpressure[0] !== undefined ? endpressure[0] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -422,18 +419,16 @@ Item {
 			//second cylinder
 			Flow {
 				width: parent.width
-
+				visible: usedCyl[1] !== undefined ? true : false
 				RowLayout {
 					id: cb2
 					width: Kirigami.Units.gridUnit * 12
 					TemplateLabelSmall {
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
-						visible: usedCyl[1] != null ? true : false
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Cylinder2:")
 					}
 					TemplateComboBox {
-						visible: usedCyl[1] != null ? true : false
 						id: cylinderBox1
 						flickable: detailsEditFlickable
 						flat: true
@@ -446,15 +441,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 8
 					height: cb2.height
 					TemplateLabelSmall {
-						visible: usedCyl[1] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Gas mix:")
 					}
 					SsrfTextField {
-						visible: usedCyl[1] != null ? true : false
 						id: txtGasMix1
-						text: usedGas[1] != null ? usedGas[1] : null
+						text: usedGas[1] !== undefined ? usedGas[1] : null
 						Layout.fillWidth: true
 						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
@@ -464,15 +457,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb2.height
 					TemplateLabelSmall {
-						visible: usedCyl[1] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Start Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[1] != null ? true : false
 						id: txtStartPressure1
-						text: startpressure[1] != null ? startpressure[1] : null
+						text: startpressure[1] !== undefined ? startpressure[1] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -481,15 +472,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb2.height
 					TemplateLabelSmall {
-						visible: usedCyl[1] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("End Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[1] != null ? true : false
 						id: txtEndPressure1
-						text: endpressure[1] != null ? endpressure[1] : null
+						text: endpressure[1] !== undefined ? endpressure[1] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -498,17 +487,16 @@ Item {
 			// third cylinder
 			Flow {
 				width: parent.width
+				visible: usedCyl[2] !== undefined ? true : false
 				RowLayout {
 					id: cb3
 					width: Kirigami.Units.gridUnit * 12
 					TemplateLabelSmall {
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
-						visible: usedCyl[2] != null ? true : false
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Cylinder3:")
 					}
 					TemplateComboBox {
-						visible: usedCyl[2] != null ? true : false
 						id: cylinderBox2
 						flickable: detailsEditFlickable
 						currentIndex: find(usedCyl[2])
@@ -522,15 +510,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 8
 					height: cb3.height
 					TemplateLabelSmall {
-						visible: usedCyl[2] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Gas mix:")
 					}
 					SsrfTextField {
-						visible: usedCyl[2] != null ? true : false
 						id: txtGasMix2
-						text: usedGas[2] != null ? usedGas[2] : null
+						text: usedGas[2] !== undefined ? usedGas[2] : null
 						Layout.fillWidth: true
 						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
@@ -540,15 +526,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb3.height
 					TemplateLabelSmall {
-						visible: usedCyl[2] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Start Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[2] != null ? true : false
 						id: txtStartPressure2
-						text: startpressure[2] != null ? startpressure[2] : null
+						text: startpressure[2] !== undefined ? startpressure[2] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -557,15 +541,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb3.height
 					TemplateLabelSmall {
-						visible: usedCyl[2] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("End Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[2] != null ? true : false
 						id: txtEndPressure2
-						text: endpressure[2] != null ? endpressure[2] : null
+						text: endpressure[2] !== undefined ? endpressure[2] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -574,17 +556,16 @@ Item {
 			// fourth cylinder
 			Flow {
 				width: parent.width
+				visible: usedCyl[3] !== undefined ? true : false
 				RowLayout {
 					id: cb4
 					width: Kirigami.Units.gridUnit * 12
 					TemplateLabelSmall {
-						visible: usedCyl[3] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Cylinder4:")
 					}
 					TemplateComboBox {
-						visible: usedCyl[3] != null ? true : false
 						id: cylinderBox3
 						flickable: detailsEditFlickable
 						currentIndex: find(usedCyl[3])
@@ -599,15 +580,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 8
 					height: cb4.height
 					TemplateLabelSmall {
-						visible: usedCyl[3] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Gas mix:")
 					}
 					SsrfTextField {
-						visible: usedCyl[3] != null ? true : false
 						id: txtGasMix3
-						text: usedGas[3] != null ? usedGas[3] : null
+						text: usedGas[3] !== undefined ? usedGas[3] : null
 						Layout.fillWidth: true
 						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
@@ -618,15 +597,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb4.height
 					TemplateLabelSmall {
-						visible: usedCyl[3] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Start Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[3] != null ? true : false
 						id: txtStartPressure3
-						text: startpressure[3] != null ? startpressure[3] : null
+						text: startpressure[3] !== undefined ? startpressure[3] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -636,15 +613,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb4.height
 					TemplateLabelSmall {
-						visible: usedCyl[3] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("End Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[3] != null ? true : false
 						id: txtEndPressure3
-						text: endpressure[3] != null ? endpressure[3] : null
+						text: endpressure[3] !== undefined ? endpressure[3] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -653,17 +628,16 @@ Item {
 			// fifth cylinder
 			Flow {
 				width: parent.width
+				visible: usedCyl[4] !== undefined ? true : false
 				RowLayout {
 					id: cb5
 					width: Kirigami.Units.gridUnit * 12
 					TemplateLabelSmall {
-						visible: usedCyl[4] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Cylinder5:")
 					}
 					TemplateComboBox {
-						visible: usedCyl[4] != null ? true : false
 						id: cylinderBox4
 						flickable: detailsEditFlickable
 						currentIndex: find(usedCyl[4])
@@ -679,15 +653,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 8
 					height: cb5.height
 					TemplateLabelSmall {
-						visible: usedCyl[4] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Gas mix:")
 					}
 					SsrfTextField {
-						visible: usedCyl[4] != null ? true : false
 						id: txtGasMix4
-						text: usedGas[4] != null ? usedGas[4] : null
+						text: usedGas[4] !== undefined ? usedGas[4] : null
 						Layout.fillWidth: true
 						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
@@ -698,15 +670,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb5.height
 					TemplateLabelSmall {
-						visible: usedCyl[4] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("Start Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[4] != null ? true : false
 						id: txtStartPressure4
-						text: startpressure[4] != null ? startpressure[4] : null
+						text: startpressure[4] !== undefined ? startpressure[4] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}
@@ -716,15 +686,13 @@ Item {
 					width: Kirigami.Units.gridUnit * 10
 					height: cb5.height
 					TemplateLabelSmall {
-						visible: usedCyl[4] != null ? true : false
 						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 						horizontalAlignment: Text.AlignRight
 						text: qsTr("End Pressure:")
 					}
 					SsrfTextField {
-						visible: usedCyl[4] != null ? true : false
 						id: txtEndPressure4
-						text: endpressure[4] != null ? endpressure[4] : null
+						text: endpressure[4] !== undefined ? endpressure[4] : null
 						Layout.fillWidth: true
 						flickable: detailsEditFlickable
 					}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -128,78 +128,160 @@ Item {
 		clearDetailsEdit()
 	}
 
-	height: editArea.height
+	height: editArea.height + Kirigami.Units.gridUnit * 3
 	width: diveDetailsPage.width - diveDetailsPage.leftPadding - diveDetailsPage.rightPadding - Kirigami.Units.smallSpacing * 2
-	ColumnLayout {
-		id: editArea
-		spacing: Kirigami.Units.smallSpacing
-		width: parent.width
-
-		GridLayout {
-			id: editorDetails
+	Item {
+		// there is a maximum width above which this becomes less pleasant to use. 42 gridUnits
+		// allows for two of the large drop downs or four of the text fields or all of a cylinder
+		// to be in one row. More just doesn't look good
+		width: Math.min(parent.width - Kirigami.Units.smallSpacing, Kirigami.Units.gridUnit * 42)
+		// weird way to create a little space from the left edge - but I can't do a margin here
+		x: Kirigami.Units.smallSpacing
+		Flow {
+			id: editArea
+			// with larger fonts we need more space, or things look too crowded
+			spacing: subsurfaceTheme.currentScale > 1.0 ? 1.5 * Kirigami.Units.largeSpacing : Kirigami.Units.largeSpacing
 			width: parent.width
-			columns: 2
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Dive number:")
-			}
-			SsrfTextField {
-				id: txtNumber;
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Date:")
-			}
-			SsrfTextField {
-				id: txtDate;
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Location:")
-			}
-			TemplateEditComboBox {
-				id: locationBox
-				flickable: detailsEditFlickable
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					       manager.locationList : null
-				onAccepted: {
-					focus = false
-					gpsText = manager.getGpsFromSiteName(editText)
+			flow: GridLayout.LeftToRight
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Date/Time:")
 				}
-				onActivated: {
-					focus = false
-					gpsText = manager.getGpsFromSiteName(editText)
+				SsrfTextField {
+					id: txtDate;
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 10
+					flickable: detailsEditFlickable
 				}
 			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Coordinates:")
-			}
-			SsrfTextField {
-				id: txtGps
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Use current\nGPS location:")
-				visible: manager.locationServiceAvailable
-			}
-			TemplateCheckBox {
-				id: checkboxGPS
-				visible: manager.locationServiceAvailable
-				onCheckedChanged: {
-					if (checked)
-						gpsText = manager.getCurrentPosition()
+			RowLayout {
+				TemplateLabelSmall {
+					horizontalAlignment: Text.AlignRight
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					text: qsTr("Dive number:")
+				}
+				SsrfTextField {
+					id: txtNumber;
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					flickable: detailsEditFlickable
+				}
+				Item {
+					// if date and dive number are on the same line, don't have the Depth behind them
+					// to ensure that we add an element that fills enough of the line that the flow
+					// will not pull the next element up
+					visible: editArea.width > Kirigami.Units.gridUnit * 27
+					Layout.preferredWidth: editArea.width - Kirigami.Units.gridUnit * 26
 				}
 			}
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Depth:")
+				}
+				SsrfTextField {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					id: txtDepth
+					validator: RegExpValidator { regExp: /[^-]*/ }
+					flickable: detailsEditFlickable
+				}
+			}
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Duration:")
+				}
+				SsrfTextField {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					id: txtDuration
+					validator: RegExpValidator { regExp: /[^-]*/ }
+					flickable: detailsEditFlickable
+				}
+
+			}
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Air Temp:")
+				}
+				SsrfTextField {
+					id: txtAirTemp
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					flickable: detailsEditFlickable
+				}
+
+			}
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Water Temp:")
+				}
+				SsrfTextField {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					id: txtWaterTemp
+					flickable: detailsEditFlickable
+				}
+			}
+			RowLayout {
+				width: Kirigami.Units.gridUnit * 20
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Location:")
+				}
+				TemplateEditComboBox {
+					// this one needs more space
+					id: locationBox
+					flickable: detailsEditFlickable
+					model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+						       manager.locationList : null
+					onAccepted: {
+						focus = false
+						gpsText = manager.getGpsFromSiteName(editText)
+					}
+					onActivated: {
+						focus = false
+						gpsText = manager.getGpsFromSiteName(editText)
+					}
+				}
+			}
+			RowLayout {
+				spacing: Kirigami.Units.smallSpacing
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 20
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Coordinates:")
+				}
+				SsrfTextField {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 16
+					id: txtGps
+					flickable: detailsEditFlickable
+				}
+			}
+			RowLayout {
+				width: manager.locationServiceAvailable ? Kirigami.Units.gridUnit * 12 : 0
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Use current\nGPS location:")
+					visible: manager.locationServiceAvailable
+				}
+				TemplateCheckBox {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+					id: checkboxGPS
+					visible: manager.locationServiceAvailable
+					onCheckedChanged: {
+						if (checked)
+							gpsText = manager.getCurrentPosition()
+					}
+				}
+			}
+
 			Connections {
 				target: manager
 				onWaitingForPositionChanged: {
@@ -207,443 +289,541 @@ Item {
 					manager.appendTextToLog("received updated position info " + gpsText)
 				}
 			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Depth:")
+			RowLayout {
+				width: Kirigami.Units.gridUnit * 20
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Suit:")
+				}
+				TemplateEditComboBox  {
+					id: suitBox
+					flickable: detailsEditFlickable
+					model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+						       manager.suitList : null
+				}
 			}
-			SsrfTextField {
-				id: txtDepth
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /[^-]*/ }
-				flickable: detailsEditFlickable
+			RowLayout {
+				width: Kirigami.Units.gridUnit * 20
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Buddy:")
+				}
+				TemplateEditComboBox {
+					id: buddyBox
+					flickable: detailsEditFlickable
+					model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+						       manager.buddyList : null
+				}
 			}
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Duration:")
-			}
-			SsrfTextField {
-				id: txtDuration
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /[^-]*/ }
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Air Temp:")
-			}
-			SsrfTextField {
-				id: txtAirTemp
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Water Temp:")
-			}
-			SsrfTextField {
-				id: txtWaterTemp
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Suit:")
-			}
-			TemplateEditComboBox  {
-				id: suitBox
-				flickable: detailsEditFlickable
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					       manager.suitList : null
+			RowLayout {
+				width: Kirigami.Units.gridUnit * 20
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Divemaster:")
+				}
+				TemplateEditComboBox {
+					id: divemasterBox
+					flickable: detailsEditFlickable
+					model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+						       manager.divemasterList : null
+				}
 			}
 
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Buddy:")
-			}
-			TemplateEditComboBox {
-				id: buddyBox
-				flickable: detailsEditFlickable
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					       manager.buddyList : null
+
+			RowLayout {
+				width: Kirigami.Units.gridUnit * 16
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Weight:")
+				}
+				SsrfTextField {
+					id: txtWeight
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 12
+					readOnly: text === "cannot edit multiple weight systems"
+					flickable: detailsEditFlickable
+				}
 			}
 
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Divemaster:")
-			}
-			TemplateEditComboBox {
-				id: divemasterBox
-				flickable: detailsEditFlickable
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					       manager.divemasterList : null
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Weight:")
-			}
-			SsrfTextField {
-				id: txtWeight
-				readOnly: text === "cannot edit multiple weight systems"
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-// all cylinder info should be able to become dynamic instead of this blob of code.
-// first cylinder
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder1:")
-			}
-			TemplateComboBox {
-				id: cylinderBox0
-				flickable: detailsEditFlickable
-				flat: true
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.cylinderList : null
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Gas mix:")
-			}
-			SsrfTextField {
-				id: txtGasMix0
-				text: usedGas[0] != null ? usedGas[0] : null
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Start Pressure:")
-			}
-			SsrfTextField {
-				id: txtStartPressure0
-				text: startpressure[0] != null ? startpressure[0] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("End Pressure:")
-			}
-			SsrfTextField {
-				id: txtEndPressure0
-				text: endpressure[0] != null ? endpressure[0] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-//second cylinder
-			TemplateLabelSmall {
-				visible: usedCyl[1] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder2:")
-			}
-			TemplateComboBox {
-				visible: usedCyl[1] != null ? true : false
-				id: cylinderBox1
-				flickable: detailsEditFlickable
-				flat: true
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.cylinderList : null
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[1] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Gas mix:")
-			}
-			SsrfTextField {
-				visible: usedCyl[1] != null ? true : false
-				id: txtGasMix1
-				text: usedGas[1] != null ? usedGas[1] : null
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[1] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Start Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[1] != null ? true : false
-				id: txtStartPressure1
-				text: startpressure[1] != null ? startpressure[1] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[1] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("End Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[1] != null ? true : false
-				id: txtEndPressure1
-				text: endpressure[1] != null ? endpressure[1] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-// third cylinder
-			TemplateLabelSmall {
-				visible: usedCyl[2] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder3:")
-			}
-			TemplateComboBox {
-				visible: usedCyl[2] != null ? true : false
-				id: cylinderBox2
-				flickable: detailsEditFlickable
-				currentIndex: find(usedCyl[2])
-				flat: true
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.cylinderList : null
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[2] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Gas mix:")
-			}
-			SsrfTextField {
-				visible: usedCyl[2] != null ? true : false
-				id: txtGasMix2
-				text: usedGas[2] != null ? usedGas[2] : null
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[2] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Start Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[2] != null ? true : false
-				id: txtStartPressure2
-				text: startpressure[2] != null ? startpressure[2] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[2] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("End Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[2] != null ? true : false
-				id: txtEndPressure2
-				text: endpressure[2] != null ? endpressure[2] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-// fourth cylinder
-			TemplateLabelSmall {
-				visible: usedCyl[3] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder4:")
-			}
-			TemplateComboBox {
-				visible: usedCyl[3] != null ? true : false
-				id: cylinderBox3
-				flickable: detailsEditFlickable
-				currentIndex: find(usedCyl[3])
-				flat: true
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.cylinderList : null
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[3] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Gas mix:")
-			}
-			SsrfTextField {
-				visible: usedCyl[3] != null ? true : false
-				id: txtGasMix3
-				text: usedGas[3] != null ? usedGas[3] : null
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[3] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Start Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[3] != null ? true : false
-				id: txtStartPressure3
-				text: startpressure[3] != null ? startpressure[3] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[3] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("End Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[3] != null ? true : false
-				id: txtEndPressure3
-				text: endpressure[3] != null ? endpressure[3] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-// fifth cylinder
-			TemplateLabelSmall {
-				visible: usedCyl[4] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Cylinder5:")
-			}
-			TemplateComboBox {
-				visible: usedCyl[4] != null ? true : false
-				id: cylinderBox4
-				flickable: detailsEditFlickable
-				currentIndex: find(usedCyl[4])
-				flat: true
-				model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-					diveDetailsListView.currentItem.modelData.cylinderList : null
-				inputMethodHints: Qt.ImhNoPredictiveText
-				Layout.fillWidth: true
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[4] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Gas mix:")
-			}
-			SsrfTextField {
-				visible: usedCyl[4] != null ? true : false
-				id: txtGasMix4
-				text: usedGas[4] != null ? usedGas[4] : null
-				Layout.fillWidth: true
-				validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[4] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Start Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[4] != null ? true : false
-				id: txtStartPressure4
-				text: startpressure[4] != null ? startpressure[4] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				visible: usedCyl[4] != null ? true : false
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("End Pressure:")
-			}
-			SsrfTextField {
-				visible: usedCyl[4] != null ? true : false
-				id: txtEndPressure4
-				text: endpressure[4] != null ? endpressure[4] : null
-				Layout.fillWidth: true
-				flickable: detailsEditFlickable
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Rating:")
-			}
-			TemplateSpinBox {
-				id: ratingPicker
-				from: 0
-				to: 5
-				value: rating
-				onValueChanged: rating = value
-			}
-
-			TemplateLabelSmall {
-				Layout.alignment: Qt.AlignRight
-				text: qsTr("Visibility:")
-			}
-			TemplateSpinBox {
-				id: visibilityPicker
-				from: 0
-				to: 5
-				value: visibility
-				onValueChanged: visibility = value
-			}
-
-			TemplateLabelSmall {
-				Layout.columnSpan: 2
-				Layout.alignment: Qt.AlignLeft
-				text: qsTr("Notes:")
-			}
-			Controls.TextArea {
-				Layout.columnSpan: 2
+			// all cylinder info should be able to become dynamic instead of this blob of code.
+			// first cylinder
+			Flow {
 				width: parent.width
-				id: txtNotes
-				textFormat: TextEdit.RichText
-				focus: true
-				color: subsurfaceTheme.textColor
-				Layout.fillWidth: true
-				Layout.fillHeight: true
-				Layout.minimumHeight: Kirigami.Units.gridUnit * 6
-				selectByMouse: true
-				wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
-				property bool firstTime: true
-				property int visibleTop: detailsEditFlickable.contentY
-				property int visibleBottom: visibleTop + detailsEditFlickable.height - 4 * Kirigami.Units.gridUnit
-				onPressed: waitForKeyboard.start()
-				onCursorRectangleChanged: {
-					ensureVisible(y + cursorRectangle.y)
-				}
 
-				// ensure that the y coordinate is inside the visible part of the detailsEditFlickable (our flickable)
-				function ensureVisible(yDest) {
-					if (yDest > visibleBottom)
-						detailsEditFlickable.contentY += yDest - visibleBottom
-					if (yDest < visibleTop)
-						detailsEditFlickable.contentY -= visibleTop - yDest
-				}
 
-				// give the OS enough time to actually resize the flickable
-				Timer {
-					id: waitForKeyboard
-					interval: 300 // 300ms seems like FOREVER
-					onTriggered: {
-						if (!Qt.inputMethod.visible) {
-							if (txtNotes.firstTime) {
-								txtNotes.firstTime = false
-								restart()
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 12
+					id: cb1
+
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Cylinder1:")
+					}
+					TemplateComboBox {
+						id: cylinderBox0
+						flickable: detailsEditFlickable
+						flat: true
+						model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+							       diveDetailsListView.currentItem.modelData.cylinderList : null
+						inputMethodHints: Qt.ImhNoPredictiveText
+					}
+				}
+				RowLayout {
+					height: cb1.height
+					width: Kirigami.Units.gridUnit * 8
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Gas mix:")
+					}
+					SsrfTextField {
+						id: txtGasMix0
+						text: usedGas[0] != null ? usedGas[0] : null
+						Layout.fillWidth: true
+						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					height: cb1.height
+					width: Kirigami.Units.gridUnit * 10
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Start Pressure:")
+					}
+					SsrfTextField {
+						id: txtStartPressure0
+						text: startpressure[0] != null ? startpressure[0] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					height: cb1.height
+					width: Kirigami.Units.gridUnit * 10
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("End Pressure:")
+					}
+					SsrfTextField {
+						id: txtEndPressure0
+						text: endpressure[0] != null ? endpressure[0] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+			}
+			//second cylinder
+			Flow {
+				width: parent.width
+
+				RowLayout {
+					id: cb2
+					width: Kirigami.Units.gridUnit * 12
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						visible: usedCyl[1] != null ? true : false
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Cylinder2:")
+					}
+					TemplateComboBox {
+						visible: usedCyl[1] != null ? true : false
+						id: cylinderBox1
+						flickable: detailsEditFlickable
+						flat: true
+						model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+							       diveDetailsListView.currentItem.modelData.cylinderList : null
+						inputMethodHints: Qt.ImhNoPredictiveText
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 8
+					height: cb2.height
+					TemplateLabelSmall {
+						visible: usedCyl[1] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Gas mix:")
+					}
+					SsrfTextField {
+						visible: usedCyl[1] != null ? true : false
+						id: txtGasMix1
+						text: usedGas[1] != null ? usedGas[1] : null
+						Layout.fillWidth: true
+						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb2.height
+					TemplateLabelSmall {
+						visible: usedCyl[1] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Start Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[1] != null ? true : false
+						id: txtStartPressure1
+						text: startpressure[1] != null ? startpressure[1] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb2.height
+					TemplateLabelSmall {
+						visible: usedCyl[1] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("End Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[1] != null ? true : false
+						id: txtEndPressure1
+						text: endpressure[1] != null ? endpressure[1] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+			}
+			// third cylinder
+			Flow {
+				width: parent.width
+				RowLayout {
+					id: cb3
+					width: Kirigami.Units.gridUnit * 12
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						visible: usedCyl[2] != null ? true : false
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Cylinder3:")
+					}
+					TemplateComboBox {
+						visible: usedCyl[2] != null ? true : false
+						id: cylinderBox2
+						flickable: detailsEditFlickable
+						currentIndex: find(usedCyl[2])
+						flat: true
+						model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+							       diveDetailsListView.currentItem.modelData.cylinderList : null
+						inputMethodHints: Qt.ImhNoPredictiveText
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 8
+					height: cb3.height
+					TemplateLabelSmall {
+						visible: usedCyl[2] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Gas mix:")
+					}
+					SsrfTextField {
+						visible: usedCyl[2] != null ? true : false
+						id: txtGasMix2
+						text: usedGas[2] != null ? usedGas[2] : null
+						Layout.fillWidth: true
+						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb3.height
+					TemplateLabelSmall {
+						visible: usedCyl[2] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Start Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[2] != null ? true : false
+						id: txtStartPressure2
+						text: startpressure[2] != null ? startpressure[2] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb3.height
+					TemplateLabelSmall {
+						visible: usedCyl[2] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("End Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[2] != null ? true : false
+						id: txtEndPressure2
+						text: endpressure[2] != null ? endpressure[2] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+			}
+			// fourth cylinder
+			Flow {
+				width: parent.width
+				RowLayout {
+					id: cb4
+					width: Kirigami.Units.gridUnit * 12
+					TemplateLabelSmall {
+						visible: usedCyl[3] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Cylinder4:")
+					}
+					TemplateComboBox {
+						visible: usedCyl[3] != null ? true : false
+						id: cylinderBox3
+						flickable: detailsEditFlickable
+						currentIndex: find(usedCyl[3])
+						flat: true
+						model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+							       diveDetailsListView.currentItem.modelData.cylinderList : null
+						inputMethodHints: Qt.ImhNoPredictiveText
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 8
+					height: cb4.height
+					TemplateLabelSmall {
+						visible: usedCyl[3] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Gas mix:")
+					}
+					SsrfTextField {
+						visible: usedCyl[3] != null ? true : false
+						id: txtGasMix3
+						text: usedGas[3] != null ? usedGas[3] : null
+						Layout.fillWidth: true
+						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+						flickable: detailsEditFlickable
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb4.height
+					TemplateLabelSmall {
+						visible: usedCyl[3] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Start Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[3] != null ? true : false
+						id: txtStartPressure3
+						text: startpressure[3] != null ? startpressure[3] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb4.height
+					TemplateLabelSmall {
+						visible: usedCyl[3] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("End Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[3] != null ? true : false
+						id: txtEndPressure3
+						text: endpressure[3] != null ? endpressure[3] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+			}
+			// fifth cylinder
+			Flow {
+				width: parent.width
+				RowLayout {
+					id: cb5
+					width: Kirigami.Units.gridUnit * 12
+					TemplateLabelSmall {
+						visible: usedCyl[4] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Cylinder5:")
+					}
+					TemplateComboBox {
+						visible: usedCyl[4] != null ? true : false
+						id: cylinderBox4
+						flickable: detailsEditFlickable
+						currentIndex: find(usedCyl[4])
+						flat: true
+						model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
+							       diveDetailsListView.currentItem.modelData.cylinderList : null
+						inputMethodHints: Qt.ImhNoPredictiveText
+						Layout.fillWidth: true
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 8
+					height: cb5.height
+					TemplateLabelSmall {
+						visible: usedCyl[4] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Gas mix:")
+					}
+					SsrfTextField {
+						visible: usedCyl[4] != null ? true : false
+						id: txtGasMix4
+						text: usedGas[4] != null ? usedGas[4] : null
+						Layout.fillWidth: true
+						validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
+						flickable: detailsEditFlickable
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb5.height
+					TemplateLabelSmall {
+						visible: usedCyl[4] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Start Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[4] != null ? true : false
+						id: txtStartPressure4
+						text: startpressure[4] != null ? startpressure[4] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					height: cb5.height
+					TemplateLabelSmall {
+						visible: usedCyl[4] != null ? true : false
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("End Pressure:")
+					}
+					SsrfTextField {
+						visible: usedCyl[4] != null ? true : false
+						id: txtEndPressure4
+						text: endpressure[4] != null ? endpressure[4] : null
+						Layout.fillWidth: true
+						flickable: detailsEditFlickable
+					}
+				}
+			}
+			// rating / visibility
+			RowLayout {
+				width: parent.width
+
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Rating:")
+					}
+					TemplateSpinBox {
+						id: ratingPicker
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						from: 0
+						to: 5
+						value: rating
+						onValueChanged: rating = value
+					}
+
+				}
+				RowLayout {
+					width: Kirigami.Units.gridUnit * 10
+					TemplateLabelSmall {
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+						horizontalAlignment: Text.AlignRight
+						text: qsTr("Visibility:")
+					}
+					TemplateSpinBox {
+						id: visibilityPicker
+						Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+						from: 0
+						to: 5
+						value: visibility
+						onValueChanged: visibility = value
+					}
+					Item { Layout.fillWidth: true }
+				}
+			}
+			ColumnLayout {
+				width: parent.width
+				TemplateLabelSmall {
+					Layout.preferredWidth: parent.width
+					text: qsTr("Notes:")
+				}
+				Controls.TextArea {
+					Layout.preferredWidth: parent.width
+					width: parent.width
+					id: txtNotes
+					textFormat: TextEdit.RichText
+					focus: true
+					color: subsurfaceTheme.textColor
+					Layout.fillWidth: true
+					Layout.fillHeight: true
+					Layout.minimumHeight: Kirigami.Units.gridUnit * 6
+					selectByMouse: true
+					wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
+					property bool firstTime: true
+					property int visibleTop: detailsEditFlickable.contentY
+					property int visibleBottom: visibleTop + detailsEditFlickable.height - 4 * Kirigami.Units.gridUnit
+					onPressed: waitForKeyboard.start()
+					onCursorRectangleChanged: {
+						ensureVisible(y + cursorRectangle.y)
+					}
+
+					// ensure that the y coordinate is inside the visible part of the detailsEditFlickable (our flickable)
+					function ensureVisible(yDest) {
+						if (yDest > visibleBottom)
+							detailsEditFlickable.contentY += yDest - visibleBottom
+						if (yDest < visibleTop)
+							detailsEditFlickable.contentY -= visibleTop - yDest
+					}
+
+					// give the OS enough time to actually resize the flickable
+					Timer {
+						id: waitForKeyboard
+						interval: 300 // 300ms seems like FOREVER
+						onTriggered: {
+							if (!Qt.inputMethod.visible) {
+								if (txtNotes.firstTime) {
+									txtNotes.firstTime = false
+									restart()
+								}
+								return
 							}
-							return
+							// make sure at least half the Notes field is visible
+							txtNotes.ensureVisible(txtNotes.y + txtNotes.cursorRectangle.y)
 						}
-						// make sure at least half the Notes field is visible
-						txtNotes.ensureVisible(txtNotes.y + txtNotes.cursorRectangle.y)
 					}
 				}
 			}
 		}
 		Item {
+			anchors.top: editArea.bottom
 			height: Kirigami.Units.gridUnit * 3
 			width: height // just to make sure the spacer doesn't produce scrollbars, but also isn't null
 		}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -309,12 +309,22 @@ TemplatePage {
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
 					Layout.columnSpan: 2
 				}
-				RowLayout {
+				Flow {
 					Layout.columnSpan: 2
 					spacing: Kirigami.Units.largeSpacing
 					TemplateButton {
-						text: qsTr("smaller")
+						text: qsTr("very small")
+						fontSize: subsurfaceTheme.regularPointSize / subsurfaceTheme.currentScale * 0.75
+						enabled: subsurfaceTheme.currentScale !== 0.75
+						onClicked: {
+							subsurfaceTheme.currentScale = 0.75
+							rootItem.setupUnits()
+						}
+					}
+					TemplateButton {
+						text: qsTr("small")
 						Layout.fillWidth: true
+						fontSize: subsurfaceTheme.regularPointSize / subsurfaceTheme.currentScale * 0.85
 						enabled: subsurfaceTheme.currentScale !== 0.85
 						onClicked: {
 							subsurfaceTheme.currentScale = 0.85
@@ -323,17 +333,29 @@ TemplatePage {
 					TemplateButton {
 						text: qsTr("regular")
 						Layout.fillWidth: true
+						fontSize: subsurfaceTheme.regularPointSize / subsurfaceTheme.currentScale * 0.85
 						enabled: subsurfaceTheme.currentScale !== 1.0
 						onClicked: {
 							subsurfaceTheme.currentScale = 1.0
 						}
 					}
 					TemplateButton {
-						text: qsTr("larger")
+						text: qsTr("large")
 						Layout.fillWidth: true
+						fontSize: subsurfaceTheme.regularPointSize / subsurfaceTheme.currentScale * 1.15
 						enabled: subsurfaceTheme.currentScale !== 1.15
 						onClicked: {
 							subsurfaceTheme.currentScale = 1.15
+						}
+					}
+					TemplateButton {
+						text: qsTr("very large")
+						Layout.fillWidth: true
+						fontSize: subsurfaceTheme.regularPointSize / subsurfaceTheme.currentScale * 1.3
+						enabled: subsurfaceTheme.currentScale !== 1.3
+						onClicked: {
+							subsurfaceTheme.currentScale = 1.3
+							rootItem.setupUnits()
 						}
 					}
 				}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -328,6 +328,7 @@ TemplatePage {
 						enabled: subsurfaceTheme.currentScale !== 0.85
 						onClicked: {
 							subsurfaceTheme.currentScale = 0.85
+							rootItem.setupUnits()
 						}
 					}
 					TemplateButton {
@@ -337,6 +338,7 @@ TemplatePage {
 						enabled: subsurfaceTheme.currentScale !== 1.0
 						onClicked: {
 							subsurfaceTheme.currentScale = 1.0
+							rootItem.setupUnits()
 						}
 					}
 					TemplateButton {
@@ -346,6 +348,7 @@ TemplatePage {
 						enabled: subsurfaceTheme.currentScale !== 1.15
 						onClicked: {
 							subsurfaceTheme.currentScale = 1.15
+							rootItem.setupUnits()
 						}
 					}
 					TemplateButton {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -362,8 +362,6 @@ TemplatePage {
 						}
 					}
 				}
-				Rectangle {
-				}
 			}
 		}
 		TemplateSection {
@@ -541,37 +539,31 @@ TemplatePage {
 				}
 				TemplateLabel {
 					text: qsTr("Distance threshold (meters)")
-					//Layout.preferredWidth: gridWidth * 0.75
 				}
 				TemplateTextField {
 					id: distanceThreshold
+					Layout.rightMargin: Kirigami.Units.smallSpacing
 					text: PrefLocationService.distance_threshold
-					//Layout.preferredWidth: gridWidth * 0.25
 					onEditingFinished: {
 						PrefLocationService.distance_threshold = distanceThreshold.text
 					}
 				}
 				TemplateLabel {
 					text: qsTr("Time threshold (minutes)")
-					//Layout.preferredWidth: gridWidth * 0.75
 				}
 				TemplateTextField {
 					id: timeThreshold
+					Layout.rightMargin: Kirigami.Units.smallSpacing
 					text: PrefLocationService.time_threshold / 60
-					//Layout.preferredWidth: gridWidth * 0.25
 					onEditingFinished: {
 						PrefLocationService.time_threshold = timeThreshold.text * 60
 					}
 				}
-			}
-			TemplateLine {
-				visible: sectionAdvanced.isExpanded
-			}
-			GridLayout {
-				id: whichBluetoothDevices
-				visible: sectionAdvanced.isExpanded
-				width: parent.width
-				columns: 2
+
+				TemplateLine {
+					visible: sectionAdvanced.isExpanded
+					Layout.columnSpan: 2
+				}
 				TemplateLabel {
 					text: qsTr("Bluetooth")
 					font.pointSize: subsurfaceTheme.headingPointSize
@@ -583,25 +575,19 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
 					Layout.fillWidth: true
-					//Layout.preferredWidth: gridWidth * 0.75
 				}
 				SsrfSwitch {
 					id: nonDCButton
 					checked: manager.showNonDiveComputers
-					//Layout.preferredWidth: gridWidth * 0.25
 					onClicked: {
 						manager.showNonDiveComputers = checked
 					}
 				}
-			}
-			TemplateLine {
-				visible: sectionAdvanced.isExpanded
-			}
-			GridLayout {
-				id: display
-				visible: sectionAdvanced.isExpanded
-				width: parent.width
-				columns: 2
+
+				TemplateLine {
+					visible: sectionAdvanced.isExpanded
+					Layout.columnSpan: 2
+				}
 				TemplateLabel {
 					text: qsTr("Display")
 					font.pointSize: subsurfaceTheme.headingPointSize
@@ -613,25 +599,18 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Show only one column in Portrait mode")
 					Layout.fillWidth: true
-					//Layout.preferredWidth: gridWidth * 0.75
 				}
 				SsrfSwitch {
 					id: singleColumnButton
 					checked: PrefDisplay.singleColumnPortrait
-					//Layout.preferredWidth: gridWidth * 0.25
 					onClicked: {
 						PrefDisplay.singleColumnPortrait = checked
 					}
 				}
-			}
-			TemplateLine {
-				visible: sectionAdvanced.isExpanded
-			}
-			GridLayout {
-				id: profilePrefs
-				visible: sectionAdvanced.isExpanded
-				width: parent.width
-				columns: 2
+				TemplateLine {
+					visible: sectionAdvanced.isExpanded
+					Layout.columnSpan: 2
+				}
 				TemplateLabel {
 					text: qsTr("Profile deco ceiling")
 					font.pointSize: subsurfaceTheme.headingPointSize
@@ -660,16 +639,10 @@ TemplatePage {
 						rootItem.settingsChanged()
 					}
 				}
-			}
-			TemplateLine {
-				visible: sectionAdvanced.isExpanded
-			}
-
-			GridLayout {
-				id: developer
-				visible: sectionAdvanced.isExpanded
-				width: parent.width
-				columns: 2
+				TemplateLine {
+					visible: sectionAdvanced.isExpanded
+					Layout.columnSpan: 2
+				}
 				TemplateLabel {
 					text: qsTr("Developer")
 					font.pointSize: subsurfaceTheme.headingPointSize
@@ -681,12 +654,10 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Display Developer menu")
 					Layout.fillWidth: true
-					//Layout.preferredWidth: gridWidth * 0.75
 				}
 				SsrfSwitch {
 					id: developerButton
 					checked: PrefDisplay.show_developer
-					//sLayout.preferredWidth: gridWidth * 0.25
 					onClicked: {
 						PrefDisplay.show_developer = checked
 					}

--- a/mobile-widgets/qml/SsrfTextField.qml
+++ b/mobile-widgets/qml/SsrfTextField.qml
@@ -11,9 +11,30 @@ Controls.TextField {
 	property var flickable
 	property bool firstTime: true
 
+	/**
+	 * set inComboBox if the TextField is used in an editable ComboBox
+	 * this ensures that the baseline that is used to visually indicate that the user can
+	 * edit the text as well as use the drop down is placed much closer to the actual text
+	 */
+	property bool inComboBox: false
+
 	id: stf
+	background: Item {
+		Rectangle {
+			width: parent.width - Kirigami.Units.smallSpacing
+			x: inComboBox ? Kirigami.Units.smallSpacing : -1
+			height: 1
+			color: stf.focus ? subsurfaceTheme.primaryColor : Qt.darker(subsurfaceTheme.backgroundColor, 1.2)
+			anchors.bottom: parent.bottom
+			anchors.bottomMargin: inComboBox ? Kirigami.Units.largeSpacing : 1
+			visible: !stf.readOnly
+		}
+	}
 
 	// while we are at it, let's put some common settings here into the shared element
+	font.pointSize: subsurfaceTheme.regularPointSize
+	topPadding: 0
+	bottomPadding: 0
 	color: subsurfaceTheme.textColor
 	onEditingFinished: {
 		focus = false

--- a/mobile-widgets/qml/SsrfTextField.qml
+++ b/mobile-widgets/qml/SsrfTextField.qml
@@ -65,8 +65,8 @@ Controls.TextField {
 			// make sure there's enough space for the input field above the keyboard and action button (and that it's not too far up, either)
 			var positionInFlickable = stf.mapToItem(flickable.contentItem, 0, 0)
 			var stfY = positionInFlickable.y
-			if (verbose)
-				manager.appendTextToLogFile("position check: lower edge of view is " + (0 + flickable.contentY + flickable.height) + " and text field is at " + stfY)
+			if (manager.verboseEnabebled)
+				manager.appendTextToLog("position check: lower edge of view is " + (0 + flickable.contentY + flickable.height) + " and text field is at " + stfY)
 			if (stfY + stf.height > flickable.contentY + flickable.height - 3 * Kirigami.Units.gridUnit || stfY < flickable.contentY)
 				flickable.contentY = Math.max(0, 3 * Kirigami.Units.gridUnit + stfY + stf.height - flickable.height)
 		}

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -15,6 +15,7 @@ Kirigami.Page {
 	bottomPadding: 0
 	width: rootItem.width
 	implicitWidth: rootItem.width
+	background: Rectangle { color: subsurfaceTheme.backgroundColor }
 	property bool wide: width > rootItem.height
 	StatsManager {
 		id: statsManager
@@ -56,6 +57,7 @@ Kirigami.Page {
 					Label {
 						text: chartName
 						font.bold: isHeader
+						color: subsurfaceTheme.textColor
 					}
 				}
 			}

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -32,6 +32,18 @@ Kirigami.Page {
 			statsManager.doit()
 		}
 	}
+	onWideChanged: {
+		// so this means we rotated the device - and sometimes after rotation
+		// the stats widget is empty.
+		rotationRedrawTrigger.start()
+	}
+	Timer {
+		// wait .5 seconds (so the OS rotation animation has a chance to run) and then set var1 again
+		// to its current value, which appears to be enough to ensure that the chart is drawn again
+		id: rotationRedrawTrigger
+		interval: 500
+		onTriggered: statsManager.var1Changed(i1.var1currentIndex)
+	}
 
 	Component {
 		id: chartListDelegate
@@ -89,6 +101,7 @@ Kirigami.Page {
 			Layout.row: 0
 			Layout.leftMargin: Kirigami.Units.smallSpacing
 			Layout.topMargin: Kirigami.Units.smallSpacing
+			property alias var1currentIndex: var1.currentIndex
 			TemplateLabelSmall {
 				text: qsTr("Base variable")
 			}

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -193,10 +193,10 @@ Kirigami.Page {
 			onClicked: chartTypePopup.open()
 		}
 		Item {
-			Layout.column: wide ? 0 : 1
+			Layout.column: wide ? 0 : 2
 			Layout.row: wide ? 6 : 2
 			Layout.preferredHeight: wide ? parent.height - Kirigami.Units.gridUnit * 16 : Kirigami.Units.gridUnit
-			Layout.preferredWidth: wide ? parent.width - i1.implicitWidt - i2.implicitWidt - i3.implicitWidt - i4.implicitWidth : Kirigami.Units.gridUnit
+			Layout.fillWidth: wide ? false : true
 			// just used for spacing
 		}
 		StatsView {

--- a/mobile-widgets/qml/TemplateButton.qml
+++ b/mobile-widgets/qml/TemplateButton.qml
@@ -5,6 +5,7 @@ import org.kde.kirigami 2.4 as Kirigami
 
 Button {
 	id: root
+	property double fontSize: subsurfaceTheme.regularPointSize
 	background: Rectangle {
 		id: buttonBackground
 		color: root.enabled? (root.pressed ? subsurfaceTheme.darkerPrimaryColor : subsurfaceTheme.primaryColor) : "gray"
@@ -15,7 +16,7 @@ Button {
 	contentItem: Text {
 		id: buttonText
 		text: root.text
-		font.pointSize: subsurfaceTheme.regularPointSize
+		font.pointSize: root.fontSize
 		anchors.centerIn: buttonBackground
 		color: root.pressed ? subsurfaceTheme.darkerPrimaryTextColor :subsurfaceTheme.primaryTextColor
 	}

--- a/mobile-widgets/qml/TemplateComboBox.qml
+++ b/mobile-widgets/qml/TemplateComboBox.qml
@@ -6,10 +6,12 @@ import org.kde.kirigami 2.4 as Kirigami
 
 ComboBox {
 	id: cb
+	editable: false
 	Layout.fillWidth: true
-	Layout.preferredHeight: Kirigami.Units.gridUnit * 2.5
+	Layout.preferredHeight: Kirigami.Units.gridUnit * 2.0
 	inputMethodHints: Qt.ImhNoPredictiveText
 	font.pointSize: subsurfaceTheme.regularPointSize
+	rightPadding: Kirigami.Units.smallSpacing
 	property var flickable // used to ensure the combobox is visible on screen
 	delegate: ItemDelegate {
 		width: cb.width
@@ -49,6 +51,7 @@ ComboBox {
 	}
 
 	contentItem: SsrfTextField {
+		inComboBox: cb.editable
 		readOnly: !cb.editable
 		anchors.right: indicator.left
 		anchors.left: cb.left
@@ -59,6 +62,7 @@ ComboBox {
 		font: cb.font
 		color: subsurfaceTheme.textColor
 		verticalAlignment: Text.AlignVCenter
+
 		onPressed: {
 			if (readOnly) {
 				if (cb.popup.opened) {

--- a/mobile-widgets/qml/TemplateSlimComboBox.qml
+++ b/mobile-widgets/qml/TemplateSlimComboBox.qml
@@ -8,7 +8,7 @@ TemplateComboBox {
 	id: cb
 	Layout.fillWidth: false
 	Layout.preferredHeight: Kirigami.Units.gridUnit * 2
-	Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+	Layout.minimumWidth: Kirigami.Units.gridUnit * 8
 	contentItem: Text {
 		text: cb.displayText
 		font.pointSize: subsurfaceTheme.regularPointSize

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -23,139 +23,143 @@ Kirigami.Page {
 		Kirigami.Heading {
 			Layout.columnSpan: 2
 			text: "Theme Information"
+			color: subsurfaceTheme.textColor
 		}
 
 		Kirigami.Heading {
 			text: "Screen"
+			color: subsurfaceTheme.textColor
 			Layout.columnSpan: 2
 			level: 3
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Geometry (pixels):"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: rootItem.width + "x" + rootItem.height
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Geometry (gridUnits):"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: Math.round(rootItem.width / Kirigami.Units.gridUnit) + "x" + Math.round(rootItem.height / Kirigami.Units.gridUnit)
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Units.gridUnit:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: Kirigami.Units.gridUnit
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Units.devicePixelRatio:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: Screen.devicePixelRatio
 		}
 
 		Kirigami.Heading {
 			text: "Font Metrics"
+			color: subsurfaceTheme.textColor
 			level: 3
 			Layout.columnSpan: 2
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "basePointSize:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: subsurfaceTheme.basePointSize
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "FontMetrics pointSize:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: fontMetrics.font.pointSize
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "FontMetrics pixelSize:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: Number(fontMetrics.height).toFixed(2)
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "FontMetrics devicePixelRatio:"
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: Number(fontMetrics.height / fontMetrics.font.pointSize).toFixed(2)
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Text item pixelSize:"
 		}
-		Text {
+		TemplateLabel {
 			text: fontMetrics.font.pixelSize
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Text item pointSize:"
 		}
-		Text {
+		TemplateLabel {
 			text: fontMetrics.font.pointSize
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Pixel density:"
 		}
-		Text {
+		TemplateLabel {
 			text: Number(Screen.pixelDensity).toFixed(2)
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "Height of default font:"
 		}
-		Text {
+		TemplateLabel {
 			text: Number(fontMetrics.font.pixelSize / Screen.pixelDensity).toFixed(2) + "mm"
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			text: "2cm x 2cm square:"
 		}
 		Rectangle {
 			width: Math.round(Screen.pixelDensity * 20)
 			height: Math.round(Screen.pixelDensity * 20)
-			color: "black"
+			color: subsurfaceTheme.textColor
 		}
-		Controls.Label {
+		TemplateLabel {
 			text: "text in 4 gridUnit square"
 		}
 		Rectangle {
 			id: backSquare
 			width: Kirigami.Units.gridUnit * 4
 			height: width
+			color: subsurfaceTheme.primaryColor
 			border.color: subsurfaceTheme.primaryColor
 			border.width: 1
 
 			Controls.Label {
 				anchors.top: backSquare.top
 				anchors.left: backSquare.left
-				color: subsurfaceTheme.textColor
+				color: subsurfaceTheme.primaryTextColor
 				font.pointSize: subsurfaceTheme.regularPointSize
 				text: "Simply 27 random characters"
 			}
 			Controls.Label {
 				anchors.bottom: backSquare.bottom
 				anchors.left: backSquare.left
-				color: subsurfaceTheme.textColor
+				color: subsurfaceTheme.primaryTextColor
 				font.pointSize: subsurfaceTheme.smallPointSize
 				text: "Simply 27 random characters"
 			}
 		}
 
-		Controls.Label {
+		TemplateLabel {
 			Layout.columnSpan: 2
 			Layout.fillHeight: true
 		}

--- a/mobile-widgets/qml/ThemeTest.qml
+++ b/mobile-widgets/qml/ThemeTest.qml
@@ -129,6 +129,31 @@ Kirigami.Page {
 			height: Math.round(Screen.pixelDensity * 20)
 			color: "black"
 		}
+		Controls.Label {
+			text: "text in 4 gridUnit square"
+		}
+		Rectangle {
+			id: backSquare
+			width: Kirigami.Units.gridUnit * 4
+			height: width
+			border.color: subsurfaceTheme.primaryColor
+			border.width: 1
+
+			Controls.Label {
+				anchors.top: backSquare.top
+				anchors.left: backSquare.left
+				color: subsurfaceTheme.textColor
+				font.pointSize: subsurfaceTheme.regularPointSize
+				text: "Simply 27 random characters"
+			}
+			Controls.Label {
+				anchors.bottom: backSquare.bottom
+				anchors.left: backSquare.left
+				color: subsurfaceTheme.textColor
+				font.pointSize: subsurfaceTheme.smallPointSize
+				text: "Simply 27 random characters"
+			}
+		}
 
 		Controls.Label {
 			Layout.columnSpan: 2

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -53,9 +53,7 @@ Kirigami.ApplicationWindow {
 	onNotificationTextChanged: {
 		// once the app is fully initialized and the UI is running, we use passive
 		// notifications to show the notification text, but during initialization
-		// we instead dump the information into the textBlock below - and to make
-		// this visually more useful we interpret a "\r" at the beginning of a notification
-		// to mean that we want to simply over-write the last line, not create a new one
+		// we instead dump the information into the textBlock below
 		if (initialized) {
 			// make sure any old notification is hidden
 			// hiding notifications is no longer supported????

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -690,11 +690,16 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		manager.appendTextToLog(numColumns + " columns with column width of " + rootItem.colWidth)
 		manager.appendTextToLog("width in Grid Units " + widthInGridUnits + " original gridUnit " + Kirigami.Units.gridUnit + " now " + kirigamiGridUnit)
 		if (Kirigami.Units.gridUnit !== kirigamiGridUnit) {
-			// change our global grid unit - make absolutely certain there is no Qt binding happening
+			// change our global grid unit and prevent Kirigami from resizing our rootItem
+			var fixWidth = rootItem.width
+			var fixHeight = rootItem.height
 			Kirigami.Units.gridUnit = kirigamiGridUnit * 1.0
+			rootItem.width = fixWidth
+			rootItem.height = fixHeight
 		}
+
 		pageStack.defaultColumnWidth = rootItem.colWidth
-		manager.appendTextToLog("Done setting up sizes")
+		manager.appendTextToLog("Done setting up sizes width " + rootItem.width + " gridUnit " + kirigamiGridUnit)
 	}
 
 	QtObject {
@@ -715,6 +720,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 
 	onWidthChanged: {
 		manager.appendTextToLog("[screensetup] width changed now " + width + " x " + height + " vs screen " + Screen.width + " x " + Screen.height)
+
 		if (screenSizeObject.lastOrientation === undefined) {
 			manager.appendTextToLog("[screensetup] found initial orientation " + Screen.orientation)
 			screenSizeObject.lastOrientation = Screen.orientation
@@ -747,6 +753,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 						manager.appendTextToLog("[screensetup] remembering better height")
 						screenSizeObject.initialWidth = width
 					}
+					setupUnits()
 				}
 			}
 		} else {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -665,9 +665,16 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		}
 	}
 
+	property double regularFontsize: subsurfaceTheme.regularPointSize
+
 	FontMetrics {
 		id: fontMetrics
-		font.pointSize: subsurfaceTheme.regularPointSize
+		font.pointSize: regularFontsize
+	}
+
+	onRegularFontsizeChanged: {
+		manager.appendTextToLog("regular font size changed to " + regularFontsize)
+		rootItem.font.pointSize = regularFontsize
 	}
 
 	function setupUnits() {

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -55,13 +55,17 @@ Kirigami.ApplicationWindow {
 		// notifications to show the notification text, but during initialization
 		// we instead dump the information into the textBlock below
 		if (initialized) {
-			// make sure any old notification is hidden
-			// hiding notifications is no longer supported????
-			// hidePassiveNotification()
 			if (notificationText !== "") {
-				// there's a risk that we have a >5 second gap in update events;
-				// still, keep the timeout at 5s to avoid odd unchanging notifications
-				showPassiveNotification(notificationText, 5000)
+				var actionEnd = notificationText.indexOf("]")
+				if (notificationText.startsWith("[") && actionEnd !== -1) {
+					// we have a notification text that starts with our special syntax to indication
+					// an action that the user can take (the actual action is always opening the context drawer
+					// so the action text should always be something that can then be found in the context drawer)
+					showPassiveNotification(notificationText.substring(actionEnd + 1), 5000, notificationText.substring(1,actionEnd),
+								function() { contextDrawer.open() })
+				} else {
+					showPassiveNotification(notificationText, 5000)
+				}
 			}
 		} else {
 			textBlock.text = textBlock.text + "\n" + notificationText

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1407,11 +1407,14 @@ void QMLManager::saveChangesLocal(bool fromUndo)
 		Command::setClean();
 		updateHaveLocalChanges(true);
 		// provide a useful undo/redo notification
-		QString msgFormat = tr("Changes saved:'%1'. %2 possible via context menu");
+		// NOTE: the QML UI interprets a leading '[action]' (where only the two brackets are checked for)
+		//       as an indication to use the text between those two brackets as the label of a button that
+		//       can be used to open the context menu
+		QString msgFormat = tr("[%1]Changes saved:'%2'.\n%1 possible via context menu");
 		if (fromUndo)
-			setNotificationText(msgFormat.arg(tr("Undo: %1").arg(getRedoText())).arg(tr("Redo")));
+			setNotificationText(msgFormat.arg(tr("Redo")).arg(tr("Undo: %1").arg(getRedoText())));
 		else
-			setNotificationText(msgFormat.arg(getUndoText()).arg(tr("Undo")));
+			setNotificationText(msgFormat.arg(tr("Undo")).arg(getUndoText()));
 	} else {
 		appendTextToLog("local save requested with no unsaved changes");
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -128,7 +128,12 @@ static void showProgress(QString msg)
 // show the git progress in the passive notification area
 extern "C" int gitProgressCB(const char *text)
 {
-	showProgress(QString(text));
+	// regular users, during regular operation, likely really don't
+	// care at all about the git progress
+	if (verbose) {
+		showProgress(QString(text));
+		appendTextToLogStandalone(text);
+	}
 	// return 0 so that we don't end the download
 	return 0;
 }

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -328,6 +328,9 @@ QMLManager::QMLManager() : m_locationServiceEnabled(false),
 
 	// we start out with clean data
 	updateHaveLocalChanges(false);
+
+	// setup Command infrastructure
+	Command::init();
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -190,9 +190,9 @@ public slots:
 	void removeDiveFromTrip(int id);
 	void addTripForDive(int id);
 	void addDiveToTrip(int id, int tripId);
-	void changesNeedSaving();
+	void changesNeedSaving(bool fromUndo = false);
 	void openNoCloudRepo();
-	void saveChangesCloud(bool forceRemoteSync);
+	void saveChangesCloud(bool forceRemoteSync, bool fromUndo = false);
 	void selectDive(int id);
 	void deleteDive(int id);
 	void toggleDiveInvalid(int id);
@@ -283,7 +283,7 @@ private:
 	void consumeFinishedLoad();
 	void mergeLocalRepo();
 	void openLocalThenRemote(QString url);
-	void saveChangesLocal();
+	void saveChangesLocal(bool fromUndo = false);
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 	QString appLogFileName;

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "themeinterface.h"
+#include "core/subsurface-string.h"
 #include "qmlmanager.h"
 #include "core/metrics.h"
 #include "core/settings/qPrefDisplay.h"
@@ -79,16 +80,17 @@ double ThemeInterface::currentScale()
 
 void ThemeInterface::set_currentScale(double newScale)
 {
-	if (newScale != qPrefDisplay::mobile_scale()) {
+	if (!IS_FP_SAME(newScale, qPrefDisplay::mobile_scale())) {
+		double factor = newScale / qPrefDisplay::mobile_scale();
 		qPrefDisplay::set_mobile_scale(newScale);
 		emit currentScaleChanged();
+
+		// Set current font size
+		m_basePointSize *= factor;
+		defaultModelFont().setPointSizeF(m_basePointSize);
 	}
-
-	// Set current font size
-	defaultModelFont().setPointSizeF(m_basePointSize * qPrefDisplay::mobile_scale());
-
 	// adjust all used font sizes
-	m_regularPointSize = m_basePointSize * qPrefDisplay::mobile_scale();
+	m_regularPointSize = m_basePointSize;
 	emit regularPointSizeChanged();
 
 	m_headingPointSize = m_regularPointSize * 1.2;

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -37,6 +37,7 @@ class ThemeInterface : public QObject {
 public:
 	static ThemeInterface *instance();
 	double currentScale();
+	void setInitialFontSize(double fontSize);
 
 public slots:
 	void set_currentTheme(const QString &theme);

--- a/stats/statsicons.qrc
+++ b/stats/statsicons.qrc
@@ -1,0 +1,15 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="chart-bar-grouped-horizontal-icon">../icons/chart_bar_grouped_horizontal.svg</file>
+        <file alias="chart-bar-grouped-vertical-icon">../icons/chart_bar_grouped_vertical.svg</file>
+        <file alias="chart-bar-stacked-horizontal-icon">../icons/chart_bar_stacked_horizontal.svg</file>
+        <file alias="chart-bar-stacked-vertical-icon">../icons/chart_bar_stacked_vertical.svg</file>
+        <file alias="chart-bar-horizontal-icon">../icons/chart_bar_horizontal.svg</file>
+        <file alias="chart-bar-vertical-icon">../icons/chart_bar_vertical.svg</file>
+        <file alias="chart-box-icon">../icons/chart_box.svg</file>
+        <file alias="chart-pie-icon">../icons/chart_pie.svg</file>
+        <file alias="chart-points-icon">../icons/chart_points.svg</file>
+        <file alias="chart-warning-icon">../icons/warning-icon.svg</file>
+    </qresource>
+</RCC>
+

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -69,7 +69,7 @@ void exit_ui()
 }
 
 #ifdef SUBSURFACE_MOBILE
-void run_mobile_ui()
+void run_mobile_ui(double initial_font_size)
 {
 #if defined(Q_OS_ANDROID)
 	// work around an odd interaction between the OnePlus flavor of Android and Qt font handling
@@ -127,9 +127,13 @@ void run_mobile_ui()
 	ctxt->setContextProperty("diveModel", MobileModels::instance()->listModel());
 	set_non_bt_addresses();
 
+	// we need to setup the initial font size before the QML UI is instantiated
+	ThemeInterface *themeInterface = ThemeInterface::instance();
+	themeInterface->setInitialFontSize(initial_font_size);
+
 	ctxt->setContextProperty("connectionListModel", &connectionListModel);
 	ctxt->setContextProperty("logModel", MessageHandlerModel::self());
-	ctxt->setContextProperty("subsurfaceTheme", ThemeInterface::instance());
+	ctxt->setContextProperty("subsurfaceTheme", themeInterface);
 
 	qmlRegisterUncreatableType<QMLManager>("org.subsurfacedivelog.mobile",1,0,"ExportType","Enum is not a type");
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -25,6 +25,7 @@
 #include "profile-widget/qmlprofile.h"
 #include "core/downloadfromdcthread.h"
 #include "core/subsurfacestartup.h" // for testqml
+#include "core/metrics.h"
 #include "qt-models/diveimportedmodel.h"
 #else
 #include "desktop-widgets/mainwindow.h"
@@ -73,6 +74,8 @@ void run_ui()
 #if defined(Q_OS_ANDROID)
 	// work around an odd interaction between the OnePlus flavor of Android and Qt font handling
 	if (getAndroidHWInfo().contains("/OnePlus/")) {
+		QFontInfo qfi(defaultModelFont());
+		double basePointSize = qfi.pointSize();
 		QFontDatabase db;
 		int id = QFontDatabase::addApplicationFont(":/fonts/Roboto-Regular.ttf");
 		QStringList fontFamilies = QFontDatabase::applicationFontFamilies(id);
@@ -80,6 +83,7 @@ void run_ui()
 			QString family = fontFamilies.at(0);
 			QFont newDefaultFont;
 			newDefaultFont.setFamily(family);
+			newDefaultFont.setPointSize(basePointSize);
 			(static_cast<QApplication *>(QCoreApplication::instance()))->setFont(newDefaultFont);
 			qDebug() << "Detected OnePlus device, trying to force bundled font" << family;
 			QFont defaultFont = (static_cast<QApplication *>(QCoreApplication::instance()))->font();

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -68,9 +68,9 @@ void exit_ui()
 	free((void *)existing_filename);
 }
 
-void run_ui()
-{
 #ifdef SUBSURFACE_MOBILE
+void run_mobile_ui()
+{
 #if defined(Q_OS_ANDROID)
 	// work around an odd interaction between the OnePlus flavor of Android and Qt font handling
 	if (getAndroidHWInfo().contains("/OnePlus/")) {
@@ -187,11 +187,16 @@ void run_ui()
 	qml_window->setWidth(width);
 #endif // not Q_OS_ANDROID and not Q_OS_IOS
 	qml_window->show();
-#else
-	MainWindow::instance()->show();
-#endif // SUBSURFACE_MOBILE
 	qApp->exec();
 }
+#else // SUBSURFACE_MOBILE
+// just run the desktop UI
+void run_ui()
+{
+	MainWindow::instance()->show();
+	qApp->exec();
+}
+#endif // SUBSURFACE_MOBILE
 
 Q_DECLARE_METATYPE(duration_t)
 static void register_meta_types()

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -19,6 +19,7 @@
 #include "core/settings/qPrefCloudStorage.h"
 
 #include <QApplication>
+#include <QFont>
 #include <QLocale>
 #include <QLoggingCategory>
 #include <QStringList>
@@ -60,6 +61,9 @@ int main(int argc, char **argv)
 
 	parse_xml_init();
 	taglist_init_global();
+
+	// grab the system font size before we overwrite this when we load preferences
+	double initial_font_size = QGuiApplication::font().pointSizeF();
 	init_ui();
 	if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE)
 		set_filename(prefs.default_filename);
@@ -76,7 +80,7 @@ int main(int argc, char **argv)
 	init_proxy();
 
 	if (!quit)
-		run_mobile_ui();
+		run_mobile_ui(initial_font_size);
 	exit_ui();
 	taglist_free(g_tag_list);
 	parse_xml_exit();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 	init_proxy();
 
 	if (!quit)
-		run_ui();
+		run_mobile_ui();
 	exit_ui();
 	taglist_free(g_tag_list);
 	parse_xml_exit();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -20,6 +20,7 @@
 
 #include <QApplication>
 #include <QFont>
+#include <QFontMetrics>
 #include <QLocale>
 #include <QLoggingCategory>
 #include <QStringList>
@@ -64,6 +65,14 @@ int main(int argc, char **argv)
 
 	// grab the system font size before we overwrite this when we load preferences
 	double initial_font_size = QGuiApplication::font().pointSizeF();
+	if (initial_font_size < 0.0) {
+		// The OS provides a default font in pixels, not points; doing some crude math
+		// to reverse engineer that information by measuring the height of a 10pt font in pixels
+		QFont testFont;
+		testFont.setPointSizeF(10.0);
+		QFontMetrics fm(testFont);
+		initial_font_size = QGuiApplication::font().pixelSize() * 10.0 / fm.height();
+	}
 	init_ui();
 	if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE)
 		set_filename(prefs.default_filename);

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -100,15 +100,5 @@
         <file alias="gps_good_result-icon">icons/resultgreen.png</file>
         <file alias="gps_warning_result-icon">icons/resultyellow.png</file>
         <file alias="gps_bad_result-icon">icons/resultred.png</file>
-        <file alias="chart-bar-grouped-horizontal-icon">icons/chart_bar_grouped_horizontal.svg</file>
-        <file alias="chart-bar-grouped-vertical-icon">icons/chart_bar_grouped_vertical.svg</file>
-        <file alias="chart-bar-stacked-horizontal-icon">icons/chart_bar_stacked_horizontal.svg</file>
-        <file alias="chart-bar-stacked-vertical-icon">icons/chart_bar_stacked_vertical.svg</file>
-        <file alias="chart-bar-horizontal-icon">icons/chart_bar_horizontal.svg</file>
-        <file alias="chart-bar-vertical-icon">icons/chart_bar_vertical.svg</file>
-        <file alias="chart-box-icon">icons/chart_box.svg</file>
-        <file alias="chart-pie-icon">icons/chart_pie.svg</file>
-        <file alias="chart-points-icon">icons/chart_points.svg</file>
-        <file alias="chart-warning-icon">icons/warning-icon.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This feels much more responsive to various screen widths to me.
Instead of a fixed grid this is now a Flow that is tries to make much
better use of the space available on the user's device. It's not always
perfect, but to me at least a massive improvement.

The commit is almost unreadable because of the re-indentation and the
move of a block of fields to earlier in the form (as that made it much
easier to flow everything). But with show -w you can get a better idea.

We have a Flow around all the fields, we pair each label with the
corresponding input field, and then have a few additional Flows to
ensure that the cylinders always start in the first column.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
see commit message. This makes MUCH better use of the screen when editing dives, especially when on a tablet

It is far from perfect - switching to large font for example can throw things off, and with small font we are actually again not doing a good enough job using the space... I had thought that the gridUnit would make sure this adjusted, but that doesn't appear to be the case. More research needed.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
yeah, this changes the way the edit screen looks, so screen shots will need updating

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson @janmulder 
Jan, I know you haven't spent much time on Subsurface lately, but there are so many changes in the mobile version that I wonder if this might be a bit more fun again these days... also, I'm desperate to get someone else in who can at least read my QML code and to bounce ideas off of...