### PR TITLE
Planner: Depth dependent setpoint changes in CCR mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- planner: allow automatic setpoint changes at specified depths in CCR mode
+- core: fix OTU und CNS calculations for CCR dives at shallow depths
 - desktop: make selection of multiple dives reasonable fast
 - mobile: add GF fields to adjust Buhlmann algorithm parameters for calculated ceiling
 - undo: save to git after editing weights [#3159]

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -4214,6 +4214,12 @@ CCR dive, add a one-minute dive segment to the end with a setpoint value of 0. T
 algorithm does not switch deco-gases automatically while in CCR mode (i.e. when a positive setpoint is specified) but
 this is calculated for bail out ascents.
 
+If you want the setpoint to change during the planned ascent at a specified depth, you can do this 
+using a "fake" cylinder that you add to the gas list: Give that cylinder a name of "SP 1.4" (or use
+a different number) and set the "Deco switch value" to the depth at which you want to set the new
+setpoint. This will make the planner stop at the specified depth and use the new setpoint from
+there on.
+
 The dive profile for a CCR dive may look something like the image below.
 
 image::images/Planner_CCR.jpg["FIGURE: Planning a CCR dive: setup",align="center"]

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -109,12 +109,14 @@ static int calculate_otu(const struct dive *dive)
 			po2f = sample->o2sensor[0].mbar;	// ... use data from the first o2 sensor
 		} else {
 			if (dc->divemode == CCR) {
-				po2i = psample->setpoint.mbar;		// if CCR has no o2 sensors then use setpoint
-				po2f = sample->setpoint.mbar;
+				po2i = MIN((int) psample->setpoint.mbar,
+					   depth_to_mbar(psample->depth.mm, dive));		// if CCR has no o2 sensors then use setpoint
+				po2f = MIN((int) sample->setpoint.mbar,
+					   depth_to_mbar(sample->depth.mm, dive));
 			} else {						// For OC and rebreather without o2 sensor/setpoint
 				int o2 = active_o2(dive, dc, psample->time);	// 	... calculate po2 from depth and FiO2.
-				po2i = lrint(o2 * depth_to_atm(psample->depth.mm, dive));	// (initial) po2 at start of segment
-				po2f = lrint(o2 * depth_to_atm(sample->depth.mm, dive));	// (final) po2 at end of segment
+				po2i = lrint(o2 * depth_to_bar(psample->depth.mm, dive));	// (initial) po2 at start of segment
+				po2f = lrint(o2 * depth_to_bar(sample->depth.mm, dive));	// (final) po2 at end of segment
 			}
 		}
 		if ((po2i > 500) || (po2f > 500)) {			// If PO2 in segment is above 500 mbar then calculate otu
@@ -164,14 +166,16 @@ static double calculate_cns_dive(const struct dive *dive)
 			trueo2 = true;
 		}
 		if ((dc->divemode == CCR) && (!trueo2)) {
-			po2i = psample->setpoint.mbar;		// if CCR has no o2 sensors then use setpoint
-			po2f = sample->setpoint.mbar;
+			po2i = MIN((int) psample->setpoint.mbar,
+				   depth_to_mbar(psample->depth.mm, dive));		// if CCR has no o2 sensors then use setpoint
+			po2f = MIN((int) sample->setpoint.mbar,
+				   depth_to_mbar(sample->depth.mm, dive));
 			trueo2 = true;
 		}
 		if (!trueo2) {
 			int o2 = active_o2(dive, dc, psample->time);			// For OC and rebreather without o2 sensor:
-			po2i = lrint(o2 * depth_to_atm(psample->depth.mm, dive));	// (initial) po2 at start of segment
-			po2f = lrint(o2 * depth_to_atm(sample->depth.mm, dive));	// (final) po2 at end of segment
+			po2i = lrint(o2 * depth_to_bar(psample->depth.mm, dive));	// (initial) po2 at start of segment
+			po2f = lrint(o2 * depth_to_bar(sample->depth.mm, dive));	// (final) po2 at end of segment
 		}
 		po2i = (po2i + po2f) / 2;	// po2i now holds the mean po2 of initial and final po2 values of segment.
 		/* Don't increase CNS when po2 below 500 matm */

