### PR TITLE
[no merging, please] desktop: don't update notes field if unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+Desktop: Don't lose cursor position in notes when switching between windows
 Statistics: Implement ordering of categorical bar charts
 Profile: Fix editing of time / duration (profile of edited dive was not shown)
 Divelist: Don't attempt to compute SAC for CCR dives


### PR DESCRIPTION
User report: when switching focus between windows, the
cursor position gets lost. This is due to a note-edit
command being fired, which then overwrites the notes tab.

This should probably fixed in a better way (recognize that
the field is being edited and not emit a signal). However,
this is a quick fix for now.

Should this be extended to other fields?

Fixes #3365

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a somewhat unsatisfying fix for #3365. It works in my simple testing though.

Of course, if we want to go this route, this should also be done for the other text fields! Let's wait for user input.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Don't set notes tab when unchanged.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3365

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
