### PR TITLE
Ratio BLE detection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ divelist: do not include planned versions of a dive if there is real data
 desktop: fix key composition in tag widgets and dive site widget
 mobile: allow cloud account deletion (Apple app store requirement)
 mobile: fix listing of local cloud cache directories
+dive computer support:
+- fix Ratio dive computer detection for BLE only devices
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.


### PR DESCRIPTION
For Ratio dive computers we can't tell by the Bluetooth name which model it is.
There are BT only models and BLE only models. The failure case here was a user
on iOS (BLE only) with a BLE only dive computer which we didn't recognize
because previously we returned a BT only device (which isn't supported on an
iPhone), and the lookup won't return a valid descriptor if the transport needed
isn't available.

These days BLE is far more common, so return a BLE enabled name by default, but
try a BT only name just in case.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
added

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger just so someone else reads the code and I'm not doing something obviously stupid here...