### PR TITLE
mobile: add GF fields for ceiling calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- mobile: add GF fields to adjust Buhlmann algorithm parameters for calculated ceiling
 - undo: save to git after editing weights [#3159]
 - undo: reset dive-mode on undo of set-point addition
 - desktop: complete rewrite of the statistics code, significantly expanding capabilities

--- a/core/settings/qPrefTechnicalDetails.cpp
+++ b/core/settings/qPrefTechnicalDetails.cpp
@@ -62,6 +62,7 @@ void qPrefTechnicalDetails::set_gfhigh(int value)
 	if (value != prefs.gfhigh) {
 		prefs.gfhigh = value;
 		disk_gfhigh(true);
+		set_gf(-1, prefs.gfhigh);
 		emit instance()->gfhighChanged(value);
 	}
 }
@@ -82,6 +83,7 @@ void qPrefTechnicalDetails::set_gflow(int value)
 	if (value != prefs.gflow) {
 		prefs.gflow = value;
 		disk_gflow(true);
+		set_gf(prefs.gflow, -1);
 		emit instance()->gflowChanged(value);
 	}
 }

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -68,7 +68,6 @@ void PreferencesGraph::syncSettings()
 	prefs.planner_deco_mode = ui->buehlmann->isChecked() ? BUEHLMANN : VPMB;
 	qPrefTechnicalDetails::set_gflow(ui->gflow->value());
 	qPrefTechnicalDetails::set_gfhigh(ui->gfhigh->value());
-	set_gf(ui->gflow->value(), ui->gfhigh->value());
 	qPrefTechnicalDetails::set_vpmb_conservatism(ui->vpmb_conservatism->value());
 	set_vpmb_conservatism(ui->vpmb_conservatism->value());
 	qPrefTechnicalDetails::set_show_ccr_setpoint(ui->show_ccr_setpoint->isChecked());

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -622,7 +622,7 @@ TemplatePage {
 					checked: PrefTechnicalDetails.dcceiling
 					onClicked: {
 						PrefTechnicalDetails.dcceiling = checked
-						rootItem.settingChanged()
+						rootItem.settingsChanged()
 					}
 				}
 				TemplateLabel {
@@ -632,6 +632,30 @@ TemplatePage {
 					checked: PrefTechnicalDetails.calcceiling
 					onClicked: {
 						PrefTechnicalDetails.calcceiling = checked
+						rootItem.settingsChanged()
+					}
+				}
+				TemplateLabel {
+					text: qsTr("GFLow")
+				}
+				TemplateTextField {
+					id: gfLow
+					text: PrefTechnicalDetails.gflow
+					inputMask: "99"
+					onEditingFinished: {
+						PrefTechnicalDetails.gflow = gfLow.text
+						rootItem.settingsChanged()
+					}
+				}
+				TemplateLabel {
+					text: qsTr("GFHigh")
+				}
+				TemplateTextField {
+					id: gfHigh
+					text: PrefTechnicalDetails.gfhigh
+					inputMask: "99"
+					onEditingFinished: {
+						PrefTechnicalDetails.gfhigh = gfHigh.text
 						rootItem.settingsChanged()
 					}
 				}

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -185,6 +185,8 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	auto tec = qPrefTechnicalDetails::instance();
 	connect(tec, &qPrefTechnicalDetails::calcalltissuesChanged           , this, &ProfileWidget2::actionRequestedReplot);
 	connect(tec, &qPrefTechnicalDetails::calcceilingChanged              , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::gflowChanged                    , this, &ProfileWidget2::actionRequestedReplot);
+	connect(tec, &qPrefTechnicalDetails::gfhighChanged                   , this, &ProfileWidget2::actionRequestedReplot);
 	connect(tec, &qPrefTechnicalDetails::dcceilingChanged                , this, &ProfileWidget2::actionRequestedReplot);
 	connect(tec, &qPrefTechnicalDetails::eadChanged                      , this, &ProfileWidget2::actionRequestedReplot);
 	connect(tec, &qPrefTechnicalDetails::calcceiling3mChanged            , this, &ProfileWidget2::actionRequestedReplot);


### PR DESCRIPTION
Signed-off-by: Doug Junkins <douglas.junkins@gmail.com>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Adds fields to the advanced preferences page to modify GFLow and GFHigh for
the Buhlmann decompression model for calculating ceilings. Also updates the 
set methods for the GF preferences to update the parameters for the Buhlmann
algorithm in core/deco.c.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Added text fields for GFLow and GFHigh to settings.qml
2) Added connections to profilewidget2.cpp to redraw profile when the GF values are changed
3) Added set_gf() calls to the set_gflow() and set_gfhigh() methods in qPrefTechnicalDetails.cpp
4) Removed set_gf() call from the desktop preference widget code in preferences_graph.cpp

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
mobile: add GF fields to adjust Buhlmann algorithm parameters for calculated ceiling

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
