### PR TITLE
Fix off-by-one causing incorrect profile display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+core: fix off-by-one causing incorrect profile display #3184
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/core/profile.c
+++ b/core/profile.c
@@ -1566,18 +1566,17 @@ static void plot_string(const struct dive *d, const struct plot_info *pi, int id
 
 int get_plot_details_new(const struct dive *d, const struct plot_info *pi, int time, struct membuffer *mb)
 {
-	int idx, i;
+	int i;
 
 	/* The two first and the two last plot entries do not have useful data */
 	if (pi->nr <= 4)
 		return 0;
-	for (i = 2; i < pi->nr - 2; i++) {
-		idx = i;
+	for (i = 2; i < pi->nr - 3; i++) {
 		if (pi->entry[i].sec >= time)
 			break;
 	}
-	plot_string(d, pi, idx, mb);
-	return idx;
+	plot_string(d, pi, i, mb);
+	return i;
 }
 
 /* Compare two plot_data entries and writes the results into a string */

--- a/core/profile.c
+++ b/core/profile.c
@@ -1566,18 +1566,19 @@ static void plot_string(const struct dive *d, const struct plot_info *pi, int id
 
 int get_plot_details_new(const struct dive *d, const struct plot_info *pi, int time, struct membuffer *mb)
 {
-	int i;
+	int idx, i;
 
 	/* The two first and the two last plot entries do not have useful data */
 	if (pi->nr <= 4)
 		return 0;
 	for (i = 2; i < pi->nr - 2; i++) {
+		idx = i;
 		if (pi->entry[i].sec >= time)
 			break;
 	}
-	plot_string(d, pi, i, mb);
-	return i;
-}
+	plot_string(d, pi, idx, mb);
+	return idx;
+} 
 
 /* Compare two plot_data entries and writes the results into a string */
 void compare_samples(const struct dive *d, const struct plot_info *pi, int idx1, int idx2, char *buf, int bufsize, bool sum)

--- a/core/profile.c
+++ b/core/profile.c
@@ -1578,7 +1578,7 @@ int get_plot_details_new(const struct dive *d, const struct plot_info *pi, int t
 	}
 	plot_string(d, pi, idx, mb);
 	return idx;
-} 
+}
 
 /* Compare two plot_data entries and writes the results into a string */
 void compare_samples(const struct dive *d, const struct plot_info *pi, int idx1, int idx2, char *buf, int bufsize, bool sum)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In commit 4724c88 get_plot_details_new was updated to pass an index instead of "entry[i]" into plot_string. This means we are passing "i" to plot_string after the final increment of the loop, instead of getting "entry[i]" within the loop before the final increment. This means if we are mousing over the far right of the graph, where the time based break is not hit, we will end up passing an index equal to nr-2, instead of nr-3, which is intended to shave off the final two rows containing data not useful to the display.

There are a handful of ways to fix this. This commit intends to be consistent with stylistic choices made elsewhere in the project.

### Related issues:
Fixes #3184
