### PR TITLE
Start rework of mainwindow quadrant code

### DIFF
--- a/core/applicationstate.h
+++ b/core/applicationstate.h
@@ -13,6 +13,10 @@ enum class ApplicationState {
 	EditDiveSite,
 	FilterDive,
 	Statistics,
+	MapMaximized,
+	ProfileMaximized,
+	ListMaximized,
+	InfoMaximized,
 	Count
 };
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -81,10 +81,6 @@ namespace {
 	QProgressDialog *progressDialog = nullptr;
 	bool progressDialogCanceled = false;
 	int progressCounter = 0;
-
-	int round_int (double value) {
-		return static_cast<int>(lrint(value));
-	};
 }
 
 extern "C" int updateProgress(const char *text)
@@ -902,12 +898,6 @@ void MainWindow::restoreSplitterSizes()
 	if (ui.mainSplitter->count() < 2 || topSplitter->count() < 2 || bottomSplitter->count() < 2)
 		return;
 
-	const int appH = qApp->desktop()->size().height();
-	const int appW = qApp->desktop()->size().width();
-
-	QList<int> mainSizes = { round_int(appH * 0.7), round_int(appH * 0.3) };
-	QList<int> infoProfileSizes = { round_int(appW * 0.3), round_int(appW * 0.7) };
-	QList<int> listGlobeSizes = { round_int(appW * 0.7), round_int(appW * 0.3) };
 
 	QSettings settings;
 	settings.beginGroup("MainWindow");
