### PR TITLE
build-system: switch submodule protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libdivecomputer"]
 	path = libdivecomputer
-	url = git://github.com/Subsurface/libdc.git
+	url = https://github.com/Subsurface/libdc.git
 	branch = Subsurface-NG

--- a/INSTALL
+++ b/INSTALL
@@ -88,7 +88,7 @@ QtWebKit is needed, if you want to print, but no longer part of Qt5,
 so you need to download it and compile. In case you just want to test
 without print possibility omit this step.
 
-    git clone -b 5.212 git://github.com/qt/qtwebkit
+    git clone -b 5.212 https://github.com/qt/qtwebkit
     mkdir -p qtwebkit/WebKitBuild/Release
     cd qtwebkit/WebKitBuild/Release
     cmake -DPORT=Qt -DCMAKE_BUILD_TYPE=Release -DQt5_DIR=/<Qt Location>/<version>/<type>/lib/cmake/Qt5 ../..

--- a/packaging/OBS/make-package.sh
+++ b/packaging/OBS/make-package.sh
@@ -9,7 +9,7 @@ if [[ $(pwd | grep "subsurface$") || ! -d subsurface || ! -d subsurface/libdivec
 	exit 1;
 fi
 if [[ ! -d googlemaps ]] ; then
-	echo "Please make sure you have the current master of git://github.com/Subsurface/googlemaps"
+	echo "Please make sure you have the current master of https://github.com/Subsurface/googlemaps"
 	echo "checked out in parallel to the Subsurface directory"
 	exit 1;
 fi

--- a/packaging/android/README
+++ b/packaging/android/README
@@ -5,7 +5,7 @@ The easiest way to build things is using our container:
 
 mkdir $HOME/src
 cd $HOME/src
-git clone git://github.com/subsurface/subsurface
+git clone https://github.com/subsurface/subsurface
 cd subsurface
 git checkout version or branch you are testing
 cd ..
@@ -49,7 +49,7 @@ cd /android
 wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip
 unzip commandlinetools-linux-*.zip
 
-git clone git://github.com/subsurface/subsurface
+git clone https://github.com/subsurface/subsurface
 
 # now get the SDK, NDK, Qt, everything that's needed
 bash /android/subsurface/packaging/android/android-build-setup.sh

--- a/packaging/headless/HOWTO
+++ b/packaging/headless/HOWTO
@@ -24,7 +24,7 @@ trac system.
 * sudo dpkg-reconfigure tzdata
 * mkdir src
 * cd src
-* git clone git://subsurface-divelog.org/subsurface.git
+* git clone https://subsurface-divelog.org/subsurface.git
 * sudo apt-get install git g++ make autoconf automake libtool cmake pkg-config \
         libxml2-dev libxslt1-dev libzip-dev libsqlite3-dev \
         libusb-1.0-0-dev libgit2-dev \

--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -12,13 +12,13 @@ if [[ $(pwd | grep "subsurface$") || ! -d subsurface || ! -d subsurface/libdivec
 	exit 1;
 fi
 if [[ ! -d googlemaps ]] ; then
-	echo "Please make sure you have the current master of git://github.com/Subsurface/googlemaps"
+	echo "Please make sure you have the current master of https://github.com/Subsurface/googlemaps"
 	echo "checked out in parallel to the Subsurface directory"
 	exit 1;
 fi
 
 if [[ ! -d libgit2 ]] ; then
-	echo "Please make sure you have libgit2 1.0 from git://github.com/libgit2/libgit2"
+	echo "Please make sure you have libgit2 1.0 from https://github.com/libgit2/libgit2"
 	echo "checked out in parallel to the Subsurface directory"
 	exit 1;
 fi

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -8,7 +8,7 @@ All it takes is this:
 
 ```
 cd /some/path/windows
-git clone git://github.com/subsurface/subsurface
+git clone https://github.com/subsurface/subsurface
 cd subsurface
 git submodule init
 git submodule update

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -264,7 +264,7 @@ if [ "$PLATFORM" = Linux ] && [[ $QT_VERSION == 5* ]] ; then
 		rm -rf "$INSTALL_ROOT"/include/QtLocation > /dev/null 2>&1
 		rm -rf "$INSTALL_ROOT"/include/QtPositioning > /dev/null 2>&1
 
-		git clone --branch "v$QT_VERSION" git://code.qt.io/qt/qtlocation.git --depth=1 $QTLOC_GIT
+		git clone --branch "v$QT_VERSION" https://code.qt.io/qt/qtlocation.git --depth=1 $QTLOC_GIT
 
 		mkdir -p "$QTLOC_PRIVATE"
 		cd $QTLOC_GIT/src/location

--- a/scripts/docker/mxe-build-container/Dockerfile
+++ b/scripts/docker/mxe-build-container/Dockerfile
@@ -51,7 +51,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
 
 # checkout MXE at the right version
 RUN mkdir -p /win
-RUN cd /win ; git clone git://github.com/mxe/mxe ; \
+RUN cd /win ; git clone https://github.com/mxe/mxe ; \
     cd mxe ; \
     git checkout ${_ver} ;
 

--- a/scripts/docker/trusty-qt512/Dockerfile
+++ b/scripts/docker/trusty-qt512/Dockerfile
@@ -52,7 +52,7 @@ ENV QT_ROOT /usr/local/Qt/5.12.10/gcc_64
 ENV PATH="/usr/local/Qt/5.12.10/gcc_64/bin/:${PATH}"
 
 # now build and install QtWebKit
-RUN git clone -b 5.212 git://github.com/qt/qtwebkit
+RUN git clone -b 5.212 https://github.com/qt/qtwebkit
 RUN mkdir -p qtwebkit/WebKitBuild/Release
 RUN cd qtwebkit/WebKitBuild/Release && cmake -DPORT=Qt -DCMAKE_BUILD_TYPE=Release -DQt5_DIR=/usr/local/Qt/5.12.10/gcc_64/lib/cmake/Qt5 ../..
 RUN cd qtwebkit/WebKitBuild/Release && make -j4 && make install
@@ -78,7 +78,7 @@ RUN apt-get remove -y libqt5core5a libqt5dbus5 libqt5gui5 ruby openssh-client
 
 # now build Subsurface once to populate the dependencies we don't get from
 # Ubuntu but that aren't really part of Subsurface (libgit, googlemaps)
-RUN git clone git://github.com/Subsurface/subsurface
+RUN git clone https://github.com/Subsurface/subsurface
 RUN bash -e -x ./subsurface/scripts/build.sh -desktop -create-appdir -build-with-webkit
 
 # remove the source, but keep the install-root

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ apps:
 
 parts:
   googlemaps:
-    source: git://github.com/Subsurface/googlemaps.git
+    source: https://github.com/Subsurface/googlemaps.git
     build-packages:
     - wget
     override-pull: |


### PR DESCRIPTION
As of today, GitHub no longer allows the 'git://' protocol, so we need to
switch the submodule to 'https://' instead.


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change
