### PR TITLE
Cloud storage updates

### DIFF
--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -106,7 +106,7 @@ bool CheckCloudConnection::nextServer()
 		{ CLOUD_HOST_US, false }
 	};
 	const char *server = nullptr;
-	for (int i = 0; i < CLOUD_NUM_HOSTS; i++) {
+	for (unsigned int i = 0; i < ARRAY_SIZE(cloudServers); i++) {
 		if (strstr(prefs.cloud_base_url, cloudServers[i].server))
 			cloudServers[i].tried = true;
 		else if (cloudServers[i].tried == false)

--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -19,6 +19,7 @@ CheckCloudConnection::CheckCloudConnection(QObject *parent) :
 
 }
 
+// our own madeup API to make sure we are talking to a Subsurface cloud server
 #define TEAPOT "/make-latte?number-of-shots=3"
 #define HTTP_I_AM_A_TEAPOT 418
 #define MILK "Linus does not like non-fat milk"

--- a/core/checkcloudconnection.h
+++ b/core/checkcloudconnection.h
@@ -14,6 +14,7 @@ public:
 	void pickServer();
 private:
 	QNetworkReply *reply;
+	bool nextServer();
 private
 slots:
 	void sslErrors(const QList<QSslError> &errorList);

--- a/core/checkcloudconnection.h
+++ b/core/checkcloudconnection.h
@@ -11,11 +11,14 @@ class CheckCloudConnection : public QObject {
 public:
 	CheckCloudConnection(QObject *parent = 0);
 	bool checkServer();
+	void pickServer();
 private:
 	QNetworkReply *reply;
 private
 slots:
 	void sslErrors(const QList<QSslError> &errorList);
+	void gotIP(QNetworkReply *reply);
+	void gotContinent(QNetworkReply *reply);
 };
 
 #endif // CHECKCLOUDCONNECTION_H

--- a/core/cloudstorage.cpp
+++ b/core/cloudstorage.cpp
@@ -92,15 +92,7 @@ void CloudStorageAuthenticate::sslErrors(const QList<QSslError> &errorList)
 	QSslConfiguration conf = reply->sslConfiguration();
 	QSslCertificate cert = conf.peerCertificate();
 	QByteArray hexDigest = cert.digest().toHex();
-	if (reply->url().toString().contains(prefs.cloud_base_url) &&
-	    hexDigest == "13ff44c62996cfa5cd69d6810675490e") {
-		if (verbose)
-			qDebug() << "Overriding SSL check as I recognize the certificate digest" << hexDigest;
-		reply->ignoreSslErrors();
-	} else {
-		if (verbose)
-			qDebug() << "got invalid SSL certificate with hex digest" << hexDigest;
-	}
+	qDebug() << "got invalid SSL certificate with hex digest" << hexDigest;
 }
 
 QNetworkAccessManager *manager()

