### PR TITLE
export: use unique temporary file for divelogs.de upload

### DIFF
--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -2,6 +2,7 @@
 #include "uploadDiveLogsDE.h"
 #include <QDir>
 #include <QDebug>
+#include <QTemporaryFile>
 #include <zip.h>
 #include <errno.h>
 #include "core/display.h"
@@ -34,21 +35,22 @@ uploadDiveLogsDE::uploadDiveLogsDE():
 }
 
 
+static QString makeTempFileName()
+{
+	QTemporaryFile tmpfile;
+	tmpfile.setFileTemplate(QDir::tempPath() + "/divelogsde-upload.XXXXXXXX.dld");
+	tmpfile.open();
+	QString filename(tmpfile.fileName());
+	tmpfile.close();
+	return filename;
+}
+
+
 void uploadDiveLogsDE::doUpload(bool selected, const QString &userid, const QString &password)
 {
 	QString err;
 
-
-	/* generate a temporary filename and create/open that file with zip_open */
-	QString filename(QDir::tempPath() + "/divelogsde-upload.dld");
-
-	// delete file if it exist
-
-	QFile f(filename);
-	if (f.open(QIODevice::ReadOnly)) {
-		f.close();
-		f.remove();
-	}
+	QString filename = makeTempFileName();
 
 	// Make zip file, with all dives, in divelogs.de format
 	if (!prepareDives(filename, selected)) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
On multi-user systems with a shared directory for temporary files, using
a static file name can lead to permissions problems and subsequent
errors due to collisions. Use a random unique file name for each
generated file to avoid these problems.

Note: the temporary file generated from the divelogs.de upload is still
left behind after the upload finishes.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Change from a static temporary file name to a generated random unique file name using QTemporaryFile

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
