### PR TITLE
Image shift improvements

### DIFF
--- a/desktop-widgets/shiftimagetimes.ui
+++ b/desktop-widgets/shiftimagetimes.ui
@@ -55,61 +55,16 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLabel" name="warningLabel">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">color: red;</string>
-        </property>
-        <property name="text">
-         <string>Warning!
-Not all media files have timestamps in the range between
-30 minutes before the start and 30 minutes after the end of any selected dive.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="matchAllImages">
-        <property name="text">
-         <string>Load media files even if the time does not match the dive time</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QTextEdit" name="invalidFilesText">
-        <property name="styleSheet">
-         <string notr="true">color: red; </string>
-        </property>
-        <property name="lineWrapMode">
-         <enum>QTextEdit::NoWrap</enum>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-        <property name="text" stdset="0">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QDialogButtonBox" name="buttonBox">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="standardButtons">
-         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
+
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox2">
+     <property name="title">
+      <string>Use camera sync</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout2">
       <item>
        <widget class="QLabel" name="label">
         <property name="maximumSize">
@@ -194,6 +149,54 @@ Not all media files have timestamps in the range between
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: red;</string>
+     </property>
+     <property name="text">
+      <string>Warning!
+Not all media files have timestamps in the range between
+30 minutes before the start and 30 minutes after the end of any selected dive.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="invalidFilesText">
+     <property name="styleSheet">
+      <string notr="true">color: red; </string>
+     </property>
+     <property name="lineWrapMode">
+      <enum>QTextEdit::NoWrap</enum>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="text" stdset="0">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="matchAllImages">
+     <property name="text">
+      <string>Load media files even if the time does not match the dive time</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/desktop-widgets/shiftimagetimes.ui
+++ b/desktop-widgets/shiftimagetimes.ui
@@ -31,72 +31,11 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Shift times of image(s) by</string>
+      <string>Manually shift times of image(s) by hours:minutes</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QTimeEdit" name="timeEdit">
-        <property name="date">
-         <date>
-          <year>2000</year>
-          <month>1</month>
-          <day>1</day>
-         </date>
-        </property>
-        <property name="maximumDateTime">
-         <datetime>
-          <hour>23</hour>
-          <minute>59</minute>
-          <second>59</second>
-          <year>2010</year>
-          <month>12</month>
-          <day>31</day>
-         </datetime>
-        </property>
-        <property name="minimumDateTime">
-         <datetime>
-          <hour>0</hour>
-          <minute>0</minute>
-          <second>0</second>
-          <year>2000</year>
-          <month>1</month>
-          <day>1</day>
-         </datetime>
-        </property>
-        <property name="maximumDate">
-         <date>
-          <year>2010</year>
-          <month>12</month>
-          <day>31</day>
-         </date>
-        </property>
-        <property name="minimumDate">
-         <date>
-          <year>2000</year>
-          <month>1</month>
-          <day>1</day>
-         </date>
-        </property>
-        <property name="maximumTime">
-         <time>
-          <hour>23</hour>
-          <minute>59</minute>
-          <second>59</second>
-         </time>
-        </property>
-        <property name="minimumTime">
-         <time>
-          <hour>0</hour>
-          <minute>0</minute>
-          <second>0</second>
-         </time>
-        </property>
-        <property name="displayFormat">
-         <string>h:mm</string>
-        </property>
-        <property name="timeSpec">
-         <enum>Qt::LocalTime</enum>
-        </property>
+       <widget class="QLineEdit" name="timeEdit">
        </widget>
       </item>
       <item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -122,15 +122,6 @@ ShiftTimesDialog::ShiftTimesDialog(QWidget *parent) : QDialog(parent),
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
 }
 
-void ShiftImageTimesDialog::buttonClicked(QAbstractButton *button)
-{
-	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
-		m_amount = ui.timeEdit->time().hour() * 3600 + ui.timeEdit->time().minute() * 60;
-		if (ui.backwards->isChecked())
-			m_amount *= -1;
-	}
-}
-
 void ShiftImageTimesDialog::syncCameraClicked()
 {
 	QPixmap picture;
@@ -140,6 +131,10 @@ void ShiftImageTimesDialog::syncCameraClicked()
 							      tr("Image files") + " (*.jpg *.jpeg)");
 	if (fileNames.isEmpty())
 		return;
+
+	ui.timeEdit->setEnabled(false);
+	ui.backwards->setEnabled(false);
+	ui.forward->setEnabled(false);
 
 	picture.load(fileNames.at(0));
 	ui.displayDC->setEnabled(true);
@@ -160,7 +155,10 @@ void ShiftImageTimesDialog::dcDateTimeChanged(const QDateTime &newDateTime)
 	if (!dcImageEpoch)
 		return;
 	newtime.setTimeSpec(Qt::UTC);
-	setOffset(dateTimeToTimestamp(newtime) - dcImageEpoch);
+
+	m_amount = dateTimeToTimestamp(newtime) - dcImageEpoch;
+	if (m_amount)
+		updateInvalid();
 }
 
 void ShiftImageTimesDialog::matchAllImagesToggled(bool state)
@@ -179,7 +177,6 @@ ShiftImageTimesDialog::ShiftImageTimesDialog(QWidget *parent, QStringList fileNa
 	matchAllImages(false)
 {
 	ui.setupUi(this);
-	connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
 	connect(ui.syncCamera, SIGNAL(clicked()), this, SLOT(syncCameraClicked()));
 	connect(ui.timeEdit, SIGNAL(timeChanged(const QTime &)), this, SLOT(timeEditChanged(const QTime &)));
 	connect(ui.backwards, SIGNAL(toggled(bool)), this, SLOT(timeEditChanged()));

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -128,7 +128,7 @@ void ShiftImageTimesDialog::syncCameraClicked()
 	QStringList fileNames = QFileDialog::getOpenFileNames(this,
 							      tr("Open image file"),
 							      DiveListView::lastUsedImageDir(),
-							      tr("Image files") + " (*.jpg *.jpeg)");
+							      QString("%1 (%2)").arg(tr("Image files"), imageExtensionFilters().join(" ")));
 	if (fileNames.isEmpty())
 		return;
 

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -77,8 +77,8 @@ private
 slots:
 	void syncCameraClicked();
 	void dcDateTimeChanged(const QDateTime &);
-	void timeEditChanged(const QTime &time);
-	void timeEditChanged();
+	void timeEdited(const QString &timeText);
+	void backwardsChanged(bool);
 	void updateInvalid();
 	void matchAllImagesToggled(bool);
 

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -75,7 +75,6 @@ public:
 	bool matchAll();
 private
 slots:
-	void buttonClicked(QAbstractButton *button);
 	void syncCameraClicked();
 	void dcDateTimeChanged(const QDateTime &);
 	void timeEditChanged(const QTime &time);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a slight redo of #3323 - it reuses those commits (with minor changes and some cleanup and updates to commit messages) and adds a couple of tweaks:
- consistent filter for image file names (it was weird that image files that you could use for the picture itself wouldn't show up for the "picture of the dive computer")
- redo the manual time delta input; `QTimeEdit` is too limited for this use case as @tsegers points out - so this implements a simple `QLineEdit` that does its own limited validation and acts reasonably well even for very large time deltas

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3323 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I guess this might need small changes to the manual - but it's really not a big change, just making things more generic

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@tsegers @bstoeger 