### PR TITLE
Fix removing/renaming events on the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: fix removal/editing of bookmarks on the profile
 export: show progress dialog when exporting to TeX
 printing: use sensible font size even for strange window size
 * Planner: Don't immediately ascent automatically

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -14,14 +14,18 @@
 
 #define DEPTH_NOT_FOUND (-2342)
 
-DiveEventItem::DiveEventItem(QGraphicsItem *parent) : DivePixmapItem(parent),
+DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix, QGraphicsItem *parent) : DivePixmapItem(parent),
 	vAxis(NULL),
 	hAxis(NULL),
 	dataModel(NULL),
-	internalEvent(NULL),
-	dive(NULL)
+	internalEvent(clone_event(ev)),
+	dive(d)
 {
 	setFlag(ItemIgnoresTransformations);
+
+	setupPixmap(lastgasmix);
+	setupToolTipString(lastgasmix);
+	recalculatePos(0);
 }
 
 DiveEventItem::~DiveEventItem()
@@ -52,19 +56,6 @@ void DiveEventItem::setVerticalAxis(DiveCartesianAxis *axis, int speed)
 struct event *DiveEventItem::getEvent()
 {
 	return internalEvent;
-}
-
-void DiveEventItem::setEvent(const struct dive *d, struct event *ev, struct gasmix lastgasmix)
-{
-	if (!ev)
-		return;
-
-	dive = d;
-	free(internalEvent);
-	internalEvent = clone_event(ev);
-	setupPixmap(lastgasmix);
-	setupToolTipString(lastgasmix);
-	recalculatePos(0);
 }
 
 void DiveEventItem::setupPixmap(struct gasmix lastgasmix)

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -14,10 +14,12 @@
 
 #define DEPTH_NOT_FOUND (-2342)
 
-DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix, QGraphicsItem *parent) : DivePixmapItem(parent),
-	vAxis(NULL),
-	hAxis(NULL),
-	dataModel(NULL),
+DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix,
+			     DivePlotDataModel *model, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
+			     int speed, QGraphicsItem *parent) : DivePixmapItem(parent),
+	vAxis(vAxis),
+	hAxis(hAxis),
+	dataModel(model),
 	internalEvent(clone_event(ev)),
 	dive(d)
 {
@@ -26,31 +28,15 @@ DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasm
 	setupPixmap(lastgasmix);
 	setupToolTipString(lastgasmix);
 	recalculatePos(0);
+
+
+	connect(vAxis, &DiveCartesianAxis::sizeChanged, this,
+		[speed, this] { recalculatePos(speed); });
 }
 
 DiveEventItem::~DiveEventItem()
 {
 	free(internalEvent);
-}
-
-void DiveEventItem::setHorizontalAxis(DiveCartesianAxis *axis)
-{
-	hAxis = axis;
-	recalculatePos(0);
-}
-
-void DiveEventItem::setModel(DivePlotDataModel *model)
-{
-	dataModel = model;
-	recalculatePos(0);
-}
-
-void DiveEventItem::setVerticalAxis(DiveCartesianAxis *axis, int speed)
-{
-	vAxis = axis;
-	recalculatePos(0);
-	connect(vAxis, &DiveCartesianAxis::sizeChanged, this,
-		[speed, this] { recalculatePos(speed); });
 }
 
 struct event *DiveEventItem::getEvent()

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -11,7 +11,9 @@ struct event;
 class DiveEventItem : public DivePixmapItem {
 	Q_OBJECT
 public:
-	DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix, QGraphicsItem *parent = 0);
+	DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix,
+		      DivePlotDataModel *model, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
+		      int speed, QGraphicsItem *parent = nullptr);
 	~DiveEventItem();
 	struct event *getEvent();
 	void eventVisibilityChanged(const QString &eventName, bool visible);

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -11,9 +11,8 @@ struct event;
 class DiveEventItem : public DivePixmapItem {
 	Q_OBJECT
 public:
-	DiveEventItem(QGraphicsItem *parent = 0);
+	DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix, QGraphicsItem *parent = 0);
 	~DiveEventItem();
-	void setEvent(const struct dive *d, struct event *ev, struct gasmix lastgasmix);
 	struct event *getEvent();
 	void eventVisibilityChanged(const QString &eventName, bool visible);
 	void setVerticalAxis(DiveCartesianAxis *axis, int speed);

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -15,7 +15,8 @@ public:
 		      DivePlotDataModel *model, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
 		      int speed, QGraphicsItem *parent = nullptr);
 	~DiveEventItem();
