### PR TITLE
add list of global objects

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -57,6 +57,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/gas-model.c \
 	core/gaspressures.c \
 	core/git-access.c \
+	core/globals.cpp \
 	core/liquivision.c \
 	core/load-git.c \
 	core/parse-xml.c \
@@ -201,6 +202,7 @@ HEADERS += \
 	core/event.h \
 	core/extradata.h \
 	core/git-access.h \
+	core/globals.h \
 	core/pref.h \
 	core/profile.h \
 	core/qthelper.h \

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -106,6 +106,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	gettextfromc.h
 	git-access.c
 	git-access.h
+	globals.cpp
+	globals.h
 	imagedownloader.cpp
 	imagedownloader.h
 	import-cobalt.c

--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "globals.h"
+
+#include <vector>
+
+static std::vector<GlobalObjectBase *> global_objects;
+
+void register_global_internal(GlobalObjectBase *o)
+{
+	global_objects.push_back(o);
+}
+
+void free_globals()
+{
+	// We free the objects by hand, so that we can free them in reverse
+	// order of creation. AFAIK, order-of-destruction is implementantion-defined
+	// for std::vector<>.
+	for (auto it = global_objects.rbegin(); it != global_objects.rend(); ++it)
+		delete *it;
+	global_objects.clear();
+}

--- a/core/globals.h
+++ b/core/globals.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+// Collection of objects that will be deleted on application exit.
+// This feature is needed because many Qt-objects crash if freed
+// after the application has exited.
+#ifndef GLOBALS_H
+#define GLOBALS_H
+
+#include <memory>
+#include <utility>
+
+template <typename T, class... Args>
+T *make_global(Args &&...args); // construct a global object of type T.
+
+template <typename T>
+T *register_global(T *); // register an already constructed object. returns input.
+
+void free_globals(); // call on application exit. frees all global objects.
+
+// Implementation
+
+// A class with a virtual destructor that will be used to destruct the objects.
+struct GlobalObjectBase
+{
+	virtual ~GlobalObjectBase() { }
+};
+
+template <typename T>
+struct GlobalObject : T, GlobalObjectBase
+{
+	using T::T; // Inherit constructor from actual object.
+};
+
+void register_global_internal(GlobalObjectBase *);
+
+template <typename T, class... Args>
+T *make_global(Args &&...args)
+{
+	GlobalObject<T> *res = new GlobalObject<T>(std::forward<Args>(args)...);
+	register_global_internal(res);
+	return res;
+}
+
+template <typename T>
+T *register_global(T *o)
+{
+	make_global<std::unique_ptr<T>>(o);
+	return o;
+}
+
+#endif

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -111,7 +111,7 @@ extern "C" void showErrorFromC(char *buf)
 	emit MainWindow::instance()->showError(error);
 }
 
-MainWindow::MainWindow() : QMainWindow(),
+MainWindow::MainWindow() :
 	appState((ApplicationState)-1), // Invalid state
 	actionNextDive(nullptr),
 	actionPreviousDive(nullptr),

--- a/stats/chartitem.cpp
+++ b/stats/chartitem.cpp
@@ -2,6 +2,7 @@
 #include "chartitem.h"
 #include "statscolors.h"
 #include "statsview.h"
+#include "core/globals.h"
 
 #include <cmath>
 #include <QQuickWindow>
@@ -136,10 +137,6 @@ static QSGTexture *createScatterTexture(StatsView &view, const QColor &color, co
 	return view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel);
 }
 
-// Note: Originally these were std::unique_ptrs, which automatically
-// freed the textures on exit. However, destroying textures after
-// QApplication finished its thread leads to crashes. Therefore, these
-// are now normal pointers and the texture objects are leaked.
 static QSGTexture *scatterItemTexture = nullptr;
 static QSGTexture *scatterItemSelectedTexture = nullptr;
 static QSGTexture *scatterItemHighlightedTexture = nullptr;
@@ -161,9 +158,9 @@ QSGTexture *ChartScatterItem::getTexture() const
 void ChartScatterItem::render()
 {
 	if (!scatterItemTexture) {
-		scatterItemTexture = createScatterTexture(view, fillColor, borderColor);
-		scatterItemSelectedTexture = createScatterTexture(view, selectedColor, selectedBorderColor);
-		scatterItemHighlightedTexture = createScatterTexture(view, highlightedColor, highlightedBorderColor);
+		scatterItemTexture = register_global(createScatterTexture(view, fillColor, borderColor));
+		scatterItemSelectedTexture = register_global(createScatterTexture(view, selectedColor, selectedBorderColor));
+		scatterItemHighlightedTexture = register_global(createScatterTexture(view, highlightedColor, highlightedBorderColor));
 	}
 	if (!node) {
 		createNode(view.w()->createImageNode());
@@ -437,7 +434,7 @@ QSGTexture *ChartBarItem::getSelectedTexture() const
 		img.fill(Qt::transparent);
 		img.setPixelColor(0, 0, selectionOverlayColor);
 		img.setPixelColor(1, 1, selectionOverlayColor);
-		selectedTexture = view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel);
+		selectedTexture = register_global(view.w()->createTextureFromImage(img, QQuickWindow::TextureHasAlphaChannel));
 	}
 	return selectedTexture;
 }

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "stats/statsview.h"
+#include "core/globals.h"
 #include "core/qt-gui.h"
 #include "core/settings/qPref.h"
 #include "core/ssrf.h"
@@ -67,6 +68,7 @@ void exit_ui()
 #ifndef SUBSURFACE_MOBILE
 	delete MainWindow::instance();
 #endif // SUBSURFACE_MOBILE
+	free_globals();
 	free((void *)existing_filename);
 }
 

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -58,16 +58,13 @@ void init_ui()
 #ifndef SUBSURFACE_MOBILE
 	register_qml_types(NULL);
 
-	MainWindow *window = new MainWindow();
+	MainWindow *window = make_global<MainWindow>();
 	window->setTitle();
 #endif // SUBSURFACE_MOBILE
 }
 
 void exit_ui()
 {
-#ifndef SUBSURFACE_MOBILE
-	delete MainWindow::instance();
-#endif // SUBSURFACE_MOBILE
 	free_globals();
 	free((void *)existing_filename);
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We traditionally have problems with global (static) QObjects that get destructed after main exits. For some reason you mustn't call destructors of many Qt-objects after the application is gone.

The simplest way to handle this is to just leak them
Somewhat more satisfying is to delete them manually.

This PR creates a registry of global objects that will be deleted before the application object is destroyed.

Perhaps Qt has something to do the same (we surely aren't the only ones with that problem). But since I didn't find anything immediately, I just thought let's do our own.

No, I am not proud about the code. But it seems to work.