--- a/core/file.c
+++ b/core/file.c
@@ -284,9 +284,7 @@ int check_git_sha(const char *filename, struct git_repository **git_p, const cha
 		*git_p = git;
 	if (branch_p)
 		*branch_p = branch;
-	if (prefs.cloud_git_url &&
-	    strstr(filename, prefs.cloud_git_url)
-	    && git == dummy_git_repository) {
+	if (strstr(filename, prefs.cloud_base_url) && git == dummy_git_repository) {
 		/* opening the cloud storage repository failed for some reason,
 		 * so we don't know if there is additional data in the remote */
 		free(current_sha);
@@ -317,13 +315,11 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 	int ret;
 
 	git = is_git_repository(filename, &branch, NULL, false);
-	if (prefs.cloud_git_url &&
-	    strstr(filename, prefs.cloud_git_url)
-	    && git == dummy_git_repository) {
+	if (strstr(filename, prefs.cloud_base_url) && git == dummy_git_repository)
 		/* opening the cloud storage repository failed for some reason
 		 * give up here and don't send errors about git repositories */
 		return -1;
-	}
+
 	if (git)
 		return git_load_dives(git, branch, table, trips, sites, devices, filter_presets);
 

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -1023,7 +1023,7 @@ static struct git_repository *is_remote_git_repository(char *remote, const char 
 
 	/* remember if the current git storage we are working on is our cloud storage
 	 * this is used to create more user friendly error message and warnings */
-	is_subsurface_cloud = strstr(remote, prefs.cloud_git_url) != NULL;
+	is_subsurface_cloud = strstr(remote, prefs.cloud_base_url) != NULL;
 
 	return get_remote_repo(localdir, remote, branch);
 }

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -15,6 +15,11 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
+#define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"
+#define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"
+#define CLOUD_HOST_PATTERN "ssrf-cloud-..\\.subsurface-divelog\\.org"
+#define CLOUD_HOST_GENERIC "cloud.subsurface-divelog.org"
+
 enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
 
 struct git_oid;

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
+#define CLOUD_NUM_HOSTS 2
 #define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"
 #define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"
 #define CLOUD_HOST_PATTERN "ssrf-cloud-..\\.subsurface-divelog\\.org"

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -15,11 +15,12 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
-#define CLOUD_NUM_HOSTS 2
 #define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"
 #define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"
 #define CLOUD_HOST_PATTERN "ssrf-cloud-..\\.subsurface-divelog\\.org"
 #define CLOUD_HOST_GENERIC "cloud.subsurface-divelog.org"
+
+#define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
 enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
 

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -58,7 +58,6 @@ struct keyword_action {
 	const char *keyword;
 	void (*fn)(char *, struct membuffer *, struct git_parser_state *);
 };
-#define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
 static git_blob *git_tree_entry_blob(git_repository *repo, const git_tree_entry *entry);
 

--- a/core/pref.c
+++ b/core/pref.c
@@ -103,7 +103,6 @@ void copy_prefs(struct preferences *src, struct preferences *dest)
 	dest->default_filename = copy_string(src->default_filename);
 	dest->default_cylinder = copy_string(src->default_cylinder);
 	dest->cloud_base_url = copy_string(src->cloud_base_url);
-	dest->cloud_git_url = copy_string(src->cloud_git_url);
 	dest->proxy_host = copy_string(src->proxy_host);
 	dest->proxy_user = copy_string(src->proxy_user);
 	dest->proxy_pass = copy_string(src->proxy_pass);

--- a/core/pref.c
+++ b/core/pref.c
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "pref.h"
 #include "subsurface-string.h"
+#include "git-access.h" // for CLOUD_HOST
 
 struct preferences prefs, git_prefs;
 struct preferences default_prefs = {
-	.cloud_base_url = "https://cloud.subsurface-divelog.org/",
+	.cloud_base_url = "https://" CLOUD_HOST_EU "/", // if we don't know any better, use the European host
 	.units = SI_UNITS,
 	.unit_system = METRIC,
 	.coordinates_traditional = true,

--- a/core/pref.h
+++ b/core/pref.h
@@ -82,7 +82,6 @@ struct preferences {
 	// ********** CloudStorage **********
 	bool        cloud_auto_sync;
 	const char *cloud_base_url;
-	const char *cloud_git_url;
 	const char *cloud_storage_email;
 	const char *cloud_storage_email_encoded;
 	const char *cloud_storage_password;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -22,6 +22,7 @@
 #include "trip.h"
 #include "imagedownloader.h"
 #include "xmlparams.h"
+#include "core/git-access.h" // for CLOUD_HOST definitions
 #include <QFile>
 #include <QRegExp>
 #include <QDir>
@@ -1453,6 +1454,15 @@ extern "C" char *cloud_url()
 	QString filename;
 	getCloudURL(filename);
 	return copy_qstring(filename);
+}
+
+extern "C" const char *normalize_cloud_name(const char *remote_in)
+{
+	// replace ssrf-cloud-XX.subsurface... names with cloud.subsurface... names
+	// that trailing '/' is to match old code
+	QString ri(remote_in);
+	ri.replace(QRegularExpression(CLOUD_HOST_PATTERN), CLOUD_HOST_GENERIC "/");
+	return strdup(ri.toUtf8().constData());
 }
 
 extern "C" bool getProxyString(char **buffer)

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1442,9 +1442,9 @@ int getCloudURL(QString &filename)
 		free((void *)prefs.cloud_storage_email_encoded);
 		prefs.cloud_storage_email_encoded = copy_qstring(email);
 	}
-	filename = QString(QString(prefs.cloud_git_url) + "/%1[%1]").arg(email);
+	filename = QString(QString(prefs.cloud_base_url) + "git/%1[%1]").arg(email);
 	if (verbose)
-		qDebug() << "cloud URL set as" << filename;
+		qDebug() << "returning cloud URL" << filename;
 	return 0;
 }
 

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -138,7 +138,7 @@ extern "C" {
 
 char *printGPSCoordsC(const location_t *loc);
 bool getProxyString(char **buffer);
-bool canReachCloudServer();
+bool canReachCloudServer(const char **remote);
 void updateWindowTitle();
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -147,6 +147,7 @@ void copy_image_and_overwrite(const char *cfileName, const char *path, const cha
 char *move_away(const char *path);
 const char *local_file_path(struct picture *picture);
 char *cloud_url();
+const char *normalize_cloud_name(const char *remote_in);
 char *hashfile_name_string();
 char *picturedir_string();
 const char *subsurface_user_agent();

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -46,11 +46,10 @@ void qPrefCloudStorage::store_cloud_base_url(const QString &value)
 }
 void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 {
-	if (doSync) {
-		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cloud_base_url"), prefs.cloud_base_url, default_prefs.cloud_base_url);
-	} else {
+	// we don't allow to automatically write back the prefs value for the cloud_base_url.
+	// in order to do that you need to use the explicit function above store_cloud_base_url()
+	if (!doSync)
 		prefs.cloud_base_url = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, "cloud_base_url"), default_prefs.cloud_base_url).toString());
-	}
 }
 
 HANDLE_PREFERENCE_TXT(CloudStorage, "email", cloud_storage_email);

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -37,6 +37,13 @@ void qPrefCloudStorage::set_cloud_base_url(const QString &value)
 		emit instance()->cloud_base_urlChanged(value);
 	}
 }
