### PR TITLE
remove global state from DivePlannerPointsModel

### DIFF
--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -229,7 +229,7 @@ void exportProfile(const struct dive *dive, const QString filename)
 	profile->setPrintMode(true);
 	double scale = profile->getFontPrintScale();
 	profile->setFontPrintScale(4 * scale);
-	profile->plotDive(dive, true, false, true);
+	profile->plotDive(dive, 0, true, false, true);
 	QImage image = QImage(profile->size() * 4, QImage::Format_RGB32);
 	QPainter paint;
 	paint.begin(&image);
@@ -238,5 +238,5 @@ void exportProfile(const struct dive *dive, const QString filename)
 	profile->setToolTipVisibile(true);
 	profile->setFontPrintScale(scale);
 	profile->setPrintMode(false);
-	profile->plotDive(dive, true);
+	profile->plotDive(dive, 0, true); // TODO: Shouldn't this plot the current dive?
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -50,12 +50,7 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	view->setColumnHidden(CylindersModel::DEPTH, false);
 	view->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
 	connect(ui.cylinderTableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addCylinder_clicked);
-
-	// addStop actually accept a call with no parameters, due to default parameters, but the connect() syntax without SIGNAL/SLOT
-	// does not understand default parameters and causes errors to be thrown.
-	// Continue to use old syntax, to avoid problems.
-	connect(ui.tableWidget, SIGNAL(addButtonClicked()), plannerModel, SLOT(addStop()));
-
+	connect(ui.tableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addDefaultStop);
 	connect(cylinders, &CylindersModel::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
 	connect(cylinders, &CylindersModel::rowsInserted, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
 	connect(cylinders, &CylindersModel::rowsRemoved, GasSelectionModel::instance(), &GasSelectionModel::repopulate);
@@ -63,7 +58,6 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(cylinders, &CylindersModel::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(cylinders, &CylindersModel::rowsRemoved, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
-
 
 	ui.tableWidget->setBtnToolTip(tr("Add dive data point"));
 	connect(ui.startTime, &QDateEdit::timeChanged, plannerModel, &DivePlannerPointsModel::setStartTime);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -540,8 +540,6 @@ PlannerWidgets::PlannerWidgets()
 void PlannerWidgets::planDive()
 {
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-
-	MainWindow::instance()->graphics->setPlanState(&displayed_dive, 0);
 	dc_number = 0;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
@@ -568,8 +566,6 @@ void PlannerWidgets::replanDive()
 	copy_dive(current_dive, &displayed_dive); // Planning works on a copy of the dive (for now).
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
-
-	MainWindow::instance()->graphics->setPlanState(&displayed_dive, 0);
 
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -545,7 +545,7 @@ void PlannerWidgets::planDive()
 	dc_number = 0;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
-	DivePlannerPointsModel::instance()->createSimpleDive();
+	DivePlannerPointsModel::instance()->createSimpleDive(&displayed_dive);
 
 	// plan the dive in the same mode as the currently selected one
 	if (current_dive) {
@@ -563,17 +563,20 @@ void PlannerWidgets::planDive()
 
 void PlannerWidgets::replanDive()
 {
+	if (!current_dive)
+		return;
+	copy_dive(current_dive, &displayed_dive); // Planning works on a copy of the dive (for now).
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
+	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 
 	MainWindow::instance()->graphics->setPlanState();
 
 	plannerWidget.setReplanButton(true);
-	plannerWidget.setupStartTime(timestampToDateTime(current_dive->when));
-	if (current_dive->surface_pressure.mbar)
-		plannerWidget.setSurfacePressure(current_dive->surface_pressure.mbar);
-	if (current_dive->salinity)
-		plannerWidget.setSalinity(current_dive->salinity);
-	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
+	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));
+	if (displayed_dive.surface_pressure.mbar)
+		plannerWidget.setSurfacePressure(displayed_dive.surface_pressure.mbar);
+	if (displayed_dive.salinity)
+		plannerWidget.setSalinity(displayed_dive.salinity);
 	reset_cylinders(&displayed_dive, true);
 	DivePlannerPointsModel::instance()->cylindersModel()->updateDive(&displayed_dive);
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -563,7 +563,6 @@ void PlannerWidgets::planDive()
 
 void PlannerWidgets::replanDive()
 {
-	DivePlannerPointsModel::instance()->clear();
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
 	MainWindow::instance()->graphics->setPlanState();

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -32,7 +32,6 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	ui.tableWidget->setTitle(tr("Dive planner points"));
 	ui.tableWidget->setModel(plannerModel);
 	connect(ui.tableWidget, &TableView::itemClicked, plannerModel, &DivePlannerPointsModel::remove);
-	plannerModel->setRecalc(true);
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::GAS, new AirTypesDelegate(this));
 	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(this));
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -541,7 +541,7 @@ void PlannerWidgets::planDive()
 {
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
-	MainWindow::instance()->graphics->setPlanState();
+	MainWindow::instance()->graphics->setPlanState(&displayed_dive, 0);
 	dc_number = 0;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
@@ -569,7 +569,7 @@ void PlannerWidgets::replanDive()
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 
-	MainWindow::instance()->graphics->setPlanState();
+	MainWindow::instance()->graphics->setPlanState(&displayed_dive, 0);
 
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -134,7 +134,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	// for the "default" mode
 	mainTab.reset(new MainTab);
 	diveList.reset(new DiveListView);
-	graphics = new ProfileWidget2(this);
+	graphics = new ProfileWidget2(DivePlannerPointsModel::instance(), this);
 	mapWidget.reset(MapWidget::instance()); // Yes, this is ominous see comment in mapwidget.cpp.
 	plannerWidgets.reset(new PlannerWidgets);
 	statistics.reset(new StatsWidget);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -771,6 +771,7 @@ void MainWindow::on_actionReplanDive_triggered()
 	// put us in PLAN mode
 	setApplicationState(ApplicationState::PlanDive);
 
+	graphics->setPlanState(&displayed_dive, 0);
 	plannerWidgets->replanDive();
 }
 
@@ -782,6 +783,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 	// put us in PLAN mode
 	setApplicationState(ApplicationState::PlanDive);
 
+	graphics->setPlanState(&displayed_dive, 0);
 	plannerWidgets->planDive();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1514,7 +1514,6 @@ void MainWindow::editCurrentDive()
 		return;
 
 	disableShortcuts();
-	DivePlannerPointsModel::instance()->clear();
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
 	graphics->setAddState();
 	setApplicationState(ApplicationState::EditDive);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1518,9 +1518,9 @@ void MainWindow::editCurrentDive()
 	disableShortcuts();
 	copy_dive(current_dive, &displayed_dive); // Work on a copy of the dive
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
+	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	graphics->setAddState(&displayed_dive, 0);
 	setApplicationState(ApplicationState::EditDive);
-	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	mainTab->enableEdition();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -434,7 +434,7 @@ void MainWindow::selectionChanged()
 		configureToolbar();
 		enableDisableOtherDCsActions();
 	}
-	graphics->plotDive(current_dive, false);
+	graphics->plotDive(current_dive, dc_number, false);
 	MapWidget::instance()->selectionChanged();
 }
 
@@ -685,7 +685,7 @@ void MainWindow::enableShortcuts()
 void MainWindow::showProfile()
 {
 	enableShortcuts();
-	graphics->setProfileState();
+	graphics->setProfileState(current_dive, dc_number);
 	setApplicationState(ApplicationState::Default);
 }
 
@@ -738,7 +738,7 @@ void MainWindow::refreshProfile()
 {
 	showProfile();
 	configureToolbar();
-	graphics->plotDive(current_dive, true);
+	graphics->plotDive(current_dive, dc_number, true);
 }
 
 void MainWindow::planCanceled()
@@ -919,7 +919,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, false);
+	graphics->plotDive(current_dive, dc_number, false);
 	mainTab->updateDiveInfo();
 }
 
@@ -928,7 +928,7 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, false);
+	graphics->plotDive(current_dive, dc_number, false);
 	mainTab->updateDiveInfo();
 }
 
@@ -1516,7 +1516,7 @@ void MainWindow::editCurrentDive()
 	disableShortcuts();
 	copy_dive(current_dive, &displayed_dive); // Work on a copy of the dive
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
-	graphics->setAddState();
+	graphics->setAddState(&displayed_dive, 0);
 	setApplicationState(ApplicationState::EditDive);
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	mainTab->enableEdition();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1514,10 +1514,11 @@ void MainWindow::editCurrentDive()
 		return;
 
 	disableShortcuts();
+	copy_dive(current_dive, &displayed_dive); // Work on a copy of the dive
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
 	graphics->setAddState();
 	setApplicationState(ApplicationState::EditDive);
