### PR TITLE
statistics: do resizing in UI thread, not render thread [Alternative to #3177]

### DIFF
--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -64,12 +64,12 @@ public:
 private slots:
 	void replotIfVisible();
 private:
-	bool resetChart;
-
 	// QtQuick related things
+	bool backgroundDirty;
 	QRectF plotRect;
 	QSGNode *updatePaintNode(QSGNode *oldNode, QQuickItem::UpdatePaintNodeData *updatePaintNodeData) override;
 
+	void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 	void plotAreaChanged(const QSizeF &size);
 	void reset(); // clears all series and axes
 	void setAxes(StatsAxis *x, StatsAxis *y);


### PR DESCRIPTION
The updatePaintNode() function, which is run on the render
thread detected a geometry change and initiated recalculation
of the chart layout.

This means that plotAreaChanged() was called in two different
thread contexts, which is questionable. Instead, hook into
the geometryChanged() function and recalculate the chart items
there.

This fixes a rendering bug, because the old code would first
delete unneeded items and then rerender the chart. Thus, old
grid and tick items were still visible.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Alternative version of #3177. Just as contentious, because I don't know what intercepting the geometry change means and if it is guaranteed to run before updatePaintNode()?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Intercept geometry changes and update the chart accordingly.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Alternative to #3177.
