### PR TITLE
cleanup: Fix a Coverity warning

### DIFF
--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -328,7 +328,7 @@ void FilterConstraintWidget::update()
 	}
 
 	// Update the unit strings in case the locale was changed
-	if (unitFrom || unitTo) {
+	if (unitFrom && unitTo) {
 		QString unitString = idx.data(FilterConstraintModel::UNIT_ROLE).value<QString>();
 		unitFrom->setText(unitString);
 		unitTo->setText(unitString);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -824,6 +824,7 @@ int DivePlannerPointsModel::addStop(int milimeters, int seconds, int cylinderid_
 	point.time = seconds;
 	point.cylinderid = cylinderid;
 	point.setpoint = ccpoint;
+	point.minimum_gas.mbar = 0;
 	point.entered = entered;
 	point.divemode = divemode;
 	point.next = NULL;


### PR DESCRIPTION
Two pointers were checked against NULL and then both were
dereferenced if at least one was not NULL. Of course, this
should have been an and, not an or expression.

That said, this is a semi-false positive, since both pointers
are set in the constructor and therefore never can be NULL.
In principle, one could remove the whole check. Of course,
realizing that would require a global analysis by Coverity,
which I reckon it doesn't do.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a valid, but harmless, Coverity warning.