### PR TITLE
statistics: fix display of month on continuous axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+statistics: show correct color of selected scatter items when switching to unbinned mode
+statistics: fix display of month number in continuous date axis
+statistics: fix range of continuous date axis
 desktop: fix dive time display in time shift dialog
 
 ---

--- a/stats/chartitem.cpp
+++ b/stats/chartitem.cpp
@@ -111,8 +111,9 @@ QRectF ChartPixmapItem::getRect() const
 static const int scatterItemDiameter = 10;
 static const int scatterItemBorder = 1;
 
-ChartScatterItem::ChartScatterItem(StatsView &v, ChartZValue z) : HideableChartItem(v, z),
-	positionDirty(false), textureDirty(false), highlight(Highlight::Unselected)
+ChartScatterItem::ChartScatterItem(StatsView &v, ChartZValue z, bool selected) : HideableChartItem(v, z),
+	positionDirty(false), textureDirty(false),
+	highlight(selected ? Highlight::Selected : Highlight::Unselected)
 {
 	rect.setSize(QSizeF(static_cast<double>(scatterItemDiameter), static_cast<double>(scatterItemDiameter)));
 }

--- a/stats/chartitem.h
+++ b/stats/chartitem.h
@@ -194,7 +194,7 @@ private:
 // scatter item here, but so it is for now.
 class ChartScatterItem : public HideableChartProxyItem<QSGImageNode> {
 public:
-	ChartScatterItem(StatsView &v, ChartZValue z);
+	ChartScatterItem(StatsView &v, ChartZValue z, bool selected);
 	~ChartScatterItem();
 
 	// Currently, there is no highlighted and selected status.

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -25,7 +25,7 @@ ScatterSeries::~ScatterSeries()
 }
 
 ScatterSeries::Item::Item(StatsView &view, ScatterSeries *series, dive *d, double pos, double value) :
-	item(view.createChartItem<ChartScatterItem>(ChartZValue::Series)),
+	item(view.createChartItem<ChartScatterItem>(ChartZValue::Series, d->selected)),
 	d(d),
 	selected(d->selected),
 	pos(pos),

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -630,7 +630,7 @@ static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
 			} else if (act[2] == 0) {
 				res.push_back({ monthname(act[1]), val, true });
 			} else {
-				QString s = format.arg(QString::number(act[2]), sep, QString::number(act[1]));
+				QString s = format.arg(QString::number(act[2]), sep, QString::number(act[1] + 1));
 				res.push_back({s, val, true });
 			}
 		}

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -623,7 +623,9 @@ static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
 		QString format = day_before_month ? QStringLiteral("%1%2%3")
 						  : QStringLiteral("%3%2%1");
 		QString sep = QString(separator);
-		for (auto act = day_from; act < day_to; inc(act)) {
+		// Attention: In a histogramm axis, we must add one more entries than
+		// histogram bins. The entries are the values *between* the histograms.
+		for (auto act = day_from; act <= day_to; inc(act)) {
 			double val = date_to_double(act[0], act[1], act[2]);
 			if (act[1] == 0) {
 				res.push_back({ QString::number(act[0]), val, true });

--- a/stats/statsvariables.cpp
+++ b/stats/statsvariables.cpp
@@ -924,7 +924,7 @@ struct DateMonthBinner : public SimpleContinuousBinner<DateMonthBinner, DateMont
 		year_month value = derived_bin(bin).value;
 		return QString("%1 %2").arg(monthname(value.second), QString::number(value.first));
 	}
-	// In histograms, output year for fill years, month otherwise
+	// In histograms, output year for full years, month otherwise
 	QString formatLowerBound(const StatsBin &bin) const override {
 		year_month value = derived_bin(bin).value;
 		return value.second == 0 ? QString::number(value.first)


### PR DESCRIPTION
tm::tm_mon is 0..11, not 1..12, so we have to add one for display.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the month in continuous date scales.
I'm not 100% sure that this is the correct fix, but it looks reasonable.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Reported in #3539.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Will do with next fixes.
