### PR TITLE
core: properly clear pressure data

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1213,8 +1213,10 @@ static void fixup_dc_sample_sensors(struct divecomputer *dc, int nr_cylinders)
 	for (int i = 0; i < dc->samples; i++) {
 		struct sample *s = dc->sample + i;
 		for (int j = 0; j < MAX_SENSORS; j++) {
-			if (s->sensor[j] < 0 || s->sensor[j] >= nr_cylinders)
+			if (s->sensor[j] < 0 || s->sensor[j] >= nr_cylinders) {
 				s->sensor[j] = NO_SENSOR;
+				s->pressure[j].mbar = 0;
+			}
 		}
 	}
 }

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -258,6 +258,9 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 		pressure_t p = sample->pressure[idx];
 		int sensor = sample->sensor[idx];
 
+		if (sensor == NO_SENSOR)
+			continue;
+
 		if (!p.mbar)
 			continue;
 

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -256,6 +256,9 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 		pressure_t p = sample->pressure[idx];
 		int sensor = sample->sensor[idx];
 
+		if (sensor == NO_SENSOR)
+			continue;
+
 		if (!p.mbar)
 			continue;
 


### PR DESCRIPTION
In 82f967ddb37022a69be2de3f38ac445093c0d6df sanitizing of sensor-ids
was introduced to prevent out-of-bound accesses. The sensor was
overwritten as -1 (NO_SENSOR).

However, this led to corrupted XML files, since the code sees this
as an "old format" indicator.

Other parts of the code simply take the pressure and sensor reading
from the previous sample. Do this here as well.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This hopefully prevents the XML file corruption described in #3312. Don't use -1 as no-sensor marker, as that's messing with the XML output. I don't understand the sensor-handling, sorry. This is simply copying a different part of the code.

Attention: completely untested!

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.