### PR TITLE
build-system: try to make GitHub Actions work again

### DIFF
--- a/.github/workflows/linux-tumbleweed-qt-latest.yml
+++ b/.github/workflows/linux-tumbleweed-qt-latest.yml
@@ -21,14 +21,16 @@ jobs:
       run: |
         echo "--------------------------------------------------------------"
         echo "update distro and install dependencies"
-        zypper -n install git gcc-c++ make autoconf automake libtool cmake libzip-devel \
-        libxml2-devel libxslt-devel sqlite3-devel libusb-1_0-devel \
-        libqt5-linguist-devel libqt5-qttools-devel libQt5WebKitWidgets-devel \
+        zypper -n update
+        zypper -n install busybox shadow
+        zypper -n install git gcc-c++ make autoconf automake libtool cmake
+        zypper -n install libzip-devel libxml2-devel libxslt-devel sqlite3-devel libusb-1_0-devel
+        zypper -n install bluez-devel libcurl-devel libgit2-devel libmtp-devel
+        zypper -n install libqt5-linguist-devel libqt5-qttools-devel libQt5WebKitWidgets-devel \
         libqt5-qtbase-devel libQt5WebKit5-devel libqt5-qtsvg-devel \
         libqt5-qtscript-devel libqt5-qtdeclarative-devel \
-        libqt5-qtconnectivity-devel libqt5-qtlocation-devel libcurl-devel \
-        libQt5QuickControls2-devel bluez-devel \
-        which libgit2-devel libssh2-devel libmtp-devel
+        libqt5-qtconnectivity-devel libqt5-qtlocation-devel \
+        libQt5QuickControls2-devel
 
 # if we want to run the tests below, add    xvfb-run
 


### PR DESCRIPTION
The error message seems to imply that openSUSE needs to have busybox before it
can install the packages that we need. Shouldn't that be handled by RPM
dependencies?

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change
