### PR TITLE
Add add C++-version of membuffer that automatically cleans up itself when going out of scope

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -86,7 +86,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/divesite.c \
 	core/equipment.c \
 	core/gas.c \
-	core/membuffer.c \
+	core/membuffer.cpp \
 	core/selection.cpp \
 	core/sha1.c \
 	core/string-format.cpp \

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -65,7 +65,7 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 	int i;
 	bool need_pagebreak = false;
 
-	struct membuffer buf = {};
+	struct membufferpp buf;
 
 	if (plain) {
 		ssrf = "";
@@ -253,7 +253,6 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 		flush_buffer(&buf, f); /*check for writing errors? */
 		fclose(f);
 	}
-	free_buffer(&buf);
 	cb.setProgress(1000);
 }
 
@@ -265,7 +264,7 @@ void export_depths(const char *filename, bool selected_only)
 	int i;
 	const char *unit = NULL;
 
-	struct membuffer buf = {};
+	struct membufferpp buf;
 
 	for_each_dive (i, dive) {
 		if (selected_only && !dive->selected)
@@ -291,7 +290,6 @@ void export_depths(const char *filename, bool selected_only)
 		flush_buffer(&buf, f); /*check for writing errors? */
 		fclose(f);
 	}
-	free_buffer(&buf);
 }
 #endif /* ! SUBSURFACE_MOBILE */
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -122,7 +122,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	libdivecomputer.h
 	liquivision.c
 	load-git.c
-	membuffer.c
+	membuffer.cpp
 	membuffer.h
 	metadata.cpp
 	metadata.h

--- a/core/divesitehelpers.cpp
+++ b/core/divesitehelpers.cpp
@@ -9,7 +9,6 @@
 #include "errorhelper.h"
 #include "subsurface-string.h"
 #include "qthelper.h"
-#include "membuffer.h"
 #include <QDebug>
 #include <QJsonDocument>
 #include <QJsonArray>

--- a/core/format.cpp
+++ b/core/format.cpp
@@ -397,7 +397,6 @@ int vasprintf_loc(char **dst, const char *cformat, va_list ap)
 	return utf8.size();
 }
 
