### PR TITLE
[EXPERIMENTAL] dive master -> dive guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+General: rename dive master to dive guide
 Statistics: Implement ordering of categorical bar charts
 Profile: Fix editing of time / duration (profile of edited dive was not shown)
 Divelist: Don't attempt to compute SAC for CCR dives

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -178,7 +178,7 @@ These dives can be imported from:
 This is usually the approach for dives without a dive computer. The basic record
 of information within _Subsurface_ is a dive. The most important information
 in a simple dive logbook usually includes dive type, date, time, duration,
-depth, the names of your dive buddy and the divemaster or dive guide, and
+depth, the names of your dive buddy and the dive guide, and
 some remarks about the dive. _Subsurface_ can store much more
 information for each dive.  To add a dive to a dive log, select _Log
 ->  Add Dive_ from the Main Menu. The program then shows three panels
@@ -635,7 +635,7 @@ increase in the amount of information stored for a dive.
 
 1. The *Notes* tab
 holds basic information about the dive, the date and time, locality,
-buddy, divemaster and some dive notes. This is about the minimum amount of
+buddy, dive guide and some dive notes. This is about the minimum amount of
 information required for a coherent dive log. 
 
 2. If one wishes, one can expand the dive information by using the
@@ -701,7 +701,7 @@ image::images/undo.jpg["FIGURE:Performing an undo",align="center"]
 Dive locations are managed as a *separate* part of the dive log (See the section entitled xref:S_DiveSiteManagement[Manipulating Dive Site Information]).
 The dive information in the *Notes* and *Equipment* tabs can therefore NOT be edited at the same
 time as the dive site information. Save all the other dive information (e.g.
-divemaster, buddy, protective gear, notes about the dive) by selecting _Apply changes_ on the
+dive guide, buddy, protective gear, notes about the dive) by selecting _Apply changes_ on the
 *Notes* tab BEFORE editing the dive site information. Then supply a dive site name in the
 textbox labelled _Location_ on the *Notes* tab.
 
@@ -863,9 +863,8 @@ dive site name in the *Notes tab*.
 Having entered information about the dive site into the *Notes* tab, the following
 additional information can be typed in:
 
-*Divemaster*: The name of the divemaster or dive guide should be
-entered in this field
-which offers auto selection based on the list of divemasters in
+*Dive guide*: The name of the dive guide should be entered in this field
+which offers auto selection based on the list of dive guides in
 the current logbook.
 
 *Buddy*: In this field, enter the name(s) of the buddy or buddies
@@ -1107,7 +1106,7 @@ and gas composition). Other fields remain empty.
 It may be useful to simultaneously edit some of the
 fields in the *Notes* and *Equipment* tabs.  For instance, it’s possible
 that a diver performed several dives during a single day, using identical equipment at the same
-dive site, or with the same divemaster and/or buddy or tags. Instead
+dive site, or with the same dive guide and/or buddy or tags. Instead
 of completing the information for each
 dive separately, select all the dives for that day in the *Dive List* and
 insert the same information in the *Notes* and *Equipment* fields that need
@@ -1443,7 +1442,7 @@ There are two types of _CSV_ dive logs that can be imported into _Subsurface_:
 
 1. _CSV dive details_: This dive log format contains similar information to that of a
    typical written dive log, e.g. dive date and time, dive depth, dive duration, names of
-   buddy and divemaster and information about cylinder pressures before and
+   buddy and dive guide and information about cylinder pressures before and
    after the dive, as well as comments about the dive. All the data for a single
    dive go on a single line of text, following the order of the column headings.
 
@@ -2713,7 +2712,7 @@ restored to view by selecting Unhide all events from the context menu.
 === Filtering the dive list
 
 The dives in the *Dive List* can be filtered, selecting only some
-of the dives based on attributes such as dive tags, dive site, divemaster or buddy.
+of the dives based on attributes such as dive tags, dive site, dive guide or buddy.
 For instance, filtering lets you list the dives during a particular year at a specific
 dive site, or otherwise the cave dives with a particular buddy. Filtering can be performed
 based on virtually any information in the *Info* panel.
@@ -3217,7 +3216,7 @@ image::images/texexample.png["Figure: Export to TeX", align="center"]
   of each of those photos/videos was taken.
 
 When the "Anonymize" option is selected for xml-based file formats, the letters A-Z
-are all replaced by the letter 'X' in the notes, buddy, divemaster, divesite name
+are all replaced by the letter 'X' in the notes, buddy, dive guide, divesite name
 and divesite description fields. This way, you can share dive log files for debugging
 purposes without revealing personal information. Please note, though, that other
 characters are not replaced, so this is not useful for languages with non-latin
@@ -5234,7 +5233,7 @@ Only a subset of the dive data is exported:
 |location| (*string*) location of the dive
 |duration| (*string*) duration of the dive
 |depth| (*string*) depth of the dive
-|divemaster| (*string*) divemaster for the dive
+|diveguide| (*string*) dive guide for the dive
 |buddy| (*string*) buddy for the dive
 |airTemp| (*string*) air temperature of the dive
 |waterTemp| (*string*) water temperature of the dive
@@ -5443,7 +5442,7 @@ _Subsurface_ ends up ignoring surface time for many things (average depth, divet
 but then come back up and wait five minutes for your buddies, your dive computer may say
 that your dive is 50 minutes long - because you have fifty minutes worth of samples - but
 subsurface will say it's 45 minutes - because you were actually diving for 45 minutes.
-It's even more noticeable if you do things like divemastering the initial OW dives, when
+It's even more noticeable if you do things like guiding the initial OW dives, when
 you may stay in the water for a long time, but spend most of it at the surface. And then
 you don't want that to count as some kind of long dive”.
 

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -204,7 +204,7 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 		put_format(&buf, "\\def\\%sprofilename{profile%d}\n", ssrf, dive->number);
 		put_format(&buf, "\\def\\%scomment{%s}\n", ssrf, dive->notes ? dive->notes : "");
 		put_format(&buf, "\\def\\%sbuddy{%s}\n", ssrf, dive->buddy ? dive->buddy : "");
-		put_format(&buf, "\\def\\%sdivemaster{%s}\n", ssrf, dive->divemaster ? dive->divemaster : "");
+		put_format(&buf, "\\def\\%sdivemaster{%s}\n", ssrf, dive->diveguide ? dive->diveguide : "");
 		put_format(&buf, "\\def\\%ssuit{%s}\n", ssrf, dive->suit ? dive->suit : "");
 
 		// Print cylinder data

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -264,9 +264,9 @@ int editBuddies(const QStringList &newList, bool currentDiveOnly)
 	return execute_edit(new EditBuddies(newList, currentDiveOnly));
 }
 
