### PR TITLE
desktop: cache isGnome3Session result

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -127,15 +127,6 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	currCombo.model = const_cast<QAbstractItemModel *>(index.model());
 	currCombo.activeText = currCombo.model->data(index).toString();
 
-	// Current display of things on Gnome3 looks like shit, so
-	// let's fix that.
-	if (isGnome3Session()) {
-		QPalette p;
-		p.setColor(QPalette::Window, QColor(Qt::white));
-		p.setColor(QPalette::Base, QColor(Qt::white));
-		comboDelegate->lineEdit()->setPalette(p);
-		comboDelegate->setPalette(p);
-	}
 	return comboDelegate;
 }
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -282,21 +282,6 @@ QString URLDialog::url() const
 	return ui.urlField->toPlainText();
 }
 
-bool isGnome3Session()
-{
-#if defined(QT_OS_WIW) || defined(QT_OS_MAC)
-	return false;
-#else
-	if (qApp->style()->objectName() != "gtk+")
-		return false;
-	QProcess p;
-	p.start("pidof", QStringList() << "gnome-shell");
-	p.waitForFinished(-1);
-	QString p_stdout = p.readAllStandardOutput();
-	return !p_stdout.isEmpty();
-#endif
-}
-
 #define COMPONENT_FROM_UI(_component) what->_component = ui._component->isChecked()
 #define UI_FROM_COMPONENT(_component) ui._component->setChecked(what->_component)
 

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -146,6 +146,4 @@ private:
 	Q_DISABLE_COPY(TextHyperlinkEventFilter)
 };
 
-bool isGnome3Session();
-
 #endif // SIMPLEWIDGETS_H

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "TabDiveEquipment.h"
 #include "maintab.h"
-#include "desktop-widgets/simplewidgets.h" // For isGnome3Session()
 #include "desktop-widgets/modeldelegates.h"
 #include "core/dive.h"
 #include "core/selection.h"
@@ -50,14 +49,6 @@ TabDiveEquipment::TabDiveEquipment(QWidget *parent) : TabBase(parent),
 	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
 	connect(cylindersModel, &CylindersModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 	connect(weightModel, &WeightModel::divesEdited, this, &TabDiveEquipment::divesEdited);
-
-	// Current display of things on Gnome3 looks like shit, so
-	// let's fix that.
-	if (isGnome3Session()) {
-		QPalette p;
-		p.setColor(QPalette::Window, QColor(Qt::white));
-		ui.scrollArea->viewport()->setPalette(p);
-	}
 
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, new TankUseDelegate(this));

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -16,7 +16,6 @@
 #include "TabDiveSite.h"
 
 #include "core/selection.h"
-#include "desktop-widgets/simplewidgets.h" // for isGnome3Session()
 #include "qt-models/diveplannermodel.h"
 
 #include <QShortcut>
@@ -63,33 +62,6 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	else
 		setDocumentMode(false);
 
-	// Current display of things on Gnome3 looks like shit, so
-	// let's fix that.
-	if (isGnome3Session()) {
-		// TODO: Either do this for all scroll areas or none
-		//QPalette p;
-		//p.setColor(QPalette::Window, QColor(Qt::white));
-		//ui.scrollArea->viewport()->setPalette(p);
-
-		// GroupBoxes in Gnome3 looks like I'v drawn them...
-		static const QString gnomeCss = QStringLiteral(
-			"QGroupBox {"
-				"background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,"
-				"stop: 0 #E0E0E0, stop: 1 #FFFFFF);"
-				"border: 2px solid gray;"
-				"border-radius: 5px;"
-				"margin-top: 1ex;"
-			"}"
-			"QGroupBox::title {"
-				"subcontrol-origin: margin;"
-				"subcontrol-position: top center;"
-				"padding: 0 3px;"
-				"background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,"
-				"stop: 0 #E0E0E0, stop: 1 #FFFFFF);"
-			"}");
-		for (QGroupBox *box: findChildren<QGroupBox *>())
-			box->setStyleSheet(gnomeCss);
-	}
 	// QLineEdit and QLabels should have minimal margin on the left and right but not waste vertical space
 	QMargins margins(3, 2, 1, 0);
 	for (QLabel *label: findChildren<QLabel *>())


### PR DESCRIPTION
On gtk based distributions, isGnome3Session() tests for Gnome3 by executing a "pidof" command. This is called everytime a combobox is created in the equipment tab. This seems a bit excessive, so let's cache the result.

Use a lambda to calculate the flag to avoid unnecessary #ifdef-ery or complex control flow.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

On GTK based distributions a command is executed everytime a combobox in the equipment tab is opened. This seems excessive. Cache the result instead.

Totally untested, since I don't have a GTK based distribution.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Not necessary.