### PR TITLE
[TRIVIAL?] cleanup: remove dead code in ToolTipItem::refresh()

### DIFF
--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -244,9 +244,6 @@ void ToolTipItem::refresh(const dive *d, const QPointF &pos, bool inPlanner)
 	painter.setBrush(QColor(Qt::red));
 	painter.drawRect(0,0,16,10);
 	if (idx) {
-		ProfileWidget2 *view = qobject_cast<ProfileWidget2*>(scene()->views().first());
-		Q_ASSERT(view);
-
 		const struct plot_data *entry = &pInfo.entry[idx];
 		painter.setPen(QColor(0, 0, 0, 255));
 		if (decoMode(inPlanner) == BUEHLMANN)


### PR DESCRIPTION
The code was downcasting the QGraphicsScene to ProfileWidget2,
but then didn't use the result. *shrug*

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
An apparently trivial code cleanup: remove a downcast that is not used afterwards.

Please check.
