### PR TITLE
profile: fix ESC in planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- planner: make ESC (cancel plan) work when moving handles
 - dive list: make dive guide visible in dive list [#3382]
 - general: rename dive master to dive guide
 - desktop: Don't lose cursor position in notes when switching between windows [#3369]

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -68,13 +68,6 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, double dp
 #ifndef SUBSURFACE_MOBILE
 	setAcceptDrops(true);
 
-	addActionShortcut(Qt::Key_Escape, &ProfileWidget2::keyEscAction);
-	addActionShortcut(Qt::Key_Delete, &ProfileWidget2::keyDeleteAction);
-	addActionShortcut(Qt::Key_Up, &ProfileWidget2::keyUpAction);
-	addActionShortcut(Qt::Key_Down, &ProfileWidget2::keyDownAction);
-	addActionShortcut(Qt::Key_Left, &ProfileWidget2::keyLeftAction);
-	addActionShortcut(Qt::Key_Right, &ProfileWidget2::keyRightAction);
-
 	connect(Thumbnailer::instance(), &Thumbnailer::thumbnailChanged, this, &ProfileWidget2::updateThumbnail, Qt::QueuedConnection);
 	connect(&diveListNotifier, &DiveListNotifier::picturesRemoved, this, &ProfileWidget2::picturesRemoved);
 	connect(&diveListNotifier, &DiveListNotifier::picturesAdded, this, &ProfileWidget2::picturesAdded);
@@ -123,14 +116,16 @@ ProfileWidget2::~ProfileWidget2()
 }
 
 #ifndef SUBSURFACE_MOBILE
-void ProfileWidget2::addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)())
+void ProfileWidget2::keyPressEvent(QKeyEvent *e)
 {
-	QAction *action = new QAction(this);
-	action->setShortcut(shortcut);
-	action->setShortcutContext(Qt::WindowShortcut);
-	addAction(action);
-	connect(action, &QAction::triggered, this, slot);
-	actionsForKeys[shortcut] = action;
+	switch (e->key()) {
+		case Qt::Key_Delete: return keyDeleteAction();
+		case Qt::Key_Up: return keyUpAction();
+		case Qt::Key_Down: return keyDownAction();
+		case Qt::Key_Left: return keyLeftAction();
+		case Qt::Key_Right: return keyRightAction();
+	}
+	QGraphicsView::keyPressEvent(e);
 }
 #endif // SUBSURFACE_MOBILE
 
@@ -444,12 +439,6 @@ void ProfileWidget2::setEditState(const dive *d, int dc)
 	mouseFollowerHorizontal->setVisible(true);
 	mouseFollowerVertical->setVisible(true);
 	disconnectTemporaryConnections();
-	actionsForKeys[Qt::Key_Left]->setShortcut(Qt::Key_Left);
-	actionsForKeys[Qt::Key_Right]->setShortcut(Qt::Key_Right);
-	actionsForKeys[Qt::Key_Up]->setShortcut(Qt::Key_Up);
-	actionsForKeys[Qt::Key_Down]->setShortcut(Qt::Key_Down);
-	actionsForKeys[Qt::Key_Escape]->setShortcut(Qt::Key_Escape);
-	actionsForKeys[Qt::Key_Delete]->setShortcut(Qt::Key_Delete);
 
 	connectPlannerModel();
 
@@ -470,12 +459,6 @@ void ProfileWidget2::setPlanState(const dive *d, int dc)
 	mouseFollowerHorizontal->setVisible(true);
 	mouseFollowerVertical->setVisible(true);
 	disconnectTemporaryConnections();
-	actionsForKeys[Qt::Key_Left]->setShortcut(Qt::Key_Left);
-	actionsForKeys[Qt::Key_Right]->setShortcut(Qt::Key_Right);
-	actionsForKeys[Qt::Key_Up]->setShortcut(Qt::Key_Up);
-	actionsForKeys[Qt::Key_Down]->setShortcut(Qt::Key_Down);
-	actionsForKeys[Qt::Key_Escape]->setShortcut(Qt::Key_Escape);
-	actionsForKeys[Qt::Key_Delete]->setShortcut(Qt::Key_Delete);
 
 	connectPlannerModel();
 
