### PR TITLE
stats: fix visibility check of the statistics tab on desktop

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -824,6 +824,9 @@ void process_loaded_dives()
 
 	/* Inform frontend of reset data. This should reset all the models. */
 	emit_reset_signal();
+
+	/* Now that everything is settled, select the newest dive. */
+	select_newest_visible_dive();
 }
 
 /*
@@ -1373,7 +1376,7 @@ int get_dive_id_closest_to(timestamp_t when)
 void clear_dive_file_data()
 {
 	fulltext_unregister_all();
-	clear_selection();
+	select_single_dive(NULL);	// This is propagate up to the UI and clears all the information.
 
 	while (dive_table.nr)
 		delete_single_dive(0);

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -93,6 +93,8 @@ StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
 	view = qobject_cast<StatsView *>(root);
 	if (!view)
 		qWarning("Oops. The root of the StatsView is not a StatsView.");
+	if (view)
+		view->setVisible(isVisible()); // Synchronize visibility of widget and QtQuick-view.
 }
 
 // Initialize QComboBox with list of variables
@@ -209,6 +211,17 @@ void StatsWidget::showEvent(QShowEvent *e)
 	unrestrict();
 	updateUi();
 	QWidget::showEvent(e);
+	// Apparently, we have to manage the visibility of the view ourselves. That's mad.
+	if (view)
+		view->setVisible(true);
+}
+
+void StatsWidget::hideEvent(QHideEvent *e)
+{
+	QWidget::hideEvent(e);
+	// Apparently, we have to manage the visibility of the view ourselves. That's mad.
+	if (view)
+		view->setVisible(false);
 }
 
 void StatsWidget::restrict()

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -37,6 +37,7 @@ private:
 
 	ChartListModel charts;
 	void showEvent(QShowEvent *) override;
+	void hideEvent(QHideEvent *) override;
 };
 
 #endif // STATSWIDGET_H

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -499,7 +499,6 @@ void DiveTripModelBase::reset()
 	uiNotification(tr("finish populating data store"));
 	endResetModel();
 	uiNotification(tr("setting up internal data structures"));
-	initSelection();
 	emit diveListNotifier.numShownChanged();
 	uiNotification(tr("done setting up internal data structures"));
 }


### PR DESCRIPTION
Apparently, the visibility flag of the view is not inherited
from the statistics widget. Therefore, the statistics is
redrawn on every action even if not visible.

Set the visibility explicitly in the show- and hide-events.

This is crazy.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I don't know whether this is a Qt bug or not, but at least on desktop the `isVisible()` function of the QQuickItem does not work and we have to set it ourselves. One would think that the visibility is passed down the object hierarchy!? Very annoying.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Explicitly set the visibility of the 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Will also have to check on mobile.
