### PR TITLE
build-system: fix AppImage build failure

### DIFF
--- a/.github/workflows/scripts/linux-in-container-build.sh
+++ b/.github/workflows/scripts/linux-in-container-build.sh
@@ -41,7 +41,7 @@ cp /ssllibs/libssl.so appdir/usr/lib/libssl.so.1.1
 cp /ssllibs/libcrypto.so appdir/usr/lib/libcrypto.so.1.1
 
 # get the linuxdeployqt tool and run it to collect the libraries
-curl -L -O "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+curl -L -O "https://github.com/probonopd/linuxdeployqt/releases/download/7/linuxdeployqt-7-x86_64.AppImage"
 chmod a+x linuxdeployqt*.AppImage
 unset QTDIR
 unset QT_PLUGIN_PATH


### PR DESCRIPTION
It's debatable if it makes sense to continue building on Trusty. The AppImage
community moved on to Xenial for a reason. But for now let's just make sure the
CI builds don't all break.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

