### PR TITLE
Add numerus translation for dive context menu

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -813,7 +813,7 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 		}
 	}
 	if (d) {
-		popup.addAction(tr("Delete %n dive(s)","",amount_selected), this, &DiveListView::deleteDive);
+		popup.addAction(tr("Delete dive(s)","",amount_selected), this, &DiveListView::deleteDive);
 		if (d->invalid)
 			popup.addAction(tr("Mark dive(s) valid","",amount_selected), this, &DiveListView::markDiveValid);
 		else

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -779,12 +779,14 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 			popup.addAction(tr("Collapse all"), this, &QTreeView::collapseAll);
 
 		// verify if there`s a need for collapse others
-		if (expanded_nodes > 1)
+		if (expanded_nodes > 1 && d->divetrip)
 			collapseAction = popup.addAction(tr("Collapse others"), this, &QTreeView::collapseAll);
 
 
 		if (d) {
-			popup.addAction(tr("Remove dive(s) from trip"), this, &DiveListView::removeFromTrip);
+			if (d->divetrip) {
+				popup.addAction(tr("Remove dive(s) from trip","",amount_selected), this, &DiveListView::removeFromTrip);
+			}
 			popup.addAction(tr("Create new trip above"), this, &DiveListView::newTripAbove);
 			if (!d->divetrip) {
 				struct dive *top = d;
@@ -800,9 +802,9 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 					}
 				}
 				if (is_trip_before_after(top, (currentOrder == Qt::AscendingOrder)))
-					popup.addAction(tr("Add dive(s) to trip immediately above"), this, &DiveListView::addToTripAbove);
+					popup.addAction(tr("Add dive(s) to trip immediately above","",amount_selected), this, &DiveListView::addToTripAbove);
 				if (is_trip_before_after(bottom, (currentOrder == Qt::DescendingOrder)))
-					popup.addAction(tr("Add dive(s) to trip immediately below"), this, &DiveListView::addToTripBelow);
+					popup.addAction(tr("Add dive(s) to trip immediately below","",amount_selected), this, &DiveListView::addToTripBelow);
 			}
 		}
 		if (trip) {
@@ -811,17 +813,17 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 		}
 	}
 	if (d) {
-		popup.addAction(tr("Delete dive(s)"), this, &DiveListView::deleteDive);
+		popup.addAction(tr("Delete %n dive(s)","",amount_selected), this, &DiveListView::deleteDive);
 		if (d->invalid)
-			popup.addAction(tr("Mark dive(s) valid"), this, &DiveListView::markDiveValid);
+			popup.addAction(tr("Mark dive(s) valid","",amount_selected), this, &DiveListView::markDiveValid);
 		else
-			popup.addAction(tr("Mark dive(s) invalid"), this, &DiveListView::markDiveInvalid);
+			popup.addAction(tr("Mark dive(s) invalid","",amount_selected), this, &DiveListView::markDiveInvalid);
 	}
 	if (amount_selected > 1 && consecutive_selected())
 		popup.addAction(tr("Merge selected dives"), this, &DiveListView::mergeDives);
 	if (amount_selected >= 1) {
-		popup.addAction(tr("Add dive(s) to arbitrary trip"), this, &DiveListView::addDivesToTrip);
-		popup.addAction(tr("Renumber dive(s)"), this, &DiveListView::renumberDives);
+		popup.addAction(tr("Add dive(s) to arbitrary trip","",amount_selected), this, &DiveListView::addDivesToTrip);
+		popup.addAction(tr("Renumber dive(s)","",amount_selected), this, &DiveListView::renumberDives);
 		popup.addAction(tr("Shift dive times"), this, &DiveListView::shiftTimes);
 		popup.addAction(tr("Split selected dives"), this, &DiveListView::splitDives);
 		popup.addAction(tr("Load media from file(s)"), this, &DiveListView::loadImages);


### PR DESCRIPTION
Add numerus translation lookup for the right-click context menu in the dive list to show proper singular/plural text

Committer: Mark Stiebel <mark@stiebel.me>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [X] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Updates to right-click context menu in the dive to enable numerus translations

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Remove dive(s) from trip
2) Add dive(s) ...
3) Renumber dive(s)
4) Also disable "Collapse Others" if the current dive is not in a trip.
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
Fixes #3256

### Release note:
UI fixes to allow singular/plurals forms in dive list context menu
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
