### PR TITLE
Feature/map short names

### DIFF
--- a/core/pref.h
+++ b/core/pref.h
@@ -104,6 +104,7 @@ struct preferences {
 	double      mobile_scale;
 	bool        show_developer;
 	bool        three_m_based_grid;
+	bool        map_short_names;
 
 	// ********** Equipment tab *******
 	const char *default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -68,6 +68,7 @@ void qPrefDisplay::loadSync(bool doSync)
 		load_singleColumnPortrait();
 	}
 	disk_three_m_based_grid(doSync);
+	disk_map_short_names(doSync);
 }
 
 void qPrefDisplay::set_divelist_font(const QString &value)
@@ -150,6 +151,8 @@ HANDLE_PREFERENCE_BOOL(Display, "displayinvalid", display_invalid_dives);
 HANDLE_PREFERENCE_BOOL(Display, "show_developer", show_developer);
 
 HANDLE_PREFERENCE_BOOL(Display, "three_m_based_grid", three_m_based_grid);
+
+HANDLE_PREFERENCE_BOOL(Display, "map_short_names", map_short_names);
 
 void qPrefDisplay::setCorrectFont()
 {

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -42,7 +42,7 @@ public:
 	static double font_size() { return prefs.font_size; }
 	static double mobile_scale() { return prefs.mobile_scale; }
 	static bool display_invalid_dives() { return prefs.display_invalid_dives; }
-	static QString lastDir() { return st_lastDir; ; }
+	static QString lastDir() { return st_lastDir; }
 	static bool show_developer() { return prefs.show_developer; }
 	static QString theme() { return st_theme; }
 	static QPointF tooltip_position() { return st_tooltip_position; }

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -26,6 +26,7 @@ class qPrefDisplay : public QObject {
 	Q_PROPERTY(int lastState READ lastState WRITE set_lastState NOTIFY lastStateChanged)
 	Q_PROPERTY(bool singleColumnPortrait READ singleColumnPortrait WRITE set_singleColumnPortrait NOTIFY singleColumnPortraitChanged)
 	Q_PROPERTY(bool three_m_based_grid READ three_m_based_grid WRITE set_three_m_based_grid NOTIFY three_m_based_gridChanged)
+	Q_PROPERTY(bool map_short_names READ map_short_names WRITE set_map_short_names NOTIFY map_short_namesChanged)
 
 public:
 	static qPrefDisplay *instance();
@@ -54,6 +55,7 @@ public:
 	static int lastState() { return st_lastState; }
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 	static bool three_m_based_grid() { return prefs.three_m_based_grid; }
+	static bool map_short_names() { return prefs.map_short_names; }
 
 public slots:
 	static void set_animation_speed(int value);
@@ -74,6 +76,7 @@ public slots:
 	static void set_lastState(int value);
 	static void set_singleColumnPortrait(bool value);
 	static void set_three_m_based_grid(bool value);
+	static void set_map_short_names(bool value);
 
 signals:
 	void animation_speedChanged(int value);
@@ -94,6 +97,7 @@ signals:
 	void lastStateChanged(int value);
 	void singleColumnPortraitChanged(bool value);
 	void three_m_based_gridChanged(bool value);
+	void map_short_namesChanged(bool value);
 
 private:
 	qPrefDisplay() {}
@@ -106,6 +110,7 @@ private:
 	static void disk_display_invalid_dives(bool doSync);
 	static void disk_show_developer(bool doSync);
 	static void disk_three_m_based_grid(bool doSync);
+	static void disk_map_short_names(bool doSync);
 
 	// functions to handle class variables
 	static void load_lastDir();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -19,7 +19,7 @@ static bool isReady = false;
 #define CHECK_IS_READY_RETURN_VOID() \
 	if (!isReady) return
 
-MapWidget *MapWidget::m_instance = NULL;
+MapWidget *MapWidget::m_instance = nullptr;
 
 MapWidget::MapWidget(QWidget *parent) : QQuickWidget(parent)
 {
@@ -128,12 +128,12 @@ void MapWidget::divesChanged(const QVector<dive *> &, DiveField field)
 // the reference is cleared. Sad.
 MapWidget::~MapWidget()
 {
-	m_instance = NULL;
+	m_instance = nullptr;
 }
 
 MapWidget *MapWidget::instance()
 {
-	if (m_instance == NULL)
+	if (m_instance == nullptr)
 		m_instance = new MapWidget();
 	return m_instance;
 }

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -29,6 +29,7 @@ MapWidget::MapWidget(QWidget *parent) : QQuickWidget(parent)
 	connect(this, &QQuickWidget::statusChanged, this, &MapWidget::doneLoading);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &MapWidget::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::dataReset, this, &MapWidget::reload);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MapWidget::reload);
 	setSource(urlMapWidget);
 }
 

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -32,6 +32,8 @@ void PreferencesDefaults::refreshSettings()
 		ui->grid3MBased->setChecked(true);
 	else
 		ui->gridGeneric->setChecked(true);
