### PR TITLE
Ignore invalid dives in subsurface-mobile dive summary

### DIFF
--- a/qt-models/divesummarymodel.cpp
+++ b/qt-models/divesummarymodel.cpp
@@ -121,6 +121,10 @@ static void calculateDive(struct dive *dive, Stats &stats)
 		return;
 	}
 
+	if (dive->invalid) {
+		return;
+	}
+
 	// one more real dive
 	stats.dives++;
 


### PR DESCRIPTION
Match subsurface-desktop's invalid dive behavior

Signed-off-by: Tim Segers <tsegers@pm.me>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Since I can't for the life of me set up the build environment required to build the android app, I have not been able to test this change. Still, I'm pretty certain that it is correct.