### PR TITLE
statistics: rudimentary theming of the color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - profile: include profile editing in undo system
+- mobile: Add a dark theme for statistics
 - core: avoid crash with corrupted cloud storage
 - mobile: fix profile scaling issue on high DPR devices
 - mobile: bring back profile icons

--- a/mobile-widgets/statsmanager.h
+++ b/mobile-widgets/statsmanager.h
@@ -49,6 +49,8 @@ signals:
 	void binner2IndexChanged();
 	void operation2IndexChanged();
 	void sortMode1IndexChanged();
+private slots:
+	void themeChanged();
 private:
 	StatsView *view;
 	ChartListModel *charts;
@@ -66,8 +68,8 @@ private:
 	int operation2Index;
 	int sortMode1Index;
 	StatsState::UIState uiState;	// Remember UI state so that we can interpret indexes
+	bool themeInitialized;		// setTheme() crashes if called in init()
 	void updateUi();
-
 };
 
 #endif

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -50,12 +50,14 @@ ThemeInterface *ThemeInterface::instance()
 	return self;
 }
 
-ThemeInterface::ThemeInterface()
+ThemeInterface::ThemeInterface() :
+	m_basePointSize(-1.0), // simply a placeholder to declare 'this isn't set, yet'
+	m_currentTheme(qPrefDisplay::theme()),
+	m_needSignals(true) // make sure the signals fire the first time
+
 {
 	// get current theme
-	m_currentTheme = qPrefDisplay::theme();
 	update_theme();
-	m_basePointSize = -1.0; // simply a placeholder to declare 'this isn't set, yet'
 }
 
 void ThemeInterface::set_currentTheme(const QString &theme)
@@ -79,14 +81,12 @@ double ThemeInterface::currentScale()
 
 void ThemeInterface::set_currentScale(double newScale)
 {
-	static bool needSignals = true; // make sure the signals fire the first time
-
 	if (!IS_FP_SAME(newScale, qPrefDisplay::mobile_scale())) {
 		qPrefDisplay::set_mobile_scale(newScale);
 		emit currentScaleChanged();
-		needSignals = true;
+		m_needSignals = true;
 	}
-	if (needSignals) {
+	if (m_needSignals) {
 		// adjust all used font sizes
 		m_regularPointSize = m_basePointSize * newScale;
 		defaultModelFont().setPointSizeF(m_regularPointSize);
@@ -101,7 +101,7 @@ void ThemeInterface::set_currentScale(double newScale)
 		m_titlePointSize = m_regularPointSize * 1.5;
 		emit titlePointSizeChanged();
 
-		needSignals = false;
+		m_needSignals = false;
 	}
 }
 

--- a/mobile-widgets/themeinterface.cpp
+++ b/mobile-widgets/themeinterface.cpp
@@ -4,7 +4,6 @@
 #include "qmlmanager.h"
 #include "core/metrics.h"
 #include "core/settings/qPrefDisplay.h"
-#include <QFontInfo>
 
 static const QColor BLUE_BACKGROUND_COLOR = "#eff0f1";
 static const QColor BLUE_CONTRAST_ACCENT_COLOR = "#FF5722";

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -87,5 +87,7 @@ private:
 	double m_titlePointSize;
 
 	QString m_currentTheme;
+
+	bool m_needSignals;
 };
 #endif

--- a/mobile-widgets/themeinterface.h
+++ b/mobile-widgets/themeinterface.h
@@ -3,8 +3,6 @@
 #define THEMEINTERFACE_H
 #include <QObject>
 #include <QColor>
-#include <QSettings>
-#include <QQmlContext>
 
 class ThemeInterface : public QObject {
 	Q_OBJECT

--- a/stats/barseries.cpp
+++ b/stats/barseries.cpp
@@ -106,7 +106,7 @@ BarSeries::~BarSeries()
 BarSeries::BarLabel::BarLabel(StatsView &view, const std::vector<QString> &labels, int bin_nr, int binCount) :
 	isOutside(false)
 {
-	QFont f; // make configurable
+	const QFont &f = view.getCurrentTheme().labelFont;
 	item = view.createChartItem<ChartTextItem>(ChartZValue::SeriesLabels, f, labels, true);
 	//highlight(false, bin_nr, binCount);
 }

--- a/stats/barseries.h
+++ b/stats/barseries.h
@@ -95,8 +95,9 @@ private:
 		bool isOutside; // Is shown outside of bar
 		BarLabel(StatsView &view, const std::vector<QString> &labels, int bin_nr, int binCount);
 		void setVisible(bool visible);
-		void updatePosition(bool horizontal, bool center, const QRectF &rect, int bin_nr, int binCount, const QColor &background);
-		void highlight(bool highlight, int bin_nr, int binCount, const QColor &background);
+		void updatePosition(bool horizontal, bool center, const QRectF &rect, int bin_nr, int binCount,
+				    const QColor &background, const StatsTheme &theme);
+		void highlight(bool highlight, int bin_nr, int binCount, const QColor &background, const StatsTheme &theme);
 	};
 
 	struct SubItem {
@@ -109,8 +110,8 @@ private:
 		bool selected;
 		QColor fill;
 		void updatePosition(BarSeries *series, bool horizontal, bool stacked,
-				    double from, double to, int binCount);
-		void highlight(bool highlight, int binCount);
+				    double from, double to, int binCount, const StatsTheme &theme);
+		void highlight(bool highlight, int binCount, const StatsTheme &theme);
 	};
 
 	struct Item {
@@ -123,9 +124,11 @@ private:
 		Item(BarSeries *series, double lowerBound, double upperBound,
 		     std::vector<SubItem> subitems,
 		     const QString &binName, const StatsOperationResults &res, int total, bool horizontal,
-		     bool stacked, int binCount);
-		void updatePosition(BarSeries *series, bool horizontal, bool stacked, int binCount);
-		void highlight(int subitem, bool highlight, int binCount);
+		     bool stacked, int binCount,
+		     const StatsTheme &theme);
+		void updatePosition(BarSeries *series, bool horizontal, bool stacked, int binCount,
+				    const StatsTheme &theme);
+		void highlight(int subitem, bool highlight, int binCount, const StatsTheme &theme);
 		int getSubItemUnderMouse(const QPointF &f, bool horizontal, bool stacked) const;
 	};
 

--- a/stats/boxseries.cpp
+++ b/stats/boxseries.cpp
@@ -27,13 +27,13 @@ BoxSeries::~BoxSeries()
 }
 
 BoxSeries::Item::Item(StatsView &view, BoxSeries *series, double lowerBound, double upperBound,
-		      const StatsQuartiles &qIn, const QString &binName) :
+		      const StatsQuartiles &qIn, const QString &binName, const StatsTheme &theme) :
 	lowerBound(lowerBound), upperBound(upperBound), q(qIn),
 	binName(binName),
 	selected(allDivesSelected(q.dives))
 {
 	item = view.createChartItem<ChartBoxItem>(ChartZValue::Series, boxBorderWidth);
-	highlight(false);
+	highlight(false, theme);
 	updatePosition(series);
 }
 
@@ -41,14 +41,14 @@ BoxSeries::Item::~Item()
 {
 }
 
