### PR TITLE
[TRIVIAL] cleanup: unify the ProfileWidget2::shouldCalculateMax* variables

### DIFF
--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -609,9 +609,8 @@ void DiveGasPressureItem::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	painter->restore();
 }
 
-DiveCalculatedCeiling::DiveCalculatedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *widget) :
-	AbstractProfilePolygonItem(model, hAxis, hColumn, vAxis, vColumn),
-	profileWidget(widget)
+DiveCalculatedCeiling::DiveCalculatedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn) :
+	AbstractProfilePolygonItem(model, hAxis, hColumn, vAxis, vColumn)
 {
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::calcceilingChanged, this, &DiveCalculatedCeiling::setVisible);
 	setVisible(prefs.calcceiling);
@@ -645,8 +644,8 @@ void DiveCalculatedCeiling::paint(QPainter *painter, const QStyleOptionGraphicsI
 	QGraphicsPolygonItem::paint(painter, option, widget);
 }
 
-DiveCalculatedTissue::DiveCalculatedTissue(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *widget) :
-	DiveCalculatedCeiling(model, hAxis, hColumn, vAxis, vColumn, widget)
+DiveCalculatedTissue::DiveCalculatedTissue(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn, const DiveCartesianAxis &vAxis, int vColumn) :
+	DiveCalculatedCeiling(model, hAxis, hColumn, vAxis, vColumn)
 {
 	setVisible(true);
 	connect(qPrefTechnicalDetails::instance(), &qPrefTechnicalDetails::calcalltissuesChanged, this, &DiveCalculatedTissue::setVisible);

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -22,7 +22,6 @@
  This is a generically item and should be used as a base for others, I think...
 */
 
-class ProfileWidget2;
 class DivePlotDataModel;
 class DiveTextItem;
 class DiveCartesianAxis;
@@ -143,12 +142,9 @@ class DiveCalculatedCeiling : public AbstractProfilePolygonItem {
 
 public:
 	DiveCalculatedCeiling(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
-			      const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
+			      const DiveCartesianAxis &vAxis, int vColumn);
 	void replot(const dive *d, bool in_planner) override;
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-
-private:
-	ProfileWidget2 *profileWidget;
 };
 
 class DiveReportedCeiling : public AbstractProfilePolygonItem {
@@ -164,7 +160,7 @@ class DiveCalculatedTissue : public DiveCalculatedCeiling {
 	Q_OBJECT
 public:
 	DiveCalculatedTissue(const DivePlotDataModel &model, const DiveCartesianAxis &hAxis, int hColumn,
-			     const DiveCartesianAxis &vAxis, int vColumn, ProfileWidget2 *profileWidget);
+			     const DiveCartesianAxis &vAxis, int vColumn);
 	void setVisible(bool visible);
 };
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -127,7 +127,7 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, QWidget *
 	ccrsensor2GasItem(createPPGas(DivePlotDataModel::CCRSENSOR2, CCRSENSOR2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max)),
 	ccrsensor3GasItem(createPPGas(DivePlotDataModel::CCRSENSOR3, CCRSENSOR3, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max)),
 	ocpo2GasItem(createPPGas(DivePlotDataModel::SCR_OC_PO2, SCR_OCPO2, PO2_ALERT, &prefs.pp_graphs.po2_threshold_min, &prefs.pp_graphs.po2_threshold_max)),
-	diveCeiling(createItem<DiveCalculatedCeiling>(*profileYAxis, DivePlotDataModel::CEILING, 1, this)),
+	diveCeiling(createItem<DiveCalculatedCeiling>(*profileYAxis, DivePlotDataModel::CEILING, 1)),
 	decoModelParameters(new DiveTextItem()),
 #ifndef SUBSURFACE_MOBILE
 	heartBeatAxis(new DiveCartesianAxis(this)),
@@ -304,7 +304,7 @@ void ProfileWidget2::setupItemOnScene()
 	decoModelParameters->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
 #ifndef SUBSURFACE_MOBILE
 	for (int i = 0; i < 16; i++) {
-		DiveCalculatedTissue *tissueItem = createItem<DiveCalculatedTissue>(*profileYAxis, DivePlotDataModel::TISSUE_1 + i, i + 1, this);
+		DiveCalculatedTissue *tissueItem = createItem<DiveCalculatedTissue>(*profileYAxis, DivePlotDataModel::TISSUE_1 + i, i + 1);
 		allTissues.append(tissueItem);
 		DivePercentageItem *percentageItem = createItem<DivePercentageItem>(*percentageAxis, DivePlotDataModel::PERCENTAGE_1 + i, i + 1, i);
 		allPercentages.append(percentageItem);

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -138,8 +138,7 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, QWidget *
 	rulerItem(new RulerItem2()),
 #endif
 	tankItem(new TankItem(*timeAxis)),
-	shouldCalculateMaxTime(true),
-	shouldCalculateMaxDepth(true),
+	shouldCalculateMax(true),
 	fontPrintScale(1.0)
 {
 	init_plot_info(&plotInfo);
@@ -568,12 +567,12 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 #ifndef SUBSURFACE_MOBILE
 	// A non-null planner_ds signals to create_plot_info_new that the dive is currently planned.
 	struct deco_state *planner_ds = currentState == PLAN && plannerModel ? &plannerModel->final_deco_state : nullptr;
-	create_plot_info_new(d, get_dive_dc_const(d, dc), &plotInfo, !shouldCalculateMaxDepth, planner_ds);
+	create_plot_info_new(d, get_dive_dc_const(d, dc), &plotInfo, !shouldCalculateMax, planner_ds);
 #else
-	create_plot_info_new(d, get_dive_dc_const(d, dc), &plotInfo, !shouldCalculateMaxDepth, nullptr);
+	create_plot_info_new(d, get_dive_dc_const(d, dc), &plotInfo, !shouldCalculateMax, nullptr);
 #endif
 	int newMaxtime = get_maxtime(&plotInfo);
-	if (shouldCalculateMaxTime || newMaxtime > maxtime)
+	if (shouldCalculateMax || newMaxtime > maxtime)
 		maxtime = newMaxtime;
 
 	/* Only update the max. depth if it's bigger than the current ones
@@ -581,7 +580,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 	 * otherwhise, update normally.
 	 */
 	int newMaxDepth = get_maxdepth(&plotInfo);
-	if (!shouldCalculateMaxDepth) {
+	if (!shouldCalculateMax) {
 		if (maxdepth < newMaxDepth) {
 			maxdepth = newMaxDepth;
 		}
@@ -626,7 +625,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, bool doClearPict
 	percentageAxis->setVisible(false);
 	percentageAxis->updateTicks(HR_AXIS);
 #endif
-	if (shouldCalculateMaxTime)
+	if (shouldCalculateMax)
 		timeAxis->setMaximum(maxtime);
 	int i, incr;
 	static int increments[8] = { 10, 20, 30, 60, 5 * 60, 10 * 60, 15 * 60, 30 * 60 };
@@ -866,21 +865,21 @@ void ProfileWidget2::mousePressEvent(QMouseEvent *event)
 		return;
 	QGraphicsView::mousePressEvent(event);
 	if (currentState == PLAN || currentState == EDIT)
-		shouldCalculateMaxDepth = shouldCalculateMaxTime = false;
+		shouldCalculateMax = false;
 }
 
 void ProfileWidget2::divePlannerHandlerClicked()
 {
 	if (zoomLevel)
 		return;
-	shouldCalculateMaxDepth = shouldCalculateMaxTime = false;
+	shouldCalculateMax = false;
 }
 
 void ProfileWidget2::divePlannerHandlerReleased()
 {
 	if (zoomLevel)
 		return;
-	shouldCalculateMaxDepth = shouldCalculateMaxTime = true;
+	shouldCalculateMax = true;
 	replot();
 }
 
@@ -890,7 +889,7 @@ void ProfileWidget2::mouseReleaseEvent(QMouseEvent *event)
 		return;
 	QGraphicsView::mouseReleaseEvent(event);
 	if (currentState == PLAN || currentState == EDIT) {
-		shouldCalculateMaxTime = shouldCalculateMaxDepth = true;
+		shouldCalculateMax = true;
 		replot();
 	}
 }

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -253,8 +253,7 @@ private:
 #endif
 	friend class DiveHandler;
 	QHash<Qt::Key, QAction *> actionsForKeys;
-	bool shouldCalculateMaxTime;
-	bool shouldCalculateMaxDepth;
+	bool shouldCalculateMax; // Calculate maximum time and depth (default). False when dragging handles.
 	int maxtime;
 	int maxdepth;
 	double fontPrintScale;


### PR DESCRIPTION
The shouldCalcluateMaxTime and shouldCalculateMaxDepth member
variables of ProfileWidget2 are set to false during drag-mode to
avoid strange shrinking of the graph. They always adopt the
same value. Therefore, replace by a single shouldCalculateMax
boolean.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
A trivial cleanup - see commit message. Merges two redundant variables into one.