-	DivePlannerPointsModel::instance()->loadFromDive(current_dive);
+	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
 	mainTab->enableEdition();
 }
 

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -38,7 +38,7 @@ void Printer::putProfileImage(const QRect &profilePlaceholder, const QRect &view
 	int y = profilePlaceholder.y() - viewPort.y();
 	// use the placeHolder and the viewPort position to calculate the relative position of the dive profile.
 	QRect pos(x, y, profilePlaceholder.width(), profilePlaceholder.height());
-	profile->plotDive(dive, true, true);
+	profile->plotDive(dive, 0, true, true);
 
 	if (!printOptions.color_selected) {
 		QImage image(pos.width(), pos.height(), QImage::Format_ARGB32);
@@ -189,7 +189,7 @@ void Printer::render(int pages)
 	qPrefDisplay::set_animation_speed(animationOriginal);
 
 	//replot the dive after returning the settings
-	profile->plotDive(current_dive, true, true);
+	profile->plotDive(current_dive, dc_number, true, true);
 }
 
 //value: ranges from 0 : 100 and shows the progress of the templating engine

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -541,11 +541,6 @@ void MainTab::rejectChanges()
 	// no harm done to call cancelPlan even if we were not PLAN mode...
 	DivePlannerPointsModel::instance()->cancelPlan();
 
-	// now make sure that the correct dive is displayed
-	if (current_dive)
-		copy_dive(current_dive, &displayed_dive);
-	else
-		clear_dive(&displayed_dive);
 	updateDiveInfo();
 
 	// show the profile and dive info

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -13,7 +13,6 @@
 #include "qt-models/diveplannermodel.h"
 #include "desktop-widgets/divelistview.h"
 #include "core/selection.h"
-#include "profile-widget/profilewidget2.h"
 #include "desktop-widgets/diveplanner.h"
 #include "qt-models/divecomputerextradatamodel.h"
 #include "qt-models/divelocationmodel.h"
@@ -355,7 +354,7 @@ void MainTab::updateDiveInfo()
 {
 	ui.location->refreshDiveSiteCache();
 	// don't execute this while adding / planning a dive
-	if (editMode || MainWindow::instance()->graphics->isPlanner())
+	if (editMode || DivePlannerPointsModel::instance()->isPlanner())
 		return;
 
 	// If there is no current dive, disable all widgets except the last two,

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -504,19 +504,15 @@ void MainTab::acceptChanges()
 	ui.dateEdit->setEnabled(true);
 	hideMessage();
 
-	if (editMode) {
-		MainWindow::instance()->showProfile();
-		DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
-		Command::editProfile(&displayed_dive);
-	}
+	MainWindow::instance()->showProfile();
+	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
+	Command::editProfile(&displayed_dive);
+
 	int scrolledBy = MainWindow::instance()->diveList->verticalScrollBar()->sliderPosition();
-	if (editMode) {
-		MainWindow::instance()->diveList->reload();
-		MainWindow::instance()->refreshDisplay();
-		MainWindow::instance()->refreshProfile();
-	} else {
-		MainWindow::instance()->refreshDisplay();
-	}
+	MainWindow::instance()->diveList->reload();
+	MainWindow::instance()->refreshDisplay();
+	MainWindow::instance()->refreshProfile();
+
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::NOTHING);
 	MainWindow::instance()->diveList->verticalScrollBar()->setSliderPosition(scrolledBy);
 	MainWindow::instance()->diveList->setFocus();
@@ -528,13 +524,12 @@ void MainTab::acceptChanges()
 
 void MainTab::rejectChanges()
 {
-	if (editMode && current_dive) {
-		if (QMessageBox::warning(MainWindow::instance(), TITLE_OR_TEXT(tr("Discard the changes?"),
-									       tr("You are about to discard your changes.")),
-					 QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard) != QMessageBox::Discard) {
-			return;
-		}
+	if (QMessageBox::warning(MainWindow::instance(), TITLE_OR_TEXT(tr("Discard the changes?"),
+								       tr("You are about to discard your changes.")),
+				 QMessageBox::Discard | QMessageBox::Cancel, QMessageBox::Discard) != QMessageBox::Discard) {
+		return;
 	}
+
 	ui.dateEdit->setEnabled(true);
 	editMode = false;
 	hideMessage();
@@ -544,6 +539,7 @@ void MainTab::rejectChanges()
 	updateDiveInfo();
 
 	// show the profile and dive info
+	MainWindow::instance()->refreshDisplay();
 	MainWindow::instance()->refreshProfile();
 	MainWindow::instance()->setEnabledToolbar(true);
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());

--- a/profile-widget/divehandler.cpp
+++ b/profile-widget/divehandler.cpp
@@ -22,7 +22,7 @@ DiveHandler::DiveHandler(const struct dive *d) : dive(d)
 int DiveHandler::parentIndex()
 {
 	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
-	return view->handles.indexOf(this);
+	return view->handleIndex(this);
 }
 
 void DiveHandler::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1813,8 +1813,6 @@ void ProfileWidget2::keyDownAction()
 	if ((currentState != ADD && currentState != PLAN) || !plannerModel)
 		return;
 
-	bool oldRecalc = plannerModel->setRecalc(false);
-
 	Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
@@ -1824,8 +1822,6 @@ void ProfileWidget2::keyDownAction()
 			plannerModel->editStop(row, dp);
 		}
 	}
-	plannerModel->setRecalc(oldRecalc);
-	replot();
 }
 
 void ProfileWidget2::keyUpAction()
@@ -1833,7 +1829,6 @@ void ProfileWidget2::keyUpAction()
 	if ((currentState != ADD && currentState != PLAN) || !plannerModel)
 		return;
 
-	bool oldRecalc = plannerModel->setRecalc(false);
 	Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
@@ -1846,8 +1841,6 @@ void ProfileWidget2::keyUpAction()
 			plannerModel->editStop(row, dp);
 		}
 	}
-	plannerModel->setRecalc(oldRecalc);
-	replot();
 }
 
 void ProfileWidget2::keyLeftAction()
@@ -1855,7 +1848,6 @@ void ProfileWidget2::keyLeftAction()
 	if ((currentState != ADD && currentState != PLAN) || !plannerModel)
 		return;
 
-	bool oldRecalc = plannerModel->setRecalc(false);
 	Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
@@ -1868,8 +1860,6 @@ void ProfileWidget2::keyLeftAction()
 			plannerModel->editStop(row, dp);
 		}
 	}
-	plannerModel->setRecalc(oldRecalc);
-	replot();
 }
 
 void ProfileWidget2::keyRightAction()
@@ -1877,7 +1867,6 @@ void ProfileWidget2::keyRightAction()
 	if ((currentState != ADD && currentState != PLAN) || !plannerModel)
 		return;
 
-	bool oldRecalc = plannerModel->setRecalc(false);
 	Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
@@ -1887,8 +1876,6 @@ void ProfileWidget2::keyRightAction()
 			plannerModel->editStop(row, dp);
 		}
 	}
-	plannerModel->setRecalc(oldRecalc);
-	replot();
 }
 
 void ProfileWidget2::keyDeleteAction()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1300,6 +1300,9 @@ void ProfileWidget2::setAddState(const dive *d, int dc)
 	diveCeiling->setVisible(true);
 	decoModelParameters->setVisible(true);
 	setBackgroundBrush(QColor("#A7DCFF"));
+
+	pointsReset();
+	repositionDiveHandlers();
 }
 
 void ProfileWidget2::setPlanState(const dive *d, int dc)
@@ -1328,6 +1331,9 @@ void ProfileWidget2::setPlanState(const dive *d, int dc)
 	diveCeiling->setVisible(true);
 	decoModelParameters->setVisible(true);
 	setBackgroundBrush(QColor("#D7E3EF"));
+
+	pointsReset();
+	repositionDiveHandlers();
 }
 #endif
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1910,17 +1910,15 @@ void ProfileWidget2::keyDeleteAction()
 	if ((currentState != ADD && currentState != PLAN) || !plannerModel)
 		return;
 
-	int selCount = scene()->selectedItems().count();
-	if (selCount) {
-		QVector<int> selectedIndices;
-		Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
-			if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
-				selectedIndices.push_back(handleIndex(handler));
-				handler->hide();
-			}
+	QVector<int> selectedIndices;
+	Q_FOREACH (QGraphicsItem *i, scene()->selectedItems()) {
+		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
+			selectedIndices.push_back(handleIndex(handler));
+			handler->hide();
 		}
-		plannerModel->removeSelectedPoints(selectedIndices);
 	}
+	if (!selectedIndices.isEmpty())
+		plannerModel->removeSelectedPoints(selectedIndices);
 }
 
 void ProfileWidget2::keyEscAction()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1873,19 +1873,6 @@ void ProfileWidget2::keyLeftAction()
 			if (dp.time / 60 <= 0)
 				continue;
 
