### PR TITLE
Minor profile code cleanups

### DIFF
--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -229,7 +229,7 @@ void exportProfile(const struct dive *dive, const QString filename)
 	profile->setPrintMode(true);
 	double scale = profile->getFontPrintScale();
 	profile->setFontPrintScale(4 * scale);
-	profile->plotDive(dive, 0, true, false, true);
+	profile->plotDive(dive, 0, false, true);
 	QImage image = QImage(profile->size() * 4, QImage::Format_RGB32);
 	QPainter paint;
 	paint.begin(&image);
@@ -238,5 +238,5 @@ void exportProfile(const struct dive *dive, const QString filename)
 	profile->setToolTipVisibile(true);
 	profile->setFontPrintScale(scale);
 	profile->setPrintMode(false);
-	profile->plotDive(dive, 0, true); // TODO: Shouldn't this plot the current dive?
+	profile->plotDive(dive, 0); // TODO: Shouldn't this plot the current dive?
 }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -432,7 +432,7 @@ void MainWindow::selectionChanged()
 		configureToolbar();
 		enableDisableOtherDCsActions();
 	}
-	graphics->plotDive(current_dive, dc_number, false);
+	graphics->plotDive(current_dive, dc_number);
 	MapWidget::instance()->selectionChanged();
 }
 
@@ -736,7 +736,7 @@ void MainWindow::refreshProfile()
 {
 	showProfile();
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number, true);
+	graphics->plotDive(current_dive, dc_number);
 }
 
 void MainWindow::planCanceled()
@@ -921,7 +921,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number, false);
+	graphics->plotDive(current_dive, dc_number);
 	mainTab->updateDiveInfo();
 }
 
@@ -930,7 +930,7 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number, false);
+	graphics->plotDive(current_dive, dc_number);
 	mainTab->updateDiveInfo();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -223,6 +223,7 @@ MainWindow::MainWindow() : QMainWindow(),
 	enableDisableCloudActions();
 
 	ui.mainErrorMessage->hide();
+	setEnabledToolbar(false);
 	graphics->setEmptyState();
 	initialUiSetup();
 	readSettings();
@@ -295,8 +296,6 @@ MainWindow::MainWindow() : QMainWindow(),
 	connect(ui.profPn2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_pn2);
 	connect(ui.profPO2, &QAction::triggered, pp_gas, &qPrefPartialPressureGas::set_po2);
 
-	// now let's set up some connections
-	connect(graphics, &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
 
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, graphics, &ProfileWidget2::settingsChanged);
@@ -425,6 +424,12 @@ void MainWindow::configureToolbar()
 	}
 }
 
+void MainWindow::plotCurrentDive()
+{
+	setEnabledToolbar(current_dive != nullptr);
+	graphics->plotDive(current_dive, dc_number);
+}
+
 void MainWindow::selectionChanged()
 {
 	mainTab->updateDiveInfo();
@@ -432,7 +437,7 @@ void MainWindow::selectionChanged()
 		configureToolbar();
 		enableDisableOtherDCsActions();
 	}
-	graphics->plotDive(current_dive, dc_number);
+	plotCurrentDive();
 	MapWidget::instance()->selectionChanged();
 }
 
@@ -736,7 +741,7 @@ void MainWindow::refreshProfile()
 {
 	showProfile();
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number);
+	plotCurrentDive();
 }
 
 void MainWindow::planCanceled()
@@ -921,7 +926,7 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number);
+	plotCurrentDive();
 	mainTab->updateDiveInfo();
 }
 
@@ -930,7 +935,7 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	configureToolbar();
-	graphics->plotDive(current_dive, dc_number);
+	plotCurrentDive();
 	mainTab->updateDiveInfo();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -297,8 +297,6 @@ MainWindow::MainWindow() : QMainWindow(),
 
 	// now let's set up some connections
 	connect(graphics, &ProfileWidget2::enableToolbar ,this, &MainWindow::setEnabledToolbar);
