### PR TITLE
printing: use sensible font-size in profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+printing: use sensible font size even for strange window size
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -150,8 +150,12 @@ void Printer::render(int pages)
 
 	QSize originalSize = profile->size();
 	if (collection.count() > 0) {
-		printFontScale = (double)collection.at(0).geometry().size().height() / (double)profile->size().height();
-		profile->resize(collection.at(0).geometry().size());
+		// A "standard" profile has about 600 pixels in height.
+		// Scale the fonts in the printed profile accordingly.
+		// This is arbitrary, but it seems to work reasonably.
+		QSize size = collection[0].geometry().size();
+		printFontScale = size.height() / 600.0;
+		profile->resize(size);
 	}
 	profile->setFontPrintScale(printFontScale);
 


### PR DESCRIPTION
The font-size in printed profiles is based on the size of the profile
in the main window. This makes no sense. Why should changing the
window size change the font-size on printouts?

Matter of fact, when making shrinking the height of the window to
its minimum, comical printouts are obtained (font way too big).

Therefore use an arbitrary rule: Say that profiles 600 pixels high
look reasonable and then scale up to the actual size on the printout.

This may need some tweaking for high-DPI mode. But that seems not
to be supported on desktop anyway?

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The printing code produces comical profiles if the window is made very "short", i.e. the height is made small. It is unclear why the printout should depend on window size? Therefore arbitrarily say that a 600-pixel high profile looks reasonable and use that. In the future, this may have to take high-dpi settings into account. But as far as I see, currently this is not supported on desktop anyway..?

PS: I need this to progress on #3186, but it is independent, so doing a separate PR.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use a fixed profile height instead of the current windows size.