### PR TITLE
Add rich text support for viewing mobile notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+mobile: Add support for rich text when displaying dive notes
 core: fix off-by-one causing incorrect profile display #3184
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -577,6 +577,7 @@ Item {
 			Layout.fillWidth: true
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			color: subsurfaceTheme.textColor
+			textFormat: Text.RichText
 		}
 		Item {
 			Layout.columnSpan: 3


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
I noticed dives created with the planner do not render the notes field properly when viewed on mobile. 
The dive planner saves notes with some html formatting, which won't render properly without rich text support.

### Changes made:
Added support for rich text on the DiveDetailsView notes field

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3320