@@ -917,9 +907,12 @@ void MainWindow::restoreSplitterSizes()
 		topSplitter->restoreState(settings.value("topSplitter").toByteArray());
 		bottomSplitter->restoreState(settings.value("bottomSplitter").toByteArray());
 	} else {
-		ui.mainSplitter->setSizes(mainSizes);
-		topSplitter->setSizes(infoProfileSizes);
-		bottomSplitter->setSizes(listGlobeSizes);
+		const int appH = qApp->desktop()->size().height();
+		const int appW = qApp->desktop()->size().width();
+
+		ui.mainSplitter->setSizes({ appH * 3 / 5, appH * 2 / 5 });
+		topSplitter->setSizes({ appW / 2, appW / 2 });
+		bottomSplitter->setSizes({ appW * 3 / 5, appW * 2 / 5 });
 	}
 }
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -205,6 +205,7 @@ private:
 	};
 
 	struct Quadrants {
+		bool allowUserChange; // Allow the user to change away from this state
 		Quadrant topLeft;
 		Quadrant topRight;
 		Quadrant bottomLeft;
@@ -213,6 +214,7 @@ private:
 
 	Quadrants applicationState[(size_t)ApplicationState::Count];
 	static void addWidgets(const Quadrant &);
+	bool userMayChangeAppState() const;
 	void setQuadrantWidget(const Quadrant &q, QSplitter *splitter);
 	void registerApplicationState(ApplicationState state, Quadrants q);
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -41,19 +41,6 @@ class LocationInformationWidget;
 class MainWindow : public QMainWindow {
 	Q_OBJECT
 public:
-	enum {
-		COLLAPSED,
-		EXPANDED
-	};
-
-	enum CurrentState {
-		VIEWALL,
-		MAP_MAXIMIZED,
-		INFO_MAXIMIZED,
-		PROFILE_MAXIMIZED,
-		LIST_MAXIMIZED
-	};
-
 	MainWindow();
 	~MainWindow();
 	static MainWindow *instance();
@@ -165,6 +152,8 @@ slots:
 private:
 	Ui::MainWindow ui;
 	FilterWidget filterWidget;
+	QSplitter *topSplitter;
+	QSplitter *bottomSplitter;
 	QAction *actionNextDive;
 	QAction *actionPreviousDive;
 	QAction *undoAction;
@@ -172,7 +161,6 @@ private:
 #ifndef NO_USERMANUAL
 	UserManual *helpView;
 #endif
-	CurrentState state;
 	QString filter_open();
 	QString filter_import();
 	QString filter_import_dive_sites();
@@ -188,15 +176,13 @@ private:
 	void writeSettings();
 	int file_save();
 	int file_save_as();
-	void beginChangeState(CurrentState s);
 	void saveSplitterSizes();
-	void toggleCollapsible(bool toggle);
-	void showFilterIfEnabled();
+	void restoreSplitterSizes();
 	void updateLastUsedDir(const QString &s);
-	void enterState(CurrentState);
+	void clearSplitters();
 	bool filesAsArguments;
 	UpdateManager *updateManager;
-	LocationInformationWidget *diveSiteEdit;
+	std::unique_ptr<LocationInformationWidget> diveSiteEdit;
 
 	bool plannerStateClean();
 	void configureToolbar();
@@ -226,8 +212,8 @@ private:
 	};
 
 	Quadrants applicationState[(size_t)ApplicationState::Count];
-	static void setQuadrant(const Quadrant &, QStackedWidget *);
-	static void addWidgets(const Quadrant &, QStackedWidget *);
+	static void addWidgets(const Quadrant &);
+	void setQuadrantWidget(const Quadrant &q, QSplitter *splitter);
 	void registerApplicationState(ApplicationState state, Quadrants q);
 
 	QMenu *connections;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -184,7 +184,6 @@ private:
 	void saveSplitterSizes();
 	void restoreSplitterSizes();
 	void updateLastUsedDir(const QString &s);
-	void clearSplitters();
 	bool filesAsArguments;
 	UpdateManager *updateManager;
 	std::unique_ptr<LocationInformationWidget> diveSiteEdit;
@@ -220,7 +219,8 @@ private:
 	Quadrants applicationState[(size_t)ApplicationState::Count];
 	static void addWidgets(const Quadrant &);
 	bool userMayChangeAppState() const;
-	void setQuadrantWidget(const Quadrant &q, QSplitter &splitter);
+	void setQuadrantWidget(QSplitter &splitter, const Quadrant &q, int pos);
+	void setQuadrantWidgets(QSplitter &splitter, const Quadrant &left, const Quadrant &right);
 	void registerApplicationState(ApplicationState state, Quadrants q);
 
 	QMenu *connections;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -30,12 +30,14 @@ class DiveTripModel;
 class QItemSelection;
 class DiveListView;
 class MainTab;
+class MapWidget;
 class QWebView;
 class QSettings;
 class UpdateManager;
 class UserManual;
 class PlannerWidgets;
 class ProfileWidget2;
+class StatsWidget;
 class LocationInformationWidget;
 
 class MainWindow : public QMainWindow {
@@ -63,8 +65,11 @@ public:
 
 	std::unique_ptr<MainTab> mainTab;
 	std::unique_ptr<PlannerWidgets> plannerWidgets;
+	std::unique_ptr<StatsWidget> statistics;
 	ProfileWidget2 *graphics;
-	DiveListView *diveList;
+	std::unique_ptr<DiveListView> diveList;
+	std::unique_ptr<QWidget> profileContainer;
+	std::unique_ptr<MapWidget> mapWidget;
 private
 slots:
 	/* file menu action */
@@ -152,8 +157,8 @@ slots:
 private:
 	Ui::MainWindow ui;
 	FilterWidget filterWidget;
-	QSplitter *topSplitter;
-	QSplitter *bottomSplitter;
+	std::unique_ptr<QSplitter> topSplitter;
+	std::unique_ptr<QSplitter> bottomSplitter;
 	QAction *actionNextDive;
 	QAction *actionPreviousDive;
 	QAction *undoAction;
@@ -215,7 +220,7 @@ private:
 	Quadrants applicationState[(size_t)ApplicationState::Count];
 	static void addWidgets(const Quadrant &);
 	bool userMayChangeAppState() const;
-	void setQuadrantWidget(const Quadrant &q, QSplitter *splitter);
+	void setQuadrantWidget(const Quadrant &q, QSplitter &splitter);
 	void registerApplicationState(ApplicationState state, Quadrants q);
 
 	QMenu *connections;

--- a/desktop-widgets/mainwindow.ui
+++ b/desktop-widgets/mainwindow.ui
@@ -32,20 +32,6 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
-      <widget class="QSplitter" name="topSplitter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <widget class="QStackedWidget" name="topLeft"/>
-       <widget class="QStackedWidget" name="topRight"/>
-      </widget>
-      <widget class="QSplitter" name="bottomSplitter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <widget class="QStackedWidget" name="bottomLeft"/>
-       <widget class="QStackedWidget" name="bottomRight"/>
-      </widget>
      </widget>
     </item>
     <item>

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -116,6 +116,15 @@ void MapWidget::divesChanged(const QVector<dive *> &, DiveField field)
 		reload();
 }
 
+// Sadly, for reasons out of our control, we can't use a normal singleton for the
+// map widget: In a standard singleton, the object is freed after main() exits.
+// However, if there is an animation running (map zooming), the thread is
+// terminated, when the QApplication object is destroyed, which is before main()
+// exits. The thread has a QQmlAnimationTimer that is freed. However, the map widget
+// then tries to free the object itself, leading to a crash. Clearly, a bug in
+// the QML MapWidget / QtQuick ecosystem.
+// To solve this, the mainwindow will destroy the map widget and in the destructor
+// the reference is cleared. Sad.
 MapWidget::~MapWidget()
 {
 	m_instance = NULL;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -316,7 +316,6 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 	if (!current_dive || !dives.contains(current_dive))
 		return;
 
-	bool replot = false;
 	if (field.visibility)
 		ui->visibility->setCurrentStars(current_dive->visibility);
 	if (field.wavesize)
@@ -327,10 +326,8 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		ui->surge->setCurrentStars(current_dive->surge);
 	if (field.chill)
 		ui->chill->setCurrentStars(current_dive->chill);
-	if (field.mode) {
+	if (field.mode)
 		updateMode(current_dive);
-		replot = true;
-	}
 	if (field.duration || field.depth || field.mode)
 		updateProfile();
 	if (field.air_temp)
@@ -347,10 +344,6 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		salinity_value = current_dive->salinity;
 	ui->waterTypeCombo->setCurrentIndex(updateSalinityComboIndex(salinity_value));
 	ui->salinityText->setText(QString("%L1g/ℓ").arg(salinity_value / 10.0));
-	// TODO: The profile should recognize itself when the dive mode changed.
-	// It seem awkward to route this via the dive-information tab.
-	if (replot)
-		MainWindow::instance()->graphics->plotDive(current_dive, true);
 }
 
 void TabDiveInformation::on_visibility_valueChanged(int value)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -269,7 +269,7 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 
 	// If duration or depth changed, the profile needs to be replotted
 	if (field.duration || field.depth)
-		MainWindow::instance()->graphics->plotDive(current_dive, true);
+		MainWindow::instance()->refreshProfile();
 }
 
 void MainTab::diveSiteEdited(dive_site *ds, int)