-			// don't overlap positions.
-			// maybe this is a good place for a 'goto'?
-			double xpos = timeAxis->posAtValue((dp.time - 60) / 60);
-			bool nextStep = false;
-			for (const auto &h: handles) {
-				if (IS_FP_SAME(h->pos().x(), xpos)) {
-					nextStep = true;
-					break;
-				}
-			}
-			if (nextStep)
-				continue;
-
 			dp.time -= 60;
 			plannerModel->editStop(row, dp);
 		}
@@ -1905,19 +1892,6 @@ void ProfileWidget2::keyRightAction()
 			int row = handleIndex(handler);
 			divedatapoint dp = plannerModel->at(row);
 			if (dp.time / 60.0 >= timeAxis->maximum())
-				continue;
-
-			// don't overlap positions.
-			// maybe this is a good place for a 'goto'?
-			double xpos = timeAxis->posAtValue((dp.time + 60) / 60);
-			bool nextStep = false;
-			for (const auto &h: handles) {
-				if (IS_FP_SAME(h->pos().x(), xpos)) {
-					nextStep = true;
-					break;
-				}
-			}
-			if (nextStep)
 				continue;
 
 			dp.time += 60;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1792,7 +1792,10 @@ void ProfileWidget2::repositionDiveHandlers()
 		QLineF line(p1, p2);
 		QPointF pos = line.pointAt(0.5);
 		gases[i]->setPos(pos);
-		gases[i]->setText(get_gas_string(get_cylinder(&displayed_dive, datapoint.cylinderid)->gasmix));
+		if (datapoint.cylinderid >= 0 && datapoint.cylinderid < displayed_dive.cylinders.nr)
+			gases[i]->setText(get_gas_string(get_cylinder(&displayed_dive, datapoint.cylinderid)->gasmix));
+		else
+			gases[i]->setText(QString());
 		gases[i]->setVisible(datapoint.entered &&
 				(i == 0 || gases[i]->text() != gases[i-1]->text()));
 	}

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -543,6 +543,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool force, bool
 #ifndef SUBSURFACE_MOBILE
 	} else {
 		plannerModel->createTemporaryPlan();
+		plannerModel->recalcTemporaryPlan();
 		struct diveplan &diveplan = plannerModel->getDiveplan();
 		if (!diveplan.dp) {
 			plannerModel->deleteTemporaryPlan();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1829,8 +1829,6 @@ void ProfileWidget2::keyDownAction()
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
 			divedatapoint dp = plannerModel->at(row);
-			if (dp.depth.mm >= profileYAxis->maximum())
-				continue;
 
 			dp.depth.mm += M_OR_FT(1, 5);
 			plannerModel->editStop(row, dp);
@@ -1894,8 +1892,6 @@ void ProfileWidget2::keyRightAction()
 		if (DiveHandler *handler = qgraphicsitem_cast<DiveHandler *>(i)) {
 			int row = handleIndex(handler);
 			divedatapoint dp = plannerModel->at(row);
-			if (dp.time / 60.0 >= timeAxis->maximum())
-				continue;
 
 			dp.time += 60;
 			plannerModel->editStop(row, dp);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1289,6 +1289,7 @@ void ProfileWidget2::setAddState()
 	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
 	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
 	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
+	connect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
 	/* show the same stuff that the profile shows. */
 	currentState = ADD; /* enable the add state. */
 	diveCeiling->setVisible(true);
@@ -1321,6 +1322,7 @@ void ProfileWidget2::setPlanState()
 	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
 	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
 	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
+	connect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
 	/* show the same stuff that the profile shows. */
 	currentState = PLAN; /* enable the add state. */
 	diveCeiling->setVisible(true);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1264,6 +1264,17 @@ void ProfileWidget2::setToolTipVisibile(bool visible)
 	toolTipItem->setVisible(visible);
 }
 
+void ProfileWidget2::connectPlannerModel()
+{
+	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
+	connect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replot);
+	connect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replot);
+	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
+	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
+	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
+	connect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
+}
+
 void ProfileWidget2::setAddState()
 {
 	if (currentState == ADD)
@@ -1283,13 +1294,8 @@ void ProfileWidget2::setAddState()
 	actionsForKeys[Qt::Key_Escape]->setShortcut(Qt::Key_Escape);
 	actionsForKeys[Qt::Key_Delete]->setShortcut(Qt::Key_Delete);
 
-	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	connect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replot);
-	connect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replot);
-	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
-	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
-	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
-	connect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
+	connectPlannerModel();
+
 	/* show the same stuff that the profile shows. */
 	currentState = ADD; /* enable the add state. */
 	diveCeiling->setVisible(true);
@@ -1316,13 +1322,8 @@ void ProfileWidget2::setPlanState()
 	actionsForKeys[Qt::Key_Escape]->setShortcut(Qt::Key_Escape);
 	actionsForKeys[Qt::Key_Delete]->setShortcut(Qt::Key_Delete);
 
-	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	connect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replot);
-	connect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replot);
-	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
-	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
-	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
-	connect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
+	connectPlannerModel();
+
 	/* show the same stuff that the profile shows. */
 	currentState = PLAN; /* enable the add state. */
 	diveCeiling->setVisible(true);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -58,32 +58,33 @@
  * hard coding the item on the scene with a random
  * value.
  */
