### PR TITLE
build-system: make -build-with-qt6 work

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -253,7 +253,9 @@ if [ -n "$CMAKE_PREFIX_PATH" ] ; then
 	QMAKE=$CMAKE_PREFIX_PATH/../../bin/qmake
 fi
 if [[ -z $QMAKE  ||  ! -x $QMAKE ]] ; then
-	hash qmake > /dev/null 2> /dev/null && QMAKE=qmake
+	[ -z $QMAKE ] && [ "$BUILD_WITH_QT6" = "1" ] && hash qmake6 > /dev/null 2> /dev/null && QMAKE=qmake6
+	[ -z $QMAKE ] && [ "$BUILD_WITH_QT6" = "1" ] && hash qmake-qt6 > /dev/null 2> /dev/null && QMAKE=qmake-qt6
+	[ -z $QMAKE ] && hash qmake > /dev/null 2> /dev/null && QMAKE=qmake
 	[ -z $QMAKE ] && hash qmake-qt5 > /dev/null 2> /dev/null && QMAKE=qmake-qt5
 	[ -z $QMAKE ] && hash qmake-qt6 > /dev/null 2> /dev/null && QMAKE=qmake-qt6
 	[ -z $QMAKE ] && echo "cannot find qmake, qmake-qt5, or qmake-qt6" && exit 1


### PR DESCRIPTION
-build-with-qt6 did not work for me, because the flag is ignored when selecting the qmake executable. It would find the system-wide qmake executable, which is Qt5 and then decide to build with Qt5.

When the flag is set, try to search for a Qt6 version of qmake first. On Ubuntu based distros this seems to be qmake6

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use correct qmake when passed -build-with-qt6 flag. See commit description.

Side remark: Bash scripting is the worst. Help.