@@ -513,7 +513,7 @@ void MainTab::acceptChanges()
 	if (editMode) {
 		MainWindow::instance()->diveList->reload();
 		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->graphics->plotDive(current_dive, true);
+		MainWindow::instance()->refreshProfile();
 	} else {
 		MainWindow::instance()->refreshDisplay();
 	}
@@ -549,7 +549,7 @@ void MainTab::rejectChanges()
 	updateDiveInfo();
 
 	// show the profile and dive info
-	MainWindow::instance()->graphics->plotDive(current_dive, true);
+	MainWindow::instance()->refreshProfile();
 	MainWindow::instance()->setEnabledToolbar(true);
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 }

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -32,7 +32,6 @@
 #include "core/gettextfromc.h"
 #include "core/imagedownloader.h"
 #endif
-#include "core/subsurface-qt/divelistnotifier.h"
 
 #include <libdivecomputer/parser.h>
 #include <QScrollBar>
@@ -174,6 +173,7 @@ ProfileWidget2::ProfileWidget2(QWidget *parent) : QGraphicsView(parent),
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &ProfileWidget2::profileChanged);
 	connect(&diveListNotifier, &DiveListNotifier::eventsChanged, this, &ProfileWidget2::profileChanged);
 	connect(&diveListNotifier, &DiveListNotifier::pictureOffsetChanged, this, &ProfileWidget2::pictureOffsetChanged);