-	connect(graphics, &ProfileWidget2::disableShortcuts, this, &MainWindow::disableShortcuts);
-	connect(graphics, &ProfileWidget2::enableShortcuts, this, &MainWindow::enableShortcuts);
 	connect(graphics, &ProfileWidget2::editCurrentDive, this, &MainWindow::editCurrentDive);
 
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, graphics, &ProfileWidget2::settingsChanged);
@@ -771,6 +769,7 @@ void MainWindow::on_actionReplanDive_triggered()
 	// put us in PLAN mode
 	setApplicationState(ApplicationState::PlanDive);
 
+	disableShortcuts(true);
 	graphics->setPlanState(&displayed_dive, 0);
 	plannerWidgets->replanDive();
 }
@@ -783,6 +782,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 	// put us in PLAN mode
 	setApplicationState(ApplicationState::PlanDive);
 
+	disableShortcuts(true);
 	graphics->setPlanState(&displayed_dive, 0);
 	plannerWidgets->planDive();
 }
@@ -1515,7 +1515,7 @@ void MainWindow::editCurrentDive()
 	if (mainTab->isEditing() || DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING)
 		return;
 
-	disableShortcuts();
+	disableShortcuts(false);
 	copy_dive(current_dive, &displayed_dive); // Work on a copy of the dive
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -236,6 +236,7 @@ private:
 	void setQuadrantWidgets(QSplitter &splitter, const Quadrant &left, const Quadrant &right);
 	void registerApplicationState(ApplicationState state, Quadrants q);
 	void disableShortcuts(bool disablePaste = true);
+	void plotCurrentDive();
 	void enableShortcuts();
 
 	QMenu *connections;

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -164,8 +164,6 @@ slots:
 	void setEnabledToolbar(bool arg1);
 	// Some shortcuts like "change DC" or "copy/paste dive components"
 	// should only be enabled when the profile's visible.
-	void disableShortcuts(bool disablePaste = true);
-	void enableShortcuts();
 	void startDiveSiteEdit();
 
 private:
@@ -237,6 +235,8 @@ private:
 	void setQuadrantWidget(QSplitter &splitter, const Quadrant &q, int pos);
 	void setQuadrantWidgets(QSplitter &splitter, const Quadrant &left, const Quadrant &right);
 	void registerApplicationState(ApplicationState state, Quadrants q);
