### PR TITLE
sanitize cylinder-ids of pressure samples

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1208,6 +1208,17 @@ static void fixup_no_o2sensors(struct divecomputer *dc)
 	}
 }
 
+static void fixup_dc_sample_sensors(struct divecomputer *dc, int nr_cylinders)
+{
+	for (int i = 0; i < dc->samples; i++) {
+		struct sample *s = dc->sample + i;
+		for (int j = 0; j < MAX_SENSORS; j++) {
+			if (s->sensor[j] < 0 || s->sensor[j] >= nr_cylinders)
+				s->sensor[j] = -1;
+		}
+	}
+}
+
 static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 {
 	/* Fixup duration and mean depth */
@@ -1227,6 +1238,9 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 
 	/* Fix up cylinder pressures based on DC info */
 	fixup_dive_pressures(dive, dc);
+
+	/* Fix up cylinder ids in pressure sensors */
+	fixup_dc_sample_sensors(dc, dive->cylinders.nr);
 
 	fixup_dc_events(dc);
 

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -642,6 +642,14 @@ static char *parse_sample_unit(struct sample *sample, double val, char *unit)
 }
 
 /*
+ * If the given cylinder doesn't exist, return -1 as a "none" marker.
+ */
+static int sanitize_cylinder_id(const struct dive *d, int nr)
+{
+	return d && nr >=0 && nr < d->cylinders.nr ? nr : -1;
+}
+
+/*
  * By default the sample data does not change unless the
  * save-file gives an explicit new value. So we copy the
  * data from the previous sample if one exists, and then
@@ -667,8 +675,8 @@ static struct sample *new_sample(struct git_parser_state *state)
 		sample->pressure[0].mbar = 0;
 		sample->pressure[1].mbar = 0;
 	} else {
-		sample->sensor[0] = !state->o2pressure_sensor;
-		sample->sensor[1] = state->o2pressure_sensor;
+		sample->sensor[0] = sanitize_cylinder_id(state->active_dive, !state->o2pressure_sensor);
+		sample->sensor[1] = sanitize_cylinder_id(state->active_dive, state->o2pressure_sensor);
 	}
 	return sample;
 }

--- a/core/parse.c
+++ b/core/parse.c
@@ -365,6 +365,14 @@ void ws_end(struct parser_state *state)
 }
 
 /*
+ * If the given cylinder doesn't exist, return -1 as a "none" marker.
+ */
+static int sanitize_cylinder_id(const struct dive *d, int nr)
+{
+	return d && nr >=0 && nr < d->cylinders.nr ? nr : -1;
+}
+
+/*
  * By default the sample data does not change unless the
  * save-file gives an explicit new value. So we copy the
  * data from the previous sample if one exists, and then
@@ -392,8 +400,8 @@ void sample_start(struct parser_state *state)
 		sample->pressure[0].mbar = 0;
 		sample->pressure[1].mbar = 0;
 	} else {
-		sample->sensor[0] = !state->o2pressure_sensor;
-		sample->sensor[1] = state->o2pressure_sensor;
+		sample->sensor[0] = sanitize_cylinder_id(state->cur_dive, !state->o2pressure_sensor);
+		sample->sensor[1] = sanitize_cylinder_id(state->cur_dive, state->o2pressure_sensor);
 	}
 	state->cur_sample = sample;
 	state->next_o2_sensor = 0;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes long-standing out-of-bound accesses
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
The two pressure-sensor values of samples were initialized to 0 and 1 by default. However, many dives don't have two cylinders. This produces out-of-bound accesses in the merging code. They were completely harmless as long as there was a fixed-size cylinder table. With the dynamic cylinder table, this can, at least theoretically, lead to crashes (access past a virtual memory page? I don't understand anything of that.).

This PR tries to fix that by sanitizing the cylinder ids in the parsers and in `fixup_dive()`. It is completely untested and will of course lead to massive breakage of the parsing tests.