-void BoxSeries::Item::highlight(bool highlight)
+void BoxSeries::Item::highlight(bool highlight, const StatsTheme &theme)
 {
 	if (highlight)
-		item->setColor(highlightedColor, highlightedBorderColor);
+		item->setColor(theme.highlightedColor, theme.highlightedBorderColor);
 	else if (selected)
-		item->setColor(selectedColor, selectedBorderColor);
+		item->setColor(theme.selectedColor, theme.selectedBorderColor);
 	else
-		item->setColor(fillColor, ::borderColor);
+		item->setColor(theme.fillColor, theme.borderColor);
 }
 
 void BoxSeries::Item::updatePosition(BoxSeries *series)
@@ -72,7 +72,7 @@ void BoxSeries::Item::updatePosition(BoxSeries *series)
 
 void BoxSeries::append(double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName)
 {
-	items.emplace_back(new Item(view, this, lowerBound, upperBound, q, binName));
+	items.emplace_back(new Item(view, this, lowerBound, upperBound, q, binName, theme));
 }
 
 void BoxSeries::updatePositions()
@@ -128,7 +128,7 @@ bool BoxSeries::hover(QPointF pos)
 	// Highlight new item (if any)
 	if (highlighted >= 0 && highlighted < (int)items.size()) {
 		Item &item = *items[highlighted];
-		item.highlight(true);
+		item.highlight(true, theme);
 		if (!information)
 			information = view.createChartItem<InformationBox>();
 		information->setText(formatInformation(item), pos);
@@ -142,7 +142,7 @@ bool BoxSeries::hover(QPointF pos)
 void BoxSeries::unhighlight()
 {
 	if (highlighted >= 0 && highlighted < (int)items.size())
-		items[highlighted]->highlight(false);
+		items[highlighted]->highlight(false, theme);
 	highlighted = -1;
 }
 
@@ -183,7 +183,7 @@ void BoxSeries::divesSelected(const QVector<dive *> &)
 
 			int idx = &item - &items[0];
 			bool highlight = idx == highlighted;
-			item->highlight(highlight);
+			item->highlight(highlight, theme);
 		}
 	}
 }

--- a/stats/boxseries.h
+++ b/stats/boxseries.h
@@ -40,10 +40,11 @@ private:
 		StatsQuartiles q;
 		QString binName;
 		bool selected;
-		Item(StatsView &view, BoxSeries *series, double lowerBound, double upperBound, const StatsQuartiles &q, const QString &binName);
+		Item(StatsView &view, BoxSeries *series, double lowerBound, double upperBound, const StatsQuartiles &q,
+		     const QString &binName, const StatsTheme &theme);
 		~Item();
 		void updatePosition(BoxSeries *series);
-		void highlight(bool highlight);
+		void highlight(bool highlight, const StatsTheme &theme);
 	};
 
 	QString variable, unit;

--- a/stats/chartitem.cpp
+++ b/stats/chartitem.cpp
@@ -64,7 +64,7 @@ void ChartPixmapItem::setPositionDirty()
 	markDirty();
 }
 
