### PR TITLE
Fix/uemis retry resuming download without retry button

### DIFF
--- a/Documentation/50-pot/subsurface-user-manual.pot
+++ b/Documentation/50-pot/subsurface-user-manual.pot
@@ -9076,6 +9076,9 @@ msgid ""
 "reconnect it. You can now retry (or start a new download session) and the "
 "download will continue where it stopped previously. You may have to do this "
 "more than once, depending on how many dives are stored on the dive computer."
+"You may define a dive number offset by setting environment variable "
+"UEMIS_DIVE_OFFSET (e.g. export UEMIS_DIVE_OFFSET=300), "
+"if subsurface starts downloading dives that are already synced."
 msgstr ""
 
 #. type: Title ===

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -32,7 +32,7 @@
 #include "subsurface-time.h"
 #include "core/subsurface-string.h"
 
-#define ERR_FS_ALMOST_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is almost full.\nDisconnect/reconnect the dive computer\nand click \'Retry\'")
+#define ERR_FS_ALMOST_FULL QT_TRANSLATE_NOOP("gettextFromC", "Disconnect/reconnect the SDA")
 #define ERR_FS_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is full.\nDisconnect/reconnect the dive computer\nand click Retry")
 #define ERR_FS_SHORT_WRITE QT_TRANSLATE_NOOP("gettextFromC", "Short write to req.txt file.\nIs the Uemis Zurich plugged in correctly?")
 #define ERR_NO_FILES QT_TRANSLATE_NOOP("gettextFromC", "No dives to download.")
@@ -1434,7 +1434,13 @@ const char *do_uemis_import(device_data_t *data)
 #if UEMIS_DEBUG & 4
 				fprintf(debugfile, "d_u_i out of memory, bailing\n");
 #endif
