### PR TITLE
[TRIVIAL] cleanup: remove double->int->double conversions

### DIFF
--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -745,8 +745,8 @@ void StatsView::RegressionLine::updatePosition()
 	auto [minY, maxY] = yAxis->minMax();
 
 	QPolygonF line;
-	line << QPoint(xAxis->toScreen(minX), yAxis->toScreen(reg.a * minX + reg.b))
-		<< QPoint(xAxis->toScreen(maxX), yAxis->toScreen(reg.a * maxX + reg.b));
+	line << QPointF(xAxis->toScreen(minX), yAxis->toScreen(reg.a * minX + reg.b))
+		<< QPointF(xAxis->toScreen(maxX), yAxis->toScreen(reg.a * maxX + reg.b));
 
 	// Draw the confidence interval according to http://www2.stat.duke.edu/~tjl13/s101/slides/unit6lec3H.pdf p.5 with t*=2 for 95% confidence
 	QPolygonF poly;
@@ -756,7 +756,7 @@ void StatsView::RegressionLine::updatePosition()
 	for (double x = maxX; x >= minX - 1; x -= (maxX - minX) / 100)
 		poly << QPointF(xAxis->toScreen(x),
 			yAxis->toScreen(reg.a * x + reg.b - 2.0 * sqrt(reg.res2 / (reg.n - 2)  * (1.0 / reg.n + (x - reg.xavg) * (x - reg.xavg) / (reg.n - 1) * (reg.n -2) / reg.sx2))));
-	QRectF box(QPoint(xAxis->toScreen(minX), yAxis->toScreen(minY)), QPoint(xAxis->toScreen(maxX), yAxis->toScreen(maxY)));
+	QRectF box(QPointF(xAxis->toScreen(minX), yAxis->toScreen(minY)), QPointF(xAxis->toScreen(maxX), yAxis->toScreen(maxY)));
 
 	item->setPolygon(poly.intersected(box));
 	central->setPolygon(line.intersected(box));


### PR DESCRIPTION
The new confidence interval code constructed integer-based
points from float-values and fed those back to float-based
polygons or lines.

Remove these back-and-forth transformations by using float-based
points.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Avoid (justified) compiler warnings caused by unnecessary float->int->float round trip conversions.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace `QPoint` by `QPointF` where appropriate.