-	struct event *getEvent();
+	const struct event *getEvent() const;
+	struct event *getEventMutable();
 	void eventVisibilityChanged(const QString &eventName, bool visible);
 	void setVerticalAxis(DiveCartesianAxis *axis, int speed);
 	void setHorizontalAxis(DiveCartesianAxis *axis);
@@ -32,7 +33,7 @@ private:
 	DiveCartesianAxis *vAxis;
 	DiveCartesianAxis *hAxis;
 	DivePlotDataModel *dataModel;
-	struct event *internalEvent;
+	struct event *ev;
 	const struct dive *dive;
 };
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -725,10 +725,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 		// printMode is always selected for SUBSURFACE_MOBILE due to font problems
 		// BUT events are wanted.
 #endif
-		DiveEventItem *item = new DiveEventItem(d, event, lastgasmix);
-		item->setHorizontalAxis(timeAxis);
-		item->setVerticalAxis(profileYAxis, qPrefDisplay::animation_speed());
-		item->setModel(dataModel);
+		DiveEventItem *item = new DiveEventItem(d, event, lastgasmix, dataModel, timeAxis, profileYAxis, animSpeed);
 		item->setZValue(2);
 #ifndef SUBSURFACE_MOBILE
 		item->setScale(printMode ? 4 :1);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1419,7 +1419,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 	if (DiveEventItem *item = dynamic_cast<DiveEventItem *>(sceneItem)) {
 		m.addAction(tr("Remove event"), [this,item] { removeEvent(item); });
 		m.addAction(tr("Hide similar events"), [this, item] { hideEvents(item); });
-		struct event *dcEvent = item->getEvent();
+		const struct event *dcEvent = item->getEvent();
 		if (dcEvent->type == SAMPLE_EVENT_BOOKMARK)
 			m.addAction(tr("Edit name"), [this, item] { editName(item); });
 #if 0 // TODO::: FINISH OR DISABLE
@@ -1496,7 +1496,7 @@ void ProfileWidget2::makeFirstDC()
 
 void ProfileWidget2::hideEvents(DiveEventItem *item)
 {
-	struct event *event = item->getEvent();
+	const struct event *event = item->getEvent();
 
 	if (QMessageBox::question(this,
 				  TITLE_OR_TEXT(tr("Hide events"), tr("Hide all %1 events?").arg(event->name)),
@@ -1529,7 +1529,7 @@ void ProfileWidget2::unhideEvents()
 
 void ProfileWidget2::removeEvent(DiveEventItem *item)
 {
-	struct event *event = item->getEvent();
+	struct event *event = item->getEventMutable();
 	if (!event || !d)
 		return;
 
@@ -1622,7 +1622,7 @@ double ProfileWidget2::getFontPrintScale() const
 #ifndef SUBSURFACE_MOBILE
 void ProfileWidget2::editName(DiveEventItem *item)
 {
-	struct event *event = item->getEvent();
+	struct event *event = item->getEventMutable();
 	if (!event || !d)
 		return;
 	bool ok;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -725,11 +725,10 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 		// printMode is always selected for SUBSURFACE_MOBILE due to font problems
 		// BUT events are wanted.
 #endif
-		DiveEventItem *item = new DiveEventItem();
+		DiveEventItem *item = new DiveEventItem(d, event, lastgasmix);
 		item->setHorizontalAxis(timeAxis);
 		item->setVerticalAxis(profileYAxis, qPrefDisplay::animation_speed());
 		item->setModel(dataModel);
-		item->setEvent(d, event, lastgasmix);
 		item->setZValue(2);
 #ifndef SUBSURFACE_MOBILE
 		item->setScale(printMode ? 4 :1);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Moving/renaming events was broken, because an internal copy of the event was passed to the undo-code. It is mysterious how this ever worked, but I'm quite sure that at one point it did...!?

Replace the internal copy with a pointer. By now (removal of displayed_dive, etc.), this should be safe.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Pass event, model, axes at construction time of DiveEventItem, to avoid having to deal with partially constructed objects.
2) Remove internalEvent.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
All the profile changes.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

@willemferguson: please check / comment.