### PR TITLE
profile: fix editing depth / duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Profile: Fix editing of time / duration (profile of edited dive was not shown)
 Divelist: Don't attempt to compute SAC for CCR dives
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -306,6 +306,7 @@ void EditDuration::set(struct dive *d, int value) const
 	d->duration = d->dc.duration;
 	d->dc.meandepth.mm = 0;
 	d->dc.samples = 0;
+	fake_dc(&d->dc);
 }
 
 int EditDuration::data(struct dive *d) const
@@ -325,6 +326,7 @@ void EditDepth::set(struct dive *d, int value) const
 	d->maxdepth = d->dc.maxdepth;
 	d->dc.meandepth.mm = 0;
 	d->dc.samples = 0;
+	fake_dc(&d->dc);
 }
 
 int EditDepth::data(struct dive *d) const


### PR DESCRIPTION
The undo commands for depth and duration editing cleared
the samples of the dive computer. They relied on the profile
automatically creating a fake profile. However, at some point
that code got removed. Therefore, do it explicitly in the undo
command.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a severe bug: Editing of the duration / depth of manually added dives made the profile not display anything. The reason being that the edit command clears the profile and relied on the profile-widget recalculating it. However, I removed that some time ago, not realizing that this was still needed in this case. Hrmpf.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.