-int editDiveMaster(const QStringList &newList, bool currentDiveOnly)
+int editDiveGuide(const QStringList &newList, bool currentDiveOnly)
 {
-	return execute_edit(new EditDiveMaster(newList, currentDiveOnly));
+	return execute_edit(new EditDiveGuide(newList, currentDiveOnly));
 }
 
 void pasteDives(const dive *d, dive_components what)

--- a/commands/command.h
+++ b/commands/command.h
@@ -90,7 +90,7 @@ int editDiveSite(struct dive_site *newValue, bool currentDiveOnly);
 int editDiveSiteNew(const QString &newName, bool currentDiveOnly);
 int editTags(const QStringList &newList, bool currentDiveOnly);
 int editBuddies(const QStringList &newList, bool currentDiveOnly);
-int editDiveMaster(const QStringList &newList, bool currentDiveOnly);
+int editDiveGuide(const QStringList &newList, bool currentDiveOnly);
 void pasteDives(const dive *d, dive_components what);
 void replanDive(dive *d); // dive computer(s) and cylinder(s) will be reset!
 void editProfile(dive *d); // dive computer(s) and cylinder(s) will be reset!

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -599,22 +599,22 @@ QString EditBuddies::fieldName() const
 	return Command::Base::tr("buddies");
 }
 
-// ***** DiveMaster *****
-QStringList EditDiveMaster::data(struct dive *d) const
+// ***** DiveGuide *****
+QStringList EditDiveGuide::data(struct dive *d) const
 {
-	return stringToList(d->divemaster);
+	return stringToList(d->diveguide);
 }
 
-void EditDiveMaster::set(struct dive *d, const QStringList &v) const
+void EditDiveGuide::set(struct dive *d, const QStringList &v) const
 {
 	QString text = v.join(", ");
-	free(d->divemaster);
-	d->divemaster = copy_qstring(text);
+	free(d->diveguide);
+	d->diveguide = copy_qstring(text);
 }
 
-QString EditDiveMaster::fieldName() const
+QString EditDiveGuide::fieldName() const
 {
-	return Command::Base::tr("dive master");
+	return Command::Base::tr("dive guide");
 }
 
 static void swapCandQString(QString &q, char *&c)
