### PR TITLE
bugfix: call fprintf() instead of printf()

### DIFF
--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -1457,7 +1457,7 @@ const char *do_uemis_import(device_data_t *data)
 				if (!uemis_get_answer(mountpath, "getDeviceId", 0, 1, &result))
 					goto bail;
 				if (strcmp(deviceid, param_buff[0]) != 0) {
-					printf(stderr, "Uemis: Device id has changed after reconnect!\n");
+					fprintf(stderr, "Uemis: Device id has changed after reconnect!\n");
 					goto bail;
 				}
 				param_buff[0] = strdup(deviceid);


### PR DESCRIPTION
This is an embarrassing oversight.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
`printf()` was called instead of `fprintf()`

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@Schwaneberg 