### PR TITLE
core: avoid crash when merging dive with no cylinders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: prevent crash when merging dives without cylinders (as we might get when importing from divelogs.de)
 - core: work around bug in TecDiving dive computer reporting spurious 0 deg C water temperature in first sample
 - core: correctly parse DC_FIELD_SALINITY response; fixes incorrect water type with some dive computers, including the Mares Smart
 - Desktop: Allow more than one media file to be imported from web

--- a/core/dive.c
+++ b/core/dive.c
@@ -2623,8 +2623,10 @@ struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset,
 	MERGE_NONZERO(res, a, b, visibility);
 	copy_pictures(a->pictures.nr ? &a->pictures : &b->pictures, &res->pictures);
 	taglist_merge(&res->tag_list, a->tag_list, b->tag_list);
-	cylinders_map_a = malloc(a->cylinders.nr * sizeof(*cylinders_map_a));
-	cylinders_map_b = malloc(b->cylinders.nr * sizeof(*cylinders_map_b));
+	/* if we get dives without any gas / cylinder information in an import, make sure
+	 * that there is at leatst one entry in the cylinder map for that dive */
+	cylinders_map_a = malloc(MAX(1, a->cylinders.nr) * sizeof(*cylinders_map_a));
+	cylinders_map_b = malloc(MAX(1, b->cylinders.nr) * sizeof(*cylinders_map_b));
 	merge_cylinders(res, a, b, cylinders_map_a, cylinders_map_b);
 	merge_equipment(res, a, b);
 	merge_temperatures(res, a, b);


### PR DESCRIPTION
Arguably every dive should at least have one cylinder, but an imported
dive from divelogs.de might end up without one. Sadly, that breaks
assumptions that we make in the cylinder remapping.

To work around it, force at least on cylinder to be assumed in the merge
code.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
This might fix the bug Rainer Mohr reported.  