--- a/dives/TestDiveDM4.xml
+++ b/dives/TestDiveDM4.xml
@@ -5,7 +5,7 @@
 <divesites>
 </divesites>
 <dives>
-<dive number='1' otu='45' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
+<dive number='1' otu='46' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
   <notes>Notes are here</notes>
   <cylinder workpressure='200.0 bar' o2='33.0%' start='205.11 bar' />
   <divecomputer>

--- a/dives/TestDiveDM5.xml
+++ b/dives/TestDiveDM5.xml
@@ -5,7 +5,7 @@
 <divesites>
 </divesites>
 <dives>
-<dive number='1' sac='11.046 l/min' otu='45' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
+<dive number='1' sac='11.046 l/min' otu='46' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
   <notes>Notes are here</notes>
   <cylinder size='12.0 l' o2='33.0%' start='205.11 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>
@@ -194,7 +194,7 @@
   <sample time='59:20 min' depth='1.88 m' pressure='53.87 bar' />
   </divecomputer>
 </dive>
-<dive number='2' sac='11.298 l/min' otu='32' cns='11%' tags='boat, photography, tag' date='2013-02-02' time='13:44:21' duration='61:00 min'>
+<dive number='2' sac='11.298 l/min' otu='33' cns='12%' tags='boat, photography, tag' date='2013-02-02' time='13:44:21' duration='61:00 min'>
   <notes>Testing notes</notes>
   <cylinder size='12.0 l' o2='33.0%' start='209.04 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>
@@ -388,7 +388,7 @@
   <sample time='61:00 min' depth='1.67 m' pressure='72.34 bar' />
   </divecomputer>
 </dive>
-<dive number='3' sac='10.109 l/min' otu='41' cns='15%' date='2013-02-02' time='10:53:54' duration='66:00 min'>
+<dive number='3' sac='10.109 l/min' otu='42' cns='15%' date='2013-02-02' time='10:53:54' duration='66:00 min'>
   <notes>Dive notes</notes>
   <cylinder size='12.0 l' o2='33.0%' start='212.74 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>
@@ -597,7 +597,7 @@
   <sample time='66:00 min' depth='2.43 m' />
   </divecomputer>
 </dive>
-<dive number='4' sac='10.260 l/min' otu='48' cns='17%' date='2013-02-02' time='08:21:50' duration='60:40 min'>
+<dive number='4' sac='10.260 l/min' otu='49' cns='18%' date='2013-02-02' time='08:21:50' duration='60:40 min'>
   <notes>Notes test</notes>
   <cylinder size='12.0 l' o2='33.0%' start='194.74 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>

--- a/dives/TestDiveDivelogsDE.xml
+++ b/dives/TestDiveDivelogsDE.xml
@@ -6,7 +6,7 @@
 </site>
 </divesites>
 <dives>
-<dive number='1' sac='15.471 l/min' otu='14' cns='5%' divesiteid='64785a00' date='2011-05-17' time='11:01:00' duration='32:00 min'>
+<dive number='1' sac='15.471 l/min' otu='15' cns='6%' divesiteid='64785a00' date='2011-05-17' time='11:01:00' duration='32:00 min'>
   <buddy>Linus</buddy>
   <notes>Second deep dive
 Linus and I planned and executed - Alex just watching

--- a/dives/TestDiveSeabearHUDC.xml
+++ b/dives/TestDiveSeabearHUDC.xml
@@ -4,7 +4,7 @@
 <divesites>
 </divesites>
 <dives>
-<dive otu='3' cns='1%' date='2009-10-10' time='05:32:41' duration='7:32 min'>
+<dive otu='4' cns='1%' date='2009-10-10' time='05:32:41' duration='7:32 min'>
   <divecomputer model='DC text' deviceid='ffffffff'>
   <depth max='40.0 m' mean='22.32 m' />
   <temperature water='1.0 C' />

--- a/dives/TestDiveSeabearNewFormat.xml
+++ b/dives/TestDiveSeabearNewFormat.xml
@@ -211,7 +211,7 @@
   <sample time='17:15 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='3' otu='13' cns='7%' date='2012-10-01' time='06:49:00' duration='16:25 min'>
