### PR TITLE
store fingerprints with the dive log

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -252,3 +252,54 @@ extern "C" void create_fingerprint_node(struct fingerprint_table *table, uint32_
 		table->fingerprints.insert(it, fpr);
 	}
 }
+
+extern "C" void create_fingerprint_node_from_hex(struct fingerprint_table *table, uint32_t model, uint32_t serial,
+						const char *hex_data, uint32_t fdeviceid, uint32_t fdiveid)
+{
+	QByteArray raw = QByteArray::fromHex(hex_data);
+	create_fingerprint_node(table, model, serial,
+				(const unsigned char *)raw.constData(), raw.size(), fdeviceid, fdiveid);
+}
+
+extern "C" int nr_fingerprints(struct fingerprint_table *table)
+{
+	return table->fingerprints.size();
+}
+
+extern "C" uint32_t fp_get_model(struct fingerprint_table *table, unsigned int i)
+{
+	if (!table || i >= table->fingerprints.size())
+		return 0;
+	return table->fingerprints[i].model;
+}
+
+extern "C" uint32_t fp_get_serial(struct fingerprint_table *table, unsigned int i)
+{
+	if (!table || i >= table->fingerprints.size())
+		return 0;
+	return table->fingerprints[i].serial;
+}
+
+extern "C" uint32_t fp_get_deviceid(struct fingerprint_table *table, unsigned int i)
+{
+	if (!table || i >= table->fingerprints.size())
+		return 0;
+	return table->fingerprints[i].fdeviceid;
+}
+
+extern "C" uint32_t fp_get_diveid(struct fingerprint_table *table, unsigned int i)
+{
+	if (!table || i >= table->fingerprints.size())
+		return 0;
+	return table->fingerprints[i].fdiveid;
+}
+
+extern "C" char *fp_get_data(struct fingerprint_table *table, unsigned int i)
+{
+	if (!table || i >= table->fingerprints.size())
+		return 0;
+	struct fingerprint_record *fpr = &table->fingerprints[i];
+	// fromRawData() avoids one copy of the raw_data
+	QByteArray hex = QByteArray::fromRawData((char *)fpr->raw_data, fpr->fsize).toHex();
+	return strdup(hex.constData());
+}

--- a/core/device.h
+++ b/core/device.h
@@ -44,8 +44,18 @@ extern void free_device_table(struct device_table *devices);
 // create fingerprint entry - raw data remains owned by caller
 extern void create_fingerprint_node(struct fingerprint_table *table, uint32_t model, uint32_t serial,
 				   const unsigned char *raw_data, unsigned int fsize, uint32_t fdeviceid, uint32_t fdiveid);
+extern void create_fingerprint_node_from_hex(struct fingerprint_table *table, uint32_t model, uint32_t serial,
+					    const char *hex_data, uint32_t fdeviceid, uint32_t fdiveid);
 // look up the fingerprint for model/serial - returns the number of bytes in the fingerprint; memory owned by the table
 extern unsigned int get_fingerprint_data(const struct fingerprint_table *table, uint32_t model, uint32_t serial, const unsigned char **fp_out);
+
+// access the fingerprint data from C
+extern int nr_fingerprints(struct fingerprint_table *table);
+extern uint32_t fp_get_model(struct fingerprint_table *table, unsigned int i);
+extern uint32_t fp_get_serial(struct fingerprint_table *table, unsigned int i);
+extern uint32_t fp_get_deviceid(struct fingerprint_table *table, unsigned int i);
+extern uint32_t fp_get_diveid(struct fingerprint_table *table, unsigned int i);
+extern char *fp_get_data(struct fingerprint_table *table, unsigned int i);
 
 #ifdef __cplusplus
 }

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1492,3 +1492,22 @@ struct dive *find_next_visible_dive(timestamp_t when)
 
 	return NULL;
 }
