### PR TITLE
core: avoid crash when reading corrupted git data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: avoid crash with corrupted cloud storage
 - planner: make ESC (cancel plan) work when moving handles
 - dive list: make dive guide visible in dive list [#3382]
 - general: rename dive master to dive guide

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -371,6 +371,14 @@ void purge_empty_dive_sites(struct dive_site_table *ds_table)
 void add_dive_to_dive_site(struct dive *d, struct dive_site *ds)
 {
 	int idx;
+	if (!d) {
+		fprintf(stderr, "Warning: add_dive_to_dive_site called with NULL dive\n");
+		return;
+	}
+	if (!ds) {
+		fprintf(stderr, "Warning: add_dive_to_dive_site called with NULL dive site\n");
+		return;
+	}
 	if (d->dive_site == ds)
 		return;
 	if (d->dive_site) {


### PR DESCRIPTION
If a merge mishap creates inconsistent data for a dive in git storage,
where the dive references a dive site that no longer exists, the app
would crash when trying to open the cloud storage.

I don't think a NULL dive could ever happen, but this seems fairly cheap
insurance.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
this caused crashes on all platforms for a user who had an unfortunate merge after editing the same dive both on Windows and on their iPhone

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

