### PR TITLE
iOS email attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 divelist: do not include planned versions of a dive if there is real data
 desktop: fix key composition in tag widgets and dive site widget
+mobile: send log files as attachments for support emails on iOS
 mobile: allow cloud account deletion (Apple app store requirement)
 mobile: fix listing of local cloud cache directories
 

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -398,7 +398,7 @@ android {
 ios {
 	SOURCES += core/ios.cpp
 	RESOURCES += packaging/ios/translations.qrc
-	QMAKE_IOS_DEPLOYMENT_TARGET = 10.0
+	QMAKE_IOS_DEPLOYMENT_TARGET = 12.0
 	QMAKE_TARGET_BUNDLE_PREFIX = org.subsurface-divelog
 	QMAKE_BUNDLE = subsurface-mobile
 	QMAKE_INFO_PLIST = packaging/ios/Info.plist

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -407,6 +407,12 @@ ios {
 	images.files = icons/subsurface-mobile-icon.png
 	QMAKE_BUNDLE_DATA += app_launch_images images
 
+	OBJECTIVE_SOURCES += ios/ios-share.mm
+	HEADERS += ios/ios-share.h
+	Q_ENABLE_BITCODE.name = ENABLE_BITCODE
+	Q_ENABLE_BITCODE.value = NO
+	QMAKE_MAC_XCODE_SETTINGS += Q_ENABLE_BITCODE
+
 	LIBS += ../install-root/ios/lib/libdivecomputer.a \
 		../install-root/ios/lib/libgit2.a \
 		../install-root/ios/lib/libzip.a \
@@ -416,6 +422,8 @@ ios {
 		-liconv \
 		-lsqlite3 \
 		-lxml2
+
+	LIBS += -framework MessageUI
 
 	INCLUDEPATH += ../install-root/ios/include/ \
 		../install-root/lib/libzip/include \

--- a/ios/ios-share.h
+++ b/ios/ios-share.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef IOSSHARE_H
+#define IOSSHARE_H
+
+// onlt Qt headers and data structures allowed here
+#include <QString>
+
+class IosShare {
+public:
+	IosShare();
+	~IosShare();
+	void supportEmail(const QString &firstPath, const QString &secondPath);
+	void shareViaEmail(const QString &subject, const QString &recipient, const QString &body, const QString &firstPath, const QString &secondPath);
+private:
+	void *self;
+};
+
+#endif /* IOSSHARE_H */

--- a/ios/ios-share.mm
+++ b/ios/ios-share.mm
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// this code was inspired by the discussions in
+// https://forum.qt.io/topic/88297/native-objective-c-calls-from-cpp-qt-ios-email-call
+
+// this include file only has the C++/Qt headers that can be used from C++
+#include "ios-share.h"
+
+// these are the required ObjC++ headers
+#import <Foundation/Foundation.h>
+#import <Foundation/NSString.h>
+#import <UIKit/UIKit.h>
+#import <MessageUI/MessageUI.h>
+
+// declare an ObjC++ class that will interact with the mail controller
+// that second member that is called when the mail app is finished is critical for this to work
+@interface IosShareObject : UIViewController  <MFMailComposeViewControllerDelegate>
+{
+}
+- (void)shareViaEmail:(const QString &) subject :(const QString &) recipient :(const QString &) body :(const QString &) firstPath :(const QString &) secondPath;
+- (void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(nullable NSError *)error;
+@end
+
+@implementation IosShareObject
+// first, inside the implementation of the ObjC++ class, implement the Qt class
+IosShare::IosShare() : self(NULL) {
+	// call init to ensure that the ObjC++ object is instantiated, which in return
+	// apparently sets up the Controller
+	self = [ [IosShareObject alloc] init];
+}
+
+IosShare::~IosShare() {
+	[(id)self dealloc];
+}
+
+// simplified method that fills subject, recipient, and body for support emails
+void IosShare::supportEmail(const QString &firstPath, const QString &secondPath) {
+	QString subject("Subsurface-mobile support request");
+	QString recipient("in-app-support@subsurface-divelog.org");
+	QString body("Please describe your issue here and keep the attached logs.\n\n\n\n");
+	shareViaEmail(subject, recipient, body, firstPath, secondPath);
+}
+
+void IosShare::shareViaEmail(const QString &subject, const QString &recipient, const QString &body, const QString &firstPath, const QString &secondPath) {
+	// ObjC++ syntax to call the shareViaEmail method of that class - so this is
+	// where we transition from Qt/C++ code to ObjC++ code that can interact
+	// directly with iOS
+	[(id)self shareViaEmail:subject:recipient:body:firstPath:secondPath];
+}
+
+// the rest is the ObjC++ implementation
+- (instancetype)init {
+	// this is just boiler plate that I really don't understand
+	// it appears to make sure that the ViewController infrastructure is initialized?
+	return super.init;
+}
+
+- (void)shareViaEmail:(const QString &) subjectQS :(const QString &) recipientQS :(const QString &) bodyQS :(const QString &) firstPathQS :(const QString &) secondPathQS {
+	// since we are mixing Qt and ObjC++ data structures, let's allocate copies
+	// of our Qt strings and convert recipients into an array
+	NSString *firstPath = [[NSString alloc] initWithUTF8String:firstPathQS.toUtf8().data()];
+	NSString *secondPath = [[NSString alloc] initWithUTF8String:secondPathQS.toUtf8().data()];
+	NSString *subject = [[NSString alloc] initWithUTF8String:subjectQS.toUtf8().data()];
+	NSString *recipient = [[NSString alloc] initWithUTF8String:recipientQS.toUtf8().data()];
+	NSString *body = [[NSString alloc] initWithUTF8String:bodyQS.toUtf8().data()];
+	NSArray *recipents = [NSArray arrayWithObject:recipient];
+	// create the mail controller and connect it with the object
+	MFMailComposeViewController *mc = [[MFMailComposeViewController alloc] init];
+	mc.mailComposeDelegate = self;
+	[mc setSubject:subject];
+	[mc setMessageBody:body isHTML:NO];
+	[mc setToRecipients:recipents];
+	// set up up to two attachments - only if we have a path and the file isn't empty (iOS throws up if you have an empty attachment)
+	if (!firstPathQS.isEmpty()) {
+		NSData *myData = [NSData dataWithContentsOfFile: firstPath];
+		if (myData != nil)
+			[mc addAttachmentData:myData mimeType:@"text/plain" fileName:[firstPath lastPathComponent]];
+	}
+	if (!secondPathQS.isEmpty()) {
+		//NSString *path = [[NSBundle mainBundle] pathForResource:@"log2" ofType:@"txt"];
+		NSData *myData = [NSData dataWithContentsOfFile: secondPath];
+		if (myData != nil)
+			[mc addAttachmentData:myData mimeType:@"text/plain" fileName:[secondPath lastPathComponent]];
+	}
+	// more black magic; get a view controller that is connected to our application window
+	UIViewController * topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+	while (topController.presentedViewController){
+		topController = topController.presentedViewController;
+	}
+	// finally, show the controller - the code returns right away, which is why we need the 'didFinishWithResult' method below
+	[topController presentViewController:mc animated:YES completion:NULL];
+}
+
+// I would have kinda liked to inform the caller that sending mail failed, but I can't figure
+// out how to get that information back to the Qt code calling us. Oh well. At least we log the results.
+// But the critically important part is that we dismiss the view controller.
+- (void) mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(nullable NSError *)error {
+	switch (result) {
+	case MFMailComposeResultCancelled:
+		NSLog(@"Mail cancelled");
+		break;
+	case MFMailComposeResultSaved:
+		NSLog(@"Mail saved");break;
+	case MFMailComposeResultSent:
+		NSLog(@"Mail sent");break;
+	case MFMailComposeResultFailed:
+		NSLog(@"Mail sent failure: %@", [error localizedDescription]);
+		break;
+	default:
+		break;
+	}
+	[controller dismissViewControllerAnimated:YES completion:NULL];
+}
+@end

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -58,7 +58,6 @@
 #include <QtAndroid>
 #include "core/serial_usb_android.h"
 std::vector<android_usb_serial_device_descriptor> androidSerialDevices;
-
 #endif
 
 QMLManager *QMLManager::m_instance = NULL;
@@ -506,7 +505,16 @@ bool QMLManager::createSupportEmail()
 			return true;
 	}
 	qDebug() << __FUNCTION__ << "failed to share the logFiles via intent, use the fall-back mail body method";
+#elif defined(Q_OS_IOS)
+	// call into objC++ code to share on iOS
+	QString libdcLogFileName(logfile_name);
+	iosshare.supportEmail(appLogFileName, libdcLogFileName);
+	// Unfortunately I haven't been able to figure out how to wait until the mail was sent
+	// so that this could tell us whether this was successful or not
+	// We always assume it worked and return to the caller.
+	return true;
 #endif
+	// fallback code that tries to copy the logs into the message body and uses the Qt send email method
 	QString mailToLink = "mailto:in-app-support@subsurface-divelog.org?subject=Subsurface-mobile support request";
 	mailToLink += "&body=";
 	mailToLink += messageBody;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -19,6 +19,8 @@
 
 #if defined(Q_OS_ANDROID)
 #include "core/serial_usb_android.h"
+#elif defined(Q_OS_IOS)
+#include "ios/ios-share.h"
 #endif
 
 class QAction;
@@ -266,6 +268,9 @@ private:
 	QString appLogFileName;
 	QFile appLogFile;
 	bool appLogFileOpen;
+#endif
+#if defined(Q_OS_IOS)
+	IosShare iosshare;
 #endif
 	qPrefCloudStorage::cloud_status m_oldStatus;
 

--- a/packaging/ios/build.sh
+++ b/packaging/ios/build.sh
@@ -124,7 +124,7 @@ for ARCH in $ARCHS; do
 	declare -x CC=$(xcrun -sdk $SDK_NAME -find clang)
 	declare -x CXX=$(xcrun -sdk $SDK_NAME -find clang++)
 	declare -x LD=$(xcrun -sdk $SDK_NAME -find ld)
-	declare -x CFLAGS="-arch $ARCH_NAME -isysroot $SDK_DIR -miphoneos-version-min=10.0 -I$SDK_DIR/usr/include -fembed-bitcode"
+	declare -x CFLAGS="-arch $ARCH_NAME -isysroot $SDK_DIR -miphoneos-version-min=12.0 -I$SDK_DIR/usr/include -fembed-bitcode"
 	declare -x CXXFLAGS="$CFLAGS"
 	declare -x LDFLAGS="$CFLAGS -lsqlite3 -lpthread -lc++ -L$SDK_DIR/usr/lib -fembed-bitcode"
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This includes a few cleanups for our iOS builds, but the main focus is the objC++ code to natively send email.
Now we can send support emails with the log files as attachments - just like we've been doing on Android for a while.

objC++ is yet another programming language that I DO NOT SPEAK but try to write code in. So this code is likely horrible (and it is to some extend borrowed from a discussion in the Qt Forums). But the good news is that it appears to work in my tests on an iPhone and an iPad.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- create a helper class in C++ and instantiate when the QMLManager is created
- create an ObjC++ class that talks to the Controller View and deals with sending an email

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger @atdotde  I don't think you know ObjC++ any more than I do... but just in case