### PR TITLE
core: clearing dive data should clear undo stack

### DIFF
--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -23,7 +23,10 @@ void init()
 
 void clear()
 {
-	undoStack->clear();
+	// this can get called from C code even if the Command code was never initialized
+	// (really only in the case of tests like TestParse)
+	if (undoStack)
+		undoStack->clear();
 }
 
 void setClean()
@@ -113,3 +116,9 @@ bool placingCommand()
 }
 
 } // namespace Command
+
+extern "C" {
+void command_clear_from_C() {
+	Command::clear();
+}
+}

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -21,6 +21,7 @@
 #include "trip.h"
 
 bool autogroup = false;
+extern void command_clear_from_C();
 
 void set_autogroup(bool value)
 {
@@ -1391,6 +1392,7 @@ void clear_dive_file_data()
 	clear_git_id();
 
 	reset_tank_info_table(&tank_info_table);
+	command_clear_from_C();
 
 	/* Inform frontend of reset data. This should reset all the models. */
 	emit_reset_signal();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,8 @@ function(TEST NAME FILE)
 		subsurface_backend_shared
 		${TEST_SPECIFIC_LIBRARIES}
 		subsurface_corelib
+		subsurface_commands
+		subsurface_corelib    # annoying circular references
 		RESOURCE_LIBRARY
 		${QT_TEST_LIBRARIES}
 		${SUBSURFACE_LINK_LIBRARIES}
@@ -99,6 +101,8 @@ add_executable(TestQML testqml.cpp)
 target_link_libraries(
 	TestQML
 	subsurface_corelib
+	subsurface_commands
+	subsurface_corelib    # annoying circular references
 	RESOURCE_LIBRARY
 	${QT_TEST_LIBRARIES}
 	${SUBSURFACE_LINK_LIBRARIES}


### PR DESCRIPTION
If we clear out our dive data, we also need to clear out the undo stack
because it otherwise will refer to dives that no longer exist.

The cleanest way to do that would be to do it in the same function used
to clear the dive data. Which causes us to call C++ code from C code and
really is a bit of a mess with a circular dependency between our
libraries.

But this does seem better than relying on people to remember to call
into a second function after clearing the data.

Suggested-by: Michael Andreen <michael@andreen.dev>
Suggested-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->



This really is just an alternative to #3431 

@michaelandreen 
@bstoeger 