### PR TITLE
profile: scale dive event items according to font print scale

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -16,7 +16,7 @@
 
 DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix,
 			     DivePlotDataModel *model, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
-			     int speed, QGraphicsItem *parent) : DivePixmapItem(parent),
+			     int speed, double fontPrintScale, QGraphicsItem *parent) : DivePixmapItem(parent),
 	vAxis(vAxis),
 	hAxis(hAxis),
 	dataModel(model),
@@ -25,7 +25,7 @@ DiveEventItem::DiveEventItem(const struct dive *d, struct event *ev, struct gasm
 {
 	setFlag(ItemIgnoresTransformations);
 
-	setupPixmap(lastgasmix);
+	setupPixmap(lastgasmix, fontPrintScale);
 	setupToolTipString(lastgasmix);
 	recalculatePos(0);
 
@@ -48,7 +48,7 @@ struct event *DiveEventItem::getEventMutable()
 	return ev;
 }
 
-void DiveEventItem::setupPixmap(struct gasmix lastgasmix)
+void DiveEventItem::setupPixmap(struct gasmix lastgasmix, double fontPrintScale)
 {
 	const IconMetrics& metrics = defaultIconMetrics();
 #ifndef SUBSURFACE_MOBILE
@@ -63,6 +63,7 @@ void DiveEventItem::setupPixmap(struct gasmix lastgasmix)
 	int sz_bigger = metrics.sz_big + metrics.sz_med;
 #endif
 #endif
+	sz_bigger = lrint(sz_bigger * fontPrintScale);
 	int sz_pix = sz_bigger/2; // ex 20px
 
 #define EVENT_PIXMAP(PIX) QPixmap(QString(PIX)).scaled(sz_pix, sz_pix, Qt::KeepAspectRatio, Qt::SmoothTransformation)

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -13,7 +13,7 @@ class DiveEventItem : public DivePixmapItem {
 public:
 	DiveEventItem(const struct dive *d, struct event *ev, struct gasmix lastgasmix,
 		      DivePlotDataModel *model, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
-		      int speed, QGraphicsItem *parent = nullptr);
+		      int speed, double fontPrintScale, QGraphicsItem *parent = nullptr);
 	~DiveEventItem();
 	const struct event *getEvent() const;
 	struct event *getEventMutable();
@@ -28,7 +28,7 @@ slots:
 
 private:
 	void setupToolTipString(struct gasmix lastgasmix);
-	void setupPixmap(struct gasmix lastgasmix);
+	void setupPixmap(struct gasmix lastgasmix, double fontPrintScale);
 	int depthAtTime(int time);
 	DiveCartesianAxis *vAxis;
 	DiveCartesianAxis *hAxis;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -719,7 +719,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 		// printMode is always selected for SUBSURFACE_MOBILE due to font problems
 		// BUT events are wanted.
 #endif
-		DiveEventItem *item = new DiveEventItem(d, event, lastgasmix, dataModel, timeAxis, profileYAxis, animSpeed);
+		DiveEventItem *item = new DiveEventItem(d, event, lastgasmix, dataModel, timeAxis, profileYAxis, animSpeed, getFontPrintScale());
 		item->setZValue(2);
 #ifndef SUBSURFACE_MOBILE
 		item->setScale(printMode ? 4 :1);


### PR DESCRIPTION
When printing with low DPI, the dive event items become comically
large, because they are not resized like the fonts. Therefore,
scale using the fontPrintScale.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
There are numerous reports of wrongly scaled event items. I cannot really reproduce them, with the one exception being very small DPI values. This quick-fix attempts to scale the event items according to the "fontPrintScale".

But I fear that there is something wrong with the size calculation. Selecting 100 DPI make the printout unreadable. I will try to dig deeper. If 100 DPI is really *that* bad, we should think about limiting the lower value to perhaps 300 DPI?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Scale dive event items according to fontPrintScale.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

First, we need confirmation that this really fixes something.
