### PR TITLE
Fix merge problem in EditSensors

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1362,9 +1362,8 @@ void EditCylinder::undo()
 }
 
 EditSensors::EditSensors(int toCylinderIn, int fromCylinderIn)
-	: d(current_dive), toCylinder(toCylinderIn), fromCylinder(fromCylinderIn)
+	: d(current_dive), dc(get_dive_dc(d, dc_number)), toCylinder(toCylinderIn), fromCylinder(fromCylinderIn)
 {
-	const struct divecomputer *dc = get_dive_dc(d, dc_number);
 	if (!d || !dc)
 		return;
 

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -446,8 +446,8 @@ public:
 	EditSensors(int cylIndex, int fromCylinder);
 
 private:
-	struct divecomputer *dc;
 	struct dive *d;
+	struct divecomputer *dc;
 	int toCylinder;
 	int fromCylinder;
 	void mapSensors(int toCyl, int fromCyl);


### PR DESCRIPTION
Need to save the current dc as a member variable so we can apply redo
and undo to the correct dc later.

Signed-off-by: Michael Andreen <michael@andreen.dev>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Initialization of the member variable dc was lost in the merge fix, which resulted in redo/undo being applied to some random piece of memory or a null pointer depending on compiler flags.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
