### PR TITLE
git: don't access global dive site table

### DIFF
--- a/core/load-git.c
+++ b/core/load-git.c
@@ -177,7 +177,7 @@ static void parse_dive_gps(char *line, struct membuffer *str, struct git_parser_
 	if (!ds) {
 		ds = get_dive_site_by_gps(&location, state->sites);
 		if (!ds)
-			ds = create_dive_site_with_gps("", &location, &dive_site_table);
+			ds = create_dive_site_with_gps("", &location, state->sites);
 		add_dive_to_dive_site(state->active_dive, ds);
 	} else {
 		if (dive_site_has_gps_location(ds) && !same_location(&ds->location, &location)) {
@@ -197,9 +197,9 @@ static void parse_dive_location(char *line, struct membuffer *str, struct git_pa
 	char *name = detach_cstring(str);
 	struct dive_site *ds = get_dive_site_for_dive(state->active_dive);
 	if (!ds) {
-		ds = get_dive_site_by_name(name, &dive_site_table);
+		ds = get_dive_site_by_name(name, state->sites);
 		if (!ds)
-			ds = create_dive_site(name, &dive_site_table);
+			ds = create_dive_site(name, state->sites);
 		add_dive_to_dive_site(state->active_dive, ds);
 	} else {
 		// we already had a dive site linked to the dive
@@ -227,7 +227,7 @@ static void parse_dive_notes(char *line, struct membuffer *str, struct git_parse
 { UNUSED(line); state->active_dive->notes = detach_cstring(str); }
 
 static void parse_dive_divesiteid(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); add_dive_to_dive_site(state->active_dive, get_dive_site_by_uuid(get_hex(line), &dive_site_table)); }
+{ UNUSED(str); add_dive_to_dive_site(state->active_dive, get_dive_site_by_uuid(get_hex(line), state->sites)); }
 
 /*
  * We can have multiple tags in the membuffer. They are separated by
@@ -1756,7 +1756,7 @@ static int parse_site_entry(struct git_parser_state *state, const git_tree_entry
 	if (*suffix == '\0')
 		return report_error("Dive site without uuid");
 	uint32_t uuid = strtoul(suffix, NULL, 16);
-	state->active_site = alloc_or_get_dive_site(uuid, &dive_site_table);
+	state->active_site = alloc_or_get_dive_site(uuid, state->sites);
 	git_blob *blob = git_tree_entry_blob(state->repo, entry);
 	if (!blob)
 		return report_error("Unable to read dive site file");


### PR DESCRIPTION
When loading a git repository, dive sites where loaded into the global dive site table, not the local table. Apparently, nobody ever tried to import a git repository into an existing divelog (as opposed to opening it in the application). Because that would have probably given funky results.

Remove this access of a global variable.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an embarrassing bug, where the git parser would load into global data structures. Thankfully, not many people know how to open git repositories via the file dialog and apparently nobody tried to import data from a git repository.

Since I don't use git, this needs independing testing.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Nobody seems to have notices, so not sure...?
