### PR TITLE
planner: avoid out-of-bound access when initializing the planner

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -1087,7 +1087,7 @@ bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, i
 		 * otherwise odd things can happen, such as CVA causing the final ascent to start *later*
 		 * if the ascent rate is slower, which is completely nonsensical.
 		 * Assume final ascent takes 20s, which is the time taken to ascend at 9m/min from 3m */
-		ds->deco_time = clock - bottom_time - stoplevels[stopidx + 1] / last_ascend_rate + 20;
+		ds->deco_time = clock - bottom_time - (M_OR_FT(3,10) * ( prefs.last_stop ? 2 : 1)) / last_ascend_rate + 20;
 	} while (!is_final_plan);
 	decostoptable[decostopcounter].depth = 0;
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -147,10 +147,10 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 			break;
 		while (j * plansamples <= i * dc->samples) {
 			const sample &s = dc->sample[j];
-			const sample &prev = dc->sample[j-1];
 			if (s.time.seconds != 0 && (!hasMarkedSamples || s.manually_entered)) {
 				depthsum += s.depth.mm;
-				last_sp = prev.setpoint;
+				if (j > 0)
+					last_sp = dc->sample[j-1].setpoint;
 				++samplecount;
 				newtime = s.time;
 			}


### PR DESCRIPTION
For dives with many samples (i.e. logged dives), samples are merged.

I'm not exactly sure how this code works, but it does an out-of-bound access in some cases. Avoid that by a simple check.

That said, I wonder if this downsampling is a good idea. A user reports that they have logged dives marked as manually added dives. We now load them into edit mode, which means a significant loss of information.

Perhaps we should consider dives with more than 100 samples as non-manual dives?

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I have no idea if this is the right thing to do, but it should remove a reproducible out-of-bound access. I don't know if this is critical, but in theory (with ASAN?) it might be.

In any case, we seem to have a more serious problem with "manually added dives" that in reality are logged dives.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

Needs comment by @atdotde.