+
+bool has_dive(unsigned int deviceid, unsigned int diveid)
+{
+       int i;
+       struct dive *dive;
+
+       for_each_dive (i, dive) {
+	       struct divecomputer *dc;
+
+	       for_each_dc (dive, dc) {
+		       if (dc->deviceid != deviceid)
+			       continue;
+		       if (dc->diveid != diveid)
+			       continue;
+		       return 1;
+	       }
+       }
+       return 0;
+}

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -69,6 +69,7 @@ void clear_dive_table(struct dive_table *table);
 void move_dive_table(struct dive_table *src, struct dive_table *dst);
 struct dive *unregister_dive(int idx);
 extern void delete_single_dive(int idx);
+extern bool has_dive(unsigned int deviceid, unsigned int diveid);
 
 #ifdef __cplusplus
 }

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -926,25 +926,6 @@ static void save_fingerprint(device_data_t *devdata)
 	free(final);
 }
 
-static int has_dive(unsigned int deviceid, unsigned int diveid)
-{
-	int i;
-	struct dive *dive;
-
-	for_each_dive (i, dive) {
-		struct divecomputer *dc;
-
-		for_each_dc (dive, dc) {
-			if (dc->deviceid != deviceid)
-				continue;
-			if (dc->diveid != diveid)
-				continue;
-			return 1;
-		}
-	}
-	return 0;
-}
-
 /*
  * The fingerprint cache files contain the actual libdivecomputer
  * fingerprint, followed by 8 bytes of (deviceid,diveid) data.

--- a/core/parse.c
+++ b/core/parse.c
@@ -186,6 +186,16 @@ void reset_dc_settings(struct parser_state *state)
 	state->cur_settings.dc.deviceid = 0;
 }
 
+void reset_fingerprint(struct parser_state *state)
+{
+	free((void *)state->cur_settings.fingerprint.data);
+	state->cur_settings.fingerprint.data = NULL;
+	state->cur_settings.fingerprint.model = 0;
+	state->cur_settings.fingerprint.serial = 0;
+	state->cur_settings.fingerprint.fdeviceid = 0;
+	state->cur_settings.fingerprint.fdiveid = 0;
+}
+
 void settings_start(struct parser_state *state)
 {
 	state->in_settings = true;
@@ -196,6 +206,20 @@ void settings_end(struct parser_state *state)
 	state->in_settings = false;
 }
 
+void fingerprint_settings_start(struct parser_state *state)
+{
+	reset_fingerprint(state);
+}
+
+void fingerprint_settings_end(struct parser_state *state)
+{
+	create_fingerprint_node_from_hex(state->fingerprints,
+			state->cur_settings.fingerprint.model,
+			state->cur_settings.fingerprint.serial,
+			state->cur_settings.fingerprint.data,
+			state->cur_settings.fingerprint.fdeviceid,
+			state->cur_settings.fingerprint.fdiveid);
+}
 void dc_settings_start(struct parser_state *state)
 {
 	reset_dc_settings(state);

--- a/core/parse.h
+++ b/core/parse.h
@@ -30,6 +30,13 @@ struct parser_settings {
 		uint32_t deviceid;
 		const char *nickname, *serial_nr, *firmware;
 	} dc;
+	struct {
+		 uint32_t model;
+		 uint32_t serial;
+		 uint32_t fdeviceid;
+		 uint32_t fdiveid;
+		 const char *data;
+	} fingerprint;
 };
 
 enum import_source {
@@ -83,6 +90,7 @@ struct parser_state {
 	struct trip_table *trips;			/* non-owning */
 	struct dive_site_table *sites;			/* non-owning */
 	struct device_table *devices;			/* non-owning */
+	struct fingerprint_table *fingerprints;         /* non-owning */
 	struct filter_preset_table *filter_presets;	/* non-owning */
 
 	sqlite3 *sql_handle;			/* for SQL based parsers */
