### PR TITLE
Selection code reshuffling, step 1 of many.

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -206,6 +206,7 @@ HEADERS += \
 	core/extradata.h \
 	core/git-access.h \
 	core/globals.h \
+	core/owning_ptrs.h \
 	core/pref.h \
 	core/profile.h \
 	core/qthelper.h \

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -277,9 +277,9 @@ void replanDive(dive *d)
 	execute(new ReplanDive(d));
 }
 
-void editProfile(const dive *d, EditProfileType type, int count)
+void editProfile(const dive *d, int dcNr, EditProfileType type, int count)
 {
-	execute(new EditProfile(d, type, count));
+	execute(new EditProfile(d, dcNr, type, count));
 }
 
 int addWeight(bool currentDiveOnly)

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -312,9 +312,9 @@ int editCylinder(int index, cylinder_t cyl, EditCylinderType type, bool currentD
 	return execute_edit(new EditCylinder(index, cyl, type, currentDiveOnly));
 }
 
-void editSensors(int toCylinder, const int fromCylinder)
+void editSensors(int toCylinder, int fromCylinder, int dcNr)
 {
-	execute(new EditSensors(toCylinder, fromCylinder));
+	execute(new EditSensors(toCylinder, fromCylinder, dcNr));
 }
 
 // Trip editing related commands

--- a/commands/command.h
+++ b/commands/command.h
@@ -30,8 +30,8 @@ void clear();				// Reset the undo stack. Delete all commands.
 void setClean();			// Call after save - this marks a state where no changes need to be saved.
 bool isClean();				// Any changes need to be saved?
 QAction *undoAction(QObject *parent);	// Create an undo action.
-QAction *redoAction(QObject *parent);	// Create an redo action.
-QString changesMade();			// return a string with the texts from all commands on the undo stack -> for commit message
+QAction *redoAction(QObject *parent);	// Create a redo action.
+QString changesMade();			// Return a string with the texts from all commands on the undo stack -> for commit message.
 bool placingCommand();			// Currently executing a new command -> might not have to update the field the user just edited.
 
 // 2) Dive-list related commands

--- a/commands/command.h
+++ b/commands/command.h
@@ -102,7 +102,7 @@ enum class EditProfileType {
 	MOVE,
 };
 void replanDive(dive *d); // dive computer(s) and cylinder(s) of first argument will be consumed!
-void editProfile(const dive *d, EditProfileType type, int count);
+void editProfile(const dive *d, int dcNr, EditProfileType type, int count);
 int addWeight(bool currentDiveOnly);
 int removeWeight(int index, bool currentDiveOnly);
 int editWeight(int index, weightsystem_t ws, bool currentDiveOnly);

--- a/commands/command.h
+++ b/commands/command.h
@@ -114,7 +114,7 @@ enum class EditCylinderType {
 	GASMIX
 };
 int editCylinder(int index, cylinder_t cyl, EditCylinderType type, bool currentDiveOnly);
-void editSensors(int toCylinder, const int fromCylinder);
+void editSensors(int toCylinder, int fromCylinder, int dcNr);
 #ifdef SUBSURFACE_MOBILE
 // Edits a dive and creates a divesite (if createDs != NULL) or edits a divesite (if changeDs != NULL).
 // Takes ownership of newDive and createDs!

--- a/commands/command_base.h
+++ b/commands/command_base.h
@@ -7,6 +7,7 @@
 #include "core/divesite.h"
 #include "core/trip.h"
 #include "core/dive.h"
+#include "core/owning_ptrs.h"
 
 #include <QUndoCommand>
 #include <QCoreApplication>	// For Q_DECLARE_TR_FUNCTIONS
@@ -152,26 +153,6 @@ QVector<T> stdToQt(const std::vector<T> &v)
 
 // We put everything in a namespace, so that we can shorten names without polluting the global namespace
 namespace Command {
-
-// Classes used to automatically call the appropriate free_*() function for owning pointers that go out of scope.
-struct DiveDeleter {
-	void operator()(dive *d) { free_dive(d); }
-};
-struct TripDeleter {
-	void operator()(dive_trip *t) { free_trip(t); }
-};
-struct DiveSiteDeleter {
-	void operator()(dive_site *ds) { free_dive_site(ds); }
-};
-struct EventDeleter {
-	void operator()(event *ev) { free(ev); }
-};
-
-// Owning pointers to dive, dive_trip, dive_site and event objects.
-typedef std::unique_ptr<dive, DiveDeleter> OwningDivePtr;
-typedef std::unique_ptr<dive_trip, TripDeleter> OwningTripPtr;
-typedef std::unique_ptr<dive_site, DiveSiteDeleter> OwningDiveSitePtr;
-typedef std::unique_ptr<event, EventDeleter> OwningEventPtr;
 
 // This is the base class of all commands.
 // It defines the Qt-translation functions

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -455,7 +455,7 @@ void AddDive::redoit()
 	sort_trip_table(divelog.trips); // Though unlikely, adding a dive may reorder trips
 
 	// Select the newly added dive
-	setSelection(divesAndSitesToRemove.dives, divesAndSitesToRemove.dives[0]);
+	setSelection(divesAndSitesToRemove.dives, divesAndSitesToRemove.dives[0], -1);
 }
 
 void AddDive::undoit()
@@ -465,7 +465,7 @@ void AddDive::undoit()
 	sort_trip_table(divelog.trips); // Though unlikely, removing a dive may reorder trips
 
 	// ...and restore the selection
-	setSelection(selection, currentDive);
+	setSelection(selection, currentDive, -1);
 }
 
 ImportDives::ImportDives(struct divelog *log, int flags, const QString &source)
@@ -540,7 +540,7 @@ void ImportDives::redoit()
 	divesToAdd = removeDives(divesAndSitesToRemove);
 
 	// Select the newly added dives
-	setSelection(divesAndSitesToRemoveNew.dives, divesAndSitesToRemoveNew.dives.back());
+	setSelection(divesAndSitesToRemoveNew.dives, divesAndSitesToRemoveNew.dives.back(), -1);
 
 	// Remember dives and sites to remove
 	divesAndSitesToRemove = std::move(divesAndSitesToRemoveNew);
@@ -571,7 +571,7 @@ void ImportDives::undoit()
 	divesAndSitesToRemove = std::move(divesAndSitesToRemoveNew);
 
 	// ...and restore the selection
-	setSelection(selection, currentDive);
+	setSelection(selection, currentDive, -1);
 
 	// Remove devices
 	for (const device &dev: devicesToAddAndRemove.devices)
@@ -608,7 +608,7 @@ void DeleteDive::undoit()
 
 	// Select all re-added dives and make the first one current
 	dive *currentDive = !divesToDelete.dives.empty() ? divesToDelete.dives[0] : nullptr;
-	setSelection(divesToDelete.dives, currentDive);
+	setSelection(divesToDelete.dives, currentDive, -1);
 }
 
 void DeleteDive::redoit()
@@ -653,7 +653,7 @@ void ShiftTime::redoit()
 	emit diveListNotifier.divesChanged(dives, DiveField::DATETIME);
 
 	// Select the changed dives
-	setSelection(diveList, diveList[0]);
+	setSelection(diveList, diveList[0], -1);
 
 	// Negate the time-shift so that the next call does the reverse
 	timeChanged = -timeChanged;
@@ -689,7 +689,7 @@ void RenumberDives::undoit()
 	dives.reserve(divesToRenumber.size());
 	for (const QPair<dive *, int> &item: divesToRenumber)
 		dives.push_back(item.first);
-	setSelection(dives, dives[0]);
+	setSelection(dives, dives[0], -1);
 }
 
 bool RenumberDives::workToBeDone()
@@ -718,7 +718,7 @@ void TripBase::redoit()
 	dives.reserve(divesToMove.divesToMove.size());
 	for (const DiveToTrip &item: divesToMove.divesToMove)
 		dives.push_back(item.dive);
-	setSelection(dives, dives[0]);
+	setSelection(dives, dives[0], -1);
 }
 
 void TripBase::undoit()
@@ -847,7 +847,7 @@ void SplitDivesBase::redoit()
 	unsplitDive = removeDives(diveToSplit);
 
 	// Select split dives and make first dive current
-	setSelection(divesToUnsplit.dives, divesToUnsplit.dives[0]);
+	setSelection(divesToUnsplit.dives, divesToUnsplit.dives[0], -1);
 }
 
 void SplitDivesBase::undoit()
@@ -857,7 +857,7 @@ void SplitDivesBase::undoit()
 	splitDives = removeDives(divesToUnsplit);
 
 	// Select unsplit dive and make it current
-	setSelection(diveToSplit.dives, diveToSplit.dives[0] );
+	setSelection(diveToSplit.dives, diveToSplit.dives[0], -1);
 }
 
 static std::array<dive *, 2> doSplitDives(const dive *d, duration_t time)
@@ -895,8 +895,9 @@ SplitDiveComputer::SplitDiveComputer(dive *d, int dc_num) : SplitDivesBase(d, sp
 	setText(Command::Base::tr("split dive computer"));
 }
 
-DiveComputerBase::DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_after_in) : dc_nr_before(dc_number),
-	dc_nr_after(dc_nr_after_in)
+DiveComputerBase::DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_before, int dc_nr_after) :
+	dc_nr_before(dc_nr_before),
+	dc_nr_after(dc_nr_after)
 {
 	if (!new_dive)
 		return;
@@ -930,11 +931,9 @@ void DiveComputerBase::redoit()
 	diveToAdd = removeDives(diveToRemove);
 	diveToRemove = std::move(addedDive);
 
-	dc_number = dc_nr_after;
-
 	// Select added dive and make it current.
 	// This automatically replots the profile.
-	setSelection(diveToRemove.dives, diveToRemove.dives[0]);
+	setSelection(diveToRemove.dives, diveToRemove.dives[0], dc_nr_after);
 
 	std::swap(dc_nr_before, dc_nr_after);
 }
@@ -946,13 +945,13 @@ void DiveComputerBase::undoit()
 }
 
 MoveDiveComputerToFront::MoveDiveComputerToFront(dive *d, int dc_num)
-	: DiveComputerBase(d, make_first_dc(d, dc_num), 0)
+	: DiveComputerBase(d, make_first_dc(d, dc_num), dc_num, 0)
 {
 	setText(Command::Base::tr("move dive computer to front"));
 }
 
 DeleteDiveComputer::DeleteDiveComputer(dive *d, int dc_num)
-	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num), std::min((int)number_of_computers(d) - 1, dc_num))
+	: DiveComputerBase(d, clone_delete_divecomputer(d, dc_num), dc_num, std::min((int)number_of_computers(d) - 1, dc_num))
 {
 	setText(Command::Base::tr("delete dive computer"));
 }
@@ -1059,7 +1058,7 @@ void MergeDives::redoit()
 	unmergedDives = removeDives(divesToMerge);
 
 	// Select merged dive and make it current
-	setSelection(diveToUnmerge.dives, diveToUnmerge.dives[0]);
+	setSelection(diveToUnmerge.dives, diveToUnmerge.dives[0], -1);
 }
 
 void MergeDives::undoit()
@@ -1069,7 +1068,7 @@ void MergeDives::undoit()
 	renumberDives(divesToRenumber);
 
 	// Select unmerged dives and make first one current
-	setSelection(divesToMerge.dives, divesToMerge.dives[0]);
+	setSelection(divesToMerge.dives, divesToMerge.dives[0], -1);
 }
 
 } // namespace Command

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -237,7 +237,7 @@ class DiveComputerBase : public DiveListBase {
 protected:
 	// old_dive must be a dive known to the core.
 	// new_dive must be new dive whose ownership is taken.
-	DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_after);
+	DiveComputerBase(dive *old_dive, dive *new_dive, int dc_nr_before, int dc_nr_after);
 private:
 	void undoit() override;
 	void redoit() override;

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -159,7 +159,7 @@ void EditBase<T>::undo()
 	DiveField id = fieldId();
 	emit diveListNotifier.divesChanged(stdToQt<dive *>(dives), id);
 	if (!placingCommand())
-		setSelection(selectedDives, current);
+		setSelection(selectedDives, current, -1);
 }
 
 // We have to manually instantiate the constructors of the EditBase class,
@@ -552,7 +552,7 @@ void EditTagsBase::undo()
 	// Send signals.
 	DiveField id = fieldId();
 	emit diveListNotifier.divesChanged(stdToQt<dive *>(dives), id);
-	setSelection(selectedDives, current);
+	setSelection(selectedDives, current, -1);
 }
 
 // Undo and redo do the same as just the stored value is exchanged
@@ -862,7 +862,7 @@ void ReplanDive::undo()
 	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DATETIME | DiveField::DURATION | DiveField::DEPTH | DiveField::MODE |
 							  DiveField::NOTES | DiveField::SALINITY | DiveField::ATM_PRESS);
 	if (!placingCommand())
-		setSelection({ d }, d);
+		setSelection({ d }, d, -1);
 }
 
 // Redo and undo do the same
@@ -935,7 +935,7 @@ void EditProfile::undo()
 	QVector<dive *> divesToNotify = { d };
 	emit diveListNotifier.divesChanged(divesToNotify, DiveField::DURATION | DiveField::DEPTH);
 	if (!placingCommand())
-		setSelection({ d }, d);
+		setSelection({ d }, d, dcNr);
 }
 
 // Redo and undo do the same
@@ -1521,7 +1521,7 @@ void EditDive::exchangeDives()
 	emit diveListNotifier.divesChanged(dives, changedFields);
 
 	// Select the changed dives
-	setSelection( { oldDive }, oldDive);
+	setSelection( { oldDive }, oldDive, -1);
 }
 
 void EditDive::editDs()

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -882,8 +882,8 @@ QString editProfileTypeToString(EditProfileType type, int count)
 	}
 }
 
-EditProfile::EditProfile(const dive *source, EditProfileType type, int count) : d(current_dive),
-	dcNr(dc_number),
+EditProfile::EditProfile(const dive *source, int dcNr, EditProfileType type, int count) : d(current_dive),
+	dcNr(dcNr),
 	maxdepth({0}),
 	meandepth({0}),
 	dcmaxdepth({0}),

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1351,8 +1351,8 @@ void EditCylinder::undo()
 	redo();
 }
 
-EditSensors::EditSensors(int toCylinderIn, int fromCylinderIn)
-	: d(current_dive), dc(get_dive_dc(d, dc_number)), toCylinder(toCylinderIn), fromCylinder(fromCylinderIn)
+EditSensors::EditSensors(int toCylinderIn, int fromCylinderIn, int dcNr)
+	: d(current_dive), dc(get_dive_dc(d, dcNr)), toCylinder(toCylinderIn), fromCylinder(fromCylinderIn)
 {
 	if (!d || !dc)
 		return;

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -352,7 +352,7 @@ class EditProfile : public Base {
 	struct divecomputer dc;
 public:
 	// Note: source must be clean (i.e. fixup_dive must have been called on it).
-	EditProfile(const dive *source, EditProfileType type, int count);
+	EditProfile(const dive *source, int dcNr, EditProfileType type, int count);
 	~EditProfile();
 private:
 	void undo() override;

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -444,7 +444,7 @@ private:
 class EditSensors : public Base
 {
 public:
-	EditSensors(int cylIndex, int fromCylinder);
+	EditSensors(int cylIndex, int fromCylinder, int dcNr);
 
 private:
 	struct dive *d;

--- a/commands/command_edit_trip.cpp
+++ b/commands/command_edit_trip.cpp
@@ -7,6 +7,7 @@
 namespace Command {
 
 EditTripBase::EditTripBase(dive_trip *tripIn, const QString &newValue) : trip(tripIn),
+	current(current_dive),
 	value(newValue)
 {
 }
@@ -26,6 +27,7 @@ void EditTripBase::undo()
 	value = old;
 
 	emit diveListNotifier.tripChanged(trip, fieldId());
+	setTripSelection(trip, current);
 }
 
 // Undo and redo do the same as just the stored value is exchanged

--- a/commands/command_edit_trip.h
+++ b/commands/command_edit_trip.h
@@ -20,6 +20,7 @@ class EditTripBase : public Base {
 	bool workToBeDone() override;
 
 	dive_trip *trip; // Trip to be edited.
+	dive *current;
 public:
 	EditTripBase(dive_trip *trip, const QString &newValue);
 

--- a/commands/command_event.cpp
+++ b/commands/command_event.cpp
@@ -32,8 +32,7 @@ void EventBase::updateDive()
 {
 	invalidate_dive_cache(d);
 	emit diveListNotifier.eventsChanged(d);
-	dc_number = dcNr;
-	setSelection({ d }, d);
+	setSelection({ d }, d, dcNr);
 }
 
 AddEventBase::AddEventBase(struct dive *d, int dcNr, struct event *ev) : EventBase(d, dcNr),

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -132,6 +132,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	metrics.cpp
 	metrics.h
 	ostctools.c
+	owning_ptrs.h
 	parse-gpx.cpp
 	parse-xml.c
 	parse.c

--- a/core/dive.c
+++ b/core/dive.c
@@ -26,11 +26,6 @@
 #include "structured_list.h"
 #include "fulltext.h"
 
-/* one could argue about the best place to have this variable -
- * it's used in the UI, but it seems to make the most sense to have it
- * here */
-struct dive displayed_dive;
-
 // For user visible text but still not translated
 const char *divemode_text_ui[] = {
 	QT_TRANSLATE_NOOP("gettextFromC", "Open circuit"),
@@ -299,9 +294,8 @@ static void copy_dive_onedc(const struct dive *s, const struct divecomputer *sdc
 }
 
 /* make a clone of the source dive and clean out the source dive;
- * this is specifically so we can create a dive in the displayed_dive and then
- * add it to the divelist.
- * Note the difference to copy_dive() / clean_dive() */
+ * this allows us to create a dive on the stack and then
+ * add it to the divelist. */
 struct dive *move_dive(struct dive *s)
 {
 	struct dive *dive = alloc_dive();

--- a/core/dive.h
+++ b/core/dive.h
@@ -111,8 +111,6 @@ extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct div
 extern depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto);
 
 extern struct dive displayed_dive;
-extern unsigned int dc_number;
-extern struct dive *current_dive;
 
 extern struct dive *get_dive(int nr);
 extern struct dive *get_dive_from_table(int nr, const struct dive_table *dt);

--- a/core/dive.h
+++ b/core/dive.h
@@ -110,8 +110,6 @@ extern int mbar_to_depth(int mbar, const struct dive *dive);
 extern depth_t gas_mod(struct gasmix mix, pressure_t po2_limit, const struct dive *dive, int roundto);
 extern depth_t gas_mnd(struct gasmix mix, depth_t end, const struct dive *dive, int roundto);
 
-extern struct dive displayed_dive;
-
 extern struct dive *get_dive(int nr);
 extern struct dive *get_dive_from_table(int nr, const struct dive_table *dt);
 extern struct dive_site *get_dive_site_for_dive(const struct dive *dive);

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -67,7 +67,7 @@ ShownChange DiveFilter::update(const QVector<dive *> &dives) const
 		updateDiveStatus(d, newStatus, res, removeFromSelection);
 	}
 	updateSelection(selection, std::vector<dive *>(), removeFromSelection);
-	res.currentChanged = setSelection(selection);
+	res.currentChanged = setSelectionKeepCurrent(selection);
 	return res;
 }
 
@@ -107,7 +107,7 @@ ShownChange DiveFilter::updateAll() const
 		}
 	}
 	updateSelection(selection, std::vector<dive *>(), removeFromSelection);
-	res.currentChanged = setSelection(selection);
+	res.currentChanged = setSelectionKeepCurrent(selection);
 	return res;
 }
 

--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -181,7 +181,6 @@ void DiveFilter::setFilterDiveSite(QVector<dive_site *> ds)
 	emit diveListNotifier.filterReset();
 #ifdef MAP_SUPPORT
 	MapWidget::instance()->setSelected(dive_sites);
-	MapWidget::instance()->selectionChanged();
 #endif
 	MainWindow::instance()->diveList->expandAll();
 }

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -57,8 +57,10 @@ public:
 private:
 	DiveFilter();
 	bool showDive(const struct dive *d) const; // Should that dive be shown?
-	bool setFilterStatus(struct dive *d, bool shown) const;
-	void updateDiveStatus(dive *d, bool newStatus, ShownChange &change) const;
+	bool setFilterStatus(struct dive *d, bool shown,
+			     std::vector<dive *> &removeFromSelection) const;
+	void updateDiveStatus(dive *d, bool newStatus, ShownChange &change,
+			      std::vector<dive *> &removeFromSelection) const;
 
 	QVector<dive_site *> dive_sites;
 	FilterData filterData;

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -773,8 +773,6 @@ void delete_single_dive(int idx)
 	struct dive *dive = get_dive(idx);
 	if (!dive)
 		return; /* this should never happen */
-	if (dive->selected)
-		deselect_dive(dive);
 	remove_dive_from_trip(dive, divelog.trips);
 	unregister_dive_from_dive_site(dive);
 	delete_dive_from_table(divelog.dives, idx);
@@ -972,6 +970,9 @@ void add_imported_dives(struct divelog *import_log, int flags)
 	 * to-be-added and to-be-removed */
 	process_imported_dives(import_log, flags, &dives_to_add, &dives_to_remove, &trips_to_add,
 			       &dive_sites_to_add, devices_to_add);