+
+void qPrefCloudStorage::store_cloud_base_url(const QString &value)
+{
+	// this is used if we want to update the on-disk settings without changing
+	// the runtime preference
+	qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cloud_base_url"), value, default_prefs.cloud_base_url);
+}
 void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 {
 	if (doSync) {

--- a/core/settings/qPrefCloudStorage.cpp
+++ b/core/settings/qPrefCloudStorage.cpp
@@ -31,7 +31,6 @@ void qPrefCloudStorage::set_cloud_base_url(const QString &value)
 		// only free and set if not default
 		if (prefs.cloud_base_url != default_prefs.cloud_base_url) {
 			qPrefPrivate::copy_txt(&prefs.cloud_base_url, value);
-			qPrefPrivate::copy_txt(&prefs.cloud_git_url, value + "/git");
 		}
 
 		disk_cloud_base_url(true);
@@ -44,7 +43,6 @@ void qPrefCloudStorage::disk_cloud_base_url(bool doSync)
 		qPrefPrivate::propSetValue(keyFromGroupAndName(group, "cloud_base_url"), prefs.cloud_base_url, default_prefs.cloud_base_url);
 	} else {
 		prefs.cloud_base_url = copy_qstring(qPrefPrivate::propValue(keyFromGroupAndName(group, "cloud_base_url"), default_prefs.cloud_base_url).toString());
-		qPrefPrivate::copy_txt(&prefs.cloud_git_url, QString(prefs.cloud_base_url) + "/git");
 	}
 }
 

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -57,6 +57,7 @@ public:
 public slots:
 	static void set_cloud_auto_sync(bool value);
 	static void set_cloud_base_url(const QString &value);
+	static void store_cloud_base_url(const QString &value);
 	static void set_cloud_storage_email(const QString &value);
 	static void set_cloud_storage_email_encoded(const QString &value);
 	static void set_cloud_storage_password(const QString &value);

--- a/core/settings/qPrefCloudStorage.h
+++ b/core/settings/qPrefCloudStorage.h
@@ -9,7 +9,6 @@ class qPrefCloudStorage : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool cloud_auto_sync READ cloud_auto_sync WRITE set_cloud_auto_sync NOTIFY cloud_auto_syncChanged)
 	Q_PROPERTY(QString cloud_base_url READ cloud_base_url WRITE set_cloud_base_url NOTIFY cloud_base_urlChanged)
