### PR TITLE
Show progress when exporting to TeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+export: show progress dialog when exporting to TeX
 printing: use sensible font size even for strange window size
 
 ---

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -29,7 +29,7 @@ bool ExportCallback::canceled() const
 }
 
 #if !defined(SUBSURFACE_MOBILE)
-void exportProfile(QString filename, bool selected_only)
+void exportProfile(QString filename, bool selected_only, ExportCallback &cb)
 {
 	struct dive *dive;
 	int i;
@@ -38,9 +38,14 @@ void exportProfile(QString filename, bool selected_only)
 		filename = filename.append(".png");
 	QFileInfo fi(filename);
 
+	int todo = selected_only ? amount_selected : dive_table.nr;
+	int done = 0;
 	for_each_dive (i, dive) {
+		if (cb.canceled())
+			return;
 		if (selected_only && !dive->selected)
 			continue;
+		cb.setProgress(done++ * 1000 / todo);
 		if (count)
 			exportProfile(dive, fi.path() + QDir::separator() + fi.completeBaseName().append(QString("-%1.").arg(count)) + fi.suffix());
 		else

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -13,7 +13,7 @@ struct ExportCallback {
 	virtual bool canceled() const;
 };
 
-void exportProfile(QString filename, bool selected_only);
+void exportProfile(QString filename, bool selected_only, ExportCallback &cb);
 void export_TeX(const char *filename, bool selected_only, bool plain, ExportCallback &cb);
 void export_depths(const char *filename, bool selected_only);
 std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -7,8 +7,14 @@
 
 struct dive_site;
 
+// A synchrounous callback interface to signal progress / check for user abort
+struct ExportCallback {
+	virtual void setProgress(int progress);	// 0-1000
+	virtual bool canceled() const;
+};
+
 void exportProfile(QString filename, bool selected_only);
-void export_TeX(const char *filename, bool selected_only, bool plain);
+void export_TeX(const char *filename, bool selected_only, bool plain, ExportCallback &cb);
 void export_depths(const char *filename, bool selected_only);
 std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
 QFuture<int> exportUsingStyleSheet(QString filename, bool doExport, int units, QString stylesheet, bool anonymize);

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -161,12 +161,12 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		} else if (ui->exportWorldMap->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export world map"), lastDir,
 								tr("HTML files") + " (*.html)");
-			if (!filename.isNull() && !filename.isEmpty())
+			if (!filename.isEmpty())
 				export_worldmap_HTML(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportSubsurfaceXML->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface XML"), lastDir,
 								tr("Subsurface files") + " (*.ssrf *.xml)");
-			if (!filename.isNull() && !filename.isEmpty()) {
+			if (!filename.isEmpty()) {
 				if (!filename.contains('.'))
 					filename.append(".ssrf");
 				QByteArray bt = QFile::encodeName(filename);
@@ -175,7 +175,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		} else if (ui->exportSubsurfaceSitesXML->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface dive sites XML"), lastDir,
 								tr("Subsurface files") + " (*.xml)");
-			if (!filename.isNull() && !filename.isEmpty()) {
+			if (!filename.isEmpty()) {
 				if (!filename.contains('.'))
 					filename.append(".xml");
 				QByteArray bt = QFile::encodeName(filename);
@@ -184,31 +184,31 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 			}
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);
-			if (!filename.isNull() && !filename.isEmpty())
+			if (!filename.isEmpty())
 				export_depths(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportTeX->isChecked() || ui->exportLaTeX->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Export to TeX file"), lastDir, tr("TeX files") + " (*.tex)");
-			if (!filename.isNull() && !filename.isEmpty())
+			if (!filename.isEmpty())
 				export_TeX(qPrintable(filename), ui->exportSelected->isChecked(), ui->exportTeX->isChecked());
 		} else if (ui->exportProfile->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile image"), lastDir);
-			if (!filename.isNull() && !filename.isEmpty())
+			if (!filename.isEmpty())
 				exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
 		} else if (ui->exportProfileData->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile data"), lastDir);
-			if (!filename.isNull() && !filename.isEmpty())
+			if (!filename.isEmpty())
 				save_profiledata(qPrintable(filename), ui->exportSelected->isChecked());
 		}
 		break;
 	case 1:
 		filename = QFileDialog::getSaveFileName(this, tr("Export HTML files as"), lastDir,
 							tr("HTML files") + " (*.html)");
-		if (!filename.isNull() && !filename.isEmpty())
+		if (!filename.isEmpty())
 			exportHtmlInit(filename);
 		break;
 	}
 
-	if (!filename.isNull() && !filename.isEmpty()) {
+	if (!filename.isEmpty()) {
 		// remember the last export path
 		QFileInfo fileInfo(filename);
 		qPrefDisplay::set_lastDir(fileInfo.dir().path());

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -222,8 +222,10 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 			}
 		} else if (ui->exportProfile->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile image"), lastDir);
-			if (!filename.isEmpty())
-				exportProfile(qPrintable(filename), ui->exportSelected->isChecked());
+			if (!filename.isEmpty()) {
+				ProgressDialogCallback cb;
+				exportProfile(qPrintable(filename), ui->exportSelected->isChecked(), cb);
+			}
 		} else if (ui->exportProfileData->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile data"), lastDir);
 			if (!filename.isEmpty())


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This adds a progress dialog when exporting to TeX, because this used to hang the UI

This is rather lame for two reasons:
1) Asynchronous code. UI still slugish
2) The user sees flipping though the profiles.

---

1) can be fixed later by multithreading, but I wanted to avoid complex code for now.
2) will be (hopefully) fixed by #3235.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Show progress when exporting to TeX
2) Minor code cleanup: remove redundant `isNull()` checks
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
#3235 hopefully removes the artifact of flipping through the profiles.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
