### PR TITLE
statistics: fix zero-range on value axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+statistics: fix value axis for degenerate value ranges
 profile: Show correct gas density when in CCR mode
 statistics: show correct color of selected scatter items when switching to unbinned mode
 statistics: fix display of month number in continuous date axis

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -284,7 +284,7 @@ void ValueAxis::updateLabels()
 	// Use full decimal increments
 	double height = max - min;
 	double inc = height / numTicks;
-	double digits = floor(log10(inc));
+	double digits = std::max(floor(log10(inc)), static_cast<double>(-decimals));
 	int digits_int = lrint(digits);
 	double digits_factor = pow(10.0, digits);
 	int inc_int = std::max((int)ceil(inc / digits_factor), 1);
@@ -294,11 +294,14 @@ void ValueAxis::updateLabels()
 	if (inc_int == 3)
 		inc_int = 4;
 	inc = inc_int * digits_factor;
-	if (-digits_int > decimals)
-		decimals = -digits_int;
+	int show_decimals = std::max(-digits_int, decimals);
 
-	double actMin = floor(min /  inc) * inc;
-	double actMax = ceil(max /  inc) * inc;
+	double actMin = floor(min / inc) * inc;
+	double actMax = ceil(max / inc) * inc;
+	if (actMax - actMin < inc) {
+		actMax += inc;
+		actMin -= inc;
+	}
 	int num = lrint((actMax - actMin) / inc);
 	setRange(actMin, actMax);
 
@@ -308,7 +311,7 @@ void ValueAxis::updateLabels()
 	ticks.reserve(num + 1);
 	QFontMetrics fm(theme.axisLabelFont);
 	for (int i = 0; i <= num; ++i) {
-		addLabel(fm, loc.toString(act, 'f', decimals), act);
+		addLabel(fm, loc.toString(act, 'f', show_decimals), act);
 		addTick(act);
 		act += actStep;
 	}


### PR DESCRIPTION
The code that calculates the bounds of the value axis was broken when all items had the same value. In that case, increase the shown range explicitly. It doesn't really matter how much the range is increased, because all items will be at the center of the graph.

Also, don't overwrite the "decimal" value of the class. That was just weird.

Fixes #3544.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Create a reasonable value axis for degenerate (single value) value ranges.

I'm a bit tired, so not 100% sure about all the code, but it seemed to work reasonably in a cursory test.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #3544.


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Not needed.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported by @KimDelmar