### PR TITLE
Add template variables for pictures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Desktop: Allow more than one media file to be imported from web
+- Printing: Add template variables for pictures
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.
 * Use this layout for new entries: `[Area]: [Details about the change] [reference thread / issue]`

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -319,6 +319,16 @@ static std::vector<const cylinder_t *> cylinderList(const dive *d)
 	return res;
 }
 
+static QStringList pictureList(const dive *d)
+{
+	QStringList res;
+	res.reserve(d->pictures.nr);
+	FOR_EACH_PICTURE(d) {
+		res << QString(picture->filename);
+	}
+	return res;
+ }
+
 void TemplateLayout::parser(QList<token> tokenList, int from, int to, QTextStream &out, State &state)
 {
 	for (int pos = from; pos < to; ++pos) {
@@ -359,6 +369,11 @@ void TemplateLayout::parser(QList<token> tokenList, int from, int to, QTextStrea
 						parser_for(tokenList, pos, loop_end, capture, state, cylinderList(*state.currentDive), state.currentCylinderObject, false);
 					else
 						qWarning("cylinderObjects loop outside of dive");
+				} else if (listname == "pictures") {
+					if (state.currentDive)
+						parser_for(tokenList, pos, loop_end, capture, state, pictureList(*state.currentDive), state.currentPicture, false);
+					else
+						qWarning("pictures loop outside of dive");
 				} else {
 					qWarning("unknown loop: %s", qPrintable(listname));
 				}
@@ -485,6 +500,10 @@ QVariant TemplateLayout::getValue(QString list, QString property, const State &s
 	} else if (list == "cylinders") {
 		if (state.currentCylinder && property == "description") {
 			return *state.currentCylinder;
+		}
+	} else if (list == "pictures") {
+		if (state.currentPicture && property == "url") {
+			return QUrl::fromUserInput(*state.currentPicture).toString();
 		}
 	} else if (list == "cylinderObjects") {
 		if (!state.currentCylinderObject)

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -43,6 +43,7 @@ private:
 		const stats_t * const *currentYear = nullptr;
 		const QString *currentCylinder = nullptr;
 		const cylinder_t * const *currentCylinderObject = nullptr;
+		const QString *currentPicture = nullptr;
 	};
 	const print_options &printOptions;
 	const template_options &templateOptions;


### PR DESCRIPTION
This introduces a new list the printing templates can loop
over: pictures contains the urls (local or remote) of media
associtated to the current dive. This allows constructs like

```
{% for pic in pictures %}
	<img src="{{ pic.url }}" width=20%>
{% endfor %}

```
in the printing template.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