-void ChartPixmapItem::render()
+void ChartPixmapItem::render(const StatsTheme &)
 {
 	if (!node) {
 		createNode(view.w()->createImageNode());
@@ -137,30 +137,25 @@ static QSGTexture *createScatterTexture(StatsView &view, const QColor &color, co
 	return view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel);
 }
 
-static QSGTexture *scatterItemTexture = nullptr;
-static QSGTexture *scatterItemSelectedTexture = nullptr;
-static QSGTexture *scatterItemHighlightedTexture = nullptr;
-static QSGTexture *selectedTexture = nullptr; // A checkerboard pattern.
-
-QSGTexture *ChartScatterItem::getTexture() const
+QSGTexture *ChartScatterItem::getTexture(const StatsTheme &theme) const
 {
 	switch (highlight) {
 	default:
 	case Highlight::Unselected:
-		return scatterItemTexture;
+		return theme.scatterItemTexture;
 	case Highlight::Selected:
-		return scatterItemSelectedTexture;
+		return theme.scatterItemSelectedTexture;
 	case Highlight::Highlighted:
-		return scatterItemHighlightedTexture;
+		return theme.scatterItemHighlightedTexture;
 	}
 }
 
-void ChartScatterItem::render()
+void ChartScatterItem::render(const StatsTheme &theme)
 {
-	if (!scatterItemTexture) {
-		scatterItemTexture = register_global(createScatterTexture(view, fillColor, borderColor));
-		scatterItemSelectedTexture = register_global(createScatterTexture(view, selectedColor, selectedBorderColor));
-		scatterItemHighlightedTexture = register_global(createScatterTexture(view, highlightedColor, highlightedBorderColor));
+	if (!theme.scatterItemTexture) {
+		theme.scatterItemTexture = register_global(createScatterTexture(view, theme.fillColor, theme.borderColor));
+		theme.scatterItemSelectedTexture = register_global(createScatterTexture(view, theme.selectedColor, theme.selectedBorderColor));
+		theme.scatterItemHighlightedTexture = register_global(createScatterTexture(view, theme.highlightedColor, theme.highlightedBorderColor));
 	}
 	if (!node) {
 		createNode(view.w()->createImageNode());
@@ -169,7 +164,7 @@ void ChartScatterItem::render()
 	}
 	updateVisible();
 	if (textureDirty) {
-		node->node->setTexture(getTexture());
+		node->node->setTexture(getTexture(theme));
 		textureDirty = false;
 	}
 	if (positionDirty) {
@@ -288,7 +283,7 @@ ChartPieItem::ChartPieItem(StatsView &v, ChartZValue z, double borderWidth) : Ch
 {
 }
 
-static QBrush makeBrush(QColor fill, bool selected)
+static QBrush makeBrush(QColor fill, bool selected, const StatsTheme &theme)
 {
 	if (!selected)
 		return QBrush(fill);
@@ -296,18 +291,18 @@ static QBrush makeBrush(QColor fill, bool selected)
 	img.fill(fill);
 	for (int x = 0; x < selectionOverlayPixelSize; ++x) {
 		for (int y = 0; y < selectionOverlayPixelSize; ++y) {
-			img.setPixelColor(x, y, selectionOverlayColor);
+			img.setPixelColor(x, y, theme.selectionOverlayColor);
 			img.setPixelColor(x + selectionOverlayPixelSize, y + selectionOverlayPixelSize,
-					  selectionOverlayColor);
+					  theme.selectionOverlayColor);
 		}
 	}
 	return QBrush(img);
 }
 
-void ChartPieItem::drawSegment(double from, double to, QColor fill, QColor border, bool selected)
+void ChartPieItem::drawSegment(double from, double to, QColor fill, QColor border, bool selected, const StatsTheme &theme)
 {
 	painter->setPen(QPen(border, borderWidth));
-	painter->setBrush(makeBrush(fill, selected));
+	painter->setBrush(makeBrush(fill, selected, theme));
 	// For whatever obscure reason, angles of pie pieces are given as 16th of a degree...?
 	// Angles increase CCW, whereas pie charts usually are read CW. Therfore, startAngle
 	// is dervied from "from" and subtracted from the origin angle at 12:00.
@@ -353,7 +348,7 @@ void setPoint(QSGGeometry::TexturedPoint2D &v, const QPointF &p, const QPointF &
 	      static_cast<float>(t.x()), static_cast<float>(t.y()));
 }
 
-void ChartLineItem::render()
+void ChartLineItem::render(const StatsTheme &)
 {
 	if (!node) {
 		geometry.reset(new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 2));
@@ -384,7 +379,7 @@ void ChartLineItem::render()
 	positionDirty = materialDirty = false;
 }
 
-void ChartRectLineItem::render()
+void ChartRectLineItem::render(const StatsTheme &)
 {
 	if (!node) {
 		geometry.reset(new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 4));
@@ -427,19 +422,19 @@ ChartBarItem::~ChartBarItem()
 {
 }
 
-QSGTexture *ChartBarItem::getSelectedTexture() const
+QSGTexture *ChartBarItem::getSelectedTexture(const StatsTheme &theme) const
 {
-	if (!selectedTexture) {
+	if (!theme.selectedTexture) {
 		QImage img(2, 2, QImage::Format_ARGB32);
 		img.fill(Qt::transparent);
-		img.setPixelColor(0, 0, selectionOverlayColor);
-		img.setPixelColor(1, 1, selectionOverlayColor);
-		selectedTexture = register_global(view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel));
+		img.setPixelColor(0, 0, theme.selectionOverlayColor);
+		img.setPixelColor(1, 1, theme.selectionOverlayColor);
+		theme.selectedTexture = register_global(view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel));
 	}
-	return selectedTexture;
+	return theme.selectedTexture;
 }
 
-void ChartBarItem::render()
+void ChartBarItem::render(const StatsTheme &theme)
 {
 	if (!node) {
 		createNode(view.w()->createRectangleNode());
@@ -483,7 +478,7 @@ void ChartBarItem::render()
 				selectionGeometry.reset(new QSGGeometry(QSGGeometry::defaultAttributes_TexturedPoint2D(), 4));
 				selectionGeometry->setDrawingMode(QSGGeometry::DrawTriangleFan);
 				selectionMaterial.reset(new QSGTextureMaterial);
-				selectionMaterial->setTexture(getSelectedTexture());
+				selectionMaterial->setTexture(getSelectedTexture(theme));
 				selectionMaterial->setHorizontalWrapMode(QSGTexture::Repeat);
 				selectionMaterial->setVerticalWrapMode(QSGTexture::Repeat);
 				selectionNode.reset(new QSGGeometryNode);
@@ -556,12 +551,12 @@ ChartBoxItem::~ChartBoxItem()
 {
 }
 
-void ChartBoxItem::render()
+void ChartBoxItem::render(const StatsTheme &theme)
 {
 	// Remember old dirty values, since ChartBarItem::render() will clear them
 	bool oldPositionDirty = positionDirty;
 	bool oldColorDirty = colorDirty;
-	ChartBarItem::render();		// This will create the base node, so no need to check for that.
+	ChartBarItem::render(theme);		// This will create the base node, so no need to check for that.
 	if (!whiskersNode) {
 		whiskersGeometry.reset(new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 10));
 		whiskersGeometry->setDrawingMode(QSGGeometry::DrawLines);

--- a/stats/chartitem.h
+++ b/stats/chartitem.h
@@ -16,12 +16,14 @@ class QSGImageNode;
 class QSGRectangleNode;
 class QSGTexture;
 class QSGTextureMaterial;
+class StatsTheme;
 class StatsView;
 enum class ChartZValue : int;
 
 class ChartItem {
 public:
-	virtual void render() = 0;		// Only call on render thread!
+	// Only call on render thread!
+	virtual void render(const StatsTheme &theme) = 0;
 	bool dirty;				// If true, call render() when rebuilding the scene
 	ChartItem *prev, *next;			// Double linked list of items
 	const ChartZValue zValue;
@@ -58,7 +60,7 @@ public:
 	~ChartPixmapItem();
 
 	void setPos(QPointF pos);
-	void render() override;		// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 	QRectF getRect() const;
 protected:
 	void resize(QSizeF size);	// Resets the canvas. Attention: image is *unitialized*.
@@ -107,7 +109,7 @@ private:
 class ChartPieItem : public ChartPixmapItem {
 public:
 	ChartPieItem(StatsView &v, ChartZValue z, double borderWidth);
-	void drawSegment(double from, double to, QColor fill, QColor border, bool selected); // from and to are relative (0-1 is full disk).
+	void drawSegment(double from, double to, QColor fill, QColor border, bool selected, const StatsTheme &theme); // from and to are relative (0-1 is full disk).
 	void resize(QSizeF size);	// As in base class, but clears the canvas
 private:
 	double borderWidth;
@@ -132,14 +134,14 @@ protected:
 class ChartLineItem : public ChartLineItemBase {
 public:
 	using ChartLineItemBase::ChartLineItemBase;
-	void render() override;		// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 };
 
 // A simple rectangle without fill. Specified by any two opposing vertices.
 class ChartRectLineItem : public ChartLineItemBase {
 public:
 	using ChartLineItemBase::ChartLineItemBase;
-	void render() override;		// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 };
 
 // A bar in a bar chart: a rectangle bordered by lines.
@@ -151,7 +153,7 @@ public:
 	void setRect(const QRectF &rect);
 	void setSelected(bool selected);
 	QRectF getRect() const;
-	void render() override;		// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 protected:
 	QColor color, borderColor;
 	double borderWidth;
@@ -168,7 +170,7 @@ private:
 	std::unique_ptr<QSGGeometryNode> selectionNode;
 	std::unique_ptr<QSGTextureMaterial> selectionMaterial;
 	std::unique_ptr<QSGGeometry> selectionGeometry;
-	QSGTexture *getSelectedTexture() const;
+	QSGTexture *getSelectedTexture(const StatsTheme &theme) const;
 };
 
 // A box-and-whiskers item. This is a bit lazy: derive from the bar item and add whiskers.
@@ -178,7 +180,7 @@ public:
 	~ChartBoxItem();
 	void setBox(const QRectF &rect, double min, double max, double median); // The rect describes Q1, Q3.
 	QRectF getRect() const;		// Note: this extends the center rectangle to include the whiskers.
-	void render() override;		// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 private:
 	double min, max, median;
 	std::unique_ptr<QSGGeometryNode> whiskersNode;
@@ -203,12 +205,12 @@ public:
 	};
 	void setPos(QPointF pos);		// Specifies the *center* of the item.
 	void setHighlight(Highlight highlight);	// In the future, support different kinds of scatter items.
-	void render() override;			// Only call on render thread!
+	void render(const StatsTheme &theme) override;
 	QRectF getRect() const;
 	bool contains(QPointF point) const;
 	bool inRect(const QRectF &rect) const;
 private:
-	QSGTexture *getTexture() const;
+	QSGTexture *getTexture(const StatsTheme &theme) const;
 	QRectF rect;
 	QSizeF textureSize;
 	bool positionDirty, textureDirty;

--- a/stats/chartitem.h
+++ b/stats/chartitem.h
@@ -95,7 +95,7 @@ public:
 	void setColor(const QColor &color); // Draw on transparent background
 	void setColor(const QColor &color, const QColor &background); // Fill rectangle with given background color
 private:
-	QFont f;
+	const QFont &f;
 	double fontHeight;
 	bool center;
 	struct Item {

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -11,8 +11,9 @@ static const int distanceFromPointer = 10; // Distance to place box from mouse p
 
 InformationBox::InformationBox(StatsView &v) :
 	ChartRectItem(v, ChartZValue::InformationBox,
-		      QPen(informationBorderColor, informationBorder),
-		      QBrush(informationColor), informationBorderRadius),
+		      QPen(v.getCurrentTheme().informationBorderColor, informationBorder),
+		      QBrush(v.getCurrentTheme().informationColor), informationBorderRadius),
+	theme(v.getCurrentTheme()),
 	width(0.0),
 	height(0.0)
 {
@@ -36,7 +37,7 @@ void InformationBox::setText(const std::vector<QString> &text, QPointF pos)
 
 	ChartRectItem::resize(QSizeF(width, height));
 
-	painter->setPen(QPen(darkLabelColor)); // QPainter uses QPen to set text color!
+	painter->setPen(QPen(theme.darkLabelColor)); // QPainter uses QPen to set text color!
 	double y = 2.0 * informationBorder;
 	for (size_t i = 0; i < widths.size(); ++i) {
 		QRectF rect(2.0 * informationBorder, y, widths[i], fontHeight);

--- a/stats/informationbox.cpp
+++ b/stats/informationbox.cpp
@@ -21,7 +21,7 @@ InformationBox::InformationBox(StatsView &v) :
 
 void InformationBox::setText(const std::vector<QString> &text, QPointF pos)
 {
-	QFontMetrics fm(font);
+	QFontMetrics fm(theme.informationBoxFont);
 	double fontHeight = fm.height();
 
 	std::vector<double> widths;
@@ -37,6 +37,7 @@ void InformationBox::setText(const std::vector<QString> &text, QPointF pos)
 
 	ChartRectItem::resize(QSizeF(width, height));
 
+	painter->setFont(theme.informationBoxFont);
 	painter->setPen(QPen(theme.darkLabelColor)); // QPainter uses QPen to set text color!
 	double y = 2.0 * informationBorder;
 	for (size_t i = 0; i < widths.size(); ++i) {
@@ -71,7 +72,7 @@ void InformationBox::setPos(QPointF pos)
 // Try to stay within three-thirds of the chart height
 int InformationBox::recommendedMaxLines() const
 {
-	QFontMetrics fm(font);
+	QFontMetrics fm(theme.informationBoxFont);
 	int maxHeight = static_cast<int>(sceneSize().height());
 	return maxHeight * 2 / fm.height() / 3;
 }

--- a/stats/informationbox.h
+++ b/stats/informationbox.h
@@ -8,7 +8,6 @@
 
 #include <vector>
 #include <memory>
-#include <QFont>
 
 struct dive;
 class StatsView;
@@ -21,7 +20,6 @@ struct InformationBox : ChartRectItem {
 	int recommendedMaxLines() const;
 private:
 	const StatsTheme &theme; // Set once in constructor.
-	QFont font; // For future specialization.
 	double width, height;
 };
 

--- a/stats/informationbox.h
+++ b/stats/informationbox.h
@@ -20,6 +20,7 @@ struct InformationBox : ChartRectItem {
 	void setPos(QPointF pos);
 	int recommendedMaxLines() const;
 private:
+	const StatsTheme &theme; // Set once in constructor.
 	QFont font; // For future specialization.
 	double width, height;
 };

--- a/stats/legend.cpp
+++ b/stats/legend.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "legend.h"
 #include "statscolors.h"
+#include "statsview.h"
 #include "zvalues.h"
 
 #include <cmath>
@@ -15,8 +16,10 @@ static const double legendInternalBorderSize = 2.0;
 
 Legend::Legend(StatsView &view, const std::vector<QString> &names) :
 	ChartRectItem(view, ChartZValue::Legend,
-		      QPen(legendBorderColor, legendBorderSize), QBrush(legendColor), legendBoxBorderRadius),
+		      QPen(view.getCurrentTheme().legendBorderColor, legendBorderSize),
+		      QBrush(view.getCurrentTheme().legendColor), legendBoxBorderRadius),
 	displayedItems(0), width(0.0), height(0.0),
+	theme(view.getCurrentTheme()),
 	font(QFont()),	// Make configurable
 	posInitialized(false)
 {
@@ -25,12 +28,12 @@ Legend::Legend(StatsView &view, const std::vector<QString> &names) :
 	fontHeight = fm.height();
 	int idx = 0;
 	for (const QString &name: names)
-		entries.emplace_back(name, idx++, (int)names.size(), fm);
+		entries.emplace_back(name, idx++, (int)names.size(), fm, theme);
 }
 
-Legend::Entry::Entry(const QString &name, int idx, int numBins, const QFontMetrics &fm) :
+Legend::Entry::Entry(const QString &name, int idx, int numBins, const QFontMetrics &fm, const StatsTheme &theme) :
 	name(name),
-	rectBrush(QBrush(binColor(idx, numBins)))
+	rectBrush(QBrush(theme.binColor(idx, numBins)))
 {
 	width = fm.height() + 2.0 * legendBoxBorderSize + fm.size(Qt::TextSingleLine, name).width();
 }
@@ -82,7 +85,7 @@ void Legend::resize()
 	ChartRectItem::resize(QSizeF(width, height));
 
 	// Paint rectangles
-	painter->setPen(QPen(legendBorderColor, legendBoxBorderSize));
+	painter->setPen(QPen(theme.legendBorderColor, legendBoxBorderSize));
 	for (int i = 0; i < displayedItems; ++i) {
 		QPointF itemPos = entries[i].pos;
 		painter->setBrush(entries[i].rectBrush);
@@ -94,7 +97,7 @@ void Legend::resize()
 	}
 
 	// Paint labels
-	painter->setPen(darkLabelColor); // QPainter uses pen not brush for text!
+	painter->setPen(theme.darkLabelColor); // QPainter uses pen not brush for text!
 	painter->setFont(font);
 	for (int i = 0; i < displayedItems; ++i) {
 		QPointF itemPos = entries[i].pos;

--- a/stats/legend.cpp
+++ b/stats/legend.cpp
@@ -20,11 +20,10 @@ Legend::Legend(StatsView &view, const std::vector<QString> &names) :
 		      QBrush(view.getCurrentTheme().legendColor), legendBoxBorderRadius),
 	displayedItems(0), width(0.0), height(0.0),
 	theme(view.getCurrentTheme()),
-	font(QFont()),	// Make configurable
 	posInitialized(false)
 {
 	entries.reserve(names.size());
-	QFontMetrics fm(font);
+	QFontMetrics fm(theme.legendFont);
 	fontHeight = fm.height();
 	int idx = 0;
 	for (const QString &name: names)
@@ -98,7 +97,7 @@ void Legend::resize()
 
 	// Paint labels
 	painter->setPen(theme.darkLabelColor); // QPainter uses pen not brush for text!
-	painter->setFont(font);
+	painter->setFont(theme.legendFont);
 	for (int i = 0; i < displayedItems; ++i) {
 		QPointF itemPos = entries[i].pos;
 		itemPos.rx() += fontHeight + 2.0 * legendBoxBorderSize;

--- a/stats/legend.h
+++ b/stats/legend.h
@@ -10,6 +10,7 @@
 #include <QFont>
 
 class QFontMetrics;
+class StatsTheme;
 
 class Legend : public ChartRectItem {
 public:
@@ -23,11 +24,12 @@ private:
 		QBrush rectBrush;
 		QPointF pos;
 		double width;
-		Entry(const QString &name, int idx, int numBins, const QFontMetrics &fm);
+		Entry(const QString &name, int idx, int numBins, const QFontMetrics &fm, const StatsTheme &);
 	};
 	int displayedItems;
 	double width;
 	double height;
+	const StatsTheme &theme; // Set once in constructor.
 	QFont font;
 	// The position is specified with respect to the center and in relative terms
 	// with respect to the canvas.

--- a/stats/legend.h
+++ b/stats/legend.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <vector>
-#include <QFont>
 
 class QFontMetrics;
 class StatsTheme;
@@ -30,7 +29,6 @@ private:
 	double width;
 	double height;
 	const StatsTheme &theme; // Set once in constructor.
-	QFont font;
 	// The position is specified with respect to the center and in relative terms
 	// with respect to the canvas.
 	QPointF centerPos;

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -23,7 +23,7 @@ PieSeries::Item::Item(StatsView &view, const QString &name, int from, std::vecto
 	dives(std::move(divesIn)),
 	selected(allDivesSelected(dives))
 {
-	QFont f; // make configurable
+	const QFont &f = theme.labelFont;
 	QLocale loc;
 
 	int count = (int)dives.size();

--- a/stats/pieseries.h
+++ b/stats/pieseries.h
@@ -49,9 +49,9 @@ private:
 		QPointF innerLabelPos, outerLabelPos; // With respect to a (-1, -1)-(1, 1) rectangle.
 		bool selected;
 		Item(StatsView &view, const QString &name, int from, std::vector<dive *> dives, int totalCount,
-		     int bin_nr, int numBins);
+		     int bin_nr, int numBins, const StatsTheme &theme);
 		void updatePositions(const QPointF &center, double radius);
-		void highlight(ChartPieItem &item, int bin_nr, bool highlight, int numBins);
+		void highlight(ChartPieItem &item, int bin_nr, bool highlight, int numBins, const StatsTheme &theme);
 	};
 	std::vector<Item> items;
 	int totalCount;

--- a/stats/quartilemarker.cpp
+++ b/stats/quartilemarker.cpp
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "quartilemarker.h"
-#include "statscolors.h"
 #include "statsaxis.h"
+#include "statscolors.h"
+#include "statsview.h"
 #include "zvalues.h"
 
 static const double quartileMarkerSize = 15.0;
 
 QuartileMarker::QuartileMarker(StatsView &view, double pos, double value, StatsAxis *xAxis, StatsAxis *yAxis) :
-	ChartLineItem(view, ChartZValue::ChartFeatures, quartileMarkerColor, 2.0),
+	ChartLineItem(view, ChartZValue::ChartFeatures, view.getCurrentTheme().quartileMarkerColor, 2.0),
 	xAxis(xAxis), yAxis(yAxis),
 	pos(pos),
 	value(value)

--- a/stats/regressionitem.cpp
+++ b/stats/regressionitem.cpp
@@ -2,6 +2,7 @@
 #include "regressionitem.h"
 #include "statsaxis.h"
 #include "statscolors.h"
+#include "statsview.h"
 #include "zvalues.h"
 
 #include <cmath>
@@ -11,6 +12,7 @@ static const double regressionLineWidth = 2.0;
 RegressionItem::RegressionItem(StatsView &view, regression_data reg,
 						   StatsAxis *xAxis, StatsAxis *yAxis) :
 	ChartPixmapItem(view, ChartZValue::ChartFeatures),
+	theme(view.getCurrentTheme()),
 	xAxis(xAxis), yAxis(yAxis), reg(reg),
 	regression(true), confidence(true)
 {
@@ -86,7 +88,7 @@ void RegressionItem::updatePosition()
 
 	img->fill(Qt::transparent);
 	if (confidence) {
-		QColor col(regressionItemColor);
+		QColor col(theme.regressionItemColor);
 		col.setAlphaF((float)reg.r2);
 		painter->setPen(Qt::NoPen);
 		painter->setBrush(QBrush(col));
@@ -94,7 +96,7 @@ void RegressionItem::updatePosition()
 	}
 
 	if (regression) {
-		painter->setPen(QPen(regressionItemColor, regressionLineWidth));
+		painter->setPen(QPen(theme.regressionItemColor, regressionLineWidth));
 		painter->drawLine(QPointF(linePolygon[0]), QPointF(linePolygon[1]));
 	}
 

--- a/stats/regressionitem.h
+++ b/stats/regressionitem.h
@@ -5,6 +5,7 @@
 #include "chartitem.h"
 
 class StatsAxis;
+class StatsTheme;
 class StatsView;
 
 struct regression_data {
@@ -20,6 +21,7 @@ public:
 	void updatePosition();
 	void setFeatures(bool regression, bool confidence);
 private:
+	const StatsTheme &theme; // Initialized once in constructor
 	StatsAxis *xAxis, *yAxis;
 	regression_data reg;
 	bool regression, confidence;

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -26,7 +26,8 @@ static const double axisTitleSpaceVertical = 2.0;	// Space between labels and ti
 
 StatsAxis::StatsAxis(StatsView &view, const QString &title, bool horizontal, bool labelsBetweenTicks) :
 	ChartPixmapItem(view, ChartZValue::Axes),
-	line(view.createChartItem<ChartLineItem>(ChartZValue::Axes, axisColor, axisWidth)),
+	theme(view.getCurrentTheme()),
+	line(view.createChartItem<ChartLineItem>(ChartZValue::Axes, theme.axisColor, axisWidth)),
 	title(title), horizontal(horizontal), labelsBetweenTicks(labelsBetweenTicks),
 	size(1.0), zeroOnScreen(0.0), min(0.0), max(1.0), labelWidth(0.0)
 {
@@ -128,7 +129,7 @@ void StatsAxis::addLabel(const QFontMetrics &fm, const QString &label, double po
 
 void StatsAxis::addTick(double pos)
 {
-	ticks.push_back({ view.createChartItem<ChartLineItem>(ChartZValue::Axes, axisColor, axisTickWidth), pos });
+	ticks.push_back({ view.createChartItem<ChartLineItem>(ChartZValue::Axes, theme.axisColor, axisTickWidth), pos });
 }
 
 std::vector<double> StatsAxis::ticksPositions() const
@@ -190,7 +191,7 @@ void StatsAxis::setSize(double sizeIn)
 		offset = QPointF(round(offsetX), round(offsetY));
 		img->fill(Qt::transparent);
 
-		painter->setPen(QPen(darkLabelColor));
+		painter->setPen(QPen(theme.darkLabelColor));
 		painter->setFont(labelFont);
 		for (const Label &label: labels) {
 			double x = (label.pos - min) / (max - min) * size + offset.x() - round(label.width / 2.0);
@@ -219,7 +220,7 @@ void StatsAxis::setSize(double sizeIn)
 		offset = QPointF(round(offsetX), round(offsetY));
 		img->fill(Qt::transparent);
 
-		painter->setPen(QPen(darkLabelColor));
+		painter->setPen(QPen(theme.darkLabelColor));
 		painter->setFont(labelFont);
 		for (const Label &label: labels) {
 			double y = (min - label.pos) / (max - min) * size + offset.y() - round(fontHeight / 2.0);

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <vector>
-#include <QFont>
 
 class StatsView;
 class ChartLineItem;
@@ -63,7 +62,6 @@ protected:
 	bool horizontal;
 	bool labelsBetweenTicks;	// When labels are between ticks, they can be moved closer to the axis
 
-	QFont labelFont, titleFont;
 	double size;			// width for horizontal, height for vertical
 	double zeroOnScreen;
 	QPointF offset;			// Offset of the label and title pixmap with respect to the (0,0) position.

--- a/stats/statsaxis.h
+++ b/stats/statsaxis.h
@@ -37,6 +37,7 @@ public:
 protected:
 	StatsAxis(StatsView &view, const QString &title, bool horizontal, bool labelsBetweenTicks);
 
+	const StatsTheme &theme; // Initialized once in constructor.
 	ChartItemPtr<ChartLineItem> line;
 	QString title;
 	double titleWidth;

--- a/stats/statscolors.cpp
+++ b/stats/statscolors.cpp
@@ -1,4 +1,5 @@
 #include "statscolors.h"
+#include "statstranslations.h"
 
 // Colors created using the Chroma.js Color Palette Helper
 // https://vis4.net/palettes/#/50|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1
@@ -15,22 +16,65 @@ static const QColor binColors[] = {
 	QRgb(0xa83e49), QRgb(0x9d3a44), QRgb(0x90383f), QRgb(0x83363a), QRgb(0x743535)
 };
 
-// Pick roughly equidistant colors out of the color set above
-// if we need more bins than we have colors (what chart is THAT?) simply loop
-QColor binColor(int bin, int numBins)
+StatsTheme::StatsTheme() :
+	scatterItemTexture(nullptr),
+	scatterItemSelectedTexture(nullptr),
+	scatterItemHighlightedTexture(nullptr),
+	selectedTexture(nullptr)
 {
-	if (numBins == 1 || bin < 0 || bin >= numBins)
-		return fillColor;
-	if (numBins > (int)std::size(binColors))
-		return binColors[bin % std::size(binColors)];
-
-	// use integer math to spread out the indices
-	int idx = bin * (std::size(binColors) - 1) / (numBins - 1);
-	return binColors[idx];
 }
 
-// Figure out if we want a light or a dark label
-QColor labelColor(int bin, size_t numBins)
-{
-	return (binColor(bin, numBins).lightness() < 150) ? lightLabelColor : darkLabelColor;
-}
+class StatsThemeLight : public StatsTheme {
+public:
+	StatsThemeLight()
+	{
+		backgroundColor = Qt::white;
+		fillColor = QColor(0x44, 0x76, 0xaa);
+		borderColor = QColor(0x66, 0xb2, 0xff);
+		selectedColor = QColor(0xaa, 0x76, 0x44);
+		selectedBorderColor = QColor(0xff, 0xb2, 0x66);
+		highlightedColor = Qt::yellow;
+		highlightedBorderColor = QColor(0xaa, 0xaa, 0x22);
+		darkLabelColor = Qt::black;
+		lightLabelColor = Qt::white;
+		axisColor = Qt::black;
+		gridColor = QColor(0xcc, 0xcc, 0xcc);
+		informationBorderColor = Qt::black;
+		informationColor = QColor(0xff, 0xff, 0x00, 192); // Note: fourth argument is opacity
+		legendColor = QColor(0x00, 0x8e, 0xcc, 192); // Note: fourth argument is opacity
+		legendBorderColor = Qt::black;
+		quartileMarkerColor = Qt::red;
+		regressionItemColor = Qt::red;
+		meanMarkerColor = Qt::green;
+		medianMarkerColor = Qt::red;
+		selectionLassoColor = Qt::black;
+		selectionOverlayColor = Qt::lightGray;
+	}
+private:
+	QString name() const
+	{
+		return StatsTranslations::tr("Light");
+	}
+
+	// Pick roughly equidistant colors out of the color set above
+	// if we need more bins than we have colors (what chart is THAT?) simply loop
+	QColor binColor(int bin, int numBins) const override
+	{
+		if (numBins == 1 || bin < 0 || bin >= numBins)
+			return fillColor;
+		if (numBins > (int)std::size(binColors))
+			return binColors[bin % std::size(binColors)];
+
+		// use integer math to spread out the indices
+		int idx = bin * (std::size(binColors) - 1) / (numBins - 1);
+		return binColors[idx];
+	}
+
+	QColor labelColor(int bin, size_t numBins) const override
+	{
+		return (binColor(bin, numBins).lightness() < 150) ? lightLabelColor : darkLabelColor;
+	}
+};
+
+static StatsThemeLight statsThemeLight;
+std::vector<const StatsTheme *> statsThemes = { &statsThemeLight };

--- a/stats/statscolors.cpp
+++ b/stats/statscolors.cpp
@@ -51,6 +51,11 @@ public:
 		medianMarkerColor = Qt::red;
 		selectionLassoColor = Qt::black;
 		selectionOverlayColor = Qt::lightGray;
+
+		// use a light version of the application font for axis labels, axis title and chart title
+		axisLabelFont.setWeight(QFont::Light);
+		axisTitleFont.setWeight(QFont::Light);
+		titleFont.setWeight(QFont::Light);
 	}
 private:
 	QString name() const
@@ -118,6 +123,11 @@ public:
 		medianMarkerColor = Qt::cyan;
 		selectionLassoColor = Qt::white;
 		selectionOverlayColor = Qt::darkGray;
+
+		// use a bold version of the application font for axis labels, axis title and chart title
+		axisLabelFont.setWeight(QFont::Bold);
+		axisTitleFont.setWeight(QFont::Bold);
+		titleFont.setWeight(QFont::Bold);
 	}
 private:
 	QString name() const

--- a/stats/statscolors.cpp
+++ b/stats/statscolors.cpp
@@ -76,5 +76,73 @@ private:
 	}
 };
 
+// we have a separate set of dark colors - but in reality te color palette the we created
+// works well in either dark or light mode, so these are the same as for the light theme
+static const QColor binColorsDark[] = {
+	QRgb(0x00108c), QRgb(0x0f1c92), QRgb(0x1a2798), QRgb(0x23319d), QRgb(0x2a3ba3),
+	QRgb(0x3144a8), QRgb(0x374eae), QRgb(0x3e58b3), QRgb(0x4461b8), QRgb(0x4b6bbd),
+	QRgb(0x5274c2), QRgb(0x587ec7), QRgb(0x6088cc), QRgb(0x6791d0), QRgb(0x6f9bd4),
+	QRgb(0x78a5d8), QRgb(0x81aedb), QRgb(0x8ab8df), QRgb(0x95c2e2), QRgb(0xa0cbe4),
+	QRgb(0xacd5e6), QRgb(0xb9dee7), QRgb(0xc7e7e7), QRgb(0xd7efe7), QRgb(0xeaf8e4),
+	QRgb(0xfff5d8), QRgb(0xffead0), QRgb(0xffe0c8), QRgb(0xffd5c0), QRgb(0xffcab8),
+	QRgb(0xffbfb0), QRgb(0xffb4a8), QRgb(0xffa99f), QRgb(0xfc9e98), QRgb(0xf99490),
+	QRgb(0xf48b89), QRgb(0xf08182), QRgb(0xea787b), QRgb(0xe46f74), QRgb(0xde666e),
+	QRgb(0xd75e67), QRgb(0xcf5661), QRgb(0xc64f5b), QRgb(0xbd4855), QRgb(0xb3434f),
+	QRgb(0xa83e49), QRgb(0x9d3a44), QRgb(0x90383f), QRgb(0x83363a), QRgb(0x743535)
+};
+
+class StatsThemeDark : public StatsTheme {
+public:
+	StatsThemeDark()
+	{
+		backgroundColor = Qt::black;
+		fillColor = QColor(0x64, 0x96, 0xca);
+		borderColor = QColor(0x66, 0xb2, 0xff);
+		selectedColor = QColor(0x55, 0x89, 0xbb);
+		selectedBorderColor = QColor(0x00, 0x4d, 0x99);
+		highlightedColor = Qt::yellow;
+		highlightedBorderColor = QColor(0x55, 0x55, 0xdd);
+		darkLabelColor = Qt::white;
+		lightLabelColor = Qt::black;
+		axisColor = Qt::white;
+		gridColor = QColor(0x33, 0x33, 0x33);
+		informationBorderColor = Qt::white;
+		informationColor = QColor(0x00, 0x00, 0xff, 192); // Note: fourth argument is opacity
+		legendColor = QColor(0xff, 0x71, 0x33, 192); // Note: fourth argument is opacity
+		legendBorderColor = Qt::white;
+		quartileMarkerColor = Qt::cyan;
+		regressionItemColor = Qt::cyan;
+		meanMarkerColor = Qt::magenta;
+		medianMarkerColor = Qt::cyan;
+		selectionLassoColor = Qt::white;
+		selectionOverlayColor = Qt::darkGray;
+	}
+private:
+	QString name() const
+	{
+		return StatsTranslations::tr("Dark");
+	}
+
+	// Pick roughly equidistant colors out of the color set above
+	// if we need more bins than we have colors (what chart is THAT?) simply loop
+	QColor binColor(int bin, int numBins) const override
+	{
+		if (numBins == 1 || bin < 0 || bin >= numBins)
+			return fillColor;
+		if (numBins > (int)std::size(binColorsDark))
+			return binColorsDark[bin % std::size(binColorsDark)];
+
+		// use integer math to spread out the indices
+		int idx = bin * (std::size(binColorsDark) - 1) / (numBins - 1);
+		return binColorsDark[idx];
+	}
+
+	QColor labelColor(int bin, size_t numBins) const override
+	{
+		return (binColor(bin, numBins).lightness() < 150) ? darkLabelColor : lightLabelColor;
+	}
+};
+
 static StatsThemeLight statsThemeLight;
-std::vector<const StatsTheme *> statsThemes = { &statsThemeLight };
+static StatsThemeDark statsThemeDark;
+std::vector<const StatsTheme *> statsThemes = { &statsThemeLight, &statsThemeDark };

--- a/stats/statscolors.cpp
+++ b/stats/statscolors.cpp
@@ -1,5 +1,7 @@
 #include "statscolors.h"
 #include "statstranslations.h"
+#include "core/globals.h"
+#include <array>
 
 // Colors created using the Chroma.js Color Palette Helper
 // https://vis4.net/palettes/#/50|d|00108c,3ed8ff,ffffe0|ffffe0,ff005e,743535|1|1
@@ -143,6 +145,16 @@ private:
 	}
 };
 
-static StatsThemeLight statsThemeLight;
-static StatsThemeDark statsThemeDark;
-std::vector<const StatsTheme *> statsThemes = { &statsThemeLight, &statsThemeDark };
+// Currently, we only support two themes: bright and dark.
+// The themes are generated on first use. Thus, the constructors are run
+// once the overall application is initialized. This ensures that the themes'
+// constructors can access the settings, etc.
+static std::array<const StatsTheme *, 2> statsThemes;
+const StatsTheme &getStatsTheme(bool dark)
+{
+	if (!statsThemes[0]) {
+		statsThemes[0] = make_global<StatsThemeLight>();
+		statsThemes[1] = make_global<StatsThemeDark>();
+	}
+	return *statsThemes[dark ? 1 : 0];
+}

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -3,31 +3,53 @@
 #ifndef STATSCOLORS_H
 #define STATSCOLORS_H
 
+#include <vector>
 #include <QColor>
+#include <QString>
 
-inline const QColor backgroundColor(Qt::white);
-inline const QColor fillColor(0x44, 0x76, 0xaa);
-inline const QColor borderColor(0x66, 0xb2, 0xff);
-inline const QColor selectedColor(0xaa, 0x76, 0x44);
-inline const QColor selectedBorderColor(0xff, 0xb2, 0x66);
-inline const QColor highlightedColor(Qt::yellow);
-inline const QColor highlightedBorderColor(0xaa, 0xaa, 0x22);
-inline const QColor darkLabelColor(Qt::black);
-inline const QColor lightLabelColor(Qt::white);
-inline const QColor axisColor(Qt::black);
-inline const QColor gridColor(0xcc, 0xcc, 0xcc);
-inline const QColor informationBorderColor(Qt::black);
-inline const QColor informationColor(0xff, 0xff, 0x00, 192); // Note: fourth argument is opacity
-inline const QColor legendColor(0x00, 0x8e, 0xcc, 192); // Note: fourth argument is opacity
-inline const QColor legendBorderColor(Qt::black);
-inline const QColor quartileMarkerColor(Qt::red);
-inline const QColor regressionItemColor(Qt::red);
-inline const QColor meanMarkerColor(Qt::green);
-inline const QColor medianMarkerColor(Qt::red);
-inline const QColor selectionLassoColor(Qt::black);
-inline const QColor selectionOverlayColor(Qt::lightGray);
+class QSGTexture;
 
-QColor binColor(int bin, int numBins);
-QColor labelColor(int bin, size_t numBins);
+class StatsTheme {
+public:
+	StatsTheme();
+	virtual QString name() const = 0;
+	QColor backgroundColor;
+	QColor fillColor;
+	QColor borderColor;
+	QColor selectedColor;
+	QColor selectedBorderColor;
+	QColor highlightedColor;
+	QColor highlightedBorderColor;
+	// The dark and light label colors are with respect to the light theme.
+	// In the dark theme, dark is light and light is dark. Might want to change the names!
+	QColor darkLabelColor;
+	QColor lightLabelColor;
+	QColor axisColor;
+	QColor gridColor;
+	QColor informationBorderColor;
+	QColor informationColor;
+	QColor legendColor;
+	QColor legendBorderColor;
+	QColor quartileMarkerColor;
+	QColor regressionItemColor;
+	QColor meanMarkerColor;
+	QColor medianMarkerColor;
+	QColor selectionLassoColor;
+	QColor selectionOverlayColor;
+	virtual QColor binColor(int bin, int numBins) const = 0;
+	virtual QColor labelColor(int bin, size_t numBins) const = 0;
+
+	// These are cashes for the QSG rendering engine
+	// Note: Originally these were std::unique_ptrs, which automatically
+	// freed the textures on exit. However, destroying textures after
+	// QApplication finished its thread leads to crashes. Therefore, these
+	// are now normal pointers and the texture objects are leaked.
+	mutable QSGTexture *scatterItemTexture = nullptr;
+	mutable QSGTexture *scatterItemSelectedTexture = nullptr;
+	mutable QSGTexture *scatterItemHighlightedTexture = nullptr;
+	mutable QSGTexture *selectedTexture = nullptr; // A checkerboard pattern.
+};
+
+extern std::vector<const StatsTheme *> statsThemes;
 
 #endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -3,7 +3,7 @@
 #ifndef STATSCOLORS_H
 #define STATSCOLORS_H
 
-#include <vector>
+#include <memory>
 #include <QColor>
 #include <QString>
 
@@ -50,6 +50,6 @@ public:
 	mutable QSGTexture *selectedTexture = nullptr; // A checkerboard pattern.
 };
 
-extern std::vector<const StatsTheme *> statsThemes;
+extern const StatsTheme &getStatsTheme(bool dark);
 
 #endif

--- a/stats/statscolors.h
+++ b/stats/statscolors.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <QColor>
+#include <QFont>
 #include <QString>
 
 class QSGTexture;
@@ -38,6 +39,13 @@ public:
 	QColor selectionOverlayColor;
 	virtual QColor binColor(int bin, int numBins) const = 0;
 	virtual QColor labelColor(int bin, size_t numBins) const = 0;
+
+	QFont axisLabelFont;
+	QFont axisTitleFont;
+	QFont informationBoxFont;
+	QFont labelFont;
+	QFont legendFont;
+	QFont titleFont;
 
 	// These are cashes for the QSG rendering engine
 	// Note: Originally these were std::unique_ptrs, which automatically

--- a/stats/statsgrid.cpp
+++ b/stats/statsgrid.cpp
@@ -9,7 +9,7 @@
 static const double gridWidth = 1.0;
 
 StatsGrid::StatsGrid(StatsView &view, const StatsAxis &xAxis, const StatsAxis &yAxis)
-	: view(view), xAxis(xAxis), yAxis(yAxis)
+	: view(view), theme(view.getCurrentTheme()), xAxis(xAxis), yAxis(yAxis)
 {
 }
 
@@ -28,11 +28,11 @@ void StatsGrid::updatePositions()
 		return;
 
 	for (double x: xtics) {
-		lines.push_back(view.createChartItem<ChartLineItem>(ChartZValue::Grid, gridColor, gridWidth));
+		lines.push_back(view.createChartItem<ChartLineItem>(ChartZValue::Grid, theme.gridColor, gridWidth));
 		lines.back()->setLine(QPointF(x, ytics.front()), QPointF(x, ytics.back()));
 	}
 	for (double y: ytics) {
-		lines.push_back(view.createChartItem<ChartLineItem>(ChartZValue::Grid, gridColor, gridWidth));
+		lines.push_back(view.createChartItem<ChartLineItem>(ChartZValue::Grid, theme.gridColor, gridWidth));
 		lines.back()->setLine(QPointF(xtics.front(), y), QPointF(xtics.back(), y));
 	}
 }

--- a/stats/statsgrid.h
+++ b/stats/statsgrid.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 class StatsAxis;
+class StatsTheme;
 class StatsView;
 class ChartLineItem;
 
@@ -16,6 +17,7 @@ public:
 	void updatePositions();
 private:
 	StatsView &view;
+	const StatsTheme &theme; // Initialized once in constructor.
 	const StatsAxis &xAxis, &yAxis;
 	std::vector<ChartItemPtr<ChartLineItem>> lines;
 };

--- a/stats/statsseries.cpp
+++ b/stats/statsseries.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "statsseries.h"
 #include "statsaxis.h"
+#include "statsview.h"
 
 StatsSeries::StatsSeries(StatsView &view, StatsAxis *xAxis, StatsAxis *yAxis) :
-	view(view), xAxis(xAxis), yAxis(yAxis)
+	view(view), theme(view.getCurrentTheme()), xAxis(xAxis), yAxis(yAxis)
 {
 }
 

--- a/stats/statsseries.h
+++ b/stats/statsseries.h
@@ -10,6 +10,7 @@
 #include <QPointF>
 
 class StatsAxis;
+class StatsTheme;
 class StatsView;
 struct dive;
 class QRectF;
@@ -30,6 +31,7 @@ public:
 
 protected:
 	StatsView &view;
+	const StatsTheme &theme;		// Theme is only set once in the constructor
 	StatsAxis *xAxis, *yAxis;		// May be zero for charts without axes (pie charts).
 	QPointF toScreen(QPointF p);
 };

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -54,9 +54,6 @@ StatsView::StatsView(QQuickItem *parent) : QQuickItem(parent),
 
 	setAcceptHoverEvents(true);
 	setAcceptedMouseButtons(Qt::LeftButton);
-
-	QFont font;
-	titleFont = QFont(font.family(), font.pointSize(), QFont::Light);	// Make configurable
 }
 
 StatsView::StatsView() : StatsView(nullptr)
@@ -470,7 +467,7 @@ void StatsView::setTitle(const QString &s)
 		// Ooops. Currently we do not support setting the title twice.
 		return;
 	}
-	title = createChartItem<ChartTextItem>(ChartZValue::Legend, titleFont, s);
+	title = createChartItem<ChartTextItem>(ChartZValue::Legend, currentTheme->titleFont, s);
 	title->setColor(currentTheme->darkLabelColor);
 }
 

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -35,7 +35,7 @@ static const double selectionLassoWidth = 2.0;		// Border between title and char
 
 StatsView::StatsView(QQuickItem *parent) : QQuickItem(parent),
 	backgroundDirty(true),
-	currentTheme(statsThemes[0]),
+	currentTheme(&getStatsTheme(false)),
 	highlightedSeries(nullptr),
 	xAxis(nullptr),
 	yAxis(nullptr),
@@ -300,10 +300,9 @@ QQuickWindow *StatsView::w() const
 	return window();
 }
 
-void StatsView::setTheme(int idx)
+void StatsView::setTheme(bool dark)
 {
-	idx = std::clamp(idx, 0, (int)statsThemes.size() - 1);
-	currentTheme = statsThemes[idx];
+	currentTheme = &getStatsTheme(dark);
 	rootNode->backgroundNode->setColor(currentTheme->backgroundColor);
 }
 

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -54,7 +54,7 @@ public:
 	QQuickWindow *w() const;			// Make window available to items
 	QSizeF size() const;
 	QRectF plotArea() const;
-	void setTheme(int idx);				// Invalid indexes will result in the default theme. Chart must be replot for theme to become effective.
+	void setTheme(bool dark);			// Chart must be replot for theme to become effective.
 	const StatsTheme &getCurrentTheme() const;
 	void addQSGNode(QSGNode *node, ChartZValue z);	// Must only be called in render thread!
 	void registerChartItem(ChartItem &item);

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -6,7 +6,6 @@
 #include "statshelper.h"
 #include "statsselection.h"
 #include <memory>
-#include <QFont>
 #include <QImage>
 #include <QPainter>
 #include <QQuickItem>
@@ -144,7 +143,6 @@ private:
 
 	StatsState state;
 	const StatsTheme *currentTheme;
-	QFont titleFont;
 	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<StatsGrid> grid;
 	std::vector<ChartItemPtr<QuartileMarker>> quartileMarkers;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -29,6 +29,7 @@ class QuartileMarker;
 class RegressionItem;
 class StatsAxis;
 class StatsGrid;
+class StatsTheme;
 class Legend;
 class QSGTexture;
 class RootNode;	// Internal implementation detail
@@ -53,6 +54,8 @@ public:
 	QQuickWindow *w() const;			// Make window available to items
 	QSizeF size() const;
 	QRectF plotArea() const;
+	void setTheme(int idx);				// Invalid indexes will result in the default theme. Chart must be replot for theme to become effective.
+	const StatsTheme &getCurrentTheme() const;
 	void addQSGNode(QSGNode *node, ChartZValue z);	// Must only be called in render thread!
 	void registerChartItem(ChartItem &item);
 	void registerDirtyChartItem(ChartItem &item);
@@ -140,6 +143,7 @@ private:
 	void addLineMarker(double pos, double low, double high, const QPen &pen, bool isHorizontal);
 
 	StatsState state;
+	const StatsTheme *currentTheme;
 	QFont titleFont;
 	std::vector<std::unique_ptr<StatsSeries>> series;
 	std::unique_ptr<StatsGrid> grid;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Dirk wants to implement a dark-theme for mobile. This PR provides a basis for just that.

For testing purposes, this implements a way to change the theme on desktop, but that finally makes the desktop UI too big.

It also shows our problem with rendering bright fonts onto a dark background. If we find no fix for that, we might have to make the font themeable as well, i.e.~support different font weights for different themes.

@dirkhh: just let me know if you need any more logic. I'll gladly do it and expect that it isn't too hard to implement. However, the color-scheme itself is up to you (or someone else who requires a dark theme).

@willemferguson: this might also interesting to you, since it finally makes the desktop UI too cluttered.