### PR TITLE
cleanup: use setDive() in ProfileWidget::plotCurrentDive()

### DIFF
--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -176,28 +176,7 @@ void ProfileWidget::plotCurrentDive()
 {
 	setEnabledToolbar(current_dive != nullptr);
 	if (current_dive) {
-		stack->setCurrentIndex(1);
-		bool freeDiveMode = current_dive->dc.divemode == FREEDIVE;
-		ui.profCalcCeiling->setDisabled(freeDiveMode);
-		ui.profCalcCeiling->setDisabled(freeDiveMode);
-		ui.profCalcAllTissues ->setDisabled(freeDiveMode);
-		ui.profIncrement3m->setDisabled(freeDiveMode);
-		ui.profDcCeiling->setDisabled(freeDiveMode);
-		ui.profPhe->setDisabled(freeDiveMode);
-		ui.profPn2->setDisabled(freeDiveMode); //TODO is the same as scuba?
-		ui.profPO2->setDisabled(freeDiveMode); //TODO is the same as scuba?
-		ui.profTankbar->setDisabled(freeDiveMode);
-		ui.profMod->setDisabled(freeDiveMode);
-		ui.profNdl_tts->setDisabled(freeDiveMode);
-		ui.profDeco->setDisabled(freeDiveMode);
-		ui.profEad->setDisabled(freeDiveMode);
-		ui.profSAC->setDisabled(freeDiveMode);
-		ui.profTissues->setDisabled(freeDiveMode);
-
-		ui.profRuler->setDisabled(false);
-		ui.profScaled->setDisabled(false); // measuring and scaling
-		ui.profTogglePicture->setDisabled(false);
-		ui.profHR->setDisabled(false);
+		setDive(current_dive);
 		view->setProfileState(current_dive, dc_number);
 		view->resetZoom(); // when switching dive, reset the zoomLevel
 		view->plotDive(current_dive, dc_number);


### PR DESCRIPTION
This removes a block of redundant code that was already broken
out into a helper function.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial(?) cleanup: replace duplicate code by an already existing function. Please check.