+
+	/* Start by deselecting all dives, so that we don't end up with an invalid selection */
+	select_single_dive(NULL);
 
 	/* Add new dives to trip and site to get reference count correct. */
 	for (i = 0; i < dives_to_add.nr; i++) {

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1318,7 +1318,6 @@ void clear_dive_file_data()
 	current_dive = NULL;
 	clear_divelog(&divelog);
 
-	clear_dive(&displayed_dive);
 	clear_event_names();
 
 	reset_min_datafile_version();

--- a/core/owning_ptrs.h
+++ b/core/owning_ptrs.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0
+// Convenience classes defining owning pointers to C-objects that
+// automatically clean up the objects if the pointers go out of
+// scope. Based on unique_ptr<>.
+// In the future, we should replace these by real destructors.
+#ifndef OWNING_PTR_H
+#define OWNING_PTR_H
+
+#include <memory>
+#include <cstdlib>
+
+struct dive;
+struct dive_trip;
+struct dive_site;
+struct event;
+
+extern "C" void free_dive(struct dive *);
+extern "C" void free_trip(struct dive_trip *);
+extern "C" void free_dive_site(struct dive_site *);
+
+// Classes used to automatically call the appropriate free_*() function for owning pointers that go out of scope.
+struct DiveDeleter {
+	void operator()(dive *d) { free_dive(d); }
+};
+struct TripDeleter {
+	void operator()(dive_trip *t) { free_trip(t); }
+};
+struct DiveSiteDeleter {
+	void operator()(dive_site *ds) { free_dive_site(ds); }
+};
+struct EventDeleter {
+	void operator()(event *ev) { free(ev); }
+};
+
+// Owning pointers to dive, dive_trip, dive_site and event objects.
+using OwningDivePtr = std::unique_ptr<dive, DiveDeleter>;
+using OwningTripPtr = std::unique_ptr<dive_trip, TripDeleter>;
+using OwningDiveSitePtr = std::unique_ptr<dive_site, DiveSiteDeleter>;
+using OwningEventPtr = std::unique_ptr<event, EventDeleter>;
+
+#endif

--- a/core/profile.c
+++ b/core/profile.c
@@ -30,9 +30,6 @@
 
 extern int ascent_velocity(int depth, int avg_depth, int bottom_time);
 
-struct dive *current_dive = NULL;
-unsigned int dc_number = 0;
-
 #ifdef DEBUG_PI
 /* debugging tool - not normally used */
 static void dump_pi(struct plot_info *pi)

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -202,7 +202,7 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive, int c
 	auto selectedDives = setSelectionCore(selection, currentDive, currentDc);
 
 	// Send the new selection to the UI.
-	emit diveListNotifier.divesSelected(selectedDives);
+	emit diveListNotifier.divesSelected(selectedDives, current_dive);
 }
 
 // Set selection, but try to keep the current dive. If current dive is not in selection,

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -177,21 +177,17 @@ static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &s
 	}
 }
 
-// Reset the selection to the dives of the "selection" vector and send the appropriate signals.
+
+// Reset the selection to the dives of the "selection" vector.
 // Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
-// null if "selection" is empty). Return true if the current dive changed.
-bool setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc)
+// null if "selection" is empty).
+// Does not send signals or clear the trip selection.
+QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *currentDive, int currentDc)
 {
 	// To do so, generate vectors of dives to be selected and deselected.
 	// We send signals batched by trip, so keep track of trip/dive pairs.
 	QVector<dive *> divesToSelect;
 	divesToSelect.reserve(selection.size());
-	const dive *oldCurrent = current_dive;
-
-	// Since we select only dives, there are no selected trips!
-	amount_trips_selected = 0;
-	for (int i = 0; i < divelog.trips->nr; ++i)
-		divelog.trips->trips[i]->selected = false;
 
 	// TODO: We might want to keep track of selected dives in a more efficient way!
 	int i;
@@ -213,11 +209,6 @@ bool setSelection(const std::vector<dive *> &selection, dive *currentDive, int c
 			++amount_selected;
 			divesToSelect.push_back(d);
 		}
-		// TODO: Instead of using select_dive() and deselect_dive(), we set selected directly.
-		// The reason is that deselect() automatically sets a new current dive, which we
-		// don't want, as we set it later anyway.
-		// There is other parts of the C++ code that touches the innards directly, but
-		// ultimately this should be pushed down to C.
 		d->selected = newState;
 	}
 
@@ -232,18 +223,48 @@ bool setSelection(const std::vector<dive *> &selection, dive *currentDive, int c
 	if (currentDc >= 0)
 		dc_number = currentDc;
 	fixup_current_dc();
-
-	// Send the new selection
-	emit diveListNotifier.divesSelected(divesToSelect);
-	return current_dive != oldCurrent;
+	return divesToSelect;
 }
 
-bool setSelection(const std::vector<dive *> &selection)
+static void clear_trip_selection()
 {
+	amount_trips_selected = 0;
+	for (int i = 0; i < divelog.trips->nr; ++i)
+		divelog.trips->trips[i]->selected = false;
+}
+
+// Reset the selection to the dives of the "selection" vector and send the appropriate signals.
+// Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
+// null if "selection" is empty).
+// If "currentDc" is negative, an attempt will be made to keep the current computer number.
+void setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc)
+{
+	// Since we select only dives, there are no selected trips!
+	clear_trip_selection();
+
+	auto selectedDives = setSelectionCore(selection, currentDive, currentDc);
+
+	// Send the new selection to the UI.
+	emit diveListNotifier.divesSelected(selectedDives);
+}
+
+// Set selection, but try to keep the current dive. If current dive is not in selection,
+// find the nearest current dive in the selection
+// Returns true if the current dive changed.
+// Do not send a signal.
+bool setSelectionKeepCurrent(const std::vector<dive *> &selection)
+{
+	// Since we select only dives, there are no selected trips!
+	clear_trip_selection();
+
+	const dive *oldCurrent = current_dive;
+
 	dive *newCurrent = current_dive;
 	if (current_dive && std::find(selection.begin(), selection.end(), current_dive) == selection.end())
 		newCurrent = closestInSelection(current_dive->when, selection);
-	return setSelection(selection, newCurrent, -1);
+	setSelectionCore(selection, newCurrent, -1);
+
+	return current_dive != oldCurrent;
 }
 
 extern "C" void select_single_dive(dive *d)

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -202,7 +202,7 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive, int c
 	auto selectedDives = setSelectionCore(selection, currentDive, currentDc);
 
 	// Send the new selection to the UI.
-	emit diveListNotifier.divesSelected(selectedDives, current_dive);
+	emit diveListNotifier.divesSelected(selectedDives, current_dive, currentDc);
 }
 
 // Set selection, but try to keep the current dive. If current dive is not in selection,

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -24,49 +24,6 @@ static void fixup_current_dc()
 	dc_number = std::min(dc_number, number_of_computers(current_dive) - 1);
 }
 
-extern "C" void select_dive(struct dive *dive)
-{
-	if (!dive)
-		return;
-	if (!dive->selected) {
-		dive->selected = 1;
-		amount_selected++;
-	}
-	current_dive = dive;
-	fixup_current_dc();
-}
-
-extern "C" void deselect_dive(struct dive *dive)
-{
-	int idx;
-	if (dive && dive->selected) {
-		dive->selected = 0;
-		if (amount_selected)
-			amount_selected--;
-		if (current_dive == dive && amount_selected > 0) {
-			/* pick a different dive as selected */
-			int selected_dive = idx = get_divenr(dive);
-			while (--selected_dive >= 0) {
-				dive = get_dive(selected_dive);
-				if (dive && dive->selected) {
-					current_dive = dive;
-					return;
-				}
-			}
-			selected_dive = idx;
-			while (++selected_dive < divelog.dives->nr) {
-				dive = get_dive(selected_dive);
-				if (dive && dive->selected) {
-					current_dive = dive;
-					return;
-				}
-			}
-		}
-		current_dive = NULL;
-	}
-	fixup_current_dc();
-}
-
 extern "C" struct dive *first_selected_dive()
 {
 	int idx;

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -224,6 +224,27 @@ bool setSelectionKeepCurrent(const std::vector<dive *> &selection)
 	return current_dive != oldCurrent;
 }
 
+void setTripSelection(dive_trip *trip, dive *currentDive)
+{
+	if (!trip)
+		return;
+
+	current_dive = currentDive;
+	for (int i = 0; i < divelog.dives->nr; ++i) {
+		dive &d = *divelog.dives->dives[i];
+		d.selected = d.divetrip == trip;
+	}
+	for (int i = 0; i < divelog.trips->nr; ++i) {
+		dive_trip *t = divelog.trips->trips[i];
+		t->selected = t == trip;
+	}
+
+	amount_selected = trip->dives.nr;
+	amount_trips_selected = 1;
+
+	emit diveListNotifier.tripSelected(trip, currentDive);
+}
+
 extern "C" void select_single_dive(dive *d)
 {
 	if (d)
@@ -313,17 +334,4 @@ extern "C" struct dive_trip *single_selected_trip()
 	}
 	fprintf(stderr, "warning: found no selected trip even though one should be selected\n");
 	return NULL; // shouldn't happen
-}
-
-extern "C" void clear_selection(void)
-{
-	current_dive = nullptr;
-	amount_selected = 0;
-	amount_trips_selected = 0;
-	int i;
-	struct dive *dive;
-	for_each_dive (i, dive)
-		dive->selected = false;
-	for (int i = 0; i < divelog.trips->nr; ++i)
-		divelog.trips->trips[i]->selected = false;
 }

--- a/core/selection.h
+++ b/core/selection.h
@@ -7,7 +7,6 @@
 struct dive;
 
 extern int amount_selected;
-extern unsigned int dc_number;
 extern struct dive *current_dive;
 
 /*** C and C++ functions ***/
@@ -45,7 +44,7 @@ extern void dump_selection(void);
 // "currentDive" must be an element of "selection" (or null if "seletion" is empty).
 // If "currentDc" is negative, an attempt will be made to keep the current computer number.
 // Returns the list of selected dives
-QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
+QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *currentDive);
 
 // As above, but sends a signal to inform the frontend of the changed selection.
 // Returns true if the current dive changed.

--- a/core/selection.h
+++ b/core/selection.h
@@ -16,8 +16,6 @@ extern struct dive *current_dive;
 extern "C" {
 #endif
 
-extern void select_dive(struct dive *dive);
-extern void deselect_dive(struct dive *dive);
 extern struct dive *first_selected_dive(void);
 extern struct dive *last_selected_dive(void);
 extern bool consecutive_selected(void);

--- a/core/selection.h
+++ b/core/selection.h
@@ -40,18 +40,24 @@ extern void dump_selection(void);
 
 #ifdef __cplusplus
 #include <vector>
+#include <QVector>
 
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
 // Set the current dive to "currentDive" and the current dive computer to "currentDc".
 // "currentDive" must be an element of "selection" (or null if "seletion" is empty).
 // If "currentDc" is negative, an attempt will be made to keep the current computer number.
+// Returns the list of selected dives
+QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
+
+// As above, but sends a signal to inform the frontend of the changed selection.
 // Returns true if the current dive changed.
-bool setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
+void setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
 
 // Set selection, but try to keep the current dive. If current dive is not in selection,
 // find the nearest current dive in the selection
 // Returns true if the current dive changed.
-bool setSelection(const std::vector<dive *> &selection);
+// Does not send a signal.
+bool setSelectionKeepCurrent(const std::vector<dive *> &selection);
 
 // Get currently selected dives
 std::vector<dive *> getDiveSelection();

--- a/core/selection.h
+++ b/core/selection.h
@@ -7,6 +7,8 @@
 struct dive;
 
 extern int amount_selected;
+extern unsigned int dc_number;
+extern struct dive *current_dive;
 
 /*** C and C++ functions ***/
 
@@ -40,9 +42,10 @@ extern void dump_selection(void);
 #include <vector>
 
 // Reset the selection to the dives of the "selection" vector and send the appropriate signals.
-// Set the current dive to "currentDive". "currentDive" must be an element of "selection" (or
-// null if "seletion" is empty).
-void setSelection(const std::vector<dive *> &selection, dive *currentDive);
+// Set the current dive to "currentDive" and the current dive computer to "currentDc".
+// "currentDive" must be an element of "selection" (or null if "seletion" is empty).
+// If "currentDc" is negative, an attempt will be made to keep the current computer number.
+void setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
 
 // Get currently selectd dives
 std::vector<dive *> getDiveSelection();

--- a/core/selection.h
+++ b/core/selection.h
@@ -45,10 +45,18 @@ extern void dump_selection(void);
 // Set the current dive to "currentDive" and the current dive computer to "currentDc".
 // "currentDive" must be an element of "selection" (or null if "seletion" is empty).
 // If "currentDc" is negative, an attempt will be made to keep the current computer number.
-void setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
+// Returns true if the current dive changed.
+bool setSelection(const std::vector<dive *> &selection, dive *currentDive, int currentDc);
 
-// Get currently selectd dives
+// Set selection, but try to keep the current dive. If current dive is not in selection,
+// find the nearest current dive in the selection
+// Returns true if the current dive changed.
+bool setSelection(const std::vector<dive *> &selection);
+
+// Get currently selected dives
 std::vector<dive *> getDiveSelection();
+bool diveInSelection(const std::vector<dive *> &selection, const dive *d);
+void updateSelection(std::vector<dive *> &selection, const std::vector<dive *> &add, const std::vector<dive *> &remove);
 
 #endif // __cplusplus
 

--- a/core/selection.h
+++ b/core/selection.h
@@ -57,6 +57,9 @@ void setSelection(const std::vector<dive *> &selection, dive *currentDive, int c
 // Does not send a signal.
 bool setSelectionKeepCurrent(const std::vector<dive *> &selection);
 
+// Select all dive in a trip and sends a trip-selected signal
+void setTripSelection(dive_trip *trip, dive *currentDive);
+
 // Get currently selected dives
 std::vector<dive *> getDiveSelection();
 bool diveInSelection(const std::vector<dive *> &selection, const dive *d);

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -112,6 +112,7 @@ signals:
 
 	// Selection changes
 	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	void tripSelected(dive_trip *trip, dive *currentDive);
 
 	// Dive site signals. Add and delete events are sent per dive site and
 	// provide an index into the global dive site table.

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -111,7 +111,8 @@ signals:
 	void tripChanged(dive_trip *trip, TripField field);
 
 	// Selection changes
-	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	// currentDC == -1 -> keep current dive computer
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 
 	// Dive site signals. Add and delete events are sent per dive site and

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -111,7 +111,7 @@ signals:
 	void tripChanged(dive_trip *trip, TripField field);
 
 	// Selection changes
-	void divesSelected(const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
 
 	// Dive site signals. Add and delete events are sent per dive site and
 	// provide an index into the global dive site table.

--- a/core/trip.c
+++ b/core/trip.c
@@ -287,26 +287,6 @@ dive_trip_t *get_dives_to_autogroup(struct dive_table *table, int start, int *fr
 	return NULL;
 }
 
-void deselect_dives_in_trip(struct dive_trip *trip)
-{
-	if (!trip)
-		return;
-	for (int i = 0; i < trip->dives.nr; ++i)
-		deselect_dive(trip->dives.dives[i]);
-}
-
-void select_dives_in_trip(struct dive_trip *trip)
-{
-	struct dive *dive;
-	if (!trip)
-		return;
-	for (int i = 0; i < trip->dives.nr; ++i) {
-		dive = trip->dives.dives[i];
-		if (!dive->hidden_by_filter)
-			select_dive(dive);
-	}
-}
-
 /* Out of two strings, copy the string that is not empty (if any). */
 static char *copy_non_empty_string(const char *a, const char *b)
 {

--- a/core/trip.h
+++ b/core/trip.h
@@ -49,9 +49,6 @@ extern dive_trip_t *get_trip_for_new_dive(struct dive *new_dive, bool *allocated
 extern dive_trip_t *get_trip_by_uniq_id(int tripId);
 extern bool trips_overlap(const struct dive_trip *t1, const struct dive_trip *t2);
 
-extern void select_dives_in_trip(struct dive_trip *trip);
-extern void deselect_dives_in_trip(struct dive_trip *trip);
-
 extern dive_trip_t *combine_trips(struct dive_trip *trip_a, struct dive_trip *trip_b);
 extern bool is_trip_before_after(const struct dive *dive, bool before);
 extern bool trip_is_single_day(const struct dive_trip *trip);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -534,6 +534,12 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 		return;
 	}
 
+	// Avoid recursion: if later we decide to select all dives of a trip,
+	// this function is called again. Avoid this by setting the
+	// programmaticalSelectionChange flag. Note that the recursion never
+	// was a problem, but it just feels correct to avoid this recursion.
+	programmaticalSelectionChange = true;
+
 	// This is a manual selection change. This means that the core does not yet know
 	// of the new selection. Update the core-structures accordingly and select/deselect
 	// all dives of a trip if a trip is selected/deselected.
@@ -587,6 +593,8 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 
 	// Display the new, processed, selection
 	QTreeView::selectionChanged(selectionModel()->selection(), newDeselected);
+
+	programmaticalSelectionChange = false;
 }
 
 enum asked_user {NOTYET, MERGE, DONTMERGE};

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -527,7 +527,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 	std::vector<dive *> selection = getDiveSelection();
 	updateSelection(selection, addToSelection, removeFromSelection);
 	dive *newCurrent = selection.empty() ? nullptr : selection.front();
-	setSelectionCore(selection, newCurrent, -1);
+	setSelectionCore(selection, newCurrent);
 
 	// Display the new, processed, selection
 	QTreeView::selectionChanged(selectionModel()->selection(), newDeselected);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -415,76 +415,6 @@ void DiveListView::currentChanged(const QModelIndex &current, const QModelIndex&
 	scrollTo(current);
 }
 
-void DiveListView::mouseReleaseEvent(QMouseEvent *event)
-{
-	// Oy vey. We hook into QTreeView's setSelection() to update the UI
-	// after selection changes. However, there is a case when this doesn't
-	// work: when narrowing the selection. If multiple dives are selected,
-	// and the user clicks on one of them, the selection is unchanged.
-	// Only on mouse-release the selection is changed, but then
-	// setSelection() is not called.
-	// Notably, this happens when the user selects a trip and then clicks
-	// on a dive in the same trip.
-	// To solve this, we hook into the mouseReleseEvent here and detect
-	// selection changes changes by comparing the selection before and after
-	// processing of the event.
-	// We really should find another way to solve this.
-	QModelIndexList selectionBefore = selectionModel()->selectedRows();
-	QTreeView::mouseReleaseEvent(event);
-	QModelIndexList selectionAfter = selectionModel()->selectedRows();
-	if (selectionBefore != selectionAfter)
-		selectionChangeDone();
-}
-
-void DiveListView::keyPressEvent(QKeyEvent *event)
-{
-	// Hook into key events that change the selection (i.e. cursor-up, cursor-down,
-	// page-up, page-down, home and end) and update selection if necessary.
-	// See comment in mouseReleaseEvent().
-	switch (event->key()) {
-		case Qt::Key_Up:
-		case Qt::Key_Down:
-		case Qt::Key_PageUp:
-		case Qt::Key_PageDown:
-		case Qt::Key_Home:
-		case Qt::Key_End:
-			break;
-		default:
-			return QTreeView::keyPressEvent(event);
-	}
-
-	QModelIndexList selectionBefore = selectionModel()->selectedRows();
-	QTreeView::keyPressEvent(event);
-	QModelIndexList selectionAfter = selectionModel()->selectedRows();
-	if (selectionBefore != selectionAfter)
-		selectionChangeDone();
-}
-
-void DiveListView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags)
-{
-	// We hook into QTreeView's setSelection() to update the UI
-	// after selection changes. However, we must be careful:
-	// when the user clicks on an already selected dive, this is called
-	// with the QItemSelectionModel::NoUpdate flags. In this case, just
-	// route through. Moreover, we get setSelection() calls on every
-	// mouseMove event. To avoid excessive reloading of the UI check
-	// if the selection changed by comparing before and after processing
-	// the selection.
-	if (flags == QItemSelectionModel::NoUpdate)
-		return QTreeView::setSelection(rect, flags);
-	QModelIndexList selectionBefore = selectionModel()->selectedRows();
-	QTreeView::setSelection(rect, flags);
-	QModelIndexList selectionAfter = selectionModel()->selectedRows();
-	if (selectionBefore != selectionAfter)
-		selectionChangeDone();
-}
-
-void DiveListView::selectAll()
-{
-	QTreeView::selectAll();
-	selectionChangeDone();
-}
-
 void DiveListView::selectionChangeDone()
 {
 #ifdef MAP_SUPPORT
@@ -593,6 +523,8 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 
 	// Display the new, processed, selection
 	QTreeView::selectionChanged(selectionModel()->selection(), newDeselected);
+
+	selectionChangeDone();
 
 	programmaticalSelectionChange = false;
 }

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -39,7 +39,7 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	setItemDelegateForColumn(DiveTripModelBase::RATING, new StarWidgetsDelegate(this));
 	MultiFilterSortModel *m = MultiFilterSortModel::instance();
 	setModel(m);
-	connect(m, &MultiFilterSortModel::selectionChanged, this, &DiveListView::diveSelectionChanged);
+	connect(m, &MultiFilterSortModel::divesSelected, this, &DiveListView::divesSelectedSlot);
 	connect(m, &MultiFilterSortModel::tripSelected, this, &DiveListView::tripSelected);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DiveListView::settingsChanged);
 
@@ -225,7 +225,7 @@ void DiveListView::reset()
 }
 
 // If items were selected, inform the selection model
-void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC)
+void DiveListView::divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC)
 {
 	// This is the entry point for programmatical selection changes.
 	// Set a flag so that selection changes are not further processed,

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -40,7 +40,6 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	MultiFilterSortModel *m = MultiFilterSortModel::instance();
 	setModel(m);
 	connect(m, &MultiFilterSortModel::selectionChanged, this, &DiveListView::diveSelectionChanged);
-	connect(m, &MultiFilterSortModel::currentDiveChanged, this, &DiveListView::currentDiveChanged);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &DiveListView::settingsChanged);
 
 	setSortingEnabled(true);
@@ -227,7 +226,7 @@ void DiveListView::reset()
 }
 
 // If items were selected, inform the selection model
-void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indices)
+void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive)
 {
 	// This is the entry point for programmatical selection changes.
 	// Set a flag so that selection changes are not further processed,
@@ -262,16 +261,13 @@ void DiveListView::diveSelectionChanged(const QVector<QModelIndex> &indices)
 
 	selectionChangeDone();
 	programmaticalSelectionChange = false;
-}
 