-static struct _ItemPos {
-	struct _Pos {
+const static struct ItemPos {
+	struct Pos {
 		QPointF on;
 		QPointF off;
 	};
-	struct _Axis {
-		_Pos pos;
+	struct Axis {
+		Pos pos;
 		QLineF shrinked;
 		QLineF expanded;
 		QLineF intermediate;
 	};
-	_Pos background;
-	_Pos dcLabel;
-	_Pos tankBar;
-	_Axis depth;
-	_Axis partialPressure;
-	_Axis partialPressureTissue;
-	_Axis partialPressureWithTankBar;
-	_Axis percentage;
-	_Axis percentageWithTankBar;
-	_Axis time;
-	_Axis cylinder;
-	_Axis temperature;
-	_Axis temperatureAll;
-	_Axis heartBeat;
-	_Axis heartBeatWithTankBar;
+	Pos background;
+	Pos dcLabel;
+	Pos tankBar;
+	Axis depth;
+	Axis partialPressure;
+	Axis partialPressureTissue;
+	Axis partialPressureWithTankBar;
+	Axis percentage;
+	Axis percentageWithTankBar;
+	Axis time;
+	Axis cylinder;
+	Axis temperature;
+	Axis temperatureAll;
+	Axis heartBeat;
+	Axis heartBeatWithTankBar;
+	ItemPos();
 } itemPos;
 
 // Constant describing at which z-level the thumbnails are located.
@@ -154,7 +155,6 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, QWidget *
 	init_plot_info(&plotInfo);
 
 	setupSceneAndFlags();
-	setupItemSizes();
 	setupItemOnScene();
 	addItemsToScene();
 	scene()->installEventFilter(this);
@@ -372,7 +372,7 @@ PartialPressureGasItem *ProfileWidget2::createPPGas(int column, color_index_t co
 	return item;
 }
 
-void ProfileWidget2::setupItemSizes()
+ItemPos::ItemPos()
 {
 	// Scene is *always* (double) 100 / 100.
 	// Background Config
@@ -381,119 +381,119 @@ void ProfileWidget2::setupItemSizes()
 	 * Axis and everything else is auto-adjusted.*
 	 */
 
-	itemPos.background.on.setX(0);
-	itemPos.background.on.setY(0);
-	itemPos.background.off.setX(0);
-	itemPos.background.off.setY(110);
+	background.on.setX(0);
+	background.on.setY(0);
+	background.off.setX(0);
+	background.off.setY(110);
 
 	//Depth Axis Config
-	itemPos.depth.pos.on.setX(3);
-	itemPos.depth.pos.on.setY(3);
-	itemPos.depth.pos.off.setX(-2);
-	itemPos.depth.pos.off.setY(3);
-	itemPos.depth.expanded.setP1(QPointF(0, 0));
+	depth.pos.on.setX(3);
+	depth.pos.on.setY(3);
+	depth.pos.off.setX(-2);
+	depth.pos.off.setY(3);
+	depth.expanded.setP1(QPointF(0, 0));
 #ifndef SUBSURFACE_MOBILE
-	itemPos.depth.expanded.setP2(QPointF(0, 85));
+	depth.expanded.setP2(QPointF(0, 85));
 #else
-	itemPos.depth.expanded.setP2(QPointF(0, 65));
+	depth.expanded.setP2(QPointF(0, 65));
 #endif
-	itemPos.depth.shrinked.setP1(QPointF(0, 0));
-	itemPos.depth.shrinked.setP2(QPointF(0, 55));
-	itemPos.depth.intermediate.setP1(QPointF(0, 0));
-	itemPos.depth.intermediate.setP2(QPointF(0, 65));
+	depth.shrinked.setP1(QPointF(0, 0));
+	depth.shrinked.setP2(QPointF(0, 55));
+	depth.intermediate.setP1(QPointF(0, 0));
+	depth.intermediate.setP2(QPointF(0, 65));
 
 	// Time Axis Config
-	itemPos.time.pos.on.setX(3);
+	time.pos.on.setX(3);
 #ifndef SUBSURFACE_MOBILE
-	itemPos.time.pos.on.setY(95);
+	time.pos.on.setY(95);
 #else
-	itemPos.time.pos.on.setY(89.5);
+	time.pos.on.setY(89.5);
 #endif
-	itemPos.time.pos.off.setX(3);
-	itemPos.time.pos.off.setY(110);
-	itemPos.time.expanded.setP1(QPointF(0, 0));
-	itemPos.time.expanded.setP2(QPointF(94, 0));
+	time.pos.off.setX(3);
+	time.pos.off.setY(110);
+	time.expanded.setP1(QPointF(0, 0));
+	time.expanded.setP2(QPointF(94, 0));
 
 	// Partial Gas Axis Config
-	itemPos.partialPressure.pos.on.setX(97);
+	partialPressure.pos.on.setX(97);
 #ifndef SUBSURFACE_MOBILE
-	itemPos.partialPressure.pos.on.setY(75);
+	partialPressure.pos.on.setY(75);
 #else
-	itemPos.partialPressure.pos.on.setY(70);
+	partialPressure.pos.on.setY(70);
 #endif
-	itemPos.partialPressure.pos.off.setX(110);
-	itemPos.partialPressure.pos.off.setY(63);
-	itemPos.partialPressure.expanded.setP1(QPointF(0, 0));
+	partialPressure.pos.off.setX(110);
+	partialPressure.pos.off.setY(63);
+	partialPressure.expanded.setP1(QPointF(0, 0));
 #ifndef SUBSURFACE_MOBILE
-	itemPos.partialPressure.expanded.setP2(QPointF(0, 19));
+	partialPressure.expanded.setP2(QPointF(0, 19));
 #else
-	itemPos.partialPressure.expanded.setP2(QPointF(0, 20));
+	partialPressure.expanded.setP2(QPointF(0, 20));
 #endif
-	itemPos.partialPressureWithTankBar = itemPos.partialPressure;
-	itemPos.partialPressureWithTankBar.expanded.setP2(QPointF(0, 17));
-	itemPos.partialPressureTissue = itemPos.partialPressure;
-	itemPos.partialPressureTissue.pos.on.setX(97);
-	itemPos.partialPressureTissue.pos.on.setY(65);
-	itemPos.partialPressureTissue.expanded.setP2(QPointF(0, 16));
+	partialPressureWithTankBar = partialPressure;
+	partialPressureWithTankBar.expanded.setP2(QPointF(0, 17));
+	partialPressureTissue = partialPressure;
+	partialPressureTissue.pos.on.setX(97);
+	partialPressureTissue.pos.on.setY(65);
+	partialPressureTissue.expanded.setP2(QPointF(0, 16));
 
 	// cylinder axis config
-	itemPos.cylinder.pos.on.setX(3);
-	itemPos.cylinder.pos.on.setY(20);
-	itemPos.cylinder.pos.off.setX(-10);
-	itemPos.cylinder.pos.off.setY(20);
-	itemPos.cylinder.expanded.setP1(QPointF(0, 15));
-	itemPos.cylinder.expanded.setP2(QPointF(0, 50));
-	itemPos.cylinder.shrinked.setP1(QPointF(0, 0));
-	itemPos.cylinder.shrinked.setP2(QPointF(0, 20));
-	itemPos.cylinder.intermediate.setP1(QPointF(0, 0));
-	itemPos.cylinder.intermediate.setP2(QPointF(0, 20));
+	cylinder.pos.on.setX(3);
+	cylinder.pos.on.setY(20);
+	cylinder.pos.off.setX(-10);
+	cylinder.pos.off.setY(20);
+	cylinder.expanded.setP1(QPointF(0, 15));
+	cylinder.expanded.setP2(QPointF(0, 50));
+	cylinder.shrinked.setP1(QPointF(0, 0));
+	cylinder.shrinked.setP2(QPointF(0, 20));
+	cylinder.intermediate.setP1(QPointF(0, 0));
+	cylinder.intermediate.setP2(QPointF(0, 20));
 
 	// Temperature axis config
-	itemPos.temperature.pos.on.setX(3);
-	itemPos.temperature.pos.off.setX(-10);
-	itemPos.temperature.pos.off.setY(40);
-	itemPos.temperature.expanded.setP1(QPointF(0, 20));
-	itemPos.temperature.expanded.setP2(QPointF(0, 33));
-	itemPos.temperature.shrinked.setP1(QPointF(0, 2));
-	itemPos.temperature.shrinked.setP2(QPointF(0, 12));
+	temperature.pos.on.setX(3);
+	temperature.pos.off.setX(-10);
+	temperature.pos.off.setY(40);
+	temperature.expanded.setP1(QPointF(0, 20));
+	temperature.expanded.setP2(QPointF(0, 33));
+	temperature.shrinked.setP1(QPointF(0, 2));
+	temperature.shrinked.setP2(QPointF(0, 12));
 #ifndef SUBSURFACE_MOBILE
-	itemPos.temperature.pos.on.setY(60);
-	itemPos.temperatureAll.pos.on.setY(51);
-	itemPos.temperature.intermediate.setP1(QPointF(0, 2));
-	itemPos.temperature.intermediate.setP2(QPointF(0, 12));
+	temperature.pos.on.setY(60);
+	temperatureAll.pos.on.setY(51);
+	temperature.intermediate.setP1(QPointF(0, 2));
+	temperature.intermediate.setP2(QPointF(0, 12));
 #else
-	itemPos.temperature.pos.on.setY(51);
-	itemPos.temperatureAll.pos.on.setY(47);
-	itemPos.temperature.intermediate.setP1(QPointF(0, 2));
-	itemPos.temperature.intermediate.setP2(QPointF(0, 12));
+	temperature.pos.on.setY(51);
+	temperatureAll.pos.on.setY(47);
+	temperature.intermediate.setP1(QPointF(0, 2));
+	temperature.intermediate.setP2(QPointF(0, 12));
 #endif
 
 	// Heart rate axis config
-	itemPos.heartBeat.pos.on.setX(3);
-	itemPos.heartBeat.pos.on.setY(82);
-	itemPos.heartBeat.expanded.setP1(QPointF(0, 0));
-	itemPos.heartBeat.expanded.setP2(QPointF(0, 10));
-	itemPos.heartBeatWithTankBar = itemPos.heartBeat;
-	itemPos.heartBeatWithTankBar.expanded.setP2(QPointF(0, 7));
+	heartBeat.pos.on.setX(3);
+	heartBeat.pos.on.setY(82);
+	heartBeat.expanded.setP1(QPointF(0, 0));
+	heartBeat.expanded.setP2(QPointF(0, 10));
+	heartBeatWithTankBar = heartBeat;
+	heartBeatWithTankBar.expanded.setP2(QPointF(0, 7));
 
 	// Percentage axis config
-	itemPos.percentage.pos.on.setX(3);
-	itemPos.percentage.pos.on.setY(80);
-	itemPos.percentage.expanded.setP1(QPointF(0, 0));
-	itemPos.percentage.expanded.setP2(QPointF(0, 15));
-	itemPos.percentageWithTankBar = itemPos.percentage;
-	itemPos.percentageWithTankBar.expanded.setP2(QPointF(0, 11.9));
+	percentage.pos.on.setX(3);
+	percentage.pos.on.setY(80);
+	percentage.expanded.setP1(QPointF(0, 0));
+	percentage.expanded.setP2(QPointF(0, 15));
+	percentageWithTankBar = percentage;
+	percentageWithTankBar.expanded.setP2(QPointF(0, 11.9));
 
-	itemPos.dcLabel.on.setX(3);
-	itemPos.dcLabel.on.setY(100);
-	itemPos.dcLabel.off.setX(-10);
-	itemPos.dcLabel.off.setY(100);
+	dcLabel.on.setX(3);
+	dcLabel.on.setY(100);
+	dcLabel.off.setX(-10);
+	dcLabel.off.setY(100);
 
-	itemPos.tankBar.on.setX(0);
+	tankBar.on.setX(0);
 #ifndef SUBSURFACE_MOBILE
-	itemPos.tankBar.on.setY(91.95);
+	tankBar.on.setY(91.95);
 #else
-	itemPos.tankBar.on.setY(86.4);
+	tankBar.on.setY(86.4);
 #endif
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -997,14 +997,14 @@ void ProfileWidget2::mouseDoubleClickEvent(QMouseEvent *event)
 
 		int minutes = lrint(timeAxis->valueAt(mappedPos) / 60);
 		int milimeters = lrint(profileYAxis->valueAt(mappedPos) / M_OR_FT(1, 1)) * M_OR_FT(1, 1);
-		plannerModel->addStop(milimeters, minutes * 60, -1, 0, true, UNDEF_COMP_TYPE);
+		plannerModel->addStop(milimeters, minutes * 60);
 	}
 }
 
 void ProfileWidget2::scrollViewTo(const QPoint &pos)
 {
 	/* since we cannot use translate() directly on the scene we hack on
- * the scroll bars (hidden) functionality */
+	 * the scroll bars (hidden) functionality */
 	if (!zoomLevel || currentState == EMPTY)
 		return;
 	QScrollBar *vs = verticalScrollBar();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -80,7 +80,10 @@ public:
 	~ProfileWidget2();
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
-	void plotDive(const struct dive *d, bool force = false, bool clearPictures = false, bool instant = false);
+	void plotDive(const struct dive *d, int dc, bool force = false, bool clearPictures = false, bool instant = false);
+	void setProfileState(const struct dive *d, int dc);
+	void setPlanState(const struct dive *d, int dc);
+	void setAddState(const struct dive *d, int dc);
 	void setPrintMode(bool mode, bool grayscale = false);
 	bool getPrintMode() const;
 	bool isPointOutOfBoundaries(const QPointF &point) const;
@@ -107,13 +110,10 @@ slots: // Necessary to call from QAction's signals.
 	void actionRequestedReplot(bool triggered);
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void setEmptyState();
-	void setProfileState();
 #ifndef SUBSURFACE_MOBILE
 	void plotPictures();
 	void picturesRemoved(dive *d, QVector<QString> filenames);
 	void picturesAdded(dive *d, QVector<PictureObj> pics);
-	void setPlanState();
-	void setAddState();
 	void pointsReset();
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
@@ -139,6 +139,7 @@ slots: // Necessary to call from QAction's signals.
 #endif
 
 private:
+	void setProfileState(); // keep currently displayed dive
 	void resizeEvent(QResizeEvent *event) override;
 #ifndef SUBSURFACE_MOBILE
 	void wheelEvent(QWheelEvent *event) override;
@@ -194,6 +195,8 @@ private:
 	// All those here should probably be merged into one structure,
 	// So it's esyer to replicate for more dives later.
 	// In the meantime, keep it here.
+	const struct dive *d;
+	int dc;
 	struct plot_info plotInfo;
 	DepthAxis *profileYAxis;
 	PartialGasPressureAxis *gasYAxis;
@@ -272,6 +275,12 @@ private:
 	int maxtime;
 	int maxdepth;
 	double fontPrintScale;
+
+	// We store a const pointer to the shown dive. However, the undo commands want
+	// (understandably) a non-const pointer. Since the profile has a context-menu
+	// with actions, it needs such a non-const pointer. This function turns the
+	// currently shown dive into such a pointer. Ugly, yes.
+	struct dive *mutable_dive() const;
 };
 
 #endif // PROFILEWIDGET2_H

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -124,7 +124,7 @@ slots: // Necessary to call from QAction's signals.
 	void removePicture(const QString &fileUrl);
 
 	/* this is called for every move on the handlers. maybe we can speed up this a bit? */
-	void recreatePlannedDive();
+	void divePlannerHandlerMoved();
 
 	/* key press handlers */
 	void keyEscAction();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -256,6 +256,7 @@ private:
 	std::vector<std::unique_ptr<DiveHandler>> handles;
 	int handleIndex(const DiveHandler *h) const;
 #ifndef SUBSURFACE_MOBILE
+	void connectPlannerModel();
 	void repositionDiveHandlers();
 	int fixHandlerIndex(DiveHandler *activeHandler);
 	DiveHandler *createHandle();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -112,8 +112,10 @@ slots: // Necessary to call from QAction's signals.
 	void picturesAdded(dive *d, QVector<PictureObj> pics);
 	void setPlanState();
 	void setAddState();
+	void pointsReset();
 	void pointInserted(const QModelIndex &parent, int start, int end);
 	void pointsRemoved(const QModelIndex &, int start, int end);
+	void pointsMoved(const QModelIndex &, int start, int end, const QModelIndex &destination, int row);
 	void updateThumbnail(QString filename, QImage thumbnail, duration_t duration);
 	void profileChanged(dive *d);
 	void pictureOffsetChanged(dive *d, QString filename, offset_t offset);
@@ -256,6 +258,8 @@ private:
 #ifndef SUBSURFACE_MOBILE
 	void repositionDiveHandlers();
 	int fixHandlerIndex(DiveHandler *activeHandler);
+	DiveHandler *createHandle();
+	QGraphicsSimpleTextItem *createGas();
 #endif
 	friend class DiveHandler;
 	QHash<Qt::Key, QAction *> actionsForKeys;

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -227,7 +227,7 @@ private:
 #endif
 	TankItem *tankItem;
 
-	QList<QGraphicsSimpleTextItem *> gases;
+	std::vector<std::unique_ptr<QGraphicsSimpleTextItem>> gases;
 
 	//specifics for ADD and PLAN
 #ifndef SUBSURFACE_MOBILE
@@ -251,7 +251,8 @@ private:
 	void updateThumbnailPaintOrder();
 #endif
 
-	QList<DiveHandler *> handles;
+	std::vector<std::unique_ptr<DiveHandler>> handles;
+	int handleIndex(const DiveHandler *h) const;
 #ifndef SUBSURFACE_MOBILE
 	void repositionDiveHandlers();
 	int fixHandlerIndex(DiveHandler *activeHandler);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -38,6 +38,7 @@ class DiveRectItem;
 class DepthAxis;
 class DiveCartesianAxis;
 class DiveProfileItem;
+class DivePlannerPointsModel;
 class TimeAxis;
 class DiveTemperatureItem;
 class DiveHeartrateItem;
@@ -74,7 +75,8 @@ public:
 		COLUMNS
 	};
 
-	ProfileWidget2(QWidget *parent = 0);
+	// Pass null as plannerModel if no support for planning required
+	ProfileWidget2(DivePlannerPointsModel *plannerModel, QWidget *parent = 0);
 	~ProfileWidget2();
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
@@ -179,6 +181,7 @@ private:
 	void splitCurrentDC();
 
 	DivePlotDataModel *dataModel;
+	DivePlannerPointsModel *plannerModel; // If null, no planning supported.
 	int zoomLevel;
 	qreal zoomFactor;
 	bool isGrayscale;

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -159,7 +159,6 @@ private:
 	void scrollViewTo(const QPoint &pos);
 	void setupSceneAndFlags();
 	template<typename T, class... Args> T *createItem(const DiveCartesianAxis &vAxis, int vColumn, int z, Args&&... args);
-	void setupItemSizes();
 	void addItemsToScene();
 	void setupItemOnScene();
 	void disconnectTemporaryConnections();

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -20,7 +20,7 @@ QMLProfile::QMLProfile(QQuickItem *parent) :
 {
 	setAntialiasing(true);
 	setFlags(QQuickItem::ItemClipsChildrenToShape | QQuickItem::ItemHasContents );
-	m_profileWidget->setProfileState();
+	m_profileWidget->setProfileState(nullptr, 0);
 	m_profileWidget->setPrintMode(true);
 	m_profileWidget->setFontPrintScale(fontScale);
 	connect(QMLManager::instance(), &QMLManager::sendScreenChanged, this, &QMLProfile::screenChanged);
@@ -135,7 +135,7 @@ void QMLProfile::updateProfile()
 		return;
 	if (verbose)
 		qDebug() << "update profile for dive #" << d->number << "offeset" << QString::number(m_xOffset, 'f', 1) << "/" << QString::number(m_yOffset, 'f', 1);
-	m_profileWidget->plotDive(d, true);
+	m_profileWidget->plotDive(d, dc_number, true);
 }
 
 void QMLProfile::setDiveId(int diveId)
@@ -189,10 +189,9 @@ void QMLProfile::divesChanged(const QVector<dive *> &dives, DiveField)
 	for (struct dive *d: dives) {
 		if (d->id == m_diveId) {
 			qDebug() << "dive #" << d->number << "changed, trigger profile update";
-			m_profileWidget->plotDive(d, true);
+			m_profileWidget->plotDive(d, dc_number, true);
 			triggerUpdate();
 			return;
 		}
 	}
-
 }

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -16,7 +16,7 @@ QMLProfile::QMLProfile(QQuickItem *parent) :
 	m_margin(0),
 	m_xOffset(0.0),
 	m_yOffset(0.0),
