### PR TITLE
Adding the capability to copy / paste dive number and date / time between dives.

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -685,6 +685,10 @@ PasteState::PasteState(dive *dIn, const dive *data, dive_components what) : d(dI
 	}
 	if (what.weights)
 		copy_weights(&data->weightsystems, &weightsystems);
+	if (what.number)
+		number = data->number;
+	if (what.when)
+		when = data->when;
 }
 
 PasteState::~PasteState()
@@ -725,6 +729,10 @@ void PasteState::swap(dive_components what)
 		std::swap(cylinders, d->cylinders);
 	if (what.weights)
 		std::swap(weightsystems, d->weightsystems);
+	if (what.number)
+		std::swap(number, d->number);
+	if (what.when)
+		std::swap(when, d->when);
 }
 
 // ***** Paste *****
@@ -767,6 +775,8 @@ void PasteDives::undo()
 	fields.chill = what.chill;
 	fields.divesite = what.divesite;
 	fields.tags = what.tags;
+	fields.datetime = what.when;
+	fields.nr = what.number;
 	emit diveListNotifier.divesChanged(divesToNotify, fields);
 	if (what.cylinders)
 		emit diveListNotifier.cylindersReset(divesToNotify);

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -301,6 +301,8 @@ struct PasteState {
 	tag_entry *tags;
 	struct cylinder_table cylinders;
 	struct weightsystem_table weightsystems;
+	int number;
+	timestamp_t when;
 
 	PasteState(dive *d, const dive *data, dive_components what); // Read data from dive data for dive d
 	~PasteState();

--- a/core/dive.c
+++ b/core/dive.c
@@ -336,6 +336,10 @@ void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_compo
 		copy_cylinder_types(s, d);
 	if (what.weights)
 		copy_weights(&s->weightsystems, &d->weightsystems);
+	if (what.number)
+		d->number = s->number;
+	if (what.when)
+		d->when = s->when;
 }
 #undef CONDITIONAL_COPY_STRING
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -90,6 +90,8 @@ struct dive_components {
 	unsigned int tags : 1;
 	unsigned int cylinders : 1;
 	unsigned int weights : 1;
+	unsigned int number : 1;
+	unsigned int when : 1;
 };
 
 extern bool has_gaschange_event(const struct dive *dive, const struct divecomputer *dc, int idx);

--- a/desktop-widgets/divecomponentselection.ui
+++ b/desktop-widgets/divecomponentselection.ui
@@ -137,6 +137,20 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="number">
+        <property name="text">
+            <string>Dive Number</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QCheckBox" name="when">
+        <property name="text">
+            <string>Date / Time</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -312,6 +312,8 @@ DiveComponentSelection::DiveComponentSelection(QWidget *parent, struct dive *tar
 	UI_FROM_COMPONENT(tags);
 	UI_FROM_COMPONENT(cylinders);
 	UI_FROM_COMPONENT(weights);
+	UI_FROM_COMPONENT(number);
+	UI_FROM_COMPONENT(when);
 	connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
 	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
@@ -332,6 +334,8 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		COMPONENT_FROM_UI(tags);
 		COMPONENT_FROM_UI(cylinders);
 		COMPONENT_FROM_UI(weights);
+		COMPONENT_FROM_UI(number);
+		COMPONENT_FROM_UI(when);
 		selective_copy_dive(current_dive, targetDive, *what, true);
 		QClipboard *clipboard = QApplication::clipboard();
 		QTextStream text;
@@ -376,6 +380,10 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 				text << ws.description << ws.weight.grams / 1000 << "kg\n";
 			}
 		}
+		if (what->number)
+			text << tr("Dive number: ") << current_dive->number << "\n";
+		if (what->when)
+			text << tr("Date / time: ") << get_dive_date_string(current_dive->when) << "\n";
 		clipboard->setText(cliptext);
 	}
 }


### PR DESCRIPTION
This is adding the capability to select 'Dive number' and 'Date / Time'
in the 'Copy dive components' dialog, and then copy them into the
clipboard.

![image](https://user-images.githubusercontent.com/4742747/118384953-af59a180-b65e-11eb-853b-500bc65a23fc.png)

When using 'Paste dive components, these values will then be pasted into
the selected dive(s).
This is intended to help with workflows that import dive information
from two different sources, like general information from another
logging program, and CCR ppO2 sensor readings from a unit log, and then
stitch them together into one cohesive entry with all data per dive.
Copied data is also output into formatted text when pasting the
clipboard outside of the application:

```
Dive number: 401
Date / time: Sun 2 May 2021 12:00 AM
```

No translations have been added as of now - I could not find any
information on how strings are translated for this project.

Reported-by: Michael Keller <mikeller@gmail.com>
Signed-off-by: Michael Keller <mikeller@gmail.com>