-void DiveListView::currentDiveChanged(QModelIndex index)
-{
 	// Set the currently activated row.
 	// Note, we have to use the QItemSelectionModel::Current mode to avoid
 	// changing our selection (in contrast to Qt's documentation, which
 	// instructs to use QItemSelectionModel::NoUpdate, which results in
 	// funny side-effects).
-	selectionModel()->setCurrentIndex(index, QItemSelectionModel::Current);
+	selectionModel()->setCurrentIndex(currentDive, QItemSelectionModel::Current);
 }
 
 // If rows are added, check which of these rows is a trip and expand the first column

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -56,10 +56,6 @@ slots:
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;
 	void reset() override;
-	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
-	void mouseReleaseEvent(QMouseEvent *event) override;
-	void keyPressEvent(QKeyEvent *event) override;
-	void selectAll() override;
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 	void selectionChangeDone();
 	void selectTripItems(QModelIndex index);

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -51,8 +51,7 @@ slots:
 	void renumberDives();
 	void addDivesToTrip();
 	void shiftTimes();
-	void diveSelectionChanged(const QVector<QModelIndex> &indices);
-	void currentDiveChanged(QModelIndex index);
+	void diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
 	void tripChanged(dive_trip *trip, TripField);
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -52,7 +52,7 @@ slots:
 	void renumberDives();
 	void addDivesToTrip();
 	void shiftTimes();
-	void diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -29,7 +29,8 @@ public:
 	void loadImages();
 	void loadWebImages();
 signals:
-	void divesSelected();
+	// currentDC = -1: don't change dc number.
+	void divesSelected(const std::vector<dive *> &dives, dive *currentDive, int currentDC);
 public
 slots:
 	void settingsChanged();
@@ -51,13 +52,13 @@ slots:
 	void renumberDives();
 	void addDivesToTrip();
 	void shiftTimes();
-	void diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;
 	void reset() override;
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-	void selectionChangeDone();
+	void selectDiveSitesOnMap(const std::vector<dive *> &dives);
 	void selectTripItems(QModelIndex index);
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -52,17 +52,17 @@ slots:
 	void addDivesToTrip();
 	void shiftTimes();
 	void diveSelectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
-	void tripChanged(dive_trip *trip, TripField);
+	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;
 	void reset() override;
 	void setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags) override;
-	void unselectDives();
 	void mouseReleaseEvent(QMouseEvent *event) override;
 	void keyPressEvent(QKeyEvent *event) override;
 	void selectAll() override;
 	void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 	void selectionChangeDone();
+	void selectTripItems(QModelIndex index);
 	DiveTripModelBase::Layout currentLayout;
 	QModelIndex contextMenuIndex;
 	// Remember the initial column widths, to avoid writing unchanged widths to the settings

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -5,6 +5,7 @@
 #include "core/planner.h"
 #include "core/qthelper.h"
 #include "core/units.h"
+#include "core/selection.h"
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "core/gettextfromc.h"

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -548,7 +548,6 @@ PlannerWidgets::PlannerWidgets()
 void PlannerWidgets::planDive(dive *currentDive)
 {
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-	dc_number = 0;
 
 	// create a simple starting dive, using the first gas from the just copied cylinders
 	DivePlannerPointsModel::instance()->createSimpleDive(&displayed_dive);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -582,7 +582,6 @@ void PlannerWidgets::planDive()
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
 	repopulateGasModel();
-	diveTypeModel->repopulate(); // TODO: this doesn't change anything!?
 	plannerWidget.setReplanButton(false);
 	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->when));	// This will reload the profile!
 }
@@ -597,7 +596,6 @@ void PlannerWidgets::replanDive(int currentDC)
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	DivePlannerPointsModel::instance()->loadFromDive(planned_dive.get(), currentDC);
 
-	diveTypeModel->repopulate(); // TODO: this doesn't change anything!?
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->when));
 	if (planned_dive->surface_pressure.mbar)

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -571,7 +571,7 @@ void PlannerWidgets::replanDive()
 		return;
 	copy_dive(current_dive, &displayed_dive); // Planning works on a copy of the dive (for now).
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
-	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive);
+	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive, dc_number);
 
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));
@@ -580,7 +580,7 @@ void PlannerWidgets::replanDive()
 	if (displayed_dive.salinity)
 		plannerWidget.setSalinity(displayed_dive.salinity);
 	reset_cylinders(&displayed_dive, true);
-	DivePlannerPointsModel::instance()->cylindersModel()->updateDive(&displayed_dive);
+	DivePlannerPointsModel::instance()->cylindersModel()->updateDive(&displayed_dive, dc_number);
 }
 
 void PlannerWidgets::printDecoPlan()

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -214,6 +214,7 @@ void DivePlannerWidget::customSalinityChanged(double density)
 
 void PlannerSettingsWidget::disableDecoElements(int mode)
 {
+	divemode_t rebreathermode = DivePlannerPointsModel::instance()->getRebreatherMode();
 	if (mode == RECREATIONAL) {
 		ui.label_gflow->setDisabled(false);
 		ui.label_gfhigh->setDisabled(false);
@@ -248,8 +249,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.sacfactor->blockSignals(false);
 		ui.problemsolvingtime->blockSignals(false);
 		ui.display_variations->setDisabled(true);
-	}
-	else if (mode == VPMB) {
+	} else if (mode == VPMB) {
 		ui.label_gflow->setDisabled(true);
 		ui.label_gfhigh->setDisabled(true);
 		ui.gflow->setDisabled(true);
@@ -266,7 +266,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 			ui.backgasBreaks->setChecked(false);
 			ui.backgasBreaks->blockSignals(false);
 		}
-		ui.bailout->setDisabled(!(displayed_dive.dc.divemode == CCR || displayed_dive.dc.divemode == PSCR));
+		ui.bailout->setDisabled(!(rebreathermode == CCR || rebreathermode == PSCR));
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -283,8 +283,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 		ui.sacfactor->setValue(PlannerShared::sacfactor());
 		ui.problemsolvingtime->setValue(prefs.problemsolvingtime);
 		ui.display_variations->setDisabled(false);
-	}
-	else if (mode == BUEHLMANN) {
+	} else if (mode == BUEHLMANN) {
 		ui.label_gflow->setDisabled(false);
 		ui.label_gfhigh->setDisabled(false);
 		ui.gflow->setDisabled(false);
@@ -301,7 +300,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode)
 			ui.backgasBreaks->setChecked(false);
 			ui.backgasBreaks->blockSignals(false);
 		}
-		ui.bailout->setDisabled(!(displayed_dive.dc.divemode == CCR || displayed_dive.dc.divemode == PSCR));
+		ui.bailout->setDisabled(!(rebreathermode == CCR || rebreathermode == PSCR));
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -560,6 +560,8 @@ void PlannerWidgets::planDive(dive *currentDive)
 		else	// No salinity means salt water
 			plannerWidget.setSalinity(SEAWATER_SALINITY);
 	}
+	GasSelectionModel::instance()->repopulate();
+	DiveTypeSelectionModel::instance()->repopulate();
 	plannerWidget.setReplanButton(false);
 
 	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));	// This will reload the profile!
@@ -570,6 +572,7 @@ void PlannerWidgets::replanDive(int currentDC)
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	DivePlannerPointsModel::instance()->loadFromDive(&displayed_dive, currentDC);
 
+	DiveTypeSelectionModel::instance()->repopulate();
 	plannerWidget.setReplanButton(true);
 	plannerWidget.setupStartTime(timestampToDateTime(displayed_dive.when));
 	if (displayed_dive.surface_pressure.mbar)

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -2,6 +2,7 @@
 #ifndef DIVEPLANNER_H
 #define DIVEPLANNER_H
 
+#include <memory>
 #include <QAbstractTableModel>
 #include <QAbstractButton>
 #include <QDateTime>
@@ -9,6 +10,9 @@
 class QListView;
 class QModelIndex;
 class DivePlannerPointsModel;
+class GasSelectionModel;
+class DiveTypeSelectionModel;
+class PlannerWidgets;
 struct dive;
 
 #include "ui_diveplanner.h"
@@ -16,7 +20,8 @@ struct dive;
 class DivePlannerWidget : public QWidget {
 	Q_OBJECT
 public:
-	explicit DivePlannerWidget(QWidget *parent = 0);
+	explicit DivePlannerWidget(PlannerWidgets *parent);
+	~DivePlannerWidget();
 	void setReplanButton(bool replan);
 public
 slots:
@@ -76,6 +81,7 @@ class PlannerWidgets : public QObject {
 	Q_OBJECT
 public:
 	PlannerWidgets();
+	~PlannerWidgets();
 	void planDive(dive *currentDive);
 	void replanDive(int currentDC);
 public
@@ -85,6 +91,8 @@ public:
 	DivePlannerWidget plannerWidget;
 	PlannerSettingsWidget plannerSettingsWidget;
 	PlannerDetails plannerDetails;
+	std::unique_ptr<GasSelectionModel> gasModel;
+	std::unique_ptr<DiveTypeSelectionModel> diveTypeModel;
 };
 
 #endif // DIVEPLANNER_H

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -9,6 +9,7 @@
 class QListView;
 class QModelIndex;
 class DivePlannerPointsModel;
+struct dive;
 
 #include "ui_diveplanner.h"
 
@@ -75,8 +76,8 @@ class PlannerWidgets : public QObject {
 	Q_OBJECT
 public:
 	PlannerWidgets();
-	void planDive();
-	void replanDive();
+	void planDive(dive *currentDive);
+	void replanDive(int currentDC);
 public
 slots:
 	void printDecoPlan();

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -2,6 +2,7 @@
 #ifndef DIVEPLANNER_H
 #define DIVEPLANNER_H
 
+#include "core/divemode.h"
 #include "core/owning_ptrs.h"
 
 #include <QAbstractTableModel>
@@ -43,13 +44,13 @@ private:
 class PlannerSettingsWidget : public QWidget {
 	Q_OBJECT
 public:
-	explicit PlannerSettingsWidget(QWidget *parent = 0);
+	explicit PlannerSettingsWidget(PlannerWidgets *parent);
 	~PlannerSettingsWidget();
 public
 slots:
 	void settingsChanged();
 	void setBackgasBreaks(bool dobreaks);
-	void disableDecoElements(int mode);
+	void disableDecoElements(int mode, divemode_t rebreathermode);
 	void disableBackgasBreaks(bool enabled);
 	void setDiveMode(int mode);
 	void setBailoutVisibility(int mode);
@@ -86,6 +87,7 @@ public:
 	void prepareReplanDive(const dive *d); // Make a copy of the dive to be replanned
 	void replanDive(int currentDC);
 	struct dive *getDive() const;
+	divemode_t getRebreatherMode() const;
 public
 slots:
 	void printDecoPlan();

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -2,13 +2,12 @@
 #ifndef DIVEPLANNER_H
 #define DIVEPLANNER_H
 
-#include <memory>
+#include "core/owning_ptrs.h"
+
 #include <QAbstractTableModel>
 #include <QAbstractButton>
 #include <QDateTime>
 
-class QListView;
-class QModelIndex;
 class DivePlannerPointsModel;
 class GasSelectionModel;
 class DiveTypeSelectionModel;
@@ -20,7 +19,7 @@ struct dive;
 class DivePlannerWidget : public QWidget {
 	Q_OBJECT
 public:
-	explicit DivePlannerWidget(PlannerWidgets *parent);
+	explicit DivePlannerWidget(dive &planned_dive, PlannerWidgets *parent);
 	~DivePlannerWidget();
 	void setReplanButton(bool replan);
 public
@@ -82,12 +81,17 @@ class PlannerWidgets : public QObject {
 public:
 	PlannerWidgets();
 	~PlannerWidgets();
-	void planDive(dive *currentDive);
+	void preparePlanDive(const dive *currentDive); // Create a new planned dive
+	void planDive();
+	void prepareReplanDive(const dive *d); // Make a copy of the dive to be replanned
 	void replanDive(int currentDC);
+	struct dive *getDive() const;
 public
 slots:
 	void printDecoPlan();
 public:
+	void repopulateGasModel();
+	OwningDivePtr planned_dive;
 	DivePlannerWidget plannerWidget;
 	PlannerSettingsWidget plannerSettingsWidget;
 	PlannerDetails plannerDetails;

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -14,6 +14,7 @@
 #include "desktop-widgets/modeldelegates.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "core/taxonomy.h"
+#include "core/selection.h"
 #include "core/settings/qPrefUnit.h"
 #include "commands/command.h"
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -337,9 +337,6 @@ void MainWindow::divesSelected(const std::vector<dive *> &selection, dive *curre
 	if (currentDive)
 		enableDisableOtherDCsActions();
 	profile->plotCurrentDive();
-#ifdef MAP_SUPPORT
-	MapWidget::instance()->selectionChanged();
-#endif
 }
 
 void MainWindow::on_actionNew_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -549,7 +549,7 @@ void MainWindow::on_actionPrint_triggered()
 {
 #ifndef NO_PRINTING
 	// When in planner, only print the planned dive.
-	dive *singleDive = appState == ApplicationState::PlanDive ? &displayed_dive
+	dive *singleDive = appState == ApplicationState::PlanDive ? plannerWidgets->getDive()
 								  : nullptr;
 	PrintDialog dlg(singleDive, this);
 
@@ -636,8 +636,6 @@ bool MainWindow::plannerStateClean()
 
 void MainWindow::planCanceled()
 {
-	// while planning we might have modified the displayed_dive
-	// let's refresh what's shown on the profile
 	showProfile();
 	refreshDisplay();
 }
@@ -665,8 +663,8 @@ void MainWindow::on_actionReplanDive_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	disableShortcuts(true);
-	copy_dive(current_dive, &displayed_dive); // Planning works on a copy of the dive (for now).
-	profile->setPlanState(&displayed_dive, profile->dc);
+	plannerWidgets->prepareReplanDive(current_dive);
+	profile->setPlanState(plannerWidgets->getDive(), profile->dc);
 	plannerWidgets->replanDive(profile->dc);
 }
 
@@ -679,8 +677,9 @@ void MainWindow::on_actionDivePlanner_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	disableShortcuts(true);
-	profile->setPlanState(&displayed_dive, 0);
-	plannerWidgets->planDive(current_dive);
+	plannerWidgets->preparePlanDive(current_dive);
+	profile->setPlanState(plannerWidgets->getDive(), 0);
+	plannerWidgets->planDive();
 }
 
 void MainWindow::on_actionAddDive_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -548,8 +548,10 @@ void MainWindow::updateLastUsedDir(const QString &dir)
 void MainWindow::on_actionPrint_triggered()
 {
 #ifndef NO_PRINTING
-	bool in_planner = inPlanner();
-	PrintDialog dlg(in_planner, this);
+	// When in planner, only print the planned dive.
+	dive *singleDive = appState == ApplicationState::PlanDive ? &displayed_dive
+								  : nullptr;
+	PrintDialog dlg(singleDive, this);
 
 	dlg.exec();
 #endif

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -333,7 +333,7 @@ void MainWindow::updateAutogroup()
 
 void MainWindow::divesSelected(const std::vector<dive *> &selection, dive *currentDive, int currentDC)
 {
-	mainTab->updateDiveInfo();
+	mainTab->updateDiveInfo(selection, currentDive, currentDC);
 	if (currentDive)
 		enableDisableOtherDCsActions();
 	profile->plotCurrentDive();
@@ -827,7 +827,8 @@ void MainWindow::on_actionPreviousDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + nrdc - 1) % nrdc;
 	profile->plotCurrentDive();
-	mainTab->updateDiveInfo();
+	// TODO: remove
+	mainTab->updateDiveInfo(getDiveSelection(), current_dive, dc_number);
 }
 
 void MainWindow::on_actionNextDC_triggered()
@@ -835,7 +836,8 @@ void MainWindow::on_actionNextDC_triggered()
 	unsigned nrdc = number_of_computers(current_dive);
 	dc_number = (dc_number + 1) % nrdc;
 	profile->plotCurrentDive();
-	mainTab->updateDiveInfo();
+	// TODO: remove
+	mainTab->updateDiveInfo(getDiveSelection(), current_dive, dc_number);
 }
 
 void MainWindow::on_actionFullScreen_triggered(bool checked)

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -664,8 +664,9 @@ void MainWindow::on_actionReplanDive_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	disableShortcuts(true);
-	profile->setPlanState(&displayed_dive, 0);
-	plannerWidgets->replanDive();
+	copy_dive(current_dive, &displayed_dive); // Planning works on a copy of the dive (for now).
+	profile->setPlanState(&displayed_dive, dc_number);
+	plannerWidgets->replanDive(dc_number);
 }
 
 void MainWindow::on_actionDivePlanner_triggered()
@@ -678,7 +679,7 @@ void MainWindow::on_actionDivePlanner_triggered()
 
 	disableShortcuts(true);
 	profile->setPlanState(&displayed_dive, 0);
-	plannerWidgets->planDive();
+	plannerWidgets->planDive(current_dive);
 }
 
 void MainWindow::on_actionAddDive_triggered()

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -151,8 +151,6 @@ MainWindow::MainWindow() :
 								    { diveList.get(), FLAG_NONE }, { mapWidget.get(), FLAG_NONE } });
 	registerApplicationState(ApplicationState::PlanDive, { false, { &plannerWidgets->plannerWidget, FLAG_NONE },         { profile.get(), FLAG_NONE },
 								      { &plannerWidgets->plannerSettingsWidget, FLAG_NONE }, { &plannerWidgets->plannerDetails, FLAG_NONE } });
-	registerApplicationState(ApplicationState::EditPlannedDive, { true, { &plannerWidgets->plannerWidget, FLAG_NONE }, { profile.get(), FLAG_NONE },
-									    { diveList.get(), FLAG_NONE },                 { mapWidget.get(), FLAG_NONE } });
 	registerApplicationState(ApplicationState::EditDiveSite, { false, { diveSiteEdit.get(), FLAG_NONE }, { profile.get(), FLAG_DISABLED },
 									  { diveList.get(), FLAG_DISABLED }, { mapWidget.get(), FLAG_NONE } });
 	registerApplicationState(ApplicationState::FilterDive, { true, { mainTab.get(), FLAG_NONE },  { profile.get(), FLAG_NONE },
@@ -550,7 +548,7 @@ void MainWindow::updateLastUsedDir(const QString &dir)
 void MainWindow::on_actionPrint_triggered()
 {
 #ifndef NO_PRINTING
-	bool in_planner = appState == ApplicationState::PlanDive || appState == ApplicationState::EditPlannedDive;
+	bool in_planner = inPlanner();
 	PrintDialog dlg(in_planner, this);
 
 	dlg.exec();

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -28,6 +28,7 @@
 #include "core/import-csv.h"
 #include "core/planner.h"
 #include "core/qthelper.h"
+#include "core/selection.h"
 #include "core/subsurface-string.h"
 #include "core/trip.h"
 #include "core/version.h"

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -176,7 +176,7 @@ MainWindow::MainWindow() :
 	if (!QIcon::hasThemeIcon("window-close")) {
 		QIcon::setThemeName("subsurface");
 	}
-	connect(diveList.get(), &DiveListView::divesSelected, this, &MainWindow::selectionChanged);
+	connect(diveList.get(), &DiveListView::divesSelected, this, &MainWindow::divesSelected);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainWindow::readSettings);
 	for (int i = 0; i < NUM_RECENT_FILES; i++) {
 		actionsRecent[i] = new QAction(this);
@@ -331,10 +331,10 @@ void MainWindow::updateAutogroup()
 	ui.actionAutoGroup->setChecked(divelog.autogroup);
 }
 
-void MainWindow::selectionChanged()
+void MainWindow::divesSelected(const std::vector<dive *> &selection, dive *currentDive, int currentDC)
 {
 	mainTab->updateDiveInfo();
-	if (current_dive)
+	if (currentDive)
 		enableDisableOtherDCsActions();
 	profile->plotCurrentDive();
 #ifdef MAP_SUPPORT

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -129,7 +129,7 @@ slots:
 	void on_actionReplanDive_triggered();
 	void on_action_Check_for_Updates_triggered();
 
-	void selectionChanged();
+	void divesSelected(const std::vector<dive *> &selection, dive *currentDive, int currentDC);
 	void initialUiSetup();
 
 	void on_actionImportDiveLog_triggered();

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -56,7 +56,6 @@ public:
 	enum class ApplicationState {
 		Default,
 		PlanDive,
-		EditPlannedDive,
 		EditDiveSite,
 		FilterDive,
 		Statistics,

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -75,7 +75,6 @@ public:
 	void enterPreviousState();
 	NotificationWidget *getNotificationWidget();
 	void enableDisableCloudActions();
-	void enableDisableOtherDCsActions();
 	void editDiveSite(dive_site *ds);
 	void setEnabledToolbar(bool arg1);
 

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -83,12 +83,6 @@ void MapWidget::setSelected(const QVector<dive_site *> &divesites)
 {
 	CHECK_IS_READY_RETURN_VOID();
 	m_mapHelper->setSelected(divesites);
-}
-
-void MapWidget::selectionChanged()
-{
-	CHECK_IS_READY_RETURN_VOID();
-	m_mapHelper->selectionChanged();
 	m_mapHelper->centerOnSelectedDiveSite();
 }
 

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -103,7 +103,7 @@ void MapWidget::selectedDivesChanged(const QList<int> &list)
 		if (dive *d = get_dive(idx))
 			selection.push_back(d);
 	}
-	setSelection(selection, current_dive);
+	setSelection(selection, current_dive, -1);
 }
 
 void MapWidget::coordinatesChanged(struct dive_site *ds, const location_t &location)

--- a/desktop-widgets/mapwidget.h
+++ b/desktop-widgets/mapwidget.h
@@ -23,7 +23,6 @@ public:
 
 	static MapWidget *instance();
 	void reload();
-	void selectionChanged();
 	void setSelected(const QVector<dive_site *> &divesites);
 	bool editMode() const;
 

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -250,27 +250,24 @@ void TankInfoDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHin
 		mymodel->setData(IDX(CylindersModel::TYPE), currCombo.activeText, CylindersModel::COMMIT_ROLE);
 }
 
-TankUseDelegate::TankUseDelegate(QObject *parent) : QStyledItemDelegate(parent)
+TankUseDelegate::TankUseDelegate(QObject *parent) : QStyledItemDelegate(parent), currentdc(nullptr)
 {
+}
+
+void TankUseDelegate::setCurrentDC(divecomputer *dc)
+{
+	currentdc = dc;
 }
 
 QWidget *TankUseDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &) const
 {
-	struct divecomputer *currentDc;
-	if (DivePlannerPointsModel::instance()->currentMode() != DivePlannerPointsModel::NOTHING) {
-		currentDc = &displayed_dive.dc;
-	} else {
-		currentDc = get_dive_dc(current_dive, dc_number);
-	}
 	QComboBox *comboBox = new QComboBox(parent);
-	if (!currentDc) {
+	if (!currentdc)
 		return comboBox;
-	}
-	bool isCcrDive = currentDc->divemode == CCR;
+	bool isCcrDive = currentdc->divemode == CCR;
 	for (int i = 0; i < NUM_GAS_USE; i++) {
-		if (isCcrDive || (i != DILUENT && i != OXYGEN)) {
+		if (isCcrDive || (i != DILUENT && i != OXYGEN))
 			comboBox->addItem(gettextFromC::tr(cylinderuse_text[i]));
-		}
 	}
 	return comboBox;
 }
