### PR TITLE
Fix crash when switching from empty state to planner

### DIFF
--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -155,7 +155,6 @@ void ProfileWidget::setEnabledToolbar(bool enabled)
 
 void ProfileWidget::setDive(const struct dive *d)
 {
-	// If the user was currently editing a dive, exit edit mode.
 	stack->setCurrentIndex(1); // show profile
 
 	bool freeDiveMode = d->dc.divemode == FREEDIVE;
@@ -198,13 +197,13 @@ void ProfileWidget::plotCurrentDive()
 
 	setEnabledToolbar(current_dive != nullptr);
 	if (editedDive) {
-		setDive(originalDive);
 		view->plotDive(editedDive.get(), editedDc);
+		setDive(editedDive.get());
 	} else if (current_dive) {
-		setDive(current_dive);
 		view->setProfileState(current_dive, dc_number);
 		view->resetZoom(); // when switching dive, reset the zoomLevel
 		view->plotDive(current_dive, dc_number);
+		setDive(current_dive);
 	} else {
 		view->clear();
 		stack->setCurrentIndex(0);
@@ -235,8 +234,8 @@ void ProfileWidget::divesChanged(const QVector<dive *> &dives, DiveField field)
 void ProfileWidget::setPlanState(const struct dive *d, int dc)
 {
 	exitEditMode();
-	setDive(d);
 	view->setPlanState(d, dc);
+	setDive(d);
 }
 
 void ProfileWidget::unsetProfHR()

--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -90,6 +90,7 @@ ProfileScene::ProfileScene(double dpr, bool printMode, bool isGrayscale) :
 	dpr(dpr),
 	printMode(printMode),
 	isGrayscale(isGrayscale),
+	empty(true),
 	maxtime(-1),
 	maxdepth(-1),
 	profileYAxis(new DiveCartesianAxis(DiveCartesianAxis::Position::Left, true, 3, 0, TIME_GRID, Qt::red, true, true,
@@ -200,6 +201,7 @@ void ProfileScene::clear()
 	qDeleteAll(eventItems);
 	eventItems.clear();
 	free_plot_info_data(&plotInfo);
+	empty = true;
 }
 
 static bool ppGraphsEnabled(const struct divecomputer *dc, bool simplified)
@@ -429,6 +431,11 @@ void ProfileScene::plotDive(const struct dive *dIn, int dcIn, DivePlannerPointsM
 		return;
 	}
 
+	// If we come from the empty state, the plot info has to be recalculated.
+	if (empty)
+		keepPlotInfo = false;
+	empty = false;
+
 	int animSpeed = instant || printMode ? 0 : qPrefDisplay::animation_speed();
 
 	// A non-null planner_ds signals to create_plot_info_new that the dive is currently planned.
@@ -465,9 +472,8 @@ void ProfileScene::plotDive(const struct dive *dIn, int dcIn, DivePlannerPointsM
 	 */
 	int newMaxDepth = get_maxdepth(&plotInfo);
 	if (!calcMax) {
-		if (maxdepth < newMaxDepth) {
+		if (maxdepth < newMaxDepth)
 			maxdepth = newMaxDepth;
-		}
 	} else {
 		maxdepth = newMaxDepth;
 	}

--- a/profile-widget/profilescene.h
+++ b/profile-widget/profilescene.h
@@ -65,6 +65,7 @@ private:
 	double dpr; // Device Pixel Ratio. A DPR of one corresponds to a "standard" PC screen.
 	bool printMode;
 	bool isGrayscale;
+	bool empty; // The profile currently shows nothing.
 	int maxtime;
 	int maxdepth;
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -397,6 +397,8 @@ void ProfileWidget2::clear()
 	handles.clear();
 	gases.clear();
 	empty = true;
+	d = nullptr;
+	dc = 0;
 }
 
 void ProfileWidget2::setProfileState(const dive *dIn, int dcIn)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

See discussion on mailing list. I was never able to reproduce this.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Recalculate plot info when switch from "too small" state.
2) First plot, then show profile
3) Clear dive pointer when clearing profile

This is all guessing, since I can't reproduce the crash.\