### PR TITLE
desktop: fix crash when right-clicking of trip headers

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -779,7 +779,7 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 			popup.addAction(tr("Collapse all"), this, &QTreeView::collapseAll);
 
 		// verify if there`s a need for collapse others
-		if (expanded_nodes > 1 && d->divetrip)
+		if (expanded_nodes > 1 && (trip || (d && d->divetrip)))
 			collapseAction = popup.addAction(tr("Collapse others"), this, &QTreeView::collapseAll);
 
 


### PR DESCRIPTION
Commit e42fc1a1e9a13c77d3474dbcb26b68b8772b8c6d introduced a
crash condition. Apparently the code attempts to test whether
the clicked-on item is a top-level dive. The "Collapse others"
menu item should not be shown in that case. It does this by
testing "d->divetrip". However, "d" might quite logically be
null if clicking on an unexpanded trip header.

Therefore, check explicitly for the trip header case (which
should show the menu item) and for good measure prevent
the nullpointer access (that should be caught by testing
for trip, but who knows).

Fixes #3301.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes crash, see commit message.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3301.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.