### PR TITLE
build-system: don't build against Qt6 by default

### DIFF
--- a/.github/workflows/linux-fedora-qt6.yml
+++ b/.github/workflows/linux-fedora-qt6.yml
@@ -42,7 +42,7 @@ jobs:
         git reset --hard
         cd ..
         ls -l . subsurface subsurface/scripts
-        bash -e -x subsurface/scripts/build.sh -desktop
+        bash -e -x subsurface/scripts/build.sh -desktop -build-with-qt6
 
     - name: test desktop build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ option(FTDISUPPORT "enable support for libftdi based serial" OFF)
 # Options regarding What should we build on subsurface
 option(MAKE_TESTS "Make the tests" ON)
 
+# Option whether we should try to build against Qt6, if it is available
+option(BUILD_WITH_QT6 "try to build against Qt6 (incomplete)" OFF)
+
 SET(SUBSURFACE_TARGET_EXECUTABLE "DesktopExecutable" CACHE STRING "The type of application, DesktopExecutable, MobileExecutable, or DownloaderExecutable")
 LIST(APPEND SUBSURFACE_ACCEPTED_EXECUTABLES  "DesktopExecutable" "MobileExecutable" "DownloaderExecutable")
 SET_PROPERTY(CACHE SUBSURFACE_TARGET_EXECUTABLE PROPERTY STRINGS ${SUBSURFACE_ACCEPTED_EXECUTABLES})
@@ -173,12 +176,19 @@ include_directories(.
 	${CMAKE_BINARY_DIR}/desktop-widgets
 )
 
+# decide what to do about Qt
+# this is messy because we want to support older Qt5 versions, newer Qt5 versions,
+# and Qt6 when enabled / available.
+if(BUILD_WITH_QT6)
+	set(CHECK_QT6 "Qt6")
+endif()
+
 # figure out which version of Qt we are building against
 # in theory this should get us all the variables set up correctly, but that
 # ended up failing in subtle ways to do what was advertized; in the Qt5 case
 # some of the variables didn't get set up, so we'll immediately call it again
 # for Qt5
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
+find_package(QT NAMES ${CHECK_QT6} Qt5 REQUIRED COMPONENTS Core Widgets)
 
 # right now there are a few things that don't work with Qt6
 # let's disable them right here and remember our Qt version

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -96,6 +96,14 @@ while [[ $# -gt 0 ]] ; do
 			# is still available on Linux distros)
 			BUILD_WITH_WEBKIT="1"
 			;;
+		-build-with-qt6)
+			# Qt6 is not enabled by default as there are a few issues still with the port
+			# - by default the Qt6 packages don't include QtLocation, so no maps (see below)
+			# - WebKit doesn't work with Qt6, so no printing or in-app user manual
+			# - there are a few other random bugs that we still find here and there
+			# So by default we only try to build against Qt5. This overwrites that
+			BUILD_WITH_QT6="1"
+			;;
 		-build-with-map)
 			# Qt6 doesn't include QtLocation (as of Qt 6.3) - but you can build / install it from source.
 			# use this flag to force building googlemaps with Qt6
@@ -603,6 +611,9 @@ for (( i=0 ; i < ${#BUILDS[@]} ; i++ )) ; do
 		EXTRA_OPTS="-DNO_USERMANUAL=OFF -DNO_PRINTING=OFF"
 	else
 		EXTRA_OPTS="-DNO_USERMANUAL=ON -DNO_PRINTING=ON"
+	fi
+	if [ "$BUILD_WITH_QT6" = "1" ] ; then
+		EXTRA_OPTS="$EXTRA_OPTS -DBUILD_WITH_QT6=ON"
 	fi
 
 	cd "$SRC"/${SRC_DIR}


### PR DESCRIPTION
As some Linux distros start to ship both Qt5 and Qt6, it actually makes more
sense to build only against Qt6 when the user explicitly asks for it. Having it
preferred over Qt5 seems completely wrong in hind sight.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This deals with the problem people reported in the user group that on some distros we now build against Qt6 and things fails / miss featuers.

