### PR TITLE
mobile: fix broken cylinder name tracking in dive edit

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -168,11 +168,11 @@ Kirigami.ApplicationWindow {
 		detailsWindow.suitModel = manager.suitList
 		detailsWindow.suitIndex = -1
 		detailsWindow.suitText = ""
-		detailsWindow.cylinderModel0 = manager.cylinderInit
-		detailsWindow.cylinderModel1 = manager.cylinderInit
-		detailsWindow.cylinderModel2 = manager.cylinderInit
-		detailsWindow.cylinderModel3 = manager.cylinderInit
-		detailsWindow.cylinderModel4 = manager.cylinderInit
+		detailsWindow.cylinderModel0 = manager.cylinderListInit
+		detailsWindow.cylinderModel1 = manager.cylinderListInit
+		detailsWindow.cylinderModel2 = manager.cylinderListInit
+		detailsWindow.cylinderModel3 = manager.cylinderListInit
+		detailsWindow.cylinderModel4 = manager.cylinderListInit
 		detailsWindow.cylinderIndex0 = PrefEquipment.default_cylinder == "" ? -1 : detailsWindow.cylinderModel0.indexOf(PrefEquipment.default_cylinder)
 		detailsWindow.usedCyl = ["",]
 		detailsWindow.weight = ""
@@ -482,7 +482,7 @@ if you have network connectivity and want to sync your data to cloud storage."),
 				text: qsTr("Settings")
 				onTriggered: {
 					globalDrawer.close()
-					settingsWindow.defaultCylinderModel = manager.cylinderInit
+					settingsWindow.defaultCylinderModel = manager.defaultCylinderListInit
 					PrefEquipment.default_cylinder === "" ? defaultCylinderIndex = "-1" : defaultCylinderIndex = settingsWindow.defaultCylinderModel.indexOf(PrefEquipment.default_cylinder)
 					showPage(settingsWindow)
 					detailsWindow.endEditMode()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1867,27 +1867,17 @@ QStringList QMLManager::locationList() const
 	return locationModel.allSiteNames();
 }
 
-QStringList QMLManager::cylinderInit() const
+// this is the cylinder list used when editing a dive
+QStringList QMLManager::cylinderListInit() const
 {
-	QStringList cylinders;
-	struct dive *d;
-	int i = 0;
-	for_each_dive (i, d) {
-		for (int j = 0; j < d->cylinders.nr; j++) {
-			if (!empty_string(get_cylinder(d, j)->type.description))
-				cylinders << get_cylinder(d, j)->type.description;
-		}
-	}
+	return formatFullCylinderList();
+}
 
-	for (int ti = 0; ti < tank_info_table.nr; ti++) {
-		QString cyl = tank_info_table.infos[ti].name;
-		if (cyl == "")
-			continue;
-		cylinders << cyl;
-	}
-
-	cylinders.removeDuplicates();
-	cylinders.sort();
+// this is the cylinder list used to pick your default cylinder
+// it starts with the (translated) "no default cylinder" in order to special-case this
+QStringList QMLManager::defaultCylinderListInit() const
+{
+	QStringList cylinders = cylinderListInit();
 	// now add fist one that indicates that the user wants no default cylinder
 	cylinders.prepend(tr("no default cylinder"));
 	return cylinders;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -38,7 +38,8 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QStringList buddyList READ buddyList NOTIFY buddyListChanged)
 	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
 	Q_PROPERTY(QStringList locationList READ locationList NOTIFY locationListChanged)
-	Q_PROPERTY(QStringList cylinderInit READ cylinderInit CONSTANT)
+	Q_PROPERTY(QStringList cylinderListInit READ cylinderListInit CONSTANT)
+	Q_PROPERTY(QStringList defaultCylinderListInit READ defaultCylinderListInit CONSTANT)
 	Q_PROPERTY(QStringList cloudCacheList READ cloudCacheList NOTIFY cloudCacheListChanged)
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
 	Q_PROPERTY(bool btEnabled MEMBER m_btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
@@ -162,7 +163,8 @@ public:
 	QStringList buddyList() const;
 	QStringList divemasterList() const;
 	QStringList locationList() const;
-	QStringList cylinderInit() const;
+	QStringList cylinderListInit() const;
+	QStringList defaultCylinderListInit() const;
 	QStringList cloudCacheList() const;
 	Q_INVOKABLE void setStatusbarColor(QColor color);
 	void btHostModeChange(QBluetoothLocalDevice::HostMode state);


### PR DESCRIPTION
Prior to this change, we had two different cylinder lists as models for
drop down boxes - one that prepends the "no default cylinder" entry
(which we need for setting up no default cylinder to be used in the
app), and another one that only includes actual cylinders.

The problem occured if a dive is created before the first time we edit
an existing dive: in this case we are applying indices across the two
models, but the indices are of course off by one; this results in
actually picking the wrong cylinder. So each time we try to edit a dive,
we end up with the previous cylinder in the list.

This commit simplifies the code by having only one place where we create
list of cylinder names (which is then used as the model for the combo
box). It also uses more logical names for the two 'flavors' of this list
to make it clear which one is supposed to be used (the regular list when
editing or adding dives, the one with the "no default cylinder" entry
prependet for the Settings page).

Reported-by: Brian Fransen
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
this was a subtle bug that depended on the order in which these models were initialized.
I actually still don't completely understand why we in certain circumstances got the list without the prepended value "no default cylinder". But this makes it explicit which list we want and it appears to work in all my tests.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- create the cylinder list only once
- use that list when editing / adding dives
- use a different list / model when setting the default cylinder to be used

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
this was reported by a user of the app on iOS

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