@@ -810,10 +793,6 @@ void ProfileWidget2::disconnectTemporaryConnections()
 		disconnect(plannerModel, &DivePlannerPointsModel::rowsMoved, this, &ProfileWidget2::pointsMoved);
 	}
 #endif
-	Q_FOREACH (QAction *action, actionsForKeys.values()) {
-		action->setShortcut(QKeySequence());
-		action->setShortcutContext(Qt::WidgetShortcut);
-	}
 }
 
 int ProfileWidget2::handleIndex(const DiveHandler *h) const
@@ -1024,20 +1003,6 @@ void ProfileWidget2::keyDeleteAction()
 	}
 	if (!selectedIndices.isEmpty())
 		plannerModel->removeSelectedPoints(selectedIndices);
-}
-
-void ProfileWidget2::keyEscAction()
-{
-	if ((currentState != EDIT && currentState != PLAN) || !plannerModel)
-		return;
-
-	if (scene()->selectedItems().count()) {
-		scene()->clearSelection();
-		return;
-	}
-
-	if (plannerModel->isPlanner())
-		plannerModel->cancelPlan();
 }
 
 void ProfileWidget2::clearPictures()

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -87,15 +87,6 @@ slots: // Necessary to call from QAction's signals.
 
 	/* this is called for every move on the handlers. maybe we can speed up this a bit? */
 	void divePlannerHandlerMoved();
-
-	/* key press handlers */
-	void keyEscAction();
-	void keyDeleteAction();
-	void keyUpAction();
-	void keyDownAction();
-	void keyLeftAction();
-	void keyRightAction();
-
 	void divePlannerHandlerClicked();
 	void divePlannerHandlerReleased();
 #endif
@@ -110,6 +101,7 @@ private:
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseReleaseEvent(QMouseEvent *event) override;
+	void keyPressEvent(QKeyEvent *e) override;
 #endif
 	void dropEvent(QDropEvent *event) override;
 	void dragEnterEvent(QDragEnterEvent *event) override;
@@ -123,7 +115,6 @@ private:
 	void setupItemOnScene();
 	void disconnectTemporaryConnections();
 	struct plot_data *getEntryFromPos(QPointF pos);
-	void addActionShortcut(const Qt::Key shortcut, void (ProfileWidget2::*slot)());
 	void clearPictures();
 	void plotPicturesInternal(const struct dive *d, bool synchronous);
 	void updateThumbnails();
@@ -176,6 +167,12 @@ private:
 	void calculatePictureYPositions();
 	void updateDurationLine(PictureEntry &e);
 	void updateThumbnailPaintOrder();
+
+	void keyDeleteAction();
+	void keyUpAction();
+	void keyDownAction();
+	void keyLeftAction();
+	void keyRightAction();
 #endif
 
 	std::vector<std::unique_ptr<DiveHandler>> handles;
@@ -188,7 +185,6 @@ private:
 	QGraphicsSimpleTextItem *createGas();
 #endif
 	friend class DiveHandler;
-	QHash<Qt::Key, QAction *> actionsForKeys;
 	bool shouldCalculateMax; // Calculate maximum time and depth (default). False when dragging handles.
 
 	// We store a const pointer to the shown dive. However, the undo commands want


### PR DESCRIPTION
When in the planner, ESC should cancel the plan.

However, when the user manipulates the dive-handles in the
profile and presses ESC, first nothing happens, then an obscure
message appears.

The reason is that ESC "shortcuts" are introduced in two places.

To fix this, remove the ESC shortcut in the profile (the planner
widget cancels the plan anyway) and replace all the shortcuts in
the profile with a simple override of the keyPressEvent().

The latter is not strictly necessary, but hopefully avoids further
complications with multiple shortcuts. And the code is easier
to follow too.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a tiny UI issue: escape doesn't always work in planner. I wonder if we should replace the other ESC shortcuts as well or at least set their mode to "widget and children" instead of "window".

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.