### PR TITLE
Don't update notes field when placing an undo command [supersedes #3379]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- desktop: Don't lose cursor position in notes when switching between windows [#3369]
 - libdivecomputer: add support for latest BLE hardware in OSTC dive computers
 
 ---

--- a/commands/command.h
+++ b/commands/command.h
@@ -26,6 +26,7 @@ bool isClean();				// Any changes need to be saved?
 QAction *undoAction(QObject *parent);	// Create an undo action.
 QAction *redoAction(QObject *parent);	// Create an redo action.
 QString changesMade();			// return a string with the texts from all commands on the undo stack -> for commit message
+bool placingCommand();			// Currently executing a new command -> might not have to update the field the user just edited.
 
 // 2) Dive-list related commands
 

--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -112,5 +112,3 @@ bool placingCommand()
 }
 
 } // namespace Command
-
-

--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -91,16 +91,24 @@ QString changesMade()
 	return changeTexts;
 }
 
+static bool executingCommand = false;
 bool execute(Base *cmd)
 {
 	if (cmd->workToBeDone()) {
+		executingCommand = true;
 		undoStack.push(cmd);
+		executingCommand = false;
 		emit diveListNotifier.commandExecuted();
 		return true;
 	} else {
 		delete cmd;
 		return false;
 	}
+}
+
+bool placingCommand()
+{
+	return executingCommand;
 }
 
 } // namespace Command

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -156,7 +156,8 @@ void EditBase<T>::undo()
 	// Send signals.
 	DiveField id = fieldId();
 	emit diveListNotifier.divesChanged(stdToQt<dive *>(dives), id);
-	setSelection(selectedDives, current);
+	if (!placingCommand())
+		setSelection(selectedDives, current);
 }
 
 // We have to manually instantiate the constructors of the EditBase class,

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -248,7 +248,7 @@ void MainTab::divesChanged(const QVector<dive *> &dives, DiveField field)
 		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
 	if (field.rating)
 		ui.rating->setCurrentStars(current_dive->rating);
-	if (field.notes)
+	if (field.notes && !Command::placingCommand())
 		updateNotes(current_dive);
 	if (field.datetime) {
 		updateDateTime(current_dive);
@@ -306,11 +306,10 @@ static bool isHtml(const QString &s)
 void MainTab::updateNotes(const struct dive *d)
 {
 	QString tmp(d->notes);
-	if (isHtml(tmp)) {
+	if (isHtml(tmp))
 		ui.notes->setHtml(tmp);
-	} else {
+	else
 		ui.notes->setPlainText(tmp);
-	}
 }
 
 void MainTab::updateDateTime(const struct dive *d)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Avoid resetting the cursor when losing focus owing to the command executing and reloading the contents of the notes tab. See discussion in #3379.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add flag that indicates that the changed-signal is due to a freshly placed command
2) Don't update the notes field on a freshly executed command.
3) Don't update the selection on a freshly executed command.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3369
Supersedes #3379

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
