### PR TITLE
statistics: fix placement of horizontal labels in bar charts

### DIFF
--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -151,6 +151,7 @@ void BarSeries::BarLabel::updatePosition(bool horizontal, bool center, const QRe
 				setVisible(false);
 				return;
 			}
+			pos.rx() -= itemSize.width() / 2.0;
 		}
 		item->setPos(roundPos(pos)); // Round to integer to avoid ugly artifacts.
 	}


### PR DESCRIPTION
The subtraction of half the label width, needed for centered
labels, must have been lost somewhere.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes the label placement in bar charts. I didn't investigate when the bug was introduced or if it was there "forever".