-	m_profileWidget(new ProfileWidget2)
+	m_profileWidget(new ProfileWidget2(nullptr, nullptr))
 {
 	setAntialiasing(true);
 	setFlags(QQuickItem::ItemClipsChildrenToShape | QQuickItem::ItemHasContents );

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -193,7 +193,6 @@ void DivePictureModel::picturesRemoved(dive *d, QVector<QString> filenamesIn)
 		endRemoveRows();
 		toIdx -= j - i;
 	}
-	copy_dive(current_dive, &displayed_dive); // TODO: Remove once displayed_dive is moved to the planner
 }
 
 // Assumes that pics is sorted!
@@ -306,7 +305,6 @@ void DivePictureModel::pictureOffsetChanged(dive *d, const QString filenameIn, o
 
 	// Update the offset here and in the backend
 	oldPos->offsetSeconds = offset.seconds;
-	copy_dive(current_dive, &displayed_dive); // TODO: remove once profile can display arbitrary dives
 
 	// Henceforth we will work with indices instead of iterators
 	int oldIndex = oldPos - pictures.begin();

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -255,14 +255,6 @@ bool DivePlannerPointsModel::isPlanner() const
 	return mode == PLAN;
 }
 
-/* When the planner adds deco stops to the model, adding those should not trigger a new deco calculation.
- * We thus start the planner only when recalc is true. */
-
-bool DivePlannerPointsModel::recalcQ() const
-{
-	return recalc;
-}
-
 int DivePlannerPointsModel::columnCount(const QModelIndex&) const
 {
 	return COLUMNS; // to disable CCSETPOINT subtract one
@@ -770,7 +762,7 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 		cylinderid = cylinderid_in;
 	else
 		usePrevious = true;
-	if (recalcQ())
+	if (recalc)
 		removeDeco();
 
 	int row = divepoints.count();

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -995,14 +995,11 @@ bool DivePlannerPointsModel::tankInUse(int cylinderid) const
 
 void DivePlannerPointsModel::clear()
 {
-	bool oldrec = std::exchange(recalc, false);
-
+	cylinders.clear();
+	preserved_until.seconds = 0;
 	beginResetModel();
 	divepoints.clear();
 	endResetModel();
-	cylinders.clear();
-	preserved_until.seconds = 0;
-	recalc = oldrec;
 }
 
 void DivePlannerPointsModel::createTemporaryPlan()

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -61,6 +61,7 @@ void DivePlannerPointsModel::createSimpleDive(struct dive *dIn)
 	d->dc.model = strdup("planned dive"); // don't translate! this is stored in the XML file
 
 	clear();
+	removeDeco();
 	setupCylinders();
 	setupStartTime();
 
@@ -119,6 +120,7 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 	duration_t newtime = {};
 
 	clear();
+	removeDeco();
 	free_dps(&diveplan);
 
 	diveplan.when = d->when;
@@ -748,11 +750,13 @@ int DivePlannerPointsModel::lastEnteredPoint() const
 
 void DivePlannerPointsModel::addDefaultStop()
 {
+	removeDeco();
 	addStop(0, 0, -1, 0, true, UNDEF_COMP_TYPE);
 }
 
 void DivePlannerPointsModel::addStop(int milimeters, int seconds)
 {
+	removeDeco();
 	addStop(milimeters, seconds, -1, 0, true, UNDEF_COMP_TYPE);
 	updateDiveProfile();
 }
@@ -767,8 +771,6 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 		cylinderid = cylinderid_in;
 	else
 		usePrevious = true;
-	if (recalc)
-		removeDeco();
 
 	int row = divepoints.count();
 	if (seconds == 0 && milimeters == 0 && row != 0) {

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -28,7 +28,7 @@ CylindersModel *DivePlannerPointsModel::cylindersModel()
 	return &cylinders;
 }
 
-void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
+void DivePlannerPointsModel::removePoints(const QVector<int> &rows)
 {
 	if (!rows.count())
 		return;
@@ -40,6 +40,12 @@ void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 		divepoints.erase(divepoints.begin() + v2[i]);
 		endRemoveRows();
 	}
+}
+
+void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
+{
+	removePoints(rows);
+
 	updateDiveProfile();
 	emitDataChanged();
 	cylinders.updateTrashIcon();
@@ -225,13 +231,12 @@ bool DivePlannerPointsModel::updateMaxDepth()
 
 void DivePlannerPointsModel::removeDeco()
 {
-	bool oldrec = std::exchange(recalc, false);
 	QVector<int> computedPoints;
-	for (int i = 0; i < rowCount(); i++)
+	for (int i = 0; i < rowCount(); i++) {
 		if (!at(i).entered)
 			computedPoints.push_back(i);
-	removeSelectedPoints(computedPoints);
-	recalc = oldrec;
+	}
+	removePoints(computedPoints);
 }
 
 void DivePlannerPointsModel::addCylinder_clicked()

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -109,11 +109,9 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 	int depthsum = 0;
 	int samplecount = 0;
 	o2pressure_t last_sp;
-	bool oldRec = recalc;
 	struct divecomputer *dc = &(d->dc);
 	const struct event *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
-	recalc = false;
 	cylinders.updateDive(d);
 	duration_t lasttime = { 0 };
 	duration_t lastrecordedtime = {};
@@ -177,7 +175,6 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 	current_divemode = get_current_divemode(dc, d->dc.duration.seconds, &evd, &current_divemode);
 	if (!hasMarkedSamples && !dc->last_manual_time.seconds)
 		addStop(0, d->dc.duration.seconds,cylinderid, last_sp.mbar, true, current_divemode);
-	recalc = oldRec;
 	DiveTypeSelectionModel::instance()->repopulate();
 	preserved_until = d->duration;
 
@@ -450,8 +447,7 @@ int DivePlannerPointsModel::rowCount(const QModelIndex&) const
 DivePlannerPointsModel::DivePlannerPointsModel(QObject *parent) : QAbstractTableModel(parent),
 	d(nullptr),
 	cylinders(true),
-	mode(NOTHING),
-	recalc(true)
+	mode(NOTHING)
 {
 	memset(&diveplan, 0, sizeof(diveplan));
 	startTime.setTimeSpec(Qt::UTC);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -826,8 +826,7 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 	point.entered = entered;
 	point.divemode = divemode;
 	point.next = NULL;
-	divepoints.append(point);
-	std::sort(divepoints.begin(), divepoints.end(), divePointsLessThan);
+	divepoints.insert(divepoints.begin() + row, point);
 	endInsertRows();
 	return row;
 }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -28,20 +28,18 @@ CylindersModel *DivePlannerPointsModel::cylindersModel()
 	return &cylinders;
 }
 