+<dive number='3' otu='14' cns='8%' date='2012-10-01' time='06:49:00' duration='16:25 min'>
   <divecomputer model='Seabear H3' deviceid='ffffffff'>
   <depth max='69.9 m' mean='32.928 m' />
   <temperature water='25.0 C' />
@@ -418,7 +418,7 @@
   <sample time='17:15 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='4' otu='13' cns='14%' date='2012-10-01' time='07:07:00' duration='16:17 min'>
+<dive number='4' otu='14' cns='16%' date='2012-10-01' time='07:07:00' duration='16:17 min'>
   <divecomputer model='Seabear H3' deviceid='ffffffff' dctype='Freedive'>
   <depth max='70.1 m' mean='33.197 m' />
   <temperature water='25.0 C' />
@@ -1351,7 +1351,7 @@
   <sample time='16:24 min' depth='0.1 m' />
   </divecomputer>
 </dive>
-<dive number='5' otu='13' cns='21%' date='2012-10-01' time='07:24:00' duration='16:25 min'>
+<dive number='5' otu='14' cns='24%' date='2012-10-01' time='07:24:00' duration='16:25 min'>
   <divecomputer model='Seabear H3' deviceid='ffffffff'>
   <depth max='69.9 m' mean='32.928 m' />
   <temperature water='25.0 C' />
@@ -1973,7 +1973,7 @@
   <sample time='17:15 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='3' otu='13' cns='12%' date='2012-10-01' time='06:49:00' duration='16:25 min'>
+<dive number='3' otu='14' cns='12%' date='2012-10-01' time='06:49:00' duration='16:25 min'>
   <divecomputer model='Seabear T1' deviceid='ffffffff'>
   <depth max='69.9 m' mean='32.928 m' />
   <temperature water='25.0 C' />
@@ -2180,7 +2180,7 @@
   <sample time='17:15 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='4' otu='13' cns='19%' date='2012-10-01' time='07:07:00' duration='16:17 min'>
+<dive number='4' otu='14' cns='20%' date='2012-10-01' time='07:07:00' duration='16:17 min'>
   <divecomputer model='Seabear T1' deviceid='ffffffff' dctype='Freedive'>
   <depth max='70.1 m' mean='33.197 m' />
   <temperature water='24.0 C' />
@@ -3113,7 +3113,7 @@
   <sample time='16:24 min' depth='0.1 m' />
   </divecomputer>
 </dive>
-<dive number='5' otu='13' cns='26%' date='2012-10-01' time='07:24:00' duration='16:25 min'>
+<dive number='5' otu='14' cns='28%' date='2012-10-01' time='07:24:00' duration='16:25 min'>
   <divecomputer model='Seabear T1' deviceid='ffffffff'>
   <depth max='69.9 m' mean='32.928 m' />
   <temperature water='25.0 C' />

--- a/dives/mergedVyperOstc.xml
+++ b/dives/mergedVyperOstc.xml
@@ -6,7 +6,7 @@
 <divesites>
 </divesites>
 <dives>
-<dive number='1' otu='52' cns='22%' date='2017-02-03' time='06:58:00' duration='72:00 min'>
+<dive number='1' otu='53' cns='22%' date='2017-02-03' time='06:58:00' duration='72:00 min'>
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='31.0%' />
@@ -103,7 +103,7 @@
   <sample time='76:56 min' depth='0.01 m' ndl='0:00 min' cns='0%' />
   </divecomputer>
 </dive>
-<dive number='2' otu='39' cns='22%' date='2017-02-03' time='10:24:00' duration='66:00 min'>
+<dive number='2' otu='40' cns='22%' date='2017-02-03' time='10:24:00' duration='66:00 min'>
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='31.0%' />
@@ -194,7 +194,7 @@
   <sample time='70:46 min' depth='0.0 m' ndl='0:00 min' cns='0%' />
   </divecomputer>
 </dive>
-<dive number='1' sac='9.026 l/min' otu='53' cns='17%' date='2017-02-03' time='06:59:41' duration='71:40 min'>
+<dive number='1' sac='9.026 l/min' otu='54' cns='17%' date='2017-02-03' time='06:59:41' duration='71:40 min'>
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
   <divecomputer model='Suunto Vyper Air' deviceid='11223344' diveid='c51cb31b'>
   <depth max='26.72 m' mean='16.837 m' />