-	Q_PROPERTY(QString cloud_git_url READ cloud_git_url)
 	Q_PROPERTY(QString cloud_storage_email READ cloud_storage_email WRITE set_cloud_storage_email NOTIFY cloud_storage_emailChanged)
 	Q_PROPERTY(QString cloud_storage_email_encoded READ cloud_storage_email_encoded WRITE set_cloud_storage_email_encoded NOTIFY cloud_storage_email_encodedChanged)
 	Q_PROPERTY(QString cloud_storage_password READ cloud_storage_password WRITE set_cloud_storage_password NOTIFY cloud_storage_passwordChanged)
@@ -43,7 +42,6 @@ public:
 
 	static bool cloud_auto_sync() { return prefs.cloud_auto_sync; }
 	static QString cloud_base_url() { return prefs.cloud_base_url; }
-	static QString cloud_git_url() { return prefs.cloud_git_url; }
 	static QString cloud_storage_email() { return prefs.cloud_storage_email; }
 	static QString cloud_storage_email_encoded() { return prefs.cloud_storage_email_encoded; }
 	static QString cloud_storage_password() { return prefs.cloud_storage_password; }

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -625,8 +625,8 @@ void MainWindow::closeCurrentFile()
 
 void MainWindow::updateCloudOnlineStatus()
 {
-	bool is_cloud = existing_filename && prefs.cloud_git_url && prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED &&
-			strstr(existing_filename, prefs.cloud_git_url);
+	bool is_cloud = existing_filename && prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED &&
+			strstr(existing_filename, prefs.cloud_base_url);
 	ui.actionCloudOnline->setEnabled(is_cloud);
 	ui.actionCloudOnline->setChecked(is_cloud && !git_local_only);
 }
@@ -1169,7 +1169,7 @@ void MainWindow::loadRecentFiles()
 		QString file = s.value(key).toString();
 
 		// never add our cloud URL to the recent files
-		if (!same_string(prefs.cloud_git_url, "") && file.startsWith(prefs.cloud_git_url))
+		if (file.startsWith(prefs.cloud_base_url))
 			continue;
 		// but allow local git repos
 		QRegularExpression gitrepo("(.*)\\[[^]]+]");
