### PR TITLE
mobile: share XML files via email

### DIFF
--- a/android-mobile/src/org/subsurfacedivelog/mobile/SubsurfaceMobileActivity.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/SubsurfaceMobileActivity.java
@@ -70,7 +70,7 @@ public class SubsurfaceMobileActivity extends QtActivity
 		attachments.add(uri);
 
 		// if there is a second file name (that's for support emails) add it and set this up as support email as well
-		if (path2 != "") {
+		if (!path2.isEmpty()) {
 			fileToShare = new File(path2);
 			try {
 				uri = FileProvider.getUriForFile(QtNative.activity(), fileProviderAuthority, fileToShare);

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -137,7 +137,6 @@ TemplatePage {
 
 		TemplateRadioButton {
 			text: qsTr("Export Subsurface XML")
-			visible: Qt.platform.os !== "android"
 			checked: true
 			onClicked: {
 				selectedExport = ExportType.EX_DIVES_XML
@@ -146,7 +145,6 @@ TemplatePage {
 		}
 		TemplateRadioButton {
 			text: qsTr("Export Subsurface dive sites XML")
-			visible: Qt.platform.os !== "android"
 			onClicked: {
 				selectedExport = ExportType.EX_DIVE_SITES_XML
 				explain.text = qsTr("Subsurface dive sites native XML format.")
@@ -209,8 +207,12 @@ TemplatePage {
 					exportSelection.visible = false
 					textPassword.visible = false
 					uploadDialog.visible = true
-				} else if (Qt.platform.os !== "android") {
+				} else if (Qt.platform.os !== "android" && Qt.platform.os !== "ios") {
 					saveAsDialog.open()
+				} else {
+					manager.appendTextToLog("Send export of type " + selectedExport + " via email.")
+					manager.shareViaEmail(selectedExport, anonymize.checked)
+					pageStack.pop()
 				}
 			}
 		}

--- a/mobile-widgets/qml/Export.qml
+++ b/mobile-widgets/qml/Export.qml
@@ -153,14 +153,6 @@ TemplatePage {
 			}
 		}
 		TemplateRadioButton {
-			text: qsTr("Export UDDF")
-			visible: Qt.platform.os !== "android"
-			onClicked: {
-				selectedExport = ExportType.EX_UDDF
-				explain.text = qsTr("Generic format that is used for data exchange between a variety of diving related programs.")
-			}
-		}
-		TemplateRadioButton {
 			text: qsTr("Upload divelogs.de")
 			onClicked: {
 				selectedExport = ExportType.EX_DIVELOGS_DE

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2211,9 +2211,6 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 				save_dive_sites_logic(qPrintable(fileName + ".xml"), sites.data(), (int)sites.size(), anonymize);
 				break;
 			}
-		case EX_UDDF:
-			exportUsingStyleSheet(fileName + ".uddf", true, 0, "uddf-export.xslt", anonymize);
-			break;
 		default:
 			qDebug() << "export to unknown type " << type << " using " << dir << " remove names " << anonymize;
 			break;

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -74,7 +74,7 @@ public:
 	Q_INVOKABLE void exportToFile(export_types type, QString directory, bool anonymize);
 #endif
 	Q_INVOKABLE void exportToWEB(export_types type, QString userId, QString password, bool anonymize);
-
+	Q_INVOKABLE void shareViaEmail(export_types type, bool anonymize);
 
 	QString DC_vendor() const;
 	void DC_setVendor(const QString& vendor);

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -66,7 +66,6 @@ public:
 	enum export_types {
 		EX_DIVES_XML,
 		EX_DIVE_SITES_XML,
-		EX_UDDF,
 		EX_DIVELOGS_DE,
 		EX_DIVESHARE
 	};


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
A very frequently requested change... the ability to extract dive data from a mobile device without using the Subsurface cloud.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- clean up the horrendous existing export thingy
- use "share via email" as the poor man's file sharing
- change the UI to allow this for both the full dive list as well as just the dive site

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Of course what is missing now is the ability to somehow IMPORT an XML file.
Hmm. That's a lot more frustrating to contemplate...

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
missing

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
missing

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger the usual request for a sanity check
This has been tested on both Android and iOS and does appear to work...