### PR TITLE
For warnings, show icon in infobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+infobox: show an icon for warnings
 import: allow import of divesites without UUID
 profile: implement panning of the profile
 planner: allow handle manipulation in zoomed in state

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -170,7 +170,7 @@ void DiveEventItem::setupToolTipString(struct gasmix lastgasmix)
 		name += ev->flags & SAMPLE_FLAGS_BEGIN ? tr(" begin", "Starts with space!") :
 								    ev->flags & SAMPLE_FLAGS_END ? tr(" end", "Starts with space!") : "";
 	}
-	setToolTip(name);
+	setToolTip(QString("<img height=\"16\" src=\":status-warning-icon\">&nbsp;  ") + name);
 }
 
 void DiveEventItem::eventVisibilityChanged(const QString&, bool)

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -26,9 +26,10 @@ void ToolTipItem::addToolTip(const QString &toolTip, const QPixmap &pixmap)
 	const int sp2 = iconMetrics.spacing * 2;
 	iconItem->setPos(sp2, yValue);
 
-	QGraphicsSimpleTextItem *textItem = new QGraphicsSimpleTextItem(toolTip, this);
+	QGraphicsTextItem *textItem = new QGraphicsTextItem(this);
+	textItem->setHtml(toolTip);
 	textItem->setPos(sp2 + iconMetrics.sz_small + sp2, yValue);
-	textItem->setBrush(QBrush(Qt::white));
+	textItem->setDefaultTextColor(Qt::white);
 	textItem->setFlag(ItemIgnoresTransformations);
 	toolTips.push_back(qMakePair(iconItem, textItem));
 }
@@ -251,7 +252,7 @@ void ToolTipItem::refresh(const dive *d, const QPointF &pos, bool inPlanner)
 		painter.setPen(QColor(0, 0, 0, 127));
 		for (int i = 0; i < 16; i++)
 			painter.drawLine(i, 60, i, 60 - entry->percentages[i] / 2);
-		entryToolTip.second->setText(QString::fromUtf8(mb.buffer, mb.len));
+		entryToolTip.second->setPlainText(QString::fromUtf8(mb.buffer, mb.len));
 	}
 	entryToolTip.first->setPixmap(tissues);
 

--- a/profile-widget/divetooltipitem.h
+++ b/profile-widget/divetooltipitem.h
@@ -45,7 +45,7 @@ slots:
 	void setRect(const QRectF &rect);
 
 private:
-	typedef QPair<QGraphicsPixmapItem *, QGraphicsSimpleTextItem *> ToolTip;
+	typedef QPair<QGraphicsPixmapItem *, QGraphicsTextItem *> ToolTip;
 	QVector<ToolTip> toolTips;
 	ToolTip entryToolTip;
 	QGraphicsSimpleTextItem *title;


### PR DESCRIPTION
Render a warning sign in front of the event string in the infobox. This is done in rich text.

Notes: 
1) This shows the warning sign for all events, not just warnings. Doing otherwise would require much more change in logic (as the profile icons are pixmaps that have a complicated selection logic for different types of events while here a file name is requested)
2) It adds some vertical space before the warning

Is this good enough to be an improvement over what we have so far?

This was suggested in #3501.

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
