### PR TITLE
cleanup: remove function static variables

### DIFF
--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -131,6 +131,8 @@ void ToolTipItem::expand()
 ToolTipItem::ToolTipItem(QGraphicsItem *parent) : RoundRectItem(8.0, parent),
 	title(new QGraphicsSimpleTextItem(tr("Information"), this)),
 	status(COLLAPSED),
+	tissues(16,60),
+	painter(&tissues),
 	timeAxis(0),
 	lastTime(-1)
 {
@@ -219,8 +221,6 @@ void ToolTipItem::setTimeAxis(DiveCartesianAxis *axis)
 
 void ToolTipItem::refresh(const dive *d, const QPointF &pos, bool inPlanner)
 {
-	static QPixmap tissues(16,60);
-	static QPainter painter(&tissues);
 	static struct membuffer mb = {};
 
 	if(refreshTime.elapsed() < 40)

--- a/profile-widget/divetooltipitem.h
+++ b/profile-widget/divetooltipitem.h
@@ -7,6 +7,7 @@
 #include <QRectF>
 #include <QIcon>
 #include <QElapsedTimer>
+#include <QPainter>
 #include "backend-shared/roundrectitem.h"
 #include "core/display.h"
 
@@ -48,6 +49,8 @@ private:
 	ToolTip entryToolTip;
 	QGraphicsSimpleTextItem *title;
 	Status status;
+	QPixmap tissues;
+	QPainter painter;
 	QRectF rectangle;
 	QRectF nextRectangle;
 	DiveCartesianAxis *timeAxis;


### PR DESCRIPTION
There were two function-static variables in ToolTipItem::refresh(),
which is a very scary proposition. Curently, there is only
one ToolTipItem, but this may change on mobile, where there
are multiple profiles at the same time.

Remove this timebomb and make the two objects subobjects.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removes a dangerous construct: two function-static objects. This might give hard to trackdown issues, when there are multiple ToolTipItems.

[Editorial note: static variables are _not_ allocated on the stack, as was stated in the commit message of the commit adding these variables]

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Turn static variables into member objects.
