### PR TITLE
Collect and convert git repo data to 'struct git_info'

### DIFF
--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -198,20 +198,20 @@ void CheckCloudConnection::gotContinent(QNetworkReply *reply)
 }
 
 // helper to be used from C code
-extern "C" bool canReachCloudServer(const char **remote)
+extern "C" bool canReachCloudServer(struct git_info *info)
 {
 	if (verbose)
-		qWarning() << "Cloud storage: checking connection to cloud server" << *remote;
+		qWarning() << "Cloud storage: checking connection to cloud server" << info->url;
 	bool connection = CheckCloudConnection().checkServer();
-	if (strstr(*remote, prefs.cloud_base_url) == nullptr) {
+	if (strstr(info->url, prefs.cloud_base_url) == nullptr) {
 		// we switched the cloud URL - likely because we couldn't reach the server passed in
 		// the strstr with the offset is designed so we match the right component in the name;
 		// the cloud_base_url ends with a '/', so we need the text starting at "git/..."
-		char *newremote = format_string("%s%s", prefs.cloud_base_url, strstr(*remote, "org/git/") + 4);
+		char *newremote = format_string("%s%s", prefs.cloud_base_url, strstr(info->url, "org/git/") + 4);
 		if (verbose)
 			qDebug() << "updating remote to: " << newremote;
-		free((void*)*remote);
-		*remote = newremote;
+		free((void*)info->url);
+		info->url = newremote;
 	}
 	return connection;
 }

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -22,30 +22,40 @@ extern "C" {
 
 #define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
-enum remote_transport { RT_OTHER, RT_HTTPS, RT_SSH };
+enum remote_transport { RT_LOCAL, RT_HTTPS, RT_SSH, RT_OTHER };
 
 struct git_oid;
 struct git_repository;
 struct device_table;
-#define dummy_git_repository ((git_repository *)3ul) /* Random bogus pointer, not NULL */
-extern struct git_repository *is_git_repository(const char *filename, const char **branchp, const char **remote, bool dry_run);
-extern int check_git_sha(const char *filename, git_repository **git_p, const char **branch_p);
-extern int sync_with_remote(struct git_repository *repo, const char *remote, const char *branch, enum remote_transport rt);
-extern int git_save_dives(struct git_repository *, const char *, const char *remote, bool select_only);
-extern int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
+
+struct git_info {
+	const char *url;
+	const char *branch;
+	const char *username;
+	const char *localdir;
+	struct git_repository *repo;
+	unsigned is_subsurface_cloud:1;
+	enum remote_transport transport;
+};
+
+extern bool is_git_repository(const char *filename, struct git_info *info);
+extern bool open_git_repository(struct git_info *info);
+extern bool check_git_sha(const char *filename, struct git_info *info);
+extern int sync_with_remote(struct git_info *);
+extern int git_save_dives(struct git_info *, bool select_only);
+extern int git_load_dives(struct git_info *, struct dive_table *table, struct trip_table *trips,
 			  struct dive_site_table *sites, struct device_table *devices,
 			  struct filter_preset_table *filter_presets);
 extern const char *get_sha(git_repository *repo, const char *branch);
-extern int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty);
+extern int do_git_save(struct git_info *, bool select_only, bool create_empty);
 extern const char *saved_git_id;
 extern bool git_local_only;
 extern bool git_remote_sync_successful;
 extern void clear_git_id(void);
 extern void set_git_id(const struct git_oid *);
-extern enum remote_transport url_to_remote_transport(const char *remote);
 void set_git_update_cb(int(*)(const char *));
 int git_storage_update_progress(const char *text);
-char *get_local_dir(const char *remote, const char *branch);
+char *get_local_dir(const char *, const char *);
 int git_create_local_repo(const char *filename);
 int get_authorship(git_repository *repo, git_signature **authorp);
 

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1945,23 +1945,23 @@ const char *get_sha(git_repository *repo, const char *branch)
  * If it is a git repository, we return zero for success,
  * or report an error and return 1 if the load failed.
  */
-int git_load_dives(struct git_repository *repo, const char *branch, struct dive_table *table, struct trip_table *trips,
+int git_load_dives(struct git_info *info, struct dive_table *table, struct trip_table *trips,
 		   struct dive_site_table *sites, struct device_table *devices, struct filter_preset_table *filter_presets)
 {
 	int ret;
 	struct git_parser_state state = { 0 };
-	state.repo = repo;
+	state.repo = info->repo;
 	state.table = table;
 	state.trips = trips;
 	state.sites = sites;
 	state.devices = devices;
 	state.filter_presets = filter_presets;
 
-	if (repo == dummy_git_repository)
-		return report_error("Unable to open git repository at '%s'", branch);
-	ret = do_git_load(repo, branch, &state);
-	git_repository_free(repo);
-	free((void *)branch);
+	if (!info->repo)
+		return report_error("Unable to open git repository '%s[%s]'", info->url, info->branch);
+	ret = do_git_load(info->repo, info->branch, &state);
+	git_repository_free(info->repo);
+	free((void *)info->branch);
 	finish_active_dive(&state);
 	finish_active_trip(&state);
 	return ret;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -141,9 +141,11 @@ void moveInVector(Vector &v, int rangeBegin, int rangeEnd, int destination)
 extern "C" {
 #endif
 
+struct git_info;
+
 char *printGPSCoordsC(const location_t *loc);
 bool getProxyString(char **buffer);
-bool canReachCloudServer(const char **remote);
+bool canReachCloudServer(struct git_info *);
 void updateWindowTitle();
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1178,7 +1178,7 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 		SSRF_INFO("Commit message:\n\n%s\n", mb_cstring(msg));
 }
 
-static int create_new_commit(git_repository *repo, const char *remote, const char *branch, git_oid *tree_id, bool create_empty)
+static int create_new_commit(struct git_info *info, git_oid *tree_id, bool create_empty)
 {
 	int ret;
 	git_reference *ref;
@@ -1188,19 +1188,19 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	git_commit *commit;
 	git_tree *tree;
 
-	ret = git_branch_lookup(&ref, repo, branch, GIT_BRANCH_LOCAL);
+	ret = git_branch_lookup(&ref, info->repo, info->branch, GIT_BRANCH_LOCAL);
 	switch (ret) {
 	default:
-		return report_error("Bad branch '%s' (%s)", branch, strerror(errno));
+		return report_error("Bad branch '%s' (%s)", info->branch, strerror(errno));
 	case GIT_EINVALIDSPEC:
-		return report_error("Invalid branch name '%s'", branch);
+		return report_error("Invalid branch name '%s'", info->branch);
 	case GIT_ENOTFOUND: /* We'll happily create it */
 		ref = NULL;
-		parent = try_to_find_parent(saved_git_id, repo);
+		parent = try_to_find_parent(saved_git_id, info->repo);
 		break;
 	case 0:
 		if (git_reference_peel(&parent, ref, GIT_OBJ_COMMIT))
-			return report_error("Unable to look up parent in branch '%s'", branch);
+			return report_error("Unable to look up parent in branch '%s'", info->branch);
 
 		if (saved_git_id) {
 			if (existing_filename && verbose)
@@ -1208,7 +1208,7 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 			const git_oid *id = git_commit_id((const git_commit *) parent);
 			/* if we are saving to the same git tree we got this from, let's make
 			 * sure there is no confusion */
-			if (same_string(existing_filename, remote) && git_oid_strcmp(id, saved_git_id))
+			if (same_string(existing_filename, info->url) && git_oid_strcmp(id, saved_git_id))
 				return report_error("The git branch does not match the git parent of the source");
 		}
 
@@ -1216,10 +1216,10 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 		break;
 	}
 
-	if (git_tree_lookup(&tree, repo, tree_id))
+	if (git_tree_lookup(&tree, info->repo, tree_id))
 		return report_error("Could not look up newly created tree");
 
-	if (get_authorship(repo, &author))
+	if (get_authorship(info->repo, &author))
 		return report_error("No user name configuration in git repo");
 
 	/* If the parent commit has the same tree ID, do not create a new commit */
@@ -1235,13 +1235,13 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 		struct membuffer commit_msg = { 0 };
 
 		create_commit_message(&commit_msg, create_empty);
-		if (git_commit_create_v(&commit_id, repo, NULL, author, author, NULL, mb_cstring(&commit_msg), tree, parent != NULL, parent)) {
+		if (git_commit_create_v(&commit_id, info->repo, NULL, author, author, NULL, mb_cstring(&commit_msg), tree, parent != NULL, parent)) {
 			git_signature_free(author);
 			return report_error("Git commit create failed (%s)", strerror(errno));
 		}
 		free_buffer(&commit_msg);
 
-		if (git_commit_lookup(&commit, repo, &commit_id)) {
+		if (git_commit_lookup(&commit, info->repo, &commit_id)) {
 			git_signature_free(author);
 			return report_error("Could not look up newly created commit");
 		}
@@ -1250,8 +1250,8 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	git_signature_free(author);
 
 	if (!ref) {
-		if (git_branch_create(&ref, repo, branch, commit, 0))
-			return report_error("Failed to create branch '%s'", branch);
+		if (git_branch_create(&ref, info->repo, info->branch, commit, 0))
+			return report_error("Failed to create branch '%s'", info->branch);
 	}
 	/*
 	 * If it's a checked-out branch, try to also update the working
@@ -1260,17 +1260,17 @@ static int create_new_commit(git_repository *repo, const char *remote, const cha
 	 * the object database), but it can cause extreme confusion, so
 	 * warn about it.
 	 */
-	if (git_branch_is_head(ref) && !git_repository_is_bare(repo)) {
-		if (update_git_checkout(repo, parent, tree)) {
+	if (git_branch_is_head(ref) && !git_repository_is_bare(info->repo)) {
+		if (update_git_checkout(info->repo, parent, tree)) {
 			const git_error *err = giterr_last();
 			const char *errstr = err ? err->message : strerror(errno);
 			report_error("Git branch '%s' is checked out, but worktree is dirty (%s)",
-				branch, errstr);
+				info->branch, errstr);
 		}
 	}
 
 	if (git_reference_set_target(&ref, ref, &commit_id, "Subsurface save event"))
-		return report_error("Failed to update branch '%s'", branch);
+		return report_error("Failed to update branch '%s'", info->branch);
 
 	/*
 	 * if this was the empty commit to initialize a new repo, don't remember the
@@ -1312,11 +1312,14 @@ static int write_git_tree(git_repository *repo, struct dir *tree, git_oid *resul
 	return ret;
 }
 
-int do_git_save(git_repository *repo, const char *branch, const char *remote, bool select_only, bool create_empty)
+int do_git_save(struct git_info *info, bool select_only, bool create_empty)
 {
 	struct dir tree;
 	git_oid id;
 	bool cached_ok;
+
+	if (!info->repo)
+		return report_error("Unable to open git repository '%s[%s]'", info->url, info->branch);
 
 	if (verbose)
 		SSRF_INFO("git storage: do git save\n");
@@ -1328,43 +1331,66 @@ int do_git_save(git_repository *repo, const char *branch, const char *remote, bo
 	 * Check if we can do the cached writes - we need to
 	 * have the original git commit we loaded in the repo
 	 */
-	cached_ok = try_to_find_parent(saved_git_id, repo);
+	cached_ok = try_to_find_parent(saved_git_id, info->repo);
 
 	/* Start with an empty tree: no subdirectories, no files */
 	tree.name[0] = 0;
 	tree.subdirs = NULL;
-	if (git_treebuilder_new(&tree.files, repo, NULL))
+	if (git_treebuilder_new(&tree.files, info->repo, NULL))
 		return report_error("git treebuilder failed");
 
 	if (!create_empty)
 		/* Populate our tree data structure */
-		if (create_git_tree(repo, &tree, select_only, cached_ok))
+		if (create_git_tree(info->repo, &tree, select_only, cached_ok))
 			return -1;
 
 	if (verbose)
 		SSRF_INFO("git storage, write git tree\n");
 
-	if (write_git_tree(repo, &tree, &id))
+	if (write_git_tree(info->repo, &tree, &id))
 		return report_error("git tree write failed");
 
 	/* And save the tree! */
-	if (create_new_commit(repo, remote, branch, &id, create_empty))
+	if (create_new_commit(info, &id, create_empty))
 		return report_error("creating commit failed");
 
 	/* now sync the tree with the remote server */
-	if (remote && !git_local_only)
-		return sync_with_remote(repo, remote, branch, url_to_remote_transport(remote));
+	if (info->url && !git_local_only)
+		return sync_with_remote(info);
 	return 0;
 }
 
-int git_save_dives(struct git_repository *repo, const char *branch, const char *remote, bool select_only)
+int git_save_dives(struct git_info *info, bool select_only)
 {
 	int ret;
 
-	if (repo == dummy_git_repository)
-		return report_error("Unable to open git repository '%s'", branch);
-	ret = do_git_save(repo, branch, remote, select_only, false);
-	git_repository_free(repo);
-	free((void *)branch);
+	/*
+	 * FIXME!! This open_git_repository() will
+	 * sync with the cloud. That is NOT what
+	 * we actually want to do here. We want
+	 * to just open the local repo, and then
+	 * sync with the clound after having saved.
+	 *
+	 * NOTE! The "we already have a repo" case
+	 * case is fairly easy (we can just treat
+	 * it as a local repository and open it
+	 * as-is). But the "need to create it by
+	 * cloning" case is what we currently also
+	 * do in 'open_git_repository()', and that
+	 * all needs to be thought about a lot.
+	 *
+	 * Do we want to have the rule that you
+	 * can't save to a git repo unless you first
+	 * opened it for reading, and make all that
+	 * complexity be a load-time thing? That
+	 * would make the saving rules be very clear
+	 * and simple.
+	 */
+	if (!open_git_repository(info))
+		report_error(translate("gettextFromC", "Failed to save dives to %s[%s] (%s)"), info->url, info->branch, strerror(errno));
+
+	ret = do_git_save(info, select_only, false);
+	git_repository_free(info->repo);
+	free((void *)info->branch);
 	return ret;
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -822,14 +822,12 @@ static void try_to_backup(const char *filename)
 int save_dives_logic(const char *filename, const bool select_only, bool anonymize)
 {
 	struct membuffer buf = { 0 };
+	struct git_info info;
 	FILE *f;
-	void *git;
-	const char *branch, *remote;
 	int error = 0;
 
-	git = is_git_repository(filename, &branch, &remote, false);
-	if (git)
-		return git_save_dives(git, branch, remote, select_only);
+	if (is_git_repository(filename, &info))
+		return git_save_dives(&info, select_only);
 
 	save_dives_buffer(&buf, select_only, anonymize);
 

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -44,23 +44,21 @@ void print_version()
 
 void print_files()
 {
-	const char *branch = 0;
-	const char *remote = 0;
-	const char *filename, *local_git;
+	struct git_info info = { };
+	const char *filename;
 
 	printf("\nFile locations:\n\n");
 	printf("Cloud email:%s\n", prefs.cloud_storage_email);
 	if (!empty_string(prefs.cloud_storage_email) && !empty_string(prefs.cloud_storage_password)) {
 		filename = cloud_url();
 
-		is_git_repository(filename, &branch, &remote, true);
+		is_git_repository(filename, &info);
 	} else {
 		/* strdup so the free below works in either case */
 		filename = strdup("No valid cloud credentials set.\n");
 	}
-	if (branch && remote) {
-		local_git = get_local_dir(remote, branch);
-		printf("Local git storage: %s\n", local_git);
+	if (info.localdir) {
+		printf("Local git storage: %s\n", info.localdir);
 	} else {
 		printf("Unable to get local git directory\n");
 	}


### PR DESCRIPTION
We have this nasty habit of randomly passing down all the different
things that we use to look up the local and remote git repository, and
the information associated with it.

Start collecting the data into a 'struct git_info' instead, so that it
is easier to manage, and easier and more logical to just look up
different parts of the puzzle.

This is a fairly mechanical conversion, but has moved all the basic
information collection to the 'is_git_repository()' function.  That
function no longer actually opens the repository (so the 'dry_run'
argument is gone, and instead a successful 'is_git_repository()' is
followed by 'opn_git_repository()' if you actually want the old
non-dry_run semantics.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
