### PR TITLE
planner: properly keep track of cylinder count in model

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -484,6 +484,7 @@ void CylindersModel::add()
 	cylinder_t cyl = create_new_cylinder(d);
 	beginInsertRows(QModelIndex(), row, row);
 	add_cylinder(&d->cylinders, row, cyl);
+	++numRows;
 	endInsertRows();
 	emit dataChanged(createIndex(row, 0), createIndex(row, COLUMNS - 1));
 }
@@ -539,6 +540,7 @@ void CylindersModel::remove(QModelIndex index)
 
 	beginRemoveRows(QModelIndex(), index.row(), index.row());
 	remove_cylinder(d, index.row());
+	--numRows;
 	endRemoveRows();
 
 	std::vector<int> mapping = get_cylinder_map_for_remove(d->cylinders.nr + 1, index.row());


### PR DESCRIPTION
In a40b40a the cylinder-hiding functionality was changed,
which made it necessary to keep track of the number of
cylinders. Ironically, that code was removed previously,
as it was redundant. The count was not readded to the
functions called by the planner, making editing of cylinders
in the planner impossible.

I wonder more and more if the models for planner and the
equipment tab should be changed. They are too different.

Fixes #3375

Reported-by: Anton Lundin <glance@acc.umu.se>
Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not much to say - hopefully fixes #3375.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Keep track of rowCount in cylinder model.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3375 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No - not in release.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