-/* TODO: Port this to CleanerTableModel to remove a bit of boilerplate. */
 void DivePlannerPointsModel::removeSelectedPoints(const QVector<int> &rows)
 {
 	if (!rows.count())
 		return;
-	int firstRow = rowCount() - rows.count();
 	QVector<int> v2 = rows;
 	std::sort(v2.begin(), v2.end());
 
-	beginRemoveRows(QModelIndex(), firstRow, rowCount() - 1);
 	for (int i = v2.count() - 1; i >= 0; i--) {
-		divepoints.remove(v2[i]);
+		beginRemoveRows(QModelIndex(), v2[i], v2[i]);
+		divepoints.erase(divepoints.begin() + v2[i]);
+		endRemoveRows();
 	}
-	endRemoveRows();
 	cylinders.updateTrashIcon();
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -844,6 +844,18 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	 */
 	int old_first_cylid = divepoints[0].cylinderid;
 
+	// Refuse creation of two points with the same time stamp.
+	// Note: "time" is moved in the positive direction to avoid
+	// time becoming zero or, worse, negative.
+	while (std::any_of(divepoints.begin(), divepoints.begin() + row,
+			[t = newData.time] (const divedatapoint &data)
+			{ return data.time == t; }))
+		newData.time += 10;
+	while (std::any_of(divepoints.begin() + row + 1, divepoints.end(),
+			[t = newData.time] (const divedatapoint &data)
+			{ return data.time == t; }))
+		newData.time += 10;
+
 	// Is it ok to change data first and then move the rows?
 	divepoints[row] = newData;
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -885,11 +885,6 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	emit dataChanged(createIndex(row, 0), createIndex(row, COLUMNS - 1));
 }
 
