### PR TITLE
parser: allow import of dive sites without UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+import: allow import of divesites without UUID
 divelist: do not include planned versions of a dive if there is real data
 desktop: fix key composition in tag widgets and dive site widget
 mobile: send log files as attachments for support emails on iOS

--- a/core/parse.c
+++ b/core/parse.c
@@ -247,13 +247,13 @@ void dive_site_end(struct parser_state *state)
 {
 	if (!state->cur_dive_site)
 		return;
-	if (state->cur_dive_site->uuid) {
-		struct dive_site *ds = alloc_or_get_dive_site(state->cur_dive_site->uuid, state->sites);
-		merge_dive_site(ds, state->cur_dive_site);
 
-		if (verbose > 3)
-			printf("completed dive site uuid %x8 name {%s}\n", ds->uuid, ds->name);
-	}
+	struct dive_site *ds = alloc_or_get_dive_site(state->cur_dive_site->uuid, state->sites);
+	merge_dive_site(ds, state->cur_dive_site);
+
+	if (verbose > 3)
+		printf("completed dive site uuid %x8 name {%s}\n", ds->uuid, ds->name);
+
 	free_dive_site(state->cur_dive_site);
 	state->cur_dive_site = NULL;
 }


### PR DESCRIPTION
Fixes #3493.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Don't ignore non-UUID dive sites on import.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3493.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Done.