@@ -113,6 +121,8 @@ void reset_dc_info(struct divecomputer *dc, struct parser_state *state);
 void reset_dc_settings(struct parser_state *state);
 void settings_start(struct parser_state *state);
 void settings_end(struct parser_state *state);
+void fingerprint_settings_start(struct parser_state *state);
+void fingerprint_settings_end(struct parser_state *state);
 void dc_settings_start(struct parser_state *state);
 void dc_settings_end(struct parser_state *state);
 void dive_site_start(struct parser_state *state);

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -869,6 +869,16 @@ static void save_one_device(struct membuffer *b, const struct device *d)
 	put_string(b, "\n");
 }
 
+static void save_one_fingerprint(struct membuffer *b, unsigned int i)
+{
+	put_format(b, "fingerprint model=%08x serial=%08x deviceid=%08x diveid=%08x data=\"%s\"\n",
+		   fp_get_model(&fingerprint_table, i),
+		   fp_get_serial(&fingerprint_table, i),
+		   fp_get_deviceid(&fingerprint_table, i),
+		   fp_get_diveid(&fingerprint_table, i),
+		   fp_get_data(&fingerprint_table, i));
+}
+
 static void save_settings(git_repository *repo, struct dir *tree)
 {
 	struct membuffer b = { 0 };
@@ -876,6 +886,10 @@ static void save_settings(git_repository *repo, struct dir *tree)
 	put_format(&b, "version %d\n", DATAFORMAT_VERSION);
 	for (int i = 0; i < nr_devices(&device_table); i++)
 		save_one_device(&b, get_device(&device_table, i));
+	/* save the fingerprint data */
+	for (unsigned int i = 0; i < nr_fingerprints(&fingerprint_table); i++)
+		save_one_fingerprint(&b, i);
+
 	cond_put_format(autogroup, &b, "autogroup\n");
 	save_units(&b);
 	if (prefs.tankbar)

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -607,6 +607,16 @@ static void save_one_device(struct membuffer *b, const struct device *d)
 	put_format(b, "/>\n");
 }
 
+static void save_one_fingerprint(struct membuffer *b, int i)
+{
+	put_format(b, "<fingerprint model='%08x' serial='%08x' deviceid='%08x' diveid='%08x' data='%s'/>\n",
+		   fp_get_model(&fingerprint_table, i),
+		   fp_get_serial(&fingerprint_table, i),
+		   fp_get_deviceid(&fingerprint_table, i),
+		   fp_get_diveid(&fingerprint_table, i),
+		   fp_get_data(&fingerprint_table, i));
+}
+
 int save_dives(const char *filename)
 {
 	return save_dives_logic(filename, false, false);
@@ -676,6 +686,10 @@ static void save_dives_buffer(struct membuffer *b, bool select_only, bool anonym
 		if (!select_only || device_used_by_selected_dive(d))
 			save_one_device(b, d);
 	}
+	/* save the fingerprint data */
+	for (int i = 0; i < nr_fingerprints(&fingerprint_table); i++)
+		save_one_fingerprint(b, i);
+
 	if (autogroup)
 		put_format(b, "  <autogroup state='1' />\n");
 	put_format(b, "</settings>\n");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
As discussed on the mailing list. Considering the fingerprint data "system local" is flawed - especially for divecomputers like the G2 that download all the data if we don't have a valid fingerprint, before they start to parse the data.

This creates an internal data structure to manage the fingerprints, including accessor functions that can be used from C code.
It then adds lookup and storage of fingerprints in that data structure
Finally it adds load/save support for both XML and git

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
this deserves some solid review.
I don't think I am ready to contemplate how this might interact with the undo system. There seemed too many weird issues when I tried to think about undoing a download operation. We don't throw away the on disk fingerprint either (or go back to a previous version, which would be more idiomatic).

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
yeah, I should write something :)

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
I don't think that's something we want to really document. It fixes a weird cornercase that most people won't care about - but people with a G2 **really** care about.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @torvalds 