### PR TITLE
desktop: set composition flag in dive site list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: fix key composition in tag widgets and dive site widget
 mobile: allow cloud account deletion (Apple app store requirement)
 
 ---

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -421,6 +421,16 @@ int DiveLocationModel::rowCount(const QModelIndex&) const
 	return dive_site_table.nr + 2;
 }
 
+Qt::ItemFlags DiveLocationModel::flags(const QModelIndex &index) const
+{
+	// This is crazy: If an entry is not marked as editable, the QListView
+	// (or rather the QAbstractItemView base class) clears the WA_InputMethod
+	// flag, which means that key-composition events are disabled. This
+	// breaks composition as long as the popup is openen. Therefore,
+	// make all items editable.
+	return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
+}
+
 bool DiveLocationModel::setData(const QModelIndex &index, const QVariant &value, int)
 {
 	if (!index.isValid())

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -67,12 +67,13 @@ class DiveLocationModel : public QAbstractTableModel {
 public:
 	DiveLocationModel(QObject *o = 0);
 	void resetModel();
-	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-	int rowCount(const QModelIndex& parent = QModelIndex()) const;
-	int columnCount(const QModelIndex& parent = QModelIndex()) const;
-	bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+	bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 private:
 	QString new_ds_value[2];
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+	int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 };
 
 class DiveLocationListView : public QListView {


### PR DESCRIPTION
This is crazy: when view() is called, the dive-site-suggestion
popup (DiveLocationListView) clears its WA_InputMethodEnabled
flag. This makes key composition not work as long as the
popup is open.

Thus, when showing the popup, explicitly set the flag.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes composition in the dive-site field on the main tab. For some reason the dive site list clears its composition enabled flag, when show() is called. Extremely weird, but there must be some good reason. For now, just set it explicitly.

Contains a few coding-style fixes.