### PR TITLE
configure-dc: Add support for ostc3 Auto SP mode

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -2413,6 +2413,11 @@
                 <string>Sensor</string>
                </property>
               </item>
+              <item>
+               <property name="text">
+                <string>Auto SP</string>
+               </property>
+              </item>
              </widget>
             </item>
             <item row="6" column="2">


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Way back in time, in HwOS 1.86 a CCR mode was added which automatically
switched between setpoints based on depth.

This entry was never added in our system to configure the dc, and caused
the issue seen in #3304

This adds the Auto SP mode, to the dropdown, thus fixing #3304.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dadefay