### PR TITLE
desktop: improve composition on TagWidgets

### DIFF
--- a/desktop-widgets/tagwidget.cpp
+++ b/desktop-widgets/tagwidget.cpp
@@ -96,6 +96,18 @@ void TagWidget::inputMethodEvent(QInputMethodEvent *e)
 		reparse();
 }
 
+// Call complete on a QCompleter and set the WA_InputMethodEnabled on
+// the popup if a popup is opened. We need that flag, otherwise composition
+// events are not forwarded to the widget and the user cannot enter
+// multi-key characters as long as the popup is active.
+static void complete(QCompleter *completer)
+{
+	completer->complete();
+	QWidget *popup = completer->popup();
+	if (popup)
+		popup->setAttribute(Qt::WA_InputMethodEnabled);
+}
+
 void TagWidget::reparse()
 {
 	highlight();
@@ -112,10 +124,10 @@ void TagWidget::reparse()
 				if (popup)
 					popup->hide();
 			} else {
-				m_completer->complete();
+				complete(m_completer);
 			}
 		} else {
-			m_completer->complete();
+			complete(m_completer);
 		}
 	}
 }

--- a/desktop-widgets/tagwidget.h
+++ b/desktop-widgets/tagwidget.h
@@ -18,20 +18,20 @@ public:
 	void clear();
 	void setCursorPosition(int position);
 	void wheelEvent(QWheelEvent *event);
-public
+private
 slots:
-	void reparse();
 	void completionSelected(const QString &text);
 	void completionHighlighted(const QString &text);
 
-protected:
+private:
 	void keyPressEvent(QKeyEvent *e) override;
 	void dragEnterEvent(QDragEnterEvent *e) override;
 	void dragLeaveEvent(QDragLeaveEvent *e) override;
 	void dragMoveEvent(QDragMoveEvent *e) override;
 	void dropEvent(QDropEvent *e) override;
-private:
 	void focusOutEvent(QFocusEvent *ev) override;
+	void inputMethodEvent(QInputMethodEvent *e) override;
+	void reparse();
 	QCompleter *m_completer;
 	bool lastFinishedTag;
 };


### PR DESCRIPTION
The TagWidgets hook into the textChanged() signal to invoke
the word-completer. However, that signal is also emitted for
composition-keys, making composition impossible if the completer
decides that it should show some entries.

Instead, hook into the inputMethodEvent() function, where one
can test whether a real character was input.

Also, don't hook into cursorPositionChanged(), since that led
to an uncanny cascade of reparse() calls when editing text.

The UI experience is still rough as sometimes the completer
popup steals the focus and hinders further entry.

Also, this doesn't fix the location field, which is its own class.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Try to improve composition in the TagWidgets by not reacting to `textChanged` but to `inputMethodEvent`.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Hook into `inputMethodEvent` instead of `textChanged`.
2) Don't listen to `cursorPositionChanged` signal.
3) Minot code cleanups.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes part of #1405.

Needs testing! The whole interaction with the completer is ominous.