### PR TITLE
Sensor index fixup

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -1240,11 +1240,11 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 	/* Fix up gas switch events */
 	fixup_dc_gasswitch(dive, dc);
 
-	/* Fix up cylinder pressures based on DC info */
-	fixup_dive_pressures(dive, dc);
-
 	/* Fix up cylinder ids in pressure sensors */
 	fixup_dc_sample_sensors(dc, dive->cylinders.nr);
+
+	/* Fix up cylinder pressures based on DC info */
+	fixup_dive_pressures(dive, dc);
 
 	fixup_dc_events(dc);
 

--- a/core/dive.c
+++ b/core/dive.c
@@ -1210,16 +1210,40 @@ static void fixup_no_o2sensors(struct divecomputer *dc)
 	}
 }
 
-static void fixup_dc_sample_sensors(struct divecomputer *dc, int nr_cylinders)
+static void fixup_dc_sample_sensors(struct dive *dive, struct divecomputer *dc)
 {
+	unsigned long sensor_mask = 0;
+
 	for (int i = 0; i < dc->samples; i++) {
 		struct sample *s = dc->sample + i;
 		for (int j = 0; j < MAX_SENSORS; j++) {
-			if (s->sensor[j] < 0 || s->sensor[j] >= nr_cylinders) {
+			int sensor = s->sensor[j];
+
+			// No invalid sensor ID's, please
+			if (sensor < 0 || sensor > MAX_SENSORS) {
 				s->sensor[j] = NO_SENSOR;
 				s->pressure[j].mbar = 0;
+				continue;
 			}
+
+			// Don't bother tracking sensors with no data
+			if (!s->pressure[j].mbar) {
+				s->sensor[j] = NO_SENSOR;
+				continue;
+			}
+
+			// Remember the set of sensors we had
+			sensor_mask |= 1ul << sensor;
 		}
+	}
+
+	// Ignore the sensors we have cylinders for
+	sensor_mask >>= dive->cylinders.nr;
+
+	// Do we need to add empty cylinders?
+	while (sensor_mask) {
+		add_empty_cylinder(&dive->cylinders);
+		sensor_mask >>= 1;
 	}
 }
 
@@ -1241,7 +1265,7 @@ static void fixup_dive_dc(struct dive *dive, struct divecomputer *dc)
 	fixup_dc_gasswitch(dive, dc);
 
 	/* Fix up cylinder ids in pressure sensors */
-	fixup_dc_sample_sensors(dc, dive->cylinders.nr);
+	fixup_dc_sample_sensors(dive, dc);
 
 	/* Fix up cylinder pressures based on DC info */
 	fixup_dive_pressures(dive, dc);

--- a/core/load-git.c
+++ b/core/load-git.c
@@ -644,7 +644,7 @@ static char *parse_sample_unit(struct sample *sample, double val, char *unit)
 /*
  * If the given cylinder doesn't exist, return NO_SENSOR.
  */
-static uint8_t sanitize_sensor_id(const struct dive *d, int nr)
+static int sanitize_sensor_id(const struct dive *d, int nr)
 {
 	return d && nr >= 0 && nr < d->cylinders.nr ? nr : NO_SENSOR;
 }

--- a/core/parse.c
+++ b/core/parse.c
@@ -393,7 +393,7 @@ void ws_end(struct parser_state *state)
 /*
  * If the given cylinder doesn't exist, return NO_SENSOR.
  */
-static uint8_t sanitize_sensor_id(const struct dive *d, int nr)
+static int sanitize_sensor_id(const struct dive *d, int nr)
 {
 	return d && nr >= 0 && nr < d->cylinders.nr ? nr : NO_SENSOR;
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This fixes up the pressure sensor index code to not be quite so eager to get rid of pressures that it doesn't understand.

In particular, if for some reason a dive computer was saved with a pressure sensor index bigger than the number of cylinders, it now tries to fix up the situation by renumbering the indexes to a minimal set. And if even that doesn't then fit in the number of cylinders, we just accept the sensor data as-is rather than clear it.

The user can then add cylinders as needed, or whatever.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
