### PR TITLE
Allow editing sensors through equipment tab

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -314,6 +314,11 @@ int editCylinder(int index, cylinder_t cyl, EditCylinderType type, bool currentD
 	return execute_edit(new EditCylinder(index, cyl, type, currentDiveOnly));
 }
 
+void editSensors(int toCylinder, const int fromCylinder)
+{
+	execute(new EditSensors(toCylinder, fromCylinder));
+}
+
 // Trip editing related commands
 void editTripLocation(dive_trip *trip, const QString &s)
 {

--- a/commands/command.h
+++ b/commands/command.h
@@ -106,6 +106,7 @@ enum class EditCylinderType {
 	GASMIX
 };
 int editCylinder(int index, cylinder_t cyl, EditCylinderType type, bool currentDiveOnly);
+void editSensors(int toCylinder, const int fromCylinder);
 #ifdef SUBSURFACE_MOBILE
 // Edits a dive and creates a divesite (if createDs != NULL) or edits a divesite (if changeDs != NULL).
 // Takes ownership of newDive and createDs!

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -424,6 +424,22 @@ private:
 	void redo() override;
 };
 
+class EditSensors : public Base
+{
+public:
+	EditSensors(int cylIndex, int fromCylinder);
+
+private:
+	struct divecomputer *dc;
+	struct dive *d;
+	int toCylinder;
+	int fromCylinder;
+	void mapSensors(int toCyl, int fromCyl);
+	void undo() override;
+	void redo() override;
+	bool workToBeDone() override;
+};
+
 #ifdef SUBSURFACE_MOBILE
 // Edit a full dive. This is used on mobile where we don't have per-field granularity.
 // It may add or edit a dive site.

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -343,8 +343,7 @@ static void parse_dives(int log_version, const unsigned char *buf, unsigned int 
 					sample->time.seconds = event.time;
 					sample->depth.mm = array_uint16_le(ds + (d - 1) * 2) * 10; // cm->mm
 					sample->temperature.mkelvin = C_to_mkelvin((float) array_uint16_le(ts + (d - 1) * 2) / 10); // dC->mK
-					sample->sensor[0] = event.pressure.sensor;
-					sample->pressure[0].mbar = event.pressure.mbar;
+					add_sample_pressure(sample, event.pressure.sensor, event.pressure.mbar);
 					finish_sample(dc);
 
 					break;
@@ -361,16 +360,14 @@ static void parse_dives(int log_version, const unsigned char *buf, unsigned int 
 					sample->time.seconds = sample_time;
 					sample->depth.mm = depth_mm;
 					sample->temperature.mkelvin = temp_mk;
-					sample->sensor[0] = event.pressure.sensor;
-					sample->pressure[0].mbar = event.pressure.mbar;
+					add_sample_pressure(sample, event.pressure.sensor, event.pressure.mbar);
 					finish_sample(dc);
 					d++;
 
 					break;
 				} else {	// Event is prior to sample
 					sample->time.seconds = event.time;
-					sample->sensor[0] = event.pressure.sensor;
-					sample->pressure[0].mbar = event.pressure.mbar;
+					add_sample_pressure(sample, event.pressure.sensor, event.pressure.mbar);
 					if (last_time == sample_time) {
 						sample->depth.mm = depth_mm;
 						sample->temperature.mkelvin = temp_mk;

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -96,6 +96,8 @@ signals:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesImported(); // A general signal when multiple dives have been imported.
 
+	void diveComputerEdited(divecomputer *dc);
+
 	void cylindersReset(const QVector<dive *> &dives);
 	void cylinderAdded(dive *d, int pos);
 	void cylinderRemoved(dive *d, int pos);

--- a/core/uemis.c
+++ b/core/uemis.c
@@ -359,9 +359,7 @@ void uemis_parse_divelog_binary(char *base64, void *datap)
 		sample->time.seconds = u_sample->dive_time;
 		sample->depth.mm = rel_mbar_to_depth(u_sample->water_pressure, dive);
 		sample->temperature.mkelvin = C_to_mkelvin(u_sample->dive_temperature / 10.0);
-		sample->sensor[0] = active;
-		sample->pressure[0].mbar =
-			(u_sample->tank_pressure_high * 256 + u_sample->tank_pressure_low) * 10;
+		add_sample_pressure(sample, active, (u_sample->tank_pressure_high * 256 + u_sample->tank_pressure_low) * 10);
 		sample->cns = u_sample->cns;
 		uemis_event(dive, dc, sample, u_sample);
 		finish_sample(dc);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -49,6 +49,7 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	view->setColumnHidden(CylindersModel::DEPTH, false);
 	view->setColumnHidden(CylindersModel::WORKINGPRESS_INT, true);
 	view->setColumnHidden(CylindersModel::SIZE_INT, true);
+	view->setColumnHidden(CylindersModel::SENSORS, true);
 	view->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
 	connect(ui.cylinderTableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addCylinder_clicked);
 	connect(ui.tableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addDefaultStop);

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -20,6 +20,15 @@ static bool ignoreHiddenFlag(int i)
 	       i == CylindersModel::WORKINGPRESS_INT || i == CylindersModel::SIZE_INT;
 }
 
+static bool hiddenByDefault(int i)
+{
+	switch (i) {
+	case CylindersModel::SENSORS:
+		return true;
+	}
+	return false;
+}
+
 TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	cylindersModel(new CylindersModel(false, true, this)),
 	weightModel(new WeightModel(this))
@@ -81,7 +90,8 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	for (int i = 0; i < CylindersModel::COLUMNS; i++) {
 		if (ignoreHiddenFlag(i))
 			continue;
-		bool checked = s.value(QString("column%1_hidden").arg(i)).toBool();
+		auto setting = s.value(QString("column%1_hidden").arg(i));
+		bool checked = setting.isValid() ? setting.toBool() : hiddenByDefault(i) ;
 		QAction *action = new QAction(cylindersModel->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString(), ui.cylinders->view());
 		action->setCheckable(true);
 		action->setData(i);

--- a/dives/testsensormove.xml
+++ b/dives/testsensormove.xml
@@ -1,0 +1,4025 @@
+<divelog program='subsurface' version='3'>
+<settings>
+<fingerprint model='56d79d84' serial='c8ca11d3' deviceid='93bea6a4' diveid='e78b651a' data='4332344a333434362e666974000000000000000000000000'/>
+<fingerprint model='7ae0fae1' serial='01d473df' deviceid='91be1c96' diveid='c37f8c08' data='120f2fe6070204'/>
+</settings>
+<divesites>
+<site uuid='1bf0d3b5' name='Xxxxxxxxxxx' gps='27.813745 33.920344'>
+</site>
+</divesites>
+<dives>
+<dive number='473' sac='12.565 l/min' otu='44' cns='15%' divesiteid='1bf0d3b5' date='2021-11-29' time='06:31:23' duration='61:47 min'>
+  <buddy>Xxxxxx Xxxxxxxx</buddy>
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='30.0%' depth='42.963 m' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='29.0%' start='201.0 bar' end='66.0 bar' depth='44.793 m' />
+  <divetemperature water='24.0 C'/>
+  <divecomputer model='Garmin Descent Mk2/Mk2i' deviceid='93bea6a4' diveid='3e79dbfc'>
+  <depth max='29.79 m' mean='18.119 m' />
+  <temperature water='24.0 C' />
+  <water salinity='1025 g/l' />
+  <extradata key='Deco model' value='Buhlmann ZHL-16C 50/70' />
+  <extradata key='Firmware' value='8.40' />
+  <extradata key='GPS1' value='27.813745, 33.920344' />
+  <extradata key='GPS2' value='27.813809, 33.920163' />
+  <event time='2:57 min' type='11' value='29' name='gaschange' cylinder='1' o2='29.0%' />
+  <event time='6:02 min' type='26' flags='8' name='Approaching NDL' />
+  <event time='6:06 min' type='26' flags='4' name='Alert timed out' />
+  <event time='14:55 min' type='26' flags='8' name='Approaching NDL' />
+  <event time='14:59 min' type='26' flags='4' name='Alert timed out' />
+  <event time='20:14 min' type='26' flags='8' name='Deco required' />
+  <event time='20:20 min' type='26' flags='4' name='Alert timed out' />
+  <event time='31:57 min' type='26' flags='12' name='Ascent speed critical' />
+  <event time='32:00 min' type='26' flags='4' name='Alert timed out' />
+  <event time='38:21 min' type='11' value='30' name='gaschange' cylinder='0' o2='30.0%' />
+  <event time='52:02 min' type='26' flags='4' name='Approaching deco stop' />
+  <event time='52:06 min' type='26' flags='4' name='Alert timed out' />
+  <event time='57:15 min' type='26' flags='4' name='Deco completed' />
+  <event time='57:19 min' type='26' flags='4' name='Alert timed out' />
+  <event time='66:29 min' type='26' flags='4' name='Surface' />
+  <event time='66:32 min' type='26' flags='4' name='Alert timed out' />
+  <sample time='0:00 min' depth='1.384 m' temp='29.0 C' tts='0:09 min' heartbeat='103' />
+  <sample time='0:01 min' depth='1.514 m' ndl='0:00 min' tts='0:00 min' />
+  <sample time='0:02 min' depth='1.643 m' tts='0:10 min' />
+  <sample time='0:04 min' depth='1.783 m' tts='0:11 min' heartbeat='102' />
+  <sample time='0:05 min' depth='1.581 m' tts='0:10 min' />
+  <sample time='0:06 min' depth='2.058 m' tts='0:13 min' heartbeat='103' />
+  <sample time='0:07 min' depth='2.624 m' tts='0:17 min' heartbeat='104' />
+  <sample time='0:08 min' depth='2.491 m' tts='0:16 min' />
+  <sample time='0:10 min' depth='2.756 m' temp='28.0 C' tts='0:18 min' heartbeat='105' />
+  <sample time='0:11 min' depth='3.18 m' tts='0:20 min' heartbeat='104' />
+  <sample time='0:13 min' depth='2.972 m' tts='0:19 min' heartbeat='107' />
+  <sample time='0:14 min' depth='3.075 m' tts='0:20 min' heartbeat='106' />
+  <sample time='0:15 min' depth='3.418 m' tts='0:22 min' heartbeat='105' />
+  <sample time='0:16 min' depth='3.531 m' tts='0:23 min' heartbeat='104' />
+  <sample time='0:17 min' depth='3.594 m' heartbeat='109' />
+  <sample time='0:18 min' depth='3.864 m' tts='0:25 min' heartbeat='105' />
+  <sample time='0:19 min' depth='4.059 m' tts='0:26 min' />
+  <sample time='0:21 min' depth='4.092 m' temp='27.0 C' />
+  <sample time='0:22 min' depth='4.339 m' tts='0:28 min' heartbeat='107' />
+  <sample time='0:23 min' depth='4.351 m' heartbeat='106' />
+  <sample time='0:24 min' depth='4.427 m' tts='0:29 min' heartbeat='110' />
+  <sample time='0:25 min' depth='4.444 m' heartbeat='109' />
+  <sample time='0:26 min' depth='4.404 m' tts='0:28 min' />
+  <sample time='0:27 min' depth='4.425 m' pressure='205.39 bar' tts='0:00 min' />
+  <sample time='0:28 min' depth='4.446 m' tts='0:29 min' heartbeat='110' />
+  <sample time='0:29 min' depth='4.405 m' tts='0:28 min' heartbeat='111' />
+  <sample time='0:30 min' depth='4.421 m' tts='0:29 min' />
+  <sample time='0:32 min' depth='4.436 m' pressure='205.32 bar' heartbeat='112' />
+  <sample time='0:33 min' depth='4.459 m' heartbeat='108' />
+  <sample time='0:34 min' depth='4.47 m' heartbeat='109' />
+  <sample time='0:35 min' depth='4.471 m' heartbeat='110' />
+  <sample time='0:36 min' depth='4.414 m' tts='0:28 min' />
+  <sample time='0:37 min' depth='4.426 m' pressure='204.98 bar' tts='0:29 min' />
+  <sample time='0:38 min' depth='4.622 m' tts='0:30 min' />
+  <sample time='0:39 min' depth='4.705 m' heartbeat='111' />
+  <sample time='0:40 min' depth='4.765 m' tts='0:31 min' />
+  <sample time='0:41 min' depth='5.038 m' tts='0:33 min' />
+  <sample time='0:43 min' depth='5.234 m' temp='26.0 C' tts='0:34 min' heartbeat='110' />
+  <sample time='0:44 min' depth='5.424 m' tts='0:35 min' />
+  <sample time='0:45 min' depth='5.532 m' tts='0:36 min' heartbeat='111' />
+  <sample time='0:46 min' depth='5.726 m' tts='0:37 min' />
+  <sample time='0:47 min' depth='5.581 m' pressure='203.94 bar' tts='0:36 min' heartbeat='113' />
+  <sample time='0:48 min' depth='5.849 m' tts='0:38 min' heartbeat='110' />
+  <sample time='0:49 min' depth='5.93 m' heartbeat='111' />
+  <sample time='0:50 min' depth='5.964 m' tts='0:39 min' heartbeat='110' />
+  <sample time='0:51 min' depth='5.897 m' tts='0:38 min' heartbeat='109' />
+  <sample time='0:52 min' depth='5.911 m' pressure='203.67 bar' heartbeat='110' />
+  <sample time='0:53 min' depth='6.256 m' tts='0:41 min' heartbeat='109' />
+  <sample time='0:55 min' depth='6.23 m' tts='0:40 min' />
+  <sample time='0:57 min' depth='6.251 m' pressure='203.8 bar' tts='0:41 min' heartbeat='107' />
+  <sample time='0:58 min' depth='6.246 m' tts='0:40 min' />
+  <sample time='0:59 min' depth='6.351 m' tts='0:41 min' heartbeat='109' />
+  <sample time='1:00 min' depth='6.381 m' heartbeat='107' />
+  <sample time='1:01 min' depth='6.415 m' tts='0:42 min' heartbeat='108' />
+  <sample time='1:02 min' depth='6.544 m' pressure='203.46 bar' />
+  <sample time='1:03 min' depth='6.661 m' tts='0:43 min' heartbeat='107' />
+  <sample time='1:04 min' depth='6.787 m' tts='0:44 min' heartbeat='105' />
+  <sample time='1:05 min' depth='6.98 m' tts='0:45 min' heartbeat='104' />
+  <sample time='1:06 min' depth='7.368 m' tts='0:48 min' heartbeat='105' />
+  <sample time='1:07 min' depth='7.691 m' tts='0:50 min' />
+  <sample time='1:08 min' depth='7.921 m' tts='0:51 min' heartbeat='106' />
+  <sample time='1:09 min' depth='7.864 m' heartbeat='105' />
+  <sample time='1:10 min' depth='8.041 m' tts='0:52 min' />
+  <sample time='1:11 min' depth='8.258 m' tts='0:54 min' heartbeat='104' />
+  <sample time='1:12 min' depth='8.436 m' tts='0:55 min' />
+  <sample time='1:13 min' depth='8.589 m' tts='0:56 min' heartbeat='103' />
+  <sample time='1:14 min' depth='8.798 m' tts='0:57 min' heartbeat='104' />
+  <sample time='1:15 min' depth='9.0 m' tts='0:59 min' heartbeat='107' />
+  <sample time='1:16 min' depth='9.314 m' ndl='843:52 min' tts='1:01 min' />
+  <sample time='1:17 min' depth='9.484 m' ndl='745:43 min' tts='1:02 min' heartbeat='106' />
+  <sample time='1:18 min' depth='9.635 m' ndl='675:22 min' tts='1:03 min' heartbeat='105' />
+  <sample time='1:19 min' depth='9.884 m' ndl='564:15 min' tts='1:04 min' heartbeat='106' />
+  <sample time='1:20 min' depth='10.075 m' ndl='498:38 min' tts='1:06 min' heartbeat='107' />
+  <sample time='1:21 min' depth='10.451 m' ndl='392:49 min' tts='1:08 min' heartbeat='106' />
+  <sample time='1:22 min' depth='10.692 m' ndl='324:10 min' tts='1:10 min' />
+  <sample time='1:23 min' depth='10.876 m' temp='25.0 C' ndl='292:00 min' tts='1:11 min' />
+  <sample time='1:24 min' depth='11.078 m' ndl='265:48 min' tts='1:12 min' />
+  <sample time='1:25 min' depth='11.152 m' ndl='257:50 min' tts='1:13 min' heartbeat='105' />
+  <sample time='1:26 min' depth='11.367 m' ndl='236:28 min' tts='1:14 min' heartbeat='106' />
+  <sample time='1:27 min' depth='11.794 m' pressure='201.32 bar' ndl='190:42 min' tts='1:17 min' heartbeat='105' />
+  <sample time='1:28 min' depth='12.027 m' ndl='174:41 min' tts='1:18 min' />
+  <sample time='1:29 min' depth='12.067 m' ndl='172:19 min' tts='1:19 min' />
+  <sample time='1:30 min' depth='12.319 m' ndl='159:04 min' tts='1:20 min' heartbeat='104' />
+  <sample time='1:31 min' depth='12.638 m' ndl='145:41 min' tts='1:22 min' />
+  <sample time='1:32 min' depth='13.144 m' ndl='122:37 min' tts='1:26 min' />
+  <sample time='1:33 min' depth='13.375 m' ndl='114:31 min' tts='1:27 min' heartbeat='102' />
+  <sample time='1:34 min' depth='13.657 m' ndl='106:20 min' tts='1:29 min' heartbeat='104' />
+  <sample time='1:35 min' depth='13.96 m' ndl='99:02 min' tts='1:31 min' heartbeat='102' />
+  <sample time='1:36 min' depth='14.004 m' ndl='98:03 min' heartbeat='104' />
+  <sample time='1:37 min' depth='14.268 m' pressure='199.81 bar' ndl='92:46 min' tts='1:33 min' />
+  <sample time='1:38 min' depth='14.749 m' ndl='84:42 min' tts='1:36 min' heartbeat='103' />
+  <sample time='1:39 min' depth='14.986 m' ndl='81:18 min' tts='1:38 min' />
+  <sample time='1:40 min' depth='15.221 m' ndl='78:13 min' tts='1:39 min' heartbeat='102' />
+  <sample time='1:41 min' depth='15.26 m' ndl='77:43 min' tts='1:40 min' />
+  <sample time='1:42 min' depth='15.534 m' ndl='74:30 min' tts='1:41 min' />
+  <sample time='1:43 min' depth='15.784 m' ndl='70:58 min' tts='1:43 min' />
+  <sample time='1:44 min' depth='16.25 m' ndl='65:03 min' tts='1:46 min' heartbeat='101' />
+  <sample time='1:45 min' depth='16.512 m' ndl='62:13 min' tts='1:48 min' heartbeat='100' />
+  <sample time='1:46 min' depth='16.665 m' ndl='60:41 min' tts='1:49 min' heartbeat='99' />
+  <sample time='1:47 min' depth='16.856 m' pressure='198.5 bar' ndl='58:53 min' tts='1:50 min' heartbeat='98' />
+  <sample time='1:48 min' depth='17.13 m' ndl='56:32 min' tts='1:52 min' heartbeat='97' />
+  <sample time='1:49 min' depth='17.61 m' ndl='51:39 min' tts='1:55 min' heartbeat='96' />
+  <sample time='1:50 min' depth='17.88 m' ndl='49:08 min' tts='1:57 min' />
+  <sample time='1:51 min' depth='18.179 m' ndl='46:40 min' tts='1:59 min' heartbeat='95' />
+  <sample time='1:52 min' depth='18.433 m' pressure='198.5 bar' ndl='44:48 min' tts='2:00 min' />
+  <sample time='1:53 min' depth='18.589 m' ndl='43:44 min' tts='2:01 min' />
+  <sample time='1:54 min' depth='18.747 m' ndl='42:43 min' tts='2:03 min' />
+  <sample time='1:55 min' depth='18.962 m' ndl='41:25 min' tts='2:04 min' heartbeat='94' />
+  <sample time='1:56 min' depth='19.383 m' ndl='39:08 min' tts='2:07 min' heartbeat='93' />
+  <sample time='1:57 min' depth='19.69 m' pressure='198.36 bar' ndl='37:12 min' tts='2:09 min' />
+  <sample time='1:58 min' depth='19.749 m' ndl='36:47 min' heartbeat='94' />
+  <sample time='1:59 min' depth='19.953 m' ndl='35:27 min' tts='2:10 min' />
+  <sample time='2:00 min' depth='20.228 m' ndl='33:50 min' tts='2:12 min' />
+  <sample time='2:01 min' depth='20.584 m' ndl='32:00 min' tts='2:15 min' heartbeat='93' />
+  <sample time='2:02 min' depth='20.778 m' pressure='197.53 bar' ndl='31:06 min' tts='2:16 min' heartbeat='94' />
+  <sample time='2:03 min' depth='20.989 m' ndl='30:11 min' tts='2:17 min' heartbeat='93' />
+  <sample time='2:04 min' depth='21.114 m' ndl='29:39 min' tts='2:18 min' heartbeat='94' />
+  <sample time='2:05 min' depth='21.214 m' ndl='29:15 min' tts='2:19 min' />
+  <sample time='2:06 min' depth='21.447 m' ndl='28:22 min' tts='2:20 min' heartbeat='95' />
+  <sample time='2:07 min' depth='21.664 m' ndl='27:37 min' tts='2:22 min' />
+  <sample time='2:08 min' depth='21.853 m' ndl='26:59 min' tts='2:23 min' heartbeat='96' />
+  <sample time='2:09 min' depth='21.922 m' ndl='26:45 min' />
+  <sample time='2:10 min' depth='22.333 m' ndl='25:31 min' tts='2:26 min' />
+  <sample time='2:11 min' depth='22.601 m' ndl='24:47 min' tts='2:28 min' heartbeat='97' />
+  <sample time='2:12 min' depth='22.724 m' ndl='24:27 min' tts='2:29 min' />
+  <sample time='2:13 min' depth='22.904 m' ndl='23:46 min' tts='2:30 min' heartbeat='98' />
+  <sample time='2:14 min' depth='22.968 m' ndl='23:30 min' heartbeat='99' />
+  <sample time='2:15 min' depth='22.899 m' ndl='23:45 min' />
+  <sample time='2:16 min' depth='23.089 m' ndl='23:01 min' tts='2:31 min' heartbeat='98' />
+  <sample time='2:17 min' depth='23.254 m' ndl='22:26 min' tts='2:32 min' heartbeat='99' />
+  <sample time='2:18 min' depth='23.546 m' ndl='21:29 min' tts='2:34 min' />
+  <sample time='2:19 min' depth='23.583 m' ndl='21:21 min' heartbeat='97' />
+  <sample time='2:20 min' depth='23.708 m' ndl='20:58 min' tts='2:35 min' heartbeat='100' />
+  <sample time='2:21 min' depth='23.764 m' ndl='20:48 min' heartbeat='101' />
+  <sample time='2:22 min' depth='23.79 m' ndl='20:42 min' tts='2:36 min' />
+  <sample time='2:23 min' depth='23.916 m' ndl='20:20 min' />
+  <sample time='2:24 min' depth='23.99 m' ndl='20:08 min' tts='2:37 min' />
+  <sample time='2:25 min' depth='24.071 m' ndl='19:54 min' heartbeat='102' />
+  <sample time='2:26 min' depth='24.139 m' ndl='19:43 min' tts='2:38 min' heartbeat='103' />
+  <sample time='2:27 min' depth='24.158 m' ndl='19:39 min' />
+  <sample time='2:28 min' depth='24.162 m' ndl='19:38 min' />
+  <sample time='2:29 min' depth='24.119 m' ndl='19:43 min' heartbeat='104' />
+  <sample time='2:30 min' depth='24.191 m' ndl='19:31 min' heartbeat='102' />
+  <sample time='2:31 min' depth='23.937 m' ndl='20:09 min' tts='2:37 min' heartbeat='104' />
+  <sample time='2:32 min' depth='23.893 m' ndl='20:15 min' tts='2:36 min' heartbeat='102' />
+  <sample time='2:33 min' depth='24.315 m' ndl='19:11 min' tts='2:39 min' />
+  <sample time='2:34 min' depth='24.262 m' ndl='19:17 min' />
+  <sample time='2:35 min' depth='24.05 m' ndl='19:48 min' tts='2:37 min' heartbeat='101' />
+  <sample time='2:36 min' depth='24.277 m' ndl='19:13 min' tts='2:39 min' heartbeat='102' />
+  <sample time='2:37 min' depth='24.347 m' pressure='194.98 bar' ndl='19:02 min' />
+  <sample time='2:38 min' depth='24.415 m' ndl='18:52 min' tts='2:40 min' />
+  <sample time='2:39 min' depth='24.495 m' ndl='18:40 min' heartbeat='103' />
+  <sample time='2:40 min' depth='24.56 m' ndl='18:30 min' tts='2:41 min' heartbeat='102' />
+  <sample time='2:41 min' depth='24.598 m' ndl='18:24 min' />
+  <sample time='2:42 min' depth='24.584 m' pressure='195.12 bar' ndl='18:25 min' heartbeat='101' />
+  <sample time='2:43 min' depth='24.406 m' ndl='18:48 min' tts='2:40 min' heartbeat='100' />
+  <sample time='2:44 min' depth='24.449 m' ndl='18:41 min' heartbeat='99' />
+  <sample time='2:45 min' depth='24.452 m' ndl='18:40 min' heartbeat='98' />
+  <sample time='2:46 min' depth='24.782 m' ndl='17:56 min' tts='2:42 min' heartbeat='97' />
+  <sample time='2:47 min' depth='24.635 m' pressure='194.63 bar' ndl='18:14 min' tts='2:41 min' />
+  <sample time='2:48 min' depth='24.733 m' ndl='18:00 min' tts='2:42 min' heartbeat='96' />
+  <sample time='2:49 min' depth='24.851 m' ndl='17:45 min' tts='2:43 min' heartbeat='97' />
+  <sample time='2:50 min' depth='24.919 m' ndl='17:36 min' heartbeat='98' />
+  <sample time='2:51 min' depth='24.842 m' ndl='17:44 min' />
+  <sample time='2:52 min' depth='24.875 m' pressure='194.77 bar' ndl='17:39 min' heartbeat='99' />
+  <sample time='2:53 min' depth='24.927 m' ndl='17:32 min' heartbeat='101' />
+  <sample time='2:54 min' depth='24.902 m' ndl='17:34 min' heartbeat='102' />
+  <sample time='2:55 min' depth='24.911 m' ndl='17:32 min' heartbeat='104' />
+  <sample time='2:56 min' depth='24.983 m' ndl='17:22 min' heartbeat='105' />
+  <sample time='2:57 min' depth='24.954 m' ndl='17:25 min' heartbeat='106' />
+  <sample time='2:58 min' depth='25.001 m' ndl='17:18 min' tts='2:44 min' heartbeat='107' />
+  <sample time='2:59 min' depth='25.122 m' ndl='17:03 min' heartbeat='108' />
+  <sample time='3:00 min' depth='25.165 m' ndl='16:58 min' tts='2:45 min' heartbeat='109' />
+  <sample time='3:01 min' depth='25.023 m' ndl='17:13 min' tts='2:44 min' />
+  <sample time='3:02 min' depth='24.966 m' pressure='195.12 bar' ndl='17:18 min' tts='2:43 min' heartbeat='110' />
+  <sample time='3:03 min' depth='24.987 m' ndl='17:15 min' />
+  <sample time='3:04 min' depth='24.978 m' heartbeat='111' />
+  <sample time='3:05 min' depth='24.977 m' ndl='17:14 min' />
+  <sample time='3:06 min' depth='24.973 m' ndl='17:13 min' />
+  <sample time='3:07 min' depth='25.004 m' pressure='195.39 bar' ndl='17:09 min' tts='2:44 min' />
+  <sample time='3:08 min' depth='24.901 m' ndl='17:20 min' tts='2:43 min' />
+  <sample time='3:09 min' depth='24.839 m' ndl='17:26 min' tts='2:42 min' />
+  <sample time='3:10 min' depth='24.787 m' ndl='17:31 min' heartbeat='110' />
+  <sample time='3:11 min' depth='24.723 m' ndl='17:38 min' />
+  <sample time='3:12 min' depth='24.774 m' ndl='17:31 min' />
+  <sample time='3:13 min' depth='24.902 m' ndl='17:15 min' tts='2:43 min' />
+  <sample time='3:14 min' depth='25.09 m' ndl='16:52 min' tts='2:44 min' />
+  <sample time='3:15 min' depth='25.151 m' ndl='16:44 min' tts='2:45 min' />
+  <sample time='3:16 min' depth='25.197 m' ndl='16:38 min' heartbeat='111' />
+  <sample time='3:17 min' depth='25.247 m' pressure='195.6 bar' ndl='16:32 min' />
+  <sample time='3:18 min' depth='25.328 m' ndl='16:22 min' tts='2:46 min' heartbeat='110' />
+  <sample time='3:19 min' depth='25.393 m' ndl='16:15 min' />
+  <sample time='3:20 min' depth='25.494 m' ndl='16:03 min' tts='2:47 min' />
+  <sample time='3:21 min' depth='25.606 m' ndl='15:51 min' tts='2:48 min' heartbeat='109' />
+  <sample time='3:22 min' depth='25.663 m' ndl='15:45 min' heartbeat='108' />
+  <sample time='3:23 min' depth='25.597 m' ndl='15:50 min' tts='2:47 min' />
+  <sample time='3:24 min' depth='25.907 m' ndl='15:20 min' tts='2:49 min' heartbeat='109' />
+  <sample time='3:25 min' depth='26.027 m' ndl='15:08 min' tts='2:50 min' heartbeat='110' />
+  <sample time='3:26 min' depth='26.047 m' ndl='15:05 min' />
+  <sample time='3:27 min' depth='26.081 m' pressure='195.88 bar' ndl='15:01 min' tts='2:51 min' heartbeat='111' />
+  <sample time='3:28 min' depth='26.154 m' ndl='14:54 min' heartbeat='112' />
+  <sample time='3:30 min' depth='26.114 m' ndl='14:55 min' />
+  <sample time='3:31 min' depth='26.176 m' ndl='14:49 min' />
+  <sample time='3:32 min' depth='26.278 m' pressure='196.01 bar' ndl='14:39 min' tts='2:52 min' heartbeat='111' />
+  <sample time='3:33 min' depth='26.376 m' ndl='14:30 min' tts='2:53 min' />
+  <sample time='3:34 min' depth='26.362 m' tts='2:52 min' heartbeat='110' />
+  <sample time='3:35 min' depth='26.458 m' ndl='14:21 min' tts='2:53 min' heartbeat='109' />
+  <sample time='3:37 min' depth='26.455 m' pressure='196.01 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='3:38 min' depth='26.454 m' ndl='14:19 min' tts='2:53 min' heartbeat='107' />
+  <sample time='3:39 min' depth='26.587 m' ndl='14:07 min' tts='2:54 min' heartbeat='106' />
+  <sample time='3:40 min' depth='26.648 m' ndl='14:02 min' heartbeat='104' />
+  <sample time='3:41 min' depth='26.551 m' ndl='14:08 min' heartbeat='102' />
+  <sample time='3:42 min' depth='26.594 m' ndl='14:04 min' heartbeat='99' />
+  <sample time='3:43 min' depth='26.719 m' ndl='13:53 min' tts='2:55 min' heartbeat='95' />
+  <sample time='3:44 min' depth='26.748 m' ndl='13:50 min' heartbeat='92' />
+  <sample time='3:45 min' depth='26.425 m' ndl='14:14 min' tts='2:53 min' heartbeat='90' />
+  <sample time='3:46 min' depth='26.685 m' ndl='13:53 min' tts='2:55 min' heartbeat='88' />
+  <sample time='3:47 min' depth='26.579 m' pressure='196.22 bar' ndl='14:00 min' tts='2:54 min' heartbeat='87' />
+  <sample time='3:48 min' depth='26.499 m' ndl='14:05 min' tts='2:53 min' heartbeat='86' />
+  <sample time='3:50 min' depth='26.41 m' ndl='14:10 min' />
+  <sample time='3:51 min' depth='26.353 m' ndl='14:14 min' tts='2:52 min' />
+  <sample time='3:52 min' depth='26.36 m' pressure='196.5 bar' ndl='14:12 min' />
+  <sample time='3:53 min' depth='26.406 m' temp='24.0 C' ndl='14:08 min' tts='2:53 min' />
+  <sample time='3:54 min' depth='26.442 m' ndl='14:04 min' />
+  <sample time='3:55 min' depth='26.508 m' ndl='13:57 min' />
+  <sample time='3:56 min' depth='26.459 m' ndl='14:00 min' />
+  <sample time='3:57 min' depth='26.566 m' pressure='196.36 bar' ndl='13:51 min' tts='2:54 min' />
+  <sample time='3:58 min' depth='26.664 m' ndl='13:42 min' />
+  <sample time='3:59 min' depth='26.862 m' ndl='13:27 min' tts='2:56 min' />
+  <sample time='4:00 min' depth='26.769 m' ndl='13:32 min' tts='2:55 min' heartbeat='85' />
+  <sample time='4:01 min' depth='26.9 m' ndl='13:22 min' tts='2:56 min' />
+  <sample time='4:02 min' depth='26.978 m' pressure='196.5 bar' ndl='13:15 min' tts='2:57 min' />
+  <sample time='4:03 min' depth='27.119 m' ndl='13:04 min' heartbeat='84' />
+  <sample time='4:04 min' depth='27.125 m' ndl='13:03 min' cns='1%' heartbeat='83' />
+  <sample time='4:05 min' depth='27.132 m' ndl='13:01 min' tts='2:58 min' heartbeat='82' />
+  <sample time='4:06 min' depth='27.129 m' heartbeat='81' />
+  <sample time='4:07 min' depth='26.969 m' ndl='13:11 min' tts='2:56 min' />
+  <sample time='4:08 min' depth='26.658 m' ndl='13:33 min' tts='2:54 min' />
+  <sample time='4:09 min' depth='26.983 m' ndl='13:08 min' tts='2:57 min' heartbeat='82' />
+  <sample time='4:10 min' depth='27.02 m' ndl='13:04 min' />
+  <sample time='4:11 min' depth='27.084 m' ndl='12:59 min' heartbeat='81' />
+  <sample time='4:12 min' depth='27.105 m' pressure='196.63 bar' ndl='12:56 min' />
+  <sample time='4:13 min' depth='27.183 m' ndl='12:50 min' tts='2:58 min' heartbeat='80' />
+  <sample time='4:14 min' depth='27.207 m' ndl='12:47 min' />
+  <sample time='4:15 min' depth='27.152 m' ndl='12:50 min' heartbeat='81' />
+  <sample time='4:16 min' depth='27.115 m' ndl='12:52 min' tts='2:57 min' heartbeat='82' />
+  <sample time='4:17 min' depth='27.196 m' ndl='12:45 min' tts='2:58 min' heartbeat='81' />
+  <sample time='4:18 min' depth='27.25 m' ndl='12:41 min' />
+  <sample time='4:19 min' depth='27.34 m' ndl='12:34 min' tts='2:59 min' />
+  <sample time='4:20 min' depth='27.402 m' ndl='12:29 min' />
+  <sample time='4:21 min' depth='27.433 m' ndl='12:26 min' tts='3:00 min' />
+  <sample time='4:22 min' depth='27.481 m' pressure='196.63 bar' ndl='12:21 min' />
+  <sample time='4:23 min' depth='27.309 m' ndl='12:32 min' tts='2:59 min' heartbeat='82' />
+  <sample time='4:24 min' depth='27.386 m' ndl='12:26 min' />
+  <sample time='4:25 min' depth='27.284 m' ndl='12:31 min' heartbeat='83' />
+  <sample time='4:26 min' depth='27.241 m' ndl='12:33 min' tts='2:58 min' />
+  <sample time='4:27 min' depth='27.214 m' pressure='196.63 bar' ndl='12:34 min' />
+  <sample time='4:28 min' depth='27.181 m' ndl='12:35 min' />
+  <sample time='4:29 min' depth='27.137 m' ndl='12:37 min' />
+  <sample time='4:30 min' depth='27.161 m' ndl='12:34 min' heartbeat='82' />
+  <sample time='4:31 min' depth='27.128 m' ndl='12:36 min' heartbeat='84' />
+  <sample time='4:32 min' depth='27.167 m' pressure='196.84 bar' ndl='12:32 min' />
+  <sample time='4:33 min' depth='27.258 m' ndl='12:25 min' heartbeat='85' />
+  <sample time='4:34 min' depth='27.344 m' ndl='12:18 min' tts='2:59 min' />
+  <sample time='4:35 min' depth='27.371 m' ndl='12:16 min' />
+  <sample time='4:37 min' depth='27.413 m' pressure='196.84 bar' ndl='12:11 min' />
+  <sample time='4:38 min' depth='27.471 m' ndl='12:06 min' tts='3:00 min' />
+  <sample time='4:39 min' depth='27.496 m' ndl='12:04 min' />
+  <sample time='4:40 min' depth='27.457 m' ndl='12:05 min' />
+  <sample time='4:41 min' depth='27.41 m' ndl='12:07 min' tts='2:59 min' />
+  <sample time='4:42 min' depth='27.489 m' ndl='12:01 min' tts='3:00 min' heartbeat='84' />
+  <sample time='4:43 min' depth='27.548 m' ndl='11:56 min' />
+  <sample time='4:44 min' depth='27.603 m' ndl='11:52 min' tts='3:01 min' heartbeat='83' />
+  <sample time='4:45 min' depth='27.656 m' ndl='11:48 min' heartbeat='82' />
+  <sample time='4:46 min' depth='27.669 m' ndl='11:46 min' heartbeat='81' />
+  <sample time='4:47 min' depth='27.678 m' pressure='196.91 bar' ndl='11:45 min' heartbeat='80' />
+  <sample time='4:48 min' depth='27.672 m' ndl='11:44 min' />
+  <sample time='4:49 min' depth='27.672 m' ndl='11:43 min' heartbeat='79' />
+  <sample time='4:50 min' depth='27.685 m' ndl='11:41 min' />
+  <sample time='4:52 min' depth='27.649 m' pressure='196.91 bar' heartbeat='78' />
+  <sample time='4:53 min' depth='27.613 m' ndl='11:42 min' />
+  <sample time='4:54 min' depth='27.621 m' ndl='11:41 min' />
+  <sample time='4:55 min' depth='27.673 m' ndl='11:37 min' heartbeat='77' />
+  <sample time='4:56 min' depth='27.642 m' ndl='11:38 min' />
+  <sample time='4:57 min' depth='27.781 m' ndl='11:28 min' tts='3:02 min' />
+  <sample time='4:58 min' depth='27.931 m' ndl='11:19 min' tts='3:03 min' />
+  <sample time='4:59 min' depth='27.895 m' ndl='11:20 min' />
+  <sample time='5:00 min' depth='27.823 m' ndl='11:23 min' tts='3:02 min' />
+  <sample time='5:01 min' depth='28.158 m' ndl='11:03 min' tts='3:04 min' />
+  <sample time='5:02 min' depth='28.126 m' ndl='11:04 min' />
+  <sample time='5:03 min' depth='28.194 m' ndl='10:59 min' tts='3:05 min' heartbeat='78' />
+  <sample time='5:04 min' depth='28.231 m' ndl='10:56 min' />
+  <sample time='5:05 min' depth='28.223 m' heartbeat='79' />
+  <sample time='5:06 min' depth='28.059 m' ndl='11:04 min' tts='3:04 min' />
+  <sample time='5:07 min' depth='28.132 m' pressure='196.98 bar' ndl='10:59 min' />
+  <sample time='5:08 min' depth='28.261 m' ndl='10:51 min' tts='3:05 min' />
+  <sample time='5:09 min' depth='28.216 m' ndl='10:52 min' heartbeat='78' />
+  <sample time='5:10 min' depth='28.212 m' ndl='10:51 min' />
+  <sample time='5:11 min' depth='28.197 m' heartbeat='77' />
+  <sample time='5:12 min' depth='28.304 m' pressure='197.19 bar' ndl='10:44 min' heartbeat='76' />
+  <sample time='5:13 min' depth='28.308 m' ndl='10:43 min' />
+  <sample time='5:14 min' depth='28.24 m' ndl='10:46 min' heartbeat='75' />
+  <sample time='5:15 min' depth='28.288 m' ndl='10:42 min' />
+  <sample time='5:17 min' depth='28.292 m' ndl='10:40 min' />
+  <sample time='5:18 min' depth='28.363 m' ndl='10:35 min' tts='3:06 min' />
+  <sample time='5:19 min' depth='28.381 m' ndl='10:33 min' heartbeat='74' />
+  <sample time='5:20 min' depth='28.477 m' ndl='10:27 min' />
+  <sample time='5:22 min' depth='28.383 m' pressure='197.12 bar' ndl='10:30 min' />
+  <sample time='5:23 min' depth='28.192 m' ndl='10:39 min' tts='3:04 min' />
+  <sample time='5:24 min' depth='28.066 m' ndl='10:45 min' heartbeat='75' />
+  <sample time='5:25 min' depth='27.972 m' ndl='10:49 min' tts='3:03 min' />
+  <sample time='5:26 min' depth='27.952 m' heartbeat='76' />
+  <sample time='5:27 min' depth='27.989 m' pressure='197.12 bar' ndl='10:46 min' />
+  <sample time='5:28 min' depth='27.978 m' heartbeat='77' />
+  <sample time='5:29 min' depth='27.897 m' ndl='10:49 min' />
+  <sample time='5:30 min' depth='27.827 m' ndl='10:52 min' tts='3:02 min' />
+  <sample time='5:31 min' depth='27.829 m' ndl='10:51 min' heartbeat='78' />
+  <sample time='5:32 min' depth='27.829 m' pressure='197.12 bar' ndl='10:50 min' heartbeat='77' />
+  <sample time='5:33 min' depth='27.874 m' ndl='10:47 min' heartbeat='78' />
+  <sample time='5:35 min' depth='27.838 m' heartbeat='79' />
+  <sample time='5:36 min' depth='27.831 m' ndl='10:46 min' />
+  <sample time='5:37 min' depth='27.821 m' pressure='197.25 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='5:38 min' depth='27.811 m' ndl='10:45 min' tts='3:02 min' />
+  <sample time='5:39 min' depth='27.805 m' ndl='10:44 min' />
+  <sample time='5:40 min' depth='27.69 m' ndl='10:50 min' tts='3:01 min' />
+  <sample time='5:41 min' depth='27.621 m' ndl='10:53 min' />
+  <sample time='5:42 min' depth='27.664 m' ndl='10:49 min' heartbeat='78' />
+  <sample time='5:43 min' depth='27.704 m' ndl='10:46 min' />
+  <sample time='5:44 min' depth='27.711 m' ndl='10:45 min' heartbeat='80' />
+  <sample time='5:45 min' depth='27.824 m' ndl='10:37 min' tts='3:02 min' heartbeat='79' />
+  <sample time='5:46 min' depth='27.906 m' ndl='10:32 min' tts='3:03 min' />
+  <sample time='5:47 min' depth='27.915 m' pressure='197.19 bar' ndl='10:30 min' heartbeat='78' />
+  <sample time='5:48 min' depth='27.852 m' ndl='10:33 min' tts='3:02 min' />
+  <sample time='5:49 min' depth='27.775 m' ndl='10:36 min' />
+  <sample time='5:50 min' depth='27.674 m' ndl='10:41 min' tts='3:01 min' />
+  <sample time='5:51 min' depth='27.61 m' ndl='10:44 min' />
+  <sample time='5:52 min' depth='27.73 m' pressure='197.19 bar' ndl='10:36 min' />
+  <sample time='5:53 min' depth='27.762 m' ndl='10:33 min' tts='3:02 min' heartbeat='79' />
+  <sample time='5:54 min' depth='27.762 m' ndl='10:32 min' />
+  <sample time='5:55 min' depth='27.819 m' ndl='10:28 min' heartbeat='78' />
+  <sample time='5:56 min' depth='27.882 m' ndl='10:23 min' />
+  <sample time='5:57 min' depth='27.923 m' pressure='197.19 bar' ndl='10:20 min' tts='3:03 min' heartbeat='79' />
+  <sample time='5:58 min' depth='27.997 m' ndl='10:15 min' />
+  <sample time='5:59 min' depth='28.048 m' ndl='10:11 min' tts='3:04 min' />
+  <sample time='6:00 min' depth='28.153 m' ndl='10:05 min' />
+  <sample time='6:01 min' depth='28.198 m' ndl='10:02 min' tts='3:05 min' />
+  <sample time='6:02 min' depth='28.198 m' ndl='10:01 min' heartbeat='80' />
+  <sample time='6:03 min' depth='28.224 m' ndl='9:58 min' />
+  <sample time='6:04 min' depth='28.345 m' ndl='9:51 min' />
+  <sample time='6:05 min' depth='28.478 m' ndl='9:44 min' tts='3:06 min' />
+  <sample time='6:06 min' depth='28.482 m' ndl='9:42 min' />
+  <sample time='6:07 min' depth='28.412 m' ndl='9:45 min' />
+  <sample time='6:08 min' depth='28.467 m' ndl='9:41 min' />
+  <sample time='6:09 min' depth='28.496 m' ndl='9:39 min' heartbeat='81' />
+  <sample time='6:10 min' depth='28.48 m' heartbeat='78' />
+  <sample time='6:11 min' depth='28.387 m' ndl='9:42 min' heartbeat='81' />
+  <sample time='6:12 min' depth='28.39 m' pressure='197.25 bar' ndl='9:41 min' />
+  <sample time='6:13 min' depth='28.345 m' ndl='9:42 min' tts='3:05 min' heartbeat='82' />
+  <sample time='6:14 min' depth='28.265 m' ndl='9:45 min' heartbeat='81' />
+  <sample time='6:15 min' depth='28.206 m' ndl='9:47 min' />
+  <sample time='6:16 min' depth='28.142 m' ndl='9:49 min' tts='3:04 min' />
+  <sample time='6:17 min' depth='27.798 m' pressure='197.25 bar' ndl='10:06 min' tts='3:02 min' />
+  <sample time='6:18 min' depth='27.598 m' ndl='10:16 min' tts='3:01 min' />
+  <sample time='6:19 min' depth='27.639 m' ndl='10:13 min' cns='2%' heartbeat='80' />
+  <sample time='6:20 min' depth='27.714 m' ndl='10:08 min' />
+  <sample time='6:21 min' depth='27.854 m' ndl='9:59 min' tts='3:02 min' />
+  <sample time='6:22 min' depth='28.002 m' pressure='197.25 bar' ndl='9:51 min' tts='3:03 min' />
+  <sample time='6:23 min' depth='28.242 m' ndl='9:37 min' tts='3:05 min' heartbeat='79' />
+  <sample time='6:24 min' depth='28.514 m' ndl='9:23 min' tts='3:07 min' heartbeat='80' />
+  <sample time='6:25 min' depth='28.696 m' ndl='9:14 min' tts='3:08 min' />
+  <sample time='6:26 min' depth='28.707 m' ndl='9:12 min' />
+  <sample time='6:27 min' depth='28.724 m' pressure='197.39 bar' ndl='9:11 min' />
+  <sample time='6:28 min' depth='28.778 m' ndl='9:07 min' />
+  <sample time='6:29 min' depth='28.891 m' ndl='9:01 min' tts='3:09 min' />
+  <sample time='6:30 min' depth='28.955 m' ndl='8:56 min' />
+  <sample time='6:31 min' depth='29.032 m' ndl='8:49 min' tts='3:10 min' heartbeat='79' />
+  <sample time='6:32 min' depth='29.105 m' pressure='197.39 bar' ndl='8:43 min' />
+  <sample time='6:33 min' depth='29.081 m' ndl='8:44 min' />
+  <sample time='6:34 min' depth='29.208 m' ndl='8:35 min' tts='3:11 min' />
+  <sample time='6:35 min' depth='29.259 m' ndl='8:30 min' />
+  <sample time='6:36 min' depth='29.336 m' ndl='8:24 min' tts='3:12 min' />
+  <sample time='6:37 min' depth='29.384 m' pressure='197.39 bar' ndl='8:20 min' />
+  <sample time='6:38 min' depth='29.445 m' ndl='8:16 min' tts='3:13 min' />
+  <sample time='6:39 min' depth='29.49 m' ndl='8:12 min' heartbeat='80' />
+  <sample time='6:40 min' depth='29.402 m' ndl='8:16 min' tts='3:12 min' />
+  <sample time='6:41 min' depth='29.413 m' ndl='8:14 min' heartbeat='81' />
+  <sample time='6:42 min' depth='29.48 m' pressure='197.19 bar' ndl='8:09 min' tts='3:13 min' heartbeat='80' />
+  <sample time='6:43 min' depth='29.548 m' ndl='8:04 min' heartbeat='81' />
+  <sample time='6:44 min' depth='29.606 m' ndl='8:00 min' tts='3:14 min' />
+  <sample time='6:45 min' depth='29.65 m' ndl='7:56 min' heartbeat='82' />
+  <sample time='6:46 min' depth='29.61 m' ndl='7:58 min' />
+  <sample time='6:47 min' depth='29.495 m' ndl='8:03 min' tts='3:13 min' heartbeat='83' />
+  <sample time='6:48 min' depth='29.332 m' ndl='8:12 min' tts='3:12 min' />
+  <sample time='6:49 min' depth='29.357 m' ndl='8:10 min' heartbeat='84' />
+  <sample time='6:50 min' depth='29.233 m' ndl='8:17 min' tts='3:11 min' />
+  <sample time='6:51 min' depth='29.078 m' ndl='8:26 min' tts='3:10 min' />
+  <sample time='6:52 min' depth='28.866 m' ndl='8:39 min' tts='3:09 min' />
+  <sample time='6:53 min' depth='28.715 m' ndl='8:44 min' tts='3:08 min' />
+  <sample time='6:54 min' depth='28.925 m' ndl='8:33 min' tts='3:09 min' heartbeat='83' />
+  <sample time='6:55 min' depth='29.002 m' ndl='8:27 min' tts='3:10 min' heartbeat='84' />
+  <sample time='6:56 min' depth='29.048 m' ndl='8:23 min' />
+  <sample time='6:57 min' depth='29.036 m' heartbeat='83' />
+  <sample time='6:58 min' depth='29.053 m' ndl='8:21 min' />
+  <sample time='6:59 min' depth='29.106 m' ndl='8:16 min' />
+  <sample time='7:00 min' depth='29.146 m' ndl='8:12 min' tts='3:11 min' />
+  <sample time='7:01 min' depth='29.154 m' ndl='8:11 min' heartbeat='82' />
+  <sample time='7:02 min' depth='29.116 m' pressure='196.98 bar' ndl='8:12 min' heartbeat='81' />
+  <sample time='7:03 min' depth='29.132 m' ndl='8:10 min' />
+  <sample time='7:04 min' depth='29.116 m' heartbeat='82' />
+  <sample time='7:05 min' depth='29.139 m' ndl='8:08 min' heartbeat='81' />
+  <sample time='7:06 min' depth='29.204 m' ndl='8:03 min' />
+  <sample time='7:07 min' depth='29.261 m' pressure='196.98 bar' ndl='7:58 min' tts='3:12 min' heartbeat='80' />
+  <sample time='7:08 min' depth='29.35 m' ndl='7:52 min' />
+  <sample time='7:09 min' depth='29.373 m' ndl='7:49 min' />
+  <sample time='7:10 min' depth='29.34 m' ndl='7:50 min' />
+  <sample time='7:11 min' depth='29.318 m' ndl='7:51 min' />
+  <sample time='7:12 min' depth='29.275 m' pressure='196.98 bar' ndl='7:52 min' />
+  <sample time='7:13 min' depth='29.21 m' ndl='7:55 min' tts='3:11 min' />
+  <sample time='7:14 min' depth='29.143 m' ndl='7:59 min' />
+  <sample time='7:15 min' depth='29.081 m' ndl='8:02 min' tts='3:10 min' />
+  <sample time='7:16 min' depth='29.057 m' heartbeat='79' />
+  <sample time='7:17 min' depth='29.074 m' ndl='8:00 min' />
+  <sample time='7:18 min' depth='29.047 m' ndl='8:01 min' heartbeat='78' />
+  <sample time='7:19 min' depth='28.881 m' ndl='8:11 min' tts='3:09 min' />
+  <sample time='7:20 min' depth='28.914 m' ndl='8:08 min' />
+  <sample time='7:21 min' depth='28.862 m' ndl='8:09 min' />
+  <sample time='7:22 min' depth='28.679 m' pressure='196.98 bar' ndl='8:16 min' tts='3:08 min' />
+  <sample time='7:23 min' depth='28.412 m' ndl='8:27 min' tts='3:06 min' />
+  <sample time='7:24 min' depth='28.122 m' ndl='8:39 min' tts='3:04 min' />
+  <sample time='7:26 min' depth='28.267 m' ndl='8:30 min' tts='3:05 min' />
+  <sample time='7:27 min' depth='28.203 m' ndl='8:32 min' />
+  <sample time='7:28 min' depth='28.01 m' ndl='8:40 min' tts='3:03 min' />
+  <sample time='7:29 min' depth='27.784 m' ndl='8:50 min' tts='3:02 min' />
+  <sample time='7:30 min' depth='27.695 m' ndl='8:54 min' tts='3:01 min' />
+  <sample time='7:31 min' depth='27.714 m' ndl='8:52 min' />
+  <sample time='7:32 min' depth='27.607 m' pressure='197.19 bar' ndl='8:56 min' />
+  <sample time='7:33 min' depth='27.402 m' ndl='9:06 min' tts='2:59 min' heartbeat='77' />
+  <sample time='7:34 min' depth='27.342 m' ndl='9:08 min' />
+  <sample time='7:35 min' depth='27.311 m' ndl='9:09 min' />
+  <sample time='7:36 min' depth='27.34 m' ndl='9:06 min' heartbeat='78' />
+  <sample time='7:37 min' depth='27.374 m' ndl='9:03 min' heartbeat='79' />
+  <sample time='7:38 min' depth='27.383 m' ndl='9:02 min' />
+  <sample time='7:39 min' depth='27.458 m' ndl='8:57 min' tts='3:00 min' />
+  <sample time='7:40 min' depth='27.526 m' ndl='8:52 min' />
+  <sample time='7:41 min' depth='27.563 m' ndl='8:49 min' heartbeat='78' />
+  <sample time='7:42 min' depth='27.542 m' ndl='8:50 min' heartbeat='77' />
+  <sample time='7:43 min' depth='27.499 m' ndl='8:51 min' heartbeat='76' />
+  <sample time='7:44 min' depth='27.403 m' ndl='8:55 min' tts='2:59 min' heartbeat='75' />
+  <sample time='7:45 min' depth='27.21 m' ndl='9:04 min' tts='2:58 min' heartbeat='74' />
+  <sample time='7:46 min' depth='27.237 m' ndl='9:02 min' heartbeat='75' />
+  <sample time='7:47 min' depth='27.352 m' pressure='196.98 bar' ndl='8:54 min' tts='2:59 min' />
+  <sample time='7:48 min' depth='27.392 m' ndl='8:51 min' />
+  <sample time='7:49 min' depth='27.34 m' ndl='8:53 min' />
+  <sample time='7:50 min' depth='27.34 m' ndl='8:52 min' />
+  <sample time='7:51 min' depth='27.325 m' heartbeat='76' />
+  <sample time='7:52 min' depth='27.287 m' ndl='8:53 min' />
+  <sample time='7:53 min' depth='27.339 m' ndl='8:49 min' />
+  <sample time='7:54 min' depth='27.415 m' ndl='8:44 min' />
+  <sample time='7:55 min' depth='27.386 m' ndl='8:45 min' />
+  <sample time='7:56 min' depth='27.276 m' ndl='8:50 min' tts='2:58 min' />
+  <sample time='7:57 min' depth='27.371 m' ndl='8:44 min' tts='2:59 min' />
+  <sample time='7:58 min' depth='27.5 m' ndl='8:36 min' tts='3:00 min' />
+  <sample time='7:59 min' depth='27.501 m' ndl='8:35 min' />
+  <sample time='8:00 min' depth='27.489 m' ndl='8:34 min' heartbeat='77' />
+  <sample time='8:02 min' depth='27.295 m' ndl='8:42 min' tts='2:59 min' />
+  <sample time='8:03 min' depth='27.114 m' ndl='8:51 min' tts='2:57 min' />
+  <sample time='8:04 min' depth='27.001 m' ndl='8:56 min' />
+  <sample time='8:05 min' depth='26.861 m' ndl='9:03 min' tts='2:56 min' heartbeat='76' />
+  <sample time='8:06 min' depth='26.644 m' ndl='9:15 min' tts='2:54 min' heartbeat='75' />
+  <sample time='8:07 min' depth='26.359 m' ndl='9:32 min' tts='2:52 min' />
+  <sample time='8:08 min' depth='26.258 m' ndl='9:38 min' heartbeat='76' />
+  <sample time='8:09 min' depth='26.228 m' ndl='9:39 min' />
+  <sample time='8:10 min' depth='26.219 m' ndl='9:38 min' />
+  <sample time='8:11 min' depth='26.101 m' ndl='9:45 min' tts='2:51 min' />
+  <sample time='8:12 min' depth='26.004 m' pressure='197.12 bar' ndl='9:51 min' tts='2:50 min' />
+  <sample time='8:13 min' depth='25.794 m' ndl='10:05 min' tts='2:49 min' heartbeat='77' />
+  <sample time='8:14 min' depth='25.648 m' ndl='10:15 min' tts='2:48 min' />
+  <sample time='8:15 min' depth='25.517 m' ndl='10:24 min' tts='2:47 min' heartbeat='76' />
+  <sample time='8:16 min' depth='25.31 m' ndl='10:40 min' tts='2:46 min' />
+  <sample time='8:17 min' depth='25.246 m' pressure='197.12 bar' ndl='10:45 min' tts='2:45 min' />
+  <sample time='8:18 min' depth='25.357 m' ndl='10:34 min' tts='2:46 min' />
+  <sample time='8:19 min' depth='25.34 m' ndl='10:35 min' heartbeat='75' />
+  <sample time='8:20 min' depth='25.306 m' ndl='10:36 min' />
+  <sample time='8:21 min' depth='25.118 m' ndl='10:52 min' tts='2:44 min' heartbeat='76' />
+  <sample time='8:22 min' depth='25.058 m' pressure='197.12 bar' ndl='10:56 min' heartbeat='77' />
+  <sample time='8:23 min' depth='25.066 m' ndl='10:54 min' heartbeat='78' />
+  <sample time='8:25 min' depth='24.97 m' ndl='11:01 min' tts='2:43 min' />
+  <sample time='8:26 min' depth='24.904 m' ndl='11:06 min' />
+  <sample time='8:27 min' depth='24.888 m' pressure='197.12 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='8:28 min' depth='24.871 m' ndl='11:07 min' tts='2:43 min' />
+  <sample time='8:29 min' depth='24.732 m' ndl='11:19 min' tts='2:42 min' />
+  <sample time='8:30 min' depth='24.72 m' ndl='11:20 min' />
+  <sample time='8:31 min' depth='24.694 m' ndl='11:21 min' />
+  <sample time='8:32 min' depth='24.677 m' ndl='11:22 min' tts='2:41 min' />
+  <sample time='8:33 min' depth='24.571 m' ndl='11:32 min' />
+  <sample time='8:34 min' depth='24.603 m' ndl='11:27 min' cns='3%' />
+  <sample time='8:35 min' depth='24.629 m' ndl='11:24 min' heartbeat='77' />
+  <sample time='8:36 min' depth='24.549 m' ndl='11:31 min' />
+  <sample time='8:37 min' depth='24.455 m' pressure='197.19 bar' ndl='11:40 min' tts='2:40 min' heartbeat='78' />
+  <sample time='8:38 min' depth='24.412 m' ndl='11:43 min' />
+  <sample time='8:39 min' depth='24.415 m' ndl='11:42 min' />
+  <sample time='8:40 min' depth='24.212 m' ndl='12:04 min' tts='2:38 min' />
+  <sample time='8:41 min' depth='24.122 m' ndl='12:13 min' />
+  <sample time='8:42 min' depth='24.088 m' pressure='197.19 bar' ndl='12:17 min' />
+  <sample time='8:43 min' depth='24.114 m' ndl='12:12 min' />
+  <sample time='8:44 min' depth='24.159 m' ndl='12:06 min' />
+  <sample time='8:45 min' depth='24.096 m' ndl='12:13 min' />
+  <sample time='8:46 min' depth='24.088 m' heartbeat='77' />
+  <sample time='8:47 min' depth='24.11 m' pressure='197.19 bar' ndl='12:09 min' />
+  <sample time='8:48 min' depth='24.265 m' ndl='11:50 min' tts='2:39 min' />
+  <sample time='8:49 min' depth='24.363 m' ndl='11:38 min' />
+  <sample time='8:50 min' depth='24.342 m' ndl='11:39 min' heartbeat='78' />
+  <sample time='8:51 min' depth='24.32 m' ndl='11:41 min' heartbeat='77' />
+  <sample time='8:52 min' depth='24.327 m' ndl='11:39 min' heartbeat='78' />
+  <sample time='8:53 min' depth='24.415 m' ndl='11:28 min' tts='2:40 min' heartbeat='77' />
+  <sample time='8:54 min' depth='24.574 m' ndl='11:11 min' tts='2:41 min' />
+  <sample time='8:55 min' depth='24.578 m' ndl='11:09 min' heartbeat='76' />
+  <sample time='8:56 min' depth='24.601 m' ndl='11:06 min' />
+  <sample time='8:57 min' depth='24.6 m' pressure='197.19 bar' ndl='11:05 min' heartbeat='75' />
+  <sample time='8:58 min' depth='24.521 m' ndl='11:12 min' tts='2:40 min' />
+  <sample time='8:59 min' depth='24.528 m' ndl='11:11 min' heartbeat='76' />
+  <sample time='9:00 min' depth='24.513 m' heartbeat='77' />
+  <sample time='9:01 min' depth='24.495 m' ndl='11:12 min' heartbeat='78' />
+  <sample time='9:02 min' depth='24.434 m' pressure='197.19 bar' ndl='11:17 min' heartbeat='79' />
+  <sample time='9:03 min' depth='24.462 m' ndl='11:13 min' />
+  <sample time='9:05 min' depth='24.457 m' ndl='11:12 min' />
+  <sample time='9:06 min' depth='24.51 m' ndl='11:05 min' heartbeat='78' />
+  <sample time='9:07 min' depth='24.631 m' pressure='197.19 bar' ndl='10:52 min' tts='2:41 min' heartbeat='77' />
+  <sample time='9:08 min' depth='24.722 m' ndl='10:43 min' tts='2:42 min' heartbeat='76' />
+  <sample time='9:09 min' depth='24.815 m' ndl='10:33 min' heartbeat='75' />
+  <sample time='9:10 min' depth='24.87 m' ndl='10:27 min' tts='2:43 min' heartbeat='74' />
+  <sample time='9:11 min' depth='24.892 m' ndl='10:24 min' />
+  <sample time='9:12 min' depth='24.892 m' pressure='197.19 bar' ndl='10:23 min' />
+  <sample time='9:13 min' depth='24.899 m' ndl='10:21 min' />
+  <sample time='9:14 min' depth='24.763 m' ndl='10:33 min' tts='2:42 min' heartbeat='73' />
+  <sample time='9:15 min' depth='24.624 m' ndl='10:45 min' tts='2:41 min' />
+  <sample time='9:16 min' depth='24.542 m' ndl='10:52 min' />
+  <sample time='9:17 min' depth='24.49 m' pressure='197.19 bar' ndl='10:56 min' tts='2:40 min' heartbeat='75' />
+  <sample time='9:18 min' depth='24.488 m' ndl='10:55 min' />
+  <sample time='9:19 min' depth='24.515 m' ndl='10:52 min' />
+  <sample time='9:20 min' depth='24.551 m' ndl='10:47 min' tts='2:41 min' heartbeat='74' />
+  <sample time='9:21 min' depth='24.622 m' ndl='10:39 min' />
+  <sample time='9:22 min' depth='24.622 m' pressure='197.19 bar' ndl='10:38 min' />
+  <sample time='9:23 min' depth='24.644 m' ndl='10:35 min' />
+  <sample time='9:24 min' depth='24.72 m' ndl='10:27 min' tts='2:42 min' />
+  <sample time='9:25 min' depth='24.824 m' ndl='10:16 min' />
+  <sample time='9:26 min' depth='24.947 m' ndl='10:04 min' tts='2:43 min' />
+  <sample time='9:27 min' depth='25.022 m' pressure='197.19 bar' ndl='9:57 min' tts='2:44 min' heartbeat='75' />
+  <sample time='9:28 min' depth='24.996 m' ndl='9:58 min' />
+  <sample time='9:29 min' depth='24.893 m' ndl='10:06 min' tts='2:43 min' heartbeat='74' />
+  <sample time='9:30 min' depth='24.871 m' ndl='10:07 min' />
+  <sample time='9:31 min' depth='24.887 m' ndl='10:04 min' heartbeat='73' />
+  <sample time='9:32 min' depth='25.007 m' pressure='197.25 bar' ndl='9:53 min' tts='2:44 min' />
+  <sample time='9:33 min' depth='25.041 m' ndl='9:49 min' heartbeat='72' />
+  <sample time='9:34 min' depth='24.869 m' ndl='10:03 min' tts='2:43 min' />
+  <sample time='9:35 min' depth='24.737 m' ndl='10:14 min' tts='2:42 min' heartbeat='71' />
+  <sample time='9:36 min' depth='24.681 m' ndl='10:18 min' tts='2:41 min' heartbeat='70' />
+  <sample time='9:37 min' depth='24.66 m' pressure='197.19 bar' ndl='10:19 min' heartbeat='71' />
+  <sample time='9:38 min' depth='24.661 m' ndl='10:18 min' heartbeat='72' />
+  <sample time='9:39 min' depth='24.741 m' ndl='10:10 min' tts='2:42 min' />
+  <sample time='9:40 min' depth='24.874 m' ndl='9:57 min' tts='2:43 min' />
+  <sample time='9:41 min' depth='24.955 m' ndl='9:49 min' />
+  <sample time='9:42 min' depth='25.039 m' ndl='9:40 min' tts='2:44 min' />
+  <sample time='9:43 min' depth='25.062 m' ndl='9:38 min' />
+  <sample time='9:44 min' depth='25.089 m' ndl='9:34 min' />
+  <sample time='9:45 min' depth='24.926 m' ndl='9:47 min' tts='2:43 min' />
+  <sample time='9:46 min' depth='24.839 m' ndl='9:54 min' tts='2:42 min' />
+  <sample time='9:47 min' depth='24.841 m' pressure='197.25 bar' ndl='9:52 min' heartbeat='73' />
+  <sample time='9:48 min' depth='24.933 m' ndl='9:43 min' tts='2:43 min' />
+  <sample time='9:49 min' depth='25.154 m' ndl='9:24 min' tts='2:45 min' heartbeat='74' />
+  <sample time='9:50 min' depth='25.313 m' ndl='9:11 min' tts='2:46 min' />
+  <sample time='9:51 min' depth='25.264 m' ndl='9:13 min' tts='2:45 min' />
+  <sample time='9:52 min' depth='25.156 m' pressure='197.19 bar' ndl='9:21 min' heartbeat='73' />
+  <sample time='9:53 min' depth='25.088 m' ndl='9:25 min' tts='2:44 min' />
+  <sample time='9:54 min' depth='25.025 m' ndl='9:30 min' />
+  <sample time='9:55 min' depth='24.812 m' ndl='9:47 min' tts='2:42 min' heartbeat='72' />
+  <sample time='9:56 min' depth='24.918 m' ndl='9:37 min' tts='2:43 min' />
+  <sample time='9:57 min' depth='25.145 m' pressure='197.25 bar' ndl='9:17 min' tts='2:44 min' heartbeat='73' />
+  <sample time='9:58 min' depth='25.157 m' ndl='9:15 min' tts='2:45 min' />
+  <sample time='10:00 min' depth='25.065 m' ndl='9:20 min' tts='2:44 min' heartbeat='72' />
+  <sample time='10:01 min' depth='24.92 m' ndl='9:31 min' tts='2:43 min' />
+  <sample time='10:02 min' depth='24.919 m' pressure='197.25 bar' ndl='9:30 min' heartbeat='71' />
+  <sample time='10:03 min' depth='24.825 m' ndl='9:38 min' tts='2:42 min' />
+  <sample time='10:04 min' depth='24.673 m' ndl='9:50 min' tts='2:41 min' heartbeat='70' />
+  <sample time='10:05 min' depth='24.654 m' ndl='9:51 min' heartbeat='69' />
+  <sample time='10:06 min' depth='24.522 m' ndl='10:02 min' tts='2:40 min' heartbeat='68' />
+  <sample time='10:07 min' depth='24.356 m' ndl='10:18 min' tts='2:39 min' heartbeat='69' />
+  <sample time='10:08 min' depth='24.304 m' ndl='10:22 min' />
+  <sample time='10:09 min' depth='24.116 m' ndl='10:41 min' tts='2:38 min' heartbeat='71' />
+  <sample time='10:10 min' depth='24.002 m' ndl='10:53 min' tts='2:37 min' heartbeat='72' />
+  <sample time='10:11 min' depth='23.945 m' ndl='10:59 min' heartbeat='73' />
+  <sample time='10:12 min' depth='23.883 m' pressure='197.25 bar' ndl='11:05 min' tts='2:36 min' heartbeat='74' />
+  <sample time='10:13 min' depth='23.692 m' ndl='11:28 min' tts='2:35 min' />
+  <sample time='10:14 min' depth='23.612 m' ndl='11:37 min' tts='2:34 min' heartbeat='75' />
+  <sample time='10:15 min' depth='23.544 m' ndl='11:46 min' />
+  <sample time='10:16 min' depth='23.489 m' ndl='11:52 min' heartbeat='74' />
+  <sample time='10:17 min' depth='23.354 m' pressure='197.25 bar' ndl='12:11 min' tts='2:33 min' />
+  <sample time='10:18 min' depth='23.295 m' ndl='12:19 min' tts='2:32 min' heartbeat='75' />
+  <sample time='10:19 min' depth='23.301 m' ndl='12:17 min' />
+  <sample time='10:20 min' depth='23.181 m' ndl='12:35 min' />
+  <sample time='10:21 min' depth='22.999 m' ndl='13:04 min' tts='2:30 min' heartbeat='76' />
+  <sample time='10:22 min' depth='22.941 m' pressure='197.25 bar' ndl='13:14 min' heartbeat='77' />
+  <sample time='10:23 min' depth='22.88 m' ndl='13:24 min' />
+  <sample time='10:24 min' depth='22.879 m' ndl='13:23 min' />
+  <sample time='10:25 min' depth='22.835 m' ndl='13:31 min' tts='2:29 min' heartbeat='78' />
+  <sample time='10:26 min' depth='22.815 m' ndl='13:33 min' heartbeat='77' />
+  <sample time='10:27 min' depth='22.773 m' pressure='197.39 bar' ndl='13:41 min' heartbeat='76' />
+  <sample time='10:28 min' depth='22.806 m' ndl='13:33 min' />
+  <sample time='10:29 min' depth='22.843 m' ndl='13:25 min' />
+  <sample time='10:30 min' depth='22.867 m' ndl='13:19 min' tts='2:30 min' />
+  <sample time='10:31 min' depth='22.845 m' ndl='13:23 min' tts='2:29 min' />
+  <sample time='10:32 min' depth='22.843 m' pressure='197.25 bar' ndl='13:22 min' heartbeat='75' />
+  <sample time='10:33 min' depth='22.84 m' heartbeat='76' />
+  <sample time='10:34 min' depth='22.826 m' ndl='13:23 min' />
+  <sample time='10:35 min' depth='22.797 m' ndl='13:28 min' />
+  <sample time='10:36 min' depth='22.813 m' ndl='13:24 min' heartbeat='79' />
+  <sample time='10:37 min' depth='22.817 m' pressure='197.25 bar' ndl='13:22 min' heartbeat='77' />
+  <sample time='10:38 min' depth='22.824 m' ndl='13:20 min' heartbeat='78' />
+  <sample time='10:39 min' depth='22.83 m' ndl='13:17 min' />
+  <sample time='10:40 min' depth='22.832 m' ndl='13:16 min' />
+  <sample time='10:41 min' depth='22.961 m' ndl='12:51 min' tts='2:30 min' />
+  <sample time='10:42 min' depth='23.052 m' ndl='12:35 min' tts='2:31 min' />
+  <sample time='10:43 min' depth='23.186 m' ndl='12:12 min' tts='2:32 min' heartbeat='77' />
+  <sample time='10:45 min' depth='23.193 m' ndl='12:09 min' />
+  <sample time='10:46 min' depth='23.374 m' ndl='11:40 min' tts='2:33 min' />
+  <sample time='10:47 min' depth='23.399 m' pressure='197.39 bar' ndl='11:36 min' />
+  <sample time='10:48 min' depth='23.42 m' ndl='11:32 min' />
+  <sample time='10:49 min' depth='23.405 m' ndl='11:33 min' />
+  <sample time='10:50 min' depth='23.297 m' ndl='11:48 min' tts='2:32 min' />
+  <sample time='10:51 min' depth='23.38 m' ndl='11:34 min' tts='2:33 min' />
+  <sample time='10:52 min' depth='23.502 m' pressure='197.39 bar' ndl='11:16 min' tts='2:34 min' />
+  <sample time='10:53 min' depth='23.458 m' ndl='11:21 min' tts='2:33 min' />
+  <sample time='10:54 min' depth='23.48 m' ndl='11:17 min' tts='2:34 min' />
+  <sample time='10:55 min' depth='23.523 m' ndl='11:11 min' heartbeat='78' />
+  <sample time='10:56 min' depth='23.532 m' ndl='11:08 min' />
+  <sample time='10:57 min' depth='23.58 m' pressure='197.39 bar' ndl='11:01 min' />
+  <sample time='10:58 min' depth='23.601 m' ndl='10:57 min' heartbeat='77' />
+  <sample time='10:59 min' depth='23.689 m' ndl='10:45 min' tts='2:35 min' />
+  <sample time='11:00 min' depth='23.786 m' ndl='10:32 min' tts='2:36 min' heartbeat='75' />
+  <sample time='11:01 min' depth='23.839 m' ndl='10:25 min' heartbeat='77' />
+  <sample time='11:02 min' depth='23.913 m' ndl='10:15 min' />
+  <sample time='11:03 min' depth='23.944 m' ndl='10:11 min' tts='2:37 min' />
+  <sample time='11:04 min' depth='23.965 m' ndl='10:07 min' />
+  <sample time='11:05 min' depth='23.928 m' ndl='10:11 min' />
+  <sample time='11:06 min' depth='23.859 m' ndl='10:17 min' tts='2:36 min' />
+  <sample time='11:07 min' depth='23.86 m' pressure='197.39 bar' ndl='10:16 min' />
+  <sample time='11:08 min' depth='23.731 m' ndl='10:31 min' tts='2:35 min' />
+  <sample time='11:09 min' depth='23.666 m' ndl='10:38 min' heartbeat='76' />
+  <sample time='11:10 min' depth='23.676 m' ndl='10:35 min' />
+  <sample time='11:11 min' depth='23.765 m' ndl='10:24 min' />
+  <sample time='11:12 min' depth='23.766 m' pressure='197.46 bar' ndl='10:22 min' />
+  <sample time='11:13 min' depth='23.778 m' ndl='10:20 min' tts='2:36 min' />
+  <sample time='11:14 min' depth='23.838 m' ndl='10:12 min' heartbeat='77' />
+  <sample time='11:15 min' depth='23.849 m' ndl='10:10 min' />
+  <sample time='11:16 min' depth='23.906 m' ndl='10:02 min' />
+  <sample time='11:17 min' depth='24.063 m' pressure='197.39 bar' ndl='9:44 min' tts='2:37 min' heartbeat='78' />
+  <sample time='11:18 min' depth='24.034 m' ndl='9:46 min' heartbeat='79' />
+  <sample time='11:19 min' depth='23.986 m' ndl='9:50 min' />
+  <sample time='11:20 min' depth='23.967 m' ndl='9:51 min' />
+  <sample time='11:21 min' depth='23.977 m' ndl='9:49 min' />
+  <sample time='11:22 min' depth='24.065 m' pressure='197.39 bar' ndl='9:39 min' />
+  <sample time='11:23 min' depth='24.023 m' ndl='9:42 min' />
+  <sample time='11:24 min' depth='24.1 m' ndl='9:33 min' tts='2:38 min' cns='4%' heartbeat='78' />
+  <sample time='11:25 min' depth='24.142 m' ndl='9:28 min' />
+  <sample time='11:26 min' depth='24.147 m' ndl='9:26 min' heartbeat='77' />
+  <sample time='11:27 min' depth='24.188 m' pressure='197.39 bar' ndl='9:21 min' />
+  <sample time='11:28 min' depth='24.057 m' ndl='9:34 min' tts='2:37 min' heartbeat='78' />
+  <sample time='11:29 min' depth='23.95 m' ndl='9:44 min' />
+  <sample time='11:30 min' depth='23.896 m' ndl='9:49 min' tts='2:36 min' />
+  <sample time='11:31 min' depth='23.844 m' ndl='9:54 min' />
+  <sample time='11:32 min' depth='23.915 m' pressure='197.39 bar' ndl='9:45 min' heartbeat='77' />
+  <sample time='11:33 min' depth='23.904 m' heartbeat='76' />
+  <sample time='11:34 min' depth='23.849 m' ndl='9:50 min' />
+  <sample time='11:35 min' depth='23.806 m' ndl='9:54 min' />
+  <sample time='11:36 min' depth='23.798 m' heartbeat='75' />
+  <sample time='11:37 min' depth='23.825 m' pressure='197.39 bar' ndl='9:50 min' />
+  <sample time='11:38 min' depth='23.885 m' ndl='9:42 min' />
+  <sample time='11:39 min' depth='23.834 m' ndl='9:47 min' />
+  <sample time='11:40 min' depth='23.841 m' ndl='9:45 min' />
+  <sample time='11:41 min' depth='23.927 m' ndl='9:35 min' tts='2:37 min' />
+  <sample time='11:42 min' depth='24.023 m' pressure='197.39 bar' ndl='9:23 min' />
+  <sample time='11:43 min' depth='24.05 m' ndl='9:20 min' />
+  <sample time='11:44 min' depth='24.074 m' ndl='9:16 min' />
+  <sample time='11:45 min' depth='24.107 m' ndl='9:12 min' tts='2:38 min' />
+  <sample time='11:46 min' depth='24.126 m' ndl='9:09 min' heartbeat='76' />
+  <sample time='11:47 min' depth='24.157 m' pressure='197.39 bar' ndl='9:05 min' />
+  <sample time='11:48 min' depth='24.176 m' ndl='9:02 min' heartbeat='77' />
+  <sample time='11:49 min' depth='24.184 m' ndl='9:00 min' />
+  <sample time='11:50 min' depth='24.225 m' ndl='8:55 min' />
+  <sample time='11:51 min' depth='24.3 m' ndl='8:47 min' tts='2:39 min' />
+  <sample time='11:52 min' depth='24.363 m' pressure='197.39 bar' ndl='8:41 min' />
+  <sample time='11:53 min' depth='24.454 m' ndl='8:31 min' tts='2:40 min' />
+  <sample time='11:54 min' depth='24.427 m' ndl='8:33 min' />
+  <sample time='11:55 min' depth='24.381 m' ndl='8:36 min' tts='2:39 min' />
+  <sample time='11:56 min' depth='24.382 m' ndl='8:35 min' />
+  <sample time='11:57 min' depth='24.374 m' pressure='197.39 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='11:58 min' depth='24.367 m' ndl='8:34 min' tts='2:39 min' />
+  <sample time='11:59 min' depth='24.26 m' ndl='8:43 min' />
+  <sample time='12:00 min' depth='24.214 m' ndl='8:46 min' tts='2:38 min' />
+  <sample time='12:01 min' depth='24.194 m' ndl='8:47 min' />
+  <sample time='12:02 min' depth='24.242 m' ndl='8:42 min' tts='2:39 min' />
+  <sample time='12:03 min' depth='24.341 m' ndl='8:32 min' />
+  <sample time='12:04 min' depth='24.466 m' ndl='8:19 min' tts='2:40 min' />
+  <sample time='12:05 min' depth='24.438 m' ndl='8:21 min' heartbeat='76' />
+  <sample time='12:06 min' depth='24.461 m' ndl='8:18 min' />
+  <sample time='12:07 min' depth='24.456 m' ndl='8:17 min' />
+  <sample time='12:08 min' depth='24.461 m' ndl='8:16 min' />
+  <sample time='12:09 min' depth='24.504 m' ndl='8:11 min' />
+  <sample time='12:10 min' depth='24.6 m' ndl='8:02 min' tts='2:41 min' heartbeat='75' />
+  <sample time='12:11 min' depth='24.669 m' ndl='7:56 min' />
+  <sample time='12:12 min' depth='24.739 m' pressure='197.53 bar' ndl='7:49 min' tts='2:42 min' />
+  <sample time='12:13 min' depth='24.801 m' ndl='7:44 min' />
+  <sample time='12:14 min' depth='24.823 m' ndl='7:41 min' heartbeat='74' />
+  <sample time='12:15 min' depth='24.854 m' ndl='7:38 min' tts='2:43 min' />
+  <sample time='12:16 min' depth='24.852 m' ndl='7:37 min' />
+  <sample time='12:17 min' depth='24.831 m' pressure='197.39 bar' tts='2:42 min' />
+  <sample time='12:18 min' depth='24.844 m' ndl='7:35 min' tts='2:43 min' />
+  <sample time='12:19 min' depth='24.876 m' ndl='7:32 min' heartbeat='75' />
+  <sample time='12:20 min' depth='24.89 m' ndl='7:30 min' />
+  <sample time='12:22 min' depth='24.951 m' pressure='197.39 bar' ndl='7:24 min' />
+  <sample time='12:23 min' depth='24.999 m' ndl='7:19 min' tts='2:44 min' />
+  <sample time='12:24 min' depth='24.99 m' tts='2:43 min' />
+  <sample time='12:26 min' depth='24.986 m' ndl='7:17 min' />
+  <sample time='12:27 min' depth='25.036 m' pressure='197.39 bar' ndl='7:13 min' tts='2:44 min' />
+  <sample time='12:28 min' depth='25.116 m' ndl='7:06 min' />
+  <sample time='12:29 min' depth='25.219 m' ndl='6:59 min' tts='2:45 min' />
+  <sample time='12:30 min' depth='25.245 m' ndl='6:56 min' />
+  <sample time='12:31 min' depth='25.206 m' ndl='6:57 min' heartbeat='74' />
+  <sample time='12:32 min' depth='25.22 m' pressure='197.39 bar' ndl='6:55 min' />
+  <sample time='12:33 min' depth='25.217 m' />
+  <sample time='12:34 min' depth='25.259 m' ndl='6:51 min' heartbeat='75' />
+  <sample time='12:35 min' depth='25.255 m' ndl='6:50 min' />
+  <sample time='12:36 min' depth='25.169 m' ndl='6:55 min' />
+  <sample time='12:37 min' depth='25.114 m' pressure='197.39 bar' ndl='6:57 min' tts='2:44 min' heartbeat='74' />
+  <sample time='12:38 min' depth='25.12 m' ndl='6:56 min' />
+  <sample time='12:39 min' depth='25.156 m' ndl='6:53 min' tts='2:45 min' />
+  <sample time='12:40 min' depth='25.262 m' ndl='6:45 min' />
+  <sample time='12:41 min' depth='25.341 m' ndl='6:39 min' tts='2:46 min' />
+  <sample time='12:42 min' depth='25.392 m' pressure='197.39 bar' ndl='6:35 min' />
+  <sample time='12:43 min' depth='25.439 m' ndl='6:31 min' />
+  <sample time='12:44 min' depth='25.459 m' ndl='6:29 min' tts='2:47 min' />
+  <sample time='12:45 min' depth='25.429 m' ndl='6:30 min' tts='2:46 min' />
+  <sample time='12:46 min' depth='25.384 m' ndl='6:31 min' />
+  <sample time='12:47 min' depth='25.315 m' pressure='197.39 bar' ndl='6:35 min' heartbeat='75' />
+  <sample time='12:48 min' depth='25.243 m' ndl='6:38 min' tts='2:45 min' heartbeat='74' />
+  <sample time='12:49 min' depth='25.216 m' ndl='6:39 min' />
+  <sample time='12:50 min' depth='25.221 m' ndl='6:37 min' />
+  <sample time='12:51 min' depth='25.254 m' ndl='6:34 min' />
+  <sample time='12:52 min' depth='25.323 m' pressure='197.39 bar' ndl='6:29 min' tts='2:46 min' />
+  <sample time='12:53 min' depth='25.343 m' ndl='6:27 min' heartbeat='72' />
+  <sample time='12:54 min' depth='25.397 m' ndl='6:23 min' />
+  <sample time='12:56 min' depth='25.23 m' ndl='6:31 min' tts='2:45 min' />
+  <sample time='12:57 min' depth='25.261 m' pressure='197.39 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='12:58 min' depth='25.292 m' ndl='6:25 min' tts='2:45 min' />
+  <sample time='12:59 min' depth='25.206 m' ndl='6:29 min' />
+  <sample time='13:01 min' depth='25.212 m' ndl='6:27 min' heartbeat='73' />
+  <sample time='13:02 min' depth='25.241 m' pressure='197.39 bar' ndl='6:24 min' heartbeat='74' />
+  <sample time='13:03 min' depth='25.234 m' ndl='6:23 min' />
+  <sample time='13:04 min' depth='25.138 m' ndl='6:28 min' tts='2:44 min' heartbeat='73' />
+  <sample time='13:05 min' depth='25.16 m' ndl='6:26 min' tts='2:45 min' />
+  <sample time='13:06 min' depth='25.161 m' ndl='6:25 min' heartbeat='74' />
+  <sample time='13:07 min' depth='25.21 m' pressure='197.39 bar' ndl='6:21 min' />
+  <sample time='13:08 min' depth='25.182 m' ndl='6:22 min' heartbeat='75' />
+  <sample time='13:09 min' depth='25.159 m' heartbeat='76' />
+  <sample time='13:10 min' depth='25.207 m' ndl='6:18 min' />
+  <sample time='13:11 min' depth='25.281 m' ndl='6:13 min' heartbeat='77' />
+  <sample time='13:12 min' depth='25.36 m' pressure='197.39 bar' ndl='6:07 min' tts='2:46 min' />
+  <sample time='13:13 min' depth='25.468 m' ndl='6:00 min' tts='2:47 min' />
+  <sample time='13:14 min' depth='25.397 m' ndl='6:03 min' tts='2:46 min' />
+  <sample time='13:16 min' depth='25.393 m' ndl='6:01 min' />
+  <sample time='13:17 min' depth='25.431 m' pressure='197.39 bar' ndl='5:58 min' />
+  <sample time='13:18 min' depth='25.399 m' ndl='5:59 min' />
+  <sample time='13:19 min' depth='25.318 m' ndl='6:03 min' />
+  <sample time='13:20 min' depth='25.291 m' tts='2:45 min' />
+  <sample time='13:21 min' depth='25.298 m' ndl='6:02 min' />
+  <sample time='13:22 min' depth='25.356 m' pressure='197.39 bar' ndl='5:57 min' tts='2:46 min' />
+  <sample time='13:23 min' depth='25.409 m' ndl='5:53 min' />
+  <sample time='13:24 min' depth='25.414 m' ndl='5:52 min' />
+  <sample time='13:25 min' depth='25.424 m' ndl='5:51 min' />
+  <sample time='13:26 min' depth='25.44 m' ndl='5:49 min' />
+  <sample time='13:27 min' depth='25.451 m' pressure='197.39 bar' ndl='5:47 min' />
+  <sample time='13:28 min' depth='25.413 m' ndl='5:48 min' />
+  <sample time='13:29 min' depth='25.386 m' ndl='5:49 min' />
+  <sample time='13:30 min' depth='25.395 m' ndl='5:47 min' />
+  <sample time='13:31 min' depth='25.431 m' ndl='5:44 min' />
+  <sample time='13:32 min' depth='25.441 m' pressure='197.39 bar' ndl='5:43 min' heartbeat='76' />
+  <sample time='13:33 min' depth='25.376 m' ndl='5:45 min' heartbeat='75' />
+  <sample time='13:34 min' depth='25.408 m' ndl='5:43 min' />
+  <sample time='13:35 min' depth='25.42 m' ndl='5:41 min' />
+  <sample time='13:36 min' depth='25.438 m' ndl='5:39 min' />
+  <sample time='13:37 min' depth='25.398 m' pressure='197.39 bar' ndl='5:40 min' />
+  <sample time='13:39 min' depth='25.411 m' ndl='5:37 min' />
+  <sample time='13:40 min' depth='25.47 m' ndl='5:33 min' tts='2:47 min' />
+  <sample time='13:41 min' depth='25.382 m' ndl='5:37 min' tts='2:46 min' />
+  <sample time='13:42 min' depth='25.408 m' pressure='197.39 bar' ndl='5:34 min' />
+  <sample time='13:43 min' depth='25.47 m' ndl='5:30 min' tts='2:47 min' />
+  <sample time='13:44 min' depth='25.341 m' ndl='5:36 min' tts='2:46 min' />
+  <sample time='13:45 min' depth='25.221 m' ndl='5:41 min' tts='2:45 min' />
+  <sample time='13:46 min' depth='25.234 m' ndl='5:40 min' />
+  <sample time='13:47 min' depth='25.162 m' pressure='197.39 bar' ndl='5:43 min' />
+  <sample time='13:48 min' depth='25.022 m' ndl='5:50 min' tts='2:44 min' heartbeat='76' />
+  <sample time='13:49 min' depth='24.957 m' ndl='5:53 min' tts='2:43 min' />
+  <sample time='13:50 min' depth='24.975 m' ndl='5:51 min' heartbeat='77' />
+  <sample time='13:51 min' depth='25.031 m' ndl='5:46 min' tts='2:44 min' />
+  <sample time='13:52 min' depth='25.031 m' pressure='197.46 bar' ndl='5:45 min' />
+  <sample time='13:53 min' depth='25.064 m' ndl='5:42 min' />
+  <sample time='13:54 min' depth='25.114 m' ndl='5:39 min' />
+  <sample time='13:55 min' depth='25.169 m' ndl='5:34 min' tts='2:45 min' />
+  <sample time='13:56 min' depth='25.193 m' ndl='5:32 min' />
+  <sample time='13:57 min' depth='25.15 m' pressure='197.39 bar' ndl='5:34 min' />
+  <sample time='13:58 min' depth='25.133 m' ndl='5:33 min' tts='2:44 min' heartbeat='78' />
+  <sample time='13:59 min' depth='25.136 m' ndl='5:32 min' heartbeat='79' />
+  <sample time='14:00 min' depth='25.187 m' ndl='5:29 min' tts='2:45 min' heartbeat='80' />
+  <sample time='14:01 min' depth='25.117 m' ndl='5:31 min' tts='2:44 min' heartbeat='81' />
+  <sample time='14:02 min' depth='25.176 m' pressure='197.39 bar' ndl='5:27 min' tts='2:45 min' />
+  <sample time='14:03 min' depth='25.237 m' ndl='5:23 min' />
+  <sample time='14:04 min' depth='25.139 m' ndl='5:27 min' tts='2:44 min' cns='5%' heartbeat='80' />
+  <sample time='14:05 min' depth='25.159 m' ndl='5:25 min' tts='2:45 min' />
+  <sample time='14:06 min' depth='25.19 m' ndl='5:22 min' />
+  <sample time='14:07 min' depth='25.138 m' ndl='5:24 min' tts='2:44 min' heartbeat='81' />
+  <sample time='14:10 min' depth='25.106 m' ndl='5:23 min' />
+  <sample time='14:11 min' depth='24.957 m' ndl='5:30 min' tts='2:43 min' />
+  <sample time='14:12 min' depth='24.986 m' pressure='197.39 bar' ndl='5:28 min' />
+  <sample time='14:13 min' depth='25.042 m' ndl='5:23 min' tts='2:44 min' />
+  <sample time='14:14 min' depth='24.975 m' ndl='5:26 min' tts='2:43 min' heartbeat='82' />
+  <sample time='14:16 min' depth='24.958 m' ndl='5:25 min' heartbeat='83' />
+  <sample time='14:17 min' depth='24.849 m' pressure='197.39 bar' ndl='5:30 min' heartbeat='84' />
+  <sample time='14:18 min' depth='24.789 m' ndl='5:33 min' tts='2:42 min' heartbeat='85' />
+  <sample time='14:19 min' depth='24.799 m' ndl='5:31 min' />
+  <sample time='14:20 min' depth='24.821 m' ndl='5:29 min' />
+  <sample time='14:21 min' depth='24.723 m' ndl='5:34 min' heartbeat='84' />
+  <sample time='14:22 min' depth='24.685 m' pressure='197.39 bar' ndl='5:35 min' tts='2:41 min' />
+  <sample time='14:23 min' depth='24.726 m' ndl='5:32 min' tts='2:42 min' />
+  <sample time='14:24 min' depth='24.646 m' ndl='5:35 min' tts='2:41 min' heartbeat='83' />
+  <sample time='14:25 min' depth='24.555 m' ndl='5:40 min' />
+  <sample time='14:26 min' depth='24.5 m' ndl='5:43 min' tts='2:40 min' />
+  <sample time='14:27 min' depth='24.479 m' pressure='197.39 bar' heartbeat='84' />
+  <sample time='14:29 min' depth='24.451 m' />
+  <sample time='14:30 min' depth='24.462 m' ndl='5:41 min' />
+  <sample time='14:31 min' depth='24.56 m' ndl='5:34 min' tts='2:41 min' />
+  <sample time='14:32 min' depth='24.535 m' pressure='197.39 bar' tts='2:40 min' />
+  <sample time='14:33 min' depth='24.491 m' ndl='5:36 min' heartbeat='85' />
+  <sample time='14:34 min' depth='24.447 m' ndl='5:38 min' heartbeat='84' />
+  <sample time='14:35 min' depth='24.401 m' ndl='5:40 min' heartbeat='85' />
+  <sample time='14:37 min' depth='24.308 m' pressure='197.39 bar' ndl='5:44 min' tts='2:39 min' />
+  <sample time='14:38 min' depth='24.265 m' ndl='5:46 min' />
+  <sample time='14:40 min' depth='24.37 m' ndl='5:37 min' />
+  <sample time='14:41 min' depth='24.42 m' ndl='5:33 min' tts='2:40 min' />
+  <sample time='14:42 min' depth='24.452 m' pressure='197.39 bar' ndl='5:30 min' heartbeat='84' />
+  <sample time='14:43 min' depth='24.497 m' ndl='5:26 min' />
+  <sample time='14:44 min' depth='24.537 m' ndl='5:23 min' tts='2:41 min' heartbeat='85' />
+  <sample time='14:45 min' depth='24.582 m' ndl='5:19 min' />
+  <sample time='14:46 min' depth='24.546 m' ndl='5:20 min' heartbeat='84' />
+  <sample time='14:47 min' depth='24.597 m' pressure='197.46 bar' ndl='5:16 min' heartbeat='85' />
+  <sample time='14:48 min' depth='24.579 m' />
+  <sample time='14:49 min' depth='24.549 m' ndl='5:17 min' heartbeat='86' />
+  <sample time='14:50 min' depth='24.57 m' ndl='5:15 min' heartbeat='85' />
+  <sample time='14:51 min' depth='24.581 m' ndl='5:13 min' />
+  <sample time='14:52 min' depth='24.622 m' pressure='197.39 bar' ndl='5:09 min' heartbeat='84' />
+  <sample time='14:53 min' depth='24.707 m' ndl='5:04 min' tts='2:42 min' />
+  <sample time='14:54 min' depth='24.623 m' ndl='5:07 min' tts='2:41 min' />
+  <sample time='14:55 min' depth='24.659 m' ndl='5:04 min' heartbeat='85' />
+  <sample time='14:56 min' depth='24.732 m' ndl='4:59 min' tts='2:42 min' />
+  <sample time='14:58 min' depth='24.789 m' ndl='4:54 min' heartbeat='86' />
+  <sample time='14:59 min' depth='24.848 m' ndl='4:50 min' tts='2:43 min' heartbeat='85' />
+  <sample time='15:00 min' depth='24.816 m' ndl='4:51 min' tts='2:42 min' />
+  <sample time='15:01 min' depth='24.847 m' ndl='4:48 min' tts='2:43 min' />
+  <sample time='15:02 min' depth='24.88 m' pressure='197.39 bar' ndl='4:45 min' />
+  <sample time='15:03 min' depth='24.962 m' ndl='4:40 min' heartbeat='84' />
+  <sample time='15:04 min' depth='24.982 m' ndl='4:38 min' />
+  <sample time='15:05 min' depth='24.98 m' ndl='4:37 min' heartbeat='83' />
+  <sample time='15:06 min' depth='25.019 m' ndl='4:34 min' tts='2:44 min' />
+  <sample time='15:07 min' depth='25.098 m' pressure='197.39 bar' ndl='4:30 min' heartbeat='82' />
+  <sample time='15:08 min' depth='25.039 m' ndl='4:31 min' />
+  <sample time='15:09 min' depth='25.04 m' ndl='4:30 min' />
+  <sample time='15:10 min' depth='25.07 m' ndl='4:28 min' heartbeat='81' />
+  <sample time='15:11 min' depth='25.117 m' ndl='4:25 min' />
+  <sample time='15:12 min' depth='25.184 m' pressure='197.39 bar' ndl='4:21 min' tts='2:45 min' />
+  <sample time='15:13 min' depth='25.281 m' ndl='4:16 min' />
+  <sample time='15:16 min' depth='25.265 m' ndl='4:13 min' heartbeat='82' />
+  <sample time='15:17 min' depth='25.343 m' pressure='197.39 bar' ndl='4:09 min' tts='2:46 min' />
+  <sample time='15:18 min' depth='25.456 m' ndl='4:03 min' tts='2:47 min' heartbeat='81' />
+  <sample time='15:19 min' depth='25.547 m' ndl='3:59 min' />
+  <sample time='15:20 min' depth='25.624 m' ndl='3:55 min' tts='2:48 min' />
+  <sample time='15:21 min' depth='25.667 m' ndl='3:52 min' />
+  <sample time='15:22 min' depth='25.764 m' pressure='197.39 bar' ndl='3:48 min' tts='2:49 min' />
+  <sample time='15:23 min' depth='25.816 m' ndl='3:45 min' heartbeat='82' />
+  <sample time='15:24 min' depth='25.817 m' ndl='3:44 min' heartbeat='81' />
+  <sample time='15:25 min' depth='25.849 m' ndl='3:42 min' />
+  <sample time='15:26 min' depth='25.851 m' ndl='3:41 min' />
+  <sample time='15:27 min' depth='25.848 m' pressure='197.39 bar' ndl='3:40 min' heartbeat='82' />
+  <sample time='15:28 min' depth='25.871 m' ndl='3:38 min' heartbeat='81' />
+  <sample time='15:29 min' depth='25.947 m' ndl='3:34 min' tts='2:50 min' />
+  <sample time='15:30 min' depth='26.016 m' ndl='3:31 min' />
+  <sample time='15:31 min' depth='26.062 m' ndl='3:29 min' tts='2:51 min' />
+  <sample time='15:32 min' depth='26.112 m' pressure='197.39 bar' ndl='3:26 min' heartbeat='82' />
+  <sample time='15:33 min' depth='26.162 m' ndl='3:24 min' />
+  <sample time='15:34 min' depth='26.182 m' ndl='3:22 min' />
+  <sample time='15:35 min' depth='26.124 m' ndl='3:23 min' />
+  <sample time='15:36 min' depth='25.965 m' ndl='3:27 min' tts='2:50 min' heartbeat='81' />
+  <sample time='15:37 min' depth='26.075 m' pressure='197.39 bar' ndl='3:22 min' tts='2:51 min' />
+  <sample time='15:38 min' depth='26.199 m' ndl='3:18 min' />
+  <sample time='15:39 min' depth='26.215 m' ndl='3:16 min' tts='2:52 min' heartbeat='80' />
+  <sample time='15:40 min' depth='26.269 m' ndl='3:14 min' heartbeat='79' />
+  <sample time='15:41 min' depth='26.313 m' ndl='3:11 min' />
+  <sample time='15:42 min' depth='26.318 m' pressure='197.39 bar' ndl='3:10 min' />
+  <sample time='15:43 min' depth='26.135 m' ndl='3:14 min' tts='2:51 min' heartbeat='80' />
+  <sample time='15:44 min' depth='25.972 m' ndl='3:18 min' tts='2:50 min' />
+  <sample time='15:45 min' depth='26.166 m' ndl='3:12 min' tts='2:51 min' />
+  <sample time='15:46 min' depth='26.402 m' ndl='3:04 min' tts='2:53 min' />
+  <sample time='15:47 min' depth='26.354 m' pressure='197.39 bar' tts='2:52 min' heartbeat='81' />
+  <sample time='15:48 min' depth='26.148 m' ndl='3:09 min' tts='2:51 min' />
+  <sample time='15:49 min' depth='26.14 m' ndl='3:08 min' />
+  <sample time='15:50 min' depth='26.08 m' ndl='3:09 min' />
+  <sample time='15:51 min' depth='25.975 m' ndl='3:11 min' tts='2:50 min' heartbeat='80' />
+  <sample time='15:52 min' depth='25.986 m' pressure='197.39 bar' ndl='3:10 min' />
+  <sample time='15:53 min' depth='26.081 m' ndl='3:06 min' tts='2:51 min' />
+  <sample time='15:54 min' depth='26.108 m' ndl='3:04 min' />
+  <sample time='15:55 min' depth='26.052 m' ndl='3:05 min' tts='2:50 min' />
+  <sample time='15:56 min' depth='26.093 m' ndl='3:03 min' tts='2:51 min' />
+  <sample time='15:57 min' depth='26.088 m' pressure='197.39 bar' ndl='3:02 min' />
+  <sample time='15:58 min' depth='26.089 m' ndl='3:01 min' heartbeat='81' />
+  <sample time='15:59 min' depth='26.07 m' ndl='3:00 min' heartbeat='82' />
+  <sample time='16:00 min' depth='25.887 m' ndl='3:04 min' tts='2:49 min' heartbeat='83' />
+  <sample time='16:01 min' depth='25.751 m' ndl='3:07 min' tts='2:48 min' />
+  <sample time='16:02 min' depth='25.68 m' pressure='197.39 bar' ndl='3:09 min' heartbeat='84' />
+  <sample time='16:03 min' depth='25.627 m' />
+  <sample time='16:04 min' depth='25.493 m' ndl='3:13 min' tts='2:47 min' />
+  <sample time='16:05 min' depth='25.384 m' ndl='3:15 min' tts='2:46 min' />
+  <sample time='16:06 min' depth='25.338 m' ndl='3:16 min' />
+  <sample time='16:07 min' depth='25.352 m' ndl='3:14 min' heartbeat='85' />
+  <sample time='16:09 min' depth='25.11 m' ndl='3:21 min' tts='2:44 min' />
+  <sample time='16:10 min' depth='24.945 m' ndl='3:26 min' tts='2:43 min' heartbeat='84' />
+  <sample time='16:11 min' depth='24.822 m' ndl='3:30 min' tts='2:42 min' />
+  <sample time='16:12 min' depth='24.731 m' pressure='197.39 bar' ndl='3:32 min' />
+  <sample time='16:13 min' depth='24.632 m' ndl='3:36 min' tts='2:41 min' heartbeat='83' />
+  <sample time='16:15 min' depth='24.51 m' ndl='3:39 min' tts='2:40 min' />
+  <sample time='16:16 min' depth='24.395 m' ndl='3:43 min' />
+  <sample time='16:17 min' depth='24.261 m' pressure='197.39 bar' ndl='3:49 min' tts='2:39 min' />
+  <sample time='16:18 min' depth='24.262 m' ndl='3:48 min' />
+  <sample time='16:19 min' depth='24.274 m' ndl='3:46 min' heartbeat='84' />
+  <sample time='16:20 min' depth='24.189 m' ndl='3:49 min' tts='2:38 min' />
+  <sample time='16:21 min' depth='24.164 m' ndl='3:50 min' />
+  <sample time='16:22 min' depth='24.206 m' pressure='197.39 bar' ndl='3:46 min' />
+  <sample time='16:23 min' depth='24.212 m' ndl='3:45 min' />
+  <sample time='16:24 min' depth='24.309 m' ndl='3:39 min' tts='2:39 min' />
+  <sample time='16:25 min' depth='24.123 m' ndl='3:48 min' tts='2:38 min' heartbeat='83' />
+  <sample time='16:26 min' depth='24.051 m' ndl='3:50 min' tts='2:37 min' />
+  <sample time='16:27 min' depth='23.996 m' pressure='197.39 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='16:28 min' depth='23.94 m' ndl='3:54 min' tts='2:37 min' />
+  <sample time='16:29 min' depth='23.965 m' ndl='3:52 min' />
+  <sample time='16:30 min' depth='23.999 m' ndl='3:49 min' />
+  <sample time='16:31 min' depth='23.998 m' ndl='3:48 min' heartbeat='82' />
+  <sample time='16:32 min' depth='24.064 m' pressure='197.46 bar' ndl='3:44 min' />
+  <sample time='16:33 min' depth='24.12 m' ndl='3:40 min' tts='2:38 min' />
+  <sample time='16:34 min' depth='24.159 m' ndl='3:37 min' heartbeat='80' />
+  <sample time='16:35 min' depth='24.203 m' ndl='3:34 min' />
+  <sample time='16:36 min' depth='24.191 m' ndl='3:33 min' />
+  <sample time='16:37 min' depth='24.155 m' pressure='197.39 bar' ndl='3:34 min' />
+  <sample time='16:38 min' depth='24.155 m' ndl='3:33 min' heartbeat='81' />
+  <sample time='16:40 min' depth='24.137 m' ndl='3:32 min' cns='6%' />
+  <sample time='16:41 min' depth='24.134 m' ndl='3:31 min' />
+  <sample time='16:42 min' depth='24.136 m' pressure='197.39 bar' ndl='3:30 min' />
+  <sample time='16:43 min' depth='24.169 m' ndl='3:28 min' />
+  <sample time='16:44 min' depth='24.191 m' ndl='3:25 min' />
+  <sample time='16:46 min' depth='24.151 m' heartbeat='80' />
+  <sample time='16:47 min' depth='24.162 m' ndl='3:24 min' />
+  <sample time='16:48 min' depth='24.229 m' ndl='3:20 min' />
+  <sample time='16:49 min' depth='24.287 m' ndl='3:16 min' tts='2:39 min' heartbeat='79' />
+  <sample time='16:50 min' depth='24.359 m' ndl='3:12 min' />
+  <sample time='16:51 min' depth='24.397 m' ndl='3:10 min' tts='2:40 min' heartbeat='78' />
+  <sample time='16:52 min' depth='24.396 m' pressure='197.46 bar' ndl='3:09 min' />
+  <sample time='16:53 min' depth='24.36 m' tts='2:39 min' />
+  <sample time='16:54 min' depth='24.333 m' heartbeat='77' />
+  <sample time='16:57 min' depth='24.193 m' ndl='3:12 min' tts='2:38 min' />
+  <sample time='16:58 min' depth='24.246 m' ndl='3:09 min' tts='2:39 min' />
+  <sample time='16:59 min' depth='24.253 m' ndl='3:08 min' />
+  <sample time='17:00 min' depth='24.235 m' ndl='3:07 min' />
+  <sample time='17:01 min' depth='24.229 m' tts='2:38 min' />
+  <sample time='17:02 min' depth='24.263 m' pressure='197.39 bar' ndl='3:04 min' tts='2:39 min' />
+  <sample time='17:03 min' depth='24.244 m' />
+  <sample time='17:04 min' depth='24.241 m' ndl='3:03 min' />
+  <sample time='17:05 min' depth='24.299 m' ndl='3:00 min' />
+  <sample time='17:06 min' depth='24.355 m' ndl='2:57 min' />
+  <sample time='17:07 min' depth='24.319 m' pressure='197.46 bar' ndl='0:00 min' tts='0:00 min' />
+  <sample time='17:08 min' depth='24.283 m' ndl='2:57 min' tts='2:39 min' />
+  <sample time='17:09 min' depth='24.291 m' ndl='2:56 min' />
+  <sample time='17:10 min' depth='24.343 m' ndl='2:53 min' heartbeat='78' />
+  <sample time='17:11 min' depth='24.393 m' ndl='2:50 min' tts='2:40 min' />
+  <sample time='17:12 min' depth='24.391 m' pressure='197.46 bar' ndl='2:49 min' />
+  <sample time='17:13 min' depth='24.44 m' ndl='2:46 min' />
+  <sample time='17:14 min' depth='24.511 m' ndl='2:43 min' heartbeat='79' />
+  <sample time='17:15 min' depth='24.553 m' ndl='2:41 min' tts='2:41 min' heartbeat='80' />
+  <sample time='17:16 min' depth='24.599 m' ndl='2:38 min' />
+  <sample time='17:17 min' depth='24.6 m' pressure='197.39 bar' ndl='2:37 min' />
+  <sample time='17:18 min' depth='24.544 m' ndl='2:38 min' />
+  <sample time='17:19 min' depth='24.504 m' tts='2:40 min' />
+  <sample time='17:20 min' depth='24.529 m' ndl='2:36 min' />
+  <sample time='17:21 min' depth='24.561 m' ndl='2:34 min' tts='2:41 min' />
+  <sample time='17:22 min' depth='24.617 m' pressure='197.39 bar' ndl='2:31 min' />
+  <sample time='17:23 min' depth='24.684 m' ndl='2:28 min' heartbeat='79' />
+  <sample time='17:24 min' depth='24.682 m' ndl='2:27 min' />
+  <sample time='17:25 min' depth='24.709 m' ndl='2:26 min' tts='2:42 min' heartbeat='78' />
+  <sample time='17:26 min' depth='24.747 m' ndl='2:23 min' />
+  <sample time='17:27 min' depth='24.754 m' pressure='197.39 bar' ndl='2:22 min' heartbeat='77' />
+  <sample time='17:28 min' depth='24.762 m' ndl='2:21 min' />
+  <sample time='17:29 min' depth='24.758 m' ndl='2:20 min' heartbeat='75' />
+  <sample time='17:30 min' depth='24.795 m' ndl='2:18 min' heartbeat='74' />
+  <sample time='17:31 min' depth='24.835 m' ndl='2:16 min' />
+  <sample time='17:32 min' depth='24.861 m' pressure='197.46 bar' ndl='2:14 min' tts='2:43 min' heartbeat='75' />
+  <sample time='17:33 min' depth='24.903 m' ndl='2:12 min' />
+  <sample time='17:34 min' depth='24.957 m' ndl='2:10 min' heartbeat='76' />
+  <sample time='17:35 min' depth='24.998 m' ndl='2:08 min' tts='2:44 min' />
+  <sample time='17:36 min' depth='25.024 m' ndl='2:06 min' />
+  <sample time='17:37 min' depth='25.025 m' pressure='197.39 bar' ndl='2:05 min' heartbeat='77' />
+  <sample time='17:38 min' depth='25.03 m' ndl='2:04 min' />
+  <sample time='17:39 min' depth='25.048 m' ndl='2:03 min' heartbeat='78' />
+  <sample time='17:40 min' depth='25.122 m' ndl='2:00 min' />
+  <sample time='17:41 min' depth='25.183 m' ndl='1:57 min' tts='2:45 min' heartbeat='77' />
+  <sample time='17:42 min' depth='25.197 m' pressure='197.39 bar' ndl='1:56 min' />
+  <sample time='17:43 min' depth='25.141 m' tts='2:44 min' />
+  <sample time='17:44 min' depth='25.077 m' ndl='1:57 min' />
+  <sample time='17:45 min' depth='25.091 m' ndl='1:55 min' />
+  <sample time='17:46 min' depth='25.154 m' ndl='1:53 min' tts='2:45 min' />
+  <sample time='17:47 min' depth='25.116 m' pressure='197.39 bar' tts='2:44 min' />
+  <sample time='17:48 min' depth='25.142 m' ndl='1:51 min' />
+  <sample time='17:49 min' depth='25.087 m' ndl='1:52 min' />
+  <sample time='17:50 min' depth='25.156 m' ndl='1:49 min' tts='2:45 min' heartbeat='78' />
+  <sample time='17:51 min' depth='25.23 m' ndl='1:47 min' />
+  <sample time='17:52 min' depth='25.27 m' pressure='197.46 bar' ndl='1:45 min' />
+  <sample time='17:53 min' depth='25.295 m' ndl='1:43 min' />
+  <sample time='17:54 min' depth='25.331 m' ndl='1:42 min' tts='2:46 min' />
+  <sample time='17:55 min' depth='25.336 m' ndl='1:41 min' heartbeat='77' />
+  <sample time='17:56 min' depth='25.358 m' ndl='1:39 min' heartbeat='76' />
+  <sample time='17:57 min' depth='25.383 m' ndl='1:38 min' heartbeat='75' />
+  <sample time='17:58 min' depth='25.442 m' ndl='1:36 min' heartbeat='74' />
+  <sample time='17:59 min' depth='25.538 m' ndl='1:33 min' tts='2:47 min' heartbeat='75' />
+  <sample time='18:00 min' depth='25.607 m' ndl='1:31 min' tts='2:48 min' />
+  <sample time='18:01 min' depth='25.657 m' ndl='1:29 min' heartbeat='76' />
+  <sample time='18:02 min' depth='25.684 m' pressure='197.39 bar' ndl='1:28 min' />
+  <sample time='18:03 min' depth='25.681 m' ndl='1:27 min' heartbeat='77' />
+  <sample time='18:04 min' depth='25.641 m' ndl='1:26 min' />
+  <sample time='18:05 min' depth='25.623 m' heartbeat='78' />
+  <sample time='18:06 min' depth='25.644 m' ndl='1:24 min' heartbeat='79' />
+  <sample time='18:07 min' depth='25.714 m' ndl='1:22 min' />
+  <sample time='18:08 min' depth='25.691 m' heartbeat='80' />
+  <sample time='18:09 min' depth='25.757 m' ndl='1:20 min' tts='2:49 min' />
+  <sample time='18:10 min' depth='25.769 m' ndl='1:18 min' />
+  <sample time='18:11 min' depth='25.734 m' tts='2:48 min' heartbeat='79' />
+  <sample time='18:12 min' depth='25.709 m' pressure='197.46 bar' ndl='1:17 min' heartbeat='80' />
+  <sample time='18:13 min' depth='25.673 m' heartbeat='79' />
+  <sample time='18:14 min' depth='25.556 m' tts='2:47 min' />
+  <sample time='18:15 min' depth='25.26 m' ndl='1:21 min' tts='2:45 min' />
+  <sample time='18:16 min' depth='25.236 m' ndl='1:20 min' heartbeat='80' />
+  <sample time='18:17 min' depth='25.347 m' ndl='1:17 min' tts='2:46 min' />
+  <sample time='18:18 min' depth='25.494 m' ndl='1:14 min' tts='2:47 min' />
+  <sample time='18:19 min' depth='25.596 m' ndl='1:12 min' heartbeat='81' />
+  <sample time='18:20 min' depth='25.725 m' ndl='1:09 min' tts='2:48 min' />
+  <sample time='18:21 min' depth='25.753 m' ndl='1:08 min' heartbeat='82' />
+  <sample time='18:22 min' depth='25.724 m' pressure='197.46 bar' ndl='1:07 min' />
+  <sample time='18:23 min' depth='25.804 m' ndl='1:05 min' tts='2:49 min' heartbeat='81' />
+  <sample time='18:24 min' depth='25.808 m' ndl='1:04 min' heartbeat='80' />
+  <sample time='18:26 min' depth='25.792 m' ndl='1:03 min' />
+  <sample time='18:27 min' depth='25.779 m' pressure='197.46 bar' ndl='1:02 min' />
+  <sample time='18:28 min' depth='25.691 m' tts='2:48 min' />
+  <sample time='18:29 min' depth='25.632 m' ndl='1:01 min' />
+  <sample time='18:30 min' depth='25.521 m' ndl='1:02 min' tts='2:47 min' heartbeat='77' />
+  <sample time='18:31 min' depth='25.266 m' ndl='1:04 min' tts='2:45 min' />
+  <sample time='18:32 min' depth='25.054 m' pressure='197.39 bar' ndl='1:05 min' tts='2:44 min' heartbeat='78' />
+  <sample time='18:33 min' depth='24.884 m' ndl='1:07 min' tts='2:43 min' heartbeat='79' />
+  <sample time='18:34 min' depth='24.766 m' tts='2:42 min' />
+  <sample time='18:36 min' depth='24.677 m' ndl='1:06 min' tts='2:41 min' />
+  <sample time='18:37 min' depth='24.695 m' pressure='197.46 bar' ndl='1:05 min' tts='2:42 min' />
+  <sample time='18:38 min' depth='24.612 m' tts='2:41 min' />
+  <sample time='18:39 min' depth='24.529 m' ndl='1:06 min' tts='2:40 min' heartbeat='80' />
+  <sample time='18:40 min' depth='24.626 m' ndl='1:03 min' tts='2:41 min' />
+  <sample time='18:42 min' depth='24.525 m' pressure='197.39 bar' tts='2:40 min' heartbeat='79' />
+  <sample time='18:43 min' depth='24.353 m' ndl='1:04 min' tts='2:39 min' />
+  <sample time='18:44 min' depth='24.11 m' ndl='1:07 min' tts='2:38 min' heartbeat='78' />
+  <sample time='18:45 min' depth='24.114 m' ndl='1:06 min' heartbeat='77' />
+  <sample time='18:46 min' depth='24.023 m' ndl='1:07 min' tts='2:37 min' heartbeat='76' />
+  <sample time='18:47 min' depth='24.002 m' pressure='197.46 bar' ndl='1:06 min' heartbeat='75' />
+  <sample time='18:48 min' depth='23.955 m' heartbeat='74' />
+  <sample time='18:49 min' depth='23.929 m' ndl='1:05 min' />
+  <sample time='18:50 min' depth='23.801 m' ndl='1:06 min' tts='2:36 min' heartbeat='73' />
+  <sample time='18:51 min' depth='23.672 m' ndl='1:08 min' tts='2:35 min' />
+  <sample time='18:52 min' depth='23.575 m' pressure='197.46 bar' ndl='1:09 min' tts='2:34 min' />
+  <sample time='18:53 min' depth='23.5 m' />
+  <sample time='18:54 min' depth='23.488 m' heartbeat='75' />
+  <sample time='18:55 min' depth='23.302 m' ndl='1:12 min' tts='2:32 min' heartbeat='74' />
+  <sample time='18:56 min' depth='23.151 m' ndl='1:14 min' tts='2:31 min' heartbeat='75' />
+  <sample time='18:57 min' depth='23.099 m' pressure='197.46 bar' heartbeat='76' />
+  <sample time='18:58 min' depth='23.099 m' ndl='1:13 min' />
+  <sample time='18:59 min' depth='22.94 m' ndl='1:17 min' tts='2:30 min' heartbeat='77' />
+  <sample time='19:00 min' depth='22.899 m' heartbeat='78' />
+  <sample time='19:01 min' depth='22.865 m' heartbeat='79' />
+  <sample time='19:02 min' depth='22.813 m' pressure='197.46 bar' tts='2:29 min' heartbeat='80' />
+  <sample time='19:03 min' depth='22.822 m' ndl='1:16 min' heartbeat='81' />
+  <sample time='19:04 min' depth='22.684 m' ndl='1:19 min' tts='2:28 min' />
+  <sample time='19:05 min' depth='22.614 m' ndl='1:20 min' heartbeat='80' />
+  <sample time='19:06 min' depth='22.585 m' heartbeat='81' />
+  <sample time='19:07 min' depth='22.534 m' pressure='197.39 bar' ndl='1:21 min' tts='2:27 min' heartbeat='80' />
+  <sample time='19:08 min' depth='22.59 m' ndl='1:18 min' tts='2:28 min' />
+  <sample time='19:09 min' depth='22.628 m' ndl='1:16 min' heartbeat='79' />
+  <sample time='19:10 min' depth='22.51 m' ndl='1:19 min' tts='2:27 min' />
+  <sample time='19:11 min' depth='22.543 m' ndl='1:17 min' heartbeat='78' />
+  <sample time='19:12 min' depth='22.587 m' pressure='197.46 bar' ndl='1:14 min' tts='2:28 min' />
+  <sample time='19:13 min' depth='22.593 m' ndl='1:13 min' />
+  <sample time='19:14 min' depth='22.537 m' ndl='1:14 min' tts='2:27 min' heartbeat='77' />
+  <sample time='19:15 min' depth='22.694 m' ndl='1:08 min' tts='2:28 min' />
+  <sample time='19:16 min' depth='22.629 m' ndl='1:09 min' />
+  <sample time='19:17 min' depth='22.385 m' ndl='1:16 min' tts='2:26 min' />
+  <sample time='19:18 min' depth='22.426 m' ndl='1:13 min' tts='2:27 min' />
+  <sample time='19:19 min' depth='22.206 m' ndl='1:20 min' tts='2:25 min' />
+  <sample time='19:21 min' depth='22.299 m' ndl='1:15 min' tts='2:26 min' />
+  <sample time='19:22 min' depth='22.376 m' pressure='197.46 bar' ndl='1:11 min' />
+  <sample time='19:23 min' depth='22.34 m' heartbeat='79' />
+  <sample time='19:24 min' depth='22.313 m' cns='7%' heartbeat='78' />
+  <sample time='19:25 min' depth='22.359 m' ndl='1:09 min' heartbeat='77' />
+  <sample time='19:26 min' depth='22.386 m' ndl='1:07 min' heartbeat='78' />
+  <sample time='19:27 min' depth='22.379 m' pressure='197.46 bar' ndl='1:06 min' heartbeat='77' />
+  <sample time='19:28 min' depth='22.404 m' ndl='1:04 min' tts='2:27 min' />
+  <sample time='19:29 min' depth='22.535 m' ndl='1:00 min' heartbeat='78' />
+  <sample time='19:30 min' depth='22.679 m' ndl='0:55 min' tts='2:28 min' heartbeat='75' />
+  <sample time='19:31 min' depth='22.679 m' ndl='0:54 min' heartbeat='78' />
+  <sample time='19:32 min' depth='22.678 m' pressure='197.46 bar' ndl='0:53 min' />
+  <sample time='19:33 min' depth='22.637 m' heartbeat='79' />
+  <sample time='19:34 min' depth='22.458 m' ndl='0:56 min' tts='2:27 min' />
+  <sample time='19:35 min' depth='22.46 m' ndl='0:55 min' heartbeat='80' />
+  <sample time='19:36 min' depth='22.498 m' ndl='0:54 min' />
+  <sample time='19:37 min' depth='22.538 m' pressure='197.46 bar' ndl='0:52 min' />
+  <sample time='19:38 min' depth='22.717 m' ndl='0:47 min' tts='2:29 min' heartbeat='82' />
+  <sample time='19:39 min' depth='22.879 m' ndl='0:43 min' tts='2:30 min' heartbeat='80' />
+  <sample time='19:40 min' depth='22.906 m' ndl='0:42 min' />
+  <sample time='19:41 min' depth='22.949 m' ndl='0:40 min' heartbeat='81' />
+  <sample time='19:42 min' depth='23.116 m' pressure='197.46 bar' ndl='0:37 min' tts='2:31 min' heartbeat='82' />
+  <sample time='19:43 min' depth='23.118 m' ndl='0:36 min' />
+  <sample time='19:44 min' depth='22.982 m' tts='2:30 min' heartbeat='81' />
+  <sample time='19:45 min' depth='23.023 m' ndl='0:35 min' tts='2:31 min' />
+  <sample time='19:46 min' depth='23.122 m' ndl='0:33 min' />
+  <sample time='19:47 min' depth='22.994 m' pressure='197.46 bar' tts='2:30 min' />
+  <sample time='19:48 min' depth='23.02 m' ndl='0:32 min' tts='2:31 min' />
+  <sample time='19:49 min' depth='22.904 m' tts='2:30 min' heartbeat='82' />
+  <sample time='19:50 min' depth='22.881 m' heartbeat='81' />
+  <sample time='19:51 min' depth='22.973 m' ndl='0:30 min' />
+  <sample time='19:52 min' depth='22.984 m' pressure='197.46 bar' ndl='0:28 min' />
+  <sample time='19:53 min' depth='23.058 m' ndl='0:27 min' tts='2:31 min' />
+  <sample time='19:54 min' depth='23.175 m' ndl='0:25 min' tts='2:32 min' heartbeat='82' />
+  <sample time='19:55 min' depth='23.263 m' ndl='0:23 min' />
+  <sample time='19:56 min' depth='23.305 m' ndl='0:22 min' />
+  <sample time='19:57 min' depth='23.493 m' pressure='197.46 bar' ndl='0:19 min' tts='2:34 min' heartbeat='83' />
+  <sample time='19:58 min' depth='23.547 m' ndl='0:18 min' />
+  <sample time='19:59 min' depth='23.436 m' tts='2:33 min' />
+  <sample time='20:00 min' depth='23.451 m' ndl='0:17 min' />
+  <sample time='20:01 min' depth='23.455 m' ndl='0:16 min' />
+  <sample time='20:02 min' depth='23.383 m' pressure='197.46 bar' ndl='0:15 min' />
+  <sample time='20:03 min' depth='23.404 m' ndl='0:14 min' />
+  <sample time='20:04 min' depth='23.47 m' ndl='0:13 min' tts='2:34 min' />
+  <sample time='20:05 min' depth='23.571 m' ndl='0:11 min' />
+  <sample time='20:06 min' depth='23.617 m' ndl='0:10 min' />
+  <sample time='20:07 min' depth='23.654 m' ndl='0:09 min' tts='2:35 min' />
+  <sample time='20:08 min' depth='23.763 m' ndl='0:08 min' />
+  <sample time='20:09 min' depth='23.846 m' ndl='0:07 min' tts='2:36 min' heartbeat='84' />
+  <sample time='20:10 min' depth='23.856 m' ndl='0:06 min' />
+  <sample time='20:11 min' depth='23.868 m' ndl='0:05 min' heartbeat='83' />
+  <sample time='20:12 min' depth='23.962 m' pressure='197.46 bar' ndl='0:03 min' tts='2:37 min' />
+  <sample time='20:13 min' depth='24.06 m' ndl='0:02 min' />
+  <sample time='20:14 min' depth='24.198 m' ndl='0:01 min' tts='2:38 min' />
+  <sample time='20:15 min' depth='24.249 m' ndl='0:00 min' tts='2:39 min' in_deco='1' stoptime='0:01 min' stopdepth='3.0 m' />
+  <sample time='20:16 min' depth='24.409 m' tts='2:40 min' />
+  <sample time='20:17 min' depth='24.571 m' pressure='197.46 bar' tts='2:41 min' />
+  <sample time='20:18 min' depth='24.634 m' />
+  <sample time='20:19 min' depth='24.683 m' />
+  <sample time='20:20 min' depth='24.763 m' tts='2:42 min' stoptime='0:02 min' />
+  <sample time='20:21 min' depth='24.795 m' heartbeat='84' />
+  <sample time='20:22 min' depth='24.783 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='20:23 min' depth='24.771 m' tts='2:42 min' stoptime='0:03 min' />
+  <sample time='20:24 min' depth='24.572 m' tts='2:41 min' heartbeat='85' />
+  <sample time='20:26 min' depth='24.617 m' heartbeat='86' />
+  <sample time='20:27 min' depth='24.78 m' pressure='197.46 bar' tts='2:42 min' />
+  <sample time='20:28 min' depth='24.966 m' tts='2:43 min' stoptime='0:04 min' />
+  <sample time='20:29 min' depth='25.068 m' tts='2:44 min' />
+  <sample time='20:31 min' depth='25.218 m' tts='2:45 min' stoptime='0:05 min' />
+  <sample time='20:32 min' depth='25.255 m' pressure='197.39 bar' heartbeat='85' />
+  <sample time='20:33 min' depth='25.062 m' tts='2:44 min' heartbeat='84' />
+  <sample time='20:34 min' depth='25.184 m' tts='2:45 min' heartbeat='83' />
+  <sample time='20:35 min' depth='25.514 m' tts='2:47 min' stoptime='0:06 min' heartbeat='82' />
+  <sample time='20:36 min' depth='25.618 m' tts='2:48 min' heartbeat='83' />
+  <sample time='20:37 min' depth='25.679 m' pressure='197.46 bar' heartbeat='84' />
+  <sample time='20:38 min' depth='25.807 m' tts='2:49 min' stoptime='0:07 min' />
+  <sample time='20:40 min' depth='25.971 m' tts='2:50 min' />
+  <sample time='20:41 min' depth='25.899 m' tts='2:49 min' heartbeat='83' />
+  <sample time='20:42 min' depth='26.027 m' pressure='197.53 bar' tts='2:50 min' stoptime='0:08 min' heartbeat='82' />
+  <sample time='20:43 min' depth='26.388 m' tts='2:53 min' heartbeat='81' />
+  <sample time='20:45 min' depth='26.533 m' tts='2:54 min' stoptime='0:09 min' heartbeat='80' />
+  <sample time='20:46 min' depth='26.542 m' heartbeat='78' />
+  <sample time='20:47 min' depth='26.572 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='20:48 min' depth='26.601 m' tts='2:54 min' stoptime='0:10 min' />
+  <sample time='20:49 min' depth='26.707 m' tts='2:55 min' />
+  <sample time='20:51 min' depth='26.783 m' stoptime='0:11 min' heartbeat='79' />
+  <sample time='20:52 min' depth='26.799 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='20:53 min' depth='26.815 m' tts='2:55 min' stoptime='0:12 min' heartbeat='80' />
+  <sample time='20:54 min' depth='26.897 m' tts='2:56 min' />
+  <sample time='20:55 min' depth='26.963 m' heartbeat='81' />
+  <sample time='20:56 min' depth='27.028 m' tts='2:57 min' stoptime='0:13 min' />
+  <sample time='20:57 min' depth='26.881 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='20:58 min' depth='26.734 m' tts='2:55 min' />
+  <sample time='20:59 min' depth='26.864 m' tts='2:56 min' stoptime='0:14 min' heartbeat='82' />
+  <sample time='21:00 min' depth='27.073 m' tts='2:57 min' />
+  <sample time='21:02 min' depth='27.073 m' pressure='197.46 bar' stoptime='0:15 min' />
+  <sample time='21:03 min' depth='27.113 m' heartbeat='83' />
+  <sample time='21:04 min' depth='27.165 m' tts='2:58 min' heartbeat='84' />
+  <sample time='21:05 min' depth='27.181 m' stoptime='0:16 min' heartbeat='85' />
+  <sample time='21:06 min' depth='27.18 m' heartbeat='84' />
+  <sample time='21:07 min' depth='27.23 m' pressure='197.46 bar' stoptime='0:17 min' />
+  <sample time='21:08 min' depth='27.233 m' heartbeat='83' />
+  <sample time='21:10 min' depth='27.291 m' tts='2:59 min' stoptime='0:18 min' heartbeat='82' />
+  <sample time='21:11 min' depth='27.374 m' heartbeat='81' />
+  <sample time='21:12 min' depth='27.434 m' pressure='197.46 bar' tts='3:00 min' heartbeat='80' />
+  <sample time='21:13 min' depth='27.413 m' tts='2:59 min' stoptime='0:19 min' />
+  <sample time='21:15 min' depth='27.401 m' stoptime='0:20 min' />
+  <sample time='21:16 min' depth='27.452 m' tts='3:00 min' />
+  <sample time='21:17 min' depth='27.562 m' />
+  <sample time='21:18 min' depth='27.581 m' stoptime='0:21 min' heartbeat='79' />
+  <sample time='21:19 min' depth='27.616 m' tts='3:01 min' heartbeat='80' />
+  <sample time='21:20 min' depth='27.742 m' tts='3:02 min' heartbeat='79' />
+  <sample time='21:21 min' depth='27.686 m' tts='3:01 min' stoptime='0:22 min' />
+  <sample time='21:22 min' depth='27.8 m' pressure='197.67 bar' tts='0:00 min' />
+  <sample time='21:23 min' depth='27.913 m' tts='3:03 min' stoptime='0:23 min' heartbeat='78' />
+  <sample time='21:24 min' depth='28.204 m' tts='3:05 min' />
+  <sample time='21:25 min' depth='28.359 m' tts='3:06 min' />
+  <sample time='21:26 min' depth='28.378 m' stoptime='0:24 min' heartbeat='77' />
+  <sample time='21:27 min' depth='28.511 m' pressure='197.46 bar' tts='3:07 min' heartbeat='78' />
+  <sample time='21:28 min' depth='28.666 m' tts='3:08 min' stoptime='0:25 min' />
+  <sample time='21:29 min' depth='28.854 m' tts='3:09 min' />
+  <sample time='21:30 min' depth='29.015 m' tts='3:10 min' stoptime='0:26 min' />
+  <sample time='21:31 min' depth='29.15 m' tts='3:11 min' />
+  <sample time='21:32 min' depth='29.292 m' pressure='197.46 bar' tts='3:12 min' />
+  <sample time='21:33 min' depth='29.484 m' tts='3:13 min' stoptime='0:27 min' />
+  <sample time='21:34 min' depth='29.65 m' tts='3:14 min' heartbeat='79' />
+  <sample time='21:35 min' depth='29.71 m' stoptime='0:28 min' />
+  <sample time='21:36 min' depth='29.728 m' tts='3:15 min' />
+  <sample time='21:37 min' depth='29.748 m' pressure='197.46 bar' stoptime='0:29 min' />
+  <sample time='21:38 min' depth='29.774 m' />
+  <sample time='21:39 min' depth='29.785 m' stoptime='0:30 min' heartbeat='80' />
+  <sample time='21:41 min' depth='29.689 m' tts='3:14 min' stoptime='0:31 min' />
+  <sample time='21:42 min' depth='29.669 m' pressure='197.46 bar' />
+  <sample time='21:43 min' depth='29.596 m' stoptime='0:32 min' />
+  <sample time='21:44 min' depth='29.315 m' tts='3:12 min' />
+  <sample time='21:45 min' depth='29.387 m' stoptime='0:33 min' />
+  <sample time='21:46 min' depth='29.139 m' tts='3:11 min' />
+  <sample time='21:47 min' depth='29.295 m' pressure='197.46 bar' tts='3:12 min' />
+  <sample time='21:48 min' depth='29.1 m' tts='3:10 min' stoptime='0:34 min' heartbeat='79' />
+  <sample time='21:50 min' depth='28.909 m' tts='3:09 min' stoptime='0:35 min' heartbeat='78' />
+  <sample time='21:51 min' depth='28.674 m' tts='3:08 min' heartbeat='77' />
+  <sample time='21:52 min' depth='28.45 m' pressure='197.46 bar' tts='3:06 min' stoptime='0:36 min' />
+  <sample time='21:53 min' depth='28.26 m' tts='3:05 min' />
+  <sample time='21:54 min' depth='28.196 m' cns='8%' heartbeat='75' />
+  <sample time='21:55 min' depth='28.204 m' stoptime='0:37 min' />
+  <sample time='21:57 min' depth='28.328 m' heartbeat='74' />
+  <sample time='21:58 min' depth='28.305 m' stoptime='0:38 min' heartbeat='73' />
+  <sample time='21:59 min' depth='28.284 m' heartbeat='72' />
+  <sample time='22:00 min' depth='28.333 m' stoptime='0:39 min' heartbeat='73' />
+  <sample time='22:02 min' depth='28.363 m' pressure='197.39 bar' tts='3:06 min' heartbeat='74' />
+  <sample time='22:03 min' depth='28.475 m' stoptime='0:40 min' />
+  <sample time='22:04 min' depth='28.57 m' tts='3:07 min' heartbeat='75' />
+  <sample time='22:05 min' depth='28.679 m' tts='3:08 min' stoptime='0:41 min' />
+  <sample time='22:06 min' depth='28.772 m' heartbeat='76' />
+  <sample time='22:07 min' depth='28.855 m' tts='3:10 min' heartbeat='77' />
+  <sample time='22:08 min' depth='28.918 m' tts='3:11 min' stoptime='0:42 min' heartbeat='78' />
+  <sample time='22:09 min' depth='28.943 m' tts='3:12 min' />
+  <sample time='22:10 min' depth='28.89 m' stoptime='0:43 min' />
+  <sample time='22:11 min' depth='28.841 m' tts='3:13 min' />
+  <sample time='22:12 min' depth='28.826 m' pressure='197.46 bar' heartbeat='79' />
+  <sample time='22:13 min' depth='28.886 m' tts='3:14 min' stoptime='0:44 min' />
+  <sample time='22:14 min' depth='28.862 m' tts='3:15 min' />
+  <sample time='22:15 min' depth='28.792 m' tts='3:14 min' stoptime='0:45 min' />
+  <sample time='22:16 min' depth='28.843 m' tts='3:16 min' />
+  <sample time='22:17 min' depth='28.858 m' pressure='197.67 bar' tts='3:17 min' />
+  <sample time='22:18 min' depth='28.857 m' stoptime='0:46 min' heartbeat='80' />
+  <sample time='22:19 min' depth='28.867 m' tts='3:18 min' />
+  <sample time='22:20 min' depth='28.768 m' tts='3:17 min' stoptime='0:47 min' />
+  <sample time='22:21 min' depth='28.734 m' tts='3:18 min' />
+  <sample time='22:22 min' depth='28.66 m' pressure='197.46 bar' heartbeat='81' />
+  <sample time='22:23 min' depth='28.623 m' stoptime='0:48 min' />
+  <sample time='22:25 min' depth='28.628 m' tts='3:19 min' stoptime='0:49 min' />
+  <sample time='22:26 min' depth='28.667 m' tts='3:21 min' />
+  <sample time='22:27 min' depth='28.639 m' pressure='197.46 bar' tts='3:20 min' heartbeat='82' />
+  <sample time='22:28 min' depth='28.682 m' tts='3:22 min' stoptime='0:50 min' />
+  <sample time='22:29 min' depth='28.743 m' tts='3:23 min' />
+  <sample time='22:31 min' depth='28.696 m' tts='3:24 min' stoptime='0:51 min' />
+  <sample time='22:32 min' depth='28.717 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='22:33 min' depth='28.738 m' tts='3:25 min' stoptime='0:52 min' />
+  <sample time='22:34 min' depth='28.795 m' tts='3:26 min' heartbeat='83' />
+  <sample time='22:35 min' depth='28.871 m' tts='3:28 min' />
+  <sample time='22:36 min' depth='28.905 m' tts='3:29 min' stoptime='0:53 min' heartbeat='82' />
+  <sample time='22:37 min' depth='28.832 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='22:38 min' depth='28.759 m' tts='3:29 min' />
+  <sample time='22:39 min' depth='28.761 m' stoptime='0:54 min' />
+  <sample time='22:40 min' depth='28.78 m' tts='3:30 min' />
+  <sample time='22:41 min' depth='28.697 m' stoptime='0:55 min' />
+  <sample time='22:42 min' depth='28.682 m' pressure='197.46 bar' tts='3:31 min' heartbeat='83' />
+  <sample time='22:43 min' depth='28.717 m' tts='3:32 min' />
+  <sample time='22:44 min' depth='28.732 m' stoptime='0:56 min' />
+  <sample time='22:45 min' depth='28.754 m' tts='3:33 min' />
+  <sample time='22:46 min' depth='28.777 m' tts='3:34 min' />
+  <sample time='22:47 min' depth='28.737 m' pressure='197.46 bar' stoptime='0:57 min' />
+  <sample time='22:48 min' depth='28.706 m' tts='3:35 min' />
+  <sample time='22:49 min' depth='28.672 m' stoptime='0:58 min' />
+  <sample time='22:50 min' depth='28.674 m' tts='3:36 min' />
+  <sample time='22:51 min' depth='28.781 m' tts='3:37 min' heartbeat='84' />
+  <sample time='22:52 min' depth='28.808 m' pressure='197.46 bar' tts='3:38 min' stoptime='0:59 min' />
+  <sample time='22:54 min' depth='28.791 m' tts='3:39 min' heartbeat='83' />
+  <sample time='22:55 min' depth='28.839 m' tts='3:40 min' stoptime='1:00 min' heartbeat='84' />
+  <sample time='22:56 min' depth='28.922 m' tts='3:41 min' />
+  <sample time='22:57 min' depth='28.955 m' pressure='197.67 bar' tts='3:42 min' />
+  <sample time='22:58 min' depth='29.046 m' tts='3:44 min' stoptime='1:01 min' />
+  <sample time='22:59 min' depth='29.111 m' tts='3:46 min' stoptime='1:02 min' heartbeat='85' />
+  <sample time='23:00 min' depth='29.083 m' tts='3:45 min' stoptime='1:03 min' />
+  <sample time='23:01 min' depth='29.089 m' tts='3:46 min' />
+  <sample time='23:02 min' depth='29.136 m' tts='3:48 min' stoptime='1:04 min' />
+  <sample time='23:03 min' depth='29.212 m' tts='3:49 min' stoptime='1:05 min' />
+  <sample time='23:04 min' depth='29.277 m' tts='3:51 min' />
+  <sample time='23:05 min' depth='29.313 m' stoptime='1:06 min' heartbeat='86' />
+  <sample time='23:06 min' depth='29.325 m' tts='3:52 min' stoptime='1:07 min' />
+  <sample time='23:07 min' depth='29.316 m' pressure='197.46 bar' tts='3:53 min' stoptime='1:08 min' heartbeat='87' />
+  <sample time='23:08 min' depth='29.182 m' tts='3:52 min' />
+  <sample time='23:09 min' depth='29.053 m' tts='3:51 min' stoptime='1:09 min' heartbeat='86' />
+  <sample time='23:10 min' depth='28.99 m' stoptime='1:10 min' />
+  <sample time='23:11 min' depth='28.889 m' tts='3:50 min' />
+  <sample time='23:12 min' depth='28.676 m' pressure='197.46 bar' tts='3:49 min' stoptime='1:11 min' />
+  <sample time='23:13 min' depth='28.534 m' tts='3:48 min' stoptime='1:12 min' />
+  <sample time='23:14 min' depth='28.447 m' tts='3:47 min' />
+  <sample time='23:15 min' depth='28.336 m' stoptime='1:13 min' />
+  <sample time='23:16 min' depth='28.272 m' stoptime='1:14 min' />
+  <sample time='23:17 min' depth='28.295 m' tts='3:48 min' />
+  <sample time='23:18 min' depth='28.228 m' stoptime='1:15 min' heartbeat='85' />
+  <sample time='23:20 min' depth='28.239 m' tts='3:49 min' stoptime='1:16 min' />
+  <sample time='23:21 min' depth='28.135 m' tts='3:48 min' stoptime='1:17 min' heartbeat='86' />
+  <sample time='23:22 min' depth='28.056 m' pressure='197.46 bar' tts='3:49 min' />
+  <sample time='23:23 min' depth='28.004 m' tts='3:48 min' stoptime='1:18 min' />
+  <sample time='23:24 min' depth='27.933 m' stoptime='1:19 min' />
+  <sample time='23:25 min' depth='27.852 m' tts='3:47 min' />
+  <sample time='23:26 min' depth='27.815 m' tts='3:48 min' stoptime='1:20 min' heartbeat='87' />
+  <sample time='23:27 min' depth='27.702 m' tts='3:47 min' heartbeat='88' />
+  <sample time='23:28 min' depth='27.64 m' stoptime='1:21 min' heartbeat='89' />
+  <sample time='23:29 min' depth='27.661 m' tts='3:48 min' stoptime='1:22 min' heartbeat='90' />
+  <sample time='23:31 min' depth='27.693 m' tts='3:49 min' stoptime='1:23 min' />
+  <sample time='23:33 min' depth='27.648 m' tts='3:50 min' stoptime='1:24 min' />
+  <sample time='23:35 min' depth='27.664 m' tts='3:51 min' stoptime='1:25 min' />
+  <sample time='23:36 min' depth='27.725 m' tts='3:52 min' stoptime='1:26 min' />
+  <sample time='23:37 min' depth='27.601 m' heartbeat='91' />
+  <sample time='23:38 min' depth='27.633 m' stoptime='1:27 min' />
+  <sample time='23:39 min' depth='27.797 m' tts='3:54 min' />
+  <sample time='23:40 min' depth='27.9 m' tts='3:56 min' stoptime='1:28 min' heartbeat='92' />
+  <sample time='23:41 min' depth='27.867 m' stoptime='1:29 min' heartbeat='91' />
+  <sample time='23:42 min' depth='27.879 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='23:43 min' depth='27.891 m' tts='3:58 min' stoptime='1:30 min' />
+  <sample time='23:44 min' depth='27.76 m' tts='3:57 min' />
+  <sample time='23:45 min' depth='27.779 m' tts='3:58 min' stoptime='1:31 min' heartbeat='89' />
+  <sample time='23:46 min' depth='27.755 m' heartbeat='90' />
+  <sample time='23:47 min' depth='27.777 m' tts='3:59 min' stoptime='1:32 min' />
+  <sample time='23:48 min' depth='27.837 m' stoptime='1:33 min' />
+  <sample time='23:49 min' depth='27.921 m' tts='4:01 min' heartbeat='89' />
+  <sample time='23:50 min' depth='27.89 m' stoptime='1:34 min' heartbeat='88' />
+  <sample time='23:51 min' depth='27.852 m' heartbeat='87' />
+  <sample time='23:52 min' depth='27.829 m' pressure='197.46 bar' stoptime='1:35 min' heartbeat='86' />
+  <sample time='23:53 min' depth='27.835 m' tts='4:02 min' stoptime='1:36 min' heartbeat='85' />
+  <sample time='23:54 min' depth='27.817 m' />
+  <sample time='23:55 min' depth='27.689 m' tts='4:01 min' stoptime='1:37 min' heartbeat='84' />
+  <sample time='23:56 min' depth='27.655 m' tts='4:02 min' />
+  <sample time='23:57 min' depth='27.664 m' pressure='197.53 bar' stoptime='1:38 min' />
+  <sample time='23:58 min' depth='27.777 m' tts='4:04 min' heartbeat='83' />
+  <sample time='23:59 min' depth='27.816 m' tts='4:05 min' stoptime='1:39 min' />
+  <sample time='24:01 min' depth='27.864 m' tts='4:06 min' stoptime='1:40 min' heartbeat='82' />
+  <sample time='24:02 min' depth='27.898 m' pressure='197.46 bar' tts='4:08 min' stoptime='1:41 min' heartbeat='83' />
+  <sample time='24:03 min' depth='27.902 m' />
+  <sample time='24:04 min' depth='27.899 m' tts='4:09 min' stoptime='1:42 min' heartbeat='82' />
+  <sample time='24:05 min' depth='27.877 m' tts='4:08 min' />
+  <sample time='24:06 min' depth='27.898 m' tts='4:10 min' stoptime='1:43 min' />
+  <sample time='24:07 min' depth='27.86 m' tts='4:09 min' heartbeat='81' />
+  <sample time='24:08 min' depth='27.855 m' stoptime='1:44 min' />
+  <sample time='24:09 min' depth='27.862 m' tts='4:10 min' stoptime='1:45 min' cns='9%' />
+  <sample time='24:10 min' depth='27.908 m' tts='4:12 min' heartbeat='80' />
+  <sample time='24:11 min' depth='27.842 m' tts='4:11 min' stoptime='1:46 min' heartbeat='79' />
+  <sample time='24:12 min' depth='27.802 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='24:13 min' depth='27.763 m' tts='4:12 min' stoptime='1:47 min' />
+  <sample time='24:15 min' depth='27.718 m' stoptime='1:48 min' />
+  <sample time='24:16 min' depth='27.791 m' tts='4:13 min' stoptime='1:49 min' heartbeat='80' />
+  <sample time='24:17 min' depth='27.848 m' pressure='197.39 bar' tts='4:14 min' heartbeat='81' />
+  <sample time='24:18 min' depth='27.787 m' stoptime='1:50 min' heartbeat='82' />
+  <sample time='24:19 min' depth='27.757 m' tts='4:15 min' />
+  <sample time='24:20 min' depth='27.736 m' tts='4:14 min' stoptime='1:51 min' heartbeat='83' />
+  <sample time='24:21 min' depth='27.812 m' tts='4:16 min' heartbeat='84' />
+  <sample time='24:22 min' depth='27.776 m' pressure='197.46 bar' stoptime='1:52 min' />
+  <sample time='24:23 min' depth='27.759 m' tts='4:17 min' />
+  <sample time='24:24 min' depth='27.797 m' stoptime='1:53 min' />
+  <sample time='24:25 min' depth='27.864 m' tts='4:18 min' />
+  <sample time='24:26 min' depth='27.915 m' tts='4:20 min' stoptime='1:54 min' />
+  <sample time='24:27 min' depth='27.973 m' pressure='197.46 bar' stoptime='1:55 min' heartbeat='83' />
+  <sample time='24:28 min' depth='27.985 m' tts='4:21 min' />
+  <sample time='24:29 min' depth='27.993 m' stoptime='1:56 min' heartbeat='82' />
+  <sample time='24:30 min' depth='27.954 m' tts='4:22 min' />
+  <sample time='24:31 min' depth='27.897 m' stoptime='1:57 min' />
+  <sample time='24:32 min' depth='27.861 m' pressure='197.39 bar' tts='4:21 min' heartbeat='83' />
+  <sample time='24:33 min' depth='27.781 m' tts='4:22 min' stoptime='1:58 min' />
+  <sample time='24:34 min' depth='27.7 m' tts='4:21 min' />
+  <sample time='24:35 min' depth='27.648 m' stoptime='1:59 min' />
+  <sample time='24:36 min' depth='27.557 m' tts='4:20 min' />
+  <sample time='24:37 min' depth='27.561 m' pressure='197.53 bar' tts='4:21 min' stoptime='2:00 min' />
+  <sample time='24:38 min' depth='27.509 m' stoptime='2:01 min' />
+  <sample time='24:39 min' depth='27.505 m' tts='4:22 min' />
+  <sample time='24:40 min' depth='27.377 m' tts='4:21 min' stoptime='2:02 min' />
+  <sample time='24:41 min' depth='27.242 m' tts='4:20 min' heartbeat='84' />
+  <sample time='24:42 min' depth='27.159 m' pressure='197.39 bar' stoptime='2:03 min' />
+  <sample time='24:43 min' depth='27.139 m' />
+  <sample time='24:44 min' depth='27.091 m' stoptime='2:04 min' heartbeat='86' />
+  <sample time='24:45 min' depth='27.069 m' heartbeat='87' />
+  <sample time='24:46 min' depth='27.09 m' stoptime='2:05 min' heartbeat='88' />
+  <sample time='24:47 min' depth='27.136 m' pressure='197.53 bar' tts='4:22 min' />
+  <sample time='24:48 min' depth='27.097 m' tts='4:21 min' heartbeat='89' />
+  <sample time='24:49 min' depth='27.042 m' tts='4:22 min' stoptime='2:06 min' />
+  <sample time='24:51 min' depth='26.969 m' tts='4:21 min' stoptime='2:07 min' />
+  <sample time='24:52 min' depth='26.897 m' pressure='197.46 bar' heartbeat='88' />
+  <sample time='24:53 min' depth='26.876 m' tts='4:22 min' stoptime='2:08 min' />
+  <sample time='24:54 min' depth='26.833 m' />
+  <sample time='24:55 min' depth='26.773 m' tts='4:21 min' stoptime='2:09 min' heartbeat='86' />
+  <sample time='24:56 min' depth='26.789 m' tts='4:22 min' />
+  <sample time='24:57 min' depth='26.816 m' pressure='197.39 bar' stoptime='2:10 min' />
+  <sample time='24:58 min' depth='26.887 m' tts='4:24 min' />
+  <sample time='24:59 min' depth='26.874 m' stoptime='2:11 min' />
+  <sample time='25:00 min' depth='26.842 m' tts='4:25 min' />
+  <sample time='25:01 min' depth='26.825 m' stoptime='2:12 min' />
+  <sample time='25:02 min' depth='26.875 m' tts='4:26 min' />
+  <sample time='25:03 min' depth='26.957 m' stoptime='2:13 min' />
+  <sample time='25:04 min' depth='27.03 m' tts='4:28 min' heartbeat='85' />
+  <sample time='25:05 min' depth='27.068 m' />
+  <sample time='25:06 min' depth='27.126 m' tts='4:29 min' stoptime='2:14 min' />
+  <sample time='25:07 min' depth='27.21 m' pressure='197.46 bar' tts='4:31 min' heartbeat='84' />
+  <sample time='25:08 min' depth='27.269 m' stoptime='2:15 min' />
+  <sample time='25:09 min' depth='27.319 m' tts='4:33 min' />
+  <sample time='25:10 min' depth='27.318 m' stoptime='2:16 min' />
+  <sample time='25:11 min' depth='27.269 m' heartbeat='83' />
+  <sample time='25:12 min' depth='27.249 m' pressure='197.46 bar' stoptime='2:17 min' />
+  <sample time='25:13 min' depth='27.204 m' />
+  <sample time='25:14 min' depth='27.11 m' tts='4:32 min' stoptime='2:18 min' heartbeat='82' />
+  <sample time='25:15 min' depth='27.098 m' tts='4:33 min' />
+  <sample time='25:16 min' depth='27.133 m' tts='4:34 min' stoptime='2:19 min' />
+  <sample time='25:17 min' depth='27.07 m' pressure='197.53 bar' heartbeat='81' />
+  <sample time='25:18 min' depth='27.076 m' stoptime='2:20 min' />
+  <sample time='25:19 min' depth='27.126 m' tts='4:35 min' />
+  <sample time='25:20 min' depth='27.157 m' tts='4:36 min' stoptime='2:21 min' />
+  <sample time='25:21 min' depth='27.15 m' tts='4:37 min' />
+  <sample time='25:22 min' depth='27.155 m' pressure='197.39 bar' stoptime='2:22 min' />
+  <sample time='25:23 min' depth='27.164 m' />
+  <sample time='25:24 min' depth='27.226 m' tts='4:38 min' stoptime='2:23 min' heartbeat='82' />
+  <sample time='25:25 min' depth='27.332 m' tts='4:40 min' />
+  <sample time='25:26 min' depth='27.441 m' tts='4:41 min' />
+  <sample time='25:27 min' depth='27.495 m' pressure='197.46 bar' tts='4:42 min' stoptime='2:24 min' />
+  <sample time='25:28 min' depth='27.536 m' tts='4:43 min' heartbeat='83' />
+  <sample time='25:29 min' depth='27.605 m' tts='4:44 min' stoptime='2:25 min' />
+  <sample time='25:30 min' depth='27.588 m' tts='4:45 min' />
+  <sample time='25:31 min' depth='27.458 m' tts='4:44 min' stoptime='2:26 min' />
+  <sample time='25:32 min' depth='27.384 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='25:33 min' depth='27.309 m' tts='4:43 min' stoptime='2:27 min' />
+  <sample time='25:34 min' depth='27.204 m' tts='4:42 min' />
+  <sample time='25:35 min' depth='27.157 m' tts='4:43 min' stoptime='2:28 min' />
+  <sample time='25:36 min' depth='27.01 m' tts='4:42 min' heartbeat='82' />
+  <sample time='25:37 min' depth='26.942 m' pressure='197.39 bar' tts='4:41 min' stoptime='2:29 min' />
+  <sample time='25:38 min' depth='26.957 m' heartbeat='81' />
+  <sample time='25:39 min' depth='26.809 m' tts='4:40 min' stoptime='2:30 min' heartbeat='82' />
+  <sample time='25:40 min' depth='26.657 m' tts='4:39 min' />
+  <sample time='25:41 min' depth='26.601 m' heartbeat='81' />
+  <sample time='25:42 min' depth='26.505 m' pressure='197.39 bar' stoptime='2:31 min' heartbeat='82' />
+  <sample time='25:43 min' depth='26.332 m' tts='4:38 min' />
+  <sample time='25:44 min' depth='26.233 m' stoptime='2:32 min' />
+  <sample time='25:45 min' depth='26.21 m' tts='4:37 min' />
+  <sample time='25:46 min' depth='26.058 m' tts='4:36 min' />
+  <sample time='25:47 min' depth='26.025 m' pressure='197.39 bar' stoptime='2:33 min' heartbeat='81' />
+  <sample time='25:48 min' depth='25.974 m' />
+  <sample time='25:49 min' depth='25.901 m' stoptime='2:34 min' />
+  <sample time='25:50 min' depth='25.75 m' tts='4:35 min' />
+  <sample time='25:51 min' depth='25.649 m' heartbeat='82' />
+  <sample time='25:52 min' depth='25.588 m' pressure='197.39 bar' tts='4:34 min' stoptime='2:35 min' />
+  <sample time='25:53 min' depth='25.611 m' tts='4:35 min' heartbeat='83' />
+  <sample time='25:55 min' depth='25.529 m' stoptime='2:36 min' />
+  <sample time='25:57 min' depth='25.454 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='25:58 min' depth='25.417 m' tts='4:35 min' stoptime='2:37 min' />
+  <sample time='26:00 min' depth='25.28 m' tts='4:34 min' stoptime='2:38 min' />
+  <sample time='26:01 min' depth='25.135 m' tts='4:33 min' />
+  <sample time='26:02 min' depth='25.046 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='26:03 min' depth='24.957 m' tts='4:32 min' />
+  <sample time='26:04 min' depth='24.787 m' tts='4:31 min' stoptime='2:39 min' />
+  <sample time='26:06 min' depth='24.744 m' tts='4:32 min' heartbeat='84' />
+  <sample time='26:07 min' depth='24.77 m' stoptime='2:40 min' heartbeat='83' />
+  <sample time='26:09 min' depth='24.746 m' heartbeat='84' />
+  <sample time='26:10 min' depth='24.694 m' tts='4:33 min' stoptime='2:41 min' />
+  <sample time='26:11 min' depth='24.62 m' tts='4:32 min' />
+  <sample time='26:12 min' depth='24.552 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='26:13 min' depth='24.483 m' tts='4:31 min' />
+  <sample time='26:14 min' depth='24.421 m' stoptime='2:42 min' />
+  <sample time='26:15 min' depth='24.325 m' tts='4:30 min' heartbeat='83' />
+  <sample time='26:17 min' depth='24.383 m' pressure='197.39 bar' tts='4:31 min' stoptime='2:43 min' />
+  <sample time='26:18 min' depth='24.348 m' heartbeat='84' />
+  <sample time='26:19 min' depth='24.439 m' tts='4:32 min' />
+  <sample time='26:20 min' depth='24.472 m' tts='4:33 min' />
+  <sample time='26:21 min' depth='24.401 m' stoptime='2:44 min' />
+  <sample time='26:22 min' depth='24.36 m' pressure='197.39 bar' tts='4:32 min' />
+  <sample time='26:23 min' depth='24.326 m' heartbeat='83' />
+  <sample time='26:24 min' depth='24.345 m' tts='4:33 min' />
+  <sample time='26:25 min' depth='24.216 m' tts='4:32 min' stoptime='2:45 min' />
+  <sample time='26:26 min' depth='24.229 m' heartbeat='84' />
+  <sample time='26:27 min' depth='24.208 m' heartbeat='83' />
+  <sample time='26:28 min' depth='24.259 m' tts='4:33 min' stoptime='2:46 min' heartbeat='84' />
+  <sample time='26:29 min' depth='24.318 m' tts='4:34 min' />
+  <sample time='26:32 min' depth='24.336 m' tts='4:35 min' stoptime='2:47 min' heartbeat='83' />
+  <sample time='26:33 min' depth='24.386 m' tts='4:36 min' heartbeat='84' />
+  <sample time='26:35 min' depth='24.321 m' tts='4:35 min' cns='10%' />
+  <sample time='26:36 min' depth='24.349 m' tts='4:36 min' stoptime='2:48 min' />
+  <sample time='26:37 min' depth='24.354 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='26:38 min' depth='24.359 m' tts='4:36 min' />
+  <sample time='26:40 min' depth='24.369 m' tts='4:37 min' stoptime='2:49 min' />
+  <sample time='26:41 min' depth='24.402 m' tts='4:38 min' />
+  <sample time='26:42 min' depth='24.434 m' pressure='197.46 bar' heartbeat='83' />
+  <sample time='26:43 min' depth='24.424 m' stoptime='2:50 min' />
+  <sample time='26:44 min' depth='24.406 m' tts='4:39 min' />
+  <sample time='26:47 min' depth='24.425 m' stoptime='2:51 min' heartbeat='82' />
+  <sample time='26:48 min' depth='24.511 m' tts='4:40 min' />
+  <sample time='26:49 min' depth='24.619 m' tts='4:41 min' heartbeat='81' />
+  <sample time='26:50 min' depth='24.341 m' tts='4:39 min' />
+  <sample time='26:51 min' depth='24.459 m' tts='4:40 min' stoptime='2:52 min' heartbeat='80' />
+  <sample time='26:52 min' depth='24.428 m' pressure='197.46 bar' tts='4:41 min' />
+  <sample time='26:53 min' depth='24.182 m' tts='4:38 min' />
+  <sample time='26:54 min' depth='24.391 m' tts='4:41 min' heartbeat='79' />
+  <sample time='26:55 min' depth='24.361 m' tts='4:40 min' stoptime='2:53 min' heartbeat='78' />
+  <sample time='26:56 min' depth='24.308 m' heartbeat='77' />
+  <sample time='26:57 min' depth='24.207 m' pressure='197.39 bar' tts='4:39 min' />
+  <sample time='26:58 min' depth='24.171 m' tts='4:40 min' stoptime='2:54 min' />
+  <sample time='27:00 min' depth='24.048 m' tts='4:39 min' />
+  <sample time='27:01 min' depth='23.849 m' tts='4:38 min' />
+  <sample time='27:02 min' depth='23.718 m' pressure='197.39 bar' tts='4:37 min' />
+  <sample time='27:03 min' depth='23.591 m' tts='4:36 min' stoptime='2:55 min' />
+  <sample time='27:04 min' depth='23.409 m' tts='4:35 min' heartbeat='75' />
+  <sample time='27:05 min' depth='23.265 m' tts='4:34 min' />
+  <sample time='27:06 min' depth='23.142 m' tts='4:33 min' heartbeat='76' />
+  <sample time='27:07 min' depth='23.043 m' pressure='197.39 bar' />
+  <sample time='27:08 min' depth='22.964 m' tts='4:32 min' stoptime='2:56 min' />
+  <sample time='27:09 min' depth='22.825 m' tts='4:31 min' />
+  <sample time='27:10 min' depth='22.825 m' heartbeat='77' />
+  <sample time='27:12 min' depth='22.612 m' pressure='197.39 bar' tts='4:30 min' />
+  <sample time='27:13 min' depth='22.531 m' tts='4:29 min' heartbeat='76' />
+  <sample time='27:14 min' depth='22.448 m' stoptime='2:57 min' heartbeat='77' />
+  <sample time='27:15 min' depth='22.412 m' tts='4:30 min' />
+  <sample time='27:16 min' depth='22.367 m' tts='4:29 min' />
+  <sample time='27:17 min' depth='22.273 m' pressure='197.39 bar' heartbeat='78' />
+  <sample time='27:18 min' depth='22.301 m' heartbeat='79' />
+  <sample time='27:19 min' depth='22.292 m' heartbeat='81' />
+  <sample time='27:21 min' depth='22.17 m' tts='4:28 min' stoptime='2:58 min' heartbeat='82' />
+  <sample time='27:22 min' depth='22.028 m' pressure='197.46 bar' tts='4:27 min' />
+  <sample time='27:23 min' depth='21.933 m' tts='4:26 min' heartbeat='83' />
+  <sample time='27:24 min' depth='21.927 m' />
+  <sample time='27:25 min' depth='21.954 m' tts='4:27 min' />
+  <sample time='27:26 min' depth='21.909 m' tts='4:26 min' />
+  <sample time='27:27 min' depth='21.91 m' pressure='197.46 bar' tts='4:27 min' />
+  <sample time='27:28 min' depth='21.834 m' />
+  <sample time='27:30 min' depth='21.709 m' tts='4:26 min' stoptime='2:59 min' />
+  <sample time='27:31 min' depth='21.537 m' tts='4:25 min' />
+  <sample time='27:32 min' depth='21.413 m' pressure='197.39 bar' tts='4:24 min' />
+  <sample time='27:33 min' depth='21.379 m' />
+  <sample time='27:34 min' depth='21.367 m' heartbeat='82' />
+  <sample time='27:35 min' depth='21.306 m' tts='4:23 min' />
+  <sample time='27:37 min' depth='21.161 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='27:38 min' depth='21.089 m' tts='4:22 min' />
+  <sample time='27:39 min' depth='20.997 m' tts='4:21 min' />
+  <sample time='27:40 min' depth='20.939 m' />
+  <sample time='27:41 min' depth='20.811 m' tts='4:20 min' />
+  <sample time='27:42 min' depth='20.693 m' pressure='197.46 bar' tts='4:19 min' />
+  <sample time='27:43 min' depth='20.785 m' tts='4:20 min' heartbeat='83' />
+  <sample time='27:44 min' depth='20.845 m' />
+  <sample time='27:45 min' depth='20.778 m' stoptime='3:00 min' />
+  <sample time='27:46 min' depth='20.711 m' tts='4:19 min' />
+  <sample time='27:47 min' depth='20.597 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='27:48 min' depth='20.483 m' tts='4:18 min' />
+  <sample time='27:51 min' depth='20.546 m' heartbeat='84' />
+  <sample time='27:52 min' depth='20.611 m' pressure='197.67 bar' tts='4:19 min' />
+  <sample time='27:53 min' depth='20.641 m' />
+  <sample time='27:55 min' depth='20.674 m' tts='4:20 min' />
+  <sample time='27:57 min' depth='20.667 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='27:58 min' depth='20.664 m' tts='4:20 min' />
+  <sample time='27:59 min' depth='20.719 m' />
+  <sample time='28:00 min' depth='20.762 m' tts='4:21 min' heartbeat='83' />
+  <sample time='28:02 min' depth='20.796 m' pressure='197.46 bar' heartbeat='82' />
+  <sample time='28:03 min' depth='20.758 m' heartbeat='81' />
+  <sample time='28:05 min' depth='20.749 m' heartbeat='80' />
+  <sample time='28:07 min' depth='20.73 m' tts='4:22 min' heartbeat='79' />
+  <sample time='28:09 min' depth='20.837 m' />
+  <sample time='28:10 min' depth='20.912 m' tts='4:24 min' heartbeat='78' />
+  <sample time='28:11 min' depth='20.885 m' stoptime='3:01 min' />
+  <sample time='28:12 min' depth='20.865 m' pressure='197.46 bar' tts='4:23 min' />
+  <sample time='28:13 min' depth='20.838 m' tts='4:24 min' />
+  <sample time='28:14 min' depth='20.863 m' heartbeat='77' />
+  <sample time='28:16 min' depth='20.837 m' tts='4:25 min' />
+  <sample time='28:17 min' depth='20.894 m' pressure='197.53 bar' tts='4:26 min' />
+  <sample time='28:18 min' depth='20.895 m' heartbeat='78' />
+  <sample time='28:19 min' depth='20.834 m' tts='4:25 min' />
+  <sample time='28:20 min' depth='20.843 m' tts='4:26 min' />
+  <sample time='28:22 min' depth='20.921 m' pressure='197.39 bar' tts='4:27 min' />
+  <sample time='28:23 min' depth='20.855 m' />
+  <sample time='28:24 min' depth='21.021 m' tts='4:28 min' />
+  <sample time='28:25 min' depth='21.168 m' tts='4:30 min' />
+  <sample time='28:26 min' depth='21.254 m' tts='4:31 min' />
+  <sample time='28:27 min' depth='21.341 m' pressure='197.39 bar' tts='4:33 min' heartbeat='77' />
+  <sample time='28:28 min' depth='21.458 m' heartbeat='76' />
+  <sample time='28:29 min' depth='21.529 m' tts='4:35 min' stoptime='3:02 min' heartbeat='73' />
+  <sample time='28:30 min' depth='21.618 m' heartbeat='72' />
+  <sample time='28:31 min' depth='21.763 m' tts='4:37 min' heartbeat='71' />
+  <sample time='28:32 min' depth='21.823 m' pressure='197.67 bar' tts='4:39 min' />
+  <sample time='28:33 min' depth='21.881 m' />
+  <sample time='28:35 min' depth='21.871 m' tts='4:40 min' />
+  <sample time='28:36 min' depth='21.84 m' heartbeat='74' />
+  <sample time='28:37 min' depth='21.881 m' pressure='197.46 bar' heartbeat='76' />
+  <sample time='28:38 min' depth='21.877 m' tts='4:41 min' heartbeat='77' />
+  <sample time='28:39 min' depth='21.872 m' stoptime='3:03 min' heartbeat='78' />
+  <sample time='28:40 min' depth='21.887 m' tts='4:42 min' />
+  <sample time='28:41 min' depth='21.91 m' heartbeat='79' />
+  <sample time='28:42 min' depth='21.97 m' pressure='197.46 bar' tts='4:43 min' />
+  <sample time='28:43 min' depth='22.046 m' tts='4:44 min' heartbeat='80' />
+  <sample time='28:44 min' depth='21.902 m' tts='4:43 min' />
+  <sample time='28:45 min' depth='21.864 m' heartbeat='81' />
+  <sample time='28:46 min' depth='21.86 m' tts='4:44 min' heartbeat='82' />
+  <sample time='28:47 min' depth='21.959 m' pressure='197.46 bar' tts='4:45 min' heartbeat='83' />
+  <sample time='28:48 min' depth='21.992 m' tts='4:46 min' stoptime='3:04 min' />
+  <sample time='28:50 min' depth='21.993 m' heartbeat='84' />
+  <sample time='28:51 min' depth='22.014 m' tts='4:47 min' />
+  <sample time='28:52 min' depth='22.012 m' pressure='197.46 bar' heartbeat='85' />
+  <sample time='28:53 min' depth='22.046 m' tts='4:48 min' heartbeat='84' />
+  <sample time='28:54 min' depth='22.117 m' tts='4:49 min' />
+  <sample time='28:55 min' depth='22.169 m' tts='4:50 min' />
+  <sample time='28:57 min' depth='22.27 m' pressure='197.46 bar' tts='4:52 min' stoptime='3:05 min' />
+  <sample time='28:59 min' depth='22.335 m' tts='4:53 min' />
+  <sample time='29:02 min' depth='22.388 m' pressure='197.46 bar' tts='4:54 min' stoptime='3:06 min' heartbeat='83' />
+  <sample time='29:04 min' depth='22.304 m' stoptime='3:07 min' />
+  <sample time='29:05 min' depth='22.346 m' tts='4:55 min' />
+  <sample time='29:06 min' depth='22.524 m' tts='4:57 min' />
+  <sample time='29:07 min' depth='22.579 m' pressure='197.46 bar' tts='4:58 min' stoptime='3:08 min' />
+  <sample time='29:08 min' depth='22.62 m' tts='4:59 min' />
+  <sample time='29:09 min' depth='22.63 m' stoptime='3:09 min' />
+  <sample time='29:10 min' depth='22.737 m' tts='5:01 min' heartbeat='84' />
+  <sample time='29:11 min' depth='22.591 m' tts='5:00 min' stoptime='3:10 min' />
+  <sample time='29:12 min' depth='22.603 m' pressure='197.46 bar' heartbeat='85' />
+  <sample time='29:13 min' depth='22.537 m' tts='4:59 min' heartbeat='86' />
+  <sample time='29:14 min' depth='22.534 m' tts='5:00 min' stoptime='3:11 min' />
+  <sample time='29:15 min' depth='22.538 m' heartbeat='87' />
+  <sample time='29:16 min' depth='22.594 m' tts='5:02 min' stoptime='3:12 min' />
+  <sample time='29:17 min' depth='22.792 m' pressure='197.53 bar' tts='5:04 min' />
+  <sample time='29:18 min' depth='22.745 m' />
+  <sample time='29:19 min' depth='22.822 m' tts='5:05 min' stoptime='3:13 min' />
+  <sample time='29:21 min' depth='22.817 m' stoptime='3:14 min' />
+  <sample time='29:22 min' depth='22.742 m' tts='5:06 min' />
+  <sample time='29:23 min' depth='22.716 m' stoptime='3:15 min' />
+  <sample time='29:24 min' depth='22.687 m' tts='5:05 min' />
+  <sample time='29:25 min' depth='22.636 m' heartbeat='88' />
+  <sample time='29:26 min' depth='22.646 m' tts='5:06 min' stoptime='3:16 min' />
+  <sample time='29:27 min' depth='22.709 m' tts='5:07 min' heartbeat='89' />
+  <sample time='29:28 min' depth='22.772 m' tts='5:08 min' stoptime='3:17 min' heartbeat='90' />
+  <sample time='29:29 min' depth='22.837 m' tts='5:09 min' heartbeat='91' />
+  <sample time='29:30 min' depth='22.871 m' tts='5:10 min' stoptime='3:18 min' heartbeat='92' />
+  <sample time='29:31 min' depth='22.913 m' tts='5:11 min' />
+  <sample time='29:32 min' depth='22.907 m' pressure='197.46 bar' heartbeat='91' />
+  <sample time='29:33 min' depth='22.841 m' tts='5:10 min' stoptime='3:19 min' heartbeat='92' />
+  <sample time='29:34 min' depth='22.935 m' tts='5:12 min' heartbeat='91' />
+  <sample time='29:35 min' depth='22.911 m' stoptime='3:20 min' />
+  <sample time='29:36 min' depth='22.923 m' tts='5:13 min' />
+  <sample time='29:37 min' depth='22.801 m' pressure='197.46 bar' tts='5:12 min' stoptime='3:21 min' />
+  <sample time='29:38 min' depth='22.898 m' tts='5:13 min' />
+  <sample time='29:39 min' depth='23.148 m' tts='5:15 min' cns='11%' />
+  <sample time='29:40 min' depth='23.159 m' tts='5:16 min' stoptime='3:22 min' heartbeat='90' />
+  <sample time='29:42 min' depth='23.001 m' pressure='197.46 bar' tts='5:15 min' stoptime='3:23 min' />
+  <sample time='29:43 min' depth='22.92 m' />
+  <sample time='29:44 min' depth='22.927 m' tts='5:16 min' stoptime='3:24 min' heartbeat='89' />
+  <sample time='29:46 min' depth='22.974 m' tts='5:17 min' heartbeat='88' />
+  <sample time='29:47 min' depth='23.068 m' pressure='197.67 bar' tts='5:18 min' stoptime='3:25 min' heartbeat='87' />
+  <sample time='29:48 min' depth='23.232 m' tts='5:20 min' />
+  <sample time='29:49 min' depth='23.183 m' tts='5:21 min' stoptime='3:26 min' />
+  <sample time='29:50 min' depth='23.185 m' heartbeat='86' />
+  <sample time='29:51 min' depth='23.145 m' tts='5:20 min' stoptime='3:27 min' heartbeat='85' />
+  <sample time='29:52 min' depth='23.156 m' pressure='197.46 bar' tts='5:21 min' heartbeat='84' />
+  <sample time='29:53 min' depth='23.056 m' />
+  <sample time='29:54 min' depth='23.042 m' stoptime='3:28 min' heartbeat='85' />
+  <sample time='29:55 min' depth='23.051 m' tts='5:22 min' />
+  <sample time='29:56 min' depth='23.091 m' stoptime='3:29 min' heartbeat='84' />
+  <sample time='29:57 min' depth='23.166 m' pressure='197.53 bar' tts='5:24 min' />
+  <sample time='29:58 min' depth='23.249 m' tts='5:25 min' stoptime='3:30 min' heartbeat='83' />
+  <sample time='29:59 min' depth='23.34 m' tts='5:26 min' />
+  <sample time='30:00 min' depth='23.39 m' tts='5:27 min' stoptime='3:31 min' heartbeat='84' />
+  <sample time='30:01 min' depth='23.513 m' tts='5:29 min' heartbeat='83' />
+  <sample time='30:02 min' depth='23.504 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='30:03 min' depth='23.494 m' tts='5:29 min' stoptime='3:32 min' />
+  <sample time='30:05 min' depth='23.605 m' tts='5:31 min' stoptime='3:33 min' />
+  <sample time='30:06 min' depth='23.689 m' tts='5:32 min' />
+  <sample time='30:07 min' depth='23.63 m' tts='5:33 min' stoptime='3:34 min' />
+  <sample time='30:08 min' depth='23.668 m' tts='0:00 min' />
+  <sample time='30:09 min' depth='23.707 m' tts='5:34 min' stoptime='3:35 min' />
+  <sample time='30:11 min' depth='23.737 m' tts='5:35 min' stoptime='3:36 min' />
+  <sample time='30:12 min' depth='23.785 m' pressure='197.46 bar' tts='5:36 min' />
+  <sample time='30:13 min' depth='23.908 m' tts='5:37 min' stoptime='3:37 min' heartbeat='84' />
+  <sample time='30:14 min' depth='23.73 m' tts='5:36 min' heartbeat='83' />
+  <sample time='30:15 min' depth='23.497 m' tts='5:35 min' stoptime='3:38 min' heartbeat='84' />
+  <sample time='30:16 min' depth='23.458 m' tts='5:34 min' heartbeat='85' />
+  <sample time='30:17 min' depth='23.502 m' pressure='197.53 bar' tts='5:36 min' />
+  <sample time='30:18 min' depth='23.734 m' tts='5:38 min' stoptime='3:39 min' />
+  <sample time='30:19 min' depth='23.853 m' tts='5:39 min' heartbeat='86' />
+  <sample time='30:20 min' depth='23.719 m' stoptime='3:40 min' heartbeat='87' />
+  <sample time='30:22 min' depth='23.79 m' pressure='197.46 bar' tts='5:41 min' stoptime='3:41 min' heartbeat='88' />
+  <sample time='30:23 min' depth='24.069 m' tts='5:43 min' />
+  <sample time='30:24 min' depth='24.042 m' stoptime='3:42 min' heartbeat='87' />
+  <sample time='30:25 min' depth='24.1 m' tts='5:45 min' />
+  <sample time='30:26 min' depth='24.145 m' stoptime='3:43 min' />
+  <sample time='30:27 min' depth='23.978 m' pressure='197.46 bar' tts='5:44 min' />
+  <sample time='30:28 min' depth='23.946 m' tts='5:45 min' stoptime='3:44 min' heartbeat='86' />
+  <sample time='30:29 min' depth='24.002 m' heartbeat='87' />
+  <sample time='30:30 min' depth='23.999 m' tts='5:46 min' stoptime='3:45 min' />
+  <sample time='30:32 min' depth='24.049 m' pressure='197.67 bar' tts='5:47 min' stoptime='3:46 min' />
+  <sample time='30:33 min' depth='24.073 m' />
+  <sample time='30:34 min' depth='24.131 m' tts='5:49 min' stoptime='3:47 min' heartbeat='86' />
+  <sample time='30:35 min' depth='24.141 m' tts='5:50 min' heartbeat='87' />
+  <sample time='30:36 min' depth='24.178 m' stoptime='3:48 min' />
+  <sample time='30:37 min' depth='24.145 m' tts='5:51 min' />
+  <sample time='30:38 min' depth='23.989 m' tts='5:50 min' stoptime='3:49 min' heartbeat='88' />
+  <sample time='30:39 min' depth='23.912 m' tts='5:49 min' heartbeat='89' />
+  <sample time='30:40 min' depth='23.853 m' stoptime='3:50 min' />
+  <sample time='30:41 min' depth='23.869 m' heartbeat='88' />
+  <sample time='30:42 min' depth='23.912 m' tts='5:50 min' stoptime='3:51 min' heartbeat='90' />
+  <sample time='30:43 min' depth='23.917 m' tts='5:51 min' />
+  <sample time='30:44 min' depth='23.953 m' tts='5:52 min' />
+  <sample time='30:45 min' depth='23.947 m' stoptime='3:52 min' />
+  <sample time='30:47 min' depth='23.793 m' pressure='197.39 bar' stoptime='3:53 min' />
+  <sample time='30:48 min' depth='23.856 m' tts='5:53 min' />
+  <sample time='30:49 min' depth='23.75 m' tts='5:52 min' stoptime='3:54 min' />
+  <sample time='30:50 min' depth='23.828 m' tts='5:53 min' heartbeat='89' />
+  <sample time='30:51 min' depth='23.919 m' tts='5:54 min' stoptime='3:55 min' />
+  <sample time='30:52 min' depth='23.93 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='30:53 min' depth='23.941 m' tts='5:56 min' stoptime='3:56 min' />
+  <sample time='30:54 min' depth='23.828 m' tts='5:55 min' />
+  <sample time='30:55 min' depth='23.802 m' stoptime='3:57 min' />
+  <sample time='30:57 min' depth='23.875 m' pressure='197.46 bar' tts='5:57 min' stoptime='3:58 min' />
+  <sample time='30:58 min' depth='23.839 m' heartbeat='87' />
+  <sample time='30:59 min' depth='23.846 m' heartbeat='89' />
+  <sample time='31:00 min' depth='23.847 m' tts='5:58 min' stoptime='3:59 min' heartbeat='88' />
+  <sample time='31:02 min' depth='23.886 m' tts='5:59 min' stoptime='4:00 min' />
+  <sample time='31:03 min' depth='23.892 m' heartbeat='89' />
+  <sample time='31:04 min' depth='23.953 m' tts='6:01 min' stoptime='4:01 min' heartbeat='88' />
+  <sample time='31:05 min' depth='23.901 m' tts='6:00 min' />
+  <sample time='31:06 min' depth='23.862 m' stoptime='4:02 min' />
+  <sample time='31:07 min' depth='23.867 m' pressure='197.46 bar' tts='6:01 min' />
+  <sample time='31:08 min' depth='23.932 m' tts='6:02 min' stoptime='4:03 min' />
+  <sample time='31:09 min' depth='23.993 m' tts='6:03 min' />
+  <sample time='31:10 min' depth='24.066 m' tts='6:04 min' stoptime='4:04 min' heartbeat='89' />
+  <sample time='31:11 min' depth='24.229 m' tts='6:06 min' heartbeat='90' />
+  <sample time='31:12 min' depth='24.094 m' />
+  <sample time='31:13 min' depth='24.027 m' tts='6:05 min' stoptime='4:05 min' />
+  <sample time='31:15 min' depth='24.037 m' tts='6:06 min' stoptime='4:06 min' />
+  <sample time='31:16 min' depth='23.968 m' />
+  <sample time='31:17 min' depth='23.921 m' tts='6:05 min' stoptime='4:07 min' heartbeat='89' />
+  <sample time='31:18 min' depth='23.868 m' tts='6:06 min' />
+  <sample time='31:19 min' depth='23.832 m' stoptime='4:08 min' heartbeat='88' />
+  <sample time='31:21 min' depth='23.846 m' tts='6:07 min' stoptime='4:09 min' />
+  <sample time='31:22 min' depth='23.752 m' pressure='197.46 bar' tts='6:06 min' heartbeat='87' />
+  <sample time='31:23 min' depth='23.724 m' stoptime='4:10 min' />
+  <sample time='31:24 min' depth='23.7 m' tts='6:07 min' />
+  <sample time='31:25 min' depth='23.644 m' />
+  <sample time='31:26 min' depth='23.675 m' stoptime='4:11 min' />
+  <sample time='31:27 min' depth='23.726 m' tts='6:08 min' />
+  <sample time='31:28 min' depth='23.718 m' stoptime='4:12 min' />
+  <sample time='31:29 min' depth='23.646 m' tts='6:09 min' heartbeat='88' />
+  <sample time='31:30 min' depth='23.623 m' stoptime='4:13 min' />
+  <sample time='31:32 min' depth='23.673 m' pressure='197.39 bar' tts='6:10 min' />
+  <sample time='31:33 min' depth='23.681 m' stoptime='4:14 min' />
+  <sample time='31:34 min' depth='23.689 m' tts='6:11 min' heartbeat='87' />
+  <sample time='31:35 min' depth='23.758 m' stoptime='4:15 min' />
+  <sample time='31:36 min' depth='23.755 m' tts='6:12 min' />
+  <sample time='31:37 min' depth='23.69 m' pressure='197.46 bar' stoptime='4:16 min' />
+  <sample time='31:38 min' depth='23.477 m' tts='6:11 min' />
+  <sample time='31:39 min' depth='23.282 m' tts='6:09 min' />
+  <sample time='31:40 min' depth='23.426 m' tts='6:10 min' stoptime='4:17 min' heartbeat='86' />
+  <sample time='31:41 min' depth='23.391 m' tts='6:11 min' />
+  <sample time='31:42 min' depth='23.369 m' stoptime='4:18 min' />
+  <sample time='31:43 min' depth='23.237 m' tts='6:10 min' />
+  <sample time='31:44 min' depth='23.168 m' stoptime='4:19 min' heartbeat='87' />
+  <sample time='31:45 min' depth='23.049 m' tts='6:09 min' />
+  <sample time='31:46 min' depth='22.913 m' tts='6:08 min' heartbeat='88' />
+  <sample time='31:47 min' depth='22.803 m' pressure='197.39 bar' stoptime='4:20 min' />
+  <sample time='31:48 min' depth='22.671 m' tts='6:07 min' />
+  <sample time='31:50 min' depth='22.574 m' stoptime='4:21 min' />
+  <sample time='31:51 min' depth='22.652 m' tts='6:08 min' />
+  <sample time='31:52 min' depth='22.463 m' pressure='197.39 bar' tts='6:07 min' />
+  <sample time='31:53 min' depth='22.356 m' tts='6:06 min' stoptime='4:22 min' />
+  <sample time='31:54 min' depth='22.13 m' tts='6:04 min' />
+  <sample time='31:55 min' depth='21.898 m' tts='6:02 min' />
+  <sample time='31:56 min' depth='21.741 m' tts='6:01 min' stoptime='4:23 min' heartbeat='89' />
+  <sample time='31:57 min' depth='21.486 m' pressure='197.46 bar' tts='5:59 min' />
+  <sample time='31:58 min' depth='21.255 m' tts='5:58 min' />
+  <sample time='31:59 min' depth='21.158 m' tts='5:57 min' />
+  <sample time='32:00 min' depth='21.123 m' stoptime='4:24 min' />
+  <sample time='32:02 min' depth='20.985 m' pressure='197.46 bar' />
+  <sample time='32:03 min' depth='20.949 m' heartbeat='88' />
+  <sample time='32:04 min' depth='20.807 m' tts='5:56 min' stoptime='4:25 min' />
+  <sample time='32:05 min' depth='20.676 m' tts='5:55 min' />
+  <sample time='32:07 min' depth='20.535 m' tts='5:54 min' />
+  <sample time='32:08 min' depth='20.444 m' stoptime='4:26 min' />
+  <sample time='32:09 min' depth='20.389 m' tts='5:53 min' />
+  <sample time='32:12 min' depth='20.287 m' pressure='197.46 bar' tts='5:54 min' heartbeat='89' />
+  <sample time='32:13 min' depth='20.222 m' tts='5:53 min' stoptime='4:27 min' />
+  <sample time='32:14 min' depth='20.171 m' />
+  <sample time='32:15 min' depth='20.116 m' tts='5:52 min' heartbeat='90' />
+  <sample time='32:16 min' depth='20.125 m' tts='5:53 min' heartbeat='91' />
+  <sample time='32:17 min' depth='20.182 m' heartbeat='92' />
+  <sample time='32:18 min' depth='20.246 m' tts='5:54 min' />
+  <sample time='32:19 min' depth='20.288 m' tts='5:55 min' stoptime='4:28 min' />
+  <sample time='32:21 min' depth='20.236 m' tts='5:54 min' heartbeat='93' />
+  <sample time='32:22 min' depth='20.229 m' pressure='197.46 bar' heartbeat='94' />
+  <sample time='32:23 min' depth='20.305 m' tts='5:56 min' heartbeat='95' />
+  <sample time='32:24 min' depth='20.389 m' stoptime='4:29 min' heartbeat='93' />
+  <sample time='32:26 min' depth='20.39 m' heartbeat='92' />
+  <sample time='32:27 min' depth='20.45 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='32:28 min' depth='20.509 m' tts='5:58 min' heartbeat='91' />
+  <sample time='32:29 min' depth='20.506 m' stoptime='4:30 min' />
+  <sample time='32:31 min' depth='20.608 m' tts='5:59 min' />
+  <sample time='32:32 min' depth='20.622 m' pressure='197.46 bar' tts='6:00 min' />
+  <sample time='32:33 min' depth='20.673 m' />
+  <sample time='32:34 min' depth='20.603 m' stoptime='4:31 min' heartbeat='90' />
+  <sample time='32:35 min' depth='20.547 m' tts='5:59 min' />
+  <sample time='32:36 min' depth='20.524 m' heartbeat='89' />
+  <sample time='32:37 min' depth='20.531 m' pressure='197.46 bar' tts='6:00 min' />
+  <sample time='32:38 min' depth='20.543 m' heartbeat='88' />
+  <sample time='32:39 min' depth='20.5 m' stoptime='4:32 min' heartbeat='87' />
+  <sample time='32:40 min' depth='20.39 m' tts='5:59 min' heartbeat='86' />
+  <sample time='32:41 min' depth='20.195 m' tts='5:58 min' />
+  <sample time='32:42 min' depth='20.45 m' tts='6:00 min' />
+  <sample time='32:44 min' depth='20.322 m' stoptime='4:33 min' cns='12%' />
+  <sample time='32:45 min' depth='19.983 m' tts='5:57 min' />
+  <sample time='32:46 min' depth='19.78 m' tts='5:55 min' />
+  <sample time='32:47 min' depth='19.998 m' pressure='197.46 bar' tts='5:58 min' />
+  <sample time='32:48 min' depth='19.877 m' tts='5:57 min' heartbeat='85' />
+  <sample time='32:50 min' depth='19.746 m' tts='5:56 min' stoptime='4:34 min' />
+  <sample time='32:51 min' depth='19.752 m' heartbeat='86' />
+  <sample time='32:52 min' depth='19.776 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='32:53 min' depth='19.799 m' tts='5:56 min' heartbeat='87' />
+  <sample time='32:54 min' depth='19.924 m' tts='5:58 min' />
+  <sample time='32:55 min' depth='20.066 m' tts='5:59 min' />
+  <sample time='32:56 min' depth='20.217 m' tts='6:00 min' heartbeat='86' />
+  <sample time='32:57 min' depth='20.285 m' pressure='197.46 bar' tts='6:02 min' stoptime='4:35 min' />
+  <sample time='32:58 min' depth='20.314 m' />
+  <sample time='33:00 min' depth='20.241 m' tts='6:01 min' />
+  <sample time='33:01 min' depth='20.164 m' heartbeat='87' />
+  <sample time='33:02 min' depth='19.872 m' pressure='197.46 bar' tts='5:59 min' stoptime='4:36 min' />
+  <sample time='33:03 min' depth='20.186 m' tts='6:01 min' />
+  <sample time='33:04 min' depth='20.231 m' tts='6:02 min' />
+  <sample time='33:05 min' depth='20.168 m' heartbeat='86' />
+  <sample time='33:07 min' depth='20.082 m' pressure='197.39 bar' tts='6:01 min' heartbeat='85' />
+  <sample time='33:08 min' depth='20.066 m' stoptime='4:37 min' />
+  <sample time='33:09 min' depth='20.101 m' heartbeat='84' />
+  <sample time='33:10 min' depth='20.153 m' tts='6:03 min' heartbeat='83' />
+  <sample time='33:11 min' depth='20.158 m' heartbeat='82' />
+  <sample time='33:12 min' depth='20.075 m' pressure='197.46 bar' tts='6:02 min' heartbeat='81' />
+  <sample time='33:13 min' depth='20.157 m' tts='6:03 min' heartbeat='80' />
+  <sample time='33:14 min' depth='20.17 m' stoptime='4:38 min' />
+  <sample time='33:16 min' depth='20.15 m' tts='6:04 min' />
+  <sample time='33:17 min' depth='20.158 m' pressure='197.46 bar' heartbeat='81' />
+  <sample time='33:18 min' depth='20.046 m' tts='6:03 min' heartbeat='82' />
+  <sample time='33:20 min' depth='20.038 m' stoptime='4:39 min' />
+  <sample time='33:21 min' depth='19.909 m' tts='6:02 min' />
+  <sample time='33:22 min' depth='19.85 m' pressure='197.46 bar' heartbeat='81' />
+  <sample time='33:23 min' depth='19.78 m' tts='6:01 min' />
+  <sample time='33:25 min' depth='19.569 m' tts='6:00 min' />
+  <sample time='33:26 min' depth='19.655 m' tts='6:01 min' stoptime='4:40 min' />
+  <sample time='33:27 min' depth='19.767 m' pressure='197.39 bar' tts='6:02 min' />
+  <sample time='33:28 min' depth='19.745 m' />
+  <sample time='33:30 min' depth='19.609 m' tts='6:01 min' />
+  <sample time='33:32 min' depth='19.751 m' pressure='197.46 bar' tts='6:02 min' />
+  <sample time='33:33 min' depth='19.944 m' tts='6:04 min' />
+  <sample time='33:34 min' depth='19.858 m' stoptime='4:41 min' />
+  <sample time='33:35 min' depth='20.012 m' tts='6:05 min' />
+  <sample time='33:36 min' depth='19.933 m' tts='6:04 min' />
+  <sample time='33:37 min' depth='19.994 m' pressure='197.46 bar' tts='6:05 min' />
+  <sample time='33:38 min' depth='20.064 m' tts='6:06 min' heartbeat='80' />
+  <sample time='33:40 min' depth='19.841 m' tts='6:05 min' stoptime='4:42 min' />
+  <sample time='33:41 min' depth='19.793 m' tts='6:04 min' />
+  <sample time='33:43 min' depth='19.808 m' heartbeat='81' />
+  <sample time='33:44 min' depth='19.926 m' tts='6:05 min' heartbeat='80' />
+  <sample time='33:45 min' depth='20.021 m' tts='6:07 min' heartbeat='81' />
+  <sample time='33:46 min' depth='20.043 m' stoptime='4:43 min' />
+  <sample time='33:47 min' depth='19.953 m' tts='6:06 min' />
+  <sample time='33:48 min' depth='19.839 m' />
+  <sample time='33:49 min' depth='19.781 m' tts='6:05 min' />
+  <sample time='33:50 min' depth='19.859 m' tts='6:06 min' />
+  <sample time='33:51 min' depth='19.941 m' />
+  <sample time='33:52 min' depth='19.966 m' tts='6:08 min' heartbeat='80' />
+  <sample time='33:53 min' depth='20.173 m' tts='6:09 min' stoptime='4:44 min' />
+  <sample time='33:54 min' depth='19.895 m' tts='6:07 min' heartbeat='81' />
+  <sample time='33:55 min' depth='19.721 m' tts='6:06 min' />
+  <sample time='33:56 min' depth='19.464 m' tts='6:04 min' />
+  <sample time='33:57 min' depth='19.514 m' tts='6:05 min' heartbeat='82' />
+  <sample time='33:58 min' depth='19.548 m' heartbeat='81' />
+  <sample time='33:59 min' depth='19.318 m' tts='6:03 min' />
+  <sample time='34:00 min' depth='19.11 m' tts='6:02 min' />
+  <sample time='34:01 min' depth='18.983 m' tts='6:01 min' stoptime='4:45 min' />
+  <sample time='34:02 min' depth='18.827 m' pressure='197.39 bar' tts='6:00 min' />
+  <sample time='34:03 min' depth='18.779 m' />
+  <sample time='34:04 min' depth='18.917 m' tts='6:01 min' />
+  <sample time='34:05 min' depth='18.732 m' tts='5:59 min' heartbeat='82' />
+  <sample time='34:07 min' depth='18.666 m' />
+  <sample time='34:08 min' depth='18.672 m' heartbeat='83' />
+  <sample time='34:11 min' depth='18.59 m' tts='5:58 min' heartbeat='84' />
+  <sample time='34:12 min' depth='18.407 m' pressure='197.46 bar' tts='5:57 min' heartbeat='83' />
+  <sample time='34:13 min' depth='18.424 m' />
+  <sample time='34:14 min' depth='18.457 m' tts='5:59 min' heartbeat='84' />
+  <sample time='34:15 min' depth='18.372 m' tts='5:58 min' />
+  <sample time='34:16 min' depth='18.337 m' stoptime='4:46 min' />
+  <sample time='34:17 min' depth='18.204 m' tts='5:57 min' />
+  <sample time='34:18 min' depth='17.99 m' tts='5:56 min' />
+  <sample time='34:19 min' depth='17.769 m' tts='5:54 min' heartbeat='83' />
+  <sample time='34:20 min' depth='17.656 m' tts='5:53 min' heartbeat='84' />
+  <sample time='34:21 min' depth='17.508 m' tts='5:52 min' heartbeat='86' />
+  <sample time='34:22 min' depth='17.302 m' pressure='197.46 bar' tts='5:51 min' heartbeat='84' />
+  <sample time='34:23 min' depth='17.173 m' tts='5:50 min' />
+  <sample time='34:24 min' depth='17.097 m' stoptime='4:45 min' heartbeat='85' />
+  <sample time='34:25 min' depth='17.002 m' tts='5:49 min' />
+  <sample time='34:27 min' depth='16.958 m' pressure='197.46 bar' tts='5:48 min' />
+  <sample time='34:28 min' depth='16.705 m' tts='5:47 min' />
+  <sample time='34:29 min' depth='16.589 m' tts='5:45 min' />
+  <sample time='34:32 min' depth='16.498 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='34:33 min' depth='16.467 m' tts='5:45 min' />
+  <sample time='34:34 min' depth='16.296 m' tts='5:43 min' />
+  <sample time='34:35 min' depth='16.153 m' tts='5:42 min' />
+  <sample time='34:36 min' depth='15.853 m' tts='5:41 min' />
+  <sample time='34:37 min' depth='15.659 m' pressure='197.46 bar' tts='5:39 min' stoptime='4:44 min' />
+  <sample time='34:38 min' depth='15.519 m' tts='5:38 min' />
+  <sample time='34:41 min' depth='15.794 m' tts='5:40 min' />
+  <sample time='34:42 min' depth='16.258 m' pressure='197.67 bar' tts='5:42 min' heartbeat='86' />
+  <sample time='34:43 min' depth='16.341 m' tts='5:43 min' />
+  <sample time='34:45 min' depth='16.233 m' tts='5:42 min' stoptime='4:43 min' heartbeat='88' />
+  <sample time='34:47 min' depth='16.128 m' tts='5:41 min' heartbeat='87' />
+  <sample time='34:48 min' depth='16.122 m' heartbeat='88' />
+  <sample time='34:49 min' depth='16.178 m' tts='5:42 min' heartbeat='87' />
+  <sample time='34:50 min' depth='16.251 m' heartbeat='88' />
+  <sample time='34:51 min' depth='16.372 m' />
+  <sample time='34:52 min' depth='16.409 m' pressure='197.46 bar' heartbeat='87' />
+  <sample time='34:53 min' depth='16.395 m' heartbeat='89' />
+  <sample time='34:54 min' depth='16.521 m' tts='5:43 min' />
+  <sample time='34:56 min' depth='16.577 m' stoptime='4:42 min' heartbeat='90' />
+  <sample time='34:57 min' depth='16.595 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='35:00 min' depth='16.648 m' tts='5:43 min' />
+  <sample time='35:01 min' depth='16.761 m' />
+  <sample time='35:02 min' depth='16.84 m' pressure='197.67 bar' tts='5:44 min' />
+  <sample time='35:03 min' depth='16.893 m' />
+  <sample time='35:05 min' depth='16.532 m' tts='5:42 min' heartbeat='89' />
+  <sample time='35:06 min' depth='16.75 m' tts='5:43 min' heartbeat='90' />
+  <sample time='35:07 min' depth='16.745 m' pressure='197.46 bar' heartbeat='89' />
+  <sample time='35:08 min' depth='16.682 m' heartbeat='90' />
+  <sample time='35:10 min' depth='16.262 m' tts='5:40 min' heartbeat='91' />
+  <sample time='35:11 min' depth='16.415 m' tts='5:41 min' stoptime='4:41 min' heartbeat='92' />
+  <sample time='35:12 min' depth='16.846 m' pressure='197.46 bar' tts='5:44 min' heartbeat='90' />
+  <sample time='35:13 min' depth='16.901 m' />
+  <sample time='35:14 min' depth='17.018 m' />
+  <sample time='35:15 min' depth='17.071 m' tts='5:45 min' />
+  <sample time='35:16 min' depth='17.035 m' tts='5:44 min' />
+  <sample time='35:17 min' depth='16.964 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='35:18 min' depth='16.893 m' tts='5:43 min' heartbeat='89' />
+  <sample time='35:19 min' depth='16.833 m' heartbeat='90' />
+  <sample time='35:20 min' depth='16.755 m' tts='5:42 min' />
+  <sample time='35:22 min' depth='16.801 m' pressure='197.67 bar' tts='5:43 min' />
+  <sample time='35:23 min' depth='16.809 m' heartbeat='91' />
+  <sample time='35:24 min' depth='16.775 m' heartbeat='90' />
+  <sample time='35:25 min' depth='16.725 m' tts='5:42 min' />
+  <sample time='35:26 min' depth='16.728 m' heartbeat='89' />
+  <sample time='35:27 min' depth='16.803 m' tts='5:43 min' />
+  <sample time='35:28 min' depth='16.827 m' stoptime='4:40 min' heartbeat='88' />
+  <sample time='35:29 min' depth='16.9 m' heartbeat='87' />
+  <sample time='35:30 min' depth='16.941 m' tts='5:44 min' heartbeat='86' />
+  <sample time='35:31 min' depth='16.965 m' heartbeat='85' />
+  <sample time='35:32 min' depth='16.986 m' pressure='197.46 bar' heartbeat='84' />
+  <sample time='35:33 min' depth='16.991 m' tts='5:43 min' />
+  <sample time='35:35 min' depth='16.98 m' heartbeat='83' />
+  <sample time='35:37 min' depth='17.001 m' pressure='197.46 bar' />
+  <sample time='35:38 min' depth='16.779 m' tts='5:42 min' />
+  <sample time='35:39 min' depth='16.674 m' tts='5:41 min' />
+  <sample time='35:41 min' depth='16.792 m' tts='5:42 min' />
+  <sample time='35:42 min' depth='16.856 m' heartbeat='84' />
+  <sample time='35:43 min' depth='16.719 m' tts='5:41 min' />
+  <sample time='35:44 min' depth='16.414 m' tts='5:39 min' heartbeat='82' />
+  <sample time='35:45 min' depth='16.543 m' tts='5:40 min' />
+  <sample time='35:46 min' depth='16.387 m' tts='5:39 min' stoptime='4:39 min' heartbeat='83' />
+  <sample time='35:47 min' depth='16.3 m' pressure='197.46 bar' tts='5:38 min' heartbeat='84' />
+  <sample time='35:48 min' depth='16.236 m' heartbeat='85' />
+  <sample time='35:51 min' depth='16.222 m' heartbeat='86' />
+  <sample time='35:52 min' depth='16.207 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='35:53 min' depth='16.192 m' tts='5:37 min' heartbeat='87' />
+  <sample time='35:55 min' depth='16.135 m' tts='5:36 min' />
+  <sample time='35:56 min' depth='16.168 m' tts='5:37 min' stoptime='4:38 min' />
+  <sample time='35:57 min' depth='16.248 m' pressure='197.46 bar' />
+  <sample time='35:58 min' depth='16.344 m' tts='5:38 min' heartbeat='86' />
+  <sample time='35:59 min' depth='16.355 m' heartbeat='88' />
+  <sample time='36:01 min' depth='16.473 m' tts='5:39 min' />
+  <sample time='36:02 min' depth='16.335 m' pressure='197.46 bar' tts='5:38 min' />
+  <sample time='36:03 min' depth='16.255 m' tts='5:37 min' />
+  <sample time='36:04 min' depth='16.223 m' tts='5:36 min' />
+  <sample time='36:06 min' depth='16.264 m' heartbeat='87' />
+  <sample time='36:07 min' depth='16.271 m' stoptime='4:37 min' />
+  <sample time='36:08 min' depth='16.372 m' tts='5:37 min' />
+  <sample time='36:09 min' depth='16.133 m' tts='5:35 min' />
+  <sample time='36:12 min' depth='16.123 m' pressure='197.46 bar' heartbeat='88' />
+  <sample time='36:13 min' depth='16.126 m' />
+  <sample time='36:15 min' depth='15.887 m' tts='5:34 min' />
+  <sample time='36:16 min' depth='15.581 m' tts='5:32 min' heartbeat='89' />
+  <sample time='36:17 min' depth='15.58 m' pressure='197.46 bar' stoptime='4:36 min' heartbeat='90' />
+  <sample time='36:18 min' depth='15.904 m' tts='5:33 min' />
+  <sample time='36:19 min' depth='15.993 m' heartbeat='91' />
+  <sample time='36:20 min' depth='16.018 m' tts='5:34 min' />
+  <sample time='36:23 min' depth='16.173 m' heartbeat='92' />
+  <sample time='36:24 min' depth='16.101 m' tts='5:33 min' />
+  <sample time='36:25 min' depth='15.932 m' tts='5:32 min' />
+  <sample time='36:26 min' depth='15.808 m' tts='5:31 min' stoptime='4:35 min' />
+  <sample time='36:27 min' depth='15.852 m' pressure='197.39 bar' tts='5:32 min' heartbeat='93' />
+  <sample time='36:28 min' depth='15.916 m' />
+  <sample time='36:29 min' depth='16.075 m' tts='5:33 min' heartbeat='94' />
+  <sample time='36:32 min' depth='15.842 m' pressure='197.53 bar' tts='5:31 min' heartbeat='95' />
+  <sample time='36:33 min' depth='15.825 m' heartbeat='94' />
+  <sample time='36:34 min' depth='15.946 m' stoptime='4:34 min' />
+  <sample time='36:35 min' depth='15.858 m' heartbeat='95' />
+  <sample time='36:36 min' depth='15.77 m' tts='5:30 min' heartbeat='96' />
+  <sample time='36:37 min' depth='15.768 m' pressure='197.39 bar' heartbeat='95' />
+  <sample time='36:38 min' depth='15.86 m' tts='5:31 min' heartbeat='94' />
+  <sample time='36:39 min' depth='15.843 m' tts='5:30 min' />
+  <sample time='36:40 min' depth='15.906 m' tts='5:31 min' />
+  <sample time='36:41 min' depth='15.882 m' heartbeat='95' />
+  <sample time='36:42 min' depth='15.767 m' pressure='197.39 bar' tts='5:30 min' heartbeat='94' />
+  <sample time='36:43 min' depth='15.508 m' tts='5:28 min' stoptime='4:33 min' heartbeat='95' />
+  <sample time='36:44 min' depth='15.373 m' tts='5:27 min' />
+  <sample time='36:46 min' depth='15.255 m' tts='5:26 min' />
+  <sample time='36:47 min' depth='15.208 m' pressure='197.39 bar' tts='5:25 min' heartbeat='96' />
+  <sample time='36:48 min' depth='15.213 m' />
+  <sample time='36:49 min' depth='15.229 m' stoptime='4:32 min' cns='13%' />
+  <sample time='36:50 min' depth='15.144 m' />
+  <sample time='36:51 min' depth='15.077 m' tts='5:24 min' />
+  <sample time='36:52 min' depth='15.038 m' pressure='197.39 bar' heartbeat='95' />
+  <sample time='36:53 min' depth='14.977 m' heartbeat='94' />
+  <sample time='36:54 min' depth='14.986 m' tts='5:23 min' />
+  <sample time='36:55 min' depth='14.992 m' stoptime='4:31 min' heartbeat='93' />
+  <sample time='36:57 min' depth='15.069 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='36:58 min' depth='15.107 m' tts='5:24 min' />
+  <sample time='36:59 min' depth='15.172 m' tts='5:23 min' heartbeat='91' />
+  <sample time='37:00 min' depth='15.122 m' heartbeat='92' />
+  <sample time='37:01 min' depth='15.064 m' tts='5:22 min' stoptime='4:30 min' heartbeat='91' />
+  <sample time='37:02 min' depth='14.941 m' pressure='197.46 bar' />
+  <sample time='37:03 min' depth='14.781 m' tts='5:20 min' />
+  <sample time='37:04 min' depth='14.751 m' heartbeat='90' />
+  <sample time='37:05 min' depth='14.858 m' tts='5:21 min' heartbeat='89' />
+  <sample time='37:06 min' depth='14.903 m' tts='5:20 min' stoptime='4:29 min' />
+  <sample time='37:07 min' depth='14.896 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='37:08 min' depth='14.889 m' tts='5:20 min' heartbeat='88' />
+  <sample time='37:09 min' depth='15.014 m' tts='5:21 min' heartbeat='89' />
+  <sample time='37:10 min' depth='15.098 m' tts='5:22 min' heartbeat='88' />
+  <sample time='37:11 min' depth='15.133 m' tts='5:21 min' />
+  <sample time='37:12 min' depth='15.175 m' pressure='197.46 bar' stoptime='4:28 min' />
+  <sample time='37:13 min' depth='15.199 m' />
+  <sample time='37:14 min' depth='15.303 m' tts='5:22 min' />
+  <sample time='37:16 min' depth='15.291 m' tts='5:21 min' />
+  <sample time='37:17 min' depth='15.312 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='37:18 min' depth='15.333 m' tts='5:21 min' stoptime='4:27 min' />
+  <sample time='37:20 min' depth='15.407 m' tts='5:22 min' heartbeat='89' />
+  <sample time='37:21 min' depth='15.348 m' tts='5:21 min' />
+  <sample time='37:22 min' depth='15.307 m' heartbeat='88' />
+  <sample time='37:24 min' depth='15.177 m' tts='5:20 min' />
+  <sample time='37:25 min' depth='15.226 m' stoptime='4:26 min' />
+  <sample time='37:26 min' depth='15.233 m' heartbeat='89' />
+  <sample time='37:27 min' depth='15.233 m' pressure='197.46 bar' heartbeat='88' />
+  <sample time='37:30 min' depth='15.301 m' tts='5:21 min' />
+  <sample time='37:31 min' depth='15.311 m' stoptime='4:25 min' />
+  <sample time='37:32 min' depth='15.281 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='37:34 min' depth='15.222 m' tts='5:20 min' />
+  <sample time='37:35 min' depth='15.207 m' heartbeat='87' />
+  <sample time='37:36 min' depth='15.249 m' tts='5:21 min' />
+  <sample time='37:37 min' depth='15.216 m' pressure='197.53 bar' tts='0:00 min' />
+  <sample time='37:38 min' depth='15.182 m' tts='5:20 min' stoptime='4:24 min' />
+  <sample time='37:40 min' depth='15.065 m' tts='5:19 min' />
+  <sample time='37:41 min' depth='15.086 m' heartbeat='86' />
+  <sample time='37:42 min' depth='15.076 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='37:43 min' depth='15.066 m' tts='5:20 min' />
+  <sample time='37:44 min' depth='15.006 m' stoptime='4:23 min' heartbeat='85' />
+  <sample time='37:45 min' depth='14.925 m' tts='5:19 min' />
+  <sample time='37:46 min' depth='14.87 m' heartbeat='84' />
+  <sample time='37:47 min' depth='14.827 m' pressure='197.46 bar' tts='0:00 min' />
+  <sample time='37:48 min' depth='14.784 m' tts='5:19 min' />
+  <sample time='37:49 min' depth='14.787 m' stoptime='4:22 min' />
+  <sample time='37:51 min' depth='14.767 m' tts='5:18 min' />
+  <sample time='37:52 min' depth='14.683 m' pressure='197.46 bar' />
+  <sample time='37:54 min' depth='14.625 m' tts='5:17 min' stoptime='4:21 min' />
+  <sample time='37:56 min' depth='14.575 m' />
+  <sample time='37:57 min' depth='14.593 m' pressure='197.39 bar' heartbeat='85' />
+  <sample time='37:58 min' depth='14.611 m' />
+  <sample time='37:59 min' depth='14.841 m' tts='5:19 min' stoptime='4:20 min' heartbeat='84' />
+  <sample time='38:00 min' depth='14.727 m' tts='5:18 min' heartbeat='85' />
+  <sample time='38:01 min' depth='14.668 m' heartbeat='84' />
+  <sample time='38:02 min' depth='14.472 m' pressure='197.46 bar' tts='5:16 min' />
+  <sample time='38:03 min' depth='14.778 m' tts='5:18 min' heartbeat='83' />
+  <sample time='38:04 min' depth='14.561 m' tts='5:17 min' heartbeat='84' />
+  <sample time='38:05 min' depth='14.659 m' tts='5:18 min' heartbeat='85' />
+  <sample time='38:06 min' depth='14.709 m' heartbeat='86' />
+  <sample time='38:07 min' depth='14.747 m' heartbeat='88' />
+  <sample time='38:08 min' depth='14.938 m' tts='5:20 min' heartbeat='93' />
+  <sample time='38:09 min' depth='15.229 m' tts='5:21 min' heartbeat='95' />
+  <sample time='38:10 min' depth='15.116 m' heartbeat='99' />
+  <sample time='38:11 min' depth='15.215 m' heartbeat='102' />
+  <sample time='38:12 min' depth='15.352 m' pressure='197.46 bar' tts='5:22 min' />
+  <sample time='38:13 min' depth='15.429 m' tts='5:23 min' heartbeat='104' />
+  <sample time='38:14 min' depth='15.402 m' heartbeat='105' />
+  <sample time='38:15 min' depth='15.478 m' />
+  <sample time='38:16 min' depth='15.618 m' tts='5:24 min' />
+  <sample time='38:17 min' depth='15.592 m' pressure='197.39 bar' tts='0:00 min' />
+  <sample time='38:18 min' depth='15.565 m' tts='5:24 min' />
+  <sample time='38:19 min' depth='15.398 m' tts='5:23 min' heartbeat='104' />
+  <sample time='38:20 min' depth='15.391 m' tts='5:22 min' stoptime='4:21 min' heartbeat='103' />
+  <sample time='38:21 min' depth='15.461 m' tts='5:23 min' />
+  <sample time='38:22 min' depth='15.547 m' pressure='196.98 bar' tts='5:30 min' stoptime='4:25 min' />
+  <sample time='38:23 min' depth='15.632 m' />
+  <sample time='38:24 min' depth='15.675 m' tts='5:31 min' heartbeat='102' />
+  <sample time='38:25 min' depth='15.684 m' heartbeat='101' />
+  <sample time='38:27 min' depth='15.707 m' pressure='196.63 bar' tts='5:32 min' stoptime='4:26 min' />
+  <sample time='38:28 min' depth='15.734 m' />
+  <sample time='38:30 min' depth='15.876 m' tts='5:33 min' />
+  <sample time='38:32 min' depth='15.91 m' tts='5:34 min' heartbeat='100' />
+  <sample time='38:33 min' depth='15.996 m' />
+  <sample time='38:34 min' depth='15.891 m' />
+  <sample time='38:35 min' depth='15.944 m' stoptime='4:27 min' />
+  <sample time='38:36 min' depth='16.148 m' tts='5:35 min' />
+  <sample time='38:37 min' depth='16.304 m' pressure='195.05 bar' tts='5:37 min' />
+  <sample time='38:38 min' depth='16.223 m' />
+  <sample time='38:39 min' depth='16.374 m' tts='5:38 min' />
+  <sample time='38:40 min' depth='16.478 m' tts='5:39 min' />
+  <sample time='38:41 min' depth='16.433 m' stoptime='4:28 min' />
+  <sample time='38:42 min' depth='16.513 m' pressure='194.98 bar' tts='5:40 min' heartbeat='102' />
+  <sample time='38:43 min' depth='16.603 m' heartbeat='100' />
+  <sample time='38:45 min' depth='16.64 m' tts='5:42 min' />
+  <sample time='38:46 min' depth='16.639 m' stoptime='4:29 min' heartbeat='99' />
+  <sample time='38:47 min' depth='16.685 m' pressure='194.22 bar' heartbeat='100' />
+  <sample time='38:48 min' depth='16.677 m' />
+  <sample time='38:50 min' depth='16.682 m' tts='5:43 min' heartbeat='101' />
+  <sample time='38:51 min' depth='16.641 m' stoptime='4:30 min' />
+  <sample time='38:52 min' depth='16.57 m' pressure='193.26 bar' tts='5:42 min' />
+  <sample time='38:53 min' depth='16.577 m' heartbeat='102' />
+  <sample time='38:54 min' depth='16.661 m' tts='5:43 min' />
+  <sample time='38:55 min' depth='16.699 m' tts='5:44 min' heartbeat='103' />
+  <sample time='38:56 min' depth='16.638 m' stoptime='4:31 min' />
+  <sample time='38:57 min' depth='16.438 m' pressure='193.19 bar' tts='5:42 min' />
+  <sample time='38:58 min' depth='16.499 m' tts='5:43 min' />
+  <sample time='38:59 min' depth='16.565 m' heartbeat='106' />
+  <sample time='39:00 min' depth='16.56 m' heartbeat='104' />
+  <sample time='39:01 min' depth='16.547 m' tts='5:44 min' />
+  <sample time='39:02 min' depth='16.496 m' stoptime='4:32 min' />
+  <sample time='39:03 min' depth='16.476 m' heartbeat='105' />
+  <sample time='39:04 min' depth='16.389 m' tts='5:43 min' />
+  <sample time='39:05 min' depth='16.28 m' tts='5:42 min' />
+  <sample time='39:07 min' depth='16.279 m' stoptime='4:33 min' />
+  <sample time='39:08 min' depth='16.172 m' heartbeat='106' />
+  <sample time='39:10 min' depth='16.06 m' tts='5:41 min' heartbeat='105' />
+  <sample time='39:11 min' depth='16.071 m' tts='5:42 min' />
+  <sample time='39:12 min' depth='15.893 m' tts='5:41 min' heartbeat='104' />
+  <sample time='39:13 min' depth='15.695 m' tts='5:39 min' />
+  <sample time='39:14 min' depth='15.58 m' stoptime='4:34 min' heartbeat='105' />
+  <sample time='39:17 min' depth='15.547 m' heartbeat='104' />
+  <sample time='39:18 min' depth='15.48 m' tts='5:38 min' heartbeat='105' />
+  <sample time='39:20 min' depth='15.407 m' heartbeat='104' />
+  <sample time='39:21 min' depth='15.429 m' heartbeat='105' />
+  <sample time='39:22 min' depth='15.337 m' pressure='190.36 bar' tts='5:37 min' heartbeat='104' />
+  <sample time='39:23 min' depth='15.358 m' heartbeat='105' />
+  <sample time='39:24 min' depth='15.359 m' heartbeat='106' />
+  <sample time='39:25 min' depth='15.255 m' stoptime='4:35 min' />
+  <sample time='39:26 min' depth='15.19 m' tts='5:36 min' />
+  <sample time='39:28 min' depth='15.137 m' tts='5:37 min' heartbeat='105' />
+  <sample time='39:29 min' depth='15.18 m' heartbeat='106' />
+  <sample time='39:30 min' depth='15.425 m' tts='5:39 min' />
+  <sample time='39:31 min' depth='15.402 m' heartbeat='107' />
+  <sample time='39:32 min' depth='15.483 m' pressure='189.88 bar' heartbeat='108' />
+  <sample time='39:33 min' depth='15.452 m' heartbeat='109' />
+  <sample time='39:35 min' depth='15.619 m' tts='5:40 min' heartbeat='111' />
+  <sample time='39:36 min' depth='15.767 m' tts='5:42 min' />
+  <sample time='39:37 min' depth='15.851 m' pressure='189.26 bar' tts='5:43 min' stoptime='4:36 min' heartbeat='112' />
+  <sample time='39:38 min' depth='15.996 m' heartbeat='113' />
+  <sample time='39:39 min' depth='16.122 m' tts='5:44 min' heartbeat='114' />
+  <sample time='39:40 min' depth='16.177 m' tts='5:46 min' heartbeat='115' />
+  <sample time='39:41 min' depth='16.344 m' tts='5:47 min' />
+  <sample time='39:42 min' depth='16.462 m' pressure='189.26 bar' tts='5:48 min' heartbeat='116' />
+  <sample time='39:43 min' depth='16.623 m' tts='5:50 min' />
+  <sample time='39:44 min' depth='16.784 m' tts='5:51 min' stoptime='4:37 min' />
+  <sample time='39:45 min' depth='16.903 m' heartbeat='114' />
+  <sample time='39:46 min' depth='16.821 m' heartbeat='112' />
+  <sample time='39:47 min' depth='16.814 m' pressure='188.36 bar' tts='5:52 min' />
+  <sample time='39:48 min' depth='16.884 m' stoptime='4:38 min' />
+  <sample time='39:49 min' depth='16.861 m' heartbeat='111' />
+  <sample time='39:50 min' depth='16.825 m' heartbeat='115' />
+  <sample time='39:51 min' depth='16.871 m' heartbeat='114' />
+  <sample time='39:52 min' depth='16.94 m' pressure='187.46 bar' tts='5:54 min' />
+  <sample time='39:53 min' depth='16.924 m' stoptime='4:39 min' heartbeat='113' />
+  <sample time='39:54 min' depth='16.925 m' heartbeat='114' />
+  <sample time='39:56 min' depth='16.892 m' heartbeat='112' />
+  <sample time='39:57 min' depth='16.866 m' pressure='187.6 bar' heartbeat='111' />
+  <sample time='39:58 min' depth='16.893 m' stoptime='4:40 min' heartbeat='109' />
+  <sample time='39:59 min' depth='16.825 m' heartbeat='111' />
+  <sample time='40:00 min' depth='16.719 m' tts='5:53 min' heartbeat='110' />
+  <sample time='40:02 min' depth='16.609 m' pressure='187.05 bar' tts='5:52 min' stoptime='4:41 min' heartbeat='109' />
+  <sample time='40:03 min' depth='16.623 m' tts='5:54 min' heartbeat='108' />
+  <sample time='40:04 min' depth='16.687 m' heartbeat='107' />
+  <sample time='40:05 min' depth='16.746 m' heartbeat='108' />
+  <sample time='40:06 min' depth='16.723 m' heartbeat='106' />
+  <sample time='40:07 min' depth='16.764 m' tts='5:56 min' heartbeat='107' />
+  <sample time='40:08 min' depth='16.75 m' tts='5:55 min' stoptime='4:42 min' heartbeat='106' />
+  <sample time='40:11 min' depth='16.774 m' tts='5:56 min' heartbeat='105' />
+  <sample time='40:12 min' depth='16.897 m' tts='5:57 min' stoptime='4:43 min' />
+  <sample time='40:13 min' depth='16.978 m' tts='5:58 min' />
+  <sample time='40:14 min' depth='16.891 m' tts='5:57 min' heartbeat='104' />
+  <sample time='40:15 min' depth='16.898 m' heartbeat='103' />
+  <sample time='40:16 min' depth='16.826 m' heartbeat='105' />
+  <sample time='40:17 min' depth='16.817 m' pressure='185.6 bar' tts='5:58 min' stoptime='4:44 min' heartbeat='101' />
+  <sample time='40:18 min' depth='16.732 m' tts='5:57 min' heartbeat='103' />
+  <sample time='40:19 min' depth='16.669 m' heartbeat='102' />
+  <sample time='40:21 min' depth='16.894 m' tts='5:59 min' />
+  <sample time='40:22 min' depth='17.015 m' pressure='184.64 bar' tts='6:00 min' stoptime='4:45 min' />
+  <sample time='40:23 min' depth='17.004 m' />
+  <sample time='40:25 min' depth='16.906 m' tts='5:59 min' />
+  <sample time='40:26 min' depth='16.807 m' tts='6:00 min' />
+  <sample time='40:27 min' depth='16.681 m' pressure='184.91 bar' tts='5:59 min' stoptime='4:46 min' />
+  <sample time='40:28 min' depth='16.679 m' />
+  <sample time='40:31 min' depth='16.765 m' tts='6:00 min' />
+  <sample time='40:32 min' depth='16.806 m' pressure='184.15 bar' tts='6:01 min' stoptime='4:47 min' heartbeat='101' />
+  <sample time='40:33 min' depth='16.819 m' heartbeat='100' />
+  <sample time='40:34 min' depth='16.802 m' heartbeat='99' />
+  <sample time='40:35 min' depth='16.725 m' tts='6:00 min' heartbeat='98' />
+  <sample time='40:36 min' depth='16.743 m' heartbeat='96' />
+  <sample time='40:37 min' depth='16.706 m' pressure='184.29 bar' stoptime='4:48 min' heartbeat='95' />
+  <sample time='40:38 min' depth='16.697 m' tts='6:01 min' heartbeat='94' />
+  <sample time='40:39 min' depth='16.732 m' heartbeat='93' />
+  <sample time='40:40 min' depth='16.79 m' tts='6:02 min' heartbeat='92' />
+  <sample time='40:41 min' depth='16.84 m' />
+  <sample time='40:42 min' depth='16.837 m' tts='6:03 min' stoptime='4:49 min' heartbeat='91' />
+  <sample time='40:45 min' depth='16.941 m' tts='6:04 min' />
+  <sample time='40:46 min' depth='16.969 m' tts='6:05 min' />
+  <sample time='40:47 min' depth='16.981 m' pressure='183.12 bar' stoptime='4:50 min' />
+  <sample time='40:48 min' depth='16.944 m' />
+  <sample time='40:49 min' depth='16.871 m' tts='6:04 min' />
+  <sample time='40:50 min' depth='16.823 m' />
+  <sample time='40:51 min' depth='16.832 m' stoptime='4:51 min' />
+  <sample time='40:52 min' depth='16.895 m' pressure='182.84 bar' tts='6:05 min' />
+  <sample time='40:53 min' depth='16.998 m' tts='6:06 min' heartbeat='92' />
+  <sample time='40:54 min' depth='17.002 m' heartbeat='91' />
+  <sample time='40:56 min' depth='16.808 m' tts='6:05 min' stoptime='4:52 min' />
+  <sample time='40:57 min' depth='16.823 m' pressure='182.57 bar' tts='6:06 min' />
+  <sample time='40:58 min' depth='16.752 m' tts='6:05 min' />
+  <sample time='40:59 min' depth='16.654 m' heartbeat='92' />
+  <sample time='41:01 min' depth='16.584 m' tts='6:04 min' stoptime='4:53 min' />
+  <sample time='41:02 min' depth='16.646 m' pressure='182.5 bar' tts='6:05 min' />
+  <sample time='41:03 min' depth='16.782 m' tts='6:07 min' />
+  <sample time='41:06 min' depth='16.902 m' tts='6:08 min' stoptime='4:54 min' />
+  <sample time='41:07 min' depth='16.954 m' pressure='182.43 bar' tts='6:09 min' />
+  <sample time='41:08 min' depth='16.987 m' />
+  <sample time='41:09 min' depth='17.036 m' />
+  <sample time='41:10 min' depth='17.044 m' tts='6:10 min' />
+  <sample time='41:11 min' depth='17.01 m' stoptime='4:55 min' heartbeat='91' />
+  <sample time='41:12 min' depth='16.956 m' pressure='181.53 bar' tts='0:00 min' />
+  <sample time='41:13 min' depth='16.901 m' tts='6:09 min' heartbeat='90' />
+  <sample time='41:14 min' depth='16.677 m' tts='6:08 min' />
+  <sample time='41:16 min' depth='16.964 m' tts='6:11 min' stoptime='4:56 min' heartbeat='89' />
+  <sample time='41:17 min' depth='16.918 m' pressure='180.91 bar' tts='0:00 min' />
+  <sample time='41:18 min' depth='16.871 m' tts='6:10 min' />
+  <sample time='41:19 min' depth='16.894 m' heartbeat='88' />
+  <sample time='41:20 min' depth='16.86 m' stoptime='4:57 min' />
+  <sample time='41:22 min' depth='16.688 m' pressure='181.12 bar' heartbeat='87' />
+  <sample time='41:23 min' depth='16.693 m' />
+  <sample time='41:25 min' depth='16.665 m' heartbeat='86' />
+  <sample time='41:26 min' depth='16.61 m' tts='6:09 min' stoptime='4:58 min' heartbeat='85' />
+  <sample time='41:27 min' depth='16.523 m' pressure='180.64 bar' heartbeat='84' />
+  <sample time='41:28 min' depth='16.65 m' tts='6:11 min' />
+  <sample time='41:29 min' depth='16.808 m' tts='6:12 min' heartbeat='83' />
+  <sample time='41:31 min' depth='16.845 m' stoptime='4:59 min' />
+  <sample time='41:32 min' depth='16.919 m' pressure='180.64 bar' tts='6:14 min' />
+  <sample time='41:33 min' depth='16.943 m' />
+  <sample time='41:35 min' depth='16.914 m' tts='6:13 min' />
+  <sample time='41:36 min' depth='16.844 m' stoptime='5:00 min' />
+  <sample time='41:37 min' depth='16.802 m' pressure='179.81 bar' tts='6:14 min' />
+  <sample time='41:38 min' depth='16.808 m' heartbeat='82' />
+  <sample time='41:39 min' depth='16.734 m' tts='6:13 min' cns='14%' />
+  <sample time='41:41 min' depth='16.701 m' stoptime='5:01 min' />
+  <sample time='41:42 min' depth='16.825 m' pressure='179.19 bar' tts='6:15 min' />
+  <sample time='41:43 min' depth='16.934 m' tts='6:16 min' />
+  <sample time='41:44 min' depth='16.946 m' heartbeat='81' />
+  <sample time='41:45 min' depth='16.991 m' heartbeat='82' />
+  <sample time='41:46 min' depth='17.029 m' tts='6:17 min' stoptime='5:02 min' />
+  <sample time='41:47 min' depth='17.06 m' pressure='178.5 bar' />
+  <sample time='41:48 min' depth='17.079 m' tts='6:18 min' heartbeat='83' />
+  <sample time='41:49 min' depth='17.051 m' tts='6:17 min' heartbeat='84' />
+  <sample time='41:50 min' depth='16.982 m' heartbeat='85' />
+  <sample time='41:51 min' depth='16.924 m' tts='6:18 min' stoptime='5:03 min' heartbeat='86' />
+  <sample time='41:52 min' depth='16.866 m' pressure='178.57 bar' tts='6:17 min' />
+  <sample time='41:53 min' depth='16.847 m' />
+  <sample time='41:55 min' depth='16.773 m' />
+  <sample time='41:56 min' depth='16.638 m' tts='6:16 min' stoptime='5:04 min' />
+  <sample time='41:57 min' depth='16.407 m' tts='6:14 min' />
+  <sample time='41:58 min' depth='16.16 m' tts='6:13 min' />
+  <sample time='41:59 min' depth='16.037 m' tts='6:12 min' />
+  <sample time='42:00 min' depth='15.933 m' tts='6:11 min' />
+  <sample time='42:01 min' depth='15.928 m' heartbeat='85' />
+  <sample time='42:03 min' depth='15.914 m' stoptime='5:05 min' />
+  <sample time='42:04 min' depth='15.815 m' tts='6:10 min' />
+  <sample time='42:05 min' depth='15.667 m' tts='6:09 min' />
+  <sample time='42:07 min' depth='15.614 m' tts='6:10 min' />
+  <sample time='42:08 min' depth='15.679 m' heartbeat='86' />
+  <sample time='42:09 min' depth='15.516 m' tts='6:09 min' heartbeat='87' />
+  <sample time='42:10 min' depth='15.471 m' heartbeat='88' />
+  <sample time='42:12 min' depth='15.407 m' pressure='177.33 bar' heartbeat='89' />
+  <sample time='42:13 min' depth='15.326 m' tts='6:08 min' stoptime='5:06 min' />
+  <sample time='42:14 min' depth='15.258 m' />
+  <sample time='42:15 min' depth='15.265 m' heartbeat='90' />
+  <sample time='42:16 min' depth='15.186 m' tts='6:07 min' />
+  <sample time='42:17 min' depth='15.085 m' pressure='176.78 bar' tts='6:06 min' />
+  <sample time='42:18 min' depth='15.164 m' tts='6:07 min' />
+  <sample time='42:19 min' depth='15.079 m' tts='6:06 min' />
+  <sample time='42:21 min' depth='14.998 m' heartbeat='91' />
+  <sample time='42:22 min' depth='14.92 m' pressure='177.05 bar' tts='6:05 min' heartbeat='90' />
+  <sample time='42:23 min' depth='14.918 m' />
+  <sample time='42:24 min' depth='14.869 m' heartbeat='91' />
+  <sample time='42:25 min' depth='14.882 m' heartbeat='92' />
+  <sample time='42:26 min' depth='14.933 m' heartbeat='90' />
+  <sample time='42:27 min' depth='14.886 m' pressure='176.5 bar' heartbeat='93' />
+  <sample time='42:28 min' depth='14.793 m' />
+  <sample time='42:29 min' depth='14.745 m' tts='6:04 min' heartbeat='94' />
+  <sample time='42:30 min' depth='14.69 m' />
+  <sample time='42:31 min' depth='14.631 m' heartbeat='95' />
+  <sample time='42:32 min' depth='14.616 m' pressure='176.71 bar' tts='6:03 min' />
+  <sample time='42:33 min' depth='14.583 m' />
+  <sample time='42:34 min' depth='14.564 m' heartbeat='96' />
+  <sample time='42:35 min' depth='14.579 m' heartbeat='97' />
+  <sample time='42:37 min' depth='14.351 m' pressure='176.16 bar' tts='6:02 min' heartbeat='96' />
+  <sample time='42:38 min' depth='14.298 m' tts='6:01 min' heartbeat='95' />
+  <sample time='42:39 min' depth='14.362 m' tts='6:02 min' heartbeat='96' />
+  <sample time='42:42 min' depth='14.413 m' pressure='175.74 bar' tts='0:00 min' />
+  <sample time='42:43 min' depth='14.43 m' tts='6:02 min' heartbeat='95' />
+  <sample time='42:45 min' depth='14.283 m' tts='6:01 min' />
+  <sample time='42:46 min' depth='14.144 m' tts='6:00 min' />
+  <sample time='42:47 min' depth='14.037 m' pressure='175.74 bar' />
+  <sample time='42:48 min' depth='13.926 m' tts='5:59 min' />
+  <sample time='42:49 min' depth='13.836 m' tts='5:58 min' />
+  <sample time='42:50 min' depth='13.77 m' heartbeat='94' />
+  <sample time='42:51 min' depth='13.597 m' tts='5:57 min' />
+  <sample time='42:52 min' depth='13.498 m' pressure='175.33 bar' tts='0:00 min' />
+  <sample time='42:53 min' depth='13.399 m' tts='5:55 min' />
+  <sample time='42:54 min' depth='13.395 m' stoptime='5:05 min' />
+  <sample time='42:55 min' depth='13.42 m' tts='5:56 min' heartbeat='93' />
+  <sample time='42:57 min' depth='13.629 m' pressure='174.71 bar' tts='5:57 min' />
+  <sample time='42:58 min' depth='13.542 m' tts='5:56 min' heartbeat='94' />
+  <sample time='42:59 min' depth='13.477 m' tts='5:55 min' heartbeat='95' />
+  <sample time='43:00 min' depth='13.304 m' tts='5:54 min' heartbeat='94' />
+  <sample time='43:01 min' depth='13.234 m' tts='5:53 min' />
+  <sample time='43:02 min' depth='13.202 m' pressure='174.92 bar' />
+  <sample time='43:03 min' depth='13.119 m' />
+  <sample time='43:04 min' depth='13.091 m' tts='5:52 min' stoptime='5:04 min' />
+  <sample time='43:05 min' depth='13.127 m' tts='5:53 min' heartbeat='93' />
+  <sample time='43:07 min' depth='13.112 m' pressure='174.36 bar' tts='0:00 min' />
+  <sample time='43:08 min' depth='13.104 m' tts='5:52 min' />
+  <sample time='43:10 min' depth='12.956 m' heartbeat='94' />
+  <sample time='43:11 min' depth='12.962 m' tts='5:51 min' stoptime='5:03 min' />
+  <sample time='43:12 min' depth='13.084 m' pressure='174.57 bar' />
+  <sample time='43:13 min' depth='13.152 m' tts='5:52 min' heartbeat='95' />
+  <sample time='43:14 min' depth='13.249 m' />
+  <sample time='43:15 min' depth='13.399 m' tts='5:53 min' heartbeat='94' />
+  <sample time='43:17 min' depth='13.459 m' pressure='174.02 bar' heartbeat='93' />
+  <sample time='43:18 min' depth='13.469 m' heartbeat='92' />
+  <sample time='43:19 min' depth='13.465 m' heartbeat='91' />
+  <sample time='43:21 min' depth='13.374 m' tts='5:52 min' stoptime='5:02 min' heartbeat='90' />
+  <sample time='43:22 min' depth='13.421 m' pressure='174.23 bar' tts='5:53 min' heartbeat='89' />
+  <sample time='43:23 min' depth='13.42 m' />
+  <sample time='43:24 min' depth='13.507 m' heartbeat='88' />
+  <sample time='43:27 min' depth='13.51 m' pressure='173.47 bar' tts='5:52 min' />
+  <sample time='43:28 min' depth='13.456 m' />
+  <sample time='43:29 min' depth='13.484 m' heartbeat='87' />
+  <sample time='43:30 min' depth='13.525 m' heartbeat='86' />
+  <sample time='43:31 min' depth='13.517 m' heartbeat='85' />
+  <sample time='43:32 min' depth='13.538 m' pressure='173.05 bar' stoptime='5:01 min' />
+  <sample time='43:33 min' depth='13.654 m' tts='5:53 min' heartbeat='84' />
+  <sample time='43:37 min' depth='13.716 m' pressure='173.19 bar' tts='5:52 min' />
+  <sample time='43:38 min' depth='13.626 m' />
+  <sample time='43:39 min' depth='13.677 m' heartbeat='85' />
+  <sample time='43:40 min' depth='13.805 m' tts='5:53 min' heartbeat='86' />
+  <sample time='43:41 min' depth='13.987 m' tts='5:54 min' heartbeat='85' />
+  <sample time='43:42 min' depth='14.057 m' pressure='172.57 bar' tts='5:55 min' heartbeat='86' />
+  <sample time='43:43 min' depth='14.126 m' heartbeat='87' />
+  <sample time='43:44 min' depth='14.185 m' tts='5:56 min' heartbeat='88' />
+  <sample time='43:47 min' depth='14.164 m' pressure='172.5 bar' tts='0:00 min' />
+  <sample time='43:48 min' depth='14.157 m' tts='5:55 min' />
+  <sample time='43:50 min' depth='14.109 m' stoptime='5:00 min' heartbeat='87' />
+  <sample time='43:51 min' depth='14.128 m' heartbeat='86' />
+  <sample time='43:52 min' depth='14.068 m' pressure='171.95 bar' heartbeat='85' />
+  <sample time='43:53 min' depth='14.015 m' tts='5:54 min' />
+  <sample time='43:55 min' depth='14.102 m' tts='5:55 min' />
+  <sample time='43:56 min' depth='14.156 m' />
+  <sample time='43:58 min' depth='14.159 m' tts='5:54 min' />
+  <sample time='43:59 min' depth='14.049 m' />
+  <sample time='44:00 min' depth='13.929 m' tts='5:53 min' heartbeat='84' />
+  <sample time='44:01 min' depth='14.03 m' tts='5:54 min' heartbeat='85' />
+  <sample time='44:02 min' depth='14.159 m' />
+  <sample time='44:03 min' depth='14.191 m' tts='5:55 min' heartbeat='84' />
+  <sample time='44:04 min' depth='14.261 m' />
+  <sample time='44:08 min' depth='14.173 m' tts='5:54 min' />
+  <sample time='44:09 min' depth='14.189 m' tts='5:55 min' heartbeat='85' />
+  <sample time='44:11 min' depth='14.41 m' tts='5:56 min' />
+  <sample time='44:12 min' depth='14.397 m' pressure='170.16 bar' heartbeat='86' />
+  <sample time='44:13 min' depth='14.326 m' />
+  <sample time='44:14 min' depth='14.249 m' tts='5:55 min' heartbeat='87' />
+  <sample time='44:17 min' depth='14.182 m' pressure='170.36 bar' tts='0:00 min' />
+  <sample time='44:18 min' depth='14.159 m' tts='5:54 min' />
+  <sample time='44:19 min' depth='14.128 m' />
+  <sample time='44:21 min' depth='13.974 m' tts='5:53 min' />
+  <sample time='44:22 min' depth='13.699 m' pressure='169.68 bar' tts='5:51 min' stoptime='4:59 min' heartbeat='86' />
+  <sample time='44:23 min' depth='13.461 m' tts='5:50 min' heartbeat='87' />
+  <sample time='44:24 min' depth='13.383 m' tts='5:49 min' />
+  <sample time='44:26 min' depth='13.491 m' tts='5:50 min' />
+  <sample time='44:27 min' depth='13.444 m' pressure='169.95 bar' tts='0:00 min' />
+  <sample time='44:28 min' depth='13.397 m' tts='5:49 min' />
+  <sample time='44:31 min' depth='13.41 m' tts='5:48 min' />
+  <sample time='44:32 min' depth='13.337 m' pressure='169.19 bar' />
+  <sample time='44:33 min' depth='13.206 m' tts='5:47 min' stoptime='4:58 min' />
+  <sample time='44:34 min' depth='13.105 m' tts='5:46 min' heartbeat='86' />
+  <sample time='44:36 min' depth='12.983 m' />
+  <sample time='44:37 min' depth='12.923 m' pressure='168.92 bar' tts='5:45 min' />
+  <sample time='44:38 min' depth='12.802 m' />
+  <sample time='44:39 min' depth='12.626 m' tts='5:43 min' />
+  <sample time='44:40 min' depth='12.676 m' tts='5:44 min' stoptime='4:57 min' />
+  <sample time='44:41 min' depth='12.778 m' tts='5:43 min' />
+  <sample time='44:42 min' depth='12.749 m' pressure='168.92 bar' tts='0:00 min' />
+  <sample time='44:43 min' depth='12.72 m' tts='5:43 min' />
+  <sample time='44:44 min' depth='12.879 m' tts='5:44 min' />
+  <sample time='44:45 min' depth='12.981 m' tts='5:45 min' />
+  <sample time='44:46 min' depth='12.997 m' tts='5:44 min' />
+  <sample time='44:47 min' depth='12.964 m' pressure='168.57 bar' stoptime='4:56 min' />
+  <sample time='44:48 min' depth='12.892 m' tts='5:43 min' />
+  <sample time='44:49 min' depth='12.857 m' heartbeat='87' />
+  <sample time='44:52 min' depth='12.921 m' pressure='168.71 bar' tts='0:00 min' />
+  <sample time='44:53 min' depth='12.942 m' tts='5:43 min' />
+  <sample time='44:54 min' depth='13.085 m' stoptime='4:55 min' />
+  <sample time='44:55 min' depth='13.254 m' tts='5:44 min' />
+  <sample time='44:56 min' depth='13.285 m' tts='5:45 min' />
+  <sample time='44:57 min' depth='13.18 m' pressure='168.16 bar' tts='5:44 min' />
+  <sample time='44:58 min' depth='12.996 m' tts='5:43 min' />
+  <sample time='44:59 min' depth='12.942 m' tts='5:42 min' />
+  <sample time='45:01 min' depth='12.964 m' tts='5:43 min' />
+  <sample time='45:02 min' depth='13.034 m' pressure='168.23 bar' tts='5:42 min' stoptime='4:54 min' heartbeat='86' />
+  <sample time='45:03 min' depth='13.175 m' tts='5:43 min' />
+  <sample time='45:04 min' depth='13.364 m' tts='5:44 min' />
+  <sample time='45:05 min' depth='13.413 m' tts='5:45 min' />
+  <sample time='45:06 min' depth='13.475 m' />
+  <sample time='45:07 min' depth='13.62 m' pressure='167.61 bar' />
+  <sample time='45:08 min' depth='13.704 m' heartbeat='85' />
+  <sample time='45:09 min' depth='13.797 m' tts='5:46 min' />
+  <sample time='45:11 min' depth='13.891 m' tts='5:47 min' />
+  <sample time='45:12 min' depth='13.922 m' pressure='167.33 bar' />
+  <sample time='45:13 min' depth='13.823 m' tts='5:46 min' />
+  <sample time='45:14 min' depth='13.71 m' tts='5:45 min' stoptime='4:53 min' />
+  <sample time='45:16 min' depth='13.77 m' tts='5:46 min' heartbeat='84' />
+  <sample time='45:17 min' depth='13.953 m' tts='5:47 min' />
+  <sample time='45:18 min' depth='14.101 m' tts='5:48 min' heartbeat='85' />
+  <sample time='45:20 min' depth='14.037 m' heartbeat='86' />
+  <sample time='45:21 min' depth='14.088 m' heartbeat='87' />
+  <sample time='45:22 min' depth='14.096 m' pressure='166.92 bar' heartbeat='88' />
+  <sample time='45:23 min' depth='14.188 m' heartbeat='89' />
+  <sample time='45:24 min' depth='14.298 m' heartbeat='90' />
+  <sample time='45:26 min' depth='14.133 m' tts='5:47 min' />
+  <sample time='45:27 min' depth='13.816 m' pressure='166.3 bar' tts='5:45 min' />
+  <sample time='45:28 min' depth='13.571 m' />
+  <sample time='45:29 min' depth='13.581 m' tts='5:44 min' />
+  <sample time='45:30 min' depth='13.71 m' />
+  <sample time='45:31 min' depth='13.657 m' heartbeat='89' />
+  <sample time='45:32 min' depth='13.402 m' pressure='166.43 bar' tts='5:42 min' />
+  <sample time='45:33 min' depth='13.246 m' tts='5:41 min' stoptime='4:52 min' heartbeat='88' />
+  <sample time='45:35 min' depth='13.509 m' tts='5:43 min' heartbeat='87' />
+  <sample time='45:36 min' depth='13.922 m' tts='5:46 min' />
+  <sample time='45:37 min' depth='14.031 m' pressure='166.71 bar' tts='5:47 min' heartbeat='86' />
+  <sample time='45:38 min' depth='14.26 m' tts='5:48 min' />
+  <sample time='45:40 min' depth='14.132 m' tts='5:47 min' />
+  <sample time='45:41 min' depth='14.386 m' tts='5:48 min' />
+  <sample time='45:42 min' depth='14.374 m' pressure='165.81 bar' tts='0:00 min' />
+  <sample time='45:43 min' depth='14.361 m' tts='5:48 min' />
+  <sample time='45:46 min' depth='14.23 m' tts='5:47 min' />
+  <sample time='45:47 min' depth='14.173 m' pressure='165.26 bar' heartbeat='87' />
+  <sample time='45:48 min' depth='14.189 m' />
+  <sample time='45:50 min' depth='14.233 m' heartbeat='88' />
+  <sample time='45:52 min' depth='14.188 m' pressure='164.78 bar' tts='0:00 min' />
+  <sample time='45:53 min' depth='14.166 m' tts='5:46 min' heartbeat='89' />
+  <sample time='45:55 min' depth='14.197 m' tts='5:47 min' heartbeat='88' />
+  <sample time='45:56 min' depth='14.262 m' heartbeat='87' />
+  <sample time='45:57 min' depth='14.357 m' tts='5:48 min' heartbeat='88' />
+  <sample time='45:58 min' depth='14.421 m' heartbeat='86' />
+  <sample time='45:59 min' depth='14.45 m' heartbeat='85' />
+  <sample time='46:00 min' depth='14.464 m' heartbeat='86' />
+  <sample time='46:01 min' depth='14.476 m' heartbeat='85' />
+  <sample time='46:02 min' depth='14.653 m' pressure='164.3 bar' tts='5:50 min' heartbeat='84' />
+  <sample time='46:03 min' depth='14.769 m' />
+  <sample time='46:04 min' depth='14.852 m' tts='5:51 min' />
+  <sample time='46:05 min' depth='14.897 m' />
+  <sample time='46:07 min' depth='15.012 m' tts='5:52 min' />
+  <sample time='46:08 min' depth='15.023 m' heartbeat='83' />
+  <sample time='46:11 min' depth='15.005 m' tts='5:53 min' />
+  <sample time='46:12 min' depth='15.06 m' pressure='163.75 bar' tts='0:00 min' />
+  <sample time='46:13 min' depth='15.115 m' tts='5:54 min' />
+  <sample time='46:16 min' depth='15.255 m' tts='5:55 min' />
+  <sample time='46:17 min' depth='15.263 m' pressure='163.06 bar' tts='0:00 min' />
+  <sample time='46:18 min' depth='15.271 m' tts='5:55 min' />
+  <sample time='46:19 min' depth='15.304 m' stoptime='4:53 min' />
+  <sample time='46:22 min' depth='15.436 m' pressure='162.5 bar' tts='0:00 min' />
+  <sample time='46:23 min' depth='15.48 m' tts='5:56 min' />
+  <sample time='46:24 min' depth='15.471 m' tts='5:57 min' />
+  <sample time='46:25 min' depth='15.544 m' heartbeat='84' />
+  <sample time='46:26 min' depth='15.61 m' tts='5:58 min' />
+  <sample time='46:27 min' depth='15.649 m' pressure='162.02 bar' tts='0:00 min' />
+  <sample time='46:28 min' depth='15.688 m' tts='5:58 min' />
+  <sample time='46:29 min' depth='15.628 m' heartbeat='85' />
+  <sample time='46:30 min' depth='15.496 m' tts='5:57 min' />
+  <sample time='46:31 min' depth='15.478 m' stoptime='4:54 min' />
+  <sample time='46:32 min' depth='15.512 m' pressure='161.88 bar' tts='0:00 min' />
+  <sample time='46:33 min' depth='15.545 m' tts='5:58 min' />
+  <sample time='46:34 min' depth='15.647 m' tts='5:59 min' />
+  <sample time='46:37 min' depth='15.691 m' pressure='161.26 bar' heartbeat='86' />
+  <sample time='46:38 min' depth='15.779 m' tts='6:00 min' />
+  <sample time='46:41 min' depth='15.812 m' stoptime='4:55 min' />
+  <sample time='46:42 min' depth='15.823 m' pressure='161.4 bar' tts='6:01 min' heartbeat='87' />
+  <sample time='46:43 min' depth='15.745 m' />
+  <sample time='46:44 min' depth='15.695 m' tts='6:00 min' />
+  <sample time='46:45 min' depth='15.842 m' tts='6:01 min' />
+  <sample time='46:46 min' depth='15.887 m' tts='6:02 min' />
+  <sample time='46:47 min' depth='15.931 m' pressure='160.71 bar' tts='0:00 min' />
+  <sample time='46:48 min' depth='15.975 m' tts='6:02 min' />
+  <sample time='46:49 min' depth='15.971 m' stoptime='4:56 min' />
+  <sample time='46:50 min' depth='15.966 m' tts='6:03 min' />
+  <sample time='46:51 min' depth='16.018 m' tts='6:04 min' />
+  <sample time='46:52 min' depth='16.002 m' pressure='160.23 bar' tts='0:00 min' />
+  <sample time='46:53 min' depth='15.987 m' tts='6:03 min' />
+  <sample time='46:57 min' depth='15.946 m' pressure='160.23 bar' stoptime='4:57 min' />
+  <sample time='46:58 min' depth='15.982 m' tts='6:04 min' />
+  <sample time='46:59 min' depth='15.999 m' heartbeat='86' />
+  <sample time='47:00 min' depth='16.078 m' tts='6:05 min' />
+  <sample time='47:01 min' depth='16.178 m' tts='6:06 min' />
+  <sample time='47:02 min' depth='16.299 m' pressure='159.4 bar' />
+  <sample time='47:03 min' depth='16.237 m' />
+  <sample time='47:04 min' depth='16.172 m' tts='6:07 min' />
+  <sample time='47:05 min' depth='16.14 m' tts='6:06 min' stoptime='4:58 min' heartbeat='85' />
+  <sample time='47:07 min' depth='16.081 m' pressure='159.61 bar' heartbeat='84' />
+  <sample time='47:08 min' depth='16.047 m' />
+  <sample time='47:09 min' depth='15.959 m' tts='6:05 min' cns='15%' />
+  <sample time='47:10 min' depth='15.906 m' />
+  <sample time='47:12 min' depth='15.982 m' pressure='159.26 bar' stoptime='4:59 min' />
+  <sample time='47:13 min' depth='15.906 m' heartbeat='83' />
+  <sample time='47:14 min' depth='15.866 m' tts='6:06 min' />
+  <sample time='47:15 min' depth='15.839 m' tts='6:05 min' heartbeat='84' />
+  <sample time='47:16 min' depth='15.94 m' tts='6:06 min' />
+  <sample time='47:17 min' depth='16.049 m' pressure='158.78 bar' tts='6:07 min' />
+  <sample time='47:18 min' depth='16.161 m' tts='6:08 min' />
+  <sample time='47:19 min' depth='16.253 m' tts='6:09 min' />
+  <sample time='47:20 min' depth='16.145 m' tts='6:08 min' stoptime='5:00 min' />
+  <sample time='47:21 min' depth='16.078 m' heartbeat='83' />
+  <sample time='47:22 min' depth='16.153 m' pressure='158.57 bar' tts='0:00 min' />
+  <sample time='47:23 min' depth='16.228 m' tts='6:09 min' />
+  <sample time='47:25 min' depth='16.355 m' tts='6:10 min' />
+  <sample time='47:26 min' depth='16.467 m' tts='6:12 min' heartbeat='82' />
+  <sample time='47:27 min' depth='16.424 m' pressure='157.75 bar' tts='6:11 min' stoptime='5:01 min' />
+  <sample time='47:28 min' depth='16.364 m' />
+  <sample time='47:29 min' depth='16.277 m' tts='6:10 min' />
+  <sample time='47:30 min' depth='16.208 m' />
+  <sample time='47:31 min' depth='16.066 m' tts='6:09 min' />
+  <sample time='47:32 min' depth='15.892 m' pressure='157.89 bar' tts='6:08 min' />
+  <sample time='47:33 min' depth='15.705 m' tts='6:07 min' />
+  <sample time='47:34 min' depth='15.556 m' tts='6:06 min' stoptime='5:02 min' />
+  <sample time='47:35 min' depth='15.371 m' tts='6:04 min' />
+  <sample time='47:36 min' depth='15.258 m' />
+  <sample time='47:37 min' depth='15.169 m' pressure='157.75 bar' tts='6:03 min' heartbeat='83' />
+  <sample time='47:38 min' depth='15.021 m' tts='6:02 min' />
+  <sample time='47:39 min' depth='14.88 m' tts='6:01 min' heartbeat='84' />
+  <sample time='47:41 min' depth='14.677 m' tts='6:00 min' heartbeat='85' />
+  <sample time='47:42 min' depth='14.43 m' pressure='157.82 bar' tts='5:58 min' />
+  <sample time='47:43 min' depth='14.339 m' />
+  <sample time='47:44 min' depth='14.326 m' />
+  <sample time='47:46 min' depth='14.356 m' heartbeat='86' />
+  <sample time='47:47 min' depth='14.558 m' pressure='157.33 bar' tts='5:59 min' />
+  <sample time='47:48 min' depth='14.711 m' tts='6:00 min' />
+  <sample time='47:49 min' depth='14.871 m' tts='6:01 min' />
+  <sample time='47:50 min' depth='14.897 m' heartbeat='85' />
+  <sample time='47:52 min' depth='14.971 m' pressure='157.33 bar' tts='6:02 min' />
+  <sample time='47:53 min' depth='15.053 m' />
+  <sample time='47:54 min' depth='15.115 m' tts='6:03 min' />
+  <sample time='47:55 min' depth='15.161 m' />
+  <sample time='47:56 min' depth='15.15 m' heartbeat='84' />
+  <sample time='47:57 min' depth='15.168 m' pressure='157.13 bar' tts='6:04 min' />
+  <sample time='47:58 min' depth='15.251 m' tts='6:05 min' />
+  <sample time='47:59 min' depth='15.284 m' />
+  <sample time='48:00 min' depth='15.422 m' tts='6:06 min' heartbeat='85' />
+  <sample time='48:01 min' depth='15.546 m' tts='6:07 min' heartbeat='82' />
+  <sample time='48:02 min' depth='15.597 m' pressure='156.44 bar' stoptime='5:03 min' heartbeat='86' />
+  <sample time='48:03 min' depth='15.657 m' heartbeat='83' />
+  <sample time='48:04 min' depth='15.711 m' tts='6:08 min' />
+  <sample time='48:06 min' depth='15.747 m' tts='6:09 min' />
+  <sample time='48:07 min' depth='15.65 m' tts='6:08 min' />
+  <sample time='48:09 min' depth='15.561 m' heartbeat='82' />
+  <sample time='48:10 min' depth='15.482 m' tts='6:07 min' />
+  <sample time='48:12 min' depth='15.517 m' pressure='156.3 bar' tts='0:00 min' />
+  <sample time='48:13 min' depth='15.535 m' tts='6:07 min' stoptime='5:04 min' />
+  <sample time='48:14 min' depth='15.597 m' tts='6:08 min' />
+  <sample time='48:16 min' depth='15.699 m' tts='6:09 min' />
+  <sample time='48:17 min' depth='15.642 m' pressure='155.68 bar' tts='6:08 min' />
+  <sample time='48:18 min' depth='15.524 m' tts='6:07 min' heartbeat='81' />
+  <sample time='48:19 min' depth='15.515 m' tts='6:08 min' />
+  <sample time='48:20 min' depth='15.563 m' tts='6:09 min' />
+  <sample time='48:21 min' depth='15.568 m' heartbeat='82' />
+  <sample time='48:22 min' depth='15.548 m' pressure='155.4 bar' tts='0:00 min' />
+  <sample time='48:23 min' depth='15.528 m' tts='6:08 min' heartbeat='83' />
+  <sample time='48:24 min' depth='15.488 m' stoptime='5:05 min' heartbeat='82' />
+  <sample time='48:25 min' depth='15.361 m' tts='6:07 min' />
+  <sample time='48:27 min' depth='15.261 m' pressure='155.2 bar' tts='0:00 min' />
+  <sample time='48:28 min' depth='15.211 m' tts='6:06 min' />
+  <sample time='48:30 min' depth='15.016 m' tts='6:05 min' />
+  <sample time='48:32 min' depth='14.883 m' pressure='154.92 bar' tts='6:04 min' heartbeat='83' />
+  <sample time='48:33 min' depth='14.779 m' tts='6:03 min' />
+  <sample time='48:35 min' depth='14.623 m' tts='6:02 min' />
+  <sample time='48:36 min' depth='14.454 m' tts='6:01 min' />
+  <sample time='48:37 min' depth='14.335 m' pressure='155.06 bar' />
+  <sample time='48:38 min' depth='14.317 m' tts='6:00 min' />
+  <sample time='48:39 min' depth='14.31 m' heartbeat='84' />
+  <sample time='48:40 min' depth='14.359 m' tts='6:01 min' />
+  <sample time='48:41 min' depth='14.291 m' tts='6:00 min' />
+  <sample time='48:42 min' depth='14.199 m' pressure='154.44 bar' />
+  <sample time='48:43 min' depth='14.197 m' heartbeat='85' />
+  <sample time='48:44 min' depth='14.107 m' tts='5:59 min' />
+  <sample time='48:46 min' depth='14.229 m' tts='6:00 min' />
+  <sample time='48:47 min' depth='14.304 m' pressure='153.95 bar' />
+  <sample time='48:48 min' depth='14.316 m' />
+  <sample time='48:51 min' depth='14.373 m' tts='6:01 min' />
+  <sample time='48:52 min' depth='14.444 m' pressure='153.89 bar' />
+  <sample time='48:53 min' depth='14.463 m' heartbeat='86' />
+  <sample time='48:54 min' depth='14.523 m' tts='6:02 min' heartbeat='85' />
+  <sample time='48:55 min' depth='14.553 m' />
+  <sample time='48:57 min' depth='14.576 m' pressure='153.47 bar' tts='0:00 min' />
+  <sample time='48:58 min' depth='14.588 m' tts='6:02 min' heartbeat='84' />
+  <sample time='49:01 min' depth='14.528 m' heartbeat='85' />
+  <sample time='49:02 min' depth='14.531 m' pressure='152.99 bar' heartbeat='84' />
+  <sample time='49:03 min' depth='14.512 m' />
+  <sample time='49:04 min' depth='14.473 m' tts='6:01 min' />
+  <sample time='49:05 min' depth='14.491 m' tts='6:03 min' />
+  <sample time='49:07 min' depth='14.525 m' pressure='152.64 bar' heartbeat='83' />
+  <sample time='49:08 min' depth='14.598 m' />
+  <sample time='49:09 min' depth='14.543 m' tts='6:04 min' heartbeat='82' />
+  <sample time='49:10 min' depth='14.532 m' heartbeat='83' />
+  <sample time='49:11 min' depth='14.543 m' heartbeat='84' />
+  <sample time='49:12 min' depth='14.594 m' pressure='152.71 bar' heartbeat='83' />
+  <sample time='49:13 min' depth='14.543 m' tts='6:05 min' heartbeat='85' />
+  <sample time='49:14 min' depth='14.492 m' heartbeat='81' />
+  <sample time='49:15 min' depth='14.534 m' heartbeat='82' />
+  <sample time='49:16 min' depth='14.597 m' heartbeat='84' />
+  <sample time='49:17 min' depth='14.612 m' pressure='152.16 bar' tts='6:06 min' />
+  <sample time='49:18 min' depth='14.696 m' tts='6:07 min' heartbeat='83' />
+  <sample time='49:19 min' depth='14.795 m' tts='6:08 min' />
+  <sample time='49:20 min' depth='14.819 m' tts='6:09 min' heartbeat='85' />
+  <sample time='49:21 min' depth='14.79 m' heartbeat='86' />
+  <sample time='49:22 min' depth='14.791 m' pressure='152.37 bar' heartbeat='85' />
+  <sample time='49:23 min' depth='14.739 m' tts='6:08 min' />
+  <sample time='49:24 min' depth='14.717 m' heartbeat='83' />
+  <sample time='49:25 min' depth='14.686 m' tts='6:09 min' />
+  <sample time='49:26 min' depth='14.757 m' heartbeat='87' />
+  <sample time='49:27 min' depth='14.791 m' pressure='151.82 bar' tts='6:10 min' heartbeat='83' />
+  <sample time='49:28 min' depth='14.875 m' tts='6:11 min' />
+  <sample time='49:29 min' depth='14.991 m' tts='6:12 min' />
+  <sample time='49:30 min' depth='14.995 m' tts='6:13 min' />
+  <sample time='49:31 min' depth='15.109 m' tts='6:14 min' />
+  <sample time='49:32 min' depth='15.202 m' pressure='151.96 bar' tts='0:00 min' />
+  <sample time='49:33 min' depth='15.296 m' tts='6:16 min' heartbeat='86' />
+  <sample time='49:34 min' depth='15.366 m' heartbeat='84' />
+  <sample time='49:35 min' depth='15.486 m' tts='6:18 min' />
+  <sample time='49:37 min' depth='15.231 m' pressure='151.27 bar' tts='6:16 min' heartbeat='85' />
+  <sample time='49:38 min' depth='15.259 m' tts='6:17 min' />
+  <sample time='49:39 min' depth='15.269 m' tts='6:18 min' stoptime='5:06 min' heartbeat='86' />
+  <sample time='49:42 min' depth='15.357 m' pressure='151.06 bar' tts='6:19 min' stoptime='5:07 min' />
+  <sample time='49:43 min' depth='15.462 m' tts='6:20 min' />
+  <sample time='49:44 min' depth='15.535 m' tts='6:21 min' />
+  <sample time='49:45 min' depth='15.571 m' tts='6:22 min' stoptime='5:08 min' />
+  <sample time='49:46 min' depth='15.529 m' tts='6:21 min' />
+  <sample time='49:47 min' depth='15.48 m' pressure='150.65 bar' tts='6:22 min' />
+  <sample time='49:48 min' depth='15.5 m' stoptime='5:09 min' heartbeat='87' />
+  <sample time='49:50 min' depth='15.51 m' tts='6:23 min' heartbeat='88' />
+  <sample time='49:51 min' depth='15.613 m' tts='6:24 min' stoptime='5:10 min' />
+  <sample time='49:52 min' depth='15.588 m' pressure='150.44 bar' tts='6:25 min' />
+  <sample time='49:53 min' depth='15.629 m' heartbeat='87' />
+  <sample time='49:54 min' depth='15.494 m' tts='6:24 min' stoptime='5:11 min' heartbeat='86' />
+  <sample time='49:55 min' depth='15.351 m' tts='6:23 min' />
+  <sample time='49:57 min' depth='15.293 m' pressure='150.3 bar' tts='6:24 min' stoptime='5:12 min' />
+  <sample time='49:58 min' depth='15.231 m' tts='6:23 min' heartbeat='87' />
+  <sample time='49:59 min' depth='15.114 m' />
+  <sample time='50:01 min' depth='15.082 m' tts='6:22 min' stoptime='5:13 min' />
+  <sample time='50:02 min' depth='15.093 m' pressure='150.44 bar' tts='6:24 min' />
+  <sample time='50:03 min' depth='15.189 m' />
+  <sample time='50:04 min' depth='15.305 m' tts='6:26 min' stoptime='5:14 min' heartbeat='86' />
+  <sample time='50:05 min' depth='15.517 m' tts='6:27 min' heartbeat='85' />
+  <sample time='50:06 min' depth='15.675 m' tts='6:29 min' />
+  <sample time='50:07 min' depth='15.718 m' tts='6:31 min' stoptime='5:15 min' />
+  <sample time='50:08 min' depth='15.636 m' tts='6:30 min' />
+  <sample time='50:10 min' depth='15.655 m' stoptime='5:16 min' heartbeat='86' />
+  <sample time='50:11 min' depth='15.672 m' tts='6:31 min' />
+  <sample time='50:12 min' depth='15.739 m' pressure='149.61 bar' tts='6:32 min' heartbeat='87' />
+  <sample time='50:13 min' depth='15.736 m' tts='6:33 min' stoptime='5:17 min' />
+  <sample time='50:14 min' depth='15.678 m' tts='6:32 min' />
+  <sample time='50:15 min' depth='15.729 m' tts='6:33 min' heartbeat='88' />
+  <sample time='50:16 min' depth='15.72 m' tts='6:34 min' stoptime='5:18 min' heartbeat='87' />
+  <sample time='50:17 min' depth='15.462 m' pressure='148.78 bar' tts='6:31 min' />
+  <sample time='50:18 min' depth='15.391 m' tts='6:30 min' />
+  <sample time='50:19 min' depth='15.139 m' tts='6:29 min' stoptime='5:19 min' />
+  <sample time='50:20 min' depth='14.858 m' tts='6:27 min' />
+  <sample time='50:21 min' depth='14.704 m' tts='6:26 min' heartbeat='86' />
+  <sample time='50:22 min' depth='14.588 m' pressure='148.92 bar' tts='6:25 min' />
+  <sample time='50:23 min' depth='14.442 m' tts='6:24 min' stoptime='5:20 min' heartbeat='85' />
+  <sample time='50:25 min' depth='14.299 m' tts='6:23 min' heartbeat='84' />
+  <sample time='50:26 min' depth='14.145 m' tts='6:22 min' />
+  <sample time='50:27 min' depth='14.184 m' pressure='148.71 bar' tts='6:23 min' />
+  <sample time='50:28 min' depth='14.192 m' tts='6:24 min' stoptime='5:21 min' />
+  <sample time='50:29 min' depth='14.252 m' />
+  <sample time='50:30 min' depth='14.462 m' tts='6:25 min' />
+  <sample time='50:31 min' depth='14.368 m' tts='6:26 min' />
+  <sample time='50:32 min' depth='14.41 m' pressure='148.37 bar' tts='0:00 min' />
+  <sample time='50:33 min' depth='14.452 m' tts='6:26 min' stoptime='5:22 min' />
+  <sample time='50:34 min' depth='14.49 m' tts='6:27 min' heartbeat='85' />
+  <sample time='50:35 min' depth='14.553 m' tts='6:28 min' />
+  <sample time='50:36 min' depth='14.594 m' heartbeat='86' />
+  <sample time='50:37 min' depth='14.578 m' pressure='148.37 bar' tts='0:00 min' />
+  <sample time='50:38 min' depth='14.563 m' tts='6:28 min' stoptime='5:23 min' />
+  <sample time='50:39 min' depth='14.582 m' tts='6:29 min' />
+  <sample time='50:40 min' depth='14.56 m' heartbeat='87' />
+  <sample time='50:41 min' depth='14.195 m' tts='6:26 min' />
+  <sample time='50:42 min' depth='14.063 m' pressure='148.3 bar' stoptime='5:24 min' heartbeat='88' />
+  <sample time='50:43 min' depth='14.046 m' />
+  <sample time='50:46 min' depth='14.038 m' heartbeat='89' />
+  <sample time='50:47 min' depth='13.968 m' pressure='147.82 bar' tts='6:25 min' />
+  <sample time='50:48 min' depth='13.698 m' tts='6:23 min' stoptime='5:25 min' />
+  <sample time='50:49 min' depth='13.699 m' heartbeat='90' />
+  <sample time='50:50 min' depth='13.53 m' tts='6:22 min' />
+  <sample time='50:51 min' depth='13.314 m' tts='6:21 min' heartbeat='91' />
+  <sample time='50:52 min' depth='13.186 m' pressure='147.89 bar' tts='6:20 min' />
+  <sample time='50:53 min' depth='13.159 m' />
+  <sample time='50:54 min' depth='13.121 m' heartbeat='92' />
+  <sample time='50:55 min' depth='13.007 m' tts='6:19 min' heartbeat='91' />
+  <sample time='50:56 min' depth='12.679 m' tts='6:17 min' />
+  <sample time='50:57 min' depth='12.528 m' pressure='147.54 bar' tts='6:16 min' />
+  <sample time='50:58 min' depth='12.493 m' tts='6:15 min' />
+  <sample time='51:00 min' depth='12.525 m' tts='6:16 min' heartbeat='92' />
+  <sample time='51:02 min' depth='12.508 m' pressure='147.13 bar' heartbeat='91' />
+  <sample time='51:03 min' depth='12.227 m' tts='6:14 min' />
+  <sample time='51:04 min' depth='12.069 m' tts='6:13 min' />
+  <sample time='51:05 min' depth='11.958 m' tts='6:12 min' heartbeat='90' />
+  <sample time='51:07 min' depth='11.851 m' pressure='147.13 bar' tts='0:00 min' />
+  <sample time='51:08 min' depth='11.797 m' tts='6:11 min' />
+  <sample time='51:09 min' depth='11.388 m' tts='6:08 min' heartbeat='89' />
+  <sample time='51:10 min' depth='11.333 m' heartbeat='90' />
+  <sample time='51:12 min' depth='10.963 m' pressure='146.78 bar' tts='6:05 min' heartbeat='89' />
+  <sample time='51:13 min' depth='10.959 m' stoptime='5:24 min' />
+  <sample time='51:14 min' depth='10.933 m' heartbeat='90' />
+  <sample time='51:15 min' depth='10.866 m' heartbeat='89' />
+  <sample time='51:16 min' depth='10.634 m' tts='6:03 min' />
+  <sample time='51:17 min' depth='10.384 m' pressure='146.92 bar' tts='6:02 min' />
+  <sample time='51:18 min' depth='10.357 m' tts='6:01 min' stoptime='5:23 min' heartbeat='88' />
+  <sample time='51:20 min' depth='10.128 m' tts='6:00 min' heartbeat='87' />
+  <sample time='51:21 min' depth='10.073 m' heartbeat='88' />
+  <sample time='51:22 min' depth='10.042 m' pressure='146.37 bar' tts='5:59 min' stoptime='5:22 min' heartbeat='87' />
+  <sample time='51:23 min' depth='9.936 m' tts='5:58 min' />
+  <sample time='51:24 min' depth='9.706 m' tts='5:57 min' />
+  <sample time='51:25 min' depth='9.683 m' tts='5:56 min' heartbeat='88' />
+  <sample time='51:26 min' depth='9.625 m' stoptime='5:21 min' />
+  <sample time='51:27 min' depth='9.49 m' pressure='146.51 bar' tts='5:55 min' />
+  <sample time='51:28 min' depth='9.235 m' tts='5:53 min' />
+  <sample time='51:29 min' depth='9.228 m' stoptime='5:20 min' heartbeat='89' />
+  <sample time='51:31 min' depth='9.211 m' tts='5:52 min' />
+  <sample time='51:32 min' depth='8.988 m' pressure='146.16 bar' tts='5:51 min' stoptime='5:19 min' />
+  <sample time='51:33 min' depth='8.895 m' tts='5:50 min' heartbeat='91' />
+  <sample time='51:34 min' depth='8.794 m' tts='5:49 min' heartbeat='90' />
+  <sample time='51:35 min' depth='8.693 m' stoptime='5:18 min' />
+  <sample time='51:36 min' depth='8.605 m' tts='5:48 min' />
+  <sample time='51:37 min' depth='8.603 m' pressure='146.03 bar' stoptime='5:17 min' heartbeat='89' />
+  <sample time='51:38 min' depth='8.571 m' tts='5:47 min' />
+  <sample time='51:39 min' depth='8.079 m' tts='5:45 min' stoptime='5:16 min' heartbeat='90' />
+  <sample time='51:40 min' depth='7.96 m' tts='5:44 min' />
+  <sample time='51:41 min' depth='7.985 m' heartbeat='91' />
+  <sample time='51:42 min' depth='7.856 m' pressure='145.89 bar' tts='5:42 min' stoptime='5:15 min' heartbeat='90' />
+  <sample time='51:43 min' depth='7.751 m' tts='5:41 min' heartbeat='89' />
+  <sample time='51:44 min' depth='7.688 m' stoptime='5:14 min' heartbeat='90' />
+  <sample time='51:45 min' depth='7.517 m' tts='5:40 min' />
+  <sample time='51:46 min' depth='7.509 m' stoptime='5:13 min' />
+  <sample time='51:47 min' depth='7.506 m' pressure='145.47 bar' tts='5:39 min' />
+  <sample time='51:48 min' depth='7.384 m' tts='5:38 min' stoptime='5:12 min' />
+  <sample time='51:49 min' depth='7.068 m' tts='5:36 min' stoptime='5:11 min' />
+  <sample time='51:51 min' depth='7.02 m' stoptime='5:10 min' heartbeat='91' />
+  <sample time='51:52 min' depth='6.968 m' pressure='145.68 bar' tts='5:34 min' heartbeat='90' />
+  <sample time='51:53 min' depth='6.741 m' tts='5:33 min' stoptime='5:09 min' />
+  <sample time='51:55 min' depth='6.741 m' tts='5:32 min' stoptime='5:08 min' heartbeat='91' />
+  <sample time='51:56 min' depth='6.706 m' stoptime='5:07 min' heartbeat='90' />
+  <sample time='51:57 min' depth='6.682 m' pressure='145.41 bar' tts='5:30 min' heartbeat='91' />
+  <sample time='51:58 min' depth='6.623 m' stoptime='5:06 min' heartbeat='90' />
+  <sample time='51:59 min' depth='6.234 m' tts='5:28 min' stoptime='5:05 min' heartbeat='91' />
+  <sample time='52:00 min' depth='6.175 m' tts='5:27 min' heartbeat='92' />
+  <sample time='52:01 min' depth='6.196 m' stoptime='5:04 min' heartbeat='93' />
+  <sample time='52:02 min' depth='6.176 m' pressure='145.34 bar' tts='5:26 min' stoptime='5:03 min' heartbeat='95' />
+  <sample time='52:03 min' depth='5.886 m' tts='5:25 min' heartbeat='94' />
+  <sample time='52:04 min' depth='5.694 m' tts='5:24 min' stoptime='5:02 min' heartbeat='92' />
+  <sample time='52:05 min' depth='5.652 m' tts='5:23 min' stoptime='5:01 min' heartbeat='93' />
+  <sample time='52:06 min' depth='5.625 m' tts='5:22 min' heartbeat='92' />
+  <sample time='52:07 min' depth='5.478 m' tts='5:21 min' stoptime='5:00 min' heartbeat='94' />
+  <sample time='52:08 min' depth='5.315 m' tts='5:20 min' stoptime='4:59 min' heartbeat='93' />
+  <sample time='52:09 min' depth='5.266 m' tts='5:19 min' stoptime='4:58 min' heartbeat='94' />
+  <sample time='52:10 min' depth='5.127 m' tts='5:18 min' heartbeat='95' />
+  <sample time='52:11 min' depth='5.025 m' tts='5:17 min' stoptime='4:57 min' />
+  <sample time='52:12 min' depth='5.046 m' pressure='145.06 bar' stoptime='4:56 min' heartbeat='97' />
+  <sample time='52:13 min' depth='5.0 m' tts='5:16 min' stoptime='4:55 min' heartbeat='96' />
+  <sample time='52:14 min' depth='4.972 m' tts='5:15 min' stoptime='4:54 min' heartbeat='94' />
+  <sample time='52:15 min' depth='4.941 m' tts='5:14 min' heartbeat='96' />
+  <sample time='52:16 min' depth='4.755 m' tts='5:13 min' stoptime='4:53 min' heartbeat='94' />
+  <sample time='52:17 min' depth='4.572 m' pressure='144.72 bar' stoptime='4:52 min' />
+  <sample time='52:18 min' depth='4.511 m' tts='5:11 min' stoptime='4:51 min' />
+  <sample time='52:19 min' depth='4.537 m' tts='5:10 min' stoptime='4:50 min' />
+  <sample time='52:20 min' depth='4.557 m' tts='5:09 min' heartbeat='95' />
+  <sample time='52:21 min' depth='4.539 m' tts='5:08 min' stoptime='4:49 min' heartbeat='93' />
+  <sample time='52:22 min' depth='4.504 m' pressure='144.65 bar' stoptime='4:48 min' heartbeat='95' />
+  <sample time='52:23 min' depth='4.461 m' tts='5:07 min' stoptime='4:47 min' heartbeat='96' />
+  <sample time='52:24 min' depth='4.371 m' tts='5:06 min' stoptime='4:46 min' heartbeat='98' />
+  <sample time='52:25 min' depth='4.224 m' tts='5:05 min' stoptime='4:45 min' heartbeat='99' />
+  <sample time='52:26 min' depth='4.254 m' tts='5:04 min' stoptime='4:44 min' heartbeat='100' />
+  <sample time='52:27 min' depth='4.219 m' pressure='144.65 bar' tts='5:03 min' heartbeat='101' />
+  <sample time='52:28 min' depth='4.198 m' tts='5:02 min' stoptime='4:43 min' heartbeat='103' />
+  <sample time='52:29 min' depth='4.222 m' tts='5:01 min' stoptime='4:42 min' heartbeat='102' />
+  <sample time='52:30 min' depth='4.193 m' stoptime='4:41 min' heartbeat='103' />
+  <sample time='52:31 min' depth='4.165 m' tts='5:00 min' stoptime='4:40 min' heartbeat='102' />
+  <sample time='52:32 min' depth='4.111 m' pressure='144.23 bar' tts='4:58 min' stoptime='4:39 min' heartbeat='103' />
+  <sample time='52:33 min' depth='3.751 m' stoptime='4:38 min' />
+  <sample time='52:34 min' depth='3.655 m' tts='4:56 min' stoptime='4:37 min' heartbeat='102' />
+  <sample time='52:35 min' depth='3.658 m' stoptime='4:36 min' heartbeat='101' />
+  <sample time='52:36 min' depth='3.627 m' tts='4:55 min' />
+  <sample time='52:37 min' depth='3.59 m' pressure='144.16 bar' tts='4:54 min' stoptime='4:35 min' heartbeat='99' />
+  <sample time='52:38 min' depth='3.612 m' tts='4:53 min' stoptime='4:34 min' heartbeat='102' />
+  <sample time='52:39 min' depth='3.634 m' tts='4:52 min' stoptime='4:33 min' heartbeat='100' />
+  <sample time='52:40 min' depth='3.537 m' tts='4:51 min' stoptime='4:32 min' />
+  <sample time='52:41 min' depth='3.312 m' tts='4:50 min' stoptime='4:31 min' heartbeat='101' />
+  <sample time='52:42 min' depth='3.293 m' pressure='144.03 bar' tts='4:49 min' stoptime='4:30 min' heartbeat='100' />
+  <sample time='52:43 min' depth='3.286 m' tts='4:48 min' stoptime='4:29 min' heartbeat='101' />
+  <sample time='52:44 min' depth='3.273 m' tts='4:47 min' stoptime='4:28 min' heartbeat='100' />
+  <sample time='52:45 min' depth='3.261 m' tts='4:46 min' stoptime='4:27 min' />
+  <sample time='52:46 min' depth='3.24 m' tts='4:45 min' stoptime='4:26 min' heartbeat='101' />
+  <sample time='52:47 min' depth='3.236 m' pressure='143.75 bar' tts='4:44 min' stoptime='4:25 min' />
+  <sample time='52:48 min' depth='3.245 m' tts='4:43 min' stoptime='4:24 min' heartbeat='99' />
+  <sample time='52:49 min' depth='2.852 m' tts='4:41 min' stoptime='4:23 min' heartbeat='100' />
+  <sample time='52:50 min' depth='2.78 m' tts='4:40 min' stoptime='4:22 min' heartbeat='99' />
+  <sample time='52:51 min' depth='2.723 m' tts='4:38 min' stoptime='4:21 min' />
+  <sample time='52:52 min' depth='2.873 m' pressure='143.82 bar' stoptime='4:20 min' heartbeat='98' />
+  <sample time='52:53 min' depth='2.959 m' stoptime='4:19 min' heartbeat='97' />
+  <sample time='52:54 min' depth='3.203 m' stoptime='4:18 min' heartbeat='98' />
+  <sample time='52:55 min' depth='3.665 m' tts='4:37 min' stoptime='4:17 min' heartbeat='97' />
+  <sample time='52:56 min' depth='3.801 m' tts='4:35 min' stoptime='4:16 min' />
+  <sample time='52:57 min' depth='3.77 m' pressure='143.54 bar' tts='4:34 min' stoptime='4:15 min' heartbeat='96' />
+  <sample time='52:58 min' depth='3.682 m' stoptime='4:14 min' />
+  <sample time='52:59 min' depth='3.65 m' tts='4:32 min' stoptime='4:13 min' />
+  <sample time='53:00 min' depth='3.685 m' stoptime='4:12 min' />
+  <sample time='53:01 min' depth='3.661 m' tts='4:31 min' stoptime='4:11 min' heartbeat='95' />
+  <sample time='53:02 min' depth='3.641 m' pressure='143.34 bar' tts='4:29 min' heartbeat='96' />
+  <sample time='53:03 min' depth='3.578 m' stoptime='4:10 min' />
+  <sample time='53:04 min' depth='3.573 m' tts='4:28 min' stoptime='4:09 min' />
+  <sample time='53:05 min' depth='3.539 m' tts='4:27 min' stoptime='4:08 min' heartbeat='97' />
+  <sample time='53:06 min' depth='3.544 m' tts='4:26 min' stoptime='4:07 min' heartbeat='96' />
+  <sample time='53:07 min' depth='3.355 m' pressure='143.27 bar' stoptime='4:06 min' heartbeat='97' />
+  <sample time='53:08 min' depth='3.39 m' tts='4:24 min' stoptime='4:05 min' />
+  <sample time='53:09 min' depth='3.389 m' tts='4:23 min' stoptime='4:04 min' heartbeat='99' />
+  <sample time='53:10 min' depth='3.223 m' tts='4:22 min' stoptime='4:03 min' heartbeat='97' />
+  <sample time='53:11 min' depth='3.235 m' tts='4:21 min' stoptime='4:02 min' heartbeat='96' />
+  <sample time='53:12 min' depth='3.201 m' pressure='142.99 bar' stoptime='4:01 min' heartbeat='97' />
+  <sample time='53:13 min' depth='3.209 m' tts='4:20 min' stoptime='4:00 min' heartbeat='94' />
+  <sample time='53:14 min' depth='3.227 m' tts='4:19 min' stoptime='3:59 min' heartbeat='96' />
+  <sample time='53:15 min' depth='3.217 m' tts='4:18 min' stoptime='3:58 min' />
+  <sample time='53:16 min' depth='3.173 m' tts='4:16 min' stoptime='3:57 min' heartbeat='95' />
+  <sample time='53:17 min' depth='3.071 m' pressure='142.85 bar' stoptime='3:56 min' />
+  <sample time='53:18 min' depth='3.033 m' tts='4:14 min' stoptime='3:55 min' heartbeat='93' />
+  <sample time='53:19 min' depth='3.042 m' tts='4:13 min' stoptime='3:54 min' heartbeat='91' />
+  <sample time='53:20 min' depth='3.074 m' stoptime='3:53 min' heartbeat='90' />
+  <sample time='53:21 min' depth='3.055 m' tts='4:12 min' stoptime='3:52 min' heartbeat='92' />
+  <sample time='53:22 min' depth='3.047 m' pressure='142.85 bar' tts='4:10 min' stoptime='3:51 min' heartbeat='89' />
+  <sample time='53:23 min' depth='3.015 m' tts='4:09 min' stoptime='3:50 min' heartbeat='88' />
+  <sample time='53:24 min' depth='3.008 m' tts='4:08 min' stoptime='3:49 min' />
+  <sample time='53:25 min' depth='3.04 m' tts='4:07 min' stoptime='3:48 min' />
+  <sample time='53:26 min' depth='3.021 m' tts='4:06 min' stoptime='3:47 min' heartbeat='87' />
+  <sample time='53:27 min' depth='2.967 m' pressure='142.58 bar' tts='4:05 min' stoptime='3:46 min' heartbeat='86' />
+  <sample time='53:28 min' depth='2.993 m' tts='4:04 min' stoptime='3:45 min' heartbeat='82' />
+  <sample time='53:29 min' depth='3.043 m' tts='4:03 min' stoptime='3:44 min' heartbeat='84' />
+  <sample time='53:30 min' depth='3.031 m' tts='4:02 min' stoptime='3:43 min' heartbeat='85' />
+  <sample time='53:31 min' depth='2.995 m' tts='4:01 min' stoptime='3:42 min' />
+  <sample time='53:32 min' depth='3.005 m' pressure='142.23 bar' tts='4:00 min' stoptime='3:41 min' heartbeat='87' />
+  <sample time='53:33 min' depth='3.034 m' tts='3:59 min' stoptime='3:40 min' heartbeat='85' />
+  <sample time='53:34 min' depth='3.015 m' tts='3:58 min' stoptime='3:39 min' />
+  <sample time='53:35 min' depth='3.013 m' tts='3:57 min' stoptime='3:38 min' />
+  <sample time='53:36 min' depth='2.994 m' tts='3:56 min' stoptime='3:37 min' heartbeat='84' />
+  <sample time='53:37 min' depth='2.995 m' pressure='142.1 bar' tts='3:55 min' stoptime='3:36 min' heartbeat='85' />
+  <sample time='53:38 min' depth='3.003 m' tts='3:54 min' stoptime='3:35 min' />
+  <sample time='53:39 min' depth='3.023 m' tts='3:53 min' stoptime='3:34 min' />
+  <sample time='53:40 min' depth='2.999 m' tts='3:52 min' stoptime='3:33 min' heartbeat='84' />
+  <sample time='53:41 min' depth='2.976 m' tts='3:51 min' stoptime='3:32 min' heartbeat='85' />
+  <sample time='53:42 min' depth='3.069 m' pressure='141.96 bar' stoptime='3:31 min' heartbeat='82' />
+  <sample time='53:43 min' depth='3.067 m' tts='3:50 min' stoptime='3:30 min' heartbeat='85' />
+  <sample time='53:44 min' depth='3.05 m' tts='3:49 min' stoptime='3:29 min' />
+  <sample time='53:45 min' depth='3.097 m' tts='3:48 min' stoptime='3:28 min' heartbeat='84' />
+  <sample time='53:46 min' depth='3.092 m' tts='3:47 min' stoptime='3:27 min' />
+  <sample time='53:47 min' depth='3.1 m' pressure='142.03 bar' tts='3:46 min' stoptime='3:26 min' heartbeat='83' />
+  <sample time='53:48 min' depth='3.094 m' tts='3:45 min' stoptime='3:25 min' heartbeat='84' />
+  <sample time='53:49 min' depth='3.084 m' tts='3:44 min' stoptime='3:24 min' heartbeat='83' />
+  <sample time='53:50 min' depth='3.067 m' tts='3:43 min' stoptime='3:23 min' />
+  <sample time='53:51 min' depth='3.05 m' tts='3:42 min' stoptime='3:22 min' />
+  <sample time='53:52 min' depth='3.014 m' pressure='141.75 bar' tts='3:40 min' stoptime='3:21 min' />
+  <sample time='53:53 min' depth='3.033 m' tts='3:39 min' stoptime='3:20 min' heartbeat='84' />
+  <sample time='53:54 min' depth='3.027 m' tts='3:38 min' stoptime='3:19 min' heartbeat='85' />
+  <sample time='53:55 min' depth='3.024 m' tts='3:37 min' stoptime='3:18 min' heartbeat='86' />
+  <sample time='53:56 min' depth='3.036 m' tts='3:36 min' stoptime='3:17 min' heartbeat='88' />
+  <sample time='53:57 min' depth='3.109 m' pressure='141.61 bar' stoptime='3:16 min' />
+  <sample time='53:58 min' depth='2.869 m' tts='3:33 min' stoptime='3:15 min' heartbeat='89' />
+  <sample time='53:59 min' depth='2.961 m' stoptime='3:14 min' />
+  <sample time='54:00 min' depth='3.068 m' stoptime='3:13 min' />
+  <sample time='54:01 min' depth='3.101 m' tts='3:32 min' stoptime='3:12 min' heartbeat='88' />
+  <sample time='54:02 min' depth='3.064 m' pressure='141.61 bar' tts='3:31 min' stoptime='3:11 min' />
+  <sample time='54:03 min' depth='3.081 m' tts='3:30 min' stoptime='3:10 min' />
+  <sample time='54:04 min' depth='3.032 m' tts='3:28 min' stoptime='3:09 min' />
+  <sample time='54:05 min' depth='3.055 m' stoptime='3:08 min' heartbeat='87' />
+  <sample time='54:06 min' depth='3.035 m' tts='3:26 min' stoptime='3:07 min' />
+  <sample time='54:07 min' depth='3.033 m' tts='3:25 min' stoptime='3:06 min' />
+  <sample time='54:08 min' depth='3.014 m' tts='3:24 min' stoptime='3:05 min' />
+  <sample time='54:09 min' depth='3.029 m' tts='3:23 min' stoptime='3:04 min' heartbeat='86' />
+  <sample time='54:10 min' depth='3.031 m' tts='3:22 min' stoptime='3:03 min' heartbeat='85' />
+  <sample time='54:11 min' depth='3.031 m' tts='3:21 min' stoptime='3:02 min' />
+  <sample time='54:12 min' depth='3.047 m' pressure='141.41 bar' tts='3:20 min' stoptime='3:01 min' heartbeat='84' />
+  <sample time='54:13 min' depth='3.022 m' tts='3:19 min' stoptime='3:00 min' heartbeat='83' />
+  <sample time='54:14 min' depth='2.994 m' tts='3:18 min' stoptime='2:59 min' />
+  <sample time='54:15 min' depth='3.012 m' tts='3:17 min' stoptime='2:58 min' heartbeat='82' />
+  <sample time='54:16 min' depth='3.049 m' stoptime='2:57 min' />
+  <sample time='54:17 min' depth='3.033 m' tts='3:15 min' stoptime='2:56 min' />
+  <sample time='54:18 min' depth='2.964 m' tts='3:14 min' stoptime='2:55 min' />
+  <sample time='54:19 min' depth='2.983 m' tts='3:13 min' stoptime='2:54 min' />
+  <sample time='54:20 min' depth='3.018 m' tts='3:12 min' stoptime='2:53 min' />
+  <sample time='54:21 min' depth='3.019 m' tts='3:11 min' stoptime='2:52 min' />
+  <sample time='54:22 min' depth='3.012 m' pressure='140.79 bar' tts='3:10 min' stoptime='2:51 min' />
+  <sample time='54:23 min' depth='3.004 m' tts='3:09 min' stoptime='2:50 min' />
+  <sample time='54:24 min' depth='2.989 m' tts='3:08 min' stoptime='2:49 min' />
+  <sample time='54:25 min' depth='3.01 m' tts='3:07 min' stoptime='2:48 min' heartbeat='83' />
+  <sample time='54:26 min' depth='3.062 m' stoptime='2:47 min' heartbeat='82' />
+  <sample time='54:27 min' depth='3.114 m' pressure='140.79 bar' tts='3:06 min' stoptime='2:46 min' />
+  <sample time='54:28 min' depth='3.073 m' tts='3:05 min' stoptime='2:45 min' />
+  <sample time='54:29 min' depth='3.057 m' tts='3:04 min' stoptime='2:44 min' />
+  <sample time='54:30 min' depth='3.044 m' tts='3:02 min' stoptime='2:43 min' heartbeat='81' />
+  <sample time='54:31 min' depth='3.027 m' tts='3:01 min' stoptime='2:42 min' />
+  <sample time='54:32 min' depth='2.932 m' pressure='140.58 bar' tts='3:00 min' stoptime='2:41 min' heartbeat='80' />
+  <sample time='54:33 min' depth='2.927 m' tts='2:59 min' stoptime='2:40 min' />
+  <sample time='54:34 min' depth='2.896 m' tts='2:58 min' stoptime='2:39 min' />
+  <sample time='54:35 min' depth='2.864 m' tts='2:56 min' stoptime='2:38 min' heartbeat='79' />
+  <sample time='54:36 min' depth='2.877 m' tts='2:55 min' stoptime='2:37 min' heartbeat='78' />
+  <sample time='54:37 min' depth='2.891 m' pressure='140.72 bar' tts='2:54 min' stoptime='2:36 min' />
+  <sample time='54:38 min' depth='2.964 m' stoptime='2:35 min' />
+  <sample time='54:39 min' depth='3.002 m' tts='2:53 min' stoptime='2:34 min' />
+  <sample time='54:40 min' depth='2.97 m' tts='2:52 min' stoptime='2:33 min' />
+  <sample time='54:41 min' depth='3.077 m' stoptime='2:32 min' />
+  <sample time='54:42 min' depth='3.098 m' pressure='140.37 bar' tts='2:51 min' stoptime='2:31 min' />
+  <sample time='54:43 min' depth='3.089 m' tts='2:50 min' stoptime='2:30 min' />
+  <sample time='54:44 min' depth='3.121 m' tts='2:49 min' stoptime='2:29 min' />
+  <sample time='54:45 min' depth='3.077 m' tts='2:48 min' stoptime='2:28 min' />
+  <sample time='54:46 min' depth='3.092 m' tts='2:47 min' stoptime='2:27 min' heartbeat='77' />
+  <sample time='54:47 min' depth='3.112 m' pressure='140.51 bar' tts='2:46 min' stoptime='2:26 min' />
+  <sample time='54:48 min' depth='3.088 m' tts='2:45 min' stoptime='2:25 min' />
+  <sample time='54:49 min' depth='3.087 m' tts='2:44 min' stoptime='2:24 min' heartbeat='76' />
+  <sample time='54:50 min' depth='3.095 m' tts='2:43 min' stoptime='2:23 min' />
+  <sample time='54:51 min' depth='3.077 m' tts='2:42 min' stoptime='2:22 min' heartbeat='77' />
+  <sample time='54:52 min' depth='3.099 m' pressure='140.17 bar' tts='2:41 min' stoptime='2:21 min' />
+  <sample time='54:53 min' depth='3.12 m' tts='2:40 min' stoptime='2:20 min' />
+  <sample time='54:54 min' depth='3.14 m' tts='2:39 min' stoptime='2:19 min' />
+  <sample time='54:55 min' depth='3.146 m' tts='2:38 min' stoptime='2:18 min' />
+  <sample time='54:56 min' depth='3.137 m' tts='2:37 min' stoptime='2:17 min' />
+  <sample time='54:57 min' depth='3.129 m' pressure='140.23 bar' tts='2:36 min' stoptime='2:16 min' />
+  <sample time='54:58 min' depth='3.133 m' tts='2:35 min' heartbeat='78' />
+  <sample time='54:59 min' depth='3.137 m' tts='2:34 min' stoptime='2:15 min' />
+  <sample time='55:00 min' depth='3.117 m' tts='2:33 min' stoptime='2:14 min' />
+  <sample time='55:01 min' depth='3.083 m' tts='2:32 min' stoptime='2:13 min' />
+  <sample time='55:02 min' depth='3.104 m' pressure='139.89 bar' tts='2:31 min' stoptime='2:12 min' />
+  <sample time='55:03 min' depth='3.134 m' tts='2:30 min' stoptime='2:11 min' heartbeat='77' />
+  <sample time='55:04 min' depth='3.129 m' tts='2:29 min' stoptime='2:10 min' />
+  <sample time='55:05 min' depth='3.143 m' tts='2:28 min' stoptime='2:09 min' />
+  <sample time='55:06 min' depth='3.177 m' tts='2:26 min' stoptime='2:08 min' />
+  <sample time='55:07 min' depth='3.212 m' pressure='139.96 bar' stoptime='2:07 min' heartbeat='76' />
+  <sample time='55:08 min' depth='3.296 m' tts='2:25 min' stoptime='2:06 min' />
+  <sample time='55:09 min' depth='3.321 m' tts='2:24 min' stoptime='2:05 min' />
+  <sample time='55:10 min' depth='3.321 m' tts='2:23 min' stoptime='2:04 min' />
+  <sample time='55:11 min' depth='3.206 m' tts='2:22 min' stoptime='2:03 min' heartbeat='75' />
+  <sample time='55:12 min' depth='3.232 m' pressure='139.61 bar' tts='2:21 min' stoptime='2:02 min' />
+  <sample time='55:13 min' depth='3.212 m' tts='2:20 min' stoptime='2:01 min' />
+  <sample time='55:14 min' depth='3.194 m' tts='2:19 min' stoptime='2:00 min' />
+  <sample time='55:15 min' depth='3.209 m' stoptime='1:59 min' />
+  <sample time='55:16 min' depth='3.205 m' tts='2:18 min' stoptime='1:58 min' heartbeat='74' />
+  <sample time='55:17 min' depth='3.208 m' pressure='139.68 bar' tts='2:17 min' stoptime='1:57 min' />
+  <sample time='55:18 min' depth='3.217 m' tts='2:16 min' stoptime='1:56 min' />
+  <sample time='55:19 min' depth='3.233 m' tts='2:14 min' stoptime='1:55 min' heartbeat='73' />
+  <sample time='55:20 min' depth='3.259 m' tts='2:13 min' stoptime='1:54 min' heartbeat='74' />
+  <sample time='55:21 min' depth='3.226 m' stoptime='1:53 min' />
+  <sample time='55:22 min' depth='3.197 m' tts='2:11 min' stoptime='1:52 min' />
+  <sample time='55:23 min' depth='3.228 m' stoptime='1:51 min' />
+  <sample time='55:24 min' depth='3.25 m' tts='2:09 min' stoptime='1:50 min' heartbeat='75' />
+  <sample time='55:25 min' depth='3.163 m' tts='2:08 min' stoptime='1:49 min' />
+  <sample time='55:26 min' depth='3.087 m' stoptime='1:48 min' heartbeat='76' />
+  <sample time='55:27 min' depth='3.092 m' pressure='139.48 bar' tts='2:07 min' stoptime='1:47 min' />
+  <sample time='55:28 min' depth='3.075 m' tts='2:06 min' stoptime='1:46 min' heartbeat='75' />
+  <sample time='55:29 min' depth='3.07 m' tts='2:05 min' stoptime='1:45 min' heartbeat='76' />
+  <sample time='55:30 min' depth='3.042 m' tts='2:03 min' stoptime='1:44 min' />
+  <sample time='55:31 min' depth='3.043 m' tts='2:02 min' stoptime='1:43 min' heartbeat='74' />
+  <sample time='55:32 min' depth='3.042 m' pressure='139.06 bar' tts='2:01 min' stoptime='1:42 min' heartbeat='76' />
+  <sample time='55:33 min' depth='3.044 m' tts='2:00 min' stoptime='1:41 min' />
+  <sample time='55:34 min' depth='3.055 m' stoptime='1:40 min' />
+  <sample time='55:35 min' depth='3.07 m' tts='1:59 min' stoptime='1:39 min' heartbeat='79' />
+  <sample time='55:36 min' depth='3.087 m' tts='1:58 min' stoptime='1:38 min' heartbeat='76' />
+  <sample time='55:37 min' depth='3.074 m' pressure='138.86 bar' tts='1:57 min' stoptime='1:37 min' heartbeat='77' />
+  <sample time='55:38 min' depth='3.056 m' tts='1:56 min' stoptime='1:36 min' heartbeat='74' />
+  <sample time='55:39 min' depth='3.08 m' tts='1:55 min' stoptime='1:35 min' heartbeat='75' />
+  <sample time='55:40 min' depth='3.084 m' tts='1:54 min' stoptime='1:34 min' heartbeat='76' />
+  <sample time='55:41 min' depth='3.063 m' tts='1:53 min' stoptime='1:33 min' heartbeat='77' />
+  <sample time='55:42 min' depth='3.048 m' pressure='138.86 bar' tts='1:52 min' stoptime='1:32 min' heartbeat='78' />
+  <sample time='55:43 min' depth='3.053 m' tts='1:51 min' stoptime='1:31 min' />
+  <sample time='55:44 min' depth='3.066 m' tts='1:50 min' stoptime='1:30 min' heartbeat='77' />
+  <sample time='55:45 min' depth='3.075 m' tts='1:49 min' stoptime='1:29 min' />
+  <sample time='55:46 min' depth='3.072 m' tts='1:48 min' stoptime='1:28 min' heartbeat='76' />
+  <sample time='55:47 min' depth='3.041 m' pressure='138.65 bar' tts='1:46 min' stoptime='1:27 min' heartbeat='75' />
+  <sample time='55:48 min' depth='3.051 m' stoptime='1:26 min' heartbeat='76' />
+  <sample time='55:49 min' depth='3.062 m' tts='1:45 min' stoptime='1:25 min' />
+  <sample time='55:50 min' depth='3.058 m' tts='1:44 min' stoptime='1:24 min' heartbeat='77' />
+  <sample time='55:51 min' depth='3.057 m' tts='1:43 min' stoptime='1:23 min' heartbeat='76' />
+  <sample time='55:52 min' depth='3.04 m' pressure='138.44 bar' tts='1:41 min' stoptime='1:22 min' heartbeat='78' />
+  <sample time='55:53 min' depth='3.022 m' tts='1:40 min' stoptime='1:21 min' />
+  <sample time='55:54 min' depth='3.054 m' stoptime='1:20 min' heartbeat='76' />
+  <sample time='55:55 min' depth='3.053 m' tts='1:39 min' stoptime='1:19 min' heartbeat='74' />
+  <sample time='55:56 min' depth='3.036 m' tts='1:37 min' stoptime='1:18 min' heartbeat='75' />
+  <sample time='55:57 min' depth='3.042 m' pressure='138.44 bar' tts='1:36 min' stoptime='1:17 min' heartbeat='76' />
+  <sample time='55:58 min' depth='3.049 m' stoptime='1:16 min' heartbeat='77' />
+  <sample time='55:59 min' depth='3.039 m' tts='1:34 min' stoptime='1:15 min' />
+  <sample time='56:00 min' depth='3.059 m' stoptime='1:14 min' />
+  <sample time='56:01 min' depth='3.083 m' tts='1:33 min' stoptime='1:13 min' heartbeat='79' />
+  <sample time='56:02 min' depth='3.046 m' pressure='138.3 bar' tts='1:31 min' stoptime='1:12 min' heartbeat='78' />
+  <sample time='56:03 min' depth='3.03 m' tts='1:30 min' stoptime='1:11 min' heartbeat='77' />
+  <sample time='56:04 min' depth='3.029 m' tts='1:29 min' stoptime='1:10 min' />
+  <sample time='56:05 min' depth='3.054 m' stoptime='1:09 min' />
+  <sample time='56:06 min' depth='3.046 m' tts='1:27 min' stoptime='1:08 min' />
+  <sample time='56:07 min' depth='3.094 m' stoptime='1:07 min' heartbeat='78' />
+  <sample time='56:08 min' depth='3.139 m' tts='1:25 min' stoptime='1:06 min' />
+  <sample time='56:09 min' depth='2.981 m' tts='1:24 min' stoptime='1:05 min' />
+  <sample time='56:10 min' depth='2.983 m' tts='1:23 min' stoptime='1:04 min' />
+  <sample time='56:11 min' depth='3.02 m' tts='1:22 min' stoptime='1:03 min' heartbeat='77' />
+  <sample time='56:12 min' depth='3.107 m' pressure='138.03 bar' stoptime='1:02 min' heartbeat='79' />
+  <sample time='56:13 min' depth='3.119 m' tts='1:21 min' stoptime='1:01 min' heartbeat='80' />
+  <sample time='56:14 min' depth='3.122 m' tts='1:20 min' stoptime='1:00 min' heartbeat='81' />
+  <sample time='56:15 min' depth='3.155 m' tts='1:18 min' stoptime='0:59 min' heartbeat='80' />
+  <sample time='56:16 min' depth='3.141 m' stoptime='0:58 min' heartbeat='81' />
+  <sample time='56:17 min' depth='3.112 m' pressure='138.03 bar' tts='1:17 min' stoptime='0:57 min' />
+  <sample time='56:18 min' depth='3.123 m' tts='1:16 min' heartbeat='79' />
+  <sample time='56:19 min' depth='3.128 m' tts='1:15 min' stoptime='0:56 min' heartbeat='81' />
+  <sample time='56:20 min' depth='3.127 m' tts='1:14 min' stoptime='0:55 min' />
+  <sample time='56:21 min' depth='3.137 m' tts='1:13 min' stoptime='0:54 min' />
+  <sample time='56:22 min' depth='3.124 m' tts='1:12 min' stoptime='0:53 min' />
+  <sample time='56:23 min' depth='3.122 m' tts='1:11 min' stoptime='0:52 min' />
+  <sample time='56:24 min' depth='3.126 m' tts='1:10 min' stoptime='0:51 min' />
+  <sample time='56:25 min' depth='3.137 m' tts='1:09 min' stoptime='0:50 min' />
+  <sample time='56:26 min' depth='3.121 m' tts='1:08 min' stoptime='0:49 min' />
+  <sample time='56:27 min' depth='3.121 m' pressure='137.68 bar' tts='1:07 min' stoptime='0:48 min' />
+  <sample time='56:28 min' depth='3.129 m' tts='1:06 min' stoptime='0:47 min' heartbeat='80' />
+  <sample time='56:29 min' depth='3.13 m' tts='1:05 min' stoptime='0:46 min' />
+  <sample time='56:30 min' depth='3.107 m' tts='1:04 min' stoptime='0:45 min' />
+  <sample time='56:31 min' depth='3.112 m' tts='1:03 min' stoptime='0:44 min' />
+  <sample time='56:32 min' depth='3.119 m' pressure='137.48 bar' tts='1:02 min' stoptime='0:43 min' />
+  <sample time='56:33 min' depth='3.142 m' tts='1:01 min' stoptime='0:42 min' heartbeat='82' />
+  <sample time='56:34 min' depth='3.131 m' tts='1:00 min' stoptime='0:41 min' heartbeat='80' />
+  <sample time='56:35 min' depth='3.009 m' tts='0:59 min' stoptime='0:40 min' />
+  <sample time='56:36 min' depth='3.086 m' tts='0:58 min' stoptime='0:39 min' />
+  <sample time='56:37 min' depth='3.135 m' pressure='137.2 bar' tts='0:57 min' stoptime='0:38 min' />
+  <sample time='56:38 min' depth='3.164 m' tts='0:56 min' stoptime='0:37 min' heartbeat='79' />
+  <sample time='56:39 min' depth='3.193 m' tts='0:55 min' stoptime='0:36 min' heartbeat='80' />
+  <sample time='56:40 min' depth='3.175 m' tts='0:54 min' stoptime='0:35 min' heartbeat='78' />
+  <sample time='56:41 min' depth='3.159 m' tts='0:53 min' stoptime='0:34 min' heartbeat='80' />
+  <sample time='56:42 min' depth='3.148 m' pressure='137.34 bar' tts='0:52 min' stoptime='0:33 min' />
+  <sample time='56:43 min' depth='3.161 m' tts='0:51 min' stoptime='0:32 min' />
+  <sample time='56:44 min' depth='3.168 m' tts='0:50 min' stoptime='0:31 min' heartbeat='81' />
+  <sample time='56:45 min' depth='3.155 m' tts='0:49 min' stoptime='0:30 min' heartbeat='80' />
+  <sample time='56:46 min' depth='3.154 m' tts='0:48 min' stoptime='0:29 min' />
+  <sample time='56:47 min' depth='3.17 m' pressure='137.06 bar' tts='0:47 min' stoptime='0:28 min' />
+  <sample time='56:48 min' depth='3.067 m' stoptime='0:27 min' />
+  <sample time='56:49 min' depth='3.059 m' tts='0:46 min' stoptime='0:26 min' />
+  <sample time='56:50 min' depth='3.117 m' tts='0:44 min' stoptime='0:25 min' heartbeat='78' />
+  <sample time='56:51 min' depth='3.17 m' tts='0:43 min' stoptime='0:24 min' heartbeat='79' />
+  <sample time='56:52 min' depth='3.15 m' pressure='136.92 bar' tts='0:42 min' stoptime='0:23 min' heartbeat='80' />
+  <sample time='56:53 min' depth='3.186 m' tts='0:41 min' stoptime='0:22 min' />
+  <sample time='56:54 min' depth='3.348 m' tts='0:40 min' stoptime='0:21 min' />
+  <sample time='56:55 min' depth='3.336 m' tts='0:39 min' stoptime='0:20 min' />
+  <sample time='56:56 min' depth='3.312 m' tts='0:38 min' stoptime='0:19 min' heartbeat='79' />
+  <sample time='56:57 min' depth='3.349 m' pressure='136.79 bar' tts='0:37 min' stoptime='0:18 min' heartbeat='80' />
+  <sample time='56:58 min' depth='3.38 m' stoptime='0:17 min' />
+  <sample time='56:59 min' depth='3.392 m' tts='0:36 min' stoptime='0:16 min' heartbeat='81' />
+  <sample time='57:00 min' depth='3.37 m' tts='0:35 min' stoptime='0:15 min' heartbeat='83' />
+  <sample time='57:01 min' depth='3.378 m' tts='0:34 min' stoptime='0:14 min' heartbeat='79' />
+  <sample time='57:02 min' depth='3.377 m' pressure='136.86 bar' tts='0:33 min' stoptime='0:13 min' heartbeat='77' />
+  <sample time='57:03 min' depth='3.384 m' tts='0:32 min' stoptime='0:12 min' />
+  <sample time='57:04 min' depth='3.418 m' tts='0:31 min' stoptime='0:11 min' />
+  <sample time='57:05 min' depth='3.11 m' tts='0:30 min' stoptime='0:10 min' heartbeat='78' />
+  <sample time='57:06 min' depth='3.121 m' tts='0:29 min' heartbeat='77' />
+  <sample time='57:07 min' depth='3.138 m' pressure='136.58 bar' tts='0:28 min' stoptime='0:09 min' heartbeat='78' />
+  <sample time='57:08 min' depth='3.14 m' tts='0:27 min' stoptime='0:08 min' heartbeat='77' />
+  <sample time='57:09 min' depth='3.171 m' tts='0:25 min' stoptime='0:07 min' />
+  <sample time='57:10 min' depth='3.518 m' stoptime='0:06 min' />
+  <sample time='57:11 min' depth='3.514 m' tts='0:24 min' stoptime='0:05 min' heartbeat='78' />
+  <sample time='57:12 min' depth='3.522 m' pressure='136.72 bar' tts='0:23 min' stoptime='0:04 min' heartbeat='77' />
+  <sample time='57:13 min' depth='3.496 m' tts='0:22 min' stoptime='0:03 min' heartbeat='76' />
+  <sample time='57:14 min' depth='3.48 m' stoptime='0:02 min' heartbeat='77' />
+  <sample time='57:15 min' depth='3.478 m' stoptime='0:01 min' />
+  <sample time='57:16 min' depth='3.475 m' in_deco='0' stoptime='0:00 min' stopdepth='0.0 m' />
+  <sample time='57:17 min' depth='3.472 m' heartbeat='78' />
+  <sample time='57:18 min' depth='3.439 m' heartbeat='80' />
+  <sample time='57:19 min' depth='3.444 m' tts='0:00 min' />
+  <sample time='57:20 min' depth='3.449 m' tts='0:22 min' heartbeat='79' />
+  <sample time='57:22 min' depth='3.464 m' pressure='136.44 bar' tts='0:00 min' />
+  <sample time='57:23 min' depth='3.472 m' tts='0:22 min' heartbeat='81' />
+  <sample time='57:24 min' depth='3.464 m' heartbeat='78' />
+  <sample time='57:25 min' depth='3.493 m' heartbeat='79' />
+  <sample time='57:26 min' depth='3.488 m' heartbeat='80' />
+  <sample time='57:27 min' depth='3.517 m' pressure='136.03 bar' tts='0:23 min' heartbeat='81' />
+  <sample time='57:28 min' depth='3.517 m' heartbeat='80' />
+  <sample time='57:29 min' depth='3.504 m' tts='0:22 min' />
+  <sample time='57:30 min' depth='3.531 m' tts='0:23 min' heartbeat='79' />
+  <sample time='57:31 min' depth='3.538 m' heartbeat='78' />
+  <sample time='57:32 min' depth='3.529 m' pressure='136.17 bar' heartbeat='77' />
+  <sample time='57:33 min' depth='3.497 m' tts='0:22 min' heartbeat='76' />
+  <sample time='57:34 min' depth='3.505 m' tts='0:23 min' heartbeat='75' />
+  <sample time='57:36 min' depth='3.329 m' tts='0:21 min' />
+  <sample time='57:37 min' depth='3.063 m' pressure='135.68 bar' tts='0:20 min' heartbeat='74' />
+  <sample time='57:38 min' depth='3.048 m' heartbeat='73' />
+  <sample time='57:39 min' depth='3.039 m' tts='0:19 min' />
+  <sample time='57:40 min' depth='3.076 m' tts='0:20 min' heartbeat='75' />
+  <sample time='57:41 min' depth='3.129 m' heartbeat='73' />
+  <sample time='57:42 min' depth='3.217 m' pressure='135.61 bar' tts='0:21 min' heartbeat='71' />
+  <sample time='57:43 min' depth='3.143 m' tts='0:20 min' heartbeat='73' />
+  <sample time='57:44 min' depth='3.292 m' tts='0:21 min' />
+  <sample time='57:47 min' depth='3.297 m' pressure='135.34 bar' heartbeat='72' />
+  <sample time='57:48 min' depth='3.274 m' heartbeat='73' />
+  <sample time='57:49 min' depth='3.259 m' heartbeat='71' />
+  <sample time='57:50 min' depth='3.313 m' heartbeat='73' />
+  <sample time='57:51 min' depth='3.392 m' tts='0:22 min' heartbeat='72' />
+  <sample time='57:55 min' depth='3.431 m' heartbeat='71' />
+  <sample time='57:56 min' depth='3.404 m' heartbeat='72' />
+  <sample time='57:57 min' depth='3.392 m' pressure='135.06 bar' tts='0:00 min' />
+  <sample time='57:58 min' depth='3.381 m' tts='0:22 min' />
+  <sample time='58:01 min' depth='3.402 m' heartbeat='71' />
+  <sample time='58:02 min' depth='3.574 m' tts='0:23 min' heartbeat='69' />
+  <sample time='58:03 min' depth='3.679 m' tts='0:24 min' heartbeat='72' />
+  <sample time='58:04 min' depth='3.623 m' tts='0:23 min' />
+  <sample time='58:05 min' depth='3.575 m' heartbeat='71' />
+  <sample time='58:06 min' depth='3.541 m' heartbeat='72' />
+  <sample time='58:07 min' depth='3.547 m' heartbeat='71' />
+  <sample time='58:08 min' depth='3.52 m' heartbeat='73' />
+  <sample time='58:09 min' depth='3.505 m' heartbeat='72' />
+  <sample time='58:10 min' depth='3.499 m' tts='0:22 min' heartbeat='73' />
+  <sample time='58:11 min' depth='3.518 m' tts='0:23 min' heartbeat='71' />
+  <sample time='58:12 min' depth='3.519 m' pressure='134.79 bar' heartbeat='73' />
+  <sample time='58:13 min' depth='3.498 m' tts='0:22 min' />
+  <sample time='58:14 min' depth='3.487 m' heartbeat='74' />
+  <sample time='58:15 min' depth='3.489 m' heartbeat='75' />
+  <sample time='58:16 min' depth='3.5 m' heartbeat='76' />
+  <sample time='58:18 min' depth='3.486 m' heartbeat='77' />
+  <sample time='58:19 min' depth='3.486 m' heartbeat='78' />
+  <sample time='58:21 min' depth='3.482 m' heartbeat='79' />
+  <sample time='58:22 min' depth='3.49 m' pressure='134.03 bar' tts='0:00 min' />
+  <sample time='58:23 min' depth='3.497 m' tts='0:22 min' heartbeat='80' />
+  <sample time='58:24 min' depth='3.485 m' heartbeat='81' />
+  <sample time='58:25 min' depth='3.496 m' heartbeat='79' />
+  <sample time='58:27 min' depth='3.514 m' pressure='134.1 bar' tts='0:23 min' />
+  <sample time='58:28 min' depth='3.518 m' heartbeat='77' />
+  <sample time='58:29 min' depth='3.53 m' heartbeat='81' />
+  <sample time='58:30 min' depth='3.527 m' heartbeat='77' />
+  <sample time='58:31 min' depth='3.536 m' heartbeat='79' />
+  <sample time='58:32 min' depth='3.524 m' pressure='133.82 bar' heartbeat='80' />
+  <sample time='58:33 min' depth='3.477 m' tts='0:22 min' />
+  <sample time='58:34 min' depth='3.433 m' heartbeat='79' />
+  <sample time='58:36 min' depth='3.482 m' heartbeat='78' />
+  <sample time='58:37 min' depth='3.603 m' pressure='133.82 bar' tts='0:23 min' heartbeat='77' />
+  <sample time='58:38 min' depth='3.667 m' tts='0:24 min' heartbeat='80' />
+  <sample time='58:39 min' depth='3.683 m' heartbeat='79' />
+  <sample time='58:41 min' depth='3.705 m' />
+  <sample time='58:43 min' depth='3.706 m' heartbeat='80' />
+  <sample time='58:44 min' depth='3.72 m' heartbeat='79' />
+  <sample time='58:45 min' depth='3.719 m' heartbeat='81' />
+  <sample time='58:46 min' depth='3.705 m' heartbeat='79' />
+  <sample time='58:47 min' depth='3.664 m' pressure='133.89 bar' heartbeat='78' />
+  <sample time='58:48 min' depth='3.649 m' tts='0:23 min' heartbeat='79' />
+  <sample time='58:49 min' depth='3.667 m' tts='0:24 min' heartbeat='78' />
+  <sample time='58:51 min' depth='3.695 m' heartbeat='76' />
+  <sample time='58:52 min' depth='3.675 m' pressure='133.82 bar' heartbeat='78' />
+  <sample time='58:53 min' depth='3.606 m' tts='0:23 min' heartbeat='77' />
+  <sample time='58:54 min' depth='3.57 m' heartbeat='79' />
+  <sample time='58:55 min' depth='3.52 m' heartbeat='80' />
+  <sample time='58:56 min' depth='3.491 m' tts='0:22 min' heartbeat='81' />
+  <sample time='58:57 min' depth='3.439 m' pressure='133.68 bar' />
+  <sample time='58:58 min' depth='3.485 m' heartbeat='82' />
+  <sample time='58:59 min' depth='3.514 m' tts='0:23 min' heartbeat='80' />
+  <sample time='59:00 min' depth='3.561 m' />
+  <sample time='59:01 min' depth='3.697 m' tts='0:24 min' />
+  <sample time='59:02 min' depth='3.674 m' pressure='133.68 bar' heartbeat='78' />
+  <sample time='59:03 min' depth='3.7 m' heartbeat='79' />
+  <sample time='59:04 min' depth='3.716 m' heartbeat='78' />
+  <sample time='59:05 min' depth='3.727 m' heartbeat='79' />
+  <sample time='59:06 min' depth='3.715 m' heartbeat='80' />
+  <sample time='59:07 min' depth='3.72 m' pressure='133.41 bar' heartbeat='81' />
+  <sample time='59:08 min' depth='3.735 m' />
+  <sample time='59:10 min' depth='3.834 m' tts='0:25 min' heartbeat='82' />
+  <sample time='59:12 min' depth='3.856 m' pressure='133.48 bar' heartbeat='81' />
+  <sample time='59:13 min' depth='3.903 m' heartbeat='83' />
+  <sample time='59:14 min' depth='3.937 m' heartbeat='81' />
+  <sample time='59:15 min' depth='3.889 m' heartbeat='83' />
+  <sample time='59:16 min' depth='3.964 m' tts='0:26 min' />
+  <sample time='59:17 min' depth='3.847 m' pressure='133.2 bar' tts='0:25 min' />
+  <sample time='59:18 min' depth='3.797 m' tts='0:24 min' heartbeat='80' />
+  <sample time='59:21 min' depth='3.817 m' tts='0:25 min' heartbeat='79' />
+  <sample time='59:22 min' depth='3.809 m' pressure='133.06 bar' tts='0:24 min' />
+  <sample time='59:23 min' depth='3.812 m' tts='0:25 min' />
+  <sample time='59:24 min' depth='3.759 m' tts='0:24 min' />
+  <sample time='59:25 min' depth='3.693 m' heartbeat='78' />
+  <sample time='59:26 min' depth='3.689 m' heartbeat='79' />
+  <sample time='59:27 min' depth='3.682 m' pressure='132.93 bar' heartbeat='81' />
+  <sample time='59:28 min' depth='3.492 m' tts='0:22 min' />
+  <sample time='59:29 min' depth='3.374 m' heartbeat='82' />
+  <sample time='59:30 min' depth='3.277 m' tts='0:21 min' />
+  <sample time='59:31 min' depth='3.291 m' heartbeat='84' />
+  <sample time='59:32 min' depth='3.298 m' pressure='132.65 bar' tts='0:00 min' />
+  <sample time='59:33 min' depth='3.305 m' tts='0:21 min' />
+  <sample time='59:35 min' depth='3.281 m' heartbeat='86' />
+  <sample time='59:37 min' depth='3.307 m' pressure='132.51 bar' heartbeat='87' />
+  <sample time='59:38 min' depth='3.285 m' heartbeat='86' />
+  <sample time='59:39 min' depth='3.284 m' heartbeat='87' />
+  <sample time='59:40 min' depth='3.3 m' heartbeat='86' />
+  <sample time='59:42 min' depth='3.195 m' pressure='132.58 bar' tts='0:20 min' />
+  <sample time='59:43 min' depth='3.034 m' tts='0:19 min' heartbeat='87' />
+  <sample time='59:44 min' depth='3.033 m' heartbeat='84' />
+  <sample time='59:45 min' depth='3.065 m' tts='0:20 min' heartbeat='85' />
+  <sample time='59:46 min' depth='3.085 m' heartbeat='88' />
+  <sample time='59:47 min' depth='3.092 m' pressure='132.31 bar' heartbeat='89' />
+  <sample time='59:48 min' depth='3.15 m' heartbeat='88' />
+  <sample time='59:49 min' depth='3.41 m' tts='0:22 min' />
+  <sample time='59:50 min' depth='3.625 m' tts='0:23 min' heartbeat='89' />
+  <sample time='59:51 min' depth='3.731 m' tts='0:24 min' />
+  <sample time='59:52 min' depth='3.674 m' pressure='132.44 bar' heartbeat='90' />
+  <sample time='59:53 min' depth='3.589 m' tts='0:23 min' />
+  <sample time='59:54 min' depth='3.235 m' tts='0:21 min' />
+  <sample time='59:55 min' depth='3.147 m' tts='0:20 min' />
+  <sample time='59:56 min' depth='3.333 m' tts='0:21 min' />
+  <sample time='59:57 min' depth='3.358 m' pressure='132.51 bar' tts='0:00 min' />
+  <sample time='59:58 min' depth='3.383 m' tts='0:22 min' />
+  <sample time='59:59 min' depth='3.342 m' tts='0:21 min' heartbeat='91' />
+  <sample time='60:00 min' depth='3.204 m' heartbeat='90' />
+  <sample time='60:01 min' depth='3.324 m' heartbeat='91' />
+  <sample time='60:02 min' depth='3.29 m' pressure='132.17 bar' tts='0:00 min' />
+  <sample time='60:03 min' depth='3.257 m' tts='0:21 min' heartbeat='92' />
+  <sample time='60:04 min' depth='3.217 m' />
+  <sample time='60:05 min' depth='3.386 m' tts='0:22 min' heartbeat='89' />
+  <sample time='60:06 min' depth='3.508 m' tts='0:23 min' heartbeat='92' />
+  <sample time='60:07 min' depth='3.472 m' tts='0:22 min' heartbeat='93' />
+  <sample time='60:08 min' depth='3.338 m' tts='0:21 min' heartbeat='94' />
+  <sample time='60:09 min' depth='2.882 m' tts='0:18 min' />
+  <sample time='60:10 min' depth='2.962 m' tts='0:19 min' heartbeat='95' />
+  <sample time='60:11 min' depth='3.006 m' heartbeat='96' />
+  <sample time='60:12 min' depth='2.983 m' pressure='131.89 bar' tts='0:00 min' />
+  <sample time='60:13 min' depth='2.96 m' tts='0:19 min' heartbeat='97' />
+  <sample time='60:15 min' depth='2.955 m' heartbeat='98' />
+  <sample time='60:17 min' depth='3.122 m' pressure='131.62 bar' tts='0:20 min' heartbeat='99' />
+  <sample time='60:18 min' depth='3.165 m' />
+  <sample time='60:19 min' depth='3.119 m' heartbeat='98' />
+  <sample time='60:20 min' depth='2.961 m' tts='0:19 min' heartbeat='100' />
+  <sample time='60:22 min' depth='3.238 m' tts='0:21 min' heartbeat='96' />
+  <sample time='60:23 min' depth='3.311 m' heartbeat='100' />
+  <sample time='60:24 min' depth='3.318 m' heartbeat='101' />
+  <sample time='60:26 min' depth='3.341 m' />
+  <sample time='60:28 min' depth='3.286 m' heartbeat='102' />
+  <sample time='60:29 min' depth='3.381 m' tts='0:22 min' />
+  <sample time='60:30 min' depth='3.39 m' heartbeat='105' />
+  <sample time='60:31 min' depth='3.395 m' heartbeat='102' />
+  <sample time='60:32 min' depth='3.005 m' pressure='131.06 bar' tts='0:19 min' />
+  <sample time='60:33 min' depth='3.203 m' tts='0:21 min' heartbeat='101' />
+  <sample time='60:34 min' depth='3.029 m' tts='0:19 min' />
+  <sample time='60:35 min' depth='2.988 m' heartbeat='100' />
+  <sample time='60:36 min' depth='3.047 m' heartbeat='99' />
+  <sample time='60:37 min' depth='3.083 m' pressure='131.0 bar' tts='0:20 min' />
+  <sample time='60:38 min' depth='3.077 m' heartbeat='98' />
+  <sample time='60:39 min' depth='3.199 m' heartbeat='96' />
+  <sample time='60:40 min' depth='3.402 m' tts='0:22 min' heartbeat='95' />
+  <sample time='60:41 min' depth='3.252 m' tts='0:21 min' heartbeat='93' />
+  <sample time='60:42 min' depth='3.195 m' tts='0:20 min' heartbeat='92' />
+  <sample time='60:43 min' depth='3.175 m' heartbeat='91' />
+  <sample time='60:44 min' depth='2.986 m' tts='0:19 min' />
+  <sample time='60:47 min' depth='3.05 m' pressure='130.72 bar' tts='0:00 min' />
+  <sample time='60:48 min' depth='3.072 m' tts='0:20 min' />
+  <sample time='60:49 min' depth='3.09 m' />
+  <sample time='60:52 min' depth='3.199 m' pressure='130.51 bar' />
+  <sample time='60:53 min' depth='3.189 m' />
+  <sample time='60:55 min' depth='3.087 m' />
+  <sample time='60:57 min' depth='3.094 m' pressure='130.51 bar' tts='0:00 min' />
+  <sample time='60:58 min' depth='3.098 m' tts='0:20 min' heartbeat='92' />
+  <sample time='61:00 min' depth='3.153 m' heartbeat='91' />
+  <sample time='61:02 min' depth='3.212 m' pressure='130.37 bar' tts='0:21 min' />
+  <sample time='61:03 min' depth='3.208 m' />
+  <sample time='61:04 min' depth='3.198 m' tts='0:20 min' />
+  <sample time='61:05 min' depth='3.164 m' heartbeat='89' />
+  <sample time='61:06 min' depth='3.131 m' heartbeat='91' />
+  <sample time='61:07 min' depth='3.122 m' pressure='130.1 bar' tts='0:00 min' />
+  <sample time='61:08 min' depth='3.112 m' tts='0:20 min' />
+  <sample time='61:09 min' depth='3.048 m' tts='0:19 min' heartbeat='90' />
+  <sample time='61:10 min' depth='2.678 m' tts='0:17 min' />
+  <sample time='61:11 min' depth='2.896 m' tts='0:18 min' />
+  <sample time='61:12 min' depth='3.211 m' pressure='130.17 bar' tts='0:21 min' />
+  <sample time='61:13 min' depth='2.887 m' tts='0:18 min' />
+  <sample time='61:14 min' depth='3.014 m' tts='0:19 min' heartbeat='88' />
+  <sample time='61:15 min' depth='3.055 m' tts='0:20 min' heartbeat='89' />
+  <sample time='61:16 min' depth='3.054 m' heartbeat='90' />
+  <sample time='61:17 min' depth='3.107 m' pressure='129.82 bar' heartbeat='89' />
+  <sample time='61:18 min' depth='3.02 m' tts='0:19 min' heartbeat='90' />
+  <sample time='61:19 min' depth='2.959 m' heartbeat='89' />
+  <sample time='61:22 min' depth='2.875 m' pressure='129.75 bar' tts='0:18 min' heartbeat='88' />
+  <sample time='61:23 min' depth='2.772 m' heartbeat='89' />
+  <sample time='61:25 min' depth='2.533 m' tts='0:16 min' heartbeat='91' />
+  <sample time='61:26 min' depth='2.372 m' tts='0:15 min' />
+  <sample time='61:27 min' depth='2.279 m' pressure='129.75 bar' tts='0:14 min' heartbeat='92' />
+  <sample time='61:28 min' depth='2.172 m' />
+  <sample time='61:29 min' depth='2.06 m' tts='0:13 min' heartbeat='93' />
+  <sample time='61:30 min' depth='1.936 m' tts='0:12 min' heartbeat='95' />
+  <sample time='61:31 min' depth='1.802 m' tts='0:11 min' heartbeat='94' />
+  <sample time='61:32 min' depth='1.735 m' pressure='129.55 bar' heartbeat='93' />
+  <sample time='61:33 min' depth='1.75 m' heartbeat='94' />
+  <sample time='61:34 min' depth='1.676 m' tts='0:10 min' heartbeat='91' />
+  <sample time='61:35 min' depth='1.693 m' tts='0:11 min' heartbeat='90' />
+  <sample time='61:36 min' depth='1.593 m' tts='0:10 min' heartbeat='91' />
+  <sample time='61:37 min' depth='1.501 m' pressure='129.41 bar' tts='0:09 min' heartbeat='92' />
+  <sample time='61:38 min' depth='1.221 m' tts='0:08 min' />
+  <sample time='61:40 min' depth='1.252 m' heartbeat='93' />
+  <sample time='61:42 min' depth='1.227 m' pressure='129.27 bar' tts='0:00 min' />
+  <sample time='61:43 min' depth='1.214 m' tts='0:07 min' heartbeat='92' />
+  <sample time='61:44 min' depth='1.239 m' tts='0:08 min' />
+  <sample time='61:45 min' depth='1.191 m' tts='0:07 min' />
+  <sample time='61:46 min' depth='0.881 m' tts='0:05 min' />
+  <sample time='61:47 min' depth='0.741 m' pressure='129.41 bar' tts='0:04 min' />
+  <sample time='61:48 min' depth='0.739 m' />
+  <sample time='61:49 min' depth='0.607 m' tts='0:03 min' />
+  <sample time='61:50 min' depth='0.275 m' tts='0:01 min' />
+  <sample time='61:54 min' depth='0.205 m' heartbeat='91' />
+  <sample time='61:57 min' depth='0.004 m' tts='0:00 min' />
+  <sample time='61:59 min' depth='0.003 m' pressure='128.99 bar' />
+  <sample time='62:00 min' depth='0.002 m' pressure='128.94 bar' />
+  <sample time='62:01 min' depth='0.002 m' pressure='128.82 bar' />
+  <sample time='62:02 min' depth='0.001 m' pressure='128.84 bar' heartbeat='92' />
+  <sample time='62:03 min' depth='0.001 m' pressure='128.87 bar' />
+  <sample time='62:04 min' depth='0.0 m' pressure='128.84 bar' />
+  <sample time='62:05 min' depth='0.0 m' heartbeat='93' />
+  <sample time='62:07 min' depth='0.0 m' pressure='128.74 bar' heartbeat='94' />
+  <sample time='62:08 min' depth='0.0 m' heartbeat='95' />
+  <sample time='62:10 min' depth='0.0 m' pressure='128.67 bar' />
+  <sample time='62:11 min' depth='0.0 m' />
+  <sample time='62:12 min' depth='0.0 m' />
+  <sample time='62:13 min' depth='0.0 m' pressure='128.82 bar' />
+  <sample time='62:14 min' depth='0.0 m' pressure='128.65 bar' />
+  <sample time='62:15 min' depth='0.002 m' pressure='128.54 bar' />
+  <sample time='62:16 min' depth='0.005 m' heartbeat='93' />
+  <sample time='62:17 min' depth='0.0 m' pressure='128.52 bar' heartbeat='94' />
+  <sample time='62:18 min' depth='0.009 m' heartbeat='95' />
+  <sample time='62:19 min' depth='0.007 m' pressure='128.49 bar' />
+  <sample time='62:21 min' depth='0.004 m' pressure='128.37 bar' />
+  <sample time='62:22 min' depth='0.002 m' pressure='128.42 bar' />
+  <sample time='62:23 min' depth='0.0 m' pressure='128.37 bar' heartbeat='97' />
+  <sample time='62:24 min' depth='0.0 m' heartbeat='95' />
+  <sample time='62:25 min' depth='0.0 m' pressure='128.14 bar' />
+  <sample time='62:26 min' depth='0.0 m' pressure='128.07 bar' heartbeat='94' />
+  <sample time='62:27 min' depth='0.005 m' pressure='128.19 bar' />
+  <sample time='62:28 min' depth='0.01 m' pressure='128.14 bar' />
+  <sample time='62:29 min' depth='0.015 m' pressure='128.12 bar' />
+  <sample time='62:30 min' depth='0.02 m' heartbeat='93' />
+  <sample time='62:31 min' depth='0.013 m' heartbeat='94' />
+  <sample time='62:32 min' depth='0.01 m' pressure='128.17 bar' heartbeat='91' />
+  <sample time='62:33 min' depth='0.007 m' heartbeat='93' />
+  <sample time='62:34 min' depth='0.004 m' pressure='128.19 bar' />
+  <sample time='62:35 min' depth='0.0 m' heartbeat='94' />
+  <sample time='62:36 min' depth='0.004 m' pressure='128.27 bar' heartbeat='95' />
+  <sample time='62:37 min' depth='0.003 m' heartbeat='93' />
+  <sample time='62:38 min' depth='0.005 m' pressure='128.32 bar' heartbeat='92' />
+  <sample time='62:39 min' depth='0.0 m' pressure='128.29 bar' heartbeat='94' />
+  <sample time='62:40 min' depth='0.0 m' />
+  <sample time='62:41 min' depth='0.0 m' />
+  <sample time='62:42 min' depth='0.0 m' heartbeat='93' />
+  <sample time='62:43 min' depth='0.013 m' pressure='128.37 bar' heartbeat='92' />
+  <sample time='62:46 min' depth='0.006 m' />
+  <sample time='62:47 min' depth='0.004 m' />
+  <sample time='62:48 min' depth='0.001 m' pressure='128.47 bar' heartbeat='93' />
+  <sample time='62:49 min' depth='0.0 m' pressure='128.39 bar' />
+  <sample time='62:50 min' depth='0.0 m' heartbeat='94' />
+  <sample time='62:51 min' depth='0.0 m' />
+  <sample time='62:52 min' depth='0.0 m' pressure='128.42 bar' heartbeat='96' />
+  <sample time='62:53 min' depth='0.0 m' heartbeat='95' />
+  <sample time='62:55 min' depth='0.0 m' pressure='128.42 bar' heartbeat='96' />
+  <sample time='62:58 min' depth='0.0 m' heartbeat='97' />
+  <sample time='62:59 min' depth='0.0 m' heartbeat='95' />
+  <sample time='63:00 min' depth='0.0 m' pressure='128.47 bar' heartbeat='96' />
+  <sample time='63:01 min' depth='0.0 m' heartbeat='97' />
+  <sample time='63:02 min' depth='0.0 m' />
+  <sample time='63:03 min' depth='0.0 m' pressure='128.42 bar' />
+  <sample time='63:04 min' depth='0.0 m' heartbeat='98' />
+  <sample time='63:05 min' depth='0.0 m' pressure='128.49 bar' heartbeat='99' />
+  <sample time='63:06 min' depth='0.0 m' heartbeat='97' />
+  <sample time='63:07 min' depth='0.0 m' heartbeat='96' />
+  <sample time='63:08 min' depth='0.0 m' pressure='128.49 bar' heartbeat='95' />
+  <sample time='63:09 min' depth='0.0 m' heartbeat='96' />
+  <sample time='63:10 min' depth='0.003 m' pressure='128.52 bar' heartbeat='95' />
+  <sample time='63:11 min' depth='0.0 m' heartbeat='96' />
+  <sample time='63:12 min' depth='0.0 m' pressure='128.54 bar' />
+  <sample time='63:13 min' depth='0.0 m' pressure='128.52 bar' heartbeat='97' />
+  <sample time='63:14 min' depth='0.0 m' pressure='128.59 bar' heartbeat='95' />
+  <sample time='63:15 min' depth='0.0 m' heartbeat='94' />
+  <sample time='63:16 min' depth='0.0 m' pressure='128.54 bar' heartbeat='95' />
+  <sample time='63:17 min' depth='0.0 m' pressure='128.59 bar' />
+  <sample time='63:18 min' depth='0.0 m' heartbeat='96' />
+  <sample time='63:19 min' depth='0.0 m' heartbeat='93' />
+  <sample time='63:20 min' depth='0.0 m' pressure='128.59 bar' heartbeat='94' />
+  <sample time='63:22 min' depth='0.0 m' pressure='128.62 bar' heartbeat='93' />
+  <sample time='63:23 min' depth='0.0 m' pressure='128.59 bar' />
+  <sample time='63:24 min' depth='0.0 m' pressure='128.62 bar' />
+  <sample time='63:25 min' depth='0.0 m' pressure='128.65 bar' />
+  <sample time='63:26 min' depth='0.0 m' />
+  <sample time='63:27 min' depth='0.0 m' />
+  <sample time='63:28 min' depth='0.0 m' heartbeat='91' />
+  <sample time='63:29 min' depth='0.0 m' />
+  <sample time='63:30 min' depth='0.0 m' heartbeat='94' />
+  <sample time='63:31 min' depth='0.006 m' pressure='128.65 bar' heartbeat='91' />
+  <sample time='63:32 min' depth='0.0 m' heartbeat='94' />
+  <sample time='63:34 min' depth='0.0 m' pressure='128.65 bar' heartbeat='93' />
+  <sample time='63:35 min' depth='0.0 m' />
+  <sample time='63:36 min' depth='0.0 m' heartbeat='94' />
+  <sample time='63:37 min' depth='0.005 m' pressure='128.72 bar' heartbeat='95' />
+  <sample time='63:38 min' depth='0.005 m' pressure='128.67 bar' heartbeat='94' />
+  <sample time='63:39 min' depth='0.0 m' pressure='128.65 bar' heartbeat='95' />
+  <sample time='63:40 min' depth='0.0 m' pressure='128.72 bar' />
+  <sample time='63:41 min' depth='0.001 m' heartbeat='96' />
+  <sample time='63:42 min' depth='0.0 m' heartbeat='97' />
+  <sample time='63:43 min' depth='0.001 m' heartbeat='98' />
+  <sample time='63:44 min' depth='0.0 m' pressure='128.72 bar' heartbeat='97' />
+  <sample time='63:46 min' depth='0.0 m' pressure='128.77 bar' />
+  <sample time='63:47 min' depth='0.0 m' pressure='128.72 bar' heartbeat='98' />
+  <sample time='63:48 min' depth='0.004 m' pressure='128.74 bar' />
+  <sample time='63:49 min' depth='0.009 m' pressure='128.72 bar' heartbeat='97' />
+  <sample time='63:50 min' depth='0.004 m' pressure='128.74 bar' />
+  <sample time='63:51 min' depth='0.0 m' heartbeat='99' />
+  <sample time='63:52 min' depth='0.0 m' pressure='128.77 bar' />
+  <sample time='63:53 min' depth='0.0 m' heartbeat='100' />
+  <sample time='63:56 min' depth='0.005 m' pressure='128.74 bar' heartbeat='99' />
+  <sample time='63:57 min' depth='0.0 m' heartbeat='100' />
+  <sample time='63:58 min' depth='0.0 m' pressure='128.77 bar' heartbeat='102' />
+  <sample time='63:59 min' depth='0.0 m' pressure='128.82 bar' heartbeat='98' />
+  <sample time='64:00 min' depth='0.002 m' pressure='128.77 bar' heartbeat='101' />
+  <sample time='64:01 min' depth='0.001 m' heartbeat='99' />
+  <sample time='64:02 min' depth='0.0 m' pressure='128.82 bar' heartbeat='100' />
+  <sample time='64:03 min' depth='0.0 m' pressure='128.77 bar' />
+  <sample time='64:04 min' depth='0.0 m' />
+  <sample time='64:05 min' depth='0.0 m' heartbeat='99' />
+  <sample time='64:07 min' depth='0.0 m' heartbeat='102' />
+  <sample time='64:08 min' depth='0.001 m' heartbeat='100' />
+  <sample time='64:10 min' depth='0.0 m' pressure='128.82 bar' heartbeat='102' />
+  <sample time='64:11 min' depth='0.0 m' pressure='128.77 bar' />
+  <sample time='64:12 min' depth='0.0 m' pressure='128.82 bar' heartbeat='101' />
+  <sample time='64:13 min' depth='0.001 m' heartbeat='102' />
+  <sample time='64:14 min' depth='0.002 m' heartbeat='101' />
+  <sample time='64:15 min' depth='0.002 m' />
+  <sample time='64:16 min' depth='0.002 m' />
+  <sample time='64:17 min' depth='0.003 m' heartbeat='102' />
+  <sample time='64:18 min' depth='0.001 m' heartbeat='103' />
+  <sample time='64:19 min' depth='0.008 m' heartbeat='102' />
+  <sample time='64:20 min' depth='0.008 m' pressure='128.82 bar' />
+  <sample time='64:22 min' depth='0.007 m' />
+  <sample time='64:23 min' depth='0.006 m' pressure='128.84 bar' />
+  <sample time='64:24 min' depth='0.006 m' pressure='128.82 bar' />
+  <sample time='64:25 min' depth='0.005 m' pressure='128.84 bar' />
+  <sample time='64:26 min' depth='0.002 m' pressure='128.82 bar' />
+  <sample time='64:27 min' depth='0.0 m' heartbeat='103' />
+  <sample time='64:28 min' depth='0.0 m' heartbeat='102' />
+  <sample time='64:29 min' depth='0.0 m' />
+  <sample time='64:30 min' depth='0.0 m' heartbeat='103' />
+  <sample time='64:32 min' depth='0.002 m' pressure='128.84 bar' heartbeat='104' />
+  <sample time='64:33 min' depth='0.0 m' heartbeat='103' />
+  <sample time='64:34 min' depth='0.0 m' pressure='128.82 bar' heartbeat='104' />
+  <sample time='64:35 min' depth='0.004 m' heartbeat='105' />
+  <sample time='64:36 min' depth='0.0 m' heartbeat='104' />
+  <sample time='64:37 min' depth='0.0 m' pressure='128.84 bar' heartbeat='105' />
+  <sample time='64:38 min' depth='0.0 m' heartbeat='106' />
+  <sample time='64:39 min' depth='0.0 m' />
+  <sample time='64:40 min' depth='0.0 m' />
+  <sample time='64:41 min' depth='0.001 m' heartbeat='107' />
+  <sample time='64:42 min' depth='0.001 m' heartbeat='108' />
+  <sample time='64:43 min' depth='0.0 m' pressure='128.84 bar' heartbeat='107' />
+  <sample time='64:46 min' depth='0.005 m' heartbeat='106' />
+  <sample time='64:47 min' depth='0.002 m' pressure='128.87 bar' />
+  <sample time='64:48 min' depth='0.0 m' pressure='128.84 bar' heartbeat='107' />
+  <sample time='64:49 min' depth='0.0 m' pressure='128.87 bar' heartbeat='106' />
+  <sample time='64:50 min' depth='0.0 m' pressure='128.84 bar' />
+  <sample time='64:51 min' depth='0.0 m' heartbeat='107' />
+  <sample time='64:52 min' depth='0.0 m' pressure='128.89 bar' heartbeat='108' />
+  <sample time='64:53 min' depth='0.003 m' pressure='128.87 bar' heartbeat='107' />
+  <sample time='64:54 min' depth='0.0 m' pressure='128.84 bar' heartbeat='108' />
+  <sample time='64:56 min' depth='0.0 m' pressure='128.87 bar' heartbeat='107' />
+  <sample time='64:57 min' depth='0.002 m' heartbeat='108' />
+  <sample time='64:58 min' depth='0.0 m' pressure='128.84 bar' heartbeat='109' />
+  <sample time='64:59 min' depth='0.003 m' pressure='128.87 bar' heartbeat='110' />
+  <sample time='65:00 min' depth='0.0 m' heartbeat='107' />
+  <sample time='65:01 min' depth='0.004 m' />
+  <sample time='65:02 min' depth='0.007 m' pressure='128.89 bar' heartbeat='108' />
+  <sample time='65:03 min' depth='0.006 m' pressure='128.87 bar' />
+  <sample time='65:04 min' depth='0.005 m' />
+  <sample time='65:05 min' depth='0.004 m' />
+  <sample time='65:08 min' depth='0.001 m' />
+  <sample time='65:10 min' depth='0.0 m' pressure='128.89 bar' heartbeat='107' />
+  <sample time='65:11 min' depth='0.002 m' pressure='128.87 bar' />
+  <sample time='65:12 min' depth='0.003 m' pressure='128.89 bar' heartbeat='106' />
+  <sample time='65:13 min' depth='0.001 m' pressure='128.87 bar' heartbeat='105' />
+  <sample time='65:14 min' depth='0.002 m' />
+  <sample time='65:15 min' depth='0.002 m' temp='25.0 C' pressure='128.94 bar' heartbeat='104' />
+  <sample time='65:16 min' depth='0.002 m' pressure='128.87 bar' />
+  <sample time='65:17 min' depth='0.001 m' />
+  <sample time='65:19 min' depth='0.0 m' pressure='128.89 bar' heartbeat='102' />
+  <sample time='65:20 min' depth='0.002 m' heartbeat='103' />
+  <sample time='65:22 min' depth='0.001 m' pressure='128.89 bar' />
+  <sample time='65:23 min' depth='0.0 m' pressure='128.87 bar' heartbeat='104' />
+  <sample time='65:24 min' depth='0.0 m' />
+  <sample time='65:25 min' depth='0.0 m' pressure='128.89 bar' />
+  <sample time='65:26 min' depth='0.0 m' />
+  <sample time='65:27 min' depth='0.0 m' />
+  <sample time='65:28 min' depth='0.0 m' pressure='128.94 bar' heartbeat='103' />
+  <sample time='65:29 min' depth='0.0 m' pressure='128.89 bar' />
+  <sample time='65:30 min' depth='0.0 m' pressure='128.94 bar' />
+  <sample time='65:32 min' depth='0.0 m' heartbeat='102' />
+  <sample time='65:34 min' depth='0.0 m' pressure='128.89 bar' />
+  <sample time='65:35 min' depth='0.0 m' pressure='128.94 bar' />
+  <sample time='65:36 min' depth='0.0 m' pressure='128.89 bar' />
+  <sample time='65:37 min' depth='0.0 m' />
+  <sample time='65:38 min' depth='0.0 m' />
+  <sample time='65:39 min' depth='0.005 m' heartbeat='101' />
+  <sample time='65:40 min' depth='0.003 m' />
+  <sample time='65:41 min' depth='0.002 m' pressure='128.94 bar' />
+  <sample time='65:42 min' depth='0.0 m' heartbeat='100' />
+  <sample time='65:43 min' depth='0.0 m' heartbeat='99' />
+  <sample time='65:44 min' depth='0.001 m' pressure='128.89 bar' heartbeat='98' />
+  <sample time='65:45 min' depth='0.002 m' heartbeat='96' />
+  <sample time='65:46 min' depth='0.005 m' pressure='128.89 bar' heartbeat='95' />
+  <sample time='65:48 min' depth='0.0 m' pressure='128.94 bar' heartbeat='94' />
+  <sample time='65:49 min' depth='0.0 m' pressure='128.89 bar' heartbeat='95' />
+  <sample time='65:50 min' depth='0.0 m' heartbeat='97' />
+  <sample time='65:51 min' depth='0.0 m' pressure='128.94 bar' heartbeat='98' />
+  <sample time='65:52 min' depth='0.005 m' pressure='128.99 bar' heartbeat='99' />
+  <sample time='65:53 min' depth='0.003 m' pressure='128.87 bar' />
+  <sample time='65:54 min' depth='0.001 m' heartbeat='100' />
+  <sample time='65:55 min' depth='0.001 m' pressure='128.89 bar' />
+  <sample time='65:58 min' depth='0.0 m' pressure='128.87 bar' heartbeat='101' />
+  <sample time='66:00 min' depth='0.0 m' pressure='128.94 bar' heartbeat='102' />
+  <sample time='66:01 min' depth='0.0 m' />
+  <sample time='66:03 min' depth='0.0 m' heartbeat='101' />
+  <sample time='66:04 min' depth='0.008 m' pressure='128.89 bar' />
+  <sample time='66:05 min' depth='0.016 m' heartbeat='102' />
+  <sample time='66:07 min' depth='0.017 m' heartbeat='103' />
+  <sample time='66:08 min' depth='0.0 m' heartbeat='102' />
+  <sample time='66:09 min' depth='0.0 m' heartbeat='104' />
+  <sample time='66:12 min' depth='0.001 m' heartbeat='105' />
+  <sample time='66:13 min' depth='0.001 m' pressure='128.97 bar' />
+  <sample time='66:14 min' depth='0.001 m' pressure='128.94 bar' />
+  <sample time='66:16 min' depth='0.0 m' pressure='128.89 bar' />
+  <sample time='66:17 min' depth='0.0 m' heartbeat='106' />
+  <sample time='66:20 min' depth='0.0 m' heartbeat='105' />
+  <sample time='66:22 min' depth='0.005 m' pressure='128.97 bar' heartbeat='104' />
+  <sample time='66:23 min' depth='0.002 m' heartbeat='103' />
+  <sample time='66:24 min' depth='0.001 m' heartbeat='105' />
+  <sample time='66:25 min' depth='0.001 m' pressure='128.97 bar' heartbeat='103' />
+  <sample time='66:26 min' depth='0.0 m' heartbeat='105' />
+  <sample time='66:28 min' depth='0.0 m' heartbeat='106' />
+  <sample time='66:29 min' depth='0.0 m' pressure='128.97 bar' />
+  <sample time='66:32 min' depth='0.0 m' />
+  <sample time='66:33 min' depth='0.0 m' heartbeat='108' />
+  <sample time='66:34 min' depth='0.0 m' heartbeat='106' />
+  <sample time='66:38 min' depth='0.002 m' heartbeat='107' />
+  <sample time='66:39 min' depth='0.0 m' heartbeat='108' />
+  <sample time='66:40 min' depth='0.001 m' heartbeat='107' />
+  <sample time='66:41 min' depth='0.001 m' pressure='128.99 bar' />
+  <sample time='66:46 min' depth='0.001 m' />
+  <sample time='66:48 min' depth='0.0 m' pressure='128.97 bar' heartbeat='106' />
+  <sample time='66:49 min' depth='0.003 m' heartbeat='105' />
+  <sample time='66:50 min' depth='0.003 m' />
+  </divecomputer>
+  <divecomputer model='Suunto Vyper Air' deviceid='91be1c96' diveid='cf353243' date='2021-11-29' time='06:31:16' duration='61:40 min'>
+  <depth max='29.94 m' mean='18.318 m' />
+  <temperature water='25.0 C' />
+  <event time='0:00 min' type='25' flags='1' name='gaschange' cylinder='0' o2='30.0%' />
+  <event time='0:00 min' type='20' flags='1' name='pO₂' />
+  <event time='3:00 min' type='11' value='29' name='gaschange' cylinder='1' o2='29.0%' />
+  <event time='38:43 min' type='11' value='30' name='gaschange' cylinder='0' o2='30.0%' />
+  <event time='61:45 min' type='9' name='surface' />
+  <sample time='0:00 min' depth='1.33 m' temp='25.0 C' pressure='201.26 bar' />
+  <sample time='0:10 min' depth='2.7 m' />
+  <sample time='0:20 min' depth='3.74 m' />
+  <sample time='0:30 min' depth='4.89 m' />
+  <sample time='0:40 min' depth='4.92 m' pressure='192.41 bar' />
+  <sample time='0:50 min' depth='5.91 m' pressure='190.09 bar' />
+  <sample time='1:00 min' depth='5.9 m' pressure='189.42 bar' />
+  <sample time='1:10 min' depth='8.2 m' pressure='188.92 bar' />
+  <sample time='1:20 min' depth='10.24 m' pressure='187.85 bar' />
+  <sample time='1:30 min' depth='12.51 m' pressure='185.51 bar' />
+  <sample time='1:40 min' depth='15.14 m' pressure='182.43 bar' />
+  <sample time='1:50 min' depth='17.83 m' pressure='179.63 bar' />
+  <sample time='2:00 min' depth='20.47 m' pressure='176.59 bar' />
+  <sample time='2:10 min' depth='22.52 m' pressure='174.02 bar' />
+  <sample time='2:20 min' depth='23.92 m' pressure='171.54 bar' />
+  <sample time='2:30 min' depth='24.44 m' pressure='188.76 bar' />
+  <sample time='2:40 min' depth='24.74 m' pressure='202.66 bar' />
+  <sample time='2:50 min' depth='25.14 m' pressure='203.64 bar' />
+  <sample time='3:00 min' depth='25.35 m' pressure='202.96 bar' />
+  <sample time='3:10 min' depth='25.09 m' pressure='201.75 bar' />
+  <sample time='3:20 min' depth='25.64 m' pressure='200.33 bar' />
+  <sample time='3:30 min' depth='26.45 m' pressure='198.67 bar' />
+  <sample time='3:40 min' depth='26.94 m' pressure='197.48 bar' />
+  <sample time='3:50 min' depth='26.73 m' pressure='196.31 bar' />
+  <sample time='4:00 min' depth='27.02 m' pressure='195.29 bar' />
+  <sample time='4:10 min' depth='27.29 m' pressure='195.01 bar' />
+  <sample time='4:20 min' depth='27.58 m' pressure='194.53 bar' />
+  <sample time='4:30 min' depth='27.4 m' pressure='193.46 bar' />
+  <sample time='4:40 min' depth='27.76 m' pressure='192.61 bar' />
+  <sample time='4:50 min' depth='27.94 m' pressure='191.95 bar' />
+  <sample time='5:00 min' depth='28.33 m' pressure='191.47 bar' />
+  <sample time='5:10 min' depth='28.43 m' pressure='190.83 bar' />
+  <sample time='5:20 min' depth='28.73 m' pressure='190.14 bar' />
+  <sample time='5:30 min' depth='28.08 m' pressure='190.0 bar' />
+  <sample time='5:40 min' depth='27.99 m' pressure='189.52 bar' />
+  <sample time='5:50 min' depth='28.05 m' pressure='188.62 bar' />
+  <sample time='6:00 min' depth='28.33 m' pressure='187.99 bar' />
+  <sample time='6:10 min' depth='28.65 m' pressure='186.82 bar' />
+  <sample time='6:20 min' depth='28.28 m' pressure='186.43 bar' />
+  <sample time='6:30 min' depth='28.85 m' pressure='186.01 bar' />
+  <sample time='6:40 min' depth='29.82 m' pressure='185.14 bar' />
+  <sample time='6:50 min' depth='29.52 m' pressure='184.99 bar' />
+  <sample time='7:00 min' depth='29.29 m' pressure='184.61 bar' />
+  <sample time='7:10 min' depth='29.47 m' pressure='183.48 bar' />
+  <sample time='7:20 min' depth='29.24 m' pressure='182.87 bar' />
+  <sample time='7:30 min' depth='28.0 m' pressure='181.86 bar' />
+  <sample time='7:40 min' depth='27.62 m' pressure='181.41 bar' />
+  <sample time='7:50 min' depth='27.57 m' pressure='180.73 bar' />
+  <sample time='8:00 min' depth='27.53 m' pressure='179.91 bar' />
+  <sample time='8:10 min' depth='26.49 m' pressure='179.76 bar' />
+  <sample time='8:20 min' depth='25.39 m' pressure='179.34 bar' />
+  <sample time='8:30 min' depth='24.87 m' pressure='178.84 bar' />
+  <sample time='8:40 min' depth='24.5 m' pressure='178.32 bar' />
+  <sample time='8:50 min' depth='24.53 m' pressure='177.83 bar' />
+  <sample time='9:00 min' depth='24.77 m' pressure='176.95 bar' />
+  <sample time='9:10 min' depth='24.94 m' pressure='176.26 bar' />
+  <sample time='9:20 min' depth='24.9 m' pressure='175.61 bar' />
+  <sample time='9:30 min' depth='25.29 m' pressure='174.82 bar' />
+  <sample time='9:40 min' depth='25.09 m' pressure='174.57 bar' />
+  <sample time='9:50 min' depth='25.48 m' pressure='174.0 bar' />
+  <sample time='10:00 min' depth='25.21 m' pressure='173.66 bar' />
+  <sample time='10:10 min' depth='24.36 m' pressure='173.37 bar' />
+  <sample time='10:20 min' depth='23.51 m' pressure='172.64 bar' />
+  <sample time='10:30 min' depth='23.16 m' pressure='171.95 bar' />
+  <sample time='10:40 min' depth='23.12 m' pressure='171.16 bar' />
+  <sample time='10:50 min' depth='23.54 m' pressure='170.69 bar' />
+  <sample time='11:00 min' depth='24.0 m' pressure='170.14 bar' />
+  <sample time='11:10 min' depth='24.03 m' pressure='169.21 bar' />
+  <sample time='11:20 min' depth='24.27 m' pressure='168.36 bar' />
+  <sample time='11:30 min' depth='24.18 m' pressure='167.79 bar' />
+  <sample time='11:40 min' depth='24.06 m' pressure='167.1 bar' />
+  <sample time='11:50 min' depth='24.45 m' pressure='166.58 bar' />
+  <sample time='12:00 min' depth='24.47 m' pressure='165.73 bar' />
+  <sample time='12:10 min' depth='24.78 m' pressure='165.29 bar' />
+  <sample time='12:20 min' depth='25.09 m' pressure='164.52 bar' />
+  <sample time='12:30 min' depth='25.42 m' pressure='163.99 bar' />
+  <sample time='12:40 min' depth='25.45 m' pressure='163.22 bar' />
+  <sample time='12:50 min' depth='25.44 m' pressure='162.45 bar' />
+  <sample time='13:00 min' depth='25.43 m' pressure='162.18 bar' />
+  <sample time='13:10 min' depth='25.46 m' pressure='161.68 bar' />
+  <sample time='13:20 min' depth='25.56 m' pressure='160.91 bar' />
+  <sample time='13:30 min' depth='25.68 m' pressure='160.45 bar' />
+  <sample time='13:40 min' depth='25.67 m' pressure='159.86 bar' />
+  <sample time='13:50 min' depth='25.22 m' pressure='159.3 bar' />
+  <sample time='14:00 min' depth='25.38 m' pressure='158.32 bar' />
+  <sample time='14:10 min' depth='25.34 m' pressure='157.28 bar' />
+  <sample time='14:20 min' depth='25.04 m' pressure='156.8 bar' />
+  <sample time='14:30 min' depth='24.73 m' pressure='156.07 bar' />
+  <sample time='14:40 min' depth='24.62 m' pressure='155.38 bar' />
+  <sample time='14:50 min' depth='24.84 m' pressure='155.13 bar' />
+  <sample time='15:00 min' depth='25.03 m' pressure='154.32 bar' />
+  <sample time='15:10 min' depth='25.29 m' pressure='153.64 bar' />
+  <sample time='15:20 min' depth='25.83 m' pressure='153.24 bar' />
+  <sample time='15:30 min' depth='26.21 m' pressure='152.28 bar' />
+  <sample time='15:40 min' depth='26.44 m' pressure='151.7 bar' />
+  <sample time='15:50 min' depth='26.51 m' pressure='150.76 bar' />
+  <sample time='16:00 min' depth='26.22 m' pressure='150.02 bar' />
+  <sample time='16:10 min' depth='25.3 m' pressure='149.72 bar' />
+  <sample time='16:20 min' depth='24.49 m' pressure='149.56 bar' />
+  <sample time='16:30 min' depth='24.22 m' pressure='149.05 bar' />
+  <sample time='16:40 min' depth='24.44 m' pressure='148.24 bar' />
+  <sample time='16:50 min' depth='24.55 m' pressure='147.68 bar' />
+  <sample time='17:00 min' depth='24.46 m' pressure='147.1 bar' />
+  <sample time='17:10 min' depth='24.57 m' pressure='146.3 bar' />
+  <sample time='17:20 min' depth='24.77 m' pressure='145.34 bar' />
+  <sample time='17:30 min' depth='25.03 m' pressure='144.77 bar' />
+  <sample time='17:40 min' depth='25.37 m' pressure='144.01 bar' />
+  <sample time='17:50 min' depth='25.47 m' pressure='143.7 bar' />
+  <sample time='18:00 min' depth='25.68 m' pressure='143.16 bar' />
+  <sample time='18:10 min' depth='25.89 m' pressure='142.21 bar' />
+  <sample time='18:20 min' depth='25.74 m' pressure='141.3 bar' />
+  <sample time='18:30 min' depth='25.77 m' pressure='140.88 bar' />
+  <sample time='18:40 min' depth='24.74 m' pressure='140.6 bar' />
+  <sample time='18:50 min' depth='24.15 m' pressure='140.42 bar' />
+  <sample time='19:00 min' depth='23.15 m' pressure='139.38 bar' />
+  <sample time='19:10 min' depth='22.81 m' pressure='138.82 bar' />
+  <sample time='19:20 min' depth='22.54 m' pressure='138.23 bar' />
+  <sample time='19:30 min' depth='22.74 m' pressure='137.55 bar' />
+  <sample time='19:40 min' depth='22.93 m' pressure='137.03 bar' />
+  <sample time='19:50 min' depth='23.18 m' pressure='136.46 bar' />
+  <sample time='20:00 min' depth='23.74 m' pressure='135.71 bar' />
+  <sample time='20:10 min' depth='24.13 m' pressure='135.18 bar' />
+  <sample time='20:20 min' depth='25.0 m' pressure='134.39 bar' />
+  <sample time='20:30 min' depth='25.36 m' pressure='133.65 bar' />
+  <sample time='20:40 min' depth='26.15 m' pressure='132.76 bar' />
+  <sample time='20:50 min' depth='26.9 m' pressure='131.35 bar' />
+  <sample time='21:00 min' depth='27.19 m' pressure='130.46 bar' />
+  <sample time='21:10 min' depth='27.45 m' pressure='130.21 bar' />
+  <sample time='21:20 min' depth='27.8 m' pressure='129.47 bar' />
+  <sample time='21:30 min' depth='29.11 m' pressure='128.66 bar' />
+  <sample time='21:40 min' depth='29.82 m' pressure='126.9 bar' />
+  <sample time='21:50 min' depth='29.2 m' pressure='126.52 bar' />
+  <sample time='22:00 min' depth='28.62 m' />
+  <sample time='22:10 min' depth='29.07 m' pressure='125.22 bar' />
+  <sample time='22:20 min' depth='29.05 m' pressure='124.93 bar' />
+  <sample time='22:30 min' depth='28.93 m' pressure='123.9 bar' />
+  <sample time='22:40 min' depth='29.0 m' pressure='123.32 bar' />
+  <sample time='22:50 min' depth='29.04 m' pressure='122.77 bar' />
+  <sample time='23:00 min' depth='29.33 m' pressure='122.5 bar' />
+  <sample time='23:10 min' depth='29.25 m' pressure='121.19 bar' />
+  <sample time='23:20 min' depth='28.45 m' pressure='121.5 bar' />
+  <sample time='23:30 min' depth='27.98 m' pressure='120.76 bar' />
+  <sample time='23:40 min' depth='28.06 m' pressure='120.2 bar' />
+  <sample time='23:50 min' depth='28.13 m' pressure='119.41 bar' />
+  <sample time='24:00 min' depth='28.11 m' pressure='118.59 bar' />
+  <sample time='24:10 min' depth='28.08 m' pressure='117.81 bar' />
+  <sample time='24:20 min' depth='28.09 m' pressure='117.2 bar' />
+  <sample time='24:30 min' depth='28.15 m' pressure='116.54 bar' />
+  <sample time='24:40 min' depth='27.66 m' pressure='115.85 bar' />
+  <sample time='24:50 min' depth='27.18 m' pressure='115.22 bar' />
+  <sample time='25:00 min' depth='27.17 m' pressure='114.6 bar' />
+  <sample time='25:10 min' depth='27.47 m' pressure='113.83 bar' />
+  <sample time='25:20 min' depth='27.33 m' pressure='113.42 bar' />
+  <sample time='25:30 min' depth='27.74 m' pressure='112.63 bar' />
+  <sample time='25:40 min' depth='26.97 m' pressure='112.39 bar' />
+  <sample time='25:50 min' depth='26.03 m' pressure='111.56 bar' />
+  <sample time='26:00 min' depth='25.5 m' pressure='110.99 bar' />
+  <sample time='26:10 min' depth='24.9 m' pressure='110.47 bar' />
+  <sample time='26:20 min' depth='24.61 m' pressure='110.27 bar' />
+  <sample time='26:30 min' depth='24.45 m' pressure='109.59 bar' />
+  <sample time='26:40 min' depth='24.47 m' pressure='108.2 bar' />
+  <sample time='26:50 min' depth='24.61 m' pressure='107.17 bar' />
+  <sample time='27:00 min' depth='24.18 m' pressure='106.99 bar' />
+  <sample time='27:10 min' depth='23.08 m' pressure='106.56 bar' />
+  <sample time='27:20 min' depth='22.45 m' pressure='106.03 bar' />
+  <sample time='27:30 min' depth='21.92 m' pressure='105.23 bar' />
+  <sample time='27:40 min' depth='21.15 m' pressure='104.56 bar' />
+  <sample time='27:50 min' depth='20.7 m' pressure='104.32 bar' />
+  <sample time='28:00 min' depth='20.99 m' pressure='104.01 bar' />
+  <sample time='28:10 min' depth='21.06 m' pressure='103.23 bar' />
+  <sample time='28:20 min' depth='20.99 m' pressure='102.48 bar' />
+  <sample time='28:30 min' depth='21.57 m' pressure='101.86 bar' />
+  <sample time='28:40 min' depth='21.94 m' pressure='100.71 bar' />
+  <sample time='28:50 min' depth='22.17 m' pressure='100.09 bar' />
+  <sample time='29:00 min' depth='22.33 m' pressure='99.53 bar' />
+  <sample time='29:10 min' depth='22.66 m' pressure='98.9 bar' />
+  <sample time='29:20 min' depth='22.96 m' pressure='97.73 bar' />
+  <sample time='29:30 min' depth='22.93 m' pressure='97.33 bar' />
+  <sample time='29:40 min' depth='23.23 m' pressure='96.28 bar' />
+  <sample time='29:50 min' depth='23.25 m' pressure='95.48 bar' />
+  <sample time='30:00 min' depth='23.47 m' pressure='94.94 bar' />
+  <sample time='30:10 min' depth='23.98 m' pressure='94.23 bar' />
+  <sample time='30:20 min' depth='23.95 m' pressure='93.83 bar' />
+  <sample time='30:30 min' depth='24.1 m' pressure='92.94 bar' />
+  <sample time='30:40 min' depth='23.98 m' pressure='92.31 bar' />
+  <sample time='30:50 min' depth='24.02 m' pressure='91.25 bar' />
+  <sample time='31:00 min' depth='24.06 m' pressure='90.69 bar' />
+  <sample time='31:10 min' depth='24.26 m' pressure='89.93 bar' />
+  <sample time='31:20 min' depth='24.12 m' pressure='89.14 bar' />
+  <sample time='31:30 min' depth='23.93 m' pressure='88.55 bar' />
+  <sample time='31:40 min' depth='23.46 m' pressure='88.0 bar' />
+  <sample time='31:50 min' depth='22.64 m' pressure='86.92 bar' />
+  <sample time='32:00 min' depth='21.41 m' pressure='86.34 bar' />
+  <sample time='32:10 min' depth='20.56 m' pressure='86.07 bar' />
+  <sample time='32:20 min' depth='20.43 m' pressure='85.57 bar' />
+  <sample time='32:30 min' depth='20.46 m' pressure='84.32 bar' />
+  <sample time='32:40 min' depth='20.5 m' pressure='84.02 bar' />
+  <sample time='32:50 min' depth='20.06 m' pressure='83.2 bar' />
+  <sample time='33:00 min' depth='20.31 m' pressure='82.62 bar' />
+  <sample time='33:10 min' depth='20.28 m' pressure='82.23 bar' />
+  <sample time='33:20 min' depth='20.14 m' pressure='81.74 bar' />
+  <sample time='33:30 min' depth='19.88 m' pressure='80.99 bar' />
+  <sample time='33:40 min' depth='20.0 m' pressure='80.3 bar' />
+  <sample time='33:50 min' depth='20.02 m' pressure='79.98 bar' />
+  <sample time='34:00 min' depth='19.39 m' pressure='79.21 bar' />
+  <sample time='34:10 min' depth='18.79 m' pressure='78.92 bar' />
+  <sample time='34:20 min' depth='17.95 m' pressure='78.44 bar' />
+  <sample time='34:30 min' depth='16.81 m' pressure='78.2 bar' />
+  <sample time='34:40 min' depth='16.34 m' pressure='77.57 bar' />
+  <sample time='34:50 min' depth='16.39 m' pressure='77.03 bar' />
+  <sample time='35:00 min' depth='16.75 m' pressure='76.39 bar' />
+  <sample time='35:10 min' depth='16.84 m' pressure='75.61 bar' />
+  <sample time='35:20 min' depth='16.9 m' pressure='75.17 bar' />
+  <sample time='35:30 min' depth='17.09 m' pressure='74.48 bar' />
+  <sample time='35:40 min' depth='16.98 m' pressure='74.11 bar' />
+  <sample time='35:50 min' depth='16.32 m' pressure='74.04 bar' />
+  <sample time='36:00 min' depth='16.51 m' pressure='73.14 bar' />
+  <sample time='36:10 min' depth='16.22 m' pressure='72.64 bar' />
+  <sample time='36:20 min' depth='16.24 m' pressure='72.08 bar' />
+  <sample time='36:30 min' depth='16.1 m' pressure='71.74 bar' />
+  <sample time='36:40 min' depth='15.91 m' pressure='70.97 bar' />
+  <sample time='36:50 min' depth='15.54 m' pressure='70.42 bar' />
+  <sample time='37:00 min' depth='15.41 m' pressure='69.64 bar' />
+  <sample time='37:10 min' depth='15.16 m' />
+  <sample time='37:20 min' depth='15.45 m' pressure='68.85 bar' />
+  <sample time='37:30 min' depth='15.35 m' pressure='68.21 bar' />
+  <sample time='37:40 min' depth='15.18 m' pressure='67.8 bar' />
+  <sample time='37:50 min' depth='14.91 m' pressure='67.43 bar' />
+  <sample time='38:00 min' depth='14.77 m' pressure='67.17 bar' />
+  <sample time='38:10 min' depth='15.38 m' pressure='66.35 bar' />
+  <sample time='38:20 min' depth='15.57 m' pressure='65.65 bar' />
+  <sample time='38:30 min' depth='15.99 m' pressure='65.74 bar' />
+  <sample time='38:40 min' depth='16.42 m' pressure='65.94 bar' />
+  <sample time='38:50 min' depth='16.84 m' pressure='66.05 bar' />
+  <sample time='39:00 min' depth='16.71 m' />
+  <sample time='39:10 min' depth='16.32 m' pressure='66.12 bar' />
+  <sample time='39:20 min' depth='15.92 m' pressure='66.19 bar' />
+  <sample time='39:30 min' depth='15.67 m' pressure='66.31 bar' />
+  <sample time='39:40 min' depth='16.26 m' />
+  <sample time='39:50 min' depth='16.99 m' pressure='66.55 bar' />
+  <sample time='40:00 min' depth='16.78 m' pressure='66.56 bar' />
+  <sample time='40:10 min' depth='16.86 m' />
+  <sample time='40:20 min' depth='16.95 m' />
+  <sample time='40:30 min' depth='16.75 m' />
+  <sample time='40:40 min' depth='16.85 m' />
+  <sample time='40:50 min' depth='16.95 m' />
+  <sample time='41:00 min' depth='16.79 m' />
+  <sample time='41:10 min' depth='17.13 m' pressure='66.82 bar' />
+  <sample time='41:20 min' depth='16.9 m' />
+  <sample time='41:30 min' depth='16.97 m' />
+  <sample time='41:40 min' depth='16.91 m' />
+  <sample time='41:50 min' depth='16.97 m' pressure='66.7 bar' />
+  <sample time='42:00 min' depth='16.18 m' pressure='66.82 bar' />
+  <sample time='42:10 min' depth='15.6 m' />
+  <sample time='42:20 min' depth='15.14 m' />
+  <sample time='42:30 min' depth='14.81 m' />
+  <sample time='42:40 min' depth='14.47 m' />
+  <sample time='42:50 min' depth='13.92 m' />
+  <sample time='43:00 min' depth='13.44 m' />
+  <sample time='43:10 min' depth='13.13 m' pressure='66.71 bar' />
+  <sample time='43:20 min' depth='13.55 m' pressure='66.7 bar' />
+  <sample time='43:30 min' depth='13.63 m' pressure='66.8 bar' />
+  <sample time='43:40 min' depth='13.94 m' pressure='66.82 bar' />
+  <sample time='43:50 min' depth='14.22 m' />
+  <sample time='44:00 min' depth='14.24 m' />
+  <sample time='44:10 min' depth='14.48 m' pressure='66.61 bar' />
+  <sample time='44:20 min' depth='14.37 m' pressure='66.55 bar' />
+  <sample time='44:30 min' depth='13.58 m' pressure='66.56 bar' />
+  <sample time='44:40 min' depth='12.92 m' />
+  <sample time='44:50 min' depth='13.05 m' />
+  <sample time='45:00 min' depth='13.12 m' pressure='66.52 bar' />
+  <sample time='45:10 min' depth='14.01 m' pressure='66.56 bar' />
+  <sample time='45:20 min' depth='14.35 m' pressure='66.44 bar' />
+  <sample time='45:30 min' depth='13.97 m' />
+  <sample time='45:40 min' depth='14.41 m' pressure='66.56 bar' />
+  <sample time='45:50 min' depth='14.51 m' />
+  <sample time='46:00 min' depth='14.74 m' />
+  <sample time='46:10 min' depth='15.21 m' pressure='66.38 bar' />
+  <sample time='46:20 min' depth='15.48 m' pressure='66.11 bar' />
+  <sample time='46:30 min' depth='15.79 m' pressure='65.62 bar' />
+  <sample time='46:40 min' depth='15.93 m' pressure='65.35 bar' />
+  <sample time='46:50 min' depth='16.13 m' pressure='64.9 bar' />
+  <sample time='47:00 min' depth='16.26 m' pressure='64.58 bar' />
+  <sample time='47:10 min' depth='16.09 m' pressure='64.33 bar' />
+  <sample time='47:20 min' depth='16.32 m' pressure='64.31 bar' />
+  <sample time='47:30 min' depth='16.4 m' />
+  <sample time='47:40 min' depth='14.98 m' />
+  <sample time='47:50 min' depth='14.9 m' pressure='64.22 bar' />
+  <sample time='48:00 min' depth='15.5 m' pressure='64.05 bar' />
+  <sample time='48:10 min' depth='15.65 m' />
+  <sample time='48:20 min' depth='15.68 m' />
+  <sample time='48:30 min' depth='15.18 m' />
+  <sample time='48:40 min' depth='14.46 m' />
+  <sample time='48:50 min' depth='14.41 m' />
+  <sample time='49:00 min' depth='14.73 m' />
+  <sample time='49:10 min' depth='14.69 m' />
+  <sample time='49:20 min' depth='14.85 m' />
+  <sample time='49:30 min' depth='15.1 m' />
+  <sample time='49:40 min' depth='15.46 m' />
+  <sample time='49:50 min' depth='15.65 m' />
+  <sample time='50:00 min' depth='15.32 m' />
+  <sample time='50:10 min' depth='15.84 m' />
+  <sample time='50:20 min' depth='15.16 m' />
+  <sample time='50:30 min' depth='14.42 m' />
+  <sample time='50:40 min' depth='14.5 m' />
+  <sample time='50:50 min' depth='13.69 m' />
+  <sample time='51:00 min' depth='12.72 m' />
+  <sample time='51:10 min' depth='11.55 m' />
+  <sample time='51:20 min' depth='10.56 m' />
+  <sample time='51:30 min' depth='9.29 m' />
+  <sample time='51:40 min' depth='8.27 m' />
+  <sample time='51:50 min' depth='7.21 m' />
+  <sample time='52:00 min' depth='6.31 m' />
+  <sample time='52:10 min' depth='5.24 m' pressure='64.24 bar' />
+  <sample time='52:20 min' depth='4.59 m' pressure='64.26 bar' />
+  <sample time='52:30 min' depth='4.04 m' />
+  <sample time='52:40 min' depth='3.44 m' />
+  <sample time='52:50 min' depth='3.37 m' />
+  <sample time='53:00 min' depth='3.45 m' />
+  <sample time='53:10 min' depth='3.28 m' />
+  <sample time='53:20 min' depth='2.99 m' />
+  <sample time='53:30 min' depth='3.23 m' />
+  <sample time='53:40 min' depth='3.0 m' />
+  <sample time='53:50 min' depth='2.98 m' />
+  <sample time='54:00 min' depth='2.99 m' />
+  <sample time='54:10 min' depth='2.91 m' />
+  <sample time='54:20 min' depth='3.09 m' />
+  <sample time='54:30 min' depth='2.97 m' />
+  <sample time='54:40 min' depth='2.99 m' />
+  <sample time='54:50 min' depth='3.04 m' />
+  <sample time='55:00 min' depth='3.09 m' />
+  <sample time='55:10 min' depth='3.1 m' />
+  <sample time='55:20 min' depth='3.43 m' />
+  <sample time='55:30 min' depth='3.02 m' />
+  <sample time='55:40 min' depth='3.15 m' />
+  <sample time='55:50 min' depth='3.08 m' />
+  <sample time='56:00 min' depth='3.2 m' />
+  <sample time='56:10 min' depth='2.95 m' />
+  <sample time='56:20 min' depth='3.3 m' />
+  <sample time='56:30 min' depth='3.15 m' />
+  <sample time='56:40 min' depth='3.26 m' temp='26.0 C' />
+  <sample time='56:50 min' depth='3.38 m' />
+  <sample time='57:00 min' depth='3.52 m' />
+  <sample time='57:10 min' depth='3.43 m' />
+  <sample time='57:20 min' depth='3.39 m' />
+  <sample time='57:30 min' depth='3.46 m' temp='25.0 C' />
+  <sample time='57:40 min' depth='3.47 m' />
+  <sample time='57:50 min' depth='3.49 m' />
+  <sample time='58:00 min' depth='3.53 m' />
+  <sample time='58:10 min' depth='3.42 m' />
+  <sample time='58:20 min' depth='3.69 m' />
+  <sample time='58:30 min' depth='3.67 m' />
+  <sample time='58:40 min' depth='3.81 m' />
+  <sample time='58:50 min' depth='3.6 m' pressure='64.37 bar' />
+  <sample time='59:00 min' depth='3.59 m' />
+  <sample time='59:10 min' depth='3.7 m' pressure='64.35 bar' />
+  <sample time='59:20 min' depth='3.66 m' />
+  <sample time='59:30 min' depth='3.53 m' pressure='64.31 bar' />
+  <sample time='59:40 min' depth='3.57 m' />
+  <sample time='59:50 min' depth='3.45 m' pressure='64.43 bar' />
+  <sample time='60:00 min' depth='3.32 m' />
+  <sample time='60:10 min' depth='3.31 m' pressure='64.42 bar' />
+  <sample time='60:20 min' depth='3.2 m' />
+  <sample time='60:30 min' depth='3.27 m' />
+  <sample time='60:40 min' depth='3.23 m' />
+  <sample time='60:50 min' depth='3.18 m' />
+  <sample time='61:00 min' depth='3.19 m' />
+  <sample time='61:10 min' depth='3.15 m' />
+  <sample time='61:20 min' depth='2.95 m' />
+  <sample time='61:30 min' depth='2.0 m' pressure='64.38 bar' />
+  <sample time='61:40 min' depth='1.36 m' temp='26.0 C' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -76,6 +76,7 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, double dp
 	connect(&diveListNotifier, &DiveListNotifier::pictureOffsetChanged, this, &ProfileWidget2::pictureOffsetChanged);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &ProfileWidget2::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::deviceEdited, this, &ProfileWidget2::replot);
+	connect(&diveListNotifier, &DiveListNotifier::diveComputerEdited, this, &ProfileWidget2::replot);
 #endif // SUBSURFACE_MOBILE
 
 #if !defined(QT_NO_DEBUG) && defined(SHOW_PLOT_INFO_TABLE)

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -27,6 +27,7 @@ public:
 		USE,
 		WORKINGPRESS_INT,
 		SIZE_INT,
+		SENSORS,
 		COLUMNS
 	};
 


### PR DESCRIPTION
My main use case is that I'm diving with both a Garmin and a Suunto. They each have one transmitter, connected to different cylinders. When I download the dives both transmitters gets assigned to the first cylinder, so need to change one of the sensors to the second cylinder.

I'm not sure how much of a hack this is, and how useful it is for a wider audience. I initially thought of adding a separate dialog, since I could then have one cylinder per sensor, but I realized that it was fairly easy to add a list of sensors to each cylinder like this. I think the editing turned out to be more intuitive than I initially expected and seems non-intrusive.
 
It seems to populate some undo buffer, but currently the undo doesn't do anything.

I guess something also has to be done about CCR and o2sensor, not sure if this breaks that use case.

Maybe sensors should be hidden by default?

There are some case blocks in the cylinder model that have deeper indentation than the coding style suggests. It confuses my clang format plugin, but I left those alone to keep the diff small. Same for the re-ordering of headers that clang-format wanted to do.