### PR TITLE
Use PSCR gas when computing O2 toxicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: Take into account PSCR pO2 drop when computing CNS and OTU
 - planner: allow automatic setpoint changes at specified depths in CCR mode
 - core: fix OTU und CNS calculations for CCR dives at shallow depths
 - desktop: make selection of multiple dives reasonable fast

--- a/core/gas.h
+++ b/core/gas.h
@@ -59,6 +59,8 @@ static inline int get_n2(struct gasmix mix)
 	return 1000 - get_o2(mix) - get_he(mix);
 }
 
+int pscr_o2(const double amb_pressure, struct gasmix mix);
+
 struct gas_pressures {
 	double o2, n2, he;
 };


### PR DESCRIPTION
Both the calculations for CNS and OTU did not take
into account the pO2 drop when using a PSCR. Furthermore,
there was some unit confusion due to not using internal
units.

Fixes #3203 

Reported-by: arosl
Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
