### PR TITLE
desktop: make time shift dialog show correct times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-mobile: implement paging through dive computers
-mobile: send log files as attachments for support emails on iOS
-mobile: allow cloud account deletion (Apple app store requirement)
-mobile: fix listing of local cloud cache directories
+desktop: fix dive time display in time shift dialog
 
 ---
 * Always add new entries at the very top of this file above other existing entries and this note.

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -89,13 +89,6 @@ void ShiftTimesDialog::buttonClicked(QAbstractButton *button)
 		if (amount != 0)
 			Command::shiftTime(getDiveSelection(), amount);
 	}
-
-	ui.timeEdit->setTime(QTime(0, 0, 0, 0));
-	dive *d = first_selected_dive();
-	if (d) {
-		ui.currentTime->setText(get_dive_date_string(d->when));
-		ui.shiftedTime->setText(get_dive_date_string(d->when));
-	}
 }
 
 void ShiftTimesDialog::changeTime()
@@ -120,6 +113,12 @@ ShiftTimesDialog::ShiftTimesDialog(QWidget *parent) : QDialog(parent),
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
+	dive *d = first_selected_dive();
+	if (d) {
+		when = d->when;
+		ui.currentTime->setText(get_dive_date_string(when));
+		ui.shiftedTime->setText(get_dive_date_string(when));
+	}
 }
 
 void ShiftImageTimesDialog::syncCameraClicked()


### PR DESCRIPTION
This got broken in commit 7417f865cd ("cleanup: un-singletonize ShiftTimesDialog") and no one ever noticed.

We need to intitialize the when variable and set up the initial texts in order for the time shift dialog to show the correct information. Doing this in the ButtonClicked member (right before the dialog is destroyed) makes absolutely no sense.

Fixes #3535


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
this has been broken for 2.5 years. Clearly a frequently used function?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
initialize both the time text and the `when` member variable to ensure that what is displayed makes sense
remove the pointless code updating the dialog text right before it gets destroyed

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3535

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 