### PR TITLE
Display password requirements in preferences

### DIFF
--- a/desktop-widgets/preferences/preferences_cloud.cpp
+++ b/desktop-widgets/preferences/preferences_cloud.cpp
@@ -37,7 +37,7 @@ void PreferencesCloud::syncSettings()
 	QString email = ui->cloud_storage_email->text().toLower();
 	QString password = ui->cloud_storage_password->text();
 	QString newpassword = ui->cloud_storage_new_passwd->text();
-	QString emailpasswordformatwarning = "Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.";
+	QString emailpasswordformatwarning = tr("Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.");
 
 	//TODO: Change this to the Cloud Storage Stuff, not preferences.
 	if (prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED && !newpassword.isEmpty()) {

--- a/desktop-widgets/preferences/preferences_cloud.cpp
+++ b/desktop-widgets/preferences/preferences_cloud.cpp
@@ -6,6 +6,7 @@
 #include "core/errorhelper.h"
 #include "core/settings/qPrefCloudStorage.h"
 #include <QRegularExpression>
+#include <QMessageBox>
 
 PreferencesCloud::PreferencesCloud() : AbstractPreferencesWidget(tr("Cloud"),QIcon(":preferences-cloud-icon"), 9), ui(new Ui::PreferencesCloud())
 {
@@ -36,6 +37,7 @@ void PreferencesCloud::syncSettings()
 	QString email = ui->cloud_storage_email->text().toLower();
 	QString password = ui->cloud_storage_password->text();
 	QString newpassword = ui->cloud_storage_new_passwd->text();
+	QString emailpasswordformatwarning = "Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.";
 
 	//TODO: Change this to the Cloud Storage Stuff, not preferences.
 	if (prefs.cloud_verification_status == qPrefCloudStorage::CS_VERIFIED && !newpassword.isEmpty()) {
@@ -44,11 +46,11 @@ void PreferencesCloud::syncSettings()
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
-				report_error(qPrintable(tr("Change ignored. Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				QMessageBox::warning(this, tr("Warning"), emailpasswordformatwarning);
 				return;
 			}
 			if (!reg.match(email).hasMatch() || (!newpassword.isEmpty() && !reg.match(newpassword).hasMatch())) {
-				report_error(qPrintable(tr("Change ignored. Cloud storage email and new password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				QMessageBox::warning(this, tr("Warning"), emailpasswordformatwarning);
 				ui->cloud_storage_new_passwd->setText("");
 				return;
 			}
@@ -70,7 +72,7 @@ void PreferencesCloud::syncSettings()
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || (!password.isEmpty() && !reg.match(password).hasMatch())) {
-				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				QMessageBox::warning(this, tr("Warning"), emailpasswordformatwarning);
 				cloud->set_cloud_verification_status(oldVerificationStatus);
 				return;
 			}
@@ -84,7 +86,7 @@ void PreferencesCloud::syncSettings()
 			// connect to backend server to check / create credentials
 			QRegularExpression reg("^[a-zA-Z0-9@.+_-]+$");
 			if (!reg.match(email).hasMatch() || !reg.match(password).hasMatch()) {
-				report_error(qPrintable(tr("Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.")));
+				QMessageBox::warning(this, tr("Warning"), emailpasswordformatwarning);
 				return;
 			}
 			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);

--- a/desktop-widgets/preferences/preferences_cloud.ui
+++ b/desktop-widgets/preferences/preferences_cloud.ui
@@ -117,7 +117,7 @@
       <string extracomment="Help info 1"/>
      </property>
      <property name="text">
-      <string>1) Enter an email address and a novel password that Subsurface will use to initialise the dive log in the cloud. Click Apply to send the above email address and password to the (remote) cloud server.</string>
+      <string>1) Enter an email address and a novel password that Subsurface will use to initialise the dive log in the cloud. Click Apply to send the above email address and password to the (remote) cloud server. Cloud storage email and password can only consist of letters, numbers, and '.','-','_', and '+'.</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Show password requirements in preferences dialogue so user is aware
of requirements before entering a new password.
Errors appear in main window, not preferences dialogue so not always
obvious to end user.

Signed-off-by: Jon G Massey <jon.massey@thedatalab.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Passwords entered within the cloud storage settings of the preferences dialog are validated against a set of requirements:
> Cloud storage email and password can only consist of letters, numbers, and '.', '-', '_', and '+'.

but these requirements are not shown to the user in advance of entering email or password.
In desktop UI, the error string displayed by `report_error()` shows at the bottom of the main window, rather than the preferences dialog. Thus, password/email validation errors are not clearly visible to users and even then it is better UX
to state the requirements in advance. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add the password requirements string as given in `PreferencesCloud::syncSettings()` to `label_help2` in `preferences_cloud.ui`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3471 . 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