+	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &ProfileWidget2::divesChanged);
 #endif // SUBSURFACE_MOBILE
 
 #if !defined(QT_NO_DEBUG) && defined(SHOW_PLOT_INFO_TABLE)
@@ -812,6 +812,16 @@ void ProfileWidget2::plotDive(const struct dive *d, bool force, bool doClearPict
 		qPrefTechnicalDetails::set_calcndltts(false);
 		report_error(qPrintable(tr("Show NDL / TTS was disabled because of excessive processing time")));
 	}
+}
+
+void ProfileWidget2::divesChanged(const QVector<dive *> &dives, DiveField field)
+{
+	// If the mode of the currently displayed dive changed, replot
+	if (field.mode &&
+	    std::any_of(dives.begin(), dives.end(),
+			[id = displayed_dive.id] (const dive *d)
+			{ return d->id == id; } ))
+		replot();
 }
 
 void ProfileWidget2::actionRequestedReplot(bool)

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -22,6 +22,7 @@
 #include "core/color.h"
 #include "core/pictureobj.h"
 #include "core/units.h"
+#include "core/subsurface-qt/divelistnotifier.h"
 
 class RulerItem2;
 struct dive;
@@ -102,6 +103,7 @@ public
 slots: // Necessary to call from QAction's signals.
 	void settingsChanged();
 	void actionRequestedReplot(bool triggered);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void setEmptyState();
 	void setProfileState();
 #ifndef SUBSURFACE_MOBILE

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -43,13 +43,14 @@ public:
 	~StatsView();
 
 	void plot(const StatsState &state);
-	void updateFeatures(const StatsState &state); // Updates the visibility of chart features, such as legend, regression, etc.
+	void updateFeatures(const StatsState &state);	// Updates the visibility of chart features, such as legend, regression, etc.
 	QQuickWindow *w() const;			// Make window available to items
 	QSizeF size() const;
 	QRectF plotArea() const;
 	void addQSGNode(QSGNode *node, ChartZValue z);	// Must only be called in render thread!
 	void registerChartItem(ChartItem &item);
 	void registerDirtyChartItem(ChartItem &item);
+	void emergencyShutdown();			// Called when QQuick decides to delete out root node.
 
 	// Create a chart item and add it to the scene.
 	// The item must not be deleted by the caller, but can be
@@ -151,6 +152,10 @@ private:
 
 	// There are three double linked lists of chart items:
 	// clean items, dirty items and items to be deleted.
+	// Note that only the render thread must delete chart items,
+	// and therefore these lists are the only owning pointers
+	// to chart items. All other pointers are non-owning and
+	// can therefore become stale.
 	struct ChartItemList {
 		ChartItemList();
 		ChartItem *first, *last;
@@ -161,6 +166,7 @@ private:
 	};
 	ChartItemList cleanItems, dirtyItems, deletedItems;
 	void deleteChartItemInternal(ChartItem &item);
+	void freeDeletedChartItems();
 };
 
 // This implementation detail must be known to users of the class.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This completely reworks the quadrant code: instead of two orthogonal states (application state and view state), merge everything into one state.

Moreover, remove widgets from the splitters, because this is the only way to have a widget appear at different quadrants owing to Qt's tree-based ownership model.

This is unoptimized and I've observed flickering when changing state, because all widgets are removed from the splitters and then readded. The plan is to fix these issues in future commits, but for now the goal is to make it stable.