@@ -288,16 +285,23 @@ void TankUseDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, c
 	model->setData(index, cylinderuse_from_text(qPrintable(comboBox->currentText())));
 }
 
-
-SensorDelegate::SensorDelegate(QObject *parent) : QStyledItemDelegate(parent)
+SensorDelegate::SensorDelegate(QObject *parent) : QStyledItemDelegate(parent), currentdc(nullptr)
 {
+}
+
+void SensorDelegate::setCurrentDC(divecomputer *dc)
+{
+	currentdc = dc;
 }
 
 QWidget *SensorDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
 	QComboBox *comboBox = new QComboBox(parent);
+
+	if (!currentdc)
+		return comboBox;
+
 	std::vector<int16_t> sensors;
-	const struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
 	for (int i = 0; i < currentdc->samples; ++i) {
 		auto &sample = currentdc->sample[i];
 		for (int s = 0; s < MAX_SENSORS; ++s) {

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -369,7 +369,7 @@ void AirTypesDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, 
 	model->setData(index, QVariant(combo->currentIndex()));
 }
 
-AirTypesDelegate::AirTypesDelegate(QObject *parent) : ComboBoxDelegate(GasSelectionModel::instance(), parent, false)
+AirTypesDelegate::AirTypesDelegate(QAbstractItemModel *model, QObject *parent) : ComboBoxDelegate(model, parent, false)
 {
 }
 
@@ -385,7 +385,7 @@ void DiveTypesDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
 	model->setData(index, QVariant(combo->currentIndex()));
 }
 
-DiveTypesDelegate::DiveTypesDelegate(QObject *parent) : ComboBoxDelegate(DiveTypeSelectionModel::instance(), parent, false)
+DiveTypesDelegate::DiveTypesDelegate(QAbstractItemModel *model, QObject *parent) : ComboBoxDelegate(model, parent, false)
 {
 }
 

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -17,6 +17,7 @@
 #include "qt-models/divelocationmodel.h"
 #include "core/qthelper.h"
 #include "core/divesite.h"
+#include "core/selection.h"
 #include "desktop-widgets/simplewidgets.h"
 
 #include <QCompleter>

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -12,10 +12,7 @@ struct divecomputer;
 
 class DiveListDelegate : public QStyledItemDelegate {
 public:
-	explicit DiveListDelegate(QObject *parent = 0)
-	    : QStyledItemDelegate(parent)
-	{
-	}
+	using QStyledItemDelegate::QStyledItemDelegate;
 	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
 };
 

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -106,7 +106,7 @@ private:
 class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
-	explicit AirTypesDelegate(QObject *parent = 0);
+	explicit AirTypesDelegate(QAbstractItemModel *model, QObject *parent = 0);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
@@ -115,7 +115,7 @@ private:
 class DiveTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
-	explicit DiveTypesDelegate(QObject *parent = 0);
+	explicit DiveTypesDelegate(QAbstractItemModel *model, QObject *parent = 0);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -6,7 +6,9 @@
 
 #include <QStyledItemDelegate>
 #include <QComboBox>
+
 class QPainter;
+struct divecomputer;
 
 class DiveListDelegate : public QStyledItemDelegate {
 public:
@@ -73,19 +75,23 @@ class TankUseDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit TankUseDelegate(QObject *parent = 0);
+	void setCurrentDC(divecomputer *dc);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+	divecomputer *currentdc;
 };
 
 class SensorDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
 	explicit SensorDelegate(QObject *parent = 0);
+	void setCurrentDC(divecomputer *dc);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	divecomputer *currentdc;
 };
 
 class WSInfoDelegate : public ComboBoxDelegate {

--- a/desktop-widgets/printdialog.cpp
+++ b/desktop-widgets/printdialog.cpp
@@ -19,9 +19,9 @@
 
 template_options::color_palette_struct ssrf_colors, almond_colors, blueshades_colors, custom_colors;
 
-PrintDialog::PrintDialog(bool inPlanner, QWidget *parent) :
+PrintDialog::PrintDialog(dive *singleDive, QWidget *parent) :
 	QDialog(parent, QFlag(0)),
-	inPlanner(inPlanner),
+	singleDive(singleDive),
 	printer(NULL),
 	qprinter(NULL)
 {
@@ -179,7 +179,7 @@ void PrintDialog::createPrinterObj()
 		qprinter = new QPrinter;
 		qprinter->setResolution(printOptions.resolution);
 		qprinter->setOrientation((QPrinter::Orientation)printOptions.landscape);
-		printer = new Printer(qprinter, printOptions, templateOptions, Printer::PRINT, inPlanner);
+		printer = new Printer(qprinter, printOptions, templateOptions, Printer::PRINT, singleDive);
 	}
 }
 

--- a/desktop-widgets/printdialog.h
+++ b/desktop-widgets/printdialog.h
@@ -7,6 +7,7 @@
 #include "templateedit.h"
 #include "printoptions.h"
 
+struct dive;
 class Printer;
 class QPrinter;
 class QProgressBar;
@@ -18,11 +19,12 @@ class PrintDialog : public QDialog {
 	Q_OBJECT
 
 public:
-	explicit PrintDialog(bool inPlanner, QWidget *parent = 0);
+	// If singleDive is non-null, print only that single dive
+	explicit PrintDialog(dive *singleDive, QWidget *parent = 0);
 	~PrintDialog();
 
 private:
-	bool inPlanner;
+	dive *singleDive;
 	PrintOptions *optionsWidget;
 	QProgressBar *progressBar;
 	Printer *printer;

--- a/desktop-widgets/printer.h
+++ b/desktop-widgets/printer.h
@@ -5,6 +5,7 @@
 #include "printoptions.h"
 #include "templateedit.h"
 
+struct dive;
 class ProfileScene;
 class QPainter;
 class QPaintDevice;
@@ -27,10 +28,11 @@ private:
 	const template_options &templateOptions;
 	QSize pageSize;
 	PrintMode printMode;
-	bool inPlanner;
+	struct dive *singleDive;
 	int done;
 	void render(int Pages);
 	void flowRender();
+	std::vector<dive *> getDives() const;
 	void putProfileImage(const QRect &box, const QRect &viewPort, QPainter *painter,
 			     struct dive *dive, ProfileScene *profile);
 
@@ -38,7 +40,9 @@ private slots:
 	void templateProgessUpdated(int value);
 
 public:
-	Printer(QPaintDevice *paintDevice, const print_options &printOptions, const template_options &templateOptions, PrintMode printMode, bool inPlanner);
+	// If singleDive is non-null, then only print this particular dive.
+	Printer(QPaintDevice *paintDevice, const print_options &printOptions, const template_options &templateOptions,
+		PrintMode printMode, dive *singleDive);
 	~Printer();
 	void print();
 	void previewOnePage();

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -297,7 +297,7 @@ void ProfileWidget::stopAdded()
 		return;
 	calcDepth(*editedDive, editedDc);
 	Setter s(placingCommand, true);
-	Command::editProfile(editedDive.get(), Command::EditProfileType::ADD, 0);
+	Command::editProfile(editedDive.get(), editedDc, Command::EditProfileType::ADD, 0);
 }
 
 void ProfileWidget::stopRemoved(int count)
@@ -306,7 +306,7 @@ void ProfileWidget::stopRemoved(int count)
 		return;
 	calcDepth(*editedDive, editedDc);
 	Setter s(placingCommand, true);
-	Command::editProfile(editedDive.get(), Command::EditProfileType::REMOVE, count);
+	Command::editProfile(editedDive.get(), editedDc, Command::EditProfileType::REMOVE, count);
 }
 
 void ProfileWidget::stopMoved(int count)
@@ -315,5 +315,5 @@ void ProfileWidget::stopMoved(int count)
 		return;
 	calcDepth(*editedDive, editedDc);
 	Setter s(placingCommand, true);
-	Command::editProfile(editedDive.get(), Command::EditProfileType::MOVE, count);
+	Command::editProfile(editedDive.get(), editedDc, Command::EditProfileType::MOVE, count);
 }

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -226,7 +226,7 @@ void ProfileWidget::divesChanged(const QVector<dive *> &dives, DiveField field)
 	if (editedDive) {
 		copy_dive(current_dive, editedDive.get());
 		// TODO: Holy moly that function sends too many signals. Fix it!
-		DivePlannerPointsModel::instance()->loadFromDive(editedDive.get());
+		DivePlannerPointsModel::instance()->loadFromDive(editedDive.get(), editedDc);
 	}
 
 	plotCurrentDive();
@@ -258,7 +258,7 @@ void ProfileWidget::editDive()
 	copy_dive(current_dive, editedDive.get()); // Work on a copy of the dive
 	originalDive = current_dive;
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::ADD);
-	DivePlannerPointsModel::instance()->loadFromDive(editedDive.get());
+	DivePlannerPointsModel::instance()->loadFromDive(editedDive.get(), editedDc);
 	view->setEditState(editedDive.get(), editedDc);
 }
 

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -4,6 +4,7 @@
 #include "profile-widget/profilewidget2.h"
 #include "commands/command.h"
 #include "core/color.h"
+#include "core/selection.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "core/settings/qPrefPartialPressureGas.h"
 #include "core/subsurface-string.h"

--- a/desktop-widgets/profilewidget.h
+++ b/desktop-widgets/profilewidget.h
@@ -23,9 +23,14 @@ public:
 	ProfileWidget();
 	~ProfileWidget();
 	std::unique_ptr<ProfileWidget2> view;
+	void plotDive(struct dive *d, int dc); // Attempt to keep DC number id dc < 0
 	void plotCurrentDive();
 	void setPlanState(const struct dive *d, int dc);
 	void setEnabledToolbar(bool enabled);
+	void nextDC();
+	void prevDC();
+	dive *d;
+	int dc;
 private
 slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
@@ -47,8 +52,9 @@ private:
 	void setDive(const struct dive *d);
 	void editDive();
 	void exitEditMode();
+	void rotateDC(int dir);
 	std::unique_ptr<dive, DiveDeleter> editedDive;
-	unsigned int editedDc;
+	int editedDc;
 	dive *originalDive;
 	bool placingCommand;
 };

--- a/desktop-widgets/profilewidget.h
+++ b/desktop-widgets/profilewidget.h
@@ -5,10 +5,10 @@
 #define PROFILEWIDGET_H
 
 #include "ui_profilewidget.h"
+#include "core/owning_ptrs.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 
 #include <vector>
-#include <memory>
 
 struct dive;
 class ProfileWidget2;
@@ -40,11 +40,6 @@ slots:
 	void stopRemoved(int count);
 	void stopMoved(int count);
 private:
-	// The same code is in command/command_base.h. Should we make that a global feature?
-	struct DiveDeleter {
-		void operator()(dive *d) { free_dive(d); }
-	};
-
 	std::unique_ptr<EmptyView> emptyView;
 	std::vector<QAction *> toolbarActions;
 	Ui::ProfileWidget ui;
@@ -53,7 +48,7 @@ private:
 	void editDive();
 	void exitEditMode();
 	void rotateDC(int dir);
-	std::unique_ptr<dive, DiveDeleter> editedDive;
+	OwningDivePtr editedDive;
 	int editedDc;
 	dive *originalDive;
 	bool placingCommand;

--- a/desktop-widgets/tab-widgets/TabBase.cpp
+++ b/desktop-widgets/tab-widgets/TabBase.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabBase.h"
 
+TabBase::TabBase(MainTab *parent) : parent(*parent)
+{
+}
+
 void TabBase::updateUi(QString)
 {
 }

--- a/desktop-widgets/tab-widgets/TabBase.h
+++ b/desktop-widgets/tab-widgets/TabBase.h
@@ -11,7 +11,7 @@ class TabBase : public QWidget {
 
 public:
 	using QWidget::QWidget;
-	virtual void updateData() = 0;
+	virtual void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) = 0;
 	virtual void clear() = 0;
 	virtual void updateUi(QString titleColor);
 };

--- a/desktop-widgets/tab-widgets/TabBase.h
+++ b/desktop-widgets/tab-widgets/TabBase.h
@@ -5,15 +5,18 @@
 #include <QWidget>
 
 struct dive;
+class MainTab;
 
 class TabBase : public QWidget {
 	Q_OBJECT
 
 public:
-	using QWidget::QWidget;
+	TabBase(MainTab *parent);
 	virtual void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) = 0;
 	virtual void clear() = 0;
 	virtual void updateUi(QString titleColor);
+protected:
+	MainTab &parent;
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -50,10 +50,10 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	connect(cylindersModel, &CylindersModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 	connect(weightModel, &WeightModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 
-	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
-	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, new TankUseDelegate(this));
-	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::SENSORS, new SensorDelegate(this));
-	ui.weights->view()->setItemDelegateForColumn(WeightModel::TYPE, new WSInfoDelegate(this));
+	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::TYPE, &tankInfoDelegate);
+	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, &tankUseDelegate);
+	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::SENSORS, &sensorDelegate);
+	ui.weights->view()->setItemDelegateForColumn(WeightModel::TYPE, &wsInfoDelegate);
 	ui.cylinders->view()->setColumnHidden(CylindersModel::DEPTH, true);
 	ui.cylinders->view()->setColumnHidden(CylindersModel::WORKINGPRESS_INT, true);
 	ui.cylinders->view()->setColumnHidden(CylindersModel::SIZE_INT, true);

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -28,7 +28,7 @@ static bool hiddenByDefault(int i)
 	return false;
 }
 
-TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
+TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	cylindersModel(new CylindersModel(false, true, this)),
 	weightModel(new WeightModel(this))
 {

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -137,13 +137,13 @@ void TabDiveEquipment::toggleTriggeredColumn()
 	}
 }
 
-void TabDiveEquipment::updateData()
+void TabDiveEquipment::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
-	cylindersModel->updateDive(current_dive, dc_number);
-	weightModel->updateDive(current_dive);
+	cylindersModel->updateDive(currentDive, currentDC);
+	weightModel->updateDive(currentDive);
 
-	if (current_dive && current_dive->suit)
-		ui.suit->setText(QString(current_dive->suit));
+	if (currentDive && currentDive->suit)
+		ui.suit->setText(QString(currentDive->suit));
 	else
 		ui.suit->clear();
 }

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -138,8 +138,12 @@ void TabDiveEquipment::toggleTriggeredColumn()
 
 void TabDiveEquipment::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
+	divecomputer *dc = get_dive_dc(currentDive, currentDC);
+
 	cylindersModel->updateDive(currentDive, currentDC);
 	weightModel->updateDive(currentDive);
+	sensorDelegate.setCurrentDC(dc);
+	tankUseDelegate.setCurrentDC(dc);
 
 	if (currentDive && currentDive->suit)
 		ui.suit->setText(QString(currentDive->suit));

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -114,12 +114,11 @@ TabDiveEquipment::~TabDiveEquipment()
 // Refresh the corresponding UI field.
 void TabDiveEquipment::divesChanged(const QVector<dive *> &dives, DiveField field)
 {
-	// If the current dive is not in list of changed dives, do nothing
-	if (!current_dive || !dives.contains(current_dive))
+	if (!parent.includesCurrentDive(dives))
 		return;
 
 	if (field.suit)
-		ui.suit->setText(QString(current_dive->suit));
+		ui.suit->setText(QString(parent.currentDive->suit));
 }
 
 void TabDiveEquipment::toggleTriggeredColumn()
