### PR TITLE
[TRIVIAL] cleanup: remove double layout name in statswidget.ui

### DIFF
--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -100,7 +100,7 @@
        <property name="title">
         <string>Restriction</string>
        </property>
-       <layout class="QVBoxLayout" name="chartLayout">
+       <layout class="QVBoxLayout" name="restrictionLayout">
         <item>
          <widget class="QLabel" name="restrictionLabel" />
         </item>


### PR DESCRIPTION
This gave an annoying warning.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial duplicate-name fix. Pure code-hygiene.