### PR TITLE
[TRIVIAL] cleanup: remove Printer::dpi member variable

### DIFF
--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -21,8 +21,7 @@ Printer::Printer(QPaintDevice *paintDevice, const print_options &printOptions, c
 	templateOptions(templateOptions),
 	printMode(printMode),
 	inPlanner(inPlanner),
-	done(0),
-	dpi(0)
+	done(0)
 {
 }
 
@@ -227,7 +226,7 @@ void Printer::print()
 
 	TemplateLayout t(printOptions, templateOptions);
 	connect(&t, SIGNAL(progressUpdated(int)), this, SLOT(templateProgessUpdated(int)));
-	dpi = printerPtr->resolution();
+	int dpi = printerPtr->resolution();
 	//rendering resolution = selected paper size in inchs * printer dpi
 	pageSize.setHeight(qCeil(printerPtr->pageRect(QPrinter::Inch).height() * dpi));
 	pageSize.setWidth(qCeil(printerPtr->pageRect(QPrinter::Inch).width() * dpi));

--- a/desktop-widgets/printer.h
+++ b/desktop-widgets/printer.h
@@ -29,7 +29,6 @@ private:
 	PrintMode printMode;
 	bool inPlanner;
 	int done;
-	int dpi;
 	void render(int Pages);
 	void flowRender();
 	void putProfileImage(const QRect &box, const QRect &viewPort, QPainter *painter,


### PR DESCRIPTION
This variable is not used outside a single function, where it
is reset every time the function runs. This can be realized by
a function-local variable just as well.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another one of the numerous trivial code cleanups in the profile/printing code. Removes an unused member variable.

I'll wait for CI and then commit unless someone complains.