@@ -209,7 +208,7 @@ void TabDiveEquipment::divesEdited(int i)
 
 void TabDiveEquipment::on_suit_editingFinished()
 {
-	if (!current_dive)
+	if (!parent.currentDive)
 		return;
 	divesEdited(Command::editSuit(ui.suit->text(), false));
 }

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -139,7 +139,7 @@ void TabDiveEquipment::toggleTriggeredColumn()
 
 void TabDiveEquipment::updateData()
 {
-	cylindersModel->updateDive(current_dive);
+	cylindersModel->updateDive(current_dive, dc_number);
 	weightModel->updateDive(current_dive);
 
 	if (current_dive && current_dive->suit)

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -17,7 +17,7 @@ class CylindersModel;
 class TabDiveEquipment : public TabBase {
 	Q_OBJECT
 public:
-	TabDiveEquipment(QWidget *parent = 0);
+	TabDiveEquipment(MainTab *parent);
 	~TabDiveEquipment();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -6,6 +6,7 @@
 #include "ui_TabDiveEquipment.h"
 #include "qt-models/completionmodels.h"
 #include "desktop-widgets/divelistview.h"
+#include "desktop-widgets/modeldelegates.h"
 
 namespace Ui {
 	class TabDiveEquipment;
@@ -38,6 +39,11 @@ private:
 	SuitCompletionModel suitModel;
 	CylindersModel *cylindersModel;
 	WeightModel *weightModel;
+
+	TankInfoDelegate tankInfoDelegate;
+	TankUseDelegate tankUseDelegate;
+	SensorDelegate sensorDelegate;
+	WSInfoDelegate wsInfoDelegate;
 };
 
 #endif // TAB_DIVE_EQUIPMENT_H

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -19,7 +19,7 @@ class TabDiveEquipment : public TabBase {
 public:
 	TabDiveEquipment(QWidget *parent = 0);
 	~TabDiveEquipment();
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 	void closeWarning();
 

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -19,9 +19,9 @@ TabDiveExtraInfo::~TabDiveExtraInfo()
 	delete ui;
 }
 
-void TabDiveExtraInfo::updateData()
+void TabDiveExtraInfo::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
-	const struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
+	const struct divecomputer *currentdc = get_dive_dc(currentDive, currentDC);
 	if (currentdc)
 		extraDataModel->updateDiveComputer(currentdc);
 }

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -5,7 +5,7 @@
 #include "core/selection.h"
 #include "qt-models/divecomputerextradatamodel.h"
 
-TabDiveExtraInfo::TabDiveExtraInfo(QWidget *parent) :
+TabDiveExtraInfo::TabDiveExtraInfo(MainTab *parent) :
 	TabBase(parent),
 	ui(new Ui::TabDiveExtraInfo()),
 	extraDataModel(new ExtraDataModel(this))

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -2,6 +2,7 @@
 #include "TabDiveExtraInfo.h"
 #include "ui_TabDiveExtraInfo.h"
 #include "core/dive.h"
+#include "core/selection.h"
 #include "qt-models/divecomputerextradatamodel.h"
 
 TabDiveExtraInfo::TabDiveExtraInfo(QWidget *parent) :

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
@@ -15,7 +15,7 @@ class TabDiveExtraInfo : public TabBase {
 public:
 	TabDiveExtraInfo(QWidget *parent = 0);
 	~TabDiveExtraInfo();
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 private:
 	Ui::TabDiveExtraInfo *ui;

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
@@ -13,7 +13,7 @@ class ExtraDataModel;
 class TabDiveExtraInfo : public TabBase {
 	Q_OBJECT
 public:
-	TabDiveExtraInfo(QWidget *parent = 0);
+	TabDiveExtraInfo(MainTab *parent);
 	~TabDiveExtraInfo();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -9,6 +9,7 @@
 #include "core/units.h"
 #include "core/dive.h"
 #include "core/qthelper.h"
+#include "core/selection.h"
 #include "core/statistics.h"
 #include "core/divelist.h"
 

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -203,23 +203,18 @@ void TabDiveInformation::showCurrentWidget(bool show, int position)
 	ui->diveInfoScrollAreaLayout->addWidget(ui->groupBox_current, 6, position, 1, 1);
 }
 
-void TabDiveInformation::updateData()
+void TabDiveInformation::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
-	if (!current_dive) {
-		clear();
-		return;
-	}
-
 	int salinity_value;
-	manualDive = is_manually_added_dc(&current_dive->dc);
+	manualDive = is_manually_added_dc(&currentDive->dc);
 	updateWaterTypeWidget();
 	updateProfile();
 	updateWhen();
-	ui->watertemp->setText(get_temperature_string(current_dive->watertemp, true));
-	ui->airtemp->setText(get_temperature_string(current_dive->airtemp, true));
+	ui->watertemp->setText(get_temperature_string(currentDive->watertemp, true));
+	ui->airtemp->setText(get_temperature_string(currentDive->airtemp, true));
 	ui->atmPressType->setItemText(1, get_depth_unit());  // Check for changes in depth unit (imperial/metric)
 	ui->atmPressType->setCurrentIndex(0);                // Set the atmospheric pressure combo box to mbar
-	salinity_value = get_dive_salinity(current_dive);
+	salinity_value = get_dive_salinity(currentDive);
 	if (salinity_value) {			// Set water type indicator (EN13319 = 1.020 g/l)
 		if (prefs.salinityEditDefault) {   //If edit-salinity is enabled then set correct water type in combobox:
 			ui->waterTypeCombo->setCurrentIndex(updateSalinityComboIndex(salinity_value));
@@ -234,12 +229,12 @@ void TabDiveInformation::updateData()
 	}
 	checkDcSalinityOverWritten();  // If exclamation is needed (i.e. salinity overwrite by user), then show it
 
-	updateMode(current_dive);
-	ui->visibility->setCurrentStars(current_dive->visibility);
-	ui->wavesize->setCurrentStars(current_dive->wavesize);
-	ui->current->setCurrentStars(current_dive->current);
-	ui->surge->setCurrentStars(current_dive->surge);
-	ui->chill->setCurrentStars(current_dive->chill);
+	updateMode(currentDive);
+	ui->visibility->setCurrentStars(currentDive->visibility);
+	ui->wavesize->setCurrentStars(currentDive->wavesize);
+	ui->current->setCurrentStars(currentDive->current);
+	ui->surge->setCurrentStars(currentDive->surge);
+	ui->chill->setCurrentStars(currentDive->chill);
 	if (prefs.extraEnvironmentalDefault)
 		showCurrentWidget(true, 2);   // Show current star widget at 3rd position
 	else

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -16,7 +16,7 @@
 #define COMBO_CHANGED 0
 #define TEXT_EDITED 1
 
-TabDiveInformation::TabDiveInformation(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveInformation())
+TabDiveInformation::TabDiveInformation(MainTab *parent) : TabBase(parent), ui(new Ui::TabDiveInformation())
 {
 	ui->setupUi(this);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveInformation::divesChanged);

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveInformation.h"
+#include "maintab.h"
 #include "ui_TabDiveInformation.h"
-#include "desktop-widgets/mainwindow.h" // TODO: Only used temporarilly for edit mode changes
 #include "profile-widget/profilewidget2.h"
 #include "../tagwidget.h"
 #include "commands/command.h"
@@ -108,32 +108,33 @@ void TabDiveInformation::updateWaterTypeWidget()
 // Update fields that depend on the dive profile
 void TabDiveInformation::updateProfile()
 {
-	ui->maxcnsText->setText(QString("%L1\%").arg(current_dive->maxcns));
-	ui->otuText->setText(QString("%L1").arg(current_dive->otu));
-	ui->maximumDepthText->setText(get_depth_string(current_dive->maxdepth, true));
-	ui->averageDepthText->setText(get_depth_string(current_dive->meandepth, true));
+	dive *currentDive = parent.currentDive;
+	ui->maxcnsText->setText(QString("%L1\%").arg(currentDive->maxcns));
+	ui->otuText->setText(QString("%L1").arg(currentDive->otu));
+	ui->maximumDepthText->setText(get_depth_string(currentDive->maxdepth, true));
+	ui->averageDepthText->setText(get_depth_string(currentDive->meandepth, true));
 
-	volume_t *gases = get_gas_used(current_dive);
+	volume_t *gases = get_gas_used(currentDive);
 	QString volumes;
-	std::vector<int> mean(current_dive->cylinders.nr), duration(current_dive->cylinders.nr);
-	struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
-	if (currentdc && current_dive->cylinders.nr >= 0)
-		per_cylinder_mean_depth(current_dive, currentdc, mean.data(), duration.data());
+	std::vector<int> mean(currentDive->cylinders.nr), duration(currentDive->cylinders.nr);
+	struct divecomputer *currentdc = parent.getCurrentDC();
+	if (currentdc && currentDive->cylinders.nr >= 0)
+		per_cylinder_mean_depth(currentDive, currentdc, mean.data(), duration.data());
 	volume_t sac;
 	QString gaslist, SACs, separator;
 
-	for (int i = 0; i < current_dive->cylinders.nr; i++) {
-		if (!is_cylinder_used(current_dive, i))
+	for (int i = 0; i < currentDive->cylinders.nr; i++) {
+		if (!is_cylinder_used(currentDive, i))
 			continue;
 		gaslist.append(separator); volumes.append(separator); SACs.append(separator);
 		separator = "\n";
 
-		gaslist.append(gasname(get_cylinder(current_dive, i)->gasmix));
+		gaslist.append(gasname(get_cylinder(currentDive, i)->gasmix));
 		if (!gases[i].mliter)
 			continue;
 		volumes.append(get_volume_string(gases[i], true));
 		if (duration[i]) {
-			sac.mliter = lrint(gases[i].mliter / (depth_to_atm(mean[i], current_dive) * duration[i] / 60));
+			sac.mliter = lrint(gases[i].mliter / (depth_to_atm(mean[i], currentDive) * duration[i] / 60));
 			SACs.append(get_volume_string(sac, true).append(tr("/min")));
 		}
 	}
@@ -141,23 +142,23 @@ void TabDiveInformation::updateProfile()
 	ui->gasUsedText->setText(volumes);
 	ui->oxygenHeliumText->setText(gaslist);
 
-	ui->diveTimeText->setText(get_dive_duration_string(current_dive->duration.seconds, tr("h"), tr("min"), tr("sec"),
-			" ", current_dive->dc.divemode == FREEDIVE));
+	ui->diveTimeText->setText(get_dive_duration_string(currentDive->duration.seconds, tr("h"), tr("min"), tr("sec"),
+			" ", currentDive->dc.divemode == FREEDIVE));
 
-	ui->sacText->setText(current_dive->cylinders.nr > 0 && mean[0] && current_dive->dc.divemode != CCR ? SACs : QString());
+	ui->sacText->setText(currentDive->cylinders.nr > 0 && mean[0] && currentDive->dc.divemode != CCR ? SACs : QString());
 
-	if (current_dive->surface_pressure.mbar == 0) {
+	if (currentDive->surface_pressure.mbar == 0) {
 		ui->atmPressVal->clear();			// If no atm pressure for dive then clear text box
 	} else {
 		ui->atmPressVal->setEnabled(true);
-		ui->atmPressVal->setText(QString::number(current_dive->surface_pressure.mbar));		// else display atm pressure
+		ui->atmPressVal->setText(QString::number(currentDive->surface_pressure.mbar));		// else display atm pressure
 	}
 }
 
 // Update fields that depend on start of dive
 void TabDiveInformation::updateWhen()
 {
-	timestamp_t surface_interval = get_surface_interval(current_dive->when);
+	timestamp_t surface_interval = get_surface_interval(parent.currentDive->when);
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else
@@ -182,11 +183,11 @@ int TabDiveInformation::updateSalinityComboIndex(int salinity)
 // If dive->user_salinity != dive->salinity (i.e. dc value) then show the salinity-overwrite indicator
 void TabDiveInformation::checkDcSalinityOverWritten()
 {
-	const struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
-	if (!current_dive || !currentdc)
+	const struct divecomputer *currentdc = parent.getCurrentDC();
+	if (!currentdc)
 		return;
 	int dc_value = currentdc->salinity;
-	int user_value = current_dive->user_salinity;
+	int user_value = parent.currentDive->user_salinity;
 	bool show_indicator = false;
 	if (!manualDive && user_value != 0 && user_value != dc_value)
 		show_indicator = true;
@@ -229,7 +230,7 @@ void TabDiveInformation::updateData(const std::vector<dive *> &, dive *currentDi
 	}
 	checkDcSalinityOverWritten();  // If exclamation is needed (i.e. salinity overwrite by user), then show it
 
-	updateMode(currentDive);
+	updateMode();
 	ui->visibility->setCurrentStars(currentDive->visibility);
 	ui->wavesize->setCurrentStars(currentDive->wavesize);
 	ui->current->setCurrentStars(currentDive->current);
@@ -259,7 +260,7 @@ void TabDiveInformation::on_waterTypeCombo_activated(int index)
 {
 	Q_UNUSED(index)
 	int combobox_salinity = 0;
-	const struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
+	const struct divecomputer *currentdc = parent.getCurrentDC();
 	if (!currentdc)
 		return;
 	int dc_salinity = currentdc->salinity;
@@ -301,7 +302,7 @@ void TabDiveInformation::on_waterTypeCombo_activated(int index)
 void TabDiveInformation::cylinderChanged(dive *d)
 {
 	// If this isn't the current dive, do nothing
-	if (current_dive != d)
+	if (parent.currentDive != d)
 		return;
 	updateProfile();
 }
@@ -313,78 +314,81 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 	int salinity_value;
 
 	// If the current dive is not in list of changed dives, do nothing
-	if (!current_dive || !dives.contains(current_dive))
+	if (!parent.includesCurrentDive(dives))
 		return;
 
+	dive *currentDive = parent.currentDive;
 	if (field.visibility)
-		ui->visibility->setCurrentStars(current_dive->visibility);
+		ui->visibility->setCurrentStars(currentDive->visibility);
 	if (field.wavesize)
-		ui->wavesize->setCurrentStars(current_dive->wavesize);
+		ui->wavesize->setCurrentStars(currentDive->wavesize);
 	if (field.current)
-		ui->current->setCurrentStars(current_dive->current);
+		ui->current->setCurrentStars(currentDive->current);
 	if (field.surge)
-		ui->surge->setCurrentStars(current_dive->surge);
+		ui->surge->setCurrentStars(currentDive->surge);
 	if (field.chill)
-		ui->chill->setCurrentStars(current_dive->chill);
+		ui->chill->setCurrentStars(currentDive->chill);
 	if (field.mode)
-		updateMode(current_dive);
+		updateMode();
 	if (field.duration || field.depth || field.mode)
 		updateProfile();
 	if (field.air_temp)
-		ui->airtemp->setText(get_temperature_string(current_dive->airtemp, true));
+		ui->airtemp->setText(get_temperature_string(currentDive->airtemp, true));
 	if (field.water_temp)
-		ui->watertemp->setText(get_temperature_string(current_dive->watertemp, true));
+		ui->watertemp->setText(get_temperature_string(currentDive->watertemp, true));
 	if (field.atm_press)
-		ui->atmPressVal->setText(QString::number(current_dive->surface_pressure.mbar));
+		ui->atmPressVal->setText(QString::number(currentDive->surface_pressure.mbar));
 	if (field.salinity)
 		checkDcSalinityOverWritten();
-	if (current_dive->user_salinity)
-		salinity_value = current_dive->user_salinity;
+	if (currentDive->user_salinity)
+		salinity_value = currentDive->user_salinity;
 	else
-		salinity_value = current_dive->salinity;
+		salinity_value = currentDive->salinity;
 	ui->waterTypeCombo->setCurrentIndex(updateSalinityComboIndex(salinity_value));
 	ui->salinityText->setText(QString("%L1g/ℓ").arg(salinity_value / 10.0));
 }
 
 void TabDiveInformation::on_visibility_valueChanged(int value)
 {
-	if (current_dive)
+	if (parent.currentDive)
 		divesEdited(Command::editVisibility(value, false));
 }
 
 void TabDiveInformation::on_wavesize_valueChanged(int value)
 {
-	if (current_dive)
+	if (parent.currentDive)
 		divesEdited(Command::editWaveSize(value, false));
 }
 
 void TabDiveInformation::on_current_valueChanged(int value)
 {
-	if (current_dive)
+	if (parent.currentDive)
 		divesEdited(Command::editCurrent(value, false));
 }
 
 void TabDiveInformation::on_surge_valueChanged(int value)
 {
-	if (current_dive)
+	if (parent.currentDive)
 		divesEdited(Command::editSurge(value, false));
 }
 
 void TabDiveInformation::on_chill_valueChanged(int value)
 {
-	if (current_dive)
+	if (parent.currentDive)
 		divesEdited(Command::editChill(value, false));
 }
 
-void TabDiveInformation::updateMode(struct dive *d)
+void TabDiveInformation::updateMode()
 {
-	ui->diveType->setCurrentIndex(get_dive_dc(d, dc_number)->divemode);
+	divecomputer *currentDC = parent.getCurrentDC();
+	if (currentDC)
+		ui->diveType->setCurrentIndex(currentDC->divemode);
 }
 
 void TabDiveInformation::diveModeChanged(int index)
 {
-	if (current_dive)
-		divesEdited(Command::editMode(dc_number, (enum divemode_t)index, false));
+	if (parent.currentDive)
+		divesEdited(Command::editMode(parent.currentDC, (enum divemode_t)index, false));
 }
 
 void TabDiveInformation::on_airtemp_editingFinished()
@@ -392,7 +396,7 @@ void TabDiveInformation::on_airtemp_editingFinished()
 	// If the field wasn't modified by the user, don't post a new undo command.
 	// Owing to rounding errors, this might lead to undo commands that have
 	// no user visible effects. These can be very confusing.
-	if (ui->airtemp->isModified() && current_dive)
+	if (ui->airtemp->isModified() && parent.currentDive)
 		divesEdited(Command::editAirTemp(parseTemperatureToMkelvin(ui->airtemp->text()), false));
 }
 
@@ -401,7 +405,7 @@ void TabDiveInformation::on_watertemp_editingFinished()
 	// If the field wasn't modified by the user, don't post a new undo command.
 	// Owing to rounding errors, this might lead to undo commands that have
 	// no user visible effects. These can be very confusing.
-	if (ui->watertemp->isModified() && current_dive)
+	if (ui->watertemp->isModified() && parent.currentDive)
 		divesEdited(Command::editWaterTemp(parseTemperatureToMkelvin(ui->watertemp->text()), false));
 }
 
@@ -420,13 +424,14 @@ void TabDiveInformation::updateTextBox(int event) // Either the text box has bee
 {                                       // Either way this gets a numeric value and puts it on the text box atmPressVal,
 	pressure_t atmpress = { 0 };    // then stores it in dive->surface_pressure.The undo stack for the text box content is
 	double altitudeVal;             // maintained even though two independent events trigger saving the text box contents.
-	if (current_dive) {
+	dive *currentDive = parent.currentDive;
+	if (currentDive) {
 		switch (ui->atmPressType->currentIndex()) {
 		case 0:		// If atm pressure in mbar has been selected:
 			if (event == TEXT_EDITED)         // this is only triggered by on_atmPressVal_editingFinished()
 				atmpress.mbar = ui->atmPressVal->text().toInt();    // use the specified mbar pressure
 			else                              // if no pressure has been typed, then show existing dive pressure
-				ui->atmPressVal->setText(QString::number(current_dive->surface_pressure.mbar));
+				ui->atmPressVal->setText(QString::number(currentDive->surface_pressure.mbar));
 			break;
 		case 1:		// If an altitude has been specified:
 			if (event == TEXT_EDITED) {	// this is only triggered by on_atmPressVal_editingFinished()
@@ -451,7 +456,7 @@ void TabDiveInformation::updateTextBox(int event) // Either the text box has bee
 			}
 			break;
 		case 2:          // i.e. event = COMBO_CHANGED, that is, the option "Use dc" was selected from combobox
-			atmpress = calculate_surface_pressure(current_dive);	// re-calculate air pressure from dc data
+			atmpress = calculate_surface_pressure(currentDive);	// re-calculate air pressure from dc data
 			ui->atmPressVal->setText(QString::number(atmpress.mbar)); // display it in text box
 			ui->atmPressType->setCurrentIndex(0);          // reset combobox to mbar
 			break;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -12,7 +12,7 @@ namespace Ui {
 class TabDiveInformation : public TabBase {
 	Q_OBJECT
 public:
-	TabDiveInformation(QWidget *parent = 0);
+	TabDiveInformation(MainTab *parent);
 	~TabDiveInformation();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -14,7 +14,7 @@ class TabDiveInformation : public TabBase {
 public:
 	TabDiveInformation(QWidget *parent = 0);
 	~TabDiveInformation();
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 	void updateUi(QString titleColor) override;
 private slots:

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -41,7 +41,7 @@ private:
 	int pressTypeIndex;
 	void updateWaterTypeWidget();
 	void updateTextBox(int event);
-	void updateMode(struct dive *d);
+	void updateMode();
 	void divesEdited(int);
 	void closeWarning();
 	void showCurrentWidget(bool show, int position);

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -20,7 +20,7 @@ struct Completers {
 	QCompleter *tags;
 };
 
-TabDiveNotes::TabDiveNotes(QWidget *parent) : TabBase(parent),
+TabDiveNotes::TabDiveNotes(MainTab *parent) : TabBase(parent),
 	ignoreInput(false),
 	currentTrip(0)
 {

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveNotes.h"
+#include "maintab.h"
 #include "core/divesite.h"
 #include "core/qthelper.h"
 #include "core/selection.h"
@@ -97,35 +98,36 @@ void TabDiveNotes::closeWarning()
 void TabDiveNotes::divesChanged(const QVector<dive *> &dives, DiveField field)
 {
 	// If the current dive is not in list of changed dives, do nothing
-	if (!current_dive || !dives.contains(current_dive))
+	if (!parent.includesCurrentDive(dives))
 		return;
 
+	dive *currentDive = parent.currentDive;
 	if (field.duration)
-		ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
+		ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
 	if (field.depth)
-		ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
+		ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
 	if (field.rating)
-		ui.rating->setCurrentStars(current_dive->rating);
+		ui.rating->setCurrentStars(currentDive->rating);
 	if (field.notes)
-		updateNotes(current_dive);
+		updateNotes(currentDive);
 	if (field.datetime) {
-		updateDateTime(current_dive);
-		DivePlannerPointsModel::instance()->getDiveplan().when = current_dive->when;
+		updateDateTime(currentDive);
+		DivePlannerPointsModel::instance()->getDiveplan().when = currentDive->when;
 	}
 	if (field.divesite)
-		updateDiveSite(current_dive);
+		updateDiveSite(currentDive);
 	if (field.tags)
-		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
+		ui.tagWidget->setText(get_taglist_string(currentDive->tag_list));
 	if (field.buddy)
-		ui.buddy->setText(current_dive->buddy);
+		ui.buddy->setText(currentDive->buddy);
 	if (field.diveguide)
-		ui.diveguide->setText(current_dive->diveguide);
+		ui.diveguide->setText(currentDive->diveguide);
 }
 
 void TabDiveNotes::diveSiteEdited(dive_site *ds, int)
 {
-	if (current_dive && current_dive->dive_site == ds)
-		updateDiveSite(current_dive);
+	if (parent.currentDive && parent.currentDive->dive_site == ds)
+		updateDiveSite(parent.currentDive);
 }
 
 // This function gets called if a trip-field gets updated by an undo command.
@@ -303,7 +305,7 @@ void TabDiveNotes::divesEdited(int i)
 
 void TabDiveNotes::on_buddy_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	divesEdited(Command::editBuddies(stringToList(ui.buddy->toPlainText()), false));
@@ -311,7 +313,7 @@ void TabDiveNotes::on_buddy_editingFinished()
 
 void TabDiveNotes::on_diveguide_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	divesEdited(Command::editDiveGuide(stringToList(ui.diveguide->toPlainText()), false));
@@ -319,7 +321,7 @@ void TabDiveNotes::on_diveguide_editingFinished()
 
 void TabDiveNotes::on_duration_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	// Duration editing is special: we only edit the current dive.
@@ -328,7 +330,7 @@ void TabDiveNotes::on_duration_editingFinished()
 
 void TabDiveNotes::on_depth_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	// Depth editing is special: we only edit the current dive.
@@ -337,36 +339,36 @@ void TabDiveNotes::on_depth_editingFinished()
 
 // Editing of the dive time is different. If multiple dives are edited,
 // all dives are shifted by an offset.
-static void shiftTime(QDateTime &dateTime)
+static void shiftTime(QDateTime &dateTime, dive *currentDive)
 {
 	timestamp_t when = dateTimeToTimestamp(dateTime);
-	if (current_dive && current_dive->when != when) {
-		timestamp_t offset = when - current_dive->when;
+	if (currentDive->when != when) {
+		timestamp_t offset = when - currentDive->when;
 		Command::shiftTime(getDiveSelection(), (int)offset);
 	}
 }
 
 void TabDiveNotes::on_dateEdit_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
-	QDateTime dateTime = timestampToDateTime(current_dive->when);
+	QDateTime dateTime = timestampToDateTime(parent.currentDive->when);
 	dateTime.setDate(ui.dateEdit->date());
-	shiftTime(dateTime);
+	shiftTime(dateTime, parent.currentDive);
 }
 
 void TabDiveNotes::on_timeEdit_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
-	QDateTime dateTime = timestampToDateTime(current_dive->when);
+	QDateTime dateTime = timestampToDateTime(parent.currentDive->when);
 	dateTime.setTime(ui.timeEdit->time());
-	shiftTime(dateTime);
+	shiftTime(dateTime, parent.currentDive);
 }
 
 void TabDiveNotes::on_tagWidget_editingFinished()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	divesEdited(Command::editTags(ui.tagWidget->getBlockStringList(), false));
@@ -374,7 +376,7 @@ void TabDiveNotes::on_tagWidget_editingFinished()
 
 void TabDiveNotes::on_location_diveSiteSelected()
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	struct dive_site *newDs = ui.location->currDiveSite();
@@ -398,7 +400,7 @@ void TabDiveNotes::on_diveTripLocation_editingFinished()
 
 void TabDiveNotes::on_notes_editingFinished()
 {
-	if (!currentTrip && !current_dive)
+	if (!currentTrip && !parent.currentDive)
 		return;
 
 	QString html = ui.notes->toHtml();
@@ -412,7 +414,7 @@ void TabDiveNotes::on_notes_editingFinished()
 
 void TabDiveNotes::on_rating_valueChanged(int value)
 {
-	if (ignoreInput || !current_dive)
+	if (ignoreInput || !parent.currentDive)
 		return;
 
 	divesEdited(Command::editRating(value, false));

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -191,7 +191,7 @@ void TabDiveNotes::updateDiveSite(struct dive *d)
 		ui.locationTags->show();
 }
 
-void TabDiveNotes::updateData()
+void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
 	ui.location->refreshDiveSiteCache();
 
@@ -246,25 +246,25 @@ void TabDiveNotes::updateData()
 		ui.timeLabel->setVisible(true);
 		ui.timeEdit->setVisible(true);
 		/* and fill them from the dive */
-		ui.rating->setCurrentStars(current_dive->rating);
+		ui.rating->setCurrentStars(currentDive->rating);
 		// reset labels in case we last displayed trip notes
 		ui.LocationLabel->setText(tr("Location"));
 		ui.NotesLabel->setText(tr("Notes"));
-		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
-		bool isManual = is_manually_added_dc(&current_dive->dc);
+		ui.tagWidget->setText(get_taglist_string(currentDive->tag_list));
+		bool isManual = is_manually_added_dc(&currentDive->dc);
 		ui.depth->setVisible(isManual);
 		ui.depthLabel->setVisible(isManual);
 		ui.duration->setVisible(isManual);
 		ui.durationLabel->setVisible(isManual);
 
-		updateNotes(current_dive);
-		updateDiveSite(current_dive);
-		updateDateTime(current_dive);
-		ui.diveguide->setText(current_dive->diveguide);
-		ui.buddy->setText(current_dive->buddy);
+		updateNotes(currentDive);
+		updateDiveSite(currentDive);
+		updateDateTime(currentDive);
+		ui.diveguide->setText(currentDive->diveguide);
+		ui.buddy->setText(currentDive->buddy);
 	}
-	ui.duration->setText(render_seconds_to_string(current_dive->duration.seconds));
-	ui.depth->setText(get_depth_string(current_dive->maxdepth, true));
+	ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
+	ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
 
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 	/* unset the special value text for date and time, just in case someone dove at midnight */

--- a/desktop-widgets/tab-widgets/TabDiveNotes.h
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.h
@@ -17,7 +17,7 @@ class TabDiveNotes : public TabBase {
 	Q_OBJECT
 public:
 	TabDiveNotes(QWidget *parent = 0);
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 	void closeWarning();
 

--- a/desktop-widgets/tab-widgets/TabDiveNotes.h
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.h
@@ -16,7 +16,7 @@ class DivePictureModel;
 class TabDiveNotes : public TabBase {
 	Q_OBJECT
 public:
-	TabDiveNotes(QWidget *parent = 0);
+	TabDiveNotes(MainTab *parent);
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 	void closeWarning();

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -48,7 +48,8 @@ TabDivePhotos::~TabDivePhotos()
 
 void TabDivePhotos::clear()
 {
-	updateData();
+	// TODO: clear model
+	divePictureModel->updateDivePictures();
 }
 
 void TabDivePhotos::contextMenuEvent(QContextMenuEvent *event)
@@ -159,8 +160,9 @@ void TabDivePhotos::removeAllPhotos()
 	}
 }
 
-void TabDivePhotos::updateData()
+void TabDivePhotos::updateData(const std::vector<dive *> &, dive *currentDive, int)
 {
+	// TODO: pass dive
 	divePictureModel->updateDivePictures();
 }
 

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDivePhotos.h"
+#include "maintab.h"
 #include "ui_TabDivePhotos.h"
 #include "core/imagedownloader.h"
 
@@ -113,7 +114,7 @@ void TabDivePhotos::recalculateSelectedThumbnails()
 
 void TabDivePhotos::saveSubtitles()
 {
-	if (!current_dive)
+	if (!parent.currentDive)
 		return;
 	if (!ui->photosView->selectionModel()->hasSelection())
 		return;
@@ -131,7 +132,7 @@ void TabDivePhotos::saveSubtitles()
 				if (!duration)
 					continue;
 				struct membufferpp b;
-				save_subtitles_buffer(&b, current_dive, offset, duration);
+				save_subtitles_buffer(&b, parent.currentDive, offset, duration);
 				const char *data = mb_cstring(&b);
 				subtitlefile.open(QIODevice::WriteOnly);
 				subtitlefile.write(data, strlen(data));

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -19,7 +19,7 @@
 #include "../mainwindow.h"
 #include "../divelistview.h"
 
-TabDivePhotos::TabDivePhotos(QWidget *parent)
+TabDivePhotos::TabDivePhotos(MainTab *parent)
 	: TabBase(parent),
 	ui(new Ui::TabDivePhotos()),
 	divePictureModel(DivePictureModel::instance())

--- a/desktop-widgets/tab-widgets/TabDivePhotos.cpp
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.cpp
@@ -11,8 +11,9 @@
 #include <QUrl>
 #include <QMessageBox>
 #include <QFileInfo>
-#include "core/save-profiledata.h"
 #include "core/membuffer.h"
+#include "core/save-profiledata.h"
+#include "core/selection.h"
 
 //TODO: Remove those in the future.
 #include "../mainwindow.h"

--- a/desktop-widgets/tab-widgets/TabDivePhotos.h
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.h
@@ -13,7 +13,7 @@ class DivePictureModel;
 class TabDivePhotos : public TabBase {
 	Q_OBJECT
 public:
-	TabDivePhotos(QWidget *parent = 0);
+	TabDivePhotos(MainTab *parent);
 	~TabDivePhotos();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;

--- a/desktop-widgets/tab-widgets/TabDivePhotos.h
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.h
@@ -15,7 +15,7 @@ class TabDivePhotos : public TabBase {
 public:
 	TabDivePhotos(QWidget *parent = 0);
 	~TabDivePhotos();
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 
 protected:

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -59,7 +59,7 @@ void TabDiveStatistics::divesChanged(const QVector<dive *> &dives, DiveField fie
 
 	// TODO: make this more fine grained. Currently, the core can only calculate *all* statistics.
 	if (field.duration || field.depth || field.mode || field.air_temp || field.water_temp)
-		updateData();
+		updateData(getDiveSelection(), current_dive, dc_number); // TODO: remember these data
 }
 
 void TabDiveStatistics::cylinderChanged(dive *d)
@@ -67,10 +67,10 @@ void TabDiveStatistics::cylinderChanged(dive *d)
 	// If the changed dive is not selected, do nothing
 	if (!d->selected)
 		return;
-	updateData();
+	updateData(getDiveSelection(), current_dive, dc_number); // TODO: remember these data
 }
 
-void TabDiveStatistics::updateData()
+void TabDiveStatistics::updateData(const std::vector<dive *> &, dive *currentDive, int)
 {
 	stats_t stats_selection;
 	calculate_stats_selected(&stats_selection);
@@ -109,7 +109,7 @@ void TabDiveStatistics::updateData()
 	}
 
 
-	bool is_freedive = current_dive && current_dive->dc.divemode == FREEDIVE;
+	bool is_freedive = currentDive && currentDive->dc.divemode == FREEDIVE;
 	ui->divesAllText->setText(QString::number(stats_selection.selection_size));
 	ui->totalTimeAllText->setText(get_dive_duration_string(stats_selection.total_time.seconds, tr("h"), tr("min"), tr("sec"), " ", is_freedive));
 

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveStatistics.h"
+#include "maintab.h"
 #include "ui_TabDiveStatistics.h"
 
 #include "core/qthelper.h"
@@ -29,9 +30,8 @@ TabDiveStatistics::TabDiveStatistics(MainTab *parent) : TabBase(parent), ui(new 
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &TabDiveStatistics::cylinderChanged);
 
 	const auto l = findChildren<QLabel *>(QString(), Qt::FindDirectChildrenOnly);
-	for (QLabel *label: l) {
+	for (QLabel *label: l)
 		label->setAlignment(Qt::AlignHCenter);
-	}
 }
 
 TabDiveStatistics::~TabDiveStatistics()
@@ -59,7 +59,7 @@ void TabDiveStatistics::divesChanged(const QVector<dive *> &dives, DiveField fie
 
 	// TODO: make this more fine grained. Currently, the core can only calculate *all* statistics.
 	if (field.duration || field.depth || field.mode || field.air_temp || field.water_temp)
-		updateData(getDiveSelection(), current_dive, dc_number); // TODO: remember these data
+		updateData(getDiveSelection(), parent.currentDive, parent.currentDC); // TODO: remember dive selection
 }
 
 void TabDiveStatistics::cylinderChanged(dive *d)
@@ -67,7 +67,7 @@ void TabDiveStatistics::cylinderChanged(dive *d)
 	// If the changed dive is not selected, do nothing
 	if (!d->selected)
 		return;
-	updateData(getDiveSelection(), current_dive, dc_number); // TODO: remember these data
+	updateData(getDiveSelection(), parent.currentDive, parent.currentDC); // TODO: remember dive selection
 }
 
 void TabDiveStatistics::updateData(const std::vector<dive *> &, dive *currentDive, int)

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -8,7 +8,7 @@
 #include <QLabel>
 #include <QIcon>
 
-TabDiveStatistics::TabDiveStatistics(QWidget *parent) : TabBase(parent), ui(new Ui::TabDiveStatistics())
+TabDiveStatistics::TabDiveStatistics(MainTab *parent) : TabBase(parent), ui(new Ui::TabDiveStatistics())
 {
 	ui->setupUi(this);
 	ui->sacLimits->overrideMaxToolTipText(tr("Highest total SAC of a dive"));

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.h
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.h
@@ -12,7 +12,7 @@ namespace Ui {
 class TabDiveStatistics : public TabBase {
 	Q_OBJECT
 public:
-	TabDiveStatistics(QWidget *parent = 0);
+	TabDiveStatistics(MainTab *parent);
 	~TabDiveStatistics();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.h
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.h
@@ -14,7 +14,7 @@ class TabDiveStatistics : public TabBase {
 public:
 	TabDiveStatistics(QWidget *parent = 0);
 	~TabDiveStatistics();
-	void updateData() override;
+	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
 
 private slots:

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -49,7 +49,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	// call colorsChanged() for the initial setup now that the extraWidgets are loaded
 	colorsChanged();
 
-	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainTab::updateDiveInfo);
+	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainTab::settingsChanged);
 
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::Key_Escape), this);
 	connect(closeKey, &QShortcut::activated, this, &MainTab::escDetected);
@@ -70,7 +70,13 @@ void MainTab::nextInputField(QKeyEvent *event)
 	keyPressEvent(event);
 }
 
-void MainTab::updateDiveInfo()
+void MainTab::settingsChanged()
+{
+	// TODO: remember these
+	updateDiveInfo(getDiveSelection(), current_dive, dc_number);
+}
+
+void MainTab::updateDiveInfo(const std::vector<dive *> &selection, dive *currentDive, int currentDC)
 {
 	// don't execute this while planning a dive
 	if (DivePlannerPointsModel::instance()->isPlanner())
@@ -81,9 +87,9 @@ void MainTab::updateDiveInfo()
 	for (TabBase *widget: extraWidgets)
 		widget->setEnabled(enabled);
 
-	if (current_dive) {
+	if (currentDive) {
 		for (TabBase *widget: extraWidgets)
-			widget->updateData();
+			widget->updateData(selection, currentDive, currentDC);
 		if (single_selected_trip()) {
 			// Remember the tab selected for last dive but only if we're not on the dive site tab
 			if (lastSelectedDive)

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -26,6 +26,7 @@ static bool paletteIsDark(const QPalette &p)
 }
 
 MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
+	currentDive(nullptr),
 	lastSelectedDive(true),
 	lastTabSelectedDive(0),
 	lastTabSelectedDiveTrip(0)
@@ -73,11 +74,16 @@ void MainTab::nextInputField(QKeyEvent *event)
 void MainTab::settingsChanged()
 {
 	// TODO: remember these
-	updateDiveInfo(getDiveSelection(), current_dive, dc_number);
+	updateDiveInfo(getDiveSelection(), currentDive, currentDC);
 }
 
-void MainTab::updateDiveInfo(const std::vector<dive *> &selection, dive *currentDive, int currentDC)
+void MainTab::updateDiveInfo(const std::vector<dive *> &selection, dive *currentDiveIn, int currentDCIn)
 {
+	// Remember current dive and divecomputer. This is needed to refresh the
+	// display, for example when the settings change.
+	currentDive = currentDiveIn;
+	currentDC = currentDCIn;
+
 	// don't execute this while planning a dive
 	if (DivePlannerPointsModel::instance()->isPlanner())
 		return;
@@ -171,4 +177,16 @@ void MainTab::colorsChanged()
 	// finally call the individual updateUi() functions so they can overwrite these style sheets
 	for (TabBase *widget: extraWidgets)
 		widget->updateUi(colorText);
+}
+
+// Called when dives changed. Checks whether the currently displayed
+// dive is affected by the change.
+bool MainTab::includesCurrentDive(const QVector<dive *> &dives) const
+{
+	return currentDive && dives.contains(currentDive);
+}
+
+divecomputer *MainTab::getCurrentDC() const
+{
+	return get_dive_dc(currentDive, currentDC);
 }

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -24,7 +24,9 @@ public:
 
 public
 slots:
-	void updateDiveInfo();
+	// Always called with non-null currentDive
+	void updateDiveInfo(const std::vector<dive *> &selection, dive *currentDive, int currentDC);
+	void settingsChanged();
 	void escDetected();
 	void colorsChanged();
 private:

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -21,7 +21,11 @@ public:
 	void clearTabs();
 	void nextInputField(QKeyEvent *event);
 	void stealFocus();
+	bool includesCurrentDive(const QVector<dive *> &dives) const;
+	divecomputer *getCurrentDC() const;
 
+	dive *currentDive;
+	int currentDC;
 public
 slots:
 	// Always called with non-null currentDive

--- a/desktop-widgets/templateedit.cpp
+++ b/desktop-widgets/templateedit.cpp
@@ -59,7 +59,7 @@ void TemplateEdit::updatePreview()
 	int height = ui->label->height();
 	QPixmap map(width * 2, height * 2);
 	map.fill(QColor::fromRgb(255, 255, 255));
-	Printer printer(&map, printOptions, newTemplateOptions, Printer::PREVIEW, false);
+	Printer printer(&map, printOptions, newTemplateOptions, Printer::PREVIEW, nullptr);
 	printer.previewOnePage();
 	ui->label->setPixmap(map.scaled(width, height, Qt::IgnoreAspectRatio));
 

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -95,24 +95,14 @@ TemplateLayout::TemplateLayout(const print_options &printOptions, const template
 {
 }
 
-QString TemplateLayout::generate(bool in_planner)
+QString TemplateLayout::generate(const std::vector<dive *> &dives)
 {
 	QString htmlContent;
 
 	State state;
 
-	if (in_planner) {
-		state.dives.append(&displayed_dive);
-	} else {
-		int i;
-		struct dive *dive;
-		for_each_dive (i, dive) {
-			//TODO check for exporting selected dives only
-			if (!dive->selected && printOptions.print_selected)
-				continue;
-			state.dives.append(dive);
-		}
-	}
+	for (dive *d: dives)
+		state.dives.append(d);
 
 	QString templateContents = readTemplate(printOptions.p_template);
 	numDives = state.dives.size();

--- a/desktop-widgets/templatelayout.h
+++ b/desktop-widgets/templatelayout.h
@@ -27,7 +27,7 @@ class TemplateLayout : public QObject {
 	Q_OBJECT
 public:
 	TemplateLayout(const print_options &printOptions, const template_options &templateOptions);
-	QString generate(bool in_planner);
+	QString generate(const std::vector<dive *> &dives);
 	QString generateStatistics();
 	static QString readTemplate(QString template_name);
 	static void writeTemplate(QString template_name, QString grantlee_template);

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -49,6 +49,8 @@ void MapWidgetHelper::centerOnDiveSite(struct dive_site *ds)
 void MapWidgetHelper::setSelected(const QVector<dive_site *> &divesites)
 {
 	m_mapLocationModel->setSelected(divesites);
+	m_mapLocationModel->selectionChanged();
+	updateEditMode();
 }
 
 void MapWidgetHelper::centerOnSelectedDiveSite()
@@ -116,12 +118,6 @@ void MapWidgetHelper::reloadMapLocations()
 {
 	updateEditMode();
 	m_mapLocationModel->reload(m_map);
-}
-
-void MapWidgetHelper::selectionChanged()
-{
-	updateEditMode();
-	m_mapLocationModel->selectionChanged();
 }
 
 void MapWidgetHelper::selectedLocationChanged(struct dive_site *ds_in)

--- a/map-widget/qmlmapwidgethelper.h
+++ b/map-widget/qmlmapwidgethelper.h
@@ -36,7 +36,6 @@ public:
 	Q_INVOKABLE void updateCurrentDiveSiteCoordinatesFromMap(struct dive_site *ds, QGeoCoordinate coord);
 	Q_INVOKABLE void selectVisibleLocations();
 	Q_INVOKABLE void selectedLocationChanged(struct dive_site *ds);
-	void selectionChanged();
 	void setSelected(const QVector<dive_site *> &divesites);
 	QString pluginObject();
 	bool editMode() const;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -897,7 +897,7 @@ void QMLManager::refreshDiveList()
 // The following structure describes such a change caused by a dive edit.
 // Hopefully, we can remove this in due course by using finer-grained undo-commands.
 struct DiveSiteChange {
-	Command::OwningDiveSitePtr createdDs; // not-null if we created a dive site.
+	OwningDiveSitePtr createdDs; // not-null if we created a dive site.
 
 	dive_site *editDs = nullptr; // not-null if we are supposed to edit an existing dive site.
 	location_t location = zero_location; // new value of the location if we edit an existing dive site.
@@ -1181,7 +1181,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 				      QStringLiteral("state   :'%1'\n").arg(state);
 	}
 
-	Command::OwningDivePtr d_ptr(alloc_dive()); // Automatically delete dive if we exit early!
+	OwningDivePtr d_ptr(alloc_dive()); // Automatically delete dive if we exit early!
 	dive *d = d_ptr.get();
 	copy_dive(orig, d);
 

--- a/profile-widget/qmlprofile.cpp
+++ b/profile-widget/qmlprofile.cpp
@@ -5,6 +5,7 @@
 #include "core/errorhelper.h"
 #include "core/subsurface-float.h"
 #include "core/metrics.h"
+#include "core/subsurface-string.h"
 #include <QTransform>
 #include <QScreen>
 #include <QElapsedTimer>

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -241,7 +241,8 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 		case SIZE_INT:
 			return static_cast<int>(cyl->type.size.mliter);
 		case SENSORS: {
-			const struct divecomputer *currentdc = get_dive_dc(current_dive, dc_number);
+			std::vector<int16_t> sensors;
+			const struct divecomputer *currentdc = get_dive_dc(d, dcNr);
 			for (int i = 0; i < currentdc->samples; ++i) {
 				auto &sample = currentdc->sample[i];
 				for (int s = 0; s < MAX_SENSORS; ++s) {
@@ -475,7 +476,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		bool ok = false;
 		int s = vString.toInt(&ok);
 		if (ok) {
-			Command::editSensors(index.row(), s, dc_number);
+			Command::editSensors(index.row(), s, dcNr);
 			// We don't use the edit cylinder command and editing sensors is not relevant for planner
 			return true;
 		}
@@ -521,10 +522,11 @@ void CylindersModel::clear()
 {
 	beginResetModel();
 	d = nullptr;
+	dcNr = -1;
 	endResetModel();
 }
 
-void CylindersModel::updateDive(dive *dIn)
+void CylindersModel::updateDive(dive *dIn, int dcNrIn)
 {
 #ifdef DEBUG_CYL
 	if (d)
@@ -532,6 +534,7 @@ void CylindersModel::updateDive(dive *dIn)
 #endif
 	beginResetModel();
 	d = dIn;
+	dcNr = dcNrIn;
 	numRows = calcNumRows();
 	endResetModel();
 }

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -475,7 +475,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		bool ok = false;
 		int s = vString.toInt(&ok);
 		if (ok) {
-			Command::editSensors(index.row(), s);
+			Command::editSensors(index.row(), s, dc_number);
 			// We don't use the edit cylinder command and editing sensors is not relevant for planner
 			return true;
 		}

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -8,6 +8,7 @@
 #include "qt-models/diveplannermodel.h"
 #include "core/gettextfromc.h"
 #include "core/sample.h"
+#include "core/selection.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "core/subsurface-string.h"
 #include <string>

--- a/qt-models/cylindermodel.h
+++ b/qt-models/cylindermodel.h
@@ -44,7 +44,7 @@ public:
 
 	void add();
 	void clear();
-	void updateDive(dive *d);
+	void updateDive(dive *d, int dcNr);
 	void updateDecoDepths(pressure_t olddecopo2);
 	void updateTrashIcon();
 	void moveAtFirst(int cylid);
@@ -65,6 +65,7 @@ slots:
 
 private:
 	dive *d;
+	int dcNr;
 	bool inPlanner;
 	bool hideUnused;
 	int numRows; // Does not include unused cylinders at the end

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -544,7 +544,7 @@ void DivePlannerPointsModel::setRebreatherMode(int mode)
 
 divemode_t DivePlannerPointsModel::getRebreatherMode() const
 {
-	return d->dc.divemode;
+	return d ? d->dc.divemode : OC;
 }
 
 void DivePlannerPointsModel::setVpmbConservatism(int level)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -545,6 +545,11 @@ void DivePlannerPointsModel::setRebreatherMode(int mode)
 	emitDataChanged();
 }
 
+divemode_t DivePlannerPointsModel::getRebreatherMode() const
+{
+	return d->dc.divemode;
+}
+
 void DivePlannerPointsModel::setVpmbConservatism(int level)
 {
 	if (diveplan.vpmb_conservatism != level) {

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -542,11 +542,6 @@ void DivePlannerPointsModel::setRebreatherMode(int mode)
 	emitDataChanged();
 }
 
-divemode_t DivePlannerPointsModel::getRebreatherMode() const
-{
-	return d ? d->dc.divemode : OC;
-}
-
 void DivePlannerPointsModel::setVpmbConservatism(int level)
 {
 	if (diveplan.vpmb_conservatism != level) {

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -11,6 +11,7 @@
 #include "core/qthelper.h"
 #include "core/range.h"
 #include "core/sample.h"
+#include "core/selection.h"
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/settings/qPrefUnit.h"
 #if !defined(SUBSURFACE_TESTING)

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -105,9 +105,10 @@ void DivePlannerPointsModel::setupStartTime()
 	}
 }
 
-void DivePlannerPointsModel::loadFromDive(dive *dIn)
+void DivePlannerPointsModel::loadFromDive(dive *dIn, int dcNrIn)
 {
 	d = dIn;
+	dcNr = dcNrIn;
 
 	int depthsum = 0;
 	int samplecount = 0;
@@ -115,7 +116,7 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 	struct divecomputer *dc = &(d->dc);
 	const struct event *evd = NULL;
 	enum divemode_t current_divemode = UNDEF_COMP_TYPE;
-	cylinders.updateDive(d);
+	cylinders.updateDive(d, dcNr);
 	duration_t lasttime = { 0 };
 	duration_t lastrecordedtime = {};
 	duration_t newtime = {};
@@ -197,7 +198,7 @@ void DivePlannerPointsModel::setupCylinders()
 		reset_cylinders(d, true);
 
 		if (d->cylinders.nr > 0) {
-			cylinders.updateDive(d);
+			cylinders.updateDive(d, dcNr);
 			return;		// We have at least one cylinder
 		}
 	}
@@ -215,7 +216,7 @@ void DivePlannerPointsModel::setupCylinders()
 		add_cylinder(&d->cylinders, 0, cyl);
 	}
 	reset_cylinders(d, false);
-	cylinders.updateDive(d);
+	cylinders.updateDive(d, dcNr);
 }
 
 // Update the dive's maximum depth.  Returns true if max. depth changed

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -5,8 +5,8 @@
 #include "core/divelog.h"
 #include "core/subsurface-string.h"
 #include "qt-models/cylindermodel.h"
+#include "qt-models/models.h" // For defaultModelFont().
 #include "core/planner.h"
-#include "qt-models/models.h"
 #include "core/device.h"
 #include "core/qthelper.h"
 #include "core/range.h"
@@ -87,8 +87,6 @@ void DivePlannerPointsModel::createSimpleDive(struct dive *dIn)
 		addStop(M_OR_FT(5, 15), 45 * 60, 0, cylinderid, true, UNDEF_COMP_TYPE);
 	}
 	updateDiveProfile();
-	GasSelectionModel::instance()->repopulate();
-	DiveTypeSelectionModel::instance()->repopulate();
 }
 
 void DivePlannerPointsModel::setupStartTime()
@@ -179,7 +177,6 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn, int dcNrIn)
 	current_divemode = get_current_divemode(dc, d->dc.duration.seconds, &evd, &current_divemode);
 	if (!hasMarkedSamples && !dc->last_manual_time.seconds)
 		addStop(0, d->dc.duration.seconds,cylinderid, last_sp.mbar, true, current_divemode);
-	DiveTypeSelectionModel::instance()->repopulate();
 	preserved_until = d->duration;
 
 	updateDiveProfile();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -63,7 +63,6 @@ public:
 
 	void loadFromDive(dive *d, int dcNr);
 	void addStop(int millimeters, int seconds);
-	divemode_t getRebreatherMode() const;
 public
 slots:
 	void addDefaultStop();

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -60,7 +60,7 @@ public:
 	struct diveplan &getDiveplan();
 	struct deco_state final_deco_state;
 
-	void loadFromDive(dive *d);
+	void loadFromDive(dive *d, int dcNr);
 	void addStop(int millimeters, int seconds);
 public
 slots:
@@ -132,6 +132,7 @@ private:
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
 	struct dive *d;
+	int dcNr;
 	CylindersModel cylinders;
 	Mode mode;
 	QVector<divedatapoint> divepoints;

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "core/deco.h"
+#include "core/divemode.h"
 #include "core/planner.h"
 #include "qt-models/cylindermodel.h"
 
@@ -62,6 +63,7 @@ public:
 
 	void loadFromDive(dive *d, int dcNr);
 	void addStop(int millimeters, int seconds);
+	divemode_t getRebreatherMode() const;
 public
 slots:
 	void addDefaultStop();

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -682,7 +682,7 @@ DiveTripModelTree::DiveTripModelTree(QObject *parent) : DiveTripModelBase(parent
 	connect(&diveListNotifier, &DiveListNotifier::diveSiteChanged, this, &DiveTripModelTree::diveSiteChanged);
 	connect(&diveListNotifier, &DiveListNotifier::divesMovedBetweenTrips, this, &DiveTripModelTree::divesMovedBetweenTrips);
 	connect(&diveListNotifier, &DiveListNotifier::divesTimeChanged, this, &DiveTripModelTree::divesTimeChanged);
-	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelTree::divesSelected);
+	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelTree::divesSelectedSlot);
 	connect(&diveListNotifier, &DiveListNotifier::tripSelected, this, &DiveTripModelTree::tripSelected);
 	connect(&diveListNotifier, &DiveListNotifier::tripChanged, this, &DiveTripModelTree::tripChanged);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelTree::filterReset);
@@ -1370,7 +1370,7 @@ QModelIndex DiveTripModelTree::diveToIdx(const dive *d) const
 	}
 }
 
-void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
+void DiveTripModelTree::divesSelectedSlot(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
 
@@ -1382,7 +1382,7 @@ void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *curr
 	processByTrip(dives, [this, &indices] (dive_trip *trip, const QVector<dive *> &divesInTrip)
 		      { divesSelectedTrip(trip, divesInTrip, indices); });
 
-	emit selectionChanged(indices, diveToIdx(currentDive), currentDC);
+	emit divesSelected(indices, diveToIdx(currentDive), currentDC);
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
 	currentChanged(currentDive);
@@ -1463,7 +1463,7 @@ DiveTripModelList::DiveTripModelList(QObject *parent) : DiveTripModelBase(parent
 	// Does nothing in list-view
 	//connect(&diveListNotifier, &DiveListNotifier::divesMovedBetweenTrips, this, &DiveTripModelList::divesMovedBetweenTrips);
 	connect(&diveListNotifier, &DiveListNotifier::divesTimeChanged, this, &DiveTripModelList::divesTimeChanged);
-	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelList::divesSelected);
+	connect(&diveListNotifier, &DiveListNotifier::divesSelected, this, &DiveTripModelList::divesSelectedSlot);
 	connect(&diveListNotifier, &DiveListNotifier::tripSelected, this, &DiveTripModelList::tripSelected);
 	connect(&diveListNotifier, &DiveListNotifier::filterReset, this, &DiveTripModelList::filterReset);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderAdded, this, &DiveTripModelList::diveChanged);
@@ -1659,7 +1659,7 @@ QModelIndex DiveTripModelList::diveToIdx(const dive *d) const
 	return createIndex(it - items.begin(), 0);
 }
 
-void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
+void DiveTripModelList::divesSelectedSlot(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
 {
 	QVector<dive *> dives = visibleDives(divesIn);
 
@@ -1679,7 +1679,7 @@ void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *curr
 		indices.append(createIndex(j, 0, noParent));
 	}
 
-	emit selectionChanged(indices, diveToIdx(currentDive), currentDC);
+	emit divesSelected(indices, diveToIdx(currentDive), currentDC);
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
 	currentChanged(currentDive);
@@ -1697,7 +1697,7 @@ void DiveTripModelList::tripSelected(dive_trip *trip, dive *currentDive)
 	for (int i = 0; i < trip->dives.nr; ++i)
 		dives.push_back(trip->dives.dives[i]);
 
-	divesSelected(dives, currentDive, -1);
+	divesSelectedSlot(dives, currentDive, -1);
 }
 
 // Simple sorting helper for sorting against a criterium and if

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -530,7 +530,7 @@ static ShownChange updateShownAll()
 	return res;
 }
 
-void DiveTripModelBase::currentChanged()
+void DiveTripModelBase::currentChanged(dive *currentDive)
 {
 	// On Desktop we use a signal to forward current-dive changed, on mobile we use ROLE_CURRENT.
 	// TODO: Unify - use the role for both.
@@ -540,21 +540,12 @@ void DiveTripModelBase::currentChanged()
 		QModelIndex oldIdx = diveToIdx(oldCurrent);
 		dataChanged(oldIdx, oldIdx, roles);
 	}
-	if (current_dive && oldCurrent != current_dive) {
-		QModelIndex newIdx = diveToIdx(current_dive);
+	if (currentDive && oldCurrent != currentDive) {
+		QModelIndex newIdx = diveToIdx(currentDive);
 		dataChanged(newIdx, newIdx, roles);
 	}
-#else
-	if (oldCurrent == current_dive)
-		return;
-	if (current_dive) {
-		QModelIndex newIdx = diveToIdx(current_dive);
-		emit currentDiveChanged(newIdx);
-	} else {
-		emit currentDiveChanged(QModelIndex());
-	}
 #endif
-	oldCurrent = current_dive;
+	oldCurrent = currentDive;
 }
 
 // Find a range of matching elements in a vector.
@@ -1378,7 +1369,7 @@ QModelIndex DiveTripModelTree::diveToIdx(const dive *d) const
 	}
 }
 
-void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn)
+void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *currentDive)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
 
@@ -1390,10 +1381,10 @@ void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn)
 	processByTrip(dives, [this, &indices] (dive_trip *trip, const QVector<dive *> &divesInTrip)
 		      { divesSelectedTrip(trip, divesInTrip, indices); });
 
-	emit selectionChanged(indices);
+	emit selectionChanged(indices, diveToIdx(currentDive));
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
-	currentChanged();
+	currentChanged(currentDive);
 }
 
 void DiveTripModelTree::divesSelectedTrip(dive_trip *trip, const QVector<dive *> &dives, QVector<QModelIndex> &indices)
@@ -1648,7 +1639,7 @@ QModelIndex DiveTripModelList::diveToIdx(const dive *d) const
 	return createIndex(it - items.begin(), 0);
 }
 
-void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn)
+void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *currentDive)
 {
 	QVector<dive *> dives = visibleDives(divesIn);
 
@@ -1668,10 +1659,10 @@ void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn)
 		indices.append(createIndex(j, 0, noParent));
 	}
 
