### PR TITLE
Download amount

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -840,8 +840,9 @@ static void do_save_fingerprint(device_data_t *devdata, const char *tmp, const c
 	if (fd < 0)
 		return;
 
-	dev_info(devdata, "Saving fingerprint for %08x:%08x to '%s'",
-		devdata->fdeviceid, devdata->fdiveid, final);
+	if (verbose)
+		dev_info(devdata, "Saving fingerprint for %08x:%08x to '%s'",
+			 devdata->fdeviceid, devdata->fdiveid, final);
 
 	/* The fingerprint itself.. */
 	written = write(fd, devdata->fingerprint, devdata->fsize);
@@ -855,10 +856,8 @@ static void do_save_fingerprint(device_data_t *devdata, const char *tmp, const c
 		written = -1;
 
 	if (written == devdata->fsize) {
-		if (!subsurface_rename(tmp, final)) {
-			dev_info(devdata, "  ... %d bytes and dive ID", written);
+		if (!subsurface_rename(tmp, final))
 			return;
-		}
 	}
 	unlink(tmp);
 }
@@ -965,14 +964,17 @@ static void verify_fingerprint(dc_device_t *device, device_data_t *devdata, cons
 	memcpy(&deviceid, buffer + size, 4);
 	memcpy(&diveid, buffer + size + 4, 4);
 
-	dev_info(devdata, " ... fingerprinted dive %08x:%08x", deviceid, diveid);
+	if (verbose)
+		dev_info(devdata, " ... fingerprinted dive %08x:%08x", deviceid, diveid);
 	/* Only use it if we *have* that dive! */
 	if (!has_dive(deviceid, diveid)) {
-		dev_info(devdata, " ... dive not found");
+		if (verbose)
+			dev_info(devdata, " ... dive not found");
 		return;
 	}
 	dc_device_set_fingerprint(device, buffer, size);
-	dev_info(devdata, " ... fingerprint of size %zu", size);
+	if (verbose)
+		dev_info(devdata, " ... fingerprint of size %zu", size);
 }
 
 /*
@@ -989,9 +991,11 @@ static void lookup_fingerprint(dc_device_t *device, device_data_t *devdata)
 		return;
 
 	cachename = fingerprint_file(devdata);
-	dev_info(devdata, "Looking for fingerprint in '%s'", cachename);
+	if (verbose)
+		dev_info(devdata, "Looking for fingerprint in '%s'", cachename);
 	if (readfile(cachename, &mem) > 0) {
-		dev_info(devdata, " ... got %zu bytes", mem.size);
+		if (verbose)
+			dev_info(devdata, " ... got %zu bytes", mem.size);
 		verify_fingerprint(device, devdata, mem.buffer, mem.size);
 		free(mem.buffer);
 	}

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1009,7 +1009,7 @@ QString get_short_dive_date_string(timestamp_t when)
 
 char *get_dive_date_c_string(timestamp_t when)
 {
-	QString text = get_dive_date_string(when);
+	QString text = get_short_dive_date_string(when);
 	return copy_qstring(text);
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Two small changes around the verbosity of updates during a download from a dive computer.
On the one hand, the updates about the fingerprint file really weren't all that useful for normal users.
On the other hand, especially on dive computers like the G2 that download potentially a LOT of data before starting to parse things and update the user about dives that were found, the download could look like it hung. So as a compromise between "verbosity" and "looking hung", send a quick update to the status line every 10k. That seemed like a good compromise as on BLE that still takes quite a while, yet on USBHID that still takes long enough to not look ridiculous.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
maybe? that seems pretty small

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
