### PR TITLE
[RFC] core: don't consider dives with many samples as manually added

### DIFF
--- a/core/dive.c
+++ b/core/dive.c
@@ -2333,8 +2333,8 @@ static int likely_same_dive(const struct dive *a, const struct dive *b)
 	int match, fuzz = 20 * 60;
 
 	/* don't merge manually added dives with anything */
-	if (same_string(a->dc.model, "manually added dive") ||
-	    same_string(b->dc.model, "manually added dive"))
+	if (is_manually_added_dc(&a->dc) ||
+	    is_manually_added_dc(&b->dc))
 		return 0;
 
 	/*

--- a/core/divecomputer.c
+++ b/core/divecomputer.c
@@ -548,3 +548,9 @@ void free_dc(struct divecomputer *dc)
 	free_dc_contents(dc);
 	free(dc);
 }
+
+bool is_manually_added_dc(const struct divecomputer *dc)
+{
+	return dc && dc->samples <= 50 &&
+	       same_string(dc->model, "manually added dive");
+}

--- a/core/divecomputer.c
+++ b/core/divecomputer.c
@@ -549,8 +549,15 @@ void free_dc(struct divecomputer *dc)
 	free(dc);
 }
 
+static const char *manual_dc_name = "manually added dive";
 bool is_manually_added_dc(const struct divecomputer *dc)
 {
 	return dc && dc->samples <= 50 &&
-	       same_string(dc->model, "manually added dive");
+	       same_string(dc->model, manual_dc_name);
+}
+
+void make_manually_added_dc(struct divecomputer *dc)
+{
+	free((void *)dc->model);
+	dc->model = strdup(manual_dc_name);
 }

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -70,6 +70,7 @@ extern void add_extra_data(struct divecomputer *dc, const char *key, const char 
 extern bool is_dc_planner(const struct divecomputer *dc);
 extern uint32_t calculate_string_hash(const char *str);
 extern bool is_manually_added_dc(const struct divecomputer *dc);
+extern void make_manually_added_dc(struct divecomputer *dc);
 
 /* Check if two dive computer entries are the exact same dive (-1=no/0=maybe/1=yes) */
 extern int match_one_dc(const struct divecomputer *a, const struct divecomputer *b);

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -69,6 +69,7 @@ extern void remove_event_from_dc(struct divecomputer *dc, struct event *event);
 extern void add_extra_data(struct divecomputer *dc, const char *key, const char *value);
 extern bool is_dc_planner(const struct divecomputer *dc);
 extern uint32_t calculate_string_hash(const char *str);
+extern bool is_manually_added_dc(const struct divecomputer *dc);
 
 /* Check if two dive computer entries are the exact same dive (-1=no/0=maybe/1=yes) */
 extern int match_one_dc(const struct divecomputer *a, const struct divecomputer *b);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -690,7 +690,7 @@ void MainWindow::on_actionAddDive_triggered()
 	d.dc.duration.seconds = 40 * 60;
 	d.dc.maxdepth.mm = M_OR_FT(15, 45);
 	d.dc.meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
-	d.dc.model = strdup("manually added dive"); // don't translate! this is stored in the XML file
+	make_manually_added_dc(&d.dc);
 	fake_dc(&d.dc);
 	fixup_dive(&d);
 

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -192,7 +192,7 @@ void ProfileWidget::plotCurrentDive()
 	if (current_dive && !editedDive &&
 	    DivePlannerPointsModel::instance()->currentMode() == DivePlannerPointsModel::NOTHING) {
 		struct divecomputer *dc = get_dive_dc(current_dive, dc_number);
-		if (dc && same_string(dc->model, "manually added dive") && dc->samples)
+		if (dc && is_manually_added_dc(dc) && dc->samples)
 			editDive();
 	}
 

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -210,7 +210,7 @@ void TabDiveInformation::updateData()
 	}
 
 	int salinity_value;
-	manualDive = same_string(current_dive->dc.model, "manually added dive");
+	manualDive = is_manually_added_dc(&current_dive->dc);
 	updateWaterTypeWidget();
 	updateProfile();
 	updateWhen();

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -251,7 +251,7 @@ void TabDiveNotes::updateData()
 		ui.LocationLabel->setText(tr("Location"));
 		ui.NotesLabel->setText(tr("Notes"));
 		ui.tagWidget->setText(get_taglist_string(current_dive->tag_list));
-		bool isManual = same_string(current_dive->dc.model, "manually added dive");
+		bool isManual = is_manually_added_dc(&current_dive->dc);
 		ui.depth->setVisible(isManual);
 		ui.depthLabel->setVisible(isManual);
 		ui.duration->setVisible(isManual);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1716,7 +1716,7 @@ int QMLManager::addDive()
 	d.dc.duration.seconds = 40 * 60;
 	d.dc.maxdepth.mm = M_OR_FT(15, 45);
 	d.dc.meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
-	d.dc.model = strdup("manually added dive"); // don't translate! this is stored in the XML file
+	make_manually_added_dc(&d.dc);
 	fake_dc(&d.dc);
 	fixup_dive(&d);
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1127,7 +1127,7 @@ bool QMLManager::checkDuration(struct dive *d, QString duration)
 			m = m6.captured(1).toInt();
 		}
 		d->dc.duration.seconds = d->duration.seconds = h * 3600 + m * 60 + s;
-		if (same_string(d->dc.model, "manually added dive"))
+		if (is_manually_added_dc(&d->dc))
 			free_samples(&d->dc);
 		else
 			appendTextToLog("Cannot change the duration on a dive that wasn't manually added");
@@ -1145,7 +1145,7 @@ bool QMLManager::checkDepth(dive *d, QString depth)
 		// the depth <= 500m
 		if (0 <= depthValue && depthValue <= 500000) {
 			d->maxdepth.mm = depthValue;
-			if (same_string(d->dc.model, "manually added dive")) {
+			if (is_manually_added_dc(&d->dc)) {
 				d->dc.maxdepth.mm = d->maxdepth.mm;
 				free_samples(&d->dc);
 			}
@@ -1351,7 +1351,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 	if (diveChanged) {
 		if (d->maxdepth.mm == d->dc.maxdepth.mm &&
 		    d->maxdepth.mm > 0 &&
-		    same_string(d->dc.model, "manually added dive") &&
+		    is_manually_added_dc(&d->dc) &&
 		    d->dc.samples == 0) {
 			// so we have depth > 0, a manually added dive and no samples
 			// let's create an actual profile so the desktop version can work it

--- a/smtk-import/smartrak.c
+++ b/smtk-import/smartrak.c
@@ -868,7 +868,7 @@ static int prepare_data(int data_model, char *serial, dc_family_t dc_fam, device
 {
 	dev_data->device = NULL;
 	dev_data->context = NULL;
-	if (!data_model){
+	if (!data_model) {
 		dev_data->model = copy_string("manually added dive");
 		dev_data->descriptor = NULL;
 		return DC_STATUS_NODEVICE;


### PR DESCRIPTION
This causes UI confusion. Notably we go into edit mode and reduce the number of samples, leading to loss of information.

If someone really manually adds a dive with more than 50 samples, they should still be able to explicitly open the dive in the planner.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I have no idea whether if this is correct or not.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
see discussion in #3542 
