### PR TITLE
core: add downloaded GPS to existing dive site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- add GPS fix downloaded from a dive comuter to existing dive site
 - fix broken curser left/right shortcut for showing multiple dive computers
 - allow editing the profile for dives imported without samples (via CSV)
 - fix potential crash (and other errors) importing DL7 dives

--- a/core/dive.c
+++ b/core/dive.c
@@ -2639,6 +2639,12 @@ struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset,
 
 	/* we take the first dive site, unless it's empty */
 	*site = a->dive_site && !dive_site_is_empty(a->dive_site) ? a->dive_site : b->dive_site;
+	if (!dive_site_has_gps_location(*site) && dive_site_has_gps_location(b->dive_site)) {
+		/* we picked the first dive site and that didn't have GPS data, but the new dive has
+		 * GPS data (that could be a download from a GPS enabled dive computer).
+		 * Keep the dive site, but add the GPS data */
+		(*site)->location = b->dive_site->location;
+	}
 	fixup_dive(res);
 	free(cylinders_map_a);
 	free(cylinders_map_b);


### PR DESCRIPTION
If we download a first dive computer and add a dive site to the dive (by
setting a location name for example), and then download from another
dive computer that provides us with GPS data, we should keep the
existing dive site information, but add the GPS data from the freshly
downloaded dive computer.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This seems so obvious - if the Garmin gives us a GPS fix, keep an existing dive site, but if it doesn't have a GPS fix, add the one we just downloaded

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

