### PR TITLE
profile: ignore animation-speed setting when printing

### DIFF
--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -128,7 +128,6 @@ void Printer::render(int pages)
 	// keep original preferences
 	ProfileWidget2 *profile = MainWindow::instance()->graphics;
 	int profileFrameStyle = profile->frameStyle();
-	int animationOriginal = qPrefDisplay::animation_speed();
 	double fontScale = profile->getFontPrintScale();
 	double printFontScale = 1.0;
 
@@ -136,7 +135,6 @@ void Printer::render(int pages)
 	profile->setFrameStyle(QFrame::NoFrame);
 	profile->setPrintMode(true, !printOptions.color_selected);
 	profile->setToolTipVisibile(false);
-	qPrefDisplay::set_animation_speed(0);
 
 	// render the Qwebview
 	QPainter painter;
@@ -190,7 +188,6 @@ void Printer::render(int pages)
 	profile->setFontPrintScale(fontScale);
 	profile->setToolTipVisibile(true);
 	profile->resize(originalSize);
-	qPrefDisplay::set_animation_speed(animationOriginal);
 
 	//replot the dive after returning the settings
 	profile->plotDive(current_dive, dc_number, true);

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -189,7 +189,7 @@ void ToolTipItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 	}
 }
 
-void ToolTipItem::persistPos()
+void ToolTipItem::persistPos() const
 {
 	qPrefDisplay::set_tooltip_position(pos());
 }

--- a/profile-widget/divetooltipitem.h
+++ b/profile-widget/divetooltipitem.h
@@ -20,7 +20,6 @@ class QGraphicsPixmapItem;
  */
 class ToolTipItem : public QObject, public RoundRectItem {
 	Q_OBJECT
-	void updateTitlePosition();
 	Q_PROPERTY(QRectF rect READ rect WRITE setRect)
 
 public:
@@ -32,12 +31,7 @@ public:
 	explicit ToolTipItem(QGraphicsItem *parent = 0);
 	~ToolTipItem();
 
-	void collapse();
-	void expand();
-	void clear();
 	void refresh(const dive *d, const QPointF &pos, bool inPlanner);
-	bool isExpanded() const;
-	void persistPos();
 	void readPos();
 	void mousePressEvent(QGraphicsSceneMouseEvent *event);
 	void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
@@ -63,6 +57,12 @@ private:
 	QList<QGraphicsItem*> oldSelection;
 
 	void addToolTip(const QString &toolTip, const QPixmap &pixmap);
+	void collapse();
+	void expand();
+	void clear();
+	bool isExpanded() const;
+	void persistPos() const;
+	void updateTitlePosition();
 };
 
 #endif // DIVETOOLTIPITEM_H

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -555,7 +555,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 		return;
 
 	// special handling when switching from empty state
-	animSpeed = instant || currentState == EMPTY ? 0 : qPrefDisplay::animation_speed();
+	animSpeed = instant || currentState == EMPTY || printMode ? 0 : qPrefDisplay::animation_speed();
 
 	// restore default zoom level
 	resetZoom();

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -83,7 +83,6 @@ int main(int argc, char **argv)
 		set_filename(NULL);
 
 	// some hard coded settings
-	qPrefDisplay::set_animation_speed(0); // we render the profile to pixmap, no animations
 	qPrefCloudStorage::set_save_password_local(true);
 
 	// always show the divecomputer reported ceiling in red


### PR DESCRIPTION
When printing, the animation speed was set to 0 by the
caller and later reset to the original value. Instead of
modifying global state, set it internally (in the profile-code)
to zero when in print mode.

This is another small step in making the printing independent
from the shown profile.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A (seemingly?) trivial disentangling of printing and profile: Don't use the global preferences flag to stop animations when printing. Simply set the speed to zero when in print mode.

Note that there are a few more callers of `qPrefDisplay::animation_speed()`. However, these are in hover-event functions or concern the "tooltip", which means that they are guaranteed to happen in UI context, not during printing.

Includes another random cleanup commit.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Nope.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Nope.
