### PR TITLE
build-system: consistently mark git directories safe

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/checkout@v1
 
     - name: run build
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         # this is rather awkward, but it allows us to use the preinstalled
         # Android and Qt versions with relative paths
@@ -35,5 +37,7 @@ jobs:
         # it turns out our build container doesn't have a native compiler
         # yet ECM needs that
         apt-get install --reinstall cpp-7 gcc-7-base libgcc-7-dev libcc1-0 gcc-7
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         bash -x ./subsurface/packaging/android/qmake-build.sh
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,8 +60,12 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         cd ..
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         bash -e -x subsurface/scripts/build.sh -desktop -build-with-webkit
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -38,10 +38,12 @@ jobs:
         TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
     - name: run build
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         cd ..
-        git config --global --add safe.directory /__w/subsurface/subsurface
-        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
         cov-build --dir cov-int bash -x subsurface/scripts/build.sh -desktop -build-with-webkit
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,8 +24,12 @@ jobs:
         mkdir -p $HOME/Qt
         xzcat Qt-5.14.1-ios.tar.xz | tar -x -C $HOME/Qt -f -
     - name: build Subsurface-mobile for iOS
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
-        cd $GITHUB_WORKSPACE/..
+        cd ${SUBSURFACE_REPO_PATH}/..
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         ln -s $HOME/Qt Qt
         echo "build for simulator"
         bash -x $GITHUB_WORKSPACE/packaging/ios/build.sh -simulator

--- a/.github/workflows/linux-bionic-5.9.yml
+++ b/.github/workflows/linux-bionic-5.9.yml
@@ -32,10 +32,12 @@ jobs:
         qtquickcontrols2-5-dev xvfb libbluetooth-dev libmtp-dev
 
     - name: build Subsurface
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         cd ..
-        git config --global --add safe.directory /__w/subsurface/subsurface
-        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         bash -x subsurface/scripts/build.sh -desktop -build-with-webkit
 
     - name: test desktop build

--- a/.github/workflows/linux-fedora-qt6.yml
+++ b/.github/workflows/linux-fedora-qt6.yml
@@ -34,16 +34,17 @@ jobs:
         xorg-x11-server-Xvfb
 
     - name: build Subsurface
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         echo "--------------------------------------------------------------"
         echo "building desktop"
 
         # now build for the desktop version (without WebKit)
-        git reset --hard
         cd ..
-        git config --global --add safe.directory /__w/subsurface/subsurface
-        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
-        ls -l . subsurface subsurface/scripts
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
+        git config --global --get-all safe.directory
         bash -e -x subsurface/scripts/build.sh -desktop -build-with-qt6
 
     - name: test desktop build

--- a/.github/workflows/linux-focal-5.12.yml
+++ b/.github/workflows/linux-focal-5.12.yml
@@ -36,13 +36,15 @@ jobs:
         qtquickcontrols2-5-dev xvfb libbluetooth-dev libmtp-dev
 
     - name: build Subsurface-mobile
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         echo "--------------------------------------------------------------"
         echo "building mobile"
         git config --global user.email "ci@subsurface-divelog.org"
         git config --global user.name "Subsurface CI"
-        git config --global --add safe.directory /__w/subsurface/subsurface
-        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         cd ..
         bash -e -x subsurface/scripts/build.sh -mobile
 

--- a/.github/workflows/linux-impish-5.15.yml
+++ b/.github/workflows/linux-impish-5.15.yml
@@ -36,13 +36,15 @@ jobs:
         qtquickcontrols2-5-dev xvfb libbluetooth-dev libmtp-dev
 
     - name: build Subsurface-mobile
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         echo "--------------------------------------------------------------"
         echo "building mobile"
         git config --global user.email "ci@subsurface-divelog.org"
         git config --global user.name "Subsurface CI"
-        git config --global --add safe.directory /__w/subsurface/subsurface
-        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         cd ..
         bash -e -x subsurface/scripts/build.sh -mobile
 

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -18,8 +18,12 @@ jobs:
       uses: actions/checkout@v1
 
     - name: run build
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         cd ..
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         rm -rf /install-root/include/libdivecomputer
         bash -x subsurface/.github/workflows/scripts/linux-in-container-build.sh
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -21,6 +21,8 @@ jobs:
         curl --output Qt-5.13.0-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/Qt-5.13.0-mac.tar.xz
         tar -xJ -C Qt/5.13.0 -f Qt-5.13.0-mac.tar.xz
     - name: build Subsurface-mobile
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         cd ${GITHUB_WORKSPACE}/..
         export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
@@ -30,6 +32,8 @@ jobs:
         DIR=$(pwd)
         git config --global user.email "ci@subsurface-divelog.org"
         git config --global user.name "Subsurface CI"
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         # first build Subsurface-mobile to ensure this didn't get broken
         bash -e -x ./subsurface/scripts/build.sh -mobile
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,8 +18,12 @@ jobs:
       uses: actions/checkout@v1
 
     - name: get other dependencies
+      env:
+         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
       run: |
         echo "Running script to install additional dependancies into container"
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
+        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         cd /win
         ln -s /__w/subsurface/subsurface .
         bash -x subsurface/.github/workflows/scripts/windows-container-prep.sh 2>&1 | tee pre-build.log


### PR DESCRIPTION
Even on platforms that don't have the new git version, yet.
And using the official environment variable that should point to our checked
out tree in the GitHub Action.


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This should future proof the other GitHub actions and make things overall more consistent.