-int DivePlannerPointsModel::size() const
-{
-	return divepoints.size();
-}
-
 divedatapoint DivePlannerPointsModel::at(int row) const
 {
 	/*

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -334,8 +334,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 					cylinders.updateBestMixes();
 			}
 			break;
-		case RUNTIME:
-		{
+		case RUNTIME: {
 			int secs = value.toInt() * 60;
 			i = index.row();
 			int duration = secs;
@@ -348,10 +347,9 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 			while (++i < divepoints.size())
 				if (divepoints[i].time < divepoints[i - 1].time + 10)
 					divepoints[i].time = divepoints[i - 1].time + 10;
-		}
 			break;
-		case DURATION:
-		{
+		}
+		case DURATION: {
 				int secs = value.toInt() * 60;
 				if (!secs)
 					secs = 10;
@@ -362,14 +360,15 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 					shift = divepoints[i].time - secs;
 				while (i < divepoints.size())
 					divepoints[i++].time -= shift;
-		}
 				break;
+		}
 		case CCSETPOINT: {
 			int po2 = 0;
 			QByteArray gasv = value.toByteArray();
 			if (validate_po2(gasv.data(), &po2))
 				p.setpoint = po2;
-		} break;
+			break;
+		}
 		case GAS:
 			if (value.toInt() >= 0)
 				p.cylinderid = value.toInt();
@@ -537,7 +536,7 @@ void DivePlannerPointsModel::setRebreatherMode(int mode)
 {
 	int i;
 	d->dc.divemode = (divemode_t) mode;
-	for (i=0; i < rowCount(); i++) {
+	for (i = 0; i < rowCount(); i++) {
 		divepoints[i].setpoint = mode == CCR ? prefs.defaultsetpoint : 0;
 		divepoints[i].divemode = (enum divemode_t) mode;
 	}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -956,11 +956,9 @@ void DivePlannerPointsModel::clear()
 	bool oldRecalc = setRecalc(false);
 
 	cylinders.updateDive(&displayed_dive);
-	if (rowCount() > 0) {
-		beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
-		divepoints.clear();
-		endRemoveRows();
-	}
+	beginResetModel();
+	divepoints.clear();
+	endResetModel();
 	cylinders.clear();
 	preserved_until.seconds = 0;
 	setRecalc(oldRecalc);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -993,7 +993,6 @@ void DivePlannerPointsModel::clear()
 {
 	bool oldRecalc = setRecalc(false);
 
-	cylinders.updateDive(&displayed_dive);
 	beginResetModel();
 	divepoints.clear();
 	endResetModel();

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -750,6 +750,11 @@ int DivePlannerPointsModel::lastEnteredPoint() const
 	return -1;
 }
 
+void DivePlannerPointsModel::addDefaultStop()
+{
+	addStop(0, 0, -1, 0, true, UNDEF_COMP_TYPE);
+}
+
 // cylinderid_in == -1 means same gas as before.
 // divemode == UNDEF_COMP_TYPE means determine from previous point.
 int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t divemode)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -750,6 +750,11 @@ void DivePlannerPointsModel::addDefaultStop()
 	addStop(0, 0, -1, 0, true, UNDEF_COMP_TYPE);
 }
 
+void DivePlannerPointsModel::addStop(int milimeters, int seconds)
+{
+	addStop(milimeters, seconds, -1, 0, true, UNDEF_COMP_TYPE);
+}
+
 // cylinderid_in == -1 means same gas as before.
 // divemode == UNDEF_COMP_TYPE means determine from previous point.
 int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t divemode)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -244,7 +244,7 @@ void DivePlannerPointsModel::setPlanMode(Mode m)
 	}
 }
 
-bool DivePlannerPointsModel::isPlanner()
+bool DivePlannerPointsModel::isPlanner() const
 {
 	return mode == PLAN;
 }
@@ -259,7 +259,7 @@ bool DivePlannerPointsModel::setRecalc(bool rec)
 	return old;
 }
 
-bool DivePlannerPointsModel::recalcQ()
+bool DivePlannerPointsModel::recalcQ() const
 {
 	return recalc;
 }
@@ -568,7 +568,7 @@ void DivePlannerPointsModel::setSalinity(int salinity)
 	emitDataChanged();
 }
 
-int DivePlannerPointsModel::getSurfacePressure()
+int DivePlannerPointsModel::getSurfacePressure() const
 {
 	return diveplan.surface_pressure;
 }
@@ -584,7 +584,7 @@ void DivePlannerPointsModel::setAscrate75Display(int rate)
 	qPrefDivePlanner::set_ascrate75(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
-int DivePlannerPointsModel::ascrate75Display()
+int DivePlannerPointsModel::ascrate75Display() const
 {
 	return lrint((float)prefs.ascrate75 / UNIT_FACTOR);
 }
@@ -594,7 +594,7 @@ void DivePlannerPointsModel::setAscrate50Display(int rate)
 	qPrefDivePlanner::set_ascrate50(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
-int DivePlannerPointsModel::ascrate50Display()
+int DivePlannerPointsModel::ascrate50Display() const
 {
 	return lrint((float)prefs.ascrate50 / UNIT_FACTOR);
 }
@@ -604,7 +604,7 @@ void DivePlannerPointsModel::setAscratestopsDisplay(int rate)
 	qPrefDivePlanner::set_ascratestops(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
-int DivePlannerPointsModel::ascratestopsDisplay()
+int DivePlannerPointsModel::ascratestopsDisplay() const
 {
 	return lrint((float)prefs.ascratestops / UNIT_FACTOR);
 }
@@ -614,7 +614,7 @@ void DivePlannerPointsModel::setAscratelast6mDisplay(int rate)
 	qPrefDivePlanner::set_ascratelast6m(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
-int DivePlannerPointsModel::ascratelast6mDisplay()
+int DivePlannerPointsModel::ascratelast6mDisplay() const
 {
 	return lrint((float)prefs.ascratelast6m / UNIT_FACTOR);
 }
@@ -624,7 +624,7 @@ void DivePlannerPointsModel::setDescrateDisplay(int rate)
 	qPrefDivePlanner::set_descrate(lrint(rate * UNIT_FACTOR));
 	emitDataChanged();
 }
-int DivePlannerPointsModel::descrateDisplay()
+int DivePlannerPointsModel::descrateDisplay() const
 {
 	return lrint((float)prefs.descrate / UNIT_FACTOR);
 }
@@ -742,7 +742,7 @@ bool divePointsLessThan(const divedatapoint &p1, const divedatapoint &p2)
 	return p1.time < p2.time;
 }
 
-int DivePlannerPointsModel::lastEnteredPoint()
+int DivePlannerPointsModel::lastEnteredPoint() const
 {
 	for (int i = divepoints.count() - 1; i >= 0; i--)
 		if (divepoints.at(i).entered)
@@ -845,12 +845,12 @@ void DivePlannerPointsModel::editStop(int row, divedatapoint newData)
 	emitDataChanged();
 }
 
-int DivePlannerPointsModel::size()
+int DivePlannerPointsModel::size() const
 {
 	return divepoints.size();
 }
 
-divedatapoint DivePlannerPointsModel::at(int row)
+divedatapoint DivePlannerPointsModel::at(int row) const
 {
 	/*
 	 * When moving divepoints rigorously, we might end up with index
@@ -932,10 +932,10 @@ DivePlannerPointsModel::Mode DivePlannerPointsModel::currentMode() const
 	return mode;
 }
 
-bool DivePlannerPointsModel::tankInUse(int cylinderid)
+bool DivePlannerPointsModel::tankInUse(int cylinderid) const
 {
 	for (int j = 0; j < rowCount(); j++) {
-		divedatapoint &p = divepoints[j];
+		const divedatapoint &p = divepoints[j];
 		if (p.time == 0) // special entries that hold the available gases
 			continue;
 		if (!p.entered) // removing deco gases is ok

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -106,9 +106,10 @@ void DivePlannerPointsModel::loadFromDive(dive *d)
 	duration_t lasttime = { 0 };
 	duration_t lastrecordedtime = {};
 	duration_t newtime = {};
+
+	clear();
 	free_dps(&diveplan);
-	if (mode != PLAN)
-		clear();
+
 	diveplan.when = d->when;
 	// is this a "new" dive where we marked manually entered samples?
 	// if yes then the first sample should be marked

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -86,6 +86,7 @@ slots:
 	void savePlan();
 	void saveDuplicatePlan();
 	void remove(const QModelIndex &index);
+	void removeControlPressed(const QModelIndex &index);
 	void cancelPlan();
 	void removeDeco();
 	void deleteTemporaryPlan();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -57,7 +57,6 @@ public:
 	 */
 	void editStop(int row, divedatapoint newData);
 	divedatapoint at(int row) const;
-	int size() const;
 	struct diveplan &getDiveplan();
 	void removeDeco();
 	struct deco_state final_deco_state;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -89,8 +89,6 @@ slots:
 	void remove(const QModelIndex &index);
 	void cancelPlan();
 	void removeDeco();
-	void createTemporaryPlan();
-	void recalcTemporaryPlan(); // Writes the plan into the dive.
 	void deleteTemporaryPlan();
 	void emitDataChanged();
 	void setRebreatherMode(int mode);
@@ -123,6 +121,8 @@ private:
 	int lastEnteredPoint() const;
 	bool updateMaxDepth();
 	void createPlan(bool replanCopy);
+	void updateDiveProfile(); // Creates a temporary plan and updates the dive profile with it.
+	void createTemporaryPlan();
 	struct diveplan diveplan;
 	struct divedatapoint *cloneDiveplan(struct diveplan *plan_src, struct diveplan *plan_copy);
 	void computeVariationsDone(QString text);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -66,9 +66,10 @@ public:
 	struct deco_state final_deco_state;
 
 	void loadFromDive(dive *d);
+	int addStop(int millimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t);
 public
 slots:
-	int addStop(int millimeters = 0, int seconds = 0, int cylinderid_in = -1, int ccpoint = 0, bool entered = true, enum divemode_t = UNDEF_COMP_TYPE);
+	void addDefaultStop();
 	void addCylinder_clicked();
 	void setGFHigh(const int gfhigh);
 	void setGFLow(const int gflow);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -41,7 +41,6 @@ public:
 	bool isPlanner() const;
 	void createSimpleDive(struct dive *d);
 	Mode currentMode() const;
-	bool setRecalc(bool recalc);
 	bool recalcQ() const;
 	bool tankInUse(int cylinderid) const;
 	CylindersModel *cylindersModel();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -61,7 +61,7 @@ public:
 	struct deco_state final_deco_state;
 
 	void loadFromDive(dive *d);
-	int addStop(int millimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t);
+	void addStop(int millimeters, int seconds);
 public
 slots:
 	void addDefaultStop();
@@ -117,6 +117,7 @@ signals:
 private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);
 	void clear();
