### PR TITLE
build-system: fail with Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,13 @@ elseif (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DownloaderExecutable")
 	find_package(Qt5 5.11 REQUIRED COMPONENTS ${QT_FIND_COMPONENTS})
 	set(MAKE_TESTS OFF)
 endif()
+# we don't support Qt6
+# the comparison with an invalid version of 5.15 ensures that this will keep working even if
+# there are newer Qt 5.15 versions over time (which is unfortunately doubtful)
+if (Qt5Core_VERSION VERSION_GREATER 5.15.15)
+	message(FATAL_ERROR "Subsurface cannot be built against Qt 6 or later")
+endif()
+
 foreach(_QT_COMPONENT ${QT_FIND_COMPONENTS})
 	list(APPEND QT_LIBRARIES Qt5::${_QT_COMPONENT})
 endforeach()


### PR DESCRIPTION
I thought that explicitly requesting Qt5 should be enough, but we have a report
from a user who tried to build against Qt6 and cmake happily let them proceed.
So let's fail this explicitly.


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
I don't think anyone here is interested in working on Qt6 (I sure am not), so let's at least make it obvious that this isn't supported