@@ -420,7 +420,7 @@
   <sample time='71:40 min' depth='1.5 m' pressure='53.05 bar' cns='0%' />
   </divecomputer>
 </dive>
-<dive number='2' sac='9.173 l/min' otu='40' cns='17%' date='2017-02-03' time='10:25:16' duration='65:40 min'>
+<dive number='2' sac='9.173 l/min' otu='41' cns='17%' date='2017-02-03' time='10:25:16' duration='65:40 min'>
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
   <divecomputer model='Suunto Vyper Air' deviceid='20993833' diveid='5372ae57'>
   <depth max='27.8 m' mean='14.594 m' />

--- a/dives/test40-42.xml
+++ b/dives/test40-42.xml
@@ -34,7 +34,7 @@
   <depth max='24.9 m' mean='20.1 m' />
   </divecomputer>
 </dive>
-<dive number='417' otu='135' cns='54%' divesiteid='deadbeef' date='2015-05-23' time='13:23:00' duration='100:00 min'>
+<dive number='417' otu='138' cns='54%' divesiteid='deadbeef' date='2015-05-23' time='13:23:00' duration='100:00 min'>
   <notes>{\rtf1\ansi\ansicpg1252\deff0\deflang1035{\fonttbl{\f0\fnil\fcharset0 Microsoft Sans Serif;}}
 \viewkind4\uc1\pard\f0\fs17\par
 }</notes>

--- a/dives/test47+48.xml
+++ b/dives/test47+48.xml
@@ -2,11 +2,11 @@
 <settings>
 </settings>
 <divesites>
-<site uuid='15ae02d0' name='Test dive'>
+<site uuid='15ae02d1' name='Test dive'>
 </site>
 </divesites>
 <dives>
-<dive number='1' tags='test' divesiteid='15ae02d0' date='2015-10-01' time='08:00:25' duration='46:00 min'>
+<dive number='1' cns='2%' tags='test' divesiteid='15ae02d1' date='2015-10-01' time='08:00:25' duration='46:00 min'>
   <cylinder size='11.1 l' workpressure='207.0 bar' description='unknown' />
   <divecomputer model='do not care' date='2015-10-05' time='08:45:25'>
   <depth max='13.716 m' mean='10.595 m' />

--- a/dives/test47.xml
+++ b/dives/test47.xml
@@ -2,11 +2,11 @@
 <settings>
 </settings>
 <divesites>
-<site uuid='15ae02d0' name='Test dive'>
+<site uuid='15ae02d1' name='Test dive'>
 </site>
 </divesites>
 <dives>
-<dive number='1' divesiteid='15ae02d0' date='2015-10-01' time='08:00:25' duration='46:00 min'>
+<dive number='1' cns='2%' divesiteid='15ae02d1' date='2015-10-01' time='08:00:25' duration='46:00 min'>
   <cylinder size='11.1 l' workpressure='207.0 bar' description='unknown' />
   <divecomputer model='do not care' date='2015-10-05' time='08:45:25'>
   <depth max='13.716 m' mean='10.595 m' />

--- a/dives/test48+47.xml
+++ b/dives/test48+47.xml
@@ -6,7 +6,7 @@
 </site>
 </divesites>
 <dives>
-<dive number='1' tags='test' divesiteid='15ae02d1' date='2015-10-01' time='08:00:25' duration='46:00 min'>
+<dive number='1' cns='2%' tags='test' divesiteid='15ae02d1' date='2015-10-01' time='08:00:25' duration='46:00 min'>
   <cylinder size='11.1 l' workpressure='207.0 bar' description='unknown' />
   <divecomputer model='do not care' date='2015-10-05' time='08:45:25'>
   <depth max='13.716 m' mean='10.595 m' />


### PR DESCRIPTION
We had a user request to allow for setpoint changes
at certain depths for CCR deco.

You can now enter a cylinder with name like
"SP 1.4" ('S' and 'P' and ' ' and a float) with
a switch depth and that cylinder is interpreted as
a depth dependent setpoint switch.

This user interface is a hack. But I believe that such
setpoint changes are similar enough to gas switches during
deco and should thus be handled in a simiar manner.

I would be happy to hear ideas how this could be made
less easter eggish.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
