### PR TITLE
statistics: fix date ranges smaller than two days

### DIFF
--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -584,15 +584,15 @@ static std::pair<bool, char> day_format()
 // create year, month or day-based bins. This is certainly not efficient and may need
 // some tuning. However, it should ensure that no crazy number of bins is generated.
 // Ultimately, this should be replaced by a better and dynamic scheme
-// From and to are given in seconds since "epoch".
+// From and to are given in days since "epoch".
 static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
 {
 	// from and two are given in days since the "Unix epoch".
 	// The lowest precision we do is two days.
 	if (to - from < 2.0) {
 		double center = (from + to) / 2.0;
-		from = center + 1.0;
-		to = center - 1.0;
+		from = center - 1.0;
+		to = center + 1.0;
 	}
 
 	std::vector<HistogramAxisEntry> res;


### PR DESCRIPTION
The calculation of the range was broken, it resulted in a to-value smaller than the from-value, owing to a sign-mismatch.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes display of data scatter plots for <2 day intervals.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3539.