-// This function is defined here instead of membuffer.c, because it needs to access QString.
 extern "C" void put_vformat_loc(struct membuffer *b, const char *fmt, va_list args)
 {
 	QByteArray utf8 = vqasprintf_loc(fmt, args).toUtf8();
@@ -408,4 +407,3 @@ extern "C" void put_vformat_loc(struct membuffer *b, const char *fmt, va_list ar
 	memcpy(b->buffer + b->len, data, utf8_size);
 	b->len += utf8_size;
 }
-

--- a/core/membuffer.cpp
+++ b/core/membuffer.cpp
@@ -12,6 +12,16 @@
 #include "units.h"
 #include "membuffer.h"
 
+membufferpp::membufferpp()
+	: membuffer{0, 0, nullptr}
+{
+}
+
+membufferpp::~membufferpp()
+{
+	free_buffer(this);
+}
+
 /* Only for internal use */
 static char *detach_buffer(struct membuffer *b)
 {
@@ -66,7 +76,7 @@ void make_room(struct membuffer *b, unsigned int size)
 		char *n;
 		/* round it up to not reallocate all the time.. */
 		needed = needed * 9 / 8 + 1024;
-		n = realloc(b->buffer, needed);
+		n = (char *)realloc(b->buffer, needed);
 		if (!n)
 			oom();
 		b->buffer = n;

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -36,10 +36,6 @@
 #ifndef MEMBUFFER_H
 #define MEMBUFFER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -49,6 +45,17 @@ struct membuffer {
 	unsigned int len, alloc;
 	char *buffer;
 };
+
+#ifdef __cplusplus
+
+// In C++ code use this - it automatically frees the buffer, when going out of scope.
+struct membufferpp : public membuffer {
+	membufferpp();
+	~membufferpp();
+};
+
+extern "C" {
+#endif
 
 #ifdef __GNUC__
 #define __printf(x, y) __attribute__((__format__(__printf__, x, y)))
@@ -64,6 +71,8 @@ extern void put_bytes(struct membuffer *, const char *, int);
 extern void put_string(struct membuffer *, const char *);
 extern void put_quoted(struct membuffer *, const char *, int, int);
 extern void strip_mb(struct membuffer *);
+
+/* The pointer obtained by mb_cstring is invalidated by any modifictation to the membuffer! */
 extern const char *mb_cstring(struct membuffer *);
 extern __printf(2, 0) void put_vformat(struct membuffer *, const char *, va_list);
 extern __printf(2, 0) void put_vformat_loc(struct membuffer *, const char *, va_list);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -7,7 +7,6 @@
 #include "subsurface-string.h"
 #include "gettextfromc.h"
 #include "statistics.h"
-#include "membuffer.h"
 #include "version.h"
 #include "errorhelper.h"
 #include "planner.h"

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -94,7 +94,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 	for_each_dive (i, dive) {
 		char filename[PATH_MAX];
 		int streamsize;
-		const char *membuf;
+		char *membuf;
 		xmlDoc *transformed;
 		struct zip_source *s;
 		struct membufferpp mb;
@@ -137,14 +137,12 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		if (ds) {
 			put_format(&mb, "</divelog>\n");
 		}
-		membuf = mb_cstring(&mb);
-		streamsize = mb.len;
 		/*
 		 * Parse the memory buffer into XML document and
 		 * transform it to divelogs.de format, finally dumping
 		 * the XML into a character buffer.
 		 */
-		xmlDoc *doc = xmlReadMemory(membuf, streamsize, "divelog", NULL, 0);
+		xmlDoc *doc = xmlReadMemory(mb.buffer, mb.len, "divelog", NULL, 0);
 		if (!doc) {
 			qWarning() << errPrefix << "could not parse back into memory the XML file we've just created!";
 			report_error(tr("internal error").toUtf8());
@@ -171,7 +169,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		 * Save the XML document into a zip file.
 		 */
 		snprintf(filename, PATH_MAX, "%d.xml", i + 1);
-		s = zip_source_buffer(zip, membuf, streamsize, 1);
+		s = zip_source_buffer(zip, membuf, streamsize, 1); // frees membuffer!
 		if (s) {
 			int64_t ret = zip_add(zip, filename, s);
 			if (ret == -1)

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -97,7 +97,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		const char *membuf;
 		xmlDoc *transformed;
 		struct zip_source *s;
-		struct membuffer mb = {};
+		struct membufferpp mb;
 		struct xml_params *params = alloc_xml_params();
 
 		/*
@@ -109,9 +109,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 			continue;
 		}
 
-		/* make sure the buffer is empty and add the dive */
-		mb.len = 0;
-
+		/* add the dive */
 		struct dive_site *ds = dive->dive_site;
 
 		if (ds) {
@@ -140,7 +138,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 			put_format(&mb, "</divelog>\n");
 		}
 		membuf = mb_cstring(&mb);
-		streamsize = strlen(membuf);
+		streamsize = mb.len;
 		/*
 		 * Parse the memory buffer into XML document and
 		 * transform it to divelogs.de format, finally dumping
@@ -156,7 +154,6 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 			free_xml_params(params);
 			return false;
 		}
-		free_buffer(&mb);
 
 		xml_params_add_int(params, "allcylinders", prefs.display_unused_tanks);
 		transformed = xsltApplyStylesheet(xslt, doc, xml_params_get(params));

--- a/core/uploadDiveShare.cpp
+++ b/core/uploadDiveShare.cpp
@@ -27,10 +27,9 @@ uploadDiveShare::uploadDiveShare():
 void uploadDiveShare::doUpload(bool selected, const QString &uid, bool noPublic)
 {
 	//generate json
-	struct membuffer buf = {};
+	struct membufferpp buf;
 	export_list(&buf, NULL, selected, false);
 	QByteArray json_data(buf.buffer, buf.len);
-	free_buffer(&buf);
 
 	//Request to server
 	QNetworkRequest request;

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -13,7 +13,6 @@
 #include "desktop-widgets/mapwidget.h"
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "core/selection.h"
-#include "core/membuffer.h"
 #include "core/cloudstorage.h"
 #include "core/subsurface-string.h"
 #include "core/uploadDiveLogsDE.h"

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -128,13 +128,12 @@ void TabDivePhotos::saveSubtitles()
 				// Only videos have non-zero duration
 				if (!duration)
 					continue;
-				struct membuffer b = { 0 };
+				struct membufferpp b;
 				save_subtitles_buffer(&b, current_dive, offset, duration);
-				char *data = detach_cstring(&b);
+				const char *data = mb_cstring(&b);
 				subtitlefile.open(QIODevice::WriteOnly);
 				subtitlefile.write(data, strlen(data));
 				subtitlefile.close();
-				free(data);
 			}
 		}
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -34,7 +34,6 @@
 #include "core/qt-gui.h"
 #include "core/git-access.h"
 #include "core/cloudstorage.h"
-#include "core/membuffer.h"
 #include "core/downloadfromdcthread.h"
 #include "core/subsurfacestartup.h" // for ignore_bt flag
 #include "core/subsurface-string.h"

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -4,11 +4,11 @@
 #include "profile-widget/divecartesianaxis.h"
 #include "profile-widget/animationfunctions.h"
 #include "core/event.h"
+#include "core/format.h"
 #include "core/libdivecomputer.h"
 #include "core/profile.h"
 #include "core/gettextfromc.h"
 #include "core/metrics.h"
-#include "core/membuffer.h"
 #include "core/sample.h"
 #include "core/subsurface-string.h"
 #include <QDebug>
@@ -165,7 +165,6 @@ void DiveEventItem::setupToolTipString(struct gasmix lastgasmix)
 	if (event_is_gaschange(ev)) {
 		struct icd_data icd_data;
 		struct gasmix mix = get_gasmix_from_event(dive, ev);
-		struct membuffer mb = {};
 		name += ": ";
 		name += gasname(mix);
 
@@ -174,13 +173,11 @@ void DiveEventItem::setupToolTipString(struct gasmix lastgasmix)
 			name += tr(" (cyl. %1)").arg(ev->gas.index + 1);
 		bool icd = isobaric_counterdiffusion(lastgasmix, mix, &icd_data);
 		if (icd_data.dHe < 0) {
-			put_format(&mb, "\n%s %s:%+.3g%% %s:%+.3g%%%s%+.3g%%",
-				qPrintable(tr("ICD")),
-				qPrintable(tr("ΔHe")), icd_data.dHe / 10.0,
-				qPrintable(tr("ΔN₂")), icd_data.dN2 / 10.0,
-				icd ? ">" : "<", lrint(-icd_data.dHe / 5.0) / 10.0);
-			name += QString::fromUtf8(mb.buffer, mb.len);
-			free_buffer(&mb);
+			name += qasprintf_loc("\n%s %s:%+.3g%% %s:%+.3g%%%s%+.3g%%",
+					      qPrintable(tr("ICD")),
+					      qPrintable(tr("ΔHe")), icd_data.dHe / 10.0,
+					      qPrintable(tr("ΔN₂")), icd_data.dN2 / 10.0,
+					      icd ? ">" : "<", lrint(-icd_data.dHe / 5.0) / 10.0);
 		}
 	} else if (same_string(ev->name, "modechange")) {
 		name += QString(": %1").arg(gettextFromC::tr(divemode_text_ui[ev->value]));

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -221,7 +221,7 @@ void ToolTipItem::setTimeAxis(DiveCartesianAxis *axis)
 
 void ToolTipItem::refresh(const dive *d, const QPointF &pos, bool inPlanner)
 {
-	static struct membuffer mb = {};
+	struct membufferpp mb;
 
 	if(refreshTime.elapsed() < 40)
 		return;
@@ -232,7 +232,6 @@ void ToolTipItem::refresh(const dive *d, const QPointF &pos, bool inPlanner)
 	lastTime = time;
 	clear();
 
-	mb.len = 0;
 	int idx = get_plot_details_new(d, &pInfo, time, &mb);
 
 	tissues.fill();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Adds a `membufferpp` wrapper class that cleans up after itself when going out of scope. Thus, one can return from everywhere or throw exceptions without having to bother with memory management. Of course, one can still produce dangling pointers to the buffer. There are only very few uses of `membuffer` in C++ code, so there is not much changed.

This fixes one use-after-free bug and one very questionable construct (function static variable).

One usage of `membuffer` is replaced by `qasprintf`.
 
Untested!