### PR TITLE
[TRIVIAL] remove obscure division-assignment operator

### DIFF
--- a/core/time.c
+++ b/core/time.c
@@ -56,7 +56,7 @@ void utc_mkdate(timestamp_t timestamp, struct tm *tm)
 
 	/* minutes since 1900 */
 	tm->tm_sec = timestamp % 60;
-	val = timestamp /= 60;
+	val = timestamp / 60;
 
 	/* Do the simple stuff */
 	tm->tm_min = val % 60;


### PR DESCRIPTION
In utc_mkdate() we find the interesting statement
        val = timestamp /= 60;
which not only calculates timestamp / 60, but also overwrites
timestamp with the new value. However, timestamp is never used
in the remainder of the function, because the whole point is to
switch to 32-bit types. Thus, replace the division-assignment
by a simple division operator to avoid head-scratching.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is a completely trivial code-hygiene thing. This won't change anything, but make the code less confusing for future readers.

Please check that I didn't miss something subtle!?