+
+	ui->checkBox_map_short_names->setChecked(qPrefDisplay::map_short_names());
 }
 
 void PreferencesDefaults::syncSettings()
@@ -40,4 +42,5 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_font_size(ui->fontsize->value());
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
 	qPrefDisplay::set_three_m_based_grid(ui->grid3MBased->isChecked());
+	qPrefDisplay::set_map_short_names(ui->checkBox_map_short_names->isChecked());
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -86,12 +86,12 @@
        </widget>
       </item>
 
-      <item>  
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
          <widget class="QLabel" name="label_15">
           <property name="text">
-            <string>Speed</string>
+           <string>Speed</string>
           </property>
          </widget>
         </item>
@@ -149,6 +149,29 @@
     </widget>
    </item>
    
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Map Display Options</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Short Names:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_map_short_names">
+        <property name="text">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <spacer name="verticalSpacer_2">
      <property name="orientation">

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -10,6 +10,24 @@
 
 #define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
 
+// MKW If "Map Short Names" preference is set, only return the last component
+// of the full dive site name.
+// Example:
+// Japan/Izu Peninsula/Atami/Chinsen-Aft
+//    Short name: Chinsen-Aft
+static QString siteMapDisplayName(const char *sitename)
+{
+	const char Separator = '/';
+	QString fullname(sitename);
+	QString name = fullname.section(Separator, -1).trimmed();
+
+	if (name.isEmpty()) {
+		name = fullname;
+	}
+	return name;
+}
+
+
 MapLocation::MapLocation(struct dive_site *dsIn, QGeoCoordinate coordIn, QString nameIn, bool selectedIn) :
     divesite(dsIn), coordinate(coordIn), name(nameIn), selected(selectedIn)
 {
@@ -159,7 +177,7 @@ void MapLocationModel::reload(QObject *map)
 		}
 		if (!diveSiteMode && hasSelectedDive(ds) && !m_selectedDs.contains(ds))
 			m_selectedDs.append(ds);
-		QString name(ds->name);
+		QString name = siteMapDisplayName(ds->name);
 		if (!diveSiteMode) {
 			// don't add dive locations with the same name, unless they are
 			// at least MIN_DISTANCE_BETWEEN_DIVE_SITES_M apart
@@ -223,7 +241,7 @@ void MapLocationModel::diveSiteChanged(struct dive_site *ds, int field)
 		}
 		break;
 	case LocationInformationModel::NAME:
-		m_mapLocations[row]->name = ds->name;
+		m_mapLocations[row]->name = siteMapDisplayName(ds->name);
 		break;
 	default:
 		break;

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -3,6 +3,7 @@
 #include "divelocationmodel.h"
 #include "core/divesite.h"
 #include "core/divefilter.h"
+#include "core/settings/qPrefDisplay.h"
 #if !defined(SUBSURFACE_MOBILE) && !defined(SUBSURFACE_DOWNLOADER)
 #include "qt-models/filtermodels.h"
 #include "desktop-widgets/mapwidget.h"
@@ -19,8 +20,12 @@ static QString siteMapDisplayName(const char *sitename)
 {
 	const char Separator = '/';
 	QString fullname(sitename);
-	QString name = fullname.section(Separator, -1).trimmed();
 
+	if (!qPrefDisplay::map_short_names() ) {
+		return fullname;
+	}
+
+	QString name = fullname.section(Separator, -1).trimmed();
 	if (name.isEmpty()) {
 		name = fullname;
 	}

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -222,7 +222,7 @@ MapLocation *MapLocationModel::getMapLocation(const struct dive_site *ds)
 		if (ds == location->divesite)
 			return location;
 	}
-	return NULL;
+	return nullptr;
 }
 
 void MapLocationModel::diveSiteChanged(struct dive_site *ds, int field)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Adds a new preference option "Map Short Names". If enabled, only the last component of a dive-site name is displayed on the map. Dive site name components are separated using a slash (/) character.

For example:
Japan / Izu Peninsula / Atami / Chinsen-Aft

If "Map Short Names" is enabled, only "Chinsen-Aft" is displayed on the map.  This can help reduce display clutter when there are many dive sites in close proximity to each other.




### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) qt-models/maplocationmodel.cpp : add logic to shorten the dive site name for display purposes
2) (various files) : add a new preferences setting (map_short_names), as well as the various "plumbing" required to update the map when the setting is changed.
3) (various files) : minor code cleanup to remove compiler warnings in the files which were edited as part of this change.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
(Partially) Fixes #2936 

Instead of using the originally-discussed idea of having 2 major components of a dive site (location and dive-site) split by a separator, and using a different separator to split each of those into sub-components, this solution simply uses a single separator (slsh, "/") which is already used by our exporter.

This represents the minimal viable solution for this feature request and should not impact any other software modules or raise any compatibility concerns.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Add preference option to display a shortened Dive Site Name in the Map Widget.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
