### PR TITLE
core: ignore secondary sensor on OC dives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: ignore secondary sensor on OC dives
 - core: prevent crash when merging dives without cylinders (as we might get when importing from divelogs.de)
 - core: work around bug in TecDiving dive computer reporting spurious 0 deg C water temperature in first sample
 - core: correctly parse DC_FIELD_SALINITY response; fixes incorrect water type with some dive computers, including the Mares Smart

--- a/core/dive.c
+++ b/core/dive.c
@@ -3495,7 +3495,7 @@ extern bool cylinder_with_sensor_sample(const struct dive *dive, int cylinder_id
 {
 	for (const struct divecomputer *dc = &dive->dc; dc; dc = dc->next) {
 		for (int i = 0; i < dc->samples; ++i) {
-			for (int j = 0; j < MAX_SENSORS; ++j) {
+			for (int j = 0; j < (dc->divemode == OC ? 1 : MAX_SENSORS); ++j) {
 				if (dc->sample[i].sensor[j] == cylinder_id)
 					return true;
 			}


### PR DESCRIPTION
Only the primary sensor readings indicate that a cylinder is used
in open circuit dives. The secondary sensor is only used for the
O2 cylinder in closed circuit diving.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
the old behavior makes no sense to me.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @torvalds 