### PR TITLE
core: work around water temperature bug in Tecdiving DiveComputer.eu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: work around bug in TecDiving dive computer reporting spurious 0 deg C water temperature in first sample
 - core: correctly parse DC_FIELD_SALINITY response; fixes incorrect water type with some dive computers, including the Mares Smart
 - Desktop: Allow more than one media file to be imported from web
 - undo: Clear undo stack when the current file is closed

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -831,6 +831,14 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 		dive->dc.sample[0].temperature.mkelvin = 0;
 	}
 
+	/* special case for bug in Tecdiving DiveComputer.eu
+	 * often the first sample has a water temperature of 0C, followed by the correct
+	 * temperature in the next sample */
+	if (same_string(dive->dc.model, "Tecdiving DiveComputer.eu") &&
+	    dive->dc.sample[0].temperature.mkelvin == ZERO_C_IN_MKELVIN &&
+	    dive->dc.sample[1].temperature.mkelvin > dive->dc.sample[0].temperature.mkelvin)
+		dive->dc.sample[0].temperature.mkelvin = dive->dc.sample[1].temperature.mkelvin;
+
 	record_dive_to_table(dive, devdata->download_table);
 	return true;
 


### PR DESCRIPTION
It appears to send a first sample with a water temperature of 0 C. If the next
sample contains a more likely water temperature, overwrite the first one.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