-	emit selectionChanged(indices);
+	emit selectionChanged(indices, diveToIdx(currentDive));
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
-	currentChanged();
+	currentChanged(currentDive);
 }
 
 // Simple sorting helper for sorting against a criterium and if

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -466,7 +466,7 @@ void DiveTripModelBase::initSelection()
 {
 	std::vector<dive *> dives = getDiveSelection();
 	if (!dives.empty())
-		setSelection(dives, current_dive);
+		setSelection(dives, current_dive, -1);
 	else
 		select_newest_visible_dive();
 }

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1370,7 +1370,7 @@ QModelIndex DiveTripModelTree::diveToIdx(const dive *d) const
 	}
 }
 
-void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *currentDive)
+void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
 
@@ -1382,7 +1382,7 @@ void DiveTripModelTree::divesSelected(const QVector<dive *> &divesIn, dive *curr
 	processByTrip(dives, [this, &indices] (dive_trip *trip, const QVector<dive *> &divesInTrip)
 		      { divesSelectedTrip(trip, divesInTrip, indices); });
 
-	emit selectionChanged(indices, diveToIdx(currentDive));
+	emit selectionChanged(indices, diveToIdx(currentDive), currentDC);
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
 	currentChanged(currentDive);
@@ -1659,7 +1659,7 @@ QModelIndex DiveTripModelList::diveToIdx(const dive *d) const
 	return createIndex(it - items.begin(), 0);
 }
 
