### PR TITLE
build-system: run iOS GitHub action on macOS 11

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   iOSBuild:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
     - name: switch to Xcode 11
       run: sudo xcode-select -s "/Applications/Xcode_11.7.app"


### PR DESCRIPTION
macOS 10.15 is deprecated on GitHub.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

