### PR TITLE
Correctly renumber cylinders on deletion / ask user

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1177,6 +1177,7 @@ void RemoveCylinder::undo()
 	for (size_t i = 0; i < dives.size(); ++i) {
 		std::vector<int> mapping = get_cylinder_map_for_add(dives[i]->cylinders.nr, indexes[i]);
 		add_cylinder(&dives[i]->cylinders, indexes[i], clone_cylinder(cyl[i]));
+		cylinder_renumber(dives[i], &mapping[0]);
 		update_cylinder_related_info(dives[i]);
 		emit diveListNotifier.cylinderAdded(dives[i], indexes[i]);
 		invalidate_dive_cache(dives[i]); // Ensure that dive is written in git_save()

--- a/core/dive.c
+++ b/core/dive.c
@@ -3481,3 +3481,17 @@ struct gasmix get_gasmix_at_time(const struct dive *d, const struct divecomputer
 	struct gasmix gasmix = gasmix_air;
 	return get_gasmix(d, dc, time.seconds, &ev, gasmix);
 }
+
+/* Does that cylinder have any pressure readings? */
+extern bool cylinder_with_sensor_sample(const struct dive *dive, int cylinder_id)
+{
+	for (const struct divecomputer *dc = &dive->dc; dc; dc = dc->next) {
+		for (int i = 0; i < dc->samples; ++i) {
+			for (int j = 0; j < MAX_SENSORS; ++j) {
+				if (dc->sample[i].sensor[j] == cylinder_id)
+					return true;
+			}
+		}
+	}
+	return false;
+}

--- a/core/dive.h
+++ b/core/dive.h
@@ -198,6 +198,7 @@ extern int get_cylinder_index(const struct dive *dive, const struct event *ev);
 extern struct gasmix get_gasmix_from_event(const struct dive *, const struct event *ev);
 extern int nr_cylinders(const struct dive *dive);
 extern int nr_weightsystems(const struct dive *dive);
+extern bool cylinder_with_sensor_sample(const struct dive *dive, int cylinder_id);
 
 /* UI related protopypes */
 

--- a/core/divecomputer.c
+++ b/core/divecomputer.c
@@ -548,4 +548,3 @@ void free_dc(struct divecomputer *dc)
 	free_dc_contents(dc);
 	free(dc);
 }
-

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1745,9 +1745,9 @@ int parse_xml_buffer(const char *url, const char *buffer, int size,
 	state.sites = sites;
 	state.devices = devices;
 	state.filter_presets = filter_presets;
-	doc = xmlReadMemory(res, strlen(res), url, NULL, XML_PARSE_HUGE);
+	doc = xmlReadMemory(res, strlen(res), url, NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 	if (!doc)
-		doc = xmlReadMemory(res, strlen(res), url, "latin1", XML_PARSE_HUGE);
+		doc = xmlReadMemory(res, strlen(res), url, "latin1", XML_PARSE_HUGE | XML_PARSE_RECOVER);
 
 	if (res != buffer)
 		free((char *)res);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -865,7 +865,7 @@ static int export_dives_xslt_doit(const char *filename, struct xml_params *param
 	 * transform it to selected export format, finally dumping
 	 * the XML into a character buffer.
 	 */
-	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, XML_PARSE_HUGE);
+	doc = xmlReadMemory(buf.buffer, buf.len, "divelog", NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 	free_buffer(&buf);
 	if (!doc)
 		return report_error("Failed to read XML memory");

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -142,7 +142,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		 * transform it to divelogs.de format, finally dumping
 		 * the XML into a character buffer.
 		 */
-		xmlDoc *doc = xmlReadMemory(mb.buffer, mb.len, "divelog", NULL, 0);
+		xmlDoc *doc = xmlReadMemory(mb.buffer, mb.len, "divelog", NULL, XML_PARSE_HUGE | XML_PARSE_RECOVER);
 		if (!doc) {
 			qWarning() << errPrefix << "could not parse back into memory the XML file we've just created!";
 			report_error(tr("internal error").toUtf8());


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Ouch, while looking at the cylinder handling code, I found a nasty bug (I believe): The cylinders are not renumbered on redo(), but on undo(). That can lead to disastrous results.

Do the renumbering. But this means that the sensor readings are not restored on undo!

Warn the user of the data loss.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See #3312.

Attention: completely untested!