-void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *currentDive)
+void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *currentDive, int currentDC)
 {
 	QVector<dive *> dives = visibleDives(divesIn);
 
@@ -1679,7 +1679,7 @@ void DiveTripModelList::divesSelected(const QVector<dive *> &divesIn, dive *curr
 		indices.append(createIndex(j, 0, noParent));
 	}
 
-	emit selectionChanged(indices, diveToIdx(currentDive));
+	emit selectionChanged(indices, diveToIdx(currentDive), currentDC);
 
 	// The current dive has changed. Transform the current dive into an index and pass it on to the view.
 	currentChanged(currentDive);
@@ -1697,7 +1697,7 @@ void DiveTripModelList::tripSelected(dive_trip *trip, dive *currentDive)
 	for (int i = 0; i < trip->dives.nr; ++i)
 		dives.push_back(trip->dives.dives[i]);
 
-	divesSelected(dives, currentDive);
+	divesSelected(dives, currentDive, -1);
 }
 
 // Simple sorting helper for sorting against a criterium and if

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -84,8 +84,7 @@ signals:
 	// into QModelIndexes according to the current view (tree/list). Finally, the DiveListView transforms these
 	// indices into local indices according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
-	void selectionChanged(const QVector<QModelIndex> &indices);
-	void currentDiveChanged(QModelIndex index);
+	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
 protected:
 	dive *oldCurrent;
 	QBrush invalidForeground;
@@ -97,7 +96,7 @@ protected:
 	static QString tripTitle(const dive_trip *trip);
 	static QString tripShortDate(const dive_trip *trip);
 	static QString getDescription(int column);
-	void currentChanged();
+	void currentChanged(dive *currentDive);
 
 	virtual dive *diveOrNull(const QModelIndex &index) const = 0;	// Returns a dive if this index represents a dive, null otherwise
 	virtual void clearData() = 0;
@@ -116,7 +115,7 @@ public slots:
 	void divesChanged(const QVector<dive *> &dives);
 	void diveChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
 	void tripChanged(dive_trip *trip, TripField);
 	void filterReset();
 
@@ -194,7 +193,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives);
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
 	void filterReset();
 
 public:

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -84,7 +84,7 @@ signals:
 	// into QModelIndexes according to the current view (tree/list). Finally, the DiveListView transforms these
 	// indices into local indices according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
-	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 protected:
 	dive *oldCurrent;
@@ -116,7 +116,7 @@ public slots:
 	void divesChanged(const QVector<dive *> &dives);
 	void diveChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *currentDive, int currentDC);
+	void divesSelectedSlot(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 	void tripChanged(dive_trip *trip, TripField);
 	void filterReset();
@@ -195,7 +195,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *currentDive, int currentDC);
+	void divesSelectedSlot(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 	void filterReset();
 

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -85,6 +85,7 @@ signals:
 	// indices into local indices according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
 	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 protected:
 	dive *oldCurrent;
 	QBrush invalidForeground;
@@ -116,6 +117,7 @@ public slots:
 	void diveChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	void tripSelected(dive_trip *trip, dive *currentDive);
 	void tripChanged(dive_trip *trip, TripField);
 	void filterReset();
 
@@ -194,6 +196,7 @@ public slots:
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	void tripSelected(dive_trip *trip, dive *currentDive);
 	void filterReset();
 
 public:

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -79,12 +79,14 @@ protected slots:
 signals:
 	// The propagation of selection changes is complex.
 	// The control flow of programmatical dive-selection goes:
-	// Commands/DiveListNotifier ---(dive */dive_trip *)---> DiveTripModel ---(QModelIndex)---> DiveListView
+	// Commands/DiveListNotifier ---(dive */dive_trip *)---> DiveTripModel
+	//			     ---(QModelIndex)---> MultiFilterSortModel
+	//			     ---(QModelIndex)---> DiveListView
 	// i.e. The command objects send changes in terms of pointer-to-dives, which the DiveTripModel transforms
-	// into QModelIndexes according to the current view (tree/list). Finally, the DiveListView transforms these
-	// indices into local indices according to current sorting/filtering and instructs the QSelectionModel to
+	// into QModelIndexes according to the current view (tree/list). These are modified according to current
+	// filtering/sorting. Finally, the DiveListView instructs the QSelectionModel to
 	// perform the appropriate actions.
-	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC); // currentDC < 0 -> keep DC.
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 protected:
 	dive *oldCurrent;

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -78,13 +78,13 @@ protected slots:
 	void reset();
 signals:
 	// The propagation of selection changes is complex.
-	// The control flow of dive-selection goes:
+	// The control flow of programmatical dive-selection goes:
 	// Commands/DiveListNotifier ---(dive */dive_trip *)---> DiveTripModel ---(QModelIndex)---> DiveListView
 	// i.e. The command objects send changes in terms of pointer-to-dives, which the DiveTripModel transforms
 	// into QModelIndexes according to the current view (tree/list). Finally, the DiveListView transforms these
 	// indices into local indices according to current sorting/filtering and instructs the QSelectionModel to
 	// perform the appropriate actions.
-	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 protected:
 	dive *oldCurrent;
@@ -116,7 +116,7 @@ public slots:
 	void divesChanged(const QVector<dive *> &dives);
 	void diveChanged(dive *d);
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 	void tripChanged(dive_trip *trip, TripField);
 	void filterReset();
@@ -195,7 +195,7 @@ public slots:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
-	void divesSelected(const QVector<dive *> &dives, dive *currentDive);
+	void divesSelected(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 	void filterReset();
 

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -27,6 +27,7 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 
 	setSourceModel(model.get());
 	connect(model.get(), &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
+	connect(model.get(), &DiveTripModelBase::tripSelected, this, &MultiFilterSortModel::tripSelectedSlot);
 	model->initSelection();
 	LocationInformationModel::instance()->update();
 }
@@ -43,6 +44,16 @@ void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indi
 	}
 
 	emit selectionChanged(indicesLocal, mapFromSource(currentDive));
+}
+
+// Translate selection into local indices and re-emit signal
+void MultiFilterSortModel::tripSelectedSlot(QModelIndex trip, QModelIndex currentDive)
+{
+	QModelIndex local = mapFromSource(trip);
+	if (!local.isValid())
+		return;
+
+	emit tripSelected(local, mapFromSource(currentDive));
 }
 
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -27,13 +27,12 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 
 	setSourceModel(model.get());
 	connect(model.get(), &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
-	connect(model.get(), &DiveTripModelBase::currentDiveChanged, this, &MultiFilterSortModel::currentDiveChangedSlot);
 	model->initSelection();
 	LocationInformationModel::instance()->update();
 }
 
 // Translate selection into local indices and re-emit signal
-void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indices)
+void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive)
 {
 	QVector<QModelIndex> indicesLocal;
 	indicesLocal.reserve(indices.size());
@@ -42,15 +41,8 @@ void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indi
 		if (local.isValid())
 			indicesLocal.push_back(local);
 	}
-	emit selectionChanged(indicesLocal);
-}
 
-// Translate current dive into local indices and re-emit signal
-void MultiFilterSortModel::currentDiveChangedSlot(QModelIndex index)
-{
-	QModelIndex local = mapFromSource(index);
-	if (local.isValid())
-		emit currentDiveChanged(mapFromSource(index));
+	emit selectionChanged(indicesLocal, mapFromSource(currentDive));
 }
 
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -33,7 +33,7 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 }
 
 // Translate selection into local indices and re-emit signal
-void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive)
+void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC)
 {
 	QVector<QModelIndex> indicesLocal;
 	indicesLocal.reserve(indices.size());
@@ -43,7 +43,7 @@ void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indi
 			indicesLocal.push_back(local);
 	}
 
-	emit selectionChanged(indicesLocal, mapFromSource(currentDive));
+	emit selectionChanged(indicesLocal, mapFromSource(currentDive), currentDC);
 }
 
 // Translate selection into local indices and re-emit signal

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -26,14 +26,14 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 		model.reset(new DiveTripModelList);
 
 	setSourceModel(model.get());
-	connect(model.get(), &DiveTripModelBase::selectionChanged, this, &MultiFilterSortModel::selectionChangedSlot);
+	connect(model.get(), &DiveTripModelBase::divesSelected, this, &MultiFilterSortModel::divesSelectedSlot);
 	connect(model.get(), &DiveTripModelBase::tripSelected, this, &MultiFilterSortModel::tripSelectedSlot);
 	model->initSelection();
 	LocationInformationModel::instance()->update();
 }
 
 // Translate selection into local indices and re-emit signal
-void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC)
+void MultiFilterSortModel::divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC)
 {
 	QVector<QModelIndex> indicesLocal;
 	indicesLocal.reserve(indices.size());
@@ -43,7 +43,7 @@ void MultiFilterSortModel::selectionChangedSlot(const QVector<QModelIndex> &indi
 			indicesLocal.push_back(local);
 	}
 
-	emit selectionChanged(indicesLocal, mapFromSource(currentDive), currentDC);
+	emit divesSelected(indicesLocal, mapFromSource(currentDive), currentDC);
 }
 
 // Translate selection into local indices and re-emit signal

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -18,10 +18,10 @@ public:
 
 	void resetModel(DiveTripModelBase::Layout layout);
 signals:
-	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private slots:
-	void selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelectedSlot(QModelIndex trip, QModelIndex currentDive);
 private:
 	MultiFilterSortModel(QObject *parent = 0);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -18,11 +18,9 @@ public:
 
 	void resetModel(DiveTripModelBase::Layout layout);
 signals:
-	void selectionChanged(const QVector<QModelIndex> &indices);
-	void currentDiveChanged(QModelIndex index);
+	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
 private slots:
-	void selectionChangedSlot(const QVector<QModelIndex> &indices);
-	void currentDiveChangedSlot(QModelIndex index);
+	void selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive);
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 	std::unique_ptr<DiveTripModelBase> model;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -18,7 +18,7 @@ public:
 
 	void resetModel(DiveTripModelBase::Layout layout);
 signals:
-	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC); // currentDC < 0 -> keep DC.
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private slots:
 	void divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -19,8 +19,10 @@ public:
 	void resetModel(DiveTripModelBase::Layout layout);
 signals:
 	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private slots:
 	void selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive);
+	void tripSelectedSlot(QModelIndex trip, QModelIndex currentDive);
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 	std::unique_ptr<DiveTripModelBase> model;

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -18,10 +18,10 @@ public:
 
 	void resetModel(DiveTripModelBase::Layout layout);
 signals:
