### PR TITLE
profile: don't use displayed_dive to check whether dive changed

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -246,9 +246,7 @@ void ProfileWidget2::divesChanged(const QVector<dive *> &dives, DiveField field)
 {
 	// If the mode of the currently displayed dive changed, replot
 	if (field.mode &&
-	    std::any_of(dives.begin(), dives.end(),
-			[id = displayed_dive.id] (const dive *d)
-			{ return d->id == id; } ))
+	    std::find(dives.begin(), dives.end(), d) != dives.end())
 		replot();
 }
 


### PR DESCRIPTION
The profile replots if the mode of the currently displayed dive changed. To do so, it compares the changed dive to the displayed_dive. However, that is only used for planned dives since quite some time.

Fix the check and make the replotting work again.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The profile was still using `displayed_dive` to check whether the currently displayed dive was changed. However, `displayed_dive` hasn't been updated for a long time, expect when in the planner. Fix this check.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

It *is* a user-visible bug fix, but probably too minor to warrant a changelog entry.