### PR TITLE
profile: remove last dc_number access from profile code

### DIFF
--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -514,7 +514,7 @@ void ProfileScene::plotDive(const struct dive *dIn, int dcIn, DivePlannerPointsM
 	animatedAxes.push_back(timeAxis);
 	cylinderPressureAxis->setBounds(plotInfo.minpressure, plotInfo.maxpressure);
 
-	tankItem->setData(d, firstSecond, lastSecond);
+	tankItem->setData(d, currentdc, firstSecond, lastSecond);
 
 	if (ppGraphsEnabled(currentdc, simplified)) {
 		double max = prefs.pp_graphs.phe ? max_gas(plotInfo, &gas_pressures::he) : -1;

--- a/profile-widget/tankitem.cpp
+++ b/profile-widget/tankitem.cpp
@@ -62,13 +62,13 @@ void TankItem::createBar(int startTime, int stopTime, struct gasmix gas)
 	label->setZValue(101);
 }
 
-void TankItem::setData(const struct dive *d, int plotStartTime, int plotEndTime)
+void TankItem::setData(const struct dive *d, const struct divecomputer *dc, int plotStartTime, int plotEndTime)
 {
 	// remove the old rectangles
 	qDeleteAll(rects);
 	rects.clear();
 
-	if (!d)
+	if (!d || !dc)
 		return;
 
 	// We don't have enougth data to calculate things, quit.
@@ -78,10 +78,6 @@ void TankItem::setData(const struct dive *d, int plotStartTime, int plotEndTime)
 	// Bail if there are no cylinders
 	if (d->cylinders.nr <= 0)
 		return;
-
-	// get the information directly from the displayed dive
-	// (get_dive_dc() always returns a valid dive computer)
-	const struct divecomputer *dc = get_dive_dc_const(d, dc_number);
 
 	// start with the first gasmix and at the start of the dive
 	int cyl = explicit_first_cylinder(d, dc);

--- a/profile-widget/tankitem.h
+++ b/profile-widget/tankitem.h
@@ -8,13 +8,14 @@
 #include <QBrush>
 
 struct dive;
+struct divecomputer;
 class DiveCartesianAxis;
 
 class TankItem : public QGraphicsRectItem
 {
 public:
 	explicit TankItem(const DiveCartesianAxis &axis, double dpr);
-	void setData(const struct dive *d, int plotStartTime, int plotEndTime);
+	void setData(const struct dive *d, const struct divecomputer *dc, int plotStartTime, int plotEndTime);
 	double height() const;
 
 private:


### PR DESCRIPTION
dc_number is a global variable indicating the currently displayed
dive on desktop. It makes no sense on mobile, since multiple
profiles can be active at the same time. Therefore, the profile
code should not access this global, but use the dc number that
is passed in.

This removes the last access.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The commit message says it all: The profile shouldn't use global variables, since on mobile multiple profiles are active at the same time.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove access to `dc_number`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Nope. No user-visible change.