@@ -1207,7 +1207,7 @@ void MainWindow::updateRecentFilesMenu()
 void MainWindow::addRecentFile(const QString &file, bool update)
 {
 	// never add Subsurface cloud file to the recent files - it has its own menu entry
-	if (!same_string(prefs.cloud_git_url, "") && file.startsWith(prefs.cloud_git_url))
+	if (file.startsWith(prefs.cloud_base_url))
 		return;
 	QString localFile = QDir::toNativeSeparators(file);
 	int index = recentFiles.indexOf(localFile);
@@ -1257,9 +1257,8 @@ int MainWindow::file_save_as(void)
 
 	// if the default is to save to cloud storage, pick something that will work as local file:
 	// simply extract the branch name which should be the users email address
-	if (default_filename && strstr(default_filename, prefs.cloud_git_url)) {
+	if (default_filename && strstr(default_filename, prefs.cloud_base_url)) {
 		QString filename(default_filename);
-		filename.remove(prefs.cloud_git_url);
 		filename.remove(0, filename.indexOf("[") + 1);
 		filename.replace("]", ".ssrf");
 		default_filename = copy_qstring(filename);
@@ -1350,7 +1349,7 @@ QString MainWindow::displayedFilename(QString fullFilename)
 	QFileInfo fileInfo(f);
 	QString fileName(fileInfo.fileName());
 
-	if (fullFilename.contains(prefs.cloud_git_url)) {
+	if (fullFilename.contains(prefs.cloud_base_url)) {
 		QString email = fileName.left(fileName.indexOf('['));
 		return git_local_only ?
 			tr("[local cache for] %1").arg(email) :

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1257,7 +1257,7 @@ int MainWindow::file_save_as(void)
 
 	// if the default is to save to cloud storage, pick something that will work as local file:
 	// simply extract the branch name which should be the users email address
-	if (default_filename && strstr(default_filename, prefs.cloud_base_url)) {
+	if (default_filename && QString(default_filename).contains(QRegularExpression(CLOUD_HOST_PATTERN))) {
 		QString filename(default_filename);
 		filename.remove(0, filename.indexOf("[") + 1);
 		filename.replace("]", ".ssrf");

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -15,6 +15,7 @@
 #include "core/settings/qPref.h"
 #include "core/tag.h"
 #include "desktop-widgets/mainwindow.h"
+#include "core/checkcloudconnection.h"
 
 #include <QApplication>
 #include <QLoggingCategory>
@@ -76,6 +77,8 @@ int main(int argc, char **argv)
 #endif
 	setup_system_prefs();
 	copy_prefs(&default_prefs, &prefs);
+	CheckCloudConnection ccc;
+	ccc.pickServer();
 	fill_computer_list();
 	reset_tank_info_table(&tank_info_table);
 	parse_xml_init();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -17,6 +17,7 @@
 #include "core/settings/qPrefDisplay.h"
 #include "core/tag.h"
 #include "core/settings/qPrefCloudStorage.h"
+#include "core/checkcloudconnection.h"
 
 #include <QApplication>
 #include <QFont>
@@ -57,6 +58,8 @@ int main(int argc, char **argv)
 	else
 		default_prefs.units = IMPERIAL_units;
 	copy_prefs(&default_prefs, &prefs);
+	CheckCloudConnection ccc;
+	ccc.pickServer();
 	fill_computer_list();
 	reset_tank_info_table(&tank_info_table);
 

--- a/tests/testAirPressure.cpp
+++ b/tests/testAirPressure.cpp
@@ -13,6 +13,7 @@ void TestAirPressure::initTestCase()
 {
 	/* we need to manually tell that the resource exists, because we are using it as library. */
 	Q_INIT_RESOURCE(subsurface);
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 }
 
 void TestAirPressure::get_dives()

--- a/tests/testdivesiteduplication.cpp
+++ b/tests/testdivesiteduplication.cpp
@@ -5,9 +5,11 @@
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/file.h"
+#include "core/pref.h"
 
 void TestDiveSiteDuplication::testReadV2()
 {
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/TwoTimesTwo.ssrf", &dive_table, &trip_table,
 			    &dive_site_table, &device_table, &filter_preset_table), 0);
 	QCOMPARE(dive_site_table.nr, 2);

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -111,14 +111,13 @@ void TestGitStorage::initTestCase()
 	if (gitUrl.right(1) != "/")
 		gitUrl += "/";
 	gitUrl += "git";
-	prefs.cloud_git_url = copy_qstring(gitUrl);
 	prefs.cloud_storage_email_encoded = copy_qstring(email);
 	prefs.cloud_storage_password = copy_qstring(password);
 	gitUrl += "/" + email;
 	// all user storage for historical reasons always uses the user's email both as
 	// repo name and as branch. To allow us to keep testing and not step on parallel
 	// runs we'll use actually random branch names - yes, this still has a chance of
-	// conflict, but I'm not going to implement a distributed locak manager for this
+	// conflict, but I'm not going to implement a distributed lock manager for this
 	if (email.startsWith("gitstorage")) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 		randomBranch = QString::number(QRandomGenerator::global()->bounded(0x1000000), 16) +

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -5,12 +5,14 @@
 #include "core/divesite.h"
 #include "core/file.h"
 #include "core/trip.h"
+#include "core/pref.h"
 #include <QTextStream>
 
 void TestMerge::initTestCase()
 {
 	/* we need to manually tell that the resource exists, because we are using it as library. */
 	Q_INIT_RESOURCE(subsurface);
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 }
 
 void TestMerge::cleanup()

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -35,6 +35,7 @@ void TestParse::initTestCase()
 {
 	/* we need to manually tell that the resource exists, because we are using it as library. */
 	Q_INIT_RESOURCE(subsurface);
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 }
 
 void TestParse::init()

--- a/tests/testpicture.cpp
+++ b/tests/testpicture.cpp
@@ -7,6 +7,7 @@
 #include "core/picture.h"
 #include "core/trip.h"
 #include "core/file.h"
+#include "core/pref.h"
 #include <QString>
 #include <core/qthelper.h>
 
@@ -14,6 +15,7 @@ void TestPicture::initTestCase()
 {
 	/* we need to manually tell that the resource exists, because we are using it as library. */
 	Q_INIT_RESOURCE(subsurface);
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 }
 
 #define PIC1_NAME "/dives/images/wreck.jpg"

--- a/tests/testprofile.cpp
+++ b/tests/testprofile.cpp
@@ -14,6 +14,23 @@
 // ..dives/exportprofilereference.csv) and copy the former over the later and commit that change
 // as well.
 
+void TestProfile::init()
+{
+	// Set UTF8 text codec as in real applications
+	QTextCodec::setCodecForLocale(QTextCodec::codecForMib(106));
+
+	// first, setup the preferences
+
+	// normally we should be able to do this - but it makes this test fail because the reference data
+	// assume that the prefs are all 0 / false
+	// copy_prefs(&default_prefs, &prefs);
+	// instead we just set up the cloud_base_url to prevent parse_file() from crashing
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
+
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("Subsurface");
+}
 void TestProfile::testProfileExport()
 {
 	prefs.planner_deco_mode = BUEHLMANN;

--- a/tests/testprofile.h
+++ b/tests/testprofile.h
@@ -8,6 +8,7 @@
 class TestProfile : public QObject {
 	Q_OBJECT
 private slots:
+	void init();
 	void testProfileExport();
 	void testProfileExportVPMB();
 };

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -23,7 +23,6 @@ void TestQPrefCloudStorage::test_struct_get()
 
 	prefs.cloud_auto_sync = true;
 	prefs.cloud_base_url = copy_qstring("new url");
-	prefs.cloud_git_url = copy_qstring("new again url");
 	prefs.cloud_storage_email = copy_qstring("myEmail");
 	prefs.cloud_storage_email_encoded = copy_qstring("encodedMyEMail");
 	prefs.cloud_storage_password = copy_qstring("more secret");
@@ -34,7 +33,6 @@ void TestQPrefCloudStorage::test_struct_get()
 
 	QCOMPARE(tst->cloud_auto_sync(), prefs.cloud_auto_sync);
 	QCOMPARE(tst->cloud_base_url(), QString(prefs.cloud_base_url));
-	QCOMPARE(tst->cloud_git_url(), QString(prefs.cloud_git_url));
 	QCOMPARE(tst->cloud_storage_email(), QString(prefs.cloud_storage_email));
 	QCOMPARE(tst->cloud_storage_email_encoded(), QString(prefs.cloud_storage_email_encoded));
 	QCOMPARE(tst->cloud_storage_password(), QString(prefs.cloud_storage_password));
@@ -69,9 +67,6 @@ void TestQPrefCloudStorage::test_set_struct()
 	QCOMPARE((int)prefs.cloud_timeout, 123);
 	QCOMPARE((int)prefs.cloud_verification_status, (int)qPrefCloudStorage::CS_VERIFIED);
 	QCOMPARE(prefs.save_password_local, false);
-
-	// remark is set with set_base_url
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t2 base/git"));
 }
 
 void TestQPrefCloudStorage::test_set_load_struct()
@@ -92,7 +87,6 @@ void TestQPrefCloudStorage::test_set_load_struct()
 
 	prefs.cloud_auto_sync = false;
 	prefs.cloud_base_url = copy_qstring("error1");
-	prefs.cloud_git_url = copy_qstring("error1");
 	prefs.cloud_storage_email = copy_qstring("error1");
 	prefs.cloud_storage_email_encoded = copy_qstring("error1");
 	prefs.cloud_storage_password = copy_qstring("error1");
@@ -111,9 +105,6 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	QCOMPARE((int)prefs.cloud_timeout, 321);
 	QCOMPARE((int)prefs.cloud_verification_status, (int)qPrefCloudStorage::CS_NOCLOUD);
 	QCOMPARE(prefs.save_password_local, true);
-
-	// remark is set with set_base_url
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t3 base/git"));
 }
 
 void TestQPrefCloudStorage::test_struct_disk()
@@ -136,7 +127,6 @@ void TestQPrefCloudStorage::test_struct_disk()
 
 	prefs.cloud_auto_sync = false;
 	prefs.cloud_base_url = copy_qstring("error1");
-	prefs.cloud_git_url = copy_qstring("error1");
 	prefs.cloud_storage_email = copy_qstring("error1");
 	prefs.cloud_storage_email_encoded = copy_qstring("error1");
 	prefs.cloud_storage_password = copy_qstring("error1");
@@ -156,9 +146,6 @@ void TestQPrefCloudStorage::test_struct_disk()
 	QCOMPARE((int)prefs.cloud_timeout, 123);
 	QCOMPARE((int)prefs.cloud_verification_status, (int)qPrefCloudStorage::CS_VERIFIED);
 	QCOMPARE(prefs.save_password_local, true);
-
-	// remark is set with set_base_url
-	QCOMPARE(QString(prefs.cloud_git_url), QString("t4 base/git"));
 }
 
 void TestQPrefCloudStorage::test_multiple()

--- a/tests/testqPrefCloudStorage.cpp
+++ b/tests/testqPrefCloudStorage.cpp
@@ -76,6 +76,7 @@ void TestQPrefCloudStorage::test_set_load_struct()
 	auto tst = qPrefCloudStorage::instance();
 
 	tst->set_cloud_base_url("t3 base");
+	tst->store_cloud_base_url("t3 base"); // the base URL is no longer automatically saved to disk
 	tst->set_cloud_storage_email("t3 email");
 	tst->set_cloud_storage_email_encoded("t3 email2");
 	tst->set_save_password_local(true);
@@ -114,6 +115,7 @@ void TestQPrefCloudStorage::test_struct_disk()
 	auto tst = qPrefCloudStorage::instance();
 
 	prefs.cloud_base_url = copy_qstring("t4 base");
+	tst->store_cloud_base_url("t4 base"); // the base URL is no longer automatically saved to disk
 	prefs.cloud_storage_email = copy_qstring("t4 email");
 	prefs.cloud_storage_email_encoded = copy_qstring("t4 email2");
 	prefs.save_password_local = true;
@@ -170,8 +172,10 @@ void TestQPrefCloudStorage::test_oldPreferences()
 	auto cloud = qPrefCloudStorage::instance();
 
 	cloud->set_cloud_base_url("test_one");
+	cloud->store_cloud_base_url("test_one");
 	TEST(cloud->cloud_base_url(), QStringLiteral("test_one"));
 	cloud->set_cloud_base_url("test_two");
+	cloud->store_cloud_base_url("test_two");
 	TEST(cloud->cloud_base_url(), QStringLiteral("test_two"));
 
 	cloud->set_cloud_storage_email("tomaz@subsurface.com");

--- a/tests/testrenumber.cpp
+++ b/tests/testrenumber.cpp
@@ -5,10 +5,12 @@
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/file.h"
+#include "core/pref.h"
 #include <QTextStream>
 
 void TestRenumber::setup()
 {
+	prefs.cloud_base_url = strdup(default_prefs.cloud_base_url);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test47.xml", &dive_table, &trip_table, &dive_site_table, &device_table, &filter_preset_table), 0);
 	process_loaded_dives();
 }

--- a/tests/tst_qPrefCloudStorage.qml
+++ b/tests/tst_qPrefCloudStorage.qml
@@ -11,9 +11,6 @@ TestCase {
 		PrefCloudStorage.cloud_base_url = "my url"
 		compare(PrefCloudStorage.cloud_base_url, "my url")
 
-		var x2 = PrefCloudStorage.cloud_git_url
-		compare(PrefCloudStorage.cloud_git_url, "my url/git")
-
 		var x3 = PrefCloudStorage.cloud_storage_email
 		PrefCloudStorage.cloud_storage_email = "my email"
 		compare(PrefCloudStorage.cloud_storage_email, "my email")


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
As I am moving the cloud server around, I came up with an idea to have a hot standby instead of just a backup.
I'm sure this needs more work on the infrastructure side, but first tests have been somewhat promising.

In order to use that, the clients need to be able to use different servers. This implements the basics of that. Pick a server based on geo location (because that seemed to make sense), and make sure that downloading and uploading to the different servers works and that the backend stays in sync.

Of course the next step then would be to detect if a server is down and use the / an other one.

But let's start with what I have so people can review the code and maybe even play with it.

The goal is to have different servers in different geos, with names with a `ssrf-cloud-XX.subsurface-divelog.org` pattern. So far we have US and EU (which is hilariously inconsistent, of course - country vs. continent). But you get the idea. Interestingly, neither of those two servers is actually the server that we are all currently using as `cloud.subsurface-divelog.org` - so indeed, right now there are actually three servers in use...

I'd love review and comments.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
the random cloud outages we had over the years...

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
missing

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I'm trying really hard to make this transparent to the user so that there is nothing for us to document

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
