### PR TITLE
[TRIVIAL] cleanup: free print dialog in planner

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -588,9 +588,9 @@ void PlannerWidgets::printDecoPlan()
 	free(disclaimer);
 
 	QPrinter printer;
-	QPrintDialog *dialog = new QPrintDialog(&printer, MainWindow::instance());
-	dialog->setWindowTitle(tr("Print runtime table"));
-	if (dialog->exec() != QDialog::Accepted)
+	QPrintDialog dialog(&printer, MainWindow::instance());
+	dialog.setWindowTitle(tr("Print runtime table"));
+	if (dialog.exec() != QDialog::Accepted)
 		return;
 
 	/* render the profile as a pixmap that is inserted as base64 data into a HTML <img> tag


### PR DESCRIPTION
When printing the plan, a print-dialog was created with "new",
but not freed later. Strictly speaking, this is not a leak,
because the dialog is attached to the main-window in Qt's
object hierarchy. Thus it is freed on application exit. On
the other hand, it is a leak in the sense that resources are
pointlessly hogged until application exit.

Let's just turn it into a stack-allocated object.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A (seemingly?) trivial code cleanup: Automatically free the print-dialog after use by making it a stack-allocated object.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - trivial change.