-	void selectionChanged(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelected(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
 private slots:
-	void selectionChangedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
+	void divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelectedSlot(QModelIndex trip, QModelIndex currentDive);
 private:
 	MultiFilterSortModel(QObject *parent = 0);

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -18,12 +18,6 @@ Qt::ItemFlags GasSelectionModel::flags(const QModelIndex&) const
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-GasSelectionModel *GasSelectionModel::instance()
-{
-	static GasSelectionModel self;
-	return &self;
-}
-
 void GasSelectionModel::repopulate()
 {
 	setStringList(get_dive_gas_list(&displayed_dive));
@@ -41,12 +35,6 @@ QVariant GasSelectionModel::data(const QModelIndex &index, int role) const
 Qt::ItemFlags DiveTypeSelectionModel::flags(const QModelIndex&) const
 {
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
-}
-
-DiveTypeSelectionModel *DiveTypeSelectionModel::instance()
-{
-	static DiveTypeSelectionModel self;
-	return &self;
 }
 
 void DiveTypeSelectionModel::repopulate()

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -25,11 +25,11 @@ void GasSelectionModel::repopulate(const dive *d)
 
 QVariant GasSelectionModel::data(const QModelIndex &index, int role) const
 {
-	if (role == Qt::FontRole) {
+	if (role == Qt::FontRole)
 		return defaultModelFont();
-	}
 	return QStringListModel::data(index, role);
 }
+
 // Dive Type Model for the divetype combo box
 
 Qt::ItemFlags DiveTypeSelectionModel::flags(const QModelIndex&) const
@@ -37,7 +37,7 @@ Qt::ItemFlags DiveTypeSelectionModel::flags(const QModelIndex&) const
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-void DiveTypeSelectionModel::repopulate()
+DiveTypeSelectionModel::DiveTypeSelectionModel()
 {
 	QStringList modes;
 	for (int i = 0; i < FREEDIVE; i++)
@@ -47,12 +47,10 @@ void DiveTypeSelectionModel::repopulate()
 
 QVariant DiveTypeSelectionModel::data(const QModelIndex &index, int role) const
 {
-	if (role == Qt::FontRole) {
+	if (role == Qt::FontRole)
 		return defaultModelFont();
-	}
 	return QStringListModel::data(index, role);
 }
-
 
 // Language Model, The Model to populate the list of possible Languages.
 

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -18,9 +18,9 @@ Qt::ItemFlags GasSelectionModel::flags(const QModelIndex&) const
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-void GasSelectionModel::repopulate()
+void GasSelectionModel::repopulate(const dive *d)
 {
-	setStringList(get_dive_gas_list(&displayed_dive));
+	setStringList(get_dive_gas_list(d));
 }
 
 QVariant GasSelectionModel::data(const QModelIndex &index, int role) const

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -51,7 +51,7 @@ DiveTypeSelectionModel *DiveTypeSelectionModel::instance()
 
 void DiveTypeSelectionModel::repopulate()
 {
-	QStringList modes = QStringList();
+	QStringList modes;
 	for (int i = 0; i < FREEDIVE; i++)
 		modes.append(gettextFromC::tr(divemode_text_ui[i]));
 	setStringList(modes);

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -26,19 +26,15 @@ class GasSelectionModel : public QStringListModel {
 public:
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
-public
-slots:
 	void repopulate(const dive *d);
 };
 
 class DiveTypeSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
+	DiveTypeSelectionModel();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
-public
-slots:
-	void repopulate();
 };
 
 class LanguageModel : public QAbstractListModel {

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -22,7 +22,6 @@
 class GasSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
-	static GasSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
 public
@@ -33,7 +32,6 @@ slots:
 class DiveTypeSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
-	static DiveTypeSelectionModel *instance();
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
 public

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -19,6 +19,8 @@
 #include "cleanertablemodel.h"
 #include "treemodel.h"
 
+struct dive;
+
 class GasSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
@@ -26,7 +28,7 @@ public:
 	QVariant data(const QModelIndex &index, int role) const override;
 public
 slots:
-	void repopulate();
+	void repopulate(const dive *d);
 };
 
 class DiveTypeSelectionModel : public QStringListModel {

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -132,7 +132,7 @@ void ScatterSeries::selectItemsInRect(const QRectF &rect, SelectionModifier modi
 			selected.push_back(items[idx].d);
 	}
 
-	setSelection(selected, selected.empty() ? nullptr : selected.front());
+	setSelection(selected, selected.empty() ? nullptr : selected.front(), -1);
 }
 
 static QString dataInfo(const StatsVariable &var, const dive *d)

--- a/stats/statsselection.cpp
+++ b/stats/statsselection.cpp
@@ -38,5 +38,5 @@ void processSelection(std::vector<dive *> dives, SelectionModifier modifier)
 		selected = std::move(dives);
 	}
 
-	setSelection(selected, selected.empty() ? nullptr : selected.front());
+	setSelection(selected, selected.empty() ? nullptr : selected.front(), -1);
 }

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -12,8 +12,9 @@
 #define DEBUG 1
 
 // testing the dive plan algorithm
-struct decostop stoptable[60];
-struct deco_state test_deco_state;
+static struct dive dive = { 0 };
+static struct decostop stoptable[60];
+static struct deco_state test_deco_state;
 extern bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, int timestep, struct decostop *decostoptable, struct deco_state **cached_datap, bool is_planner, bool show_disclaimer);
 void setupPrefs()
 {
@@ -51,20 +52,20 @@ void setupPlan(struct diveplan *dp)
 	struct gasmix ean36 = {{360}, {0}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean36;
 	cyl2->gasmix = oxygen;
-	reset_cylinders(&displayed_dive, true);
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(79, 260) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(ean36, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean36, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(79, 260), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(79, 260), 0, 0, 1, OC);
 }
@@ -82,20 +83,20 @@ void setupPlanVpmb45m30mTx(struct diveplan *dp)
 	struct gasmix ean50 = {{500}, {0}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 24000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
-	reset_cylinders(&displayed_dive, true);
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(45, 150) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(45, 150), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(45, 150), 0, 0, 1, OC);
 }
@@ -113,20 +114,20 @@ void setupPlanVpmb60m10mTx(struct diveplan *dp)
 	struct gasmix tx50_15 = {{500}, {150}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 24000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = tx50_15;
 	cyl2->gasmix = oxygen;
-	reset_cylinders(&displayed_dive, true);
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(23, 75);
-	plan_add_segment(dp, 0, gas_mod(tx50_15, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(tx50_15, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 10 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -139,12 +140,12 @@ void setupPlanVpmb60m30minAir(struct diveplan *dp)
 	dp->decosac = prefs.decosac;
 
 	struct gasmix bottomgas = {{210}, {0}};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 100000;
 	cyl0->type.workingpressure.mbar = 232000;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
@@ -162,18 +163,18 @@ void setupPlanVpmb60m30minEan50(struct diveplan *dp)
 	struct gasmix bottomgas = {{210}, {0}};
 	struct gasmix ean50 = {{500}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean50;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -188,18 +189,18 @@ void setupPlanVpmb60m30minTx(struct diveplan *dp)
 	struct gasmix bottomgas = {{180}, {450}};
 	struct gasmix ean50 = {{500}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean50;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 	plan_add_segment(dp, 30 * 60 - droptime, M_OR_FT(60, 200), 0, 0, 1, OC);
 }
@@ -212,12 +213,12 @@ void setupPlanVpmbMultiLevelAir(struct diveplan *dp)
 	dp->decosac = prefs.decosac;
 
 	struct gasmix bottomgas = {{210}, {0}};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 200000;
 	cyl0->type.workingpressure.mbar = 232000;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(20, 66) * 60 / M_OR_FT(99, 330);
@@ -238,21 +239,21 @@ void setupPlanVpmb100m60min(struct diveplan *dp)
 	struct gasmix ean50 = {{500}, {0}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 200000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 60 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 }
@@ -268,21 +269,21 @@ void setupPlanVpmb100m10min(struct diveplan *dp)
 	struct gasmix ean50 = {{500}, {0}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 60000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 10 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 }
@@ -295,12 +296,12 @@ void setupPlanVpmb30m20min(struct diveplan *dp)
 	dp->decosac = prefs.decosac;
 
 	struct gasmix bottomgas = {{210}, {0}};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(30, 100) * 60 / M_OR_FT(18, 60);
@@ -320,24 +321,24 @@ void setupPlanVpmb100mTo70m30min(struct diveplan *dp)
 	struct gasmix ean50 = {{500}, {0}};
 	struct gasmix oxygen = {{1000}, {0}};
 	pressure_t po2 = {1600};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
-	cylinder_t *cyl3 = get_or_create_cylinder(&displayed_dive, 3);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
+	cylinder_t *cyl3 = get_or_create_cylinder(&dive, 3);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = tx21_35;
 	cyl2->gasmix = ean50;
 	cyl3->gasmix = oxygen;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(18, 60);
-	plan_add_segment(dp, 0, gas_mod(tx21_35, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(ean50, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
-	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &displayed_dive, M_OR_FT(3, 10)).mm, 3, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(tx21_35, po2, &dive, M_OR_FT(3, 10)).mm, 1, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(ean50, po2, &dive, M_OR_FT(3, 10)).mm, 2, 0, 1, OC);
+	plan_add_segment(dp, 0, gas_mod(oxygen, po2, &dive, M_OR_FT(3, 10)).mm, 3, 0, 1, OC);
 	plan_add_segment(dp, droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 20 * 60 - droptime, M_OR_FT(100, 330), 0, 0, 1, OC);
 	plan_add_segment(dp, 3 * 60, M_OR_FT(70, 230), 0, 0, 1, OC);
@@ -356,14 +357,14 @@ void setupPlanSeveralGases(struct diveplan *dp)
 	struct gasmix ean36 = {{360}, {0}};
 	struct gasmix tx11_50 = {{110}, {500}};
 
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
 	cyl0->gasmix = ean36;
 	cyl0->type.size.mliter = 36000;
 	cyl0->type.workingpressure.mbar = 232000;
 	cyl1->gasmix = tx11_50;
-	displayed_dive.surface_pressure.mbar = 1013;
-	reset_cylinders(&displayed_dive, true);
+	dive.surface_pressure.mbar = 1013;
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	plan_add_segment(dp, 120, 40000, 0, 0, true, OC);
@@ -385,19 +386,19 @@ void setupPlanCcr(struct diveplan *dp)
 	struct gasmix diluent = {{200}, {210}};
 	struct gasmix ean53 = {{530}, {0}};
 	struct gasmix tx19_33 = {{190}, {330}};
-	cylinder_t *cyl0 = get_or_create_cylinder(&displayed_dive, 0);
-	cylinder_t *cyl1 = get_or_create_cylinder(&displayed_dive, 1);
-	cylinder_t *cyl2 = get_or_create_cylinder(&displayed_dive, 2);
+	cylinder_t *cyl0 = get_or_create_cylinder(&dive, 0);
+	cylinder_t *cyl1 = get_or_create_cylinder(&dive, 1);
+	cylinder_t *cyl2 = get_or_create_cylinder(&dive, 2);
 	cyl0->gasmix = diluent;
-	cyl0->depth = gas_mod(diluent, po2, &displayed_dive, M_OR_FT(3, 10));
+	cyl0->depth = gas_mod(diluent, po2, &dive, M_OR_FT(3, 10));
 	cyl0->type.size.mliter = 3000;
 	cyl0->type.workingpressure.mbar = 200000;
 	cyl0->cylinder_use = DILUENT;
 	cyl1->gasmix = ean53;
-	cyl1->depth = gas_mod(ean53, po2, &displayed_dive, M_OR_FT(3, 10));
+	cyl1->depth = gas_mod(ean53, po2, &dive, M_OR_FT(3, 10));
 	cyl2->gasmix = tx19_33;
-	cyl2->depth = gas_mod(tx19_33, po2, &displayed_dive, M_OR_FT(3, 10));
-	reset_cylinders(&displayed_dive, true);
+	cyl2->depth = gas_mod(tx19_33, po2, &dive, M_OR_FT(3, 10));
+	reset_cylinders(&dive, true);
 	free_dps(dp);
 
 	plan_add_segment(dp, 0, cyl1->depth.mm, 1, 0, false, OC);
@@ -452,12 +453,12 @@ void TestPlan::testMetric()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -466,19 +467,19 @@ void TestPlan::testMetric()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 148l);
 	// check first gas change to EAN36 at 33m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 36);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 33000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 33000);
 	// check second gas change to Oxygen at 6m
 	ev = ev->next;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 2);
 	QCOMPARE(ev->value, 100);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 6000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 6000);
 	// check expected run time of 109 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 109u * 60u, 109u * 60u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 109u * 60u, 109u * 60u));
 }
 
 void TestPlan::testImperial()
@@ -493,12 +494,12 @@ void TestPlan::testImperial()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -507,19 +508,19 @@ void TestPlan::testImperial()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 155l);
 	// check first gas change to EAN36 at 33m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 36);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 33528);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 33528);
 	// check second gas change to Oxygen at 6m
 	ev = ev->next;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 2);
 	QCOMPARE(ev->value, 100);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 6096);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 6096);
 	// check expected run time of 111 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 111u * 60u - 2u, 111u * 60u - 2u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 111u * 60u - 2u, 111u * 60u - 2u));
 }
 
 void TestPlan::testVpmbMetric45m30minTx()
@@ -533,12 +534,12 @@ void TestPlan::testVpmbMetric45m30minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb45m30mTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -547,9 +548,9 @@ void TestPlan::testVpmbMetric45m30minTx()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 108l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check benchmark run time of 141 minutes, and known Subsurface runtime of 139 minutes
-	//QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
+	//QVERIFY(compareDecoTime(dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric60m10minTx()
@@ -563,12 +564,12 @@ void TestPlan::testVpmbMetric60m10minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m10mTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -577,9 +578,9 @@ void TestPlan::testVpmbMetric60m10minTx()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 162l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check benchmark run time of 141 minutes, and known Subsurface runtime of 139 minutes
-	//QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
+	//QVERIFY(compareDecoTime(dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric60m30minAir()
@@ -593,12 +594,12 @@ void TestPlan::testVpmbMetric60m30minAir()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minAir(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -607,9 +608,9 @@ void TestPlan::testVpmbMetric60m30minAir()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 180l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check benchmark run time of 141 minutes, and known Subsurface runtime of 139 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 141u * 60u + 20u, 139u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric60m30minEan50()
@@ -623,12 +624,12 @@ void TestPlan::testVpmbMetric60m30minEan50()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minEan50(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -637,15 +638,15 @@ void TestPlan::testVpmbMetric60m30minEan50()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 155l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check first gas change to EAN50 at 21m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 50);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 21000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 21000);
 	// check benchmark run time of 95 minutes, and known Subsurface runtime of 96 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 95u * 60u + 20u, 96u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 95u * 60u + 20u, 96u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric60m30minTx()
@@ -659,12 +660,12 @@ void TestPlan::testVpmbMetric60m30minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -673,15 +674,15 @@ void TestPlan::testVpmbMetric60m30minTx()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 159l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check first gas change to EAN50 at 21m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 50);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 21000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 21000);
 	// check benchmark run time of 89 minutes, and known Subsurface runtime of 89 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 89u * 60u + 20u, 89u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 89u * 60u + 20u, 89u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric100m60min()
@@ -695,12 +696,12 @@ void TestPlan::testVpmbMetric100m60min()
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m60min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -709,21 +710,21 @@ void TestPlan::testVpmbMetric100m60min()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 157l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check first gas change to EAN50 at 21m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 50);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 21000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 21000);
 	// check second gas change to Oxygen at 6m
 	ev = ev->next;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 2);
 	QCOMPARE(ev->value, 100);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 6000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 6000);
 	// check benchmark run time of 311 minutes, and known Subsurface runtime of 314 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 311u * 60u + 20u, 315u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 311u * 60u + 20u, 315u * 60u + 20u));
 }
 
 void TestPlan::testMultipleGases()
@@ -738,18 +739,18 @@ void TestPlan::testMultipleGases()
 
 	setupPlanSeveralGases(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	gasmix gas;
-	gas = get_gasmix_at_time(&displayed_dive, &displayed_dive.dc, {20 * 60 + 1});
+	gas = get_gasmix_at_time(&dive, &dive.dc, {20 * 60 + 1});
 	QCOMPARE(get_o2(gas), 110);
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 2480u, 2480u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 2480u, 2480u));
 }
 
 void TestPlan::testVpmbMetricMultiLevelAir()
@@ -763,12 +764,12 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 	struct diveplan testPlan = {};
 	setupPlanVpmbMultiLevelAir(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -777,9 +778,9 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 101l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check benchmark run time of 167 minutes, and known Subsurface runtime of 169 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 167u * 60u + 20u, 169u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 167u * 60u + 20u, 169u * 60u + 20u));
 }
 
 void TestPlan::testVpmbMetric100m10min()
@@ -793,12 +794,12 @@ void TestPlan::testVpmbMetric100m10min()
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m10min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -807,21 +808,21 @@ void TestPlan::testVpmbMetric100m10min()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 175l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check first gas change to EAN50 at 21m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->value, 50);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 21000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 21000);
 	// check second gas change to Oxygen at 6m
 	ev = ev->next;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 2);
 	QCOMPARE(ev->value, 100);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 6000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 6000);
 	// check benchmark run time of 58 minutes, and known Subsurface runtime of 57 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 58u * 60u + 20u, 57u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 58u * 60u + 20u, 57u * 60u + 20u));
 }
 
 /* This tests that a previously calculated plan isn't affecting the calculations of the next plan.
@@ -839,12 +840,12 @@ void TestPlan::testVpmbMetricRepeat()
 	struct diveplan testPlan = {};
 	setupPlanVpmb30m20min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -853,19 +854,19 @@ void TestPlan::testVpmbMetricRepeat()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 61l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check benchmark run time of 27 minutes, and known Subsurface runtime of 28 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 27u * 60u + 20u, 27u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 27u * 60u + 20u, 27u * 60u + 20u));
 
-	int firstDiveRunTimeSeconds = displayed_dive.dc.duration.seconds;
+	int firstDiveRunTimeSeconds = dive.dc.duration.seconds;
 
 	setupPlanVpmb100mTo70m30min(&testPlan);
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -874,35 +875,35 @@ void TestPlan::testVpmbMetricRepeat()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 80l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 	// check first gas change to 21/35 at 66m
-	struct event *ev = displayed_dive.dc.events;
+	struct event *ev = dive.dc.events;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->gas.mix.o2.permille, 210);
 	QCOMPARE(ev->gas.mix.he.permille, 350);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 66000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 66000);
 	// check second gas change to EAN50 at 21m
 	ev = ev->next;
 	QCOMPARE(ev->gas.index, 2);
 	QCOMPARE(ev->value, 50);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 21000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 21000);
 	// check third gas change to Oxygen at 6m
 	ev = ev->next;
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 3);
 	QCOMPARE(ev->value, 100);
-	QCOMPARE(get_depth_at_time(&displayed_dive.dc, ev->time.seconds), 6000);
+	QCOMPARE(get_depth_at_time(&dive.dc, ev->time.seconds), 6000);
 	// we don't have a benchmark, known Subsurface runtime is 126 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 127u * 60u + 20u, 127u * 60u + 20u));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 127u * 60u + 20u, 127u * 60u + 20u));
 
 	setupPlanVpmb30m20min(&testPlan);
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, 1, 0);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check minimum gas result
@@ -911,10 +912,10 @@ void TestPlan::testVpmbMetricRepeat()
 		dp = dp->next;
 	QCOMPARE(lrint(dp->minimum_gas.mbar / 1000.0), 61l);
 	// print first ceiling
-	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &displayed_dive) * 0.001));
+	printf("First ceiling %.1f m\n", (mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar, &dive) * 0.001));
 
 	// check runtime is exactly the same as the first time
-	int finalDiveRunTimeSeconds = displayed_dive.dc.duration.seconds;
+	int finalDiveRunTimeSeconds = dive.dc.duration.seconds;
 	QCOMPARE(finalDiveRunTimeSeconds, firstDiveRunTimeSeconds);
 }
 
@@ -930,37 +931,37 @@ void TestPlan::testCcrBailoutGasSelection()
 	prefs.unit_system = METRIC;
 	prefs.units.length = units::METERS;
 	prefs.planner_deco_mode = BUEHLMANN;
-	displayed_dive.dc.divemode = CCR;
+	dive.dc.divemode = CCR;
 	prefs.dobailout = true;
 
 	struct diveplan testPlan = {};
 	setupPlanCcr(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &displayed_dive, 60, stoptable, &cache, true, false);
+	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, &cache, true, false);
 
 #if DEBUG
-	free(displayed_dive.notes);
-	displayed_dive.notes = NULL;
-	save_dive(stdout, &displayed_dive, false);
+	free(dive.notes);
+	dive.notes = NULL;
+	save_dive(stdout, &dive, false);
 #endif
 
 	// check diluent used
-	cylinder_t *cylinder = get_cylinder(&displayed_dive, get_cylinderid_at_time(&displayed_dive, &displayed_dive.dc, { 20 * 60 - 1 }));
+	cylinder_t *cylinder = get_cylinder(&dive, get_cylinderid_at_time(&dive, &dive.dc, { 20 * 60 - 1 }));
 	QCOMPARE(cylinder->cylinder_use, DILUENT);
 	QCOMPARE(get_o2(cylinder->gasmix), 200);
 
 	// check deep bailout used
-	cylinder = get_cylinder(&displayed_dive, get_cylinderid_at_time(&displayed_dive, &displayed_dive.dc, { 20 * 60 + 1 }));
+	cylinder = get_cylinder(&dive, get_cylinderid_at_time(&dive, &dive.dc, { 20 * 60 + 1 }));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 190);
 
 	// check shallow bailout used
-	cylinder = get_cylinder(&displayed_dive, get_cylinderid_at_time(&displayed_dive, &displayed_dive.dc, { 30 * 60 }));
+	cylinder = get_cylinder(&dive, get_cylinderid_at_time(&dive, &dive.dc, { 30 * 60 }));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 530);
 
 	// check expected run time of 51 minutes
-	QVERIFY(compareDecoTime(displayed_dive.dc.duration.seconds, 51 * 60, 51 * 60));
+	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 51 * 60, 51 * 60));
 
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The selection code has always been a thorn in my side. It is a single horrible layering violation. And it doesn't work well with mobile, where we can have multiple profiles at the same time.

This is a beginning of cleaning this up. It does fix a small bug and removes some truly horrible code in `DiveListView`. At some points the code becomes more verbose, though arguably less convoluted. Of course, it may break things.

Ultimately I think the root cause of the problem is that the selection- and filter-status is saved in the core, when it should not be. The filter status should be stored in the filter-model and the selection-status in the `DiveListView`. However, we are very far from that vision. I see two major stumbling blocks:
1) Getting the selection into C code. Handling collections in C is very cumbersome.
2) The model/view code can be appallingly slow.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Probably not needed.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Not needed.
