### PR TITLE
Re-do the libdivecomputer fingerprint save/load code

### DIFF
--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -218,7 +218,6 @@ DCDeviceData::DCDeviceData()
 	memset(&data, 0, sizeof(data));
 	data.download_table = nullptr;
 	data.diveid = 0;
-	data.deviceid = 0;
 #if defined(BT_SUPPORT)
 	data.bluetooth_mode = true;
 #else
@@ -293,11 +292,6 @@ bool DCDeviceData::forceDownload() const
 	return data.force_download;
 }
 
-int DCDeviceData::deviceId() const
-{
-	return data.deviceid;
-}
-
 int DCDeviceData::diveId() const
 {
 	return data.diveid;
@@ -355,11 +349,6 @@ void DCDeviceData::setBluetoothMode(bool mode)
 void DCDeviceData::setForceDownload(bool force)
 {
 	data.force_download = force;
-}
-
-void DCDeviceData::setDeviceId(int deviceId)
-{
-	data.deviceid = deviceId;
 }
 
 void DCDeviceData::setDiveId(int diveId)

--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -32,7 +32,6 @@ public:
 	QString descriptor() const;
 	bool forceDownload() const;
 	bool saveLog() const;
-	int deviceId() const;
 	int diveId() const;
 
 	/* this needs to be a pointer to make the C-API happy */
@@ -44,7 +43,6 @@ public:
 	int getDetectedVendorIndex();
 	int getDetectedProductIndex(const QString &currentVendorText);
 
-	void setDeviceId(int deviceId);
 	void setDiveId(int diveId);
 	void setVendor(const QString& vendor);
 	void setProduct(const QString& product);

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -35,9 +35,9 @@ typedef struct {
 	const char *vendor, *product, *devname;
 	const char *model, *btname;
 	unsigned char *fingerprint;
-	unsigned int fsize, fdiveid;
-	uint32_t libdc_firmware;
-	uint32_t deviceid, diveid;
+	unsigned int fsize, fdeviceid, fdiveid;
+	struct dc_event_devinfo_t devinfo;
+	uint32_t diveid;
 	dc_device_t *device;
 	dc_context_t *context;
 	dc_iostream_t *iostream;

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -273,7 +273,7 @@ void OstcFirmwareCheck::checkLatest(QWidget *_parent, device_data_t *data)
 	// for the OSTC that means highbyte.lowbyte is the version number
 	// For OSTC 4's its stored as XXXX XYYY YYZZ ZZZB, -> X.Y.Z beta?
 
-	int firmwareOnDevice = devData.libdc_firmware;
+	int firmwareOnDevice = devData.devinfo.firmware;
 	QString firmwareOnDeviceString;
 	// Convert the latestFirmwareAvailable to a integear we can compare with
 	QStringList fwParts = latestFirmwareAvailable.split(".");
@@ -907,7 +907,8 @@ void ConfigureDiveComputerDialog::getDeviceData()
 	device_data.product = copy_qstring(selected_product);
 
 	device_data.descriptor = descriptorLookup.value(selected_vendor.toLower() + selected_product.toLower());
-	device_data.deviceid = device_data.diveid = 0;
+	device_data.diveid = 0;
+	memset(&device_data.devinfo, 0, sizeof(device_data.devinfo));
 
 	qPrefDiveComputer::set_device(device_data.devname);
 #ifdef BT_SUPPORT

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1892,16 +1892,6 @@ bool QMLManager::DC_saveDump() const
 	return DCDeviceData::instance()->saveDump();
 }
 
-int QMLManager::DC_deviceId() const
-{
-	return DCDeviceData::instance()->deviceId();
-}
-
-void QMLManager::DC_setDeviceId(int deviceId)
-{
-	DCDeviceData::instance()->setDeviceId(deviceId);
-}
-
 void QMLManager::DC_setVendor(const QString& vendor)
 {
 	DCDeviceData::instance()->setVendor(vendor);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -48,7 +48,6 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool DC_forceDownload READ DC_forceDownload WRITE DC_setForceDownload NOTIFY DC_ForceDownloadChanged)
 	Q_PROPERTY(bool DC_bluetoothMode READ DC_bluetoothMode WRITE DC_setBluetoothMode)
 	Q_PROPERTY(bool DC_saveDump READ DC_saveDump WRITE DC_setSaveDump)
-	Q_PROPERTY(int DC_deviceId READ DC_deviceId WRITE DC_setDeviceId)
 	Q_PROPERTY(QString pluggedInDeviceName MEMBER m_pluggedInDeviceName NOTIFY pluggedInDeviceNameChanged)
 	Q_PROPERTY(bool showNonDiveComputers MEMBER m_showNonDiveComputers WRITE setShowNonDiveComputers NOTIFY showNonDiveComputersChanged)
 	Q_PROPERTY(qPrefCloudStorage::cloud_status oldStatus MEMBER m_oldStatus WRITE setOldStatus NOTIFY oldStatusChanged)
@@ -100,9 +99,6 @@ public:
 
 	bool DC_saveDump() const;
 	void DC_setSaveDump(bool dumpMode);
-
-	int DC_deviceId() const;
-	void DC_setDeviceId(int deviceId);
 
 	QString getUndoText() const;
 	QString getRedoText() const;

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -871,7 +871,6 @@ static int prepare_data(int data_model, char *serial, dc_family_t dc_fam, device
 	if (!data_model){
 		dev_data->model = copy_string("manually added dive");
 		dev_data->descriptor = NULL;
-		dev_data->deviceid = 0;
 		return DC_STATUS_NODEVICE;
 	}
 	dev_data->descriptor = get_data_descriptor(data_model, dc_fam);
@@ -879,11 +878,11 @@ static int prepare_data(int data_model, char *serial, dc_family_t dc_fam, device
 		dev_data->vendor = dc_descriptor_get_vendor(dev_data->descriptor);
 		dev_data->product = dc_descriptor_get_product(dev_data->descriptor);
 		dev_data->model = smtk_concat_str(dev_data->model, "", "%s %s", dev_data->vendor, dev_data->product);
-		dev_data->deviceid = (uint32_t) lrint(strtod(serial, NULL));
+		dev_data->devinfo.serial = (uint32_t) lrint(strtod(serial, NULL));
 		return DC_STATUS_SUCCESS;
 	} else {
 		dev_data->model = copy_string("unsupported dive computer");
-		dev_data->deviceid = (uint32_t) lrint(strtod(serial, NULL));
+		dev_data->devinfo.serial = (uint32_t) lrint(strtod(serial, NULL));
 		return DC_STATUS_UNSUPPORTED;
 	}
 }
@@ -1012,7 +1011,6 @@ void smartrak_import(const char *file, struct dive_table *divetable)
 				dc_fam = DC_FAMILY_UWATEC_ALADIN;
 		}
 		rc = prepare_data(dc_model, copy_string(col[coln(DCNUMBER)]->bind_ptr), dc_fam, devdata);
