### PR TITLE
profile: implement panning of profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+profile: implement panning of the profile
+planner: allow handle manipulation in zoomed in state
 divelist: do not include planned versions of a dive if there is real data
 desktop: fix key composition in tag widgets and dive site widget
 mobile: send log files as attachments for support emails on iOS

--- a/profile-widget/divecartesianaxis.cpp
+++ b/profile-widget/divecartesianaxis.cpp
@@ -436,6 +436,16 @@ double DiveCartesianAxis::valueAt(const QPointF &p) const
 	return fraction * (max - min) + min;
 }
 
+double DiveCartesianAxis::deltaToValue(double delta) const
+{
+	QLineF m = line();
+	double screenSize = position == Position::Bottom ? m.x2() - m.x1()
+							 : m.y2() - m.y1();
+	double axisSize = max - min;
+	double res = delta * axisSize / screenSize;
+	return ((position == Position::Bottom) == inverted) ? -res : res;
+}
+
 double DiveCartesianAxis::posAtValue(double value, double max, double min) const
 {
 	QLineF m = line();

--- a/profile-widget/divecartesianaxis.h
+++ b/profile-widget/divecartesianaxis.h
@@ -31,6 +31,7 @@ public:
 	std::pair<double, double> screenMinMax() const;
 	double valueAt(const QPointF &p) const;
 	double posAtValue(double value) const;
+	double deltaToValue(double delta) const; // For panning: turn a screen distance to delta-value
 	void setPosition(const QRectF &rect);
 	double screenPosition(double pos) const; // 0.0 = begin, 1.0 = end of axis, independent of represented values
 	double pointInRange(double pos) const; // Point on screen is in range of axis

--- a/profile-widget/profilescene.h
+++ b/profile-widget/profilescene.h
@@ -48,6 +48,7 @@ public:
 	void draw(QPainter *painter, const QRect &pos,
 		  const struct dive *d, int dc,
 		  DivePlannerPointsModel *plannerModel = nullptr, bool inPlanner = false);
+	double calcZoomPosition(double zoom, double originalPos, double delta);
 
 	const struct dive *d;
 	int dc;

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -278,6 +278,7 @@ void ProfileWidget2::mousePressEvent(QMouseEvent *event)
 		panning = true;
 		panningOriginalMousePosition = mapToScene(event->pos()).x();
 		panningOriginalProfilePosition = zoomedPosition;
+		viewport()->setCursor(Qt::ClosedHandCursor);
 	}
 }
 
@@ -297,7 +298,10 @@ void ProfileWidget2::divePlannerHandlerReleased()
 void ProfileWidget2::mouseReleaseEvent(QMouseEvent *event)
 {
 	QGraphicsView::mouseReleaseEvent(event);
-	panning = false;
+	if (panning) {
+		panning = false;
+		viewport()->setCursor(Qt::ArrowCursor);
+	}
 	if (currentState == PLAN || currentState == EDIT) {
 		shouldCalculateMax = true;
 		replot();

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -142,6 +142,9 @@ private:
 	const struct dive *d;
 	int dc;
 	bool empty; // No dive shown.
+	bool panning; // Currently panning.
+	double panningOriginalMousePosition;
+	double panningOriginalProfilePosition;
 #ifndef SUBSURFACE_MOBILE
 	DiveLineItem *mouseFollowerVertical;
 	DiveLineItem *mouseFollowerHorizontal;


### PR DESCRIPTION
When zoomed in, the profile position was moved by hovering with
the mouse. What a horrible user experience. This is especially
useless if we want to implement an interactive profile on mobile.

Instead, let the user start the panning with a mouse click. The
code is somewhat nasty, because the position is given as a
real in the [0,1] range, which represents all possible positions
from completely to the left to completely to the right.

This commit also removes the restriction that the planner handles
can only be moved when fully zoomed out. It is not completely
clear what the implications are. Let's see.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Replace hovering by explicit click-panning when the chart is zoomed in.

Needs intense testing.

In particular this probably breaks the planner, therefore pinning @atdotde.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Don't know, haven't checked.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@tggm complained about this.