### PR TITLE
sanitize cylinder-ids of the pressure-sensors

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1208,6 +1208,17 @@ static void fixup_no_o2sensors(struct divecomputer *dc)
 	}
 }
 
+static void fixup_dc_sample_sensors(struct divecomputer *dc, int nr_cylinders)
+{
+	for (int i = 0; i < dc->samples; i++) {
+		struct sample *s = dc->sample + i;
+		for (int j = 0; j < MAX_SENSORS; j++) {
+			if (s->sensor[j] < 0 || s->sensor[j] >= nr_cylinders)
+				s->sensor[j] = NO_SENSOR;
+		}
+	}
+}
+
 static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 {
 	/* Fixup duration and mean depth */
@@ -1227,6 +1238,9 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 
 	/* Fix up cylinder pressures based on DC info */
 	fixup_dive_pressures(dive, dc);
+
+	/* Fix up cylinder ids in pressure sensors */
+	fixup_dc_sample_sensors(dc, dive->cylinders.nr);
 
 	fixup_dc_events(dc);
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -1657,9 +1657,10 @@ static void sample_renumber(struct sample *s, int i, const int mapping[])
 	int j;
 
 	for (j = 0; j < MAX_SENSORS; j++) {
-		int sensor;
+		int sensor = -1;
 
-		sensor = mapping[s->sensor[j]];
+		if (s->sensor[j] != NO_SENSOR)
+			sensor = mapping[s->sensor[j]];
 		if (sensor == -1) {
 			// Remove sensor and gas pressure info
 			if (i == 0) {

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -642,6 +642,14 @@ static char *parse_sample_unit(struct sample *sample, double val, char *unit)
 }
 
 /*
+ * If the given cylinder doesn't exist, return NO_SENSOR.
+ */
+static uint8_t sanitize_sensor_id(const struct dive *d, int nr)
+{
+	return d && nr >= 0 && nr < d->cylinders.nr ? nr : NO_SENSOR;
+}
+
+/*
  * By default the sample data does not change unless the
  * save-file gives an explicit new value. So we copy the
  * data from the previous sample if one exists, and then
@@ -667,8 +675,8 @@ static struct sample *new_sample(struct git_parser_state *state)
 		sample->pressure[0].mbar = 0;
 		sample->pressure[1].mbar = 0;
 	} else {
-		sample->sensor[0] = !state->o2pressure_sensor;
-		sample->sensor[1] = state->o2pressure_sensor;
+		sample->sensor[0] = sanitize_sensor_id(state->active_dive, !state->o2pressure_sensor);
+		sample->sensor[1] = sanitize_sensor_id(state->active_dive, state->o2pressure_sensor);
 	}
 	return sample;
 }

--- a/core/parse.c
+++ b/core/parse.c
@@ -365,6 +365,14 @@ void ws_end(struct parser_state *state)
 }
 
 /*
+ * If the given cylinder doesn't exist, return NO_SENSOR.
+ */
+static uint8_t sanitize_sensor_id(const struct dive *d, int nr)
+{
+	return d && nr >= 0 && nr < d->cylinders.nr ? nr : NO_SENSOR;
+}
+
+/*
  * By default the sample data does not change unless the
  * save-file gives an explicit new value. So we copy the
  * data from the previous sample if one exists, and then
@@ -392,8 +400,8 @@ void sample_start(struct parser_state *state)
 		sample->pressure[0].mbar = 0;
 		sample->pressure[1].mbar = 0;
 	} else {
-		sample->sensor[0] = !state->o2pressure_sensor;
-		sample->sensor[1] = state->o2pressure_sensor;
+		sample->sensor[0] = sanitize_sensor_id(state->cur_dive, !state->o2pressure_sensor);
+		sample->sensor[1] = sanitize_sensor_id(state->cur_dive, state->o2pressure_sensor);
 	}
 	state->cur_sample = sample;
 	state->next_o2_sensor = 0;

--- a/core/profile.c
+++ b/core/profile.c
@@ -566,9 +566,9 @@ static void populate_plot_entries(const struct dive *dive, const struct divecomp
 		} else {
 			entry->pressures.o2 = sample->setpoint.mbar / 1000.0;
 		}
-		if (sample->pressure[0].mbar)
+		if (sample->pressure[0].mbar && sample->sensor[0] != NO_SENSOR)
 			set_plot_pressure_data(pi, idx, SENSOR_PR, sample->sensor[0], sample->pressure[0].mbar);
-		if (sample->pressure[1].mbar)
+		if (sample->pressure[1].mbar && sample->sensor[1] != NO_SENSOR)
 			set_plot_pressure_data(pi, idx, SENSOR_PR, sample->sensor[1], sample->pressure[1].mbar);
 		if (sample->temperature.mkelvin)
 			entry->temperature = lasttemp = sample->temperature.mkelvin;

--- a/core/sample.h
+++ b/core/sample.h
@@ -9,6 +9,8 @@ extern "C" {
 #endif
 
 #define MAX_SENSORS 2
+#define NO_SENSOR ((uint8_t)-1)
+
 struct sample                         // BASE TYPE BYTES  UNITS    RANGE               DESCRIPTION
 {                                     // --------- -----  -----    -----               -----------
 	duration_t time;                  // int32_t    4  seconds  (0-34 yrs)             elapsed dive time up to this sample
@@ -23,7 +25,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
 	o2pressure_t o2sensor[3];         // uint16_t   6    mbar   (0-65 bar)             Up to 3 PO2 sensor values (rebreather)
 	bearing_t bearing;                // int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
-	uint8_t sensor[MAX_SENSORS];      // uint8_t    1  sensorID (0-255)                ID of cylinder pressure sensor
+	uint8_t sensor[MAX_SENSORS];      // uint8_t    1  sensorID (0-254)                ID of cylinder pressure sensor
 	uint16_t cns;                     // uint16_t   1     %     (0-64k %)              cns% accumulated
 	uint8_t heartbeat;                // uint8_t    1  beats/m  (0-255)                heart rate measurement
 	volume_t sac;                     //            4  ml/min                          predefined SAC


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes long-standing out-of-bound accesses

The two pressure-sensor values of samples were initialized to 0 and 1 by default. However, many dives don't have two cylinders. This produces out-of-bound accesses in the merging code. They were completely harmless as long as there was a fixed-size cylinder table. With the dynamic cylinder table, this can, at least theoretically, lead to crashes (access past a virtual memory page? I don't understand anything of that.).

This PR tries to fix that by sanitizing the cylinder ids in the parsers and in fixup_dive(). It is completely untested and will of course lead to massive breakage of the parsing tests.

Running TestMerge with valgrind before this PR:

```
==124687== Memcheck, a memory error detector
==124687== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==124687== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==124687== Command: ./tests/TestMerge
==124687== 
********* Start testing of TestMerge *********
Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.3.0), ubuntu 21.04
PASS   : TestMerge::initTestCase()
==124687== Invalid read of size 4
==124687==    at 0x1F868A: sample_renumber (dive.c:1662)
==124687==    by 0x1F8F59: dc_cylinder_renumber (dive.c:1704)
==124687==    by 0x1F9228: copy_dc_renumber (dive.c:210)
==124687==    by 0x1F9228: join_dive_computers (dive.c:2510)
==124687==    by 0x1FB745: merge_dives (dive.c:2617)
==124687==    by 0x1FC358: try_to_merge (dive.c:2340)
==124687==    by 0x17615C: try_to_merge_into (divelist.c:889)
==124687==    by 0x17615C: merge_dive_tables (divelist.c:970)
==124687==    by 0x176832: process_imported_dives (divelist.c:1275)
==124687==    by 0x17698B: add_imported_dives (divelist.c:1007)
==124687==    by 0x172964: TestMerge::testMergeEmpty() (testmerge.cpp:36)
==124687==    by 0x8F57D9A: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.2)
==124687==    by 0x8C56552: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C56FFB: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==  Address 0xdf3d004 is 0 bytes after a block of size 4 alloc'd
==124687==    at 0x4842839: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==124687==    by 0x1FB194: merge_dives (dive.c:2606)
==124687==    by 0x1FC358: try_to_merge (dive.c:2340)
==124687==    by 0x17615C: try_to_merge_into (divelist.c:889)
==124687==    by 0x17615C: merge_dive_tables (divelist.c:970)
==124687==    by 0x176832: process_imported_dives (divelist.c:1275)
==124687==    by 0x17698B: add_imported_dives (divelist.c:1007)
==124687==    by 0x172964: TestMerge::testMergeEmpty() (testmerge.cpp:36)
==124687==    by 0x8F57D9A: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.2)
==124687==    by 0x8C56552: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C56FFB: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C575E3: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C57B33: QTest::qRun() (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687== 
PASS   : TestMerge::testMergeEmpty()
==124687== Invalid read of size 4
==124687==    at 0x1F868A: sample_renumber (dive.c:1662)
==124687==    by 0x1F8F59: dc_cylinder_renumber (dive.c:1704)
==124687==    by 0x1F9305: copy_dc_renumber (dive.c:210)
==124687==    by 0x1F9305: join_dive_computers (dive.c:2514)
==124687==    by 0x1FB745: merge_dives (dive.c:2617)
==124687==    by 0x1FC358: try_to_merge (dive.c:2340)
==124687==    by 0x1760EB: try_to_merge_into (divelist.c:889)
==124687==    by 0x1760EB: merge_dive_tables (divelist.c:957)
==124687==    by 0x176832: process_imported_dives (divelist.c:1275)
==124687==    by 0x17698B: add_imported_dives (divelist.c:1007)
==124687==    by 0x173494: TestMerge::testMergeBackwards() (testmerge.cpp:64)
==124687==    by 0x8F57D9A: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.2)
==124687==    by 0x8C56552: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C56FFB: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==  Address 0xdf58234 is 0 bytes after a block of size 4 alloc'd
==124687==    at 0x4842839: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==124687==    by 0x1FB1A9: merge_dives (dive.c:2607)
==124687==    by 0x1FC358: try_to_merge (dive.c:2340)
==124687==    by 0x1760EB: try_to_merge_into (divelist.c:889)
==124687==    by 0x1760EB: merge_dive_tables (divelist.c:957)
==124687==    by 0x176832: process_imported_dives (divelist.c:1275)
==124687==    by 0x17698B: add_imported_dives (divelist.c:1007)
==124687==    by 0x173494: TestMerge::testMergeBackwards() (testmerge.cpp:64)
==124687==    by 0x8F57D9A: QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.2)
==124687==    by 0x8C56552: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C56FFB: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C575E3: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687==    by 0x8C57B33: QTest::qRun() (in /usr/lib/x86_64-linux-gnu/libQt5Test.so.5.15.2)
==124687== 
PASS   : TestMerge::testMergeBackwards()
PASS   : TestMerge::cleanupTestCase()
Totals: 4 passed, 0 failed, 0 skipped, 0 blacklisted, 1054ms
********* Finished testing of TestMerge *********
==124687== 
==124687== HEAP SUMMARY:
==124687==     in use at exit: 197,197 bytes in 1,162 blocks
==124687==   total heap usage: 10,085 allocs, 8,923 frees, 1,152,426 bytes allocated
==124687== 
==124687== LEAK SUMMARY:
==124687==    definitely lost: 4,608 bytes in 12 blocks
==124687==    indirectly lost: 0 bytes in 0 blocks
==124687==      possibly lost: 544 bytes in 1 blocks
==124687==    still reachable: 190,029 bytes in 1,128 blocks
==124687==         suppressed: 0 bytes in 0 blocks
==124687== Rerun with --leak-check=full to see details of leaked memory
==124687== 
==124687== For lists of detected and suppressed errors, rerun with: -s
==124687== ERROR SUMMARY: 12 errors from 2 contexts (suppressed: 0 from 0)
```
and after:
```
==134765== Memcheck, a memory error detector
==134765== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==134765== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==134765== Command: ./tests/TestMerge
==134765== 
********* Start testing of TestMerge *********
Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.3.0), ubuntu 21.04
PASS   : TestMerge::initTestCase()
PASS   : TestMerge::testMergeEmpty()
PASS   : TestMerge::testMergeBackwards()
PASS   : TestMerge::cleanupTestCase()
Totals: 4 passed, 0 failed, 0 skipped, 0 blacklisted, 1233ms
********* Finished testing of TestMerge *********
==134765== 
==134765== HEAP SUMMARY:
==134765==     in use at exit: 197,149 bytes in 1,162 blocks
==134765==   total heap usage: 10,095 allocs, 8,933 frees, 1,153,866 bytes allocated
==134765== 
==134765== LEAK SUMMARY:
==134765==    definitely lost: 4,608 bytes in 12 blocks
==134765==    indirectly lost: 0 bytes in 0 blocks
==134765==      possibly lost: 544 bytes in 1 blocks
==134765==    still reachable: 189,981 bytes in 1,128 blocks
==134765==         suppressed: 0 bytes in 0 blocks
==134765== Rerun with --leak-check=full to see details of leaked memory
==134765== 
==134765== For lists of detected and suppressed errors, rerun with: -s
==134765== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create a new NO_SENSOR value for the `sensor` member of `struct sample`.
2) Sanitize sensor IDs.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Second attempt of #3283.

