### PR TITLE
clean up logging, and add error reports to it too

### DIFF
--- a/core/errorhelper.c
+++ b/core/errorhelper.c
@@ -6,10 +6,27 @@
 #include <stdarg.h>
 #include "errorhelper.h"
 #include "membuffer.h"
+#include "qthelper.h"
+
+#if !defined(Q_OS_ANDROID) && !defined(__ANDROID__)
+#define LOG_MSG(fmt, ...)	fprintf(stderr, fmt, ##__VA_ARGS__)
+#else
+#include <android/log.h>
+#define LOG_MSG(fmt, ...)	__android_log_print(ANDROID_LOG_INFO, "Subsurface", fmt, ##__VA_ARGS__);
+#endif
 
 #define VA_BUF(b, fmt) do { va_list args; va_start(args, fmt); put_vformat(b, fmt, args); va_end(args); } while (0)
 
 int verbose;
+
+void report_info(const char *fmt, ...)
+{
+	struct membuffer buf = { 0 };
+
+	VA_BUF(&buf, fmt);
+	strip_mb(&buf);
+	LOG_MSG("INFO: %s\n", mb_cstring(&buf));
+}
 
 static void (*error_cb)(char *) = NULL;
 
@@ -17,13 +34,14 @@ int report_error(const char *fmt, ...)
 {
 	struct membuffer buf = { 0 };
 
+	VA_BUF(&buf, fmt);
+	strip_mb(&buf);
+	LOG_MSG("ERROR: %s\n", mb_cstring(&buf));
+
 	/* if there is no error callback registered, don't produce errors */
 	if (!error_cb)
 		return -1;
-
-	VA_BUF(&buf, fmt);
 	error_cb(detach_cstring(&buf));
-
 	return -1;
 }
 

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -174,17 +174,14 @@ fraction_t string_to_fraction(const char *str);
 char *get_changes_made();
 void emit_reset_signal();
 
+extern void report_info(const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif
 
 // 4) SSRF_INFO macro to replace fprintf calls in our code
 //    (originally based on logging bits from libdivecomputer)
-#if !defined(Q_OS_ANDROID) && !defined(__ANDROID__)
-#define SSRF_INFO(fmt, ...)	fprintf(stderr, "INFO: " fmt "\n", ##__VA_ARGS__)
-#else
-#include <android/log.h>
-#define SSRF_INFO(fmt, ...)	__android_log_print(ANDROID_LOG_INFO, "Subsurface", "INFO: " fmt "\n", ##__VA_ARGS__);
-#endif
+#define SSRF_INFO(fmt, ...) report_info(fmt, ##__VA_ARGS__)
 
 #endif // QTHELPER_H


### PR DESCRIPTION
The SSRF_INFO() macro is widely used, and there's a lot of confusion
about whether the newline at the end should be done by the SSRF_INFO or
be in the format string passed to it.  End result: we end up doing both,
and there are empty lines in the output as a result.

Clean this up by just using our existing 'strip_mb()' to strip any
whitespace at the end of the generated string, and then adding one final
newline when logging it.

Also, make sure to log our 'report_error()' messages, which apparently
only used to be showin in the red error bar on the display.

Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

Small useful logging improvement from Linus - sending it through the CI/CD here...