### PR TITLE
tests: fix integer constants

### DIFF
--- a/tests/testunitconversion.cpp
+++ b/tests/testunitconversion.cpp
@@ -10,14 +10,14 @@ void TestUnitConversion::testUnitConversions()
 	QCOMPARE(IS_FP_SAME(ml_to_cuft(1000), 0.0353147), true);
 	QCOMPARE(IS_FP_SAME(cuft_to_l(1), 28.316847), true);
 	QCOMPARE(IS_FP_SAME(mm_to_feet(1000), 3.280840), true);
-	QCOMPARE(feet_to_mm(1), (long unsigned int)305);
+	QCOMPARE(feet_to_mm(1), 305L);
 	QCOMPARE(to_feet((depth_t){1000}), 3);
 	QCOMPARE(IS_FP_SAME(mkelvin_to_C(647000), 373.85), true);
 	QCOMPARE(IS_FP_SAME(mkelvin_to_F(647000), 704.93), true);
-	QCOMPARE(F_to_mkelvin(704.93), (unsigned long)647000);
-	QCOMPARE(C_to_mkelvin(373.85), (unsigned long)647000);
+	QCOMPARE(F_to_mkelvin(704.93), 647000UL);
+	QCOMPARE(C_to_mkelvin(373.85), 647000UL);
 	QCOMPARE(IS_FP_SAME(psi_to_bar(14.6959488), 1.01325), true);
-	QCOMPARE(psi_to_mbar(14.6959488), (long)1013);
+	QCOMPARE(psi_to_mbar(14.6959488), 1013L);
 	QCOMPARE(IS_FP_SAME(to_PSI((pressure_t){1013}), 14.6923228594), true);
 	QCOMPARE(IS_FP_SAME(bar_to_atm(1.013), 1.0), true);
 	QCOMPARE(IS_FP_SAME(mbar_to_atm(1013), 1.0), true);


### PR DESCRIPTION
In TestUnitConversion we used casts instead of the more common suffix
designations to indicate the type of those integer constants.
Worse, in commit efab955d85 ("cleanup: make feet_to_mm signed") the
return type of feet_to_mm() changed, but the value it is compared to
wasn't adjusted in the test which caused some builds with more
aggressive compiler flags to fail.


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
This caused the Coverity build to fail


### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 