### PR TITLE
Prefer real data over planned

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
-ForEachMacros: [ 'foreach', 'for_each_dc', 'for_each_dive', 'for_each_line', 'Q_FOREACH', 'BOOST_FOREACH' ]
+ForEachMacros: [ 'foreach', 'for_each_dc', 'for_each_relevant_dc', 'for_each_dive', 'for_each_line', 'Q_FOREACH', 'BOOST_FOREACH' ]
 IndentFunctionDeclarationAfterType: false #personal taste, good for long methods
 IndentWidth: 8
 MaxEmptyLinesToKeep: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+divelist: do not include planned versions of a dive if there is real data
 desktop: fix key composition in tag widgets and dive site widget
 mobile: allow cloud account deletion (Apple app store requirement)
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -143,6 +143,10 @@ void split_divecomputer(const struct dive *src, int num, struct dive **out1, str
 #define for_each_dc(_dive, _dc) \
 	for (_dc = &_dive->dc; _dc; _dc = _dc->next)
 
+#define for_each_relevant_dc(_dive, _dc) \
+	bool _all_planned = !has_planned(_dive, false); \
+	for (_dc = &_dive->dc; _dc; _dc = _dc->next) if (_all_planned || !is_dc_planner(_dc))
+
 extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
 extern bool dive_site_has_gps_location(const struct dive_site *ds);


### PR DESCRIPTION
When a dive has both real dive computers as well as at
least a planned version (which is just another dive
computer with a special name), only use the data from
real dive computers for aggregate values like maxdepth,
dive time, average depth etc in order not to have
imagined data on the dive list, statistics etc.

I think, the default for the statistics should be be also to ignore dives that are only planned (and including them should require the user to check some box) but It was beyond my powers to implement that due to lack of understanding of the statistics constraints. Maybe @bstoeger could help here.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
