### PR TITLE
[Don'tMerge] Collect and convert git repo data to 'struct git_info'

### DIFF
--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -198,20 +198,20 @@ void CheckCloudConnection::gotContinent(QNetworkReply *reply)
 }
 
 // helper to be used from C code
-extern "C" bool canReachCloudServer(const char **remote)
+extern "C" bool canReachCloudServer(struct git_info *info)
 {
 	if (verbose)
-		qWarning() << "Cloud storage: checking connection to cloud server" << *remote;
+		qWarning() << "Cloud storage: checking connection to cloud server" << info->url;
 	bool connection = CheckCloudConnection().checkServer();
-	if (strstr(*remote, prefs.cloud_base_url) == nullptr) {
+	if (strstr(info->url, prefs.cloud_base_url) == nullptr) {
 		// we switched the cloud URL - likely because we couldn't reach the server passed in
 		// the strstr with the offset is designed so we match the right component in the name;
 		// the cloud_base_url ends with a '/', so we need the text starting at "git/..."
-		char *newremote = format_string("%s%s", prefs.cloud_base_url, strstr(*remote, "org/git/") + 4);
+		char *newremote = format_string("%s%s", prefs.cloud_base_url, strstr(info->url, "org/git/") + 4);
 		if (verbose)
 			qDebug() << "updating remote to: " << newremote;
-		free((void*)*remote);
-		*remote = newremote;
+		free((void*)info->url);
+		info->url = newremote;
 	}
 	return connection;
 }

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -22,30 +22,40 @@ extern "C" {
 
 #define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
-enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
+enum remote_transport { RT_LOCAL, RT_HTTPS, RT_SSH, RT_OTHER };
 
 struct git_oid;
 struct git_repository;
 struct device_table;
-#define dummy_git_repository ((git_repository *)3ul) /* Random bogus pointer, not NULL */
-extern struct git_repository *is_git_repository(const char *filename, const char **branchp, const char **remote, bool dry_run);
-extern int check_git_sha(const char *filename, git_repository **git_p, const char **branch_p);
-extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
-extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
-extern int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
+
+struct git_info {
+	const char *url;
+	const char *branch;
+	const char *username;
+	const char *localdir;
+	struct git_repository *repo;
+	unsigned is_subsurface_cloud:1;
+	enum remote_transport transport;
+};
+
+extern bool is_git_repository(const char *filename, struct git_info *info);
+extern bool open_git_repository(struct git_info *info);
+extern bool check_git_sha(const char *filename, struct git_info *info);
+extern int sync_with_remote(struct git_info *);
+extern int git_save_dives(struct git_info *, bool select_only);
+extern int git_load_dives(struct git_info *, struct dive_table *table, struct trip_table *trips,
 			  struct dive_site_table *sites, struct device_table *devices,
 			  struct filter_preset_table *filter_presets);
 extern const char *get_sha(git_repository *repo, const char *branch);
-extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
+extern int do_git_save(struct git_info *, bool select_only, bool create_empty);
 extern const char *saved_git_id;
 extern bool git_local_only;
 extern bool git_remote_sync_successful;
 extern void clear_git_id(void);
 extern void set_git_id(const struct git_oid *);
-extern enum remote_transport url_to_remote_transport(const char *remote);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
-char *get_local_dir(const char *remote, const char *branch);
+char *get_local_dir(const char *, const char *);
 int git_create_local_repo(const char *filename);
 int get_authorship(git_repository *repo, git_signature **authorp);
 

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1945,23 +1945,23 @@ const char *get_sha(git_repository *repo, const char *branch)
  * If it is a git repository, we return zero for success,
  * or report an error and return 1 if the load failed.
  */
-int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
+int git_load_dives(struct git_info *info, struct dive_table *table, struct trip_table *trips,
 		   struct dive_site_table *sites, struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	struct git_parser_state state = { 0 };
-	state.repo = repo;
+	state.repo = info->repo;
 	state.table = table;
 	state.trips = trips;
 	state.sites = sites;
 	state.devices = devices;
 	state.filter_presets = filter_presets;
 
-	if (repo == dummy_git_repository)
-		return report_error("Unable to open git repository at '%s'", branch);
-	ret = do_git_load(repo, branch, &state);
-	git_repository_free(repo);
-	free((void *)branch);
+	if (!info->repo)
+		return report_error("Unable to open git repository '%s[%s]'", info->url, info->branch);
+	ret = do_git_load(info->repo, info->branch, &state);
+	git_repository_free(info->repo);
+	free((void *)info->branch);
 	finish_active_dive(&state);
 	finish_active_trip(&state);
 	return ret;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -141,9 +141,11 @@ void moveInVector(Vector &v, int rangeBegin, int rangeEnd, int destination)
 extern "C" {
 #endif
 
+struct git_info;
+
 char *printGPSCoordsC(const location_t *loc);
 bool getProxyString(char **buffer);
-bool canReachCloudServer(const char **remote);
+bool canReachCloudServer(struct git_info *);
 void updateWindowTitle();
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -822,14 +822,12 @@ static void try_to_backup(const char *filename)
 int save_dives_logic(const char *filename, const bool select_only, bool anonymize)
 {
 	struct membuffer buf = { 0 };
+	struct git_info info;
 	FILE *f;
-	void *git;
-	const char *branch, *remote;
 	int error = 0;
 
-	git = is_git_repository(filename, &branch, &remote, false);
-	if (git)
-		return git_save_dives(git, branch, remote, select_only);
+	if (is_git_repository(filename, &info))
+		return git_save_dives(&info, select_only);
 
 	save_dives_buffer(&buf, select_only, anonymize);
 

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -44,23 +44,21 @@ void print_version()
 
 void print_files()
 {
-	const char *branch = 0;
-	const char *remote = 0;
-	const char *filename, *local_git;
+	struct git_info info = { };
+	const char *filename;
 
 	printf("\nFile locations:\n\n");
 	printf("Cloud email:%s\n", prefs.cloud_storage_email);
 	if (!empty_string(prefs.cloud_storage_email) && !empty_string(prefs.cloud_storage_password)) {
 		filename = cloud_url();
 
-		is_git_repository(filename, &branch, &remote, true);
+		is_git_repository(filename, &info);
 	} else {
 		/* strdup so the free below works in either case */
 		filename = strdup("No valid cloud credentials set.\n");
 	}
-	if (branch && remote) {
-		local_git = get_local_dir(remote, branch);
-		printf("Local git storage: %s\n", local_git);
+	if (info.localdir) {
+		printf("Local git storage: %s\n", info.localdir);
 	} else {
 		printf("Unable to get local git directory\n");
 	}


### PR DESCRIPTION
THIS IS NOT READY FOR MERGING.

Pull request purely for build test purposes for non-Linux targets (particularly mobile).

This still has the same problems the code always has had, but now we're at least passing this struct around and can start filling it in in saner ways than the old nasty call chains did in various places.

We have this nasty habit of randomly passing down all the different
things that we use to look up the local and remote git repository, and
the information associated with it.

Start collecting the data into a 'struct git_info' instead, so that it
is easier to manage, and easier and more logical to just look up
different parts of the puzzle.

This is a fairly mechanical conversion, and doesn't collect it all yet.
As an examples of things that look odd and will probably need future
work: the email that is embedded in the repository name is saved in
'prefs.cloud_storage_email_encoded' and we then pick it up from there as
the user name later.

Yes, we do want to save the user name of the cloud storage in the
preferences, but it shouldn't be this kind of crazy "as you parse the
URL, save some of it in preferences" thing.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
