### PR TITLE
desktop: avoid crash when changing dive logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- avoid potential crash when switching divelogs
 - add GPS fix downloaded from a dive comuter to existing dive site
 - fix broken curser left/right shortcut for showing multiple dive computers
 - allow editing the profile for dives imported without samples (via CSV)

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1078,7 +1078,11 @@ void ProfileWidget2::setEmptyState()
 	hideAll(allPercentages);
 	hideAll(handles);
 #endif
-	hideAll(eventItems);
+	// the events will have connected slots which can fire after
+	// the dive and its data have been deleted - so explictly delete
+	// the DiveEventItems
+	qDeleteAll(eventItems);
+	eventItems.clear();
 	hideAll(gases);
 }
 


### PR DESCRIPTION
If the last displayed dive had events, those DiveEventItems had slots connected
that would update those icons if things changed. When closing the dive log and
switching to a different one, those slots were still called and would then access
freed memory (the event structure from that old dive that is long gone by then).
This code explicitly deletes those DiveEventItems which also removes those signal
slot connections.

Fixes #3305

Sugested-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'm guessing there are more objects that should be deleted and not just hidden...

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 