### PR TITLE
[SUGGESTION] filter: normalize text of fulltext search to base letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- filter: normalize unicode code points to base letter (for searching ℓ, etc.)
 - core: when modifying cylinders across multiple dives, match cylinder number before comparing type
 - core: merge all properties in a dive, including current, waveheight, etc
 - core: prevent crash when merging dives without cylinders (as we might get when importing from divelogs.de)

--- a/core/fulltext.cpp
+++ b/core/fulltext.cpp
@@ -85,8 +85,9 @@ bool fulltext_dive_matches(const struct dive *d, const FullTextQuery &q, StringF
 
 // Class implementation
 
-// Take a text and tokenize it into words. Normalize the words to upper case
-// and add to a given list, if not already in list.
+// Take a text and tokenize it into words. Normalize the words to the base
+// upper case base character (e.g. 'ℓ' to 'L') and add to a given list,
+// if not already in list.
 // We might think about limiting the lower size of words we store.
 // Note: we convert to QString before tokenization because we rely in
 // Qt's isPunct() function.
@@ -107,7 +108,9 @@ static void tokenize(QString s, std::vector<QString> &res)
 		int end = pos;
 		while (end < size && !s[end].isSpace() && !s[end].isPunct())
 			++end;
-		QString word = loc.toUpper(s.mid(pos, end - pos)); // Sad: Locale::toUpper can't use QStringRef - we have to copy the substring!
+		QString word = s.mid(pos, end - pos);
+		word = word.normalized(QString::NormalizationForm_KD);
+		word = loc.toUpper(word);
 		pos = end;
 
 		if (find(res.begin(), res.end(), word) == res.end())
@@ -157,11 +160,10 @@ void FullText::populate()
 
 void FullText::registerDive(struct dive *d)
 {
-	if (d->full_text) {
+	if (d->full_text)
 		unregisterWords(d, d->full_text->words);
-	} else {
+	else
 		d->full_text = new full_text_cache;
-	}
 	d->full_text->words = getWords(d);
 	registerWords(d, d->full_text->words);
 }


### PR DESCRIPTION
The liter symbol is written as 'ℓ'. To allow searching for
that, normalize unicode strings to their base letter. This
corresponds to the 'compatibility' mode.

We might also think about stripping diacritics.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Someone complained on the mailing list that script-l is not found in fulltext searches. Therefore, I suggest to normalize to the base letter.

This is not even compile tested, since I'm currently "on the road".

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Normalize unicode text with "compatibility mode".

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.
