### PR TITLE
cleanup: fix conversion warning

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -3151,7 +3151,7 @@ void split_divecomputer(const struct dive *src, int num, struct dive **out1, str
 fraction_t best_o2(depth_t depth, const struct dive *dive, bool in_planner)
 {
 	fraction_t fo2;
-	int po2 = in_planner ? prefs.bottompo2 : prefs.modpO2 * 1000;
+	int po2 = in_planner ? prefs.bottompo2 : (int)(prefs.modpO2 * 1000.0);
 
 	fo2.permille = (po2 * 100 / depth_to_mbar(depth.mm, dive)) * 10;	//use integer arithmetic to round down to nearest percent
 	// Don't permit >100% O2

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -230,7 +230,7 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 				return QStringLiteral("*");
 			} else {
 				pressure_t modpO2;
-				modpO2.mbar = inPlanner ? prefs.bottompo2 : prefs.modpO2 * 1000;
+				modpO2.mbar = inPlanner ? prefs.bottompo2 : (int)(prefs.modpO2 * 1000.0);
 				return get_depth_string(gas_mod(cyl->gasmix, modpO2, d, M_OR_FT(1,1)), true);
 			}
 		case MND:


### PR DESCRIPTION
Fix a pair of warnings, which annoyed me for a long time:
For some reasons prefs.bottompo2 is an integer (mbar)
whereas prefs.modpO2 is a float (bar). This results
in mixed integer/floating point arithmetics when
conditionally using either of them. And ultimately
a warning, when storing a mbar value as an integer.
Fix this by an explicit cast to int after converting
modpO2 to mbar.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial warning-silencing, see commit message.