### PR TITLE
Android: use more recent usb library

### DIFF
--- a/android-mobile/build.gradle
+++ b/android-mobile/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.github.mik3y:usb-serial-for-android:v2.2.2'
+    implementation 'com.github.mik3y:usb-serial-for-android:v3.4.3'
 }
 
 android {
@@ -60,6 +60,11 @@ android {
             assets.srcDirs = ['assets']
             jniLibs.srcDirs = ['libs']
        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
@@ -298,9 +298,10 @@ public class AndroidSerial {
 		Log.d(TAG, "in " + Thread.currentThread().getStackTrace()[2].getMethodName());
 		try {
 			Log.d(TAG, "write length: " + data.length);
-			int retval =  usbSerialPort.write(data, timeout);
-			Log.d(TAG, "actual write length: " + retval);
-			return retval;
+			usbSerialPort.write(data, timeout);
+			/* throws an exception if we didn't write all data successfully */
+			Log.d(TAG, "successfully written");
+			return data.length;
 		} catch (Exception e) {
 			Log.e(TAG, "Error in " + Thread.currentThread().getStackTrace()[2].getMethodName(), e);
 			return AndroidSerial.DC_STATUS_IO;
@@ -313,8 +314,9 @@ public class AndroidSerial {
 		Log.d(TAG, "in " + Thread.currentThread().getStackTrace()[2].getMethodName());
 		try {
 			if ((direction | AndroidSerial.DC_DIRECTION_INPUT) > 0) readBuffer.clear();
-			boolean retval = this.usbSerialPort.purgeHwBuffers((direction | AndroidSerial.DC_DIRECTION_OUTPUT) > 0, (direction | AndroidSerial.DC_DIRECTION_INPUT) > 0);
-			return retval ? AndroidSerial.DC_STATUS_SUCCESS : AndroidSerial.DC_STATUS_IO;
+			this.usbSerialPort.purgeHwBuffers((direction | AndroidSerial.DC_DIRECTION_OUTPUT) > 0, (direction | AndroidSerial.DC_DIRECTION_INPUT) > 0);
+			/* throws exeption if an error occured or flush isn't supported */
+			return AndroidSerial.DC_STATUS_SUCCESS;
 		} catch (Exception e) {
 			Log.e(TAG, "Error in " + Thread.currentThread().getStackTrace()[2].getMethodName(), e);
 			return AndroidSerial.DC_STATUS_IO;


### PR DESCRIPTION
Builds start to fail because v2.2.2 (about 18 months old) can't be found
anymore. Let's switch to the latest and see if that helps.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change
