### PR TITLE
translations: load parent language translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
-- profile: include profile editing in undo system
-- mobile: Add a dark theme for statistics
-- core: avoid crash with corrupted cloud storage
-- mobile: fix profile scaling issue on high DPR devices
-- mobile: bring back profile icons
-- mobile/Android: add logfiles as attachment to support emails
-- planner: make ESC (cancel plan) work when moving handles
-- dive list: make dive guide visible in dive list [#3382]
-- general: rename dive master to dive guide
-- desktop: Don't lose cursor position in notes when switching between windows [#3369]
-- Uemis support: fix the ability disconnect/reconnect the Zurich when its filesystem is full
-- libdivecomputer: add support for latest BLE hardware in OSTC dive computers
+- fix missing libraries in Windows and Mac installers that caused the maps not to show
+- provide reasonable fall-back for translations so missing translations in country-specific
+  translations are picked from (hopefully more complete) "parent" languages
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.


### PR DESCRIPTION
Many language have country specific differences. We recognize different
flavors of English (US, UK (and South Africa)), German (Germany and
Switzerland), and Portuguese (Brazil and Portugal). For many other
flavors of the languages that we have translations for we have no
support and the way we hard-coded the fallbacks in the past was odd and
meant that in the cases where we do have two flavors, missing strings in
one weren't taken from the other (English as the default language being
the exception).

This tries to do a better job of recognizing some of those parent
languages and loading translators for them, first. Which means if we
then find a translator for the specific language (i.e., de_CH), strings
missing in that translation are next searched in the parent language
(de_DE), before finally providing the source language string (en_US).

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Provide a list of parent languages and load those first, if the locale is a different flavor of the same language.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
All the missing strings in the Swiss translations that @charno pointed out

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This should do the right thing in many other circumstances and deserves some testing.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger (just for my sanity)