@@ -632,8 +632,8 @@ PasteState::PasteState(dive *dIn, const dive *data, dive_components what) : d(dI
 	memset(&weightsystems, 0, sizeof(weightsystems));
 	if (what.notes)
 		notes = data->notes;
-	if (what.divemaster)
-		divemaster = data->divemaster;
+	if (what.diveguide)
+		diveguide = data->diveguide;
 	if (what.buddy)
 		buddy = data->buddy;
 	if (what.suit)
@@ -705,8 +705,8 @@ void PasteState::swap(dive_components what)
 {
 	if (what.notes)
 		swapCandQString(notes, d->notes);
-	if (what.divemaster)
-		swapCandQString(divemaster, d->divemaster);
+	if (what.diveguide)
+		swapCandQString(diveguide, d->diveguide);
 	if (what.buddy)
 		swapCandQString(buddy, d->buddy);
 	if (what.suit)
@@ -766,7 +766,7 @@ void PasteDives::undo()
 	// Send signals.
 	DiveField fields(DiveField::NONE);
 	fields.notes = what.notes;
-	fields.divemaster = what.divemaster;
+	fields.diveguide = what.diveguide;
 	fields.buddy = what.buddy;
 	fields.suit = what.suit;
 	fields.rating = what.rating;
@@ -1321,8 +1321,8 @@ EditDive::EditDive(dive *oldDiveIn, dive *newDiveIn, dive_site *createDs, dive_s
 		changedFields |= DiveField::ATM_PRESS;
 	if (oldDive->dive_site != newDive->dive_site)
 		changedFields |= DiveField::DIVESITE;
-	if (!same_string(oldDive->divemaster, newDive->divemaster))
-		changedFields |= DiveField::DIVEMASTER;
+	if (!same_string(oldDive->diveguide, newDive->diveguide))
+		changedFields |= DiveField::DIVEGUIDE;
 	if (!same_string(oldDive->buddy, newDive->buddy))
 		changedFields |= DiveField::BUDDY;
 	if (oldDive->rating != newDive->rating)

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -229,7 +229,7 @@ public:
 	QString fieldName() const override;
 };
 
-// Fields that work with tag-lists (tags, buddies, divemasters) work differently and therefore
+// Fields that work with tag-lists (tags, buddies, dive guides) work differently and therefore
 // have their own base class. In this case, it's not a template, as all these lists are base
 // on strings.
 class EditTagsBase : public EditDivesBase {
@@ -276,7 +276,7 @@ public:
 	QString fieldName() const override;
 };
 
-class EditDiveMaster : public EditTagsTemplate<DiveField::DIVEMASTER> {
+class EditDiveGuide : public EditTagsTemplate<DiveField::DIVEGUIDE> {
 public:
 	using EditTagsTemplate::EditTagsTemplate;	// Use constructor of base class.
 	QStringList data(struct dive *d) const override;
@@ -289,7 +289,7 @@ struct PasteState {
 	dive *d;
 	dive_site *divesite;
 	QString notes;
-	QString divemaster;
+	QString diveguide;
 	QString buddy;
 	QString suit;
 	int rating;

--- a/core/dive.c
+++ b/core/dive.c
@@ -224,7 +224,7 @@ static void free_dive_structures(struct dive *d)
 	fulltext_unregister(d);
 	/* free the strings */
 	free(d->buddy);
-	free(d->divemaster);
+	free(d->diveguide);
 	free(d->notes);
 	free(d->suit);
 	/* free tags, additional dive computers, and pictures */
@@ -272,7 +272,7 @@ static void copy_dive_nodc(const struct dive *s, struct dive *d)
 	d->full_text = NULL;
 	invalidate_dive_cache(d);
 	d->buddy = copy_string(s->buddy);
-	d->divemaster = copy_string(s->divemaster);
+	d->diveguide = copy_string(s->diveguide);
 	d->notes = copy_string(s->notes);
 	d->suit = copy_string(s->suit);
 	copy_cylinders(&s->cylinders, &d->cylinders);
@@ -319,7 +319,7 @@ void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_compo
 	if (clear)
 		clear_dive(d);
 	CONDITIONAL_COPY_STRING(notes);
-	CONDITIONAL_COPY_STRING(divemaster);
+	CONDITIONAL_COPY_STRING(diveguide);
 	CONDITIONAL_COPY_STRING(buddy);
 	CONDITIONAL_COPY_STRING(suit);
 	if (what.rating)
@@ -2616,7 +2616,7 @@ struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset,
 		*trip = get_preferred_trip(a, b);
 	MERGE_TXT(res, a, b, notes, "\n--\n");
 	MERGE_TXT(res, a, b, buddy, ", ");
-	MERGE_TXT(res, a, b, divemaster, ", ");
+	MERGE_TXT(res, a, b, diveguide, ", ");
 	MERGE_MAX(res, a, b, rating);
 	MERGE_TXT(res, a, b, suit, ", ");
 	MERGE_MAX(res, a, b, number);

--- a/core/dive.h
+++ b/core/dive.h
@@ -32,7 +32,7 @@ struct dive {
 	timestamp_t when;
 	struct dive_site *dive_site;
 	char *notes;
-	char *divemaster, *buddy;
+	char *diveguide, *buddy;
 	struct cylinder_table cylinders;
 	struct weightsystem_table weightsystems;
 	char *suit;
@@ -78,7 +78,7 @@ extern int same_gasmix_cylinder(const cylinder_t *cyl, int cylid, const struct d
 struct dive_components {
 	unsigned int divesite : 1;
 	unsigned int notes : 1;
-	unsigned int divemaster : 1;
+	unsigned int diveguide : 1;
 	unsigned int buddy : 1;
 	unsigned int suit : 1;
 	unsigned int rating : 1;

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -848,7 +848,7 @@ static bool has_people(const filter_constraint &c, const struct dive *d)
 	QStringList dive_people;
 	for (const QString &s: QString(d->buddy).split(",", SKIP_EMPTY))
 		dive_people.push_back(s.trimmed());
-	for (const QString &s: QString(d->divemaster).split(",", SKIP_EMPTY))
+	for (const QString &s: QString(d->diveguide).split(",", SKIP_EMPTY))
 		dive_people.push_back(s.trimmed());
 	return check(c, dive_people);
 }

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -120,7 +120,7 @@ static std::vector<QString> getWords(const dive *d)
 {
 	std::vector<QString> res;
 	tokenize(QString(d->notes), res);
-	tokenize(QString(d->divemaster), res);
+	tokenize(QString(d->diveguide), res);
 	tokenize(QString(d->buddy), res);
 	tokenize(QString(d->suit), res);
 	for (const tag_entry *tag = d->tag_list; tag; tag = tag->next)

--- a/core/import-divinglog.c
+++ b/core/import-divinglog.c
@@ -296,7 +296,7 @@ static int divinglog_dive(void *param, int columns, char **data, char **column)
 		state->cur_dive->dc.duration.seconds = atoi(data[6]) * 60;
 
 	if (data[7])
-		utf8_string(data[7], &state->cur_dive->divemaster);
+		utf8_string(data[7], &state->cur_dive->diveguide);
 
 	if (data[8])
 		state->cur_dive->airtemp.mkelvin = C_to_mkelvin(atol(data[8]));

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -214,8 +214,8 @@ static void parse_dive_location(char *line, struct membuffer *str, struct git_pa
 	free(name);
 }
 
-static void parse_dive_divemaster(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dive->divemaster = detach_cstring(str); }
+static void parse_dive_diveguide(char *line, struct membuffer *str, struct git_parser_state *state)
+{ UNUSED(line); state->active_dive->diveguide = detach_cstring(str); }
 
 static void parse_dive_buddy(char *line, struct membuffer *str, struct git_parser_state *state)
 { UNUSED(line); state->active_dive->buddy = detach_cstring(str); }
@@ -1113,8 +1113,9 @@ static void divecomputer_parser(char *line, struct membuffer *str, struct git_pa
 struct keyword_action dive_action[] = {
 #undef D
 #define D(x) { #x, parse_dive_ ## x }
-	D(airpressure), D(airtemp), D(buddy), D(chill), D(current), D(cylinder), D(divemaster), D(divesiteid), D(duration),
-	D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
+	/* For historical reasons, we accept divemaster and diveguide */
+	D(airpressure), D(airtemp), D(buddy), D(chill), D(current), D(cylinder), D(diveguide), { "divemaster", parse_dive_diveguide },
+	D(divesiteid), D(duration), D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
 	D(tags), D(visibility), D(watersalinity), D(watertemp), D(wavesize), D(weightsystem)
 };
 

--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -1322,7 +1322,10 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH("notes", utf8_string, &dive->notes))
 		return;
-	if (MATCH("divemaster", utf8_string, &dive->divemaster))
+	// For historic reasons, we accept dive guide as well as dive master
+	if (MATCH("diveguide", utf8_string, &dive->diveguide))
+		return;
+	if (MATCH("divemaster", utf8_string, &dive->diveguide))
 		return;
 	if (MATCH("buddy", utf8_string, &dive->buddy))
 		return;

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -97,7 +97,7 @@ static void show_utf8(struct membuffer *b, const char *prefix, const char *value
 
 static void save_overview(struct membuffer *b, struct dive *dive)
 {
-	show_utf8(b, "divemaster ", dive->divemaster, "\n");
+	show_utf8(b, "divemaster ", dive->diveguide, "\n");
 	show_utf8(b, "buddy ", dive->buddy, "\n");
 	show_utf8(b, "suit ", dive->suit, "\n");
 	show_utf8(b, "notes ", dive->notes, "\n");

--- a/core/save-html.c
+++ b/core/save-html.c
@@ -370,7 +370,7 @@ static void write_one_dive(struct membuffer *b, struct dive *dive, const char *p
 	put_HTML_watertemp(b, dive, "\"water\":\"", "\"");
 	put_string(b, "	},");
 	write_attribute(b, "buddy", dive->buddy, ", ");
-	write_attribute(b, "divemaster", dive->divemaster, ", ");
+	write_attribute(b, "divemaster", dive->diveguide, ", ");
 	write_attribute(b, "suit", dive->suit, ", ");
 	put_HTML_tags(b, dive, "\"tags\":", ",");
 	if (!list_only) {
@@ -528,6 +528,7 @@ void export_translation(const char *file_name)
 	write_attribute(b, "Surge", translate("gettextFromC", "Surge"), ", ");
 	write_attribute(b, "Chill", translate("gettextFromC", "Chill"), ", ");
 	write_attribute(b, "Duration", translate("gettextFromC", "Duration"), ", ");
+	write_attribute(b, "DiveGuide", translate("gettextFromC", "Diveguide"), ", ");
 	write_attribute(b, "DiveMaster", translate("gettextFromC", "Divemaster"), ", ");
 	write_attribute(b, "Buddy", translate("gettextFromC", "Buddy"), ", ");
 	write_attribute(b, "Suit", translate("gettextFromC", "Suit"), ", ");

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -162,7 +162,7 @@ static void save_salinity(struct membuffer *b, struct divecomputer *dc)
 
 static void save_overview(struct membuffer *b, struct dive *dive, bool anonymize)
 {
-	show_utf8_blanked(b, dive->divemaster, "  <divemaster>", "</divemaster>\n", 0, anonymize);
+	show_utf8_blanked(b, dive->diveguide, "  <divemaster>", "</divemaster>\n", 0, anonymize);
 	show_utf8_blanked(b, dive->buddy, "  <buddy>", "</buddy>\n", 0, anonymize);
 	show_utf8_blanked(b, dive->notes, "  <notes>", "</notes>\n", 0, anonymize);
 	show_utf8_blanked(b, dive->suit, "  <suit>", "</suit>\n", 0, anonymize);

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -25,7 +25,7 @@ struct DiveField {
 	unsigned int water_temp : 1;
 	unsigned int atm_press : 1;
 	unsigned int divesite : 1;
-	unsigned int divemaster : 1;
+	unsigned int diveguide : 1;
 	unsigned int buddy : 1;
 	unsigned int rating : 1;
 	unsigned int visibility : 1;
@@ -49,7 +49,7 @@ struct DiveField {
 		WATER_TEMP = 1 << 5,
 		ATM_PRESS = 1 << 6,
 		DIVESITE = 1 << 7,
-		DIVEMASTER = 1 << 8,
+		DIVEGUIDE = 1 << 8,
 		BUDDY = 1 << 9,
 		RATING = 1 << 10,
 		VISIBILITY = 1 << 11,
@@ -159,7 +159,7 @@ inline DiveField::DiveField(int flags) :
 	water_temp((flags & WATER_TEMP) != 0),
 	atm_press((flags & ATM_PRESS) != 0),
 	divesite((flags & DIVESITE) != 0),
-	divemaster((flags & DIVEMASTER) != 0),
+	diveguide((flags & DIVEGUIDE) != 0),
 	buddy((flags & BUDDY) != 0),
 	rating((flags & RATING) != 0),
 	visibility((flags & VISIBILITY) != 0),

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -859,7 +859,7 @@ static bool uemis_delete_dive(device_data_t *devdata, uint32_t diveid)
 
 		free(dive->dc.sample);
 		free((void *)dive->notes);
-		free((void *)dive->divemaster);
+		free((void *)dive->diveguide);
 		free((void *)dive->buddy);
 		free((void *)dive->suit);
 		taglist_free(dive->tag_list);

--- a/desktop-widgets/divecomponentselection.ui
+++ b/desktop-widgets/divecomponentselection.ui
@@ -117,9 +117,9 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QCheckBox" name="divemaster">
+       <widget class="QCheckBox" name="diveguide">
         <property name="text">
-         <string>Divemaster</string>
+         <string>Dive guide</string>
         </property>
        </widget>
       </item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -305,7 +305,7 @@ DiveComponentSelection::DiveComponentSelection(QWidget *parent, struct dive *tar
 	ui.setupUi(this);
 	what = _what;
 	UI_FROM_COMPONENT(divesite);
-	UI_FROM_COMPONENT(divemaster);
+	UI_FROM_COMPONENT(diveguide);
 	UI_FROM_COMPONENT(buddy);
 	UI_FROM_COMPONENT(rating);
 	UI_FROM_COMPONENT(visibility);
@@ -327,7 +327,7 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 {
 	if (current_dive && ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
 		COMPONENT_FROM_UI(divesite);
-		COMPONENT_FROM_UI(divemaster);
+		COMPONENT_FROM_UI(diveguide);
 		COMPONENT_FROM_UI(buddy);
 		COMPONENT_FROM_UI(rating);
 		COMPONENT_FROM_UI(visibility);
@@ -345,8 +345,8 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		text.setString(&cliptext);
 		if (what->divesite && current_dive->dive_site)
 			text << tr("Dive site: ") << current_dive->dive_site->name << "\n";
-		if (what->divemaster)
-			text << tr("Dive master: ") << current_dive->divemaster << "\n";
+		if (what->diveguide)
+			text << tr("Dive guide: ") << current_dive->diveguide << "\n";
 		if (what->buddy)
 			text << tr("Buddy: ") << current_dive->buddy << "\n";
 		if (what->rating)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -38,7 +38,7 @@
 #include <QMessageBox>
 
 struct Completers {
-	QCompleter *divemaster;
+	QCompleter *diveguide;
 	QCompleter *buddy;
 	QCompleter *tags;
 };
@@ -129,13 +129,13 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 
 	Completers completers;
 	completers.buddy = new QCompleter(&buddyModel, ui.buddy);
-	completers.divemaster = new QCompleter(&diveMasterModel, ui.divemaster);
+	completers.diveguide = new QCompleter(&diveGuideModel, ui.diveguide);
 	completers.tags = new QCompleter(&tagModel, ui.tagWidget);
 	completers.buddy->setCaseSensitivity(Qt::CaseInsensitive);
-	completers.divemaster->setCaseSensitivity(Qt::CaseInsensitive);
+	completers.diveguide->setCaseSensitivity(Qt::CaseInsensitive);
 	completers.tags->setCaseSensitivity(Qt::CaseInsensitive);
 	ui.buddy->setCompleter(completers.buddy);
-	ui.divemaster->setCompleter(completers.divemaster);
+	ui.diveguide->setCompleter(completers.diveguide);
 	ui.tagWidget->setCompleter(completers.tags);
 	ui.diveNotesMessage->hide();
 	ui.multiDiveWarningMessage->hide();
@@ -260,8 +260,8 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
 	if (field.buddy)
 		ui.buddy->setText(current_dive->buddy);
-	if (field.divemaster)
-		ui.divemaster->setText(current_dive->divemaster);
+	if (field.diveguide)
+		ui.diveguide->setText(current_dive->diveguide);
 
 	// If duration or depth changed, the profile needs to be replotted
 	if (field.duration || field.depth)
@@ -385,8 +385,8 @@ void MainTab::updateDiveInfo()
 				ui.tabWidget->setCurrentIndex(lastTabSelectedDiveTrip);
 			lastSelectedDive = false;
 			// only use trip relevant fields
-			ui.divemaster->setVisible(false);
-			ui.DivemasterLabel->setVisible(false);
+			ui.diveguide->setVisible(false);
+			ui.DiveguideLabel->setVisible(false);
 			ui.buddy->setVisible(false);
 			ui.BuddyLabel->setVisible(false);
 			ui.rating->setVisible(false);
@@ -427,12 +427,12 @@ void MainTab::updateDiveInfo()
 			ui.location->show();
 			ui.locationPopupButton->show();
 			ui.editDiveSiteButton->show();
-			ui.divemaster->setVisible(true);
+			ui.diveguide->setVisible(true);
 			ui.buddy->setVisible(true);
 			ui.rating->setVisible(true);
 			ui.RatingLabel->setVisible(true);
 			ui.BuddyLabel->setVisible(true);
-			ui.DivemasterLabel->setVisible(true);
+			ui.DiveguideLabel->setVisible(true);
 			ui.TagLabel->setVisible(true);
 			ui.tagWidget->setVisible(true);
 			ui.dateEdit->setReadOnly(false);
@@ -453,7 +453,7 @@ void MainTab::updateDiveInfo()
 			updateNotes(current_dive);
 			updateDiveSite(current_dive);
 			updateDateTime(current_dive);
-			ui.divemaster->setText(current_dive->divemaster);
+			ui.diveguide->setText(current_dive->diveguide);
 			ui.buddy->setText(current_dive->buddy);
 		}
 		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
@@ -468,7 +468,7 @@ void MainTab::updateDiveInfo()
 		clearTabs();
 		ui.rating->setCurrentStars(0);
 		ui.location->clear();
-		ui.divemaster->clear();
+		ui.diveguide->clear();
 		ui.buddy->clear();
 		ui.notes->clear();
 		/* set date and time to minimums which triggers showing the special value text */
@@ -559,12 +559,12 @@ void MainTab::on_buddy_editingFinished()
 	divesEdited(Command::editBuddies(stringToList(ui.buddy->toPlainText()), false));
 }
 
-void MainTab::on_divemaster_editingFinished()
+void MainTab::on_diveguide_editingFinished()
 {
 	if (ignoreInput || !current_dive)
 		return;
 
-	divesEdited(Command::editDiveMaster(stringToList(ui.divemaster->toPlainText()), false));
+	divesEdited(Command::editDiveGuide(stringToList(ui.diveguide->toPlainText()), false));
 }
 
 void MainTab::on_duration_editingFinished()

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -44,7 +44,7 @@ slots:
 	void rejectChanges();
 	void on_location_diveSiteSelected();
 	void on_locationPopupButton_clicked();
-	void on_divemaster_editingFinished();
+	void on_diveguide_editingFinished();
 	void on_buddy_editingFinished();
 	void on_diveTripLocation_editingFinished();
 	void on_notes_editingFinished();
@@ -67,7 +67,7 @@ private:
 	bool editMode;
 	bool ignoreInput; // When computionally editing fields, we have to ignore changed-signals
 	BuddyCompletionModel buddyModel;
-	DiveMasterCompletionModel diveMasterModel;
+	DiveGuideCompletionModel diveGuideModel;
 	TagCompletionModel tagModel;
 	bool lastSelectedDive;
 	int lastTabSelectedDive;

--- a/desktop-widgets/tab-widgets/maintab.ui
+++ b/desktop-widgets/tab-widgets/maintab.ui
@@ -314,9 +314,9 @@
               <number>0</number>
              </property>
              <item row="0" column="0">
-              <widget class="QLabel" name="DivemasterLabel">
+              <widget class="QLabel" name="DiveguideLabel">
                <property name="text">
-                <string>Divemaster</string>
+                <string>Dive guide</string>
                </property>
                <property name="isHeader" stdset="0">
                 <bool>true</bool>
@@ -340,7 +340,7 @@
               </widget>
              </item>
              <item row="1" column="0">
-              <widget class="TagWidget" name="divemaster">
+              <widget class="TagWidget" name="diveguide">
                <property name="readOnly">
                 <bool>false</bool>
                </property>

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -542,7 +542,9 @@ QVariant TemplateLayout::getValue(QString list, QString property, const State &s
 		} else if (property == "depth") {
 			return get_depth_string(d->dc.maxdepth.mm, true, true);
 		} else if (property == "divemaster") {
-			return d->divemaster;
+			return d->diveguide;
+		} else if (property == "diveguide") {
+			return d->diveguide;
 		} else if (property == "buddy") {
 			return d->buddy;
 		} else if (property == "airTemp") {

--- a/mobile-widgets/qml/CopySettings.qml
+++ b/mobile-widgets/qml/CopySettings.qml
@@ -57,15 +57,15 @@ Kirigami.ScrollablePage {
 				}
 			}
 			Controls.Label {
-				text: qsTr("Dive master")
+				text: qsTr("Dive guide")
 				font.pointSize: subsurfaceTheme.regularPointSize
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleDiveMaster(false)
+				checked: manager.toggleDiveGuide(false)
 				Layout.preferredWidth: gridWidth * 0.25
 				onClicked: {
-					manager.toggleDiveMaster(true)
+					manager.toggleDiveGuide(true)
 				}
 			}
 			Controls.Label {

--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -19,9 +19,9 @@ Kirigami.Page {
 	property alias buddyIndex: detailsEdit.buddyIndex
 	property alias buddyText: detailsEdit.buddyText
 	property alias buddyModel: detailsEdit.buddyModel
-	property alias divemasterIndex: detailsEdit.divemasterIndex
-	property alias divemasterText: detailsEdit.divemasterText
-	property alias divemasterModel: detailsEdit.divemasterModel
+	property alias diveguideIndex: detailsEdit.diveguideIndex
+	property alias diveguideText: detailsEdit.diveguideText
+	property alias diveguideModel: detailsEdit.diveguideModel
 	property alias tagText: detailsEdit.tagText
 	property alias depth: detailsEdit.depthText
 	property alias duration: detailsEdit.durationText
@@ -351,7 +351,7 @@ Kirigami.Page {
 		watertemp = modelData.waterTemp
 		suitIndex = manager.suitList.indexOf(modelData.suit)
 		buddyText = modelData.buddy;
-		divemasterText = modelData.diveMaster
+		diveguideText = modelData.diveGuide
 		tagText = modelData.tags
 		notes = modelData.notes
 		if (modelData.singleWeight) {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -20,8 +20,8 @@ Item {
 	property alias suitText: suitBox.editText
 	property alias buddyIndex: buddyBox.currentIndex
 	property alias buddyText: buddyBox.editText
-	property alias divemasterIndex: divemasterBox.currentIndex
-	property alias divemasterText: divemasterBox.editText
+	property alias diveguideIndex: diveguideBox.currentIndex
+	property alias diveguideText: diveguideBox.editText
 	property alias tagText: txtTag.text
 	property alias cylinderIndex0: cylinderBox0.currentIndex
 	property alias cylinderIndex1: cylinderBox1.currentIndex
@@ -36,7 +36,7 @@ Item {
 	property var endpressure: []
 	property var startpressure: []
 	property alias suitModel: suitBox.model
-	property alias divemasterModel: divemasterBox.model
+	property alias diveguideModel: diveguideBox.model
 	property alias buddyModel: buddyBox.model
 	property alias cylinderModel0: cylinderBox0.model
 	property alias cylinderModel1: cylinderBox1.model
@@ -64,11 +64,11 @@ Item {
 		detailsEdit.depthText = ""
 		detailsEdit.airtempText = ""
 		detailsEdit.watertempText = ""
-		detailsEdit.divemasterText = ""
+		detailsEdit.diveguideText = ""
 		detailsEdit.buddyText = ""
 		suitBox.currentIndex = -1
 		buddyBox.currentIndex = -1
-		divemasterBox.currentIndex = -1
+		diveguideBox.currentIndex = -1
 		cylinderBox0.currentIndex = -1
 		cylinderBox1.currentIndex = -1
 		cylinderBox2.currentIndex = -1
@@ -118,7 +118,7 @@ Item {
 		// apply the changes to the dive_table
 		manager.commitChanges(dive_id, detailsEdit.number, detailsEdit.dateText, locationBox.editText, detailsEdit.gpsText, detailsEdit.durationText,
 				      detailsEdit.depthText, detailsEdit.airtempText, detailsEdit.watertempText,
-				      suitBox.editText, buddyBox.editText, divemasterBox.editText, detailsEdit.tagText,
+				      suitBox.editText, buddyBox.editText, diveguideBox.editText, detailsEdit.tagText,
 				      detailsEdit.weightText, detailsEdit.notesText, startpressure,
 				      endpressure, usedGas, usedCyl,
 				      detailsEdit.rating,
@@ -296,13 +296,13 @@ Item {
 				TemplateLabelSmall {
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 					horizontalAlignment: Text.AlignRight
-					text: qsTr("Divemaster:")
+					text: qsTr("Dive guide:")
 				}
 				TemplateEditComboBox {
-					id: divemasterBox
+					id: diveguideBox
 					flickable: detailsEditFlickable
 					model: diveDetailsListView.currentItem && diveDetailsListView.currentItem.modelData !== null ?
-						       manager.divemasterList : null
+						       manager.diveguideList : null
 				}
 			}
 			RowLayout {

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -481,7 +481,7 @@ Item {
 		// fifth row
 		//-----------
 		TemplateLabelSmall {
-			text: qsTr("Divemaster:")
+			text: qsTr("Dive guide:")
 			opacity: 0.6
 			wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
@@ -501,8 +501,8 @@ Item {
 		// sixth row
 		//-----------
 		TemplateLabelSmall {
-			id: txtDiveMaster
-			text: diveMaster
+			id: txtDiveGuide
+			text: diveGuide
 			wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
 			Layout.maximumWidth: detailsView.col1Width
 			color: subsurfaceTheme.textColor

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -157,9 +157,9 @@ Kirigami.ApplicationWindow {
 		detailsWindow.buddyIndex = -1
 		detailsWindow.buddyText = ""
 		detailsWindow.depth = ""
-		detailsWindow.divemasterModel = manager.divemasterList
-		detailsWindow.divemasterIndex = -1
-		detailsWindow.divemasterText = ""
+		detailsWindow.diveguideModel = manager.diveguideList
+		detailsWindow.diveguideIndex = -1
+		detailsWindow.diveguideText = ""
 		detailsWindow.notes = ""
 		detailsWindow.location = ""
 		detailsWindow.gps = ""

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -306,7 +306,7 @@ QMLManager::QMLManager() :
 
 	// Let's set some defaults to be copied so users don't necessarily need
 	// to know how to configure this
-	what.divemaster = true;
+	what.diveguide = true;
 	what.buddy = true;
 	what.suit = true;
 	what.tags = true;
@@ -458,7 +458,7 @@ void QMLManager::updateAllGlobalLists()
 {
 	emit buddyListChanged();
 	emit suitListChanged();
-	emit divemasterListChanged();
+	emit diveguideListChanged();
 	// TODO: It would be nice if we could export the list of locations via model/view instead of a Q_PROPERTY
 	emit locationListChanged();
 }
@@ -1062,7 +1062,7 @@ bool QMLManager::checkDepth(dive *d, QString depth)
 
 // update the dive and return the notes field, stripped of the HTML junk
 void QMLManager::commitChanges(QString diveId, QString number, QString date, QString location, QString gps, QString duration, QString depth,
-			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveMaster, QString tags, QString weight, QString notes,
+			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveGuide, QString tags, QString weight, QString notes,
 			       QStringList startpressure, QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state)
 {
 	struct dive *orig = get_dive_by_uniq_id(diveId.toInt());
@@ -1083,7 +1083,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 				      QStringLiteral("watertmp:'%1'\n").arg(watertemp) <<
 				      QStringLiteral("suit    :'%1'\n").arg(suit) <<
 				      QStringLiteral("buddy   :'%1'\n").arg(buddy) <<
-				      QStringLiteral("diveMstr:'%1'\n").arg(diveMaster) <<
+				      QStringLiteral("diveGde :'%1'\n").arg(diveGuide) <<
 				      QStringLiteral("tags    :'%1'\n").arg(tags) <<
 				      QStringLiteral("weight  :'%1'\n").arg(weight) <<
 				      QStringLiteral("state   :'%1'\n").arg(state);
@@ -1212,13 +1212,13 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 		free(d->buddy);
 		d->buddy = copy_qstring(buddy);
 	}
-	if (d->divemaster != diveMaster) {
-		if (diveMaster.contains(",")){
-			diveMaster = diveMaster.replace(QRegularExpression("\\s*,\\s*"), ", ");
+	if (d->diveguide != diveGuide) {
+		if (diveGuide.contains(",")){
+			diveGuide = diveGuide.replace(QRegularExpression("\\s*,\\s*"), ", ");
 		}
 		diveChanged = true;
-		free(d->divemaster);
-		d->divemaster = copy_qstring(diveMaster);
+		free(d->diveguide);
+		d->diveguide = copy_qstring(diveGuide);
 	}
 	// normalize the tag list we have and the one we get from the UI
 	// try hard to deal with accidental white space issues
@@ -1523,12 +1523,12 @@ bool QMLManager::toggleNotes(bool toggle)
 	return what.notes;
 }
 
-bool QMLManager::toggleDiveMaster(bool toggle)
+bool QMLManager::toggleDiveGuide(bool toggle)
 {
 	if (toggle)
-		what.divemaster = what.divemaster ? false : true;
+		what.diveguide = what.diveguide ? false : true;
 
-	return what.divemaster;
+	return what.diveguide;
 }
 
 bool QMLManager::toggleBuddy(bool toggle)
@@ -1764,9 +1764,9 @@ QStringList QMLManager::buddyList() const
 	return buddyModel.stringList();
 }
 
-QStringList QMLManager::divemasterList() const
+QStringList QMLManager::diveguideList() const
 {
-	return divemasterModel.stringList();
+	return diveguideModel.stringList();
 }
 
 QStringList QMLManager::locationList() const

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -32,7 +32,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QString notificationText MEMBER m_notificationText WRITE setNotificationText NOTIFY notificationTextChanged)
 	Q_PROPERTY(QStringList suitList READ suitList NOTIFY suitListChanged)
 	Q_PROPERTY(QStringList buddyList READ buddyList NOTIFY buddyListChanged)
-	Q_PROPERTY(QStringList divemasterList READ divemasterList NOTIFY divemasterListChanged)
+	Q_PROPERTY(QStringList diveguideList READ diveguideList NOTIFY diveguideListChanged)
 	Q_PROPERTY(QStringList locationList READ locationList NOTIFY locationListChanged)
 	Q_PROPERTY(QStringList cylinderListInit READ cylinderListInit CONSTANT)
 	Q_PROPERTY(QStringList defaultCylinderListInit READ defaultCylinderListInit CONSTANT)
@@ -144,7 +144,7 @@ public:
 
 	QStringList suitList() const;
 	QStringList buddyList() const;
-	QStringList divemasterList() const;
+	QStringList diveguideList() const;
 	QStringList locationList() const;
 	QStringList cylinderListInit() const;
 	QStringList defaultCylinderListInit() const;
@@ -169,7 +169,7 @@ public slots:
 	void commitChanges(QString diveId, QString number, QString date, QString location, QString gps,
 			   QString duration, QString depth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
-			   QString diveMaster, QString tags, QString weight, QString notes, QStringList startpressure,
+			   QString diveGuide, QString tags, QString weight, QString notes, QStringList startpressure,
 			   QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state);
 	void updateTripDetails(QString tripIdString, QString tripLocation, QString tripNotes);
 	void removeDiveFromTrip(int id);
@@ -185,7 +185,7 @@ public slots:
 	void pasteDiveData(int id);
 	bool toggleDiveSite(bool toggle);
 	bool toggleNotes(bool toggle);
-	bool toggleDiveMaster(bool toggle);
+	bool toggleDiveGuide(bool toggle);
 	bool toggleBuddy(bool toggle);
 	bool toggleSuit(bool toggle);
 	bool toggleRating(bool toggle);
@@ -223,7 +223,7 @@ public slots:
 private:
 	BuddyCompletionModel buddyModel;
 	SuitCompletionModel suitModel;
-	DiveMasterCompletionModel divemasterModel;
+	DiveGuideCompletionModel diveguideModel;
 	DiveSiteSortedModel locationModel;
 	QString m_startPageText;
 	QString m_lastError;
@@ -280,7 +280,7 @@ signals:
 	void btEnabledChanged();
 	void suitListChanged();
 	void buddyListChanged();
-	void divemasterListChanged();
+	void diveguideListChanged();
 	void locationListChanged();
 	void cloudCacheListChanged();
 	void waitingForPositionChanged();

--- a/qt-models/completionmodels.cpp
+++ b/qt-models/completionmodels.cpp
@@ -53,14 +53,14 @@ bool BuddyCompletionModel::relevantDiveField(const DiveField &f)
 	return f.buddy;
 }
 
-QStringList DiveMasterCompletionModel::getStrings()
+QStringList DiveGuideCompletionModel::getStrings()
 {
-	return getCSVList(&dive::divemaster);
+	return getCSVList(&dive::diveguide);
 }
 
-bool DiveMasterCompletionModel::relevantDiveField(const DiveField &f)
+bool DiveGuideCompletionModel::relevantDiveField(const DiveField &f)
 {
-	return f.divemaster;
+	return f.diveguide;
 }
 
 QStringList SuitCompletionModel::getStrings()

--- a/qt-models/completionmodels.h
+++ b/qt-models/completionmodels.h
@@ -26,7 +26,7 @@ private:
 	bool relevantDiveField(const DiveField &f) override;
 };
 
-class DiveMasterCompletionModel final : public CompletionModelBase {
+class DiveGuideCompletionModel final : public CompletionModelBase {
 	Q_OBJECT
 private:
 	QStringList getStrings() override;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -234,7 +234,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	case MobileListModel::WaterTempRole: return get_temperature_string(d->watertemp, true);
 	case MobileListModel::SacRole: return formatSac(d);
 	case MobileListModel::SumWeightRole: return formatSumWeight(d);
-	case MobileListModel::DiveMasterRole: return d->divemaster;
+	case MobileListModel::DiveGuideRole: return d->diveguide;
 	case MobileListModel::BuddyRole: return d->buddy;
 	case MobileListModel::TagsRole: return get_taglist_string(d->tag_list);
 	case MobileListModel::NotesRole: return formatNotes(d);

--- a/qt-models/mobilelistmodel.cpp
+++ b/qt-models/mobilelistmodel.cpp
@@ -31,7 +31,7 @@ QHash<int, QByteArray> MobileListModelBase::roleNames() const
 	roles[WaterTempRole] = "waterTemp";
 	roles[SacRole] = "sac";
 	roles[SumWeightRole] = "sumWeight";
-	roles[DiveMasterRole] = "diveMaster";
+	roles[DiveGuideRole] = "diveGuide";
 	roles[BuddyRole] = "buddy";
 	roles[TagsRole] = "tags";
 	roles[NotesRole]= "notes";

--- a/qt-models/mobilelistmodel.h
+++ b/qt-models/mobilelistmodel.h
@@ -39,7 +39,7 @@ public:
 		WaterTempRole,
 		SacRole,
 		SumWeightRole,
-		DiveMasterRole,
+		DiveGuideRole,
 		BuddyRole,
 		TagsRole,
 		NotesRole,

--- a/stats/statsvariables.cpp
+++ b/stats/statsvariables.cpp
@@ -1429,7 +1429,7 @@ struct PeopleBinner : public StringBinner<PeopleBinner, StringBin> {
 		std::vector<QString> dive_people;
 		for (const QString &s: QString(d->buddy).split(",", SKIP_EMPTY))
 			dive_people.push_back(s.trimmed());
-		for (const QString &s: QString(d->divemaster).split(",", SKIP_EMPTY))
+		for (const QString &s: QString(d->diveguide).split(",", SKIP_EMPTY))
 			dive_people.push_back(s.trimmed());
 		return dive_people;
 	}
@@ -1442,10 +1442,10 @@ struct PeopleVariable : public StatsVariableTemplate<StatsVariable::Type::Discre
 	}
 	QString diveCategories(const dive *d) const override {
 		QString buddy = QString(d->buddy).trimmed();
-		QString divemaster = QString(d->divemaster).trimmed();
-		if (!buddy.isEmpty() && !divemaster.isEmpty())
+		QString diveguide = QString(d->diveguide).trimmed();
+		if (!buddy.isEmpty() && !diveguide.isEmpty())
 			buddy += ", ";
-		return buddy + divemaster;
+		return buddy + diveguide;
 	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &people_binner };
@@ -1477,7 +1477,7 @@ struct BuddyVariable : public StatsVariableTemplate<StatsVariable::Type::Discret
 struct DiveGuideBinner : public StringBinner<DiveGuideBinner, StringBin> {
 	std::vector<QString> to_bin_values(const dive *d) const {
 		std::vector<QString> dive_guides;
-		for (const QString &s: QString(d->divemaster).split(",", SKIP_EMPTY))
+		for (const QString &s: QString(d->diveguide).split(",", SKIP_EMPTY))
 			dive_guides.push_back(s.trimmed());
 		return dive_guides;
 	}
@@ -1489,7 +1489,7 @@ struct DiveGuideVariable : public StatsVariableTemplate<StatsVariable::Type::Dis
 		return StatsTranslations::tr("Dive guides");
 	}
 	QString diveCategories(const dive *d) const override {
-		return QString(d->divemaster).trimmed();
+		return QString(d->diveguide).trimmed();
 	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &dive_guide_binner };

--- a/theme/list_lib.js
+++ b/theme/list_lib.js
@@ -223,13 +223,13 @@ function getExpanded(dive)
 {
 	var res = '<table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
 		  '</td></tr></table>' +
 		  '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Rating + ':</td><td>' + putRating(dive.rating) +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveMaster + ': </td><td>' + dive.divemaster +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +
@@ -244,7 +244,7 @@ function putTags(tags)
 {
 	var result = "";
 	for (var i in tags) {
-		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, divemaster:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
+		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, diveguide:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
 		if (i < tags.length - 1)
 			result += ', ';
 	}
@@ -556,7 +556,7 @@ function SearchModules(searchfor, searchOptions)
 	if (searchOptions === null) {
 		searchOptions = {};
 		searchOptions.location = searchingModules["location"].enabled;
-		searchOptions.divemaster = searchingModules["divemaster"].enabled;
+		searchOptions.diveguide = searchingModules["diveguide"].enabled;
 		searchOptions.buddy = searchingModules["buddy"].enabled;
 		searchOptions.notes = searchingModules["notes"].enabled;
 		searchOptions.tags = searchingModules["tags"].enabled;
@@ -568,8 +568,8 @@ function SearchModules(searchfor, searchOptions)
 		if (searchOptions.location === true)
 			keywordResult.Union(searchingModules["location"].search(keywords[i]));
 
-		if (searchOptions.divemaster === true)
-			keywordResult.Union(searchingModules["divemaster"].search(keywords[i]));
+		if (searchOptions.diveguide === true)
+			keywordResult.Union(searchingModules["diveguide"].search(keywords[i]));
 
 		if (searchOptions.buddy === true)
 			keywordResult.Union(searchingModules["buddy"].search(keywords[i]));
@@ -965,7 +965,7 @@ function get_dive_HTML(dive)
 {
 	var table1 = '<h2 class="det_hed">' + translate.Dive_information + '</h2><table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
 		  '</tr></table>';
 	var table2 = '<table><tr><td class="words">' + translate.Rating + ':</td><td>' + putRating(dive.rating) + '</td>';
 	if (dive.wavesize > 0)
@@ -982,7 +982,7 @@ function get_dive_HTML(dive)
 	var table3 = '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveMaster + ': </td><td>' + dive.divemaster +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Since a user requests listing the "dive master" in the dive list (see #3382), I guess it is the right moment to change from master to guide, as discussed in #2879.

This is of course very dangerous as divemaster is used as a tag in the XML and git logs as well as in foreign formats.

Nevertheless, I would suggest to start the transition now, before this becomes a never-ending story.

I shortly tested the desktop version and it seemed to load/save the dive guide and statistics still work.