+	void disableShortcuts(bool disablePaste = true);
+	void enableShortcuts();
 
 	QMenu *connections;
 	QAction *share_on_fb;

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -38,7 +38,7 @@ void Printer::putProfileImage(const QRect &profilePlaceholder, const QRect &view
 	int y = profilePlaceholder.y() - viewPort.y();
 	// use the placeHolder and the viewPort position to calculate the relative position of the dive profile.
 	QRect pos(x, y, profilePlaceholder.width(), profilePlaceholder.height());
-	profile->plotDive(dive, 0, true, true);
+	profile->plotDive(dive, 0, true);
 
 	if (!printOptions.color_selected) {
 		QImage image(pos.width(), pos.height(), QImage::Format_ARGB32);
@@ -193,7 +193,7 @@ void Printer::render(int pages)
 	qPrefDisplay::set_animation_speed(animationOriginal);
 
 	//replot the dive after returning the settings
-	profile->plotDive(current_dive, dc_number, true, true);
+	profile->plotDive(current_dive, dc_number, true);
 }
 
 //value: ranges from 0 : 100 and shows the progress of the templating engine

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -360,7 +360,7 @@ void ProfileWidget2::setupItemOnScene()
 
 void ProfileWidget2::replot()
 {
-	plotDive(d, dc, true, false);
+	plotDive(d, dc, false);
 }
 
 PartialPressureGasItem *ProfileWidget2::createPPGas(int column, color_index_t color, color_index_t colorAlert,
@@ -521,7 +521,7 @@ void ProfileWidget2::resetZoom()
 }
 
 // Currently just one dive, but the plan is to enable All of the selected dives.
-void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool force, bool doClearPictures, bool instant)
+void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPictures, bool instant)
 {
 	d = dIn;
 	dc = dcIn;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1064,7 +1064,6 @@ void ProfileWidget2::setEmptyState()
 	setBackgroundBrush(getColor(::BACKGROUND, isGrayscale));
 	dataModel->clear();
 	currentState = EMPTY;
-	emit enableToolbar(false);
 
 	fixBackgroundPos();
 	background->setVisible(true);
@@ -1128,7 +1127,6 @@ void ProfileWidget2::setProfileState()
 	/* show the same stuff that the profile shows. */
 
 	currentState = PROFILE;
-	emit enableToolbar(true);
 	setBackgroundBrush(getColor(::BACKGROUND, isGrayscale));
 
 	background->setVisible(false);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1127,8 +1127,6 @@ void ProfileWidget2::setProfileState()
 	disconnectTemporaryConnections();
 	/* show the same stuff that the profile shows. */
 
-	emit enableShortcuts();
-
 	currentState = PROFILE;
 	emit enableToolbar(true);
 	setBackgroundBrush(getColor(::BACKGROUND, isGrayscale));
@@ -1279,7 +1277,6 @@ void ProfileWidget2::setAddState(const dive *d, int dc)
 	mouseFollowerHorizontal->setLine(timeAxis->line());
 	mouseFollowerVertical->setLine(QLineF(0, profileYAxis->pos().y(), 0, timeAxis->pos().y()));
 	disconnectTemporaryConnections();
-	emit disableShortcuts(false);
 	actionsForKeys[Qt::Key_Left]->setShortcut(Qt::Key_Left);
 	actionsForKeys[Qt::Key_Right]->setShortcut(Qt::Key_Right);
 	actionsForKeys[Qt::Key_Up]->setShortcut(Qt::Key_Up);
@@ -1310,7 +1307,6 @@ void ProfileWidget2::setPlanState(const dive *d, int dc)
 	mouseFollowerHorizontal->setLine(timeAxis->line());
 	mouseFollowerVertical->setLine(QLineF(0, profileYAxis->pos().y(), 0, timeAxis->pos().y()));
 	disconnectTemporaryConnections();
-	emit disableShortcuts(true);
 	actionsForKeys[Qt::Key_Left]->setShortcut(Qt::Key_Left);
 	actionsForKeys[Qt::Key_Right]->setShortcut(Qt::Key_Right);
 	actionsForKeys[Qt::Key_Up]->setShortcut(Qt::Key_Up);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -100,8 +100,6 @@ public:
 signals:
 	void fontPrintScaleChanged(double scale);
 	void enableToolbar(bool enable);
-	void enableShortcuts();
-	void disableShortcuts(bool paste);
 	void editCurrentDive();
 
 public

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -80,7 +80,7 @@ public:
 	~ProfileWidget2();
 	void resetZoom();
 	void scale(qreal sx, qreal sy);
-	void plotDive(const struct dive *d, int dc, bool force = false, bool clearPictures = false, bool instant = false);
+	void plotDive(const struct dive *d, int dc, bool clearPictures = false, bool instant = false);
 	void setProfileState(const struct dive *d, int dc);
 	void setPlanState(const struct dive *d, int dc);
 	void setAddState(const struct dive *d, int dc);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -99,7 +99,6 @@ public:
 
 signals:
 	void fontPrintScaleChanged(double scale);
-	void enableToolbar(bool enable);
 	void editCurrentDive();
 
 public

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -135,7 +135,7 @@ void QMLProfile::updateProfile()
 		return;
 	if (verbose)
 		qDebug() << "update profile for dive #" << d->number << "offeset" << QString::number(m_xOffset, 'f', 1) << "/" << QString::number(m_yOffset, 'f', 1);
-	m_profileWidget->plotDive(d, dc_number, true);
+	m_profileWidget->plotDive(d, dc_number);
 }
 
 void QMLProfile::setDiveId(int diveId)
@@ -189,7 +189,7 @@ void QMLProfile::divesChanged(const QVector<dive *> &dives, DiveField)
 	for (struct dive *d: dives) {
 		if (d->id == m_diveId) {
 			qDebug() << "dive #" << d->number << "changed, trigger profile update";
-			m_profileWidget->plotDive(d, dc_number, true);
+			m_profileWidget->plotDive(d, dc_number);
 			triggerUpdate();
 			return;
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Some code-hygiene things in preparation for more profile-work.

Notably, this removes reverse control-flow from the profile to the main-window via signals. In the context of mobile or printing. So let's make the MainWindow control the UI, not the profile.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove signals from the profile to the MainWindow.
2) Remove an unused parameter in plotDive().

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - code hygiene.