-		smtkdive->dc.deviceid = devdata->deviceid;
 		smtkdive->dc.model = copy_string(devdata->model);
 		if (rc == DC_STATUS_SUCCESS && *bound_lens[coln(PROFILE)]) {
 			prf_buffer = mdb_ole_read_full(mdb, col[coln(PROFILE)], &prf_length);


### PR DESCRIPTION
This tries to make our fingerprinting code work better, by avoiding
using the "deviceid" field that has always been unreliable because we've
calculated it multiple different ways, and even for the same version of
subsurface, it ends up changing in the middle (ie we calculate one value
initially, then re-calculate it when we have a proper serial number
string).

So instead, the fingerprinting code will look up and save the
fingerprint file using purely "stable" information that is available
early during the download:

 - the device model name (which is a string with vendor and product name
   separated by a space)

 - the DC_EVENT_DEVINFO 32-bit 'serial' number (which is not necessarily
   a real serial number at all, but hopefully at least a unique number
   for the particular product)

but because the model name is not necessarily a good filename (think
slashes and other possibly invalid characters), we hash that model name
and use the resulting hex number in the fingerprint file name.

This way the fingerprint file is unambiguous at load and save time, and
depends purely on libdivecomputer data.

But because we also need to verify that we have the actual _dive_
associated with that fingerprint, we also need to save the final
deviceid and diveid when saving the fingerprint file, so that when we
load it again we can look up the dive and verify that we have it before
we use the fingerprint data.

To do that, the fingerprint file itself contains not just the
fingerprint data from libdivecomputer, but the last 8 bytes of the file
are the (subsurface) deviceid and the diveid of the dive that is
associated with the fingerprint.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
