### PR TITLE
[CLEANUP] printing: "fix" progress indicator

### DIFF
--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -122,7 +122,7 @@ void Printer::flowRender()
 	painter.end();
 }
 
-void Printer::render(int Pages = 0)
+void Printer::render(int pages)
 {
 	// keep original preferences
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
@@ -155,7 +155,7 @@ void Printer::render(int Pages = 0)
 	profile->setFontPrintScale(printFontScale);
 
 	int elemNo = 0;
-	for (int i = 0; i < Pages; i++) {
+	for (int i = 0; i < pages; i++) {
 		// render the base Html template
 		webView->page()->mainFrame()->render(&painter, QWebFrame::ContentsLayer);
 
@@ -173,8 +173,8 @@ void Printer::render(int Pages = 0)
 		viewPort.adjust(0, pageSize.height(), 0, pageSize.height());
 
 		// rendering progress is 4/5 of total work
-		emit(progessUpdated(lrint((i * 80.0 / Pages) + done)));
-		if (i < Pages - 1 && printMode == Printer::PRINT)
+		emit(progessUpdated(lrint((i * 80.0 / pages) + done)));
+		if (i < pages - 1 && printMode == Printer::PRINT)
 			static_cast<QPrinter*>(paintDevice)->newPage();
 	}
 	painter.end();
@@ -220,7 +220,6 @@ void Printer::print()
 		return;
 	}
 
-
 	QPrinter *printerPtr;
 	printerPtr = static_cast<QPrinter*>(paintDevice);
 
@@ -253,13 +252,10 @@ void Printer::print()
 		divesPerPage = 1; // print each dive in a single page if the attribute is missing or malformed
 		//TODO: show warning
 	}
-	int Pages;
-	if (divesPerPage == 0) {
+	if (divesPerPage == 0)
 		flowRender();
-	} else {
-		Pages = qCeil(getTotalWork(printOptions) / (float)divesPerPage);
-		render(Pages);
-	}
+	else
+		render((t.numDives - 1) / divesPerPage + 1);
 }
 
 void Printer::previewOnePage()

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -10,7 +10,6 @@ struct print_options;
 struct template_options;
 class QTextStream;
 
-int getTotalWork(const print_options &printOptions);
 void find_all_templates();
 void set_bundled_templates_as_read_only();
 void copy_bundled_templates(QString src, QString dst, QStringList *templateBackupList);
@@ -32,6 +31,7 @@ public:
 	QString generateStatistics();
 	static QString readTemplate(QString template_name);
 	static void writeTemplate(QString template_name, QString grantlee_template);
+	int numDives; // valid after a call to generate()
 
 private:
 	struct State {
@@ -49,7 +49,7 @@ private:
 	QList<token> lexer(QString input);
 	void parser(QList<token> tokenList, int from, int to, QTextStream &out, State &state);
 	template<typename V, typename T>
-	void parser_for(QList<token> tokenList, int from, int to, QTextStream &out, State &state, const V &data, const T *&act);
+	void parser_for(QList<token> tokenList, int from, int to, QTextStream &out, State &state, const V &data, const T *&act, bool emitProgress);
 	QVariant getValue(QString list, QString property, const State &state);
 	QString translate(QString s, State &state);
 


### PR DESCRIPTION
In TemplateLayout, there was a progress indication, which reported
the progress - not of the actual rendering - but of adding the
dives to the "to render" list. Which is of course done in less than
a ms, making the whole thing completely pointless.

Instead, emit progress when actually looping over the dives or
statistics.

Nobody ever noticed the problem because even rendering is done in
fractions of a second and indeed is accounted to only one fifth
of the total progress.

The real purpose of this "fix" is to get rid of the getTotalWork()
function, which was just insane. Instead of asking the TemplateLayout
how many dives it rendered, this number was extracted from
global state. Simply store the number of dives in the TemplateLayout
object instead.

Moreover, fix two coding style issues:
 - "Page" variable identifier starting with a capital
 - The Printer::render() being defined (as opposed to declared) with
   a default parameter. This is not how C++'s default parameters work,
   sorry.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a code cleanup commit that technically fixes a bug, which however is not a real issue. For the bug, see the commit message. The printing code really is some of the worst...
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) remove silly `getTotalWork()` function.
2) coding style fixes.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - small part of bigger cleanup work.
