### PR TITLE
cleanup: avoid potential crash accessing invalid cylinder

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -1424,9 +1424,16 @@ static void plot_string(const struct dive *d, const struct plot_info *pi, int id
 		int mbar = get_plot_pressure(pi, idx, cyl);
 		if (!mbar)
 			continue;
-		struct gasmix mix = get_cylinder(d, cyl)->gasmix;
-		pressurevalue = get_pressure_units(mbar, &pressure_unit);
-		put_format_loc(b, translate("gettextFromC", "P: %d%s (%s)\n"), pressurevalue, pressure_unit, gasname(mix));
+		// one would assume that there always is such a cylinder, but users have seen
+		// crashes when this got dereferenced, so let's check there's actually a cylinder there
+		cylinder_t *cylinder = get_cylinder(d, cyl);
+		if (cylinder) {
+			struct gasmix mix = cylinder->gasmix;
+			pressurevalue = get_pressure_units(mbar, &pressure_unit);
+			put_format_loc(b, translate("gettextFromC", "P: %d%s (%s)\n"), pressurevalue, pressure_unit, gasname(mix));
+		} else {
+			fprintf(stderr, "plot_string: failed to access cylinder %d\n", cyl);
+		}
 	}
 	if (entry->temperature) {
 		tempvalue = get_temp_units(entry->temperature, &temp_unit);


### PR DESCRIPTION
This shouldn't happen if the plot_info and dive are in sync, yet we have
seen reports where a user could reproduce a crash in this call. The
added check shouldn't hurt and the warning might help us figure out
what's going wrong.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
This does seem strange, but... I also think that it wouldn't hurt. And a crash is a sucky experience for a user.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Simply check the cylinder pointer we get back before dereferencing it.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3278 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
not sure that's worth an entry

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
no

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @atdotde - am I going overboard here? Fixing the wrong thing?