### PR TITLE
Change semantic for editing cylinders for multiple dives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- core: when modifying cylinders across multiple dives, match cylinder number before comparing type
 - core: merge all properties in a dive, including current, waveheight, etc
 - core: prevent crash when merging dives without cylinders (as we might get when importing from divelogs.de)
 - core: work around bug in TecDiving dive computer reporting spurious 0 deg C water temperature in first sample

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1222,12 +1222,19 @@ EditCylinderBase::EditCylinderBase(int index, bool currentDiveOnly, bool nonProt
 	cyl.reserve(dives.size());
 
 	for (dive *d: dives) {
-		int idx = d == current ? index : find_cylinder_index(d, orig, sameCylinderFlags);
-		if (idx < 0 || (nonProtectedOnly && is_cylinder_prot(d, idx)))
+		if (nonProtectedOnly && is_cylinder_prot(d, index))
 			continue;
+		if (d != current &&
+		    (!same_cylinder_size(orig, *get_cylinder(d, index)) || !same_cylinder_type(orig, *get_cylinder(d, index))))
+			// when editing cylinders, we assume that the user wanted to edit the 'n-th' cylinder
+			// and we only do edit that cylinder, if it was the same type as the one in the current dive
+			continue;
+
 		divesNew.push_back(d);
-		indexes.push_back(idx);
-		cyl.push_back(clone_cylinder(*get_cylinder(d, idx)));
+		// that's silly as it's always the same value - but we need this vector of indices in the case where we add
+		// a cylinder to several dives as the spot will potentially be different in different dives
+		indexes.push_back(index);
+		cyl.push_back(clone_cylinder(*get_cylinder(d, index)));
 	}
 	dives = std::move(divesNew);
 }


### PR DESCRIPTION
Instead of trying to find matching cylinders, trigger on the cylinder
number first and then only edit that n-th cylinder if it matches the one
in the current dive.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
I'm not yet sure that this is a complete fix, but it significantly improves the situation and I can no longer reproduce the issue that started all this.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
N/A

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 
@torvalds 