### PR TITLE
build-system: build for Ubuntu 21.04 / hirsute as well

### DIFF
--- a/.github/workflows/linux-focal-5.12.yml
+++ b/.github/workflows/linux-focal-5.12.yml
@@ -30,7 +30,7 @@ jobs:
         libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libssl-dev \
         libtool libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make \
         pkg-config qml-module-qtlocation qml-module-qtpositioning \
-        qml-module-qtquick2 qt5-default qt5-qmake qtchooser qtconnectivity5-dev \
+        qml-module-qtquick2 qt5-qmake qtchooser qtconnectivity5-dev \
         qtdeclarative5-dev qtdeclarative5-private-dev qtlocation5-dev \
         qtpositioning5-dev qtscript5-dev qttools5-dev qttools5-dev-tools \
         qtquickcontrols2-5-dev xvfb libbluetooth-dev libmtp-dev

--- a/.github/workflows/linux-hirsute-5.15.yml
+++ b/.github/workflows/linux-hirsute-5.15.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.10 / Qt 5.14--
+name: Ubuntu 21.04 / Qt 5.15--
 on:
   push:
     branches:
@@ -11,7 +11,7 @@ jobs:
   buildUbuntuGroovy:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.10
+      image: ubuntu:21.04
 
     steps:
     - name: checkout sources

--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -110,15 +110,23 @@ cp debian/changelog ../changelog$SUFFIX
 
 debuild -S -d
 
-#create builds for the newer Ubuntu releases that Launchpad supports
+# create builds for the newer Ubuntu releases that Launchpad supports
+#
+# the bionic release is the last that needs the qt5-default package for a successful build,
+# and as of hirsute this package no longer exists. So simply remove it from the control
+# file when building the newer ones
+sed -i.bak "/qt5-default/d" debian/control
 rel=bionic
-others="focal groovy"
+others="focal groovy hirsute"
 for next in $others
 do
 	sed -i "s/${rel}/${next}/g" debian/changelog
 	debuild -S -d
 	rel=$next
 done
+if [ -f debian/control.bak ] ; then
+	mv debian/control.bak debian/control
+fi
 
 cd ..
 


### PR DESCRIPTION
This release drops the qt5-default package - which really wasn't needed since
focal. So just drop it on all of the builds after 18.04 (bionic).


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change
