### PR TITLE
core: use int16_t for sensor-id

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -700,7 +700,7 @@ static void try_to_match_autogroup(const char *name, char *buf)
 	nonmatch("autogroup", name, buf);
 }
 
-static void get_cylinderindex(char *buffer, uint8_t *i, struct parser_state *state)
+static void get_cylinderindex(char *buffer, int16_t *i, struct parser_state *state)
 {
 	*i = atoi(buffer);
 	if (state->lastcylinderindex != *i) {
@@ -709,7 +709,7 @@ static void get_cylinderindex(char *buffer, uint8_t *i, struct parser_state *sta
 	}
 }
 
-static void get_sensor(char *buffer, uint8_t *i)
+static void get_sensor(char *buffer, int16_t *i)
 {
 	*i = atoi(buffer);
 }
@@ -839,7 +839,7 @@ static void try_to_fill_dc(struct divecomputer *dc, const char *name, char *buf,
 		return;
 	if (MATCH("dctype", get_dc_type, &dc->divemode))
 		return;
-	if (MATCH("no_o2sensors", get_sensor, &dc->no_o2sensors))
+	if (MATCH("no_o2sensors", get_uint8, &dc->no_o2sensors))
 		return;
 	if (match_dc_data_fields(dc, name, buf, state))
 		return;

--- a/core/sample.h
+++ b/core/sample.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 #define MAX_SENSORS 2
-#define NO_SENSOR ((uint8_t)-1)
+#define NO_SENSOR -1
 
 struct sample                         // BASE TYPE BYTES  UNITS    RANGE               DESCRIPTION
 {                                     // --------- -----  -----    -----               -----------
@@ -21,18 +21,18 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
 	depth_t stopdepth;                // int32_t    4    mm     (0-2000 km)            depth of next deco stop
 	temperature_t temperature;        // uint32_t   4    mK     (0-4 MK)               ambient temperature
-	pressure_t pressure[MAX_SENSORS]; // int32_t    4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
+	pressure_t pressure[MAX_SENSORS]; // int32_t  2x4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
-	o2pressure_t o2sensor[3];         // uint16_t   6    mbar   (0-65 bar)             Up to 3 PO2 sensor values (rebreather)
+	o2pressure_t o2sensor[3];         // uint16_t 3x2    mbar   (0-65 bar)             Up to 3 PO2 sensor values (rebreather)
 	bearing_t bearing;                // int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
-	uint8_t sensor[MAX_SENSORS];      // uint8_t    1  sensorID (0-254)                ID of cylinder pressure sensor
-	uint16_t cns;                     // uint16_t   1     %     (0-64k %)              cns% accumulated
+	int16_t sensor[MAX_SENSORS];      // int16_t  2x2  sensorID (0-16k)                ID of cylinder pressure sensor
+	uint16_t cns;                     // uint16_t   2     %     (0-64k %)              cns% accumulated
 	uint8_t heartbeat;                // uint8_t    1  beats/m  (0-255)                heart rate measurement
 	volume_t sac;                     //            4  ml/min                          predefined SAC
 	bool in_deco;                     // bool       1    y/n      y/n                  this sample is part of deco
 	bool manually_entered;            // bool       1    y/n      y/n                  this sample was entered by the user,
 					  //                                               not calculated when planning a dive
-};	                                  // Total size of structure: 57 bytes, excluding padding at end
+};	                                  // Total size of structure: 63 bytes, excluding padding at end
 
 extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);
 


### PR DESCRIPTION
The sensor-id in the sample struct was a uint8_t, with all
the known problems of unsigned integers. In the rest of the
code cylinder ids are signed integers. To avoid confusion,
make it a signed int. int8_t should be enough (max. 127
cylinders). To allow for degenerate cases, use an int16_t.
16k cylinders should be enough for everyone.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use `int16_t` for sensor cylinder-ids. Should fix a (in my opinion questionable) Coverity warning.

Feel free to change to `int8_t` if you feel that `int16_t` eats too much memory.

Completely untested!