### PR TITLE
mobile: correctly store manually entered GPS

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -850,6 +850,7 @@ static void setupDivesite(DiveSiteChange &res, struct dive *d, struct dive_site 
 		res.location = location;
 	} else {
 		res.createdDs.reset(alloc_dive_site_with_name(locationtext));
+		res.createdDs.get()->location = location;
 		d->dive_site = res.createdDs.get();
 	}
 	res.changed = true;
@@ -981,7 +982,10 @@ bool QMLManager::checkLocation(DiveSiteChange &res, struct dive *d, QString loca
 	if (formatDiveGPS(d) != gps) {
 		double lat, lon;
 		if (parseGpsText(gps, &lat, &lon)) {
-			qDebug() << "parsed GPS, using it";
+			if (location.isEmpty())
+				location = gps;
+			if (verbose)
+				qDebug() << "parsed GPS" << gps << ", using it for dive site" << location;
 			// there are valid GPS coordinates - just use them
 			setupDivesite(res, d, ds, lat, lon, qPrintable(location));
 		} else {


### PR DESCRIPTION
If there was no pre-existing dive site for a dive, manually entered GPS
information didn't get saved.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
ensure that we have a valid name for the dive site - if there's no given, use the coordinates
save the location with a newly created dive site

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
a fair number of bug reports from Subsurface-mobile useres

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger - can you please double check my logic?