### PR TITLE
map: don't explicitly reload the map from the mainwindow

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -200,9 +200,6 @@ MainWindow::MainWindow() :
 	initialUiSetup();
 	readSettings();
 	diveList->setFocus();
-#ifdef MAP_SUPPORT
-	MapWidget::instance()->reload();
-#endif
 	diveList->expand(diveList->model()->index(0, 0));
 	diveList->scrollTo(diveList->model()->index(0, 0), QAbstractItemView::PositionAtCenter);
 #ifdef NO_USERMANUAL
@@ -507,9 +504,6 @@ void MainWindow::closeCurrentFile()
 	clear_dive_file_data(); // this clears all the core data structures and resets the models
 	setCurrentFile(nullptr);
 	diveList->setSortOrder(DiveTripModelBase::NR, Qt::DescendingOrder);
-#ifdef MAP_SUPPORT
-	MapWidget::instance()->reload();
-#endif
 	if (!existing_filename)
 		setTitle();
 	disableShortcuts();

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -120,7 +120,7 @@ void MapWidget::divesChanged(const QVector<dive *> &, DiveField field)
 // Sadly, for reasons out of our control, we can't use a normal singleton for the
 // map widget: In a standard singleton, the object is freed after main() exits.
 // However, if there is an animation running (map zooming), the thread is
-// terminated, when the QApplication object is destroyed, which is before main()
+// terminated when the QApplication object is destroyed, which is before main()
 // exits. The thread has a QQmlAnimationTimer that is freed. However, the map widget
 // then tries to free the object itself, leading to a crash. Clearly, a bug in
 // the QML MapWidget / QtQuick ecosystem.


### PR DESCRIPTION
The map listens to the reset signal by itself.

This avoids double reload of the map on open/close.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A tiny cleanup: avoid double call of Map::reload() when opening/closing the dive log.
