### PR TITLE
desktop: disable extradata tab if no site selected

### DIFF
--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -107,11 +107,11 @@ void MainTab::updateDiveInfo()
 	if (DivePlannerPointsModel::instance()->isPlanner())
 		return;
 
-	// If there is no current dive, disable all widgets except the last two,
-	// which are the dive site tab and the dive computer tabs.
-	// TODO: Conceptually, these two shouldn't even be a tabs here!
+	// If there is no current dive, disable all widgets except the last one,
+	// which is the dive site tab
+	// TODO: Conceptually, this shouldn't even be a tab here!
 	bool enabled = current_dive != nullptr;
-	for (int i = 0; i < extraWidgets.size() - 2; ++i)
+	for (int i = 0; i < extraWidgets.size() - 1; ++i)
 		extraWidgets[i]->setEnabled(enabled);
 
 	if (current_dive) {


### PR DESCRIPTION
Owing to bit-rot, the extradata tab was not disabled if no dive is selected. The reason was that there was an additional tab (dive-computers) that should not be disabled. However that tab was removed and now the extradata tab was not disabled.

Fix this, but note that there is another of these 'parasitic' tabs, that should be removed, namely the dive-site tab.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

A rather trivial cosmetic fix: disable the extradata tab when no dive is selected. This however points out the problem of the dive site tab, which should also be removed.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Not worth it.