+	int addStop(int millimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t);
 	void setupStartTime();
 	void setupCylinders();
 	int lastEnteredPoint() const;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -60,7 +60,6 @@ public:
 	int size() const;
 	struct diveplan &getDiveplan();
 	void removeDeco();
-	static bool addingDeco;
 	struct deco_state final_deco_state;
 
 	void loadFromDive(dive *d);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -132,7 +132,6 @@ private:
 	struct dive *d;
 	CylindersModel cylinders;
 	Mode mode;
-	bool recalc;
 	QVector<divedatapoint> divepoints;
 	QDateTime startTime;
 	int instanceCounter = 0;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -92,6 +92,7 @@ slots:
 	void remove(const QModelIndex &index);
 	void cancelPlan();
 	void createTemporaryPlan();
+	void recalcTemporaryPlan(); // Writes the plan into the dive.
 	void deleteTemporaryPlan();
 	void emitDataChanged();
 	void setRebreatherMode(int mode);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -41,7 +41,6 @@ public:
 	bool isPlanner() const;
 	void createSimpleDive(struct dive *d);
 	Mode currentMode() const;
-	bool recalcQ() const;
 	bool tankInUse(int cylinderid) const;
 	CylindersModel *cylindersModel();
 

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -58,7 +58,6 @@ public:
 	void editStop(int row, divedatapoint newData);
 	divedatapoint at(int row) const;
 	struct diveplan &getDiveplan();
-	void removeDeco();
 	struct deco_state final_deco_state;
 
 	void loadFromDive(dive *d);
@@ -89,6 +88,7 @@ slots:
 	void saveDuplicatePlan();
 	void remove(const QModelIndex &index);
 	void cancelPlan();
+	void removeDeco();
 	void createTemporaryPlan();
 	void recalcTemporaryPlan(); // Writes the plan into the dive.
 	void deleteTemporaryPlan();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -39,7 +39,7 @@ public:
 	void removeSelectedPoints(const QVector<int> &rows);
 	void setPlanMode(Mode mode);
 	bool isPlanner() const;
-	void createSimpleDive();
+	void createSimpleDive(struct dive *d);
 	Mode currentMode() const;
 	bool setRecalc(bool recalc);
 	bool recalcQ() const;
@@ -130,6 +130,7 @@ private:
 	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
+	struct dive *d;
 	CylindersModel cylinders;
 	Mode mode;
 	bool recalc;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -38,28 +38,28 @@ public:
 	void cylinderRenumber(int mapping[]);
 	void removeSelectedPoints(const QVector<int> &rows);
 	void setPlanMode(Mode mode);
-	bool isPlanner();
+	bool isPlanner() const;
 	void createSimpleDive();
 	void clear();
 	Mode currentMode() const;
 	bool setRecalc(bool recalc);
-	bool recalcQ();
-	bool tankInUse(int cylinderid);
+	bool recalcQ() const;
+	bool tankInUse(int cylinderid) const;
 	CylindersModel *cylindersModel();
 
-	int ascrate75Display();
-	int ascrate50Display();
-	int ascratestopsDisplay();
-	int ascratelast6mDisplay();
-	int descrateDisplay();
-	int getSurfacePressure();
+	int ascrate75Display() const;
+	int ascrate50Display() const;
+	int ascratestopsDisplay() const;
+	int ascratelast6mDisplay() const;
+	int descrateDisplay() const;
+	int getSurfacePressure() const;
 
 	/**
 	 * @return the row number.
 	 */
 	void editStop(int row, divedatapoint newData);
-	divedatapoint at(int row);
-	int size();
+	divedatapoint at(int row) const;
+	int size() const;
 	struct diveplan &getDiveplan();
 	void removeDeco();
 	static bool addingDeco;
@@ -120,7 +120,7 @@ private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);
 	void setupStartTime();
 	void setupCylinders();
-	int lastEnteredPoint();
+	int lastEnteredPoint() const;
 	bool updateMaxDepth();
 	void createPlan(bool replanCopy);
 	struct diveplan diveplan;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -115,6 +115,7 @@ private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);
 	void clear();
 	int addStop(int millimeters, int seconds, int cylinderid_in, int ccpoint, bool entered, enum divemode_t);
+	void removePoints(const QVector<int> &rows);
 	void setupStartTime();
 	void setupCylinders();
 	int lastEnteredPoint() const;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -52,6 +52,7 @@ public:
 	int ascratestopsDisplay();
 	int ascratelast6mDisplay();
 	int descrateDisplay();
+	int getSurfacePressure();
 
 	/**
 	 * @return the row number.
@@ -64,6 +65,7 @@ public:
 	static bool addingDeco;
 	struct deco_state final_deco_state;
 
+	void loadFromDive(dive *d);
 public
 slots:
 	int addStop(int millimeters = 0, int seconds = 0, int cylinderid_in = -1, int ccpoint = 0, bool entered = true, enum divemode_t = UNDEF_COMP_TYPE);
@@ -73,7 +75,6 @@ slots:
 	void setVpmbConservatism(int level);
 	void setSurfacePressure(int pressure);
 	void setSalinity(int salinity);
-	int getSurfacePressure();
 	void setBottomSac(double sac);
 	void setDecoSac(double sac);
 	void setStartTime(const QTime &t);
@@ -93,7 +94,6 @@ slots:
 	void cancelPlan();
 	void createTemporaryPlan();
 	void deleteTemporaryPlan();
-	void loadFromDive(dive *d);
 	void emitDataChanged();
 	void setRebreatherMode(int mode);
 	void setReserveGas(int reserve);

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -40,7 +40,6 @@ public:
 	void setPlanMode(Mode mode);
 	bool isPlanner() const;
 	void createSimpleDive();
-	void clear();
 	Mode currentMode() const;
 	bool setRecalc(bool recalc);
 	bool recalcQ() const;
@@ -119,6 +118,7 @@ signals:
 
 private:
 	explicit DivePlannerPointsModel(QObject *parent = 0);
+	void clear();
 	void setupStartTime();
 	void setupCylinders();
 	int lastEnteredPoint() const;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
More work in the "make profile reentrant" project. This removes `displayed_dive` from the DivePlannerPointsModel. The division of labour between model, profile and planner is incredibly complex. Therefore, currently only the global displayed_dive is supported, but this will change in the future.

To repeat the long-time goal of this work:
- Make it possible to have multiple profiles at the same time. On the one hand for printing, on the other hand for interactive profiles on mobile
- Make undo more fine grained (i.e. undo individual changes in the planner). This will makes less brittle, by removing modality.

Attention: this changes the UI behavior when moving planner points across each other. In the old code, the active planner point was switched, now it stays the same. For me this is more logical, though I'm sure that others will disagree. I can reinstate the old behavior - no problem.

This also fixes a bug when deleting multiple planner points. It's a wonder that this didn't crash.

And of course it will introduce a number of new bugs - only lightly tested.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Not yet.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
