### PR TITLE
Git cleanups

### DIFF
--- a/core/file.c
+++ b/core/file.c
@@ -306,11 +306,15 @@ int parse_file(const char *filename, struct dive_table *table, struct trip_table
 			 * Opening the cloud storage repository failed for some reason
 			 * give up here and don't send errors about git repositories
 			 */
-			if (info.is_subsurface_cloud)
+			if (info.is_subsurface_cloud) {
+				cleanup_git_info(&info);
 				return -1;
+			}
 		}
 
-		return git_load_dives(&info, table, trips, sites, devices, filter_presets);
+		ret = git_load_dives(&info, table, trips, sites, devices, filter_presets);
+		cleanup_git_info(&info);
+		return ret;
 	}
 
 	if ((ret = readfile(filename, &mem)) < 0) {

--- a/core/file.c
+++ b/core/file.c
@@ -273,7 +273,7 @@ static int parse_file_buffer(const char *filename, struct memblock *mem, struct 
 	return parse_xml_buffer(filename, mem->buffer, mem->size, table, trips, sites, devices, filter_presets, NULL);
 }
 
-bool check_git_sha(const char *filename, struct git_info *info)
+bool remote_repo_uptodate(const char *filename, struct git_info *info)
 {
 	char *current_sha = copy_string(saved_git_id);
 
@@ -282,14 +282,14 @@ bool check_git_sha(const char *filename, struct git_info *info)
 		if (!empty_string(sha) && same_string(sha, current_sha)) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
 			free(current_sha);
-			return false;
+			return true;
 		}
 	}
 
 	// Either the repository couldn't be opened, or the SHA couldn't
 	// be found.
 	free(current_sha);
-	return true;
+	return false;
 }
 
 int parse_file(const char *filename, struct dive_table *table, struct trip_table *trips, struct dive_site_table *sites,

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -1009,6 +1009,17 @@ static void extract_username(struct git_info *info, char *url)
 	prefs.cloud_storage_email_encoded = strdup(info->username);
 }
 
+void cleanup_git_info(struct git_info *info)
+{
+	if (info->repo)
+		git_repository_free(info->repo);
+	free((void *)info->url);
+	free((void *)info->branch);
+	free((void *)info->username);
+	free((void *)info->localdir);
+	memset(info, 0, sizeof(*info));
+}
+
 /*
  * If it's not a git repo, return NULL. Be very conservative.
  *

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -48,6 +48,7 @@ extern int git_load_dives(struct git_info *, struct dive_table *table, struct tr
 			  struct filter_preset_table *filter_presets);
 extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(struct git_info *, bool select_only, bool create_empty);
+extern void cleanup_git_info(struct git_info *);
 extern const char *saved_git_id;
 extern bool git_local_only;
 extern bool git_remote_sync_successful;

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -40,7 +40,7 @@ struct git_info {
 
 extern bool is_git_repository(const char *filename, struct git_info *info);
 extern bool open_git_repository(struct git_info *info);
-extern bool check_git_sha(const char *filename, struct git_info *info);
+extern bool remote_repo_uptodate(const char *filename, struct git_info *info);
 extern int sync_with_remote(struct git_info *);
 extern int git_save_dives(struct git_info *, bool select_only);
 extern int git_load_dives(struct git_info *, struct dive_table *table, struct trip_table *trips,

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -1960,8 +1960,6 @@ int git_load_dives(struct git_info *info, struct dive_table *table, struct trip_
 	if (!info->repo)
 		return report_error("Unable to open git repository '%s[%s]'", info->url, info->branch);
 	ret = do_git_load(info->repo, info->branch, &state);
-	git_repository_free(info->repo);
-	free((void *)info->branch);
 	finish_active_dive(&state);
 	finish_active_trip(&state);
 	return ret;

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -1362,8 +1362,6 @@ int do_git_save(struct git_info *info, bool select_only, bool create_empty)
 
 int git_save_dives(struct git_info *info, bool select_only)
 {
-	int ret;
-
 	/*
 	 * FIXME!! This open_git_repository() will
 	 * sync with the cloud. That is NOT what
@@ -1389,8 +1387,5 @@ int git_save_dives(struct git_info *info, bool select_only)
 	if (!open_git_repository(info))
 		report_error(translate("gettextFromC", "Failed to save dives to %s[%s] (%s)"), info->url, info->branch, strerror(errno));
 
-	ret = do_git_save(info, select_only, false);
-	git_repository_free(info->repo);
-	free((void *)info->branch);
-	return ret;
+	return do_git_save(info, select_only, false);
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -826,8 +826,11 @@ int save_dives_logic(const char *filename, const bool select_only, bool anonymiz
 	FILE *f;
 	int error = 0;
 
-	if (is_git_repository(filename, &info))
-		return git_save_dives(&info, select_only);
+	if (is_git_repository(filename, &info)) {
+		error = git_save_dives(&info, select_only);
+		cleanup_git_info(&info);
+		return error;
+	}
 
 	save_dives_buffer(&buf, select_only, anonymize);
 

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -62,6 +62,7 @@ void print_files()
 	} else {
 		printf("Unable to get local git directory\n");
 	}
+	cleanup_git_info(&info);
 	printf("Cloud URL: %s\n", filename);
 	free((void *)filename);
 	char *tmp = hashfile_name_string();

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -769,6 +769,8 @@ void QMLManager::loadDivesWithValidCredentials()
 		}
 		consumeFinishedLoad();
 	}
+	cleanup_git_info(&info);
+
 	setLoadFromCloud(true);
 
 	// if we came from local storage mode, let's merge the local data into the local cache

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -737,7 +737,7 @@ void QMLManager::loadDivesWithValidCredentials()
 	struct git_info info;
 	int error;
 
-	if (check_git_sha(fileNamePrt.data(), &info) == 0) {
+	if (remote_repo_uptodate(fileNamePrt.data(), &info)) {
 		appendTextToLog("Cloud sync shows local cache was current");
 	} else {
 		appendTextToLog("Cloud sync brought newer data, reloading the dive list");

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -66,9 +66,7 @@ static void localRemoteCleanup()
 	// and since this will have created a local repo, remove that one, again so the tests start clean
 	QCOMPARE(localCacheDirectory.removeRecursively(), true);
 
-	free((void *)info.branch);
-	free((void *)info.url);
-	git_repository_free(info.repo);
+	cleanup_git_info(&info);
 }
 
 void TestGitStorage::initTestCase()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

This does a number of cleanups to the git repo handling, with the final commit also making sure that we actually try to save to the local cloud cache repo before we do any remote sync - hopefully making saving more reliable.

This has only gotten some very cursory testing, but each step looks ObviouslyCorrect(tm) to me.

Let's see if the build check machinery agrees.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
