### PR TITLE
documentation: update installation instructions for Ubuntu

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -179,7 +179,7 @@ sudo apt install \
 	qml-module-qtgraphicaleffects qml-module-qtqml-models2 qml-module-qtquick-controls
 
 
-Package names for Ubuntu 20.04
+Package names for Ubuntu 21.04
 
 sudo apt install \
 	autoconf automake cmake g++ git libbluetooth-dev libcrypto++-dev \
@@ -187,7 +187,7 @@ sudo apt install \
 	libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libtool \
 	libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make pkg-config \
 	qml-module-qtlocation qml-module-qtpositioning qml-module-qtquick2 \
-	qt5-default qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
+	qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
 	qtdeclarative5-private-dev qtlocation5-dev qtpositioning5-dev \
 	qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev
 


### PR DESCRIPTION
Apparently, with Ubuntu 21.04 the qt5-default package doesn't
exist anymore. Removing it from the list of installed packages
makes things still work on a freshly installed system.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Finally got myself a new laptop. I had to slightly change the `apt install` list for it to work on a freshly installed Kubuntu.

BTW: I also had to set my name/email in git, otherwise the script fails.