### PR TITLE
xml parsing: add XML_PARSE_HUGE flag to xmlReadMemory()

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1748,9 +1748,9 @@ int parse_xml_buffer(const char *url, const char *buffer, int size,
 	state.sites = sites;
 	state.devices = devices;
 	state.filter_presets = filter_presets;
-	doc = xmlReadMemory(res, strlen(res), url, NULL, 0);
+	doc = xmlReadMemory(res, strlen(res), url, NULL, XML_PARSE_HUGE);
 	if (!doc)
-		doc = xmlReadMemory(res, strlen(res), url, "latin1", 0);
+		doc = xmlReadMemory(res, strlen(res), url, "latin1", XML_PARSE_HUGE);
 
 	if (res != buffer)
 		free((char *)res);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -871,7 +871,7 @@ static int export_dives_xslt_doit(const char *filename, struct xml_params *param
 	 * transform it to selected export format, finally dumping
 	 * the XML into a character buffer.
 	 */
-	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, 0);
+	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, XML_PARSE_HUGE);
 	free_buffer(&buf);
 	if (!doc)
 		return report_error("Failed to read XML memory");


### PR DESCRIPTION
It looks like libxml2 has some internal limitations by default that
causes parse failures in some situations.  Avoid them with
XML_PARSE_HUGE.

Without this, you get errors like

    test.xml:349250: parser error : internal error: Huge input lookup
    όμουν τουλάχιστον αλλά +2kg και ενδεχομένως +4
                                                                                   ^
when something in the xml file grows too large.

I don't know libxml2 internals, so I have no idea what exactly goes
wrong, but the docs say:

    XML_PARSE_HUGE = 524288 : relax any hardcoded limit from the parser

and that makes us successfully parse the Greek file from Kostas.

Reported-by: Kostas Katsioulis <kostaskatsioulis@gmail.com>
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
