### PR TITLE
Make the Mac SDK detection in build.sh more robust

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -159,13 +159,13 @@ if [ "$PLATFORM" = Darwin ] ; then
 	# find a 10.x base SDK to use, or if none can be found, find a numbered 11.x base SDK to use
 	BASESDK=$(ls $SDKROOT | grep "MacOSX10\.1.\.sdk" | head -1 | sed -e "s/MacOSX//;s/\.sdk//")
 	if [ -z "$BASESDK" ] ; then
-	  BASESDK=$(ls $SDKROOT | grep -E "MacOSX11\.[0-9]+\.sdk" | head -1 | sed -e "s/MacOSX//;s/\.sdk//")
-	  if [ -z "$BASESDK" ] ; then
-	    echo "Cannot find a base SDK of type 10.x or 11.x under the SDK root of ${SDKROOT}"
-	    exit 1;
-    fi
-  fi
-  echo "Using ${BASESDK} as the BASESDK under ${SDKROOT}"
+		BASESDK=$(ls $SDKROOT | grep -E "MacOSX11\.[0-9]+\.sdk" | head -1 | sed -e "s/MacOSX//;s/\.sdk//")
+		if [ -z "$BASESDK" ] ; then
+			echo "Cannot find a base SDK of type 10.x or 11.x under the SDK root of ${SDKROOT}"
+			exit 1;
+		fi
+	fi
+	echo "Using ${BASESDK} as the BASESDK under ${SDKROOT}"
 
 	OLDER_MAC="-mmacosx-version-min=${BASESDK} -isysroot${SDKROOT}/MacOSX${BASESDK}.sdk"
 	OLDER_MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_SYSROOT=${SDKROOT}/MacOSX${BASESDK}.sdk/"


### PR DESCRIPTION
Update how the SDK is found when building on OS X to make it easier to build on the latest OS X version
with the default SDK versions provided by the command-line tools or XCode 12.5 (while it should still be
compatible with the existing build vms)

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When trying to build on Big Sur, the xcode command-line tools
install are installed in /Library/Developer/CommandLineTools/SDKs,
and as of Xcode 12.5, it does not include a 10.x version
of SDK.

This changes it to search in the location of the command-line tools SDK
for a 10.x version, and if it can't find a 10.x version it will
find an explicit 11.x version of the SDK to use because it is
conceivable that in the near future Apple will stop installing any
10.x SDK's as part of the command-line tool installer.

If the SDK can't be found, the build script will exit now instead
of continuing with an unset BASESDK version that causes a later failure.
### Changes made:
* Search for a developer SDK in the default place that the xcode command-line-tools installs them 
* If a 10.x SDK is not found, try using a numbered 11.x SDK
* Set the `-mmacosx-version-min=` to the value specified by the `BASESDK`
* Exit with an error if an appropriate SDK can't be found

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
There are only developer-facing changes here that make the build process match existing documentation, not
require any new changes.  

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
