### PR TITLE
core: allow separators ,; after degree-style coord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: add support for separator characters when using degree-style coordinates
 - profile: include profile editing in undo system
 - mobile: Add a dark theme for statistics
 - core: avoid crash with corrupted cloud storage

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -129,6 +129,7 @@ static bool parseCoord(const QString &txt, int &pos, const QString &positives,
 		       const QString &negatives, const QString &others,
 		       double &value)
 {
+	static const QString separators = QString(",;");
 	bool numberDefined = false, degreesDefined = false,
 		minutesDefined = false, secondsDefined = false;
 	double number = 0.0;
@@ -200,11 +201,8 @@ static bool parseCoord(const QString &txt, int &pos, const QString &positives,
 			numberDefined = false;
 			secondsDefined = true;
 		} else if ((numberDefined || minutesDefined || secondsDefined) &&
-			   (txt[pos] == ',' || txt[pos] == ';')) {
-			// next coordinate coming up
-			// eat the ',' and any subsequent white space
-			while (++pos < txt.size() && txt[pos].isSpace())
-				/* nothing */ ;
+			   separators.indexOf(txt[pos]) >= 0) {
+			// separator; this coordinate is finished
 			break;
 		} else {
 			return false;
@@ -219,6 +217,12 @@ static bool parseCoord(const QString &txt, int &pos, const QString &positives,
 		value += number / 3600.0;
 	else if (numberDefined)
 		return false;
+
+	// We parsed a valid coordinate; eat any subsequent separators and/or
+	// whitespace
+	while (pos < txt.size() && (txt[pos].isSpace() || separators.indexOf(txt[pos]) >= 0))
+		pos++;
+
 	if (sign == -1) value *= -1.0;
 	return true;
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Tweak the Lat/Long coordinate parser to allow coordinates of the form:

`12.1049° N, 68.2296° W`

The coordinate parser works by tokenizing coordinates one at a time. Consequently it is invoked twice on user input to get latitude and then longitude. Normally, after parsing the first coordinate, intervening characters such as `,` or `;` and any whitespace are discarded from the input before parsing the second coordinate. But prior to this patch, if the coordinate format was in degrees followed by a sign (`N` is a sign in this example), the parser would skip the bit of code that fast forwards past any intervening separators and whitespace (`, ` in this example). This resulted in coordinates of the given form not being accepted, because the second parse would start with `, 68.2296° W` and reject this as an invalid coordinate.

To rectify this, the bit of code that fast forwards past separators and whitespace has been broken out from the tokenization loop and performed as a final step after a single coordinate has been completely parsed and validated. Doing it this way makes it independent of the state of the tokenizer, so that the fast-forward code will always execute once a coordinate has been successfully parsed.

I've also centralized the list of allowed separators into its own static string; this is necessary as part of the patch but should also make allowing additional separator characters between coordinates trivial in the future, if needed.

### Changes made:
1.  The bit of code that fast forwards past separators and whitespace has been broken out from the tokenization loop and performed as a final step after a single coordinate has been completely parsed and validated.

I saw no relevant test cases that cover this.

### Related issues:
No related issues I saw

### Additional information:
The coordinate format this adds support for happens to be the one that Google shows in quick-answer cards like this:
![image](https://user-images.githubusercontent.com/6827003/160265237-986e718d-1fdd-4076-ac0b-4469fe2c5f47.png)

After this patch, those strings can now be pasted directly into Subsurface.

### Release note:
A release note would be nice and make me feel nice. I've updated `CHANGELOG.md` accordingly.

### Documentation change:
None

### Mentions:
@pvalsecc, I see your name on the blame for the coordinate parser.
