### PR TITLE
Allow rudimentary ordering of the bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Statistics: Implement ordering of categorical bar charts
 Profile: Fix editing of time / duration (profile of edited dive was not shown)
 Divelist: Don't attempt to compute SAC for CCR dives
 ---

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -84,6 +84,7 @@ StatsWidget::StatsWidget(QWidget *parent) : QWidget(parent)
 	connect(ui.var1Binner, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::var1BinnerChanged);
 	connect(ui.var2Binner, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::var2BinnerChanged);
 	connect(ui.var2Operation, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::var2OperationChanged);
+	connect(ui.var1Sort, QOverload<int>::of(&QComboBox::activated), this, &StatsWidget::var1SortChanged);
 	connect(ui.restrictButton, &QToolButton::clicked, this, &StatsWidget::restrict);
 	connect(ui.unrestrictButton, &QToolButton::clicked, this, &StatsWidget::unrestrict);
 
@@ -129,6 +130,8 @@ void StatsWidget::updateUi()
 	setBinList(ui.var1Binner, uiState.binners1);
 	setBinList(ui.var2Binner, uiState.binners2);
 	setVariableList(ui.var2Operation, uiState.operations2);
+	setVariableList(ui.var1Sort, uiState.sortMode1);
+	ui.sortGroup->setVisible(!uiState.sortMode1.variables.empty());
 
 	// Add checkboxes for additional features
 	features.clear();
@@ -195,6 +198,12 @@ void StatsWidget::var2BinnerChanged(int idx)
 void StatsWidget::var2OperationChanged(int idx)
 {
 	state.var2OperationChanged(ui.var2Operation->itemData(idx).toInt());
+	updateUi();
+}
+
+void StatsWidget::var1SortChanged(int idx)
+{
+	state.sortMode1Changed(ui.var1Sort->itemData(idx).toInt());
 	updateUi();
 }
 

--- a/desktop-widgets/statswidget.h
+++ b/desktop-widgets/statswidget.h
@@ -24,6 +24,7 @@ slots:
 	void var1BinnerChanged(int);
 	void var2BinnerChanged(int);
 	void var2OperationChanged(int);
+	void var1SortChanged(int);
 	void featureChanged(int, bool);
 	void restrict();
 	void unrestrict();

--- a/desktop-widgets/statswidget.ui
+++ b/desktop-widgets/statswidget.ui
@@ -96,6 +96,18 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="sortGroup">
+       <property name="title">
+        <string>Sorting</string>
+       </property>
+       <layout class="QVBoxLayout" name="chartLayout">
+        <item>
+         <widget class="QComboBox" name="var1Sort" />
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="restrictionGroup">
        <property name="title">
         <string>Restriction</string>

--- a/mobile-widgets/qml/StatisticsPage.qml
+++ b/mobile-widgets/qml/StatisticsPage.qml
@@ -108,7 +108,7 @@ Kirigami.Page {
 			TemplateSlimComboBox  {
 				id: var1
 				model: statsManager.var1List
-				currentIndex: statsManager.var1Index;
+				currentIndex: statsManager.var1Index
 				onCurrentIndexChanged: {
 					statsManager.var1Changed(currentIndex)
 				}
@@ -125,7 +125,7 @@ Kirigami.Page {
 			TemplateSlimComboBox {
 				id: var1Binner
 				model: statsManager.binner1List
-				currentIndex: statsManager.binner1Index;
+				currentIndex: statsManager.binner1Index
 				onCurrentIndexChanged: {
 					statsManager.var1BinnerChanged(currentIndex)
 				}
@@ -142,7 +142,7 @@ Kirigami.Page {
 			TemplateSlimComboBox {
 				id: var2
 				model: statsManager.var2List
-				currentIndex: statsManager.var2Index;
+				currentIndex: statsManager.var2Index
 				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var2Changed(currentIndex)
@@ -160,7 +160,7 @@ Kirigami.Page {
 			TemplateSlimComboBox {
 				id: var2Binner
 				model: statsManager.binner2List
-				currentIndex: statsManager.binner2Index;
+				currentIndex: statsManager.binner2Index
 				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var2BinnerChanged(currentIndex)
@@ -178,10 +178,28 @@ Kirigami.Page {
 			TemplateSlimComboBox {
 				id: var2Operation
 				model: statsManager.operation2List
-				currentIndex: statsManager.operation2Index;
+				currentIndex: statsManager.operation2Index
 				Layout.fillWidth: false
 				onCurrentIndexChanged: {
 					statsManager.var2OperationChanged(currentIndex)
+				}
+			}
+		}
+		ColumnLayout {
+			id: i6
+			Layout.column: wide ? 0 : 0
+			Layout.row: wide ? 6 : 3
+			Layout.leftMargin: Kirigami.Units.smallSpacing
+			TemplateLabelSmall {
+				text: qsTr("SortMode")
+			}
+			TemplateSlimComboBox {
+				id: sortMode1
+				model: statsManager.sortMode1List
+				currentIndex: statsManager.sortMode1Index
+				Layout.fillWidth: false
+				onCurrentIndexChanged: {
+					statsManager.sortMode1Changed(currentIndex)
 				}
 			}
 		}
@@ -216,7 +234,7 @@ Kirigami.Page {
 		}
 		StatsView {
 			Layout.column: wide ? 1 : 0
-			Layout.row: wide ? 0 : 3
+			Layout.row: wide ? 0 : 4
 			Layout.columnSpan: wide ? 1 : 3
 			Layout.rowSpan: wide ? 7 : 1
 			id: statsView

--- a/mobile-widgets/statsmanager.cpp
+++ b/mobile-widgets/statsmanager.cpp
@@ -50,16 +50,19 @@ void StatsManager::updateUi()
 	setVariableList(uiState.var2, var2List, var2Index);
 	setBinnerList(uiState.binners2, binner2List, binner2Index);
 	setVariableList(uiState.operations2, operation2List, operation2Index);
+	setVariableList(uiState.sortMode1, sortMode1List, sortMode1Index);
 	var1ListChanged();
 	binner1ListChanged();
 	var2ListChanged();
 	binner2ListChanged();
 	operation2ListChanged();
+	sortMode1ListChanged();
 	var1IndexChanged();
 	binner1IndexChanged();
 	var2IndexChanged();
 	binner2IndexChanged();
 	operation2IndexChanged();
+	sortMode1IndexChanged();
 
 	if (charts)
 		charts->update(uiState.charts);
@@ -103,6 +106,15 @@ void StatsManager::var2OperationChanged(int idx)
 		return;
 	idx = std::clamp(idx, 0, (int)uiState.operations2.variables.size());
 	state.var2OperationChanged(uiState.operations2.variables[idx].id);
+	updateUi();
+}
+
+void StatsManager::sortMode1Changed(int idx)
+{
+	if (uiState.sortMode1.variables.empty())
+		return;
+	idx = std::clamp(idx, 0, (int)uiState.sortMode1.variables.size());
+	state.sortMode1Changed(uiState.sortMode1.variables[idx].id);
 	updateUi();
 }
 

--- a/mobile-widgets/statsmanager.h
+++ b/mobile-widgets/statsmanager.h
@@ -17,11 +17,13 @@ public:
 	Q_PROPERTY(QStringList var2List MEMBER var2List NOTIFY var2ListChanged)
 	Q_PROPERTY(QStringList binner2List MEMBER binner2List NOTIFY binner2ListChanged)
 	Q_PROPERTY(QStringList operation2List MEMBER operation2List NOTIFY operation2ListChanged)
+	Q_PROPERTY(QStringList sortMode1List MEMBER sortMode1List NOTIFY sortMode1ListChanged)
 	Q_PROPERTY(int var1Index MEMBER var1Index NOTIFY var1IndexChanged)
 	Q_PROPERTY(int binner1Index MEMBER binner1Index NOTIFY binner1IndexChanged)
 	Q_PROPERTY(int var2Index MEMBER var2Index NOTIFY var2IndexChanged)
 	Q_PROPERTY(int binner2Index MEMBER binner2Index NOTIFY binner2IndexChanged)
 	Q_PROPERTY(int operation2Index MEMBER operation2Index NOTIFY operation2IndexChanged)
+	Q_PROPERTY(int sortMode1Index MEMBER sortMode1Index NOTIFY sortMode1IndexChanged)
 
 	StatsManager();
 	~StatsManager();
@@ -32,6 +34,7 @@ public:
 	Q_INVOKABLE void var2Changed(int idx);
 	Q_INVOKABLE void var2BinnerChanged(int idx);
 	Q_INVOKABLE void var2OperationChanged(int idx);
+	Q_INVOKABLE void sortMode1Changed(int idx);
 	Q_INVOKABLE void setChart(int idx);
 signals:
 	void var1ListChanged();
@@ -39,11 +42,13 @@ signals:
 	void var2ListChanged();
 	void binner2ListChanged();
 	void operation2ListChanged();
+	void sortMode1ListChanged();
 	void var1IndexChanged();
 	void binner1IndexChanged();
 	void var2IndexChanged();
 	void binner2IndexChanged();
 	void operation2IndexChanged();
+	void sortMode1IndexChanged();
 private:
 	StatsView *view;
 	ChartListModel *charts;
@@ -53,11 +58,13 @@ private:
 	QStringList var2List;
 	QStringList binner2List;
 	QStringList operation2List;
+	QStringList sortMode1List;
 	int var1Index;
 	int binner1Index;
 	int var2Index;
 	int binner2Index;
 	int operation2Index;
+	int sortMode1Index;
 	StatsState::UIState uiState;	// Remember UI state so that we can interpret indexes
 	void updateUi();
 

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -102,7 +102,7 @@ PieSeries::PieSeries(StatsView &view, StatsAxis *xAxis, StatsAxis *yAxis, const 
 	for (const auto &[name, dives]: data)
 		totalCount += (int)dives.size();
 
-	// First of all, sort from largest to smalles slice. Instead
+	// First of all, sort from largest to smallest slice. Instead
 	// of sorting the initial array, sort a list of indices, so that
 	// the original order can be easily reconstructed later.
 	std::vector<int> sorted(data.size());

--- a/stats/pieseries.cpp
+++ b/stats/pieseries.cpp
@@ -82,7 +82,7 @@ void PieSeries::Item::highlight(ChartPieItem &item, int bin_nr, bool highlight, 
 }
 
 PieSeries::PieSeries(StatsView &view, StatsAxis *xAxis, StatsAxis *yAxis, const QString &categoryName,
-		     std::vector<std::pair<QString, std::vector<dive *>>> data, bool keepOrder) :
+		     std::vector<std::pair<QString, std::vector<dive *>>> data, ChartSortMode sortMode) :
 	StatsSeries(view, xAxis, yAxis),
 	item(view.createChartItem<ChartPieItem>(ChartZValue::Series, pieBorderWidth)),
 	categoryName(categoryName),
@@ -134,7 +134,7 @@ PieSeries::PieSeries(StatsView &view, StatsAxis *xAxis, StatsAxis *yAxis, const 
 		++it;
 
 	// Sort the main groups and the other groups back, if requested
-	if (keepOrder) {
+	if (sortMode == ChartSortMode::Bin) {
 		std::sort(sorted.begin(), it);
 		std::sort(it, sorted.end());
 	}

--- a/stats/pieseries.h
+++ b/stats/pieseries.h
@@ -15,6 +15,7 @@ struct InformationBox;
 class ChartPieItem;
 class ChartTextItem;
 class QRectF;
+enum class ChartSortMode : int;
 
 class PieSeries : public StatsSeries {
 public:
@@ -22,7 +23,7 @@ public:
 	// If keepOrder is false, bins will be sorted by size, otherwise the sorting
 	// of the shown bins will be retained. Small bins are omitted for clarity.
 	PieSeries(StatsView &view, StatsAxis *xAxis, StatsAxis *yAxis, const QString &categoryName,
-		  std::vector<std::pair<QString, std::vector<dive *>>> data, bool keepOrder);
+		  std::vector<std::pair<QString, std::vector<dive *>>> data, ChartSortMode sortMode);
 	~PieSeries();
 
 	void updatePositions() override;

--- a/stats/statsstate.h
+++ b/stats/statsstate.h
@@ -36,6 +36,12 @@ enum class ChartSubType {
 	Count
 };
 
+enum class ChartSortMode {
+	Bin = 0,	// Sort according to the binner (i.e. don't change sorting)
+	Count,		// Sort by number of dives in the bin
+	Value		// Sort by the displayed value of the bin
+};
+
 struct ChartTypeDesc; // Internal implementation detail
 struct StatsVariable;
 struct StatsBinner;
@@ -84,6 +90,9 @@ public:
 		std::vector<Feature> features;
 		BinnerList binners1;
 		BinnerList binners2;
+		// Currently, only alternative sorting on the first variable.
+		// Sort mode reuses the variable list - not very nice.
+		VariableList sortMode1;
 		// Currently, operations are only supported on the second variable
 		// This reuses the variable list - not very nice.
 		VariableList operations2;
@@ -97,6 +106,7 @@ public:
 	void binner1Changed(int id);
 	void binner2Changed(int id);
 	void var2OperationChanged(int id);
+	void sortMode1Changed(int id);
 	void featureChanged(int id, bool state);
 
 	const StatsVariable *var1;	// Independent variable
@@ -113,6 +123,7 @@ public:
 	const StatsBinner *var1Binner;	// nullptr: undefined
 	const StatsBinner *var2Binner;	// nullptr: undefined
 	StatsOperation var2Operation;
+	ChartSortMode sortMode1;
 private:
 	void validate(bool varChanged);
 	int chartFeatures;

--- a/stats/statsvariables.cpp
+++ b/stats/statsvariables.cpp
@@ -41,7 +41,7 @@ static QString join_strings(const std::vector<QString> &v)
 	return res;
 }
 
-// A wrapper around dive site, that caches the name of the dive site
+// A wrapper around dive site that caches the name of the dive site
 struct DiveSiteWrapper {
 	const dive_site *ds;
 	QString name;
@@ -67,7 +67,7 @@ struct DiveSiteWrapper {
 	}
 };
 
-// A wrapper around dive trips, that caches the name and date of the trip and sorts by trip start date
+// A wrapper around dive trips that caches the name and date of the trip and sorts by trip start date
 struct TripWrapper {
 	const dive_trip *t;
 	QString name;

--- a/stats/statsview.h
+++ b/stats/statsview.h
@@ -36,6 +36,7 @@ class RootNode;	// Internal implementation detail
 enum class ChartSubType : int;
 enum class ChartZValue : int;
 enum class StatsOperation : int;
+enum class ChartSortMode : int;
 
 class StatsView : public QQuickItem {
 	Q_OBJECT
@@ -81,17 +82,17 @@ private:
 	void reset(); // clears all series and axes
 	void setAxes(StatsAxis *x, StatsAxis *y);
 	void plotBarChart(const std::vector<dive *> &dives,
-			  ChartSubType subType,
+			  ChartSubType subType, ChartSortMode sortMode,
 			  const StatsVariable *categoryVariable, const StatsBinner *categoryBinner,
 			  const StatsVariable *valueVariable, const StatsBinner *valueBinner);
 	void plotValueChart(const std::vector<dive *> &dives,
-			    ChartSubType subType,
+			    ChartSubType subType, ChartSortMode sortMode,
 			    const StatsVariable *categoryVariable, const StatsBinner *categoryBinner,
 			    const StatsVariable *valueVariable, StatsOperation valueAxisOperation);
 	void plotDiscreteCountChart(const std::vector<dive *> &dives,
-				    ChartSubType subType,
+				    ChartSubType subType, ChartSortMode sortMode,
 				    const StatsVariable *categoryVariable, const StatsBinner *categoryBinner);
-	void plotPieChart(const std::vector<dive *> &dives,
+	void plotPieChart(const std::vector<dive *> &dives, ChartSortMode sortMode,
 			  const StatsVariable *categoryVariable, const StatsBinner *categoryBinner);
 	void plotDiscreteBoxChart(const std::vector<dive *> &dives,
 				  const StatsVariable *categoryVariable, const StatsBinner *categoryBinner, const StatsVariable *valueVariable);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was requested on the mailing list, when introducing the statistics module: allow sorting of bar charts by count. In the case of value-based charts, this sorts by value and by count.

The UI is inconsistent, since here the allowed options are based on the chart and not vice-versa. I found the other way round a bit confusing. YMMV.

The good thing about this is that it provides a rather obvious differentiation between histograms and categorical charts. That caused some confusion in the past.

For stacked/grouped bar charts, we might think about sorting on the second variable. However, the result might be extremely confusing.

The layout of the mobile version is funky in wide mode. Beware.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add rudimentary sorting of bar charts.
2) Add support on mobile.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Still has to be done. Could be a good way to clarify the dichotomy categorical charts / histograms.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@willemferguson 