### PR TITLE
Android: share log files as attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- mobile: fix profile scaling issue on high DPR devices
 - mobile/Android: add logfiles as attachment to support emails
 - planner: make ESC (cancel plan) work when moving handles
 - dive list: make dive guide visible in dive list [#3382]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- mobile/Android: add logfiles as attachment to support emails
 - planner: make ESC (cancel plan) work when moving handles
 - dive list: make dive guide visible in dive list [#3382]
 - general: rename dive master to dive guide

--- a/android-mobile/AndroidManifest.xml
+++ b/android-mobile/AndroidManifest.xml
@@ -77,6 +77,15 @@
 	    <meta-data android:name="android.max_aspect" android:value="3" />
 
         </activity>
+	<provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="org.subsurfacedivelog.mobile.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
     </application>
 
     <uses-sdk android:minSdkVersion="21"

--- a/android-mobile/build.gradle
+++ b/android-mobile/build.gradle
@@ -27,8 +27,9 @@ allprojects {
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.github.mik3y:usb-serial-for-android:v3.4.3'
+    implementation 'com.android.support:support-v4:25.3.1'
 }
 
 android {

--- a/android-mobile/res/xml/filepaths.xml
+++ b/android-mobile/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path path="./" name="logfiles" />
+</paths>

--- a/core/android.cpp
+++ b/core/android.cpp
@@ -48,7 +48,8 @@ bool subsurface_ignore_font(const char *font)
 static const char *system_default_path_append(const char *append)
 {
 	// Qt appears to find a working path for us - let's just go with that
-	QString path = QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();
+	// AppDataLocation allows potential sharing of the files we put there
+	QString path = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).first();
 
 	if (append)
 		path += QString("/%1").arg(append);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -55,6 +55,7 @@
 #include "commands/command.h"
 
 #if defined(Q_OS_ANDROID)
+#include <QtAndroid>
 #include "core/serial_usb_android.h"
 std::vector<android_usb_serial_device_descriptor> androidSerialDevices;
 
@@ -230,9 +231,11 @@ QMLManager::QMLManager() :
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 #if defined(Q_OS_ANDROID)
-	// on Android we first try the GenericDataLocation (typically /storage/emulated/0) and if that fails
-	// (as happened e.g. on a Sony Xperia phone) we try several other default locations, with the TempLocation as last resort
+	// on Android we first try the AppDataLocation (which allows sharing of files), then the
+	// GenericDataLocation (typically /storage/emulated/0), and if that fails (as happened e.g. on a
+	// Sony Xperia phone) we try several other default locations, with the TempLocation as last resort
 	QStringList fileLocations =
+		QStandardPaths::standardLocations(QStandardPaths::AppDataLocation) +
 		QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation) +
 		QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation) +
 		QStandardPaths::standardLocations(QStandardPaths::DownloadLocation) +
@@ -1825,8 +1828,6 @@ void QMLManager::writeToAppLogFile(QString logText)
 #if defined(Q_OS_ANDROID)
 //HACK to color the system bar on Android, use qtandroidextras and call the appropriate Java methods
 //this code is based on code in the Kirigami example app for Android (under LGPL-2) Copyright 2017 Marco Martin
-
-#include <QtAndroid>
 
 // there doesn't appear to be an include that defines these in an easily accessible way
 // WindowManager.LayoutParams

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -51,7 +51,10 @@ void QMLProfile::paint(QPainter *painter)
 		timer.start();
 
 	// let's look at the intended size of the content and scale our scene accordingly
+	// for some odd reason the painter transformation is set up to scale by the dpr - which results
+	// in applying that dpr scaling twice. So we hard-code it here to be the identity matrix
 	QRect painterRect = painter->viewport();
+	painter->resetTransform();
 	if (m_diveId < 0)
 		return;
 	struct dive *d = get_dive_by_uniq_id(m_diveId);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -221,7 +221,8 @@ echo Building from "$SRC", installing in "$INSTALL_ROOT"
 # find qmake
 if [ -n "$CMAKE_PREFIX_PATH" ] ; then
 	QMAKE=$CMAKE_PREFIX_PATH/../../bin/qmake
-else
+fi
+if [[ -z $QMAKE  ||  ! -x $QMAKE ]] ; then
 	hash qmake > /dev/null 2> /dev/null && QMAKE=qmake
 	[ -z $QMAKE ] && hash qmake-qt5 > /dev/null 2> /dev/null && QMAKE=qmake-qt5
 	[ -z $QMAKE ] && echo "cannot find qmake or qmake-qt5" && exit 1


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature
- [x] Code cleanup
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is something that I wanted to do for a while, and @jefdriesen ended up prompting me to raise the priority and to work on this - because today our log files in support emails are truncated since they are passed via the Binder as message body (and some versions of the Gmail app make things worse because they strip all newlines from the logs)

This creates a Java helper to share files as attachments - and cleverly this can also share files to something like Dropbox - so a fairly logical and easy extension here would be to add the ability to share dive log XML files (e.g. via Dropbox) in order to back things up... allowing bidirectional sharing via Dropbox would be quite a bit harder and is left as an exercise for the reader.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- add Java helper to share file(s)
- try using that, first, when creating support emails on Android

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
yeah, I think we should document that as the user experience no Android changed a little bit. Instead of simply opening the default email app, the user is now asked to pick an app to share the files with and if they do want to create a support email, the (obviously, I guess) need to pick an email app...

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
