### PR TITLE
build-system/windows: don't build the libmtp examples

### DIFF
--- a/packaging/windows/mxe-based-build.sh
+++ b/packaging/windows/mxe-based-build.sh
@@ -171,6 +171,7 @@ if [ "$MXEBUILDTYPE" = "x86_64-w64-mingw32.shared" ] ; then
 			--host="$MXEBUILDTYPE" \
 			--enable-shared \
 			--prefix="$BASEDIR"/"$MXEDIR"/usr/"$MXEBUILDTYPE"
+		cd src
 		make $JOBS
 		make install
 	fi


### PR DESCRIPTION
We had that fail in the GitHub Action - but really, why would we build those in the first place.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
no idea if this will work
