### PR TITLE
Uemis support: hack around the need to reconnect the Uemis Zurich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Uemis support: fix the ability disconnect/reconnect the Zurich when its filesystem is full
 - libdivecomputer: add support for latest BLE hardware in OSTC dive computers
 
 ---

--- a/Documentation/50-pot/subsurface-user-manual.pot
+++ b/Documentation/50-pot/subsurface-user-manual.pot
@@ -9076,6 +9076,9 @@ msgid ""
 "reconnect it. You can now retry (or start a new download session) and the "
 "download will continue where it stopped previously. You may have to do this "
 "more than once, depending on how many dives are stored on the dive computer."
+"You may define a dive number offset by setting environment variable "
+"UEMIS_DIVE_OFFSET (e.g. export UEMIS_DIVE_OFFSET=300), "
+"if subsurface starts downloading dives that are already synced."
 msgstr ""
 
 #. type: Title ===

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -32,6 +32,7 @@
 #include "subsurface-time.h"
 #include "core/subsurface-string.h"
 
+#define ACTION_RECONNECT QT_TRANSLATE_NOOP("gettextFromC", "Disconnect/reconnect the SDA")
 #define ERR_FS_ALMOST_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is almost full.\nDisconnect/reconnect the dive computer\nand click \'Retry\'")
 #define ERR_FS_FULL QT_TRANSLATE_NOOP("gettextFromC", "Uemis Zurich: the file system is full.\nDisconnect/reconnect the dive computer\nand click Retry")
 #define ERR_FS_SHORT_WRITE QT_TRANSLATE_NOOP("gettextFromC", "Short write to req.txt file.\nIs the Uemis Zurich plugged in correctly?")
@@ -1331,7 +1332,14 @@ const char *do_uemis_import(device_data_t *data)
 	char *endptr;
 	bool success, once = true;
 	int match_dive_and_log = 0;
+	int dive_offset = 0;
 	int uemis_mem_status = UEMIS_MEM_OK;
+
+	// To speed up sync you can skip downloading old dives by defining UEMIS_DIVE_OFFSET
+	if (getenv("UEMIS_DIVE_OFFSET")) {
+		dive_offset = atoi(getenv("UEMIS_DIVE_OFFSET"));
+		printf("Uemis: Using dive # offset %d\n", dive_offset);
+	}
 
 #if UEMIS_DEBUG
 	home = getenv("HOME");
@@ -1367,6 +1375,8 @@ const char *do_uemis_import(device_data_t *data)
 
 	first = start = atoi(newmax);
 	dive_to_read = mindiveid < first ? first - mindiveid : first;
+	if (dive_offset > 0)
+		start += dive_offset;
 	for (;;) {
 #if UEMIS_DEBUG & 2
 		debug_round++;
@@ -1434,7 +1444,29 @@ const char *do_uemis_import(device_data_t *data)
 #if UEMIS_DEBUG & 4
 				fprintf(debugfile, "d_u_i out of memory, bailing\n");
 #endif
-				break;
+				(void)uemis_get_answer(mountpath, "terminateSync", 0, 3, &result);
+				const char *errormsg = translate("gettextFromC", ACTION_RECONNECT);
+				for (int wait=60; wait >=0; wait--){
+					uemis_info("%s %ds", errormsg, wait);
+					usleep(1000000);
+				}
+				// Resetting to original state
+				filenr = 0;
+				max_mem_used = -1;
+				uemis_mem_status = get_memory(data->download_table, UEMIS_CHECK_DETAILS);
+				if (!uemis_get_answer(mountpath, "getDeviceId", 0, 1, &result))
+					goto bail;
+				if (strcmp(deviceid, param_buff[0]) != 0) {
+					printf(stderr, "Uemis: Device id has changed after reconnect!\n");
+					goto bail;
+				}
+				param_buff[0] = strdup(deviceid);
+				if (!uemis_get_answer(mountpath, "initSession", 1, 6, &result))
+					goto bail;
+				uemis_info(translate("gettextFromC", "Start download"));
+				if (!uemis_get_answer(mountpath, "processSync", 0, 2, &result))
+					goto bail;
+				param_buff[1] = "notempty";
 			}
 			/* if the user clicked cancel, exit gracefully */
 			if (import_thread_cancelled) {


### PR DESCRIPTION
When the file system of the Zurich gets full, the only way to continue to
download from it, is to disconnect and reconnect the dive computer (which
resets the FAT file system that it emulates to 'empty').

This solution is rather hacky and weird because it does a hard count down in a
busy loop, but given the narrow use case, this may be acceptable.

This also adds support for the UEMIS_DIVE_OFFSET environment variable that
allows the user to skip dives on the device.

[refactored by Dirk Hohndel]

Signed-off-by: Oliver Schwaneberg <oliver.schwaneberg@gmail.com>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [x] New feature
- [x] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is simply a combined version of the commits in #3388 - with a hopefully better commit message and some white space issues removed and a ChangeLog added

I still dislike the hard count down - but frankly, given how many people are using this particular feature, I'm not sure it's worth to create a cleaner solution

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#3385 

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@Schwaneberg 