-				break;
+				char msg[strlen(translate("gettextFromC", ERR_FS_ALMOST_FULL)) + 4];
+				for (int wait=60; wait >=0; wait--){
+					sprintf(msg, "%s %ds", translate("gettextFromC", ERR_FS_ALMOST_FULL), wait);
+					uemis_info(msg);
+					filenr = 0;
+					usleep(1000000);
+				}
 			}
 			/* if the user clicked cancel, exit gracefully */
 			if (import_thread_cancelled) {

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -33,6 +33,7 @@
 #include "core/subsurface-string.h"
 
 #define ACTION_RECONNECT QT_TRANSLATE_NOOP("gettextFromC", "Disconnect/reconnect the SDA")
+#define ERR_FS_ALMOST_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is almost full.\nDisconnect/reconnect the dive computer\nand click \'Retry\'")
 #define ERR_FS_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is full.\nDisconnect/reconnect the dive computer\nand click Retry")
 #define ERR_FS_SHORT_WRITE QT_TRANSLATE_NOOP("gettextFromC", "Short write to req.txt file.\nIs the Uemis Zurich plugged in correctly?")
 #define ERR_NO_FILES QT_TRANSLATE_NOOP("gettextFromC", "No dives to download.")
@@ -1374,7 +1375,8 @@ const char *do_uemis_import(device_data_t *data)
 
 	first = start = atoi(newmax);
 	dive_to_read = mindiveid < first ? first - mindiveid : first;
-	start += dive_offset;
+	if (dive_offset > 0)
+		start += dive_offset;
 	for (;;) {
 #if UEMIS_DEBUG & 2
 		debug_round++;
@@ -1446,7 +1448,6 @@ const char *do_uemis_import(device_data_t *data)
 				const char *errormsg = translate("gettextFromC", ACTION_RECONNECT);
 				for (int wait=60; wait >=0; wait--){
 					uemis_info("%s %ds", errormsg, wait);
-					filenr = 0;
 					usleep(1000000);
 				}
 				// Resetting to original state
@@ -1519,6 +1520,9 @@ const char *do_uemis_import(device_data_t *data)
 		else
 			next_table_index++;
 	}
+	
+	if (uemis_mem_status != UEMIS_MEM_OK)
+		result = translate("gettextFromC", ERR_FS_ALMOST_FULL);
 
 bail:
 	(void)uemis_get_answer(mountpath, "terminateSync", 0, 3, &result);

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1443,12 +1443,13 @@ const char *do_uemis_import(device_data_t *data)
 				fprintf(debugfile, "d_u_i out of memory, bailing\n");
 #endif
 				(void)uemis_get_answer(mountpath, "terminateSync", 0, 3, &result);
-				char msg[strlen(translate("gettextFromC", ACTION_RECONNECT)) + 4];
+				const char *errormsg = translate("gettextFromC", ACTION_RECONNECT);
 				for (int wait=60; wait >=0; wait--){
-					sprintf(msg, "%s %ds", translate("gettextFromC", ACTION_RECONNECT), wait);
-					uemis_info(msg);
+					uemis_info("%s %ds", errormsg, wait);
+					filenr = 0;
 					usleep(1000000);
 				}
+				// Resetting to original state
 				filenr = 0;
 				max_mem_used = -1;
 				uemis_mem_status = get_memory(data->download_table, UEMIS_CHECK_DETAILS);

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -32,7 +32,7 @@
 #include "subsurface-time.h"
 #include "core/subsurface-string.h"
 
-#define ERR_FS_ALMOST_FULL QT_TRANSLATE_NOOP("gettextFromC", "Disconnect/reconnect the SDA")
+#define ACTION_RECONNECT QT_TRANSLATE_NOOP("gettextFromC", "Disconnect/reconnect the SDA")
 #define ERR_FS_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is full.\nDisconnect/reconnect the dive computer\nand click Retry")
 #define ERR_FS_SHORT_WRITE QT_TRANSLATE_NOOP("gettextFromC", "Short write to req.txt file.\nIs the Uemis Zurich plugged in correctly?")
 #define ERR_NO_FILES QT_TRANSLATE_NOOP("gettextFromC", "No dives to download.")
@@ -1434,9 +1434,9 @@ const char *do_uemis_import(device_data_t *data)
 #if UEMIS_DEBUG & 4
 				fprintf(debugfile, "d_u_i out of memory, bailing\n");
 #endif
-				char msg[strlen(translate("gettextFromC", ERR_FS_ALMOST_FULL)) + 4];
+				char msg[strlen(translate("gettextFromC", ACTION_RECONNECT)) + 4];
 				for (int wait=60; wait >=0; wait--){
-					sprintf(msg, "%s %ds", translate("gettextFromC", ERR_FS_ALMOST_FULL), wait);
+					sprintf(msg, "%s %ds", translate("gettextFromC", ACTION_RECONNECT), wait);
 					uemis_info(msg);
 					filenr = 0;
 					usleep(1000000);
@@ -1494,9 +1494,6 @@ const char *do_uemis_import(device_data_t *data)
 		else
 			next_table_index++;
 	}
-
-	if (uemis_mem_status != UEMIS_MEM_OK)
-		result = translate("gettextFromC", ERR_FS_ALMOST_FULL);
 
 bail:
 	(void)uemis_get_answer(mountpath, "terminateSync", 0, 3, &result);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Is PR is a possible fix to issue #3385 .
There is a prompt to reconnect the Uemis from the status bar. Not a very elegant solution, but an easy solution for uemis downloader (which is written in C). I have an Uemis Zürich in excellent condition and tested the code with it.
I also added support for an environment variable to define an offset to start downloading from.

I know that this patch isn't very high quality. I'd rather suggest to re-implement the Uemis Zürich downloader from scratch in modern C++, if it wasn't for such an old legacy device. I just hope that you accept this small change to help the (few?) remaining Uemis users to elongate the useful lifespan of the remaining devices.

### Changes made:
1) Replaced "goto bail" with a prompt to reconnect the dive computer, if the synchronization memory is almost full.
2) Automatic termination, reset of filenr and re-initialization after a 60s timeout.
3) Reading an env variable UEMIS_DIVE_OFFSET, which can be used to modify the  start index for the (very slow) indexing process.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3385 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
Support synchronization over multiple reconnects with Uemis Zürich.

### Documentation change:
As you can see below, I added some lines to the documentation to provide some explanation for the use of the optional env variable.

### Mentions:
@dirkhh 
