### PR TITLE
parser: XML_PARSE_RECOVER to xmlReadMemory()

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1745,9 +1745,9 @@ int parse_xml_buffer(const char *url, const char *buffer, int size,
 	state.sites = sites;
 	state.devices = devices;
 	state.filter_presets = filter_presets;
-	doc = xmlReadMemory(res, strlen(res), url, NULL, XML_PARSE_HUGE);
+	doc = xmlReadMemory(res, strlen(res), url, NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 	if (!doc)
-		doc = xmlReadMemory(res, strlen(res), url, "latin1", XML_PARSE_HUGE);
+		doc = xmlReadMemory(res, strlen(res), url, "latin1", XML_PARSE_HUGE | XML_PARSE_RECOVER);
 
 	if (res != buffer)
 		free((char *)res);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -865,7 +865,7 @@ static int export_dives_xslt_doit(const char *filename, struct xml_params *param
 	 * transform it to selected export format, finally dumping
 	 * the XML into a character buffer.
 	 */
-	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, XML_PARSE_HUGE);
+	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 	free_buffer(&buf);
 	if (!doc)
 		return report_error("Failed to read XML memory");

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -142,7 +142,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		 * transform it to divelogs.de format, finally dumping
 		 * the XML into a character buffer.
 		 */
-		xmlDoc *doc = xmlReadMemory(mb.buffer, mb.len, "divelog", NULL, 0);
+		xmlDoc *doc = xmlReadMemory(mb.buffer, mb.len, "divelog", NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 		if (!doc) {
 			qWarning() << errPrefix << "could not parse back into memory the XML file we've just created!";
 			report_error(tr("internal error").toUtf8());


### PR DESCRIPTION
Due to changes in the handling of sensor-ids, invalid XMLs were
generated. In particular, these contained duplicate attributes
in the sample tags.

Even though these files shouldn't exist, let's try to parse
them anyway. Some data will be lost, but that's better than
not opening the file.

libxml2 can be told to try to recover from such petty(?) errors
by passing the XML_PARSE_RECOVER flag.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
At least try to parse broken XMLs. See discussion in #3312.
Makes me itch to replace the libxml2 by a custom xml parser. I have written one - it's not *that* bad and would give us much finer control.