### PR TITLE
Fixes stray divemaster references in HTML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+htmlexport: fix search in HTML export
 statistics: fix value axis for degenerate value ranges
 profile: Show correct gas density when in CCR mode
 statistics: show correct color of selected scatter items when switching to unbinned mode

--- a/theme/dive_export.html
+++ b/theme/dive_export.html
@@ -101,7 +101,7 @@ window.onload=function(){
 
 	//initializing default searchers
 	searchingModules["location"] = new SearchModule(true);
-	searchingModules["divemaster"] = new SearchModule(true);
+	searchingModules["diveguide"] = new SearchModule(true);
 	searchingModules["buddy"] = new SearchModule(true);
 	searchingModules["notes"] = new SearchModule(true);
 	searchingModules["tags"] = new SearchModule(true);
@@ -112,7 +112,7 @@ window.onload=function(){
 	for(var i=0;i<items.length;i++){
 		searchingModules["location"].Enter_search_string(items[i].location,i);
 
-		searchingModules["divemaster"].Enter_search_string(items[i].divemaster,i);
+		searchingModules["diveguide"].Enter_search_string(items[i].diveguide,i);
 
 		searchingModules["buddy"].Enter_search_string(items[i].buddy,i);
 
@@ -140,7 +140,7 @@ window.onload=function(){
 
 var user_search_preference = {
 	location : true,
-	divemaster : true,
+	diveguide : true,
 	buddy : true,
 	notes : true,
 	tags : true
@@ -152,8 +152,8 @@ function set_search_dropdown(search_preference)
 	searchingModules["location"].enabled = search_preference.location;
 	document.getElementById("search_item_location").checked = search_preference.location;
 
-	searchingModules["divemaster"].enabled = search_preference.divemaster;
-	document.getElementById("search_item_divemaster").checked = search_preference.divemaster;
+	searchingModules["diveguide"].enabled = search_preference.diveguide;
+	document.getElementById("diveguide").checked = search_preference.diveguide;
 
 	searchingModules["buddy"].enabled = search_preference.buddy;
 	document.getElementById("search_item_Buddy").checked = search_preference.buddy;
@@ -190,7 +190,7 @@ function changeAdvSearch(e){
 		<a id="adv_srch_sp" onClick="showdiv()" >Advanced search</a>
 		<div id="advanced_search">
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_location" value="location" checked>Location<br>
-		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_divemaster" value="divemaster" checked>Divemaster<br>
+		<input type="checkbox" onchange="changeAdvSearch(this)" id="diveguide" value="diveguide" checked>Diveguide<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Buddy" value="buddy" checked>Buddy<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Notes" value="notes" checked>Notes<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Tags" value="tags" checked>Tags<br>

--- a/theme/dive_export.html
+++ b/theme/dive_export.html
@@ -153,7 +153,7 @@ function set_search_dropdown(search_preference)
 	document.getElementById("search_item_location").checked = search_preference.location;
 
 	searchingModules["diveguide"].enabled = search_preference.diveguide;
-	document.getElementById("diveguide").checked = search_preference.diveguide;
+	document.getElementById("search_item_diveguide").checked = search_preference.diveguide;
 
 	searchingModules["buddy"].enabled = search_preference.buddy;
 	document.getElementById("search_item_Buddy").checked = search_preference.buddy;
@@ -190,7 +190,7 @@ function changeAdvSearch(e){
 		<a id="adv_srch_sp" onClick="showdiv()" >Advanced search</a>
 		<div id="advanced_search">
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_location" value="location" checked>Location<br>
-		<input type="checkbox" onchange="changeAdvSearch(this)" id="diveguide" value="diveguide" checked>Diveguide<br>
+		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_diveguide" value="diveguide" checked>Diveguide<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Buddy" value="buddy" checked>Buddy<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Notes" value="notes" checked>Notes<br>
 		<input type="checkbox" onchange="changeAdvSearch(this)" id="search_item_Tags" value="tags" checked>Tags<br>

--- a/theme/list_lib.js
+++ b/theme/list_lib.js
@@ -223,13 +223,13 @@ function getExpanded(dive)
 {
 	var res = '<table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
 		  '</td></tr></table>' +
 		  '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Rating + ':</td><td>' + putRating(dive.rating) +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.divemaster +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +
@@ -244,7 +244,7 @@ function putTags(tags)
 {
 	var result = "";
 	for (var i in tags) {
-		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, divemaster:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
+		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, diveguide:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
 		if (i < tags.length - 1)
 			result += ', ';
 	}
@@ -556,7 +556,7 @@ function SearchModules(searchfor, searchOptions)
 	if (searchOptions === null) {
 		searchOptions = {};
 		searchOptions.location = searchingModules["location"].enabled;
-		searchOptions.divemaster = searchingModules["divemaster"].enabled;
+		searchOptions.diveguide = searchingModules["diveguide"].enabled;
 		searchOptions.buddy = searchingModules["buddy"].enabled;
 		searchOptions.notes = searchingModules["notes"].enabled;
 		searchOptions.tags = searchingModules["tags"].enabled;
@@ -568,8 +568,8 @@ function SearchModules(searchfor, searchOptions)
 		if (searchOptions.location === true)
 			keywordResult.Union(searchingModules["location"].search(keywords[i]));
 
-		if (searchOptions.divemaster === true)
-			keywordResult.Union(searchingModules["divemaster"].search(keywords[i]));
+		if (searchOptions.diveguide === true)
+			keywordResult.Union(searchingModules["diveguide"].search(keywords[i]));
 
 		if (searchOptions.buddy === true)
 			keywordResult.Union(searchingModules["buddy"].search(keywords[i]));
@@ -965,7 +965,7 @@ function get_dive_HTML(dive)
 {
 	var table1 = '<h2 class="det_hed">' + translate.Dive_information + '</h2><table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
 		  '</tr></table>';
 	var table2 = '<table><tr><td class="words">' + translate.Rating + ':</td><td>' + putRating(dive.rating) + '</td>';
 	if (dive.wavesize > 0)
@@ -982,7 +982,7 @@ function get_dive_HTML(dive)
 	var table3 = '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.divemaster +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +

--- a/theme/list_lib.js
+++ b/theme/list_lib.js
@@ -223,13 +223,13 @@ function getExpanded(dive)
 {
 	var res = '<table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a>' + getDiveCoor(dive) +
 		  '</td></tr></table>' +
 		  '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Rating + ':</td><td>' + putRating(dive.rating) +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.divemaster +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +
@@ -244,7 +244,7 @@ function putTags(tags)
 {
 	var result = "";
 	for (var i in tags) {
-		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, diveguide:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
+		result += '<a onclick=\"Search_list_Modules(\'' + tags[i] + '\', {location:false, divemaster:false, buddy:false, notes:false, tags:true,})\">' + tags[i] + '</a>';
 		if (i < tags.length - 1)
 			result += ', ';
 	}
@@ -556,7 +556,7 @@ function SearchModules(searchfor, searchOptions)
 	if (searchOptions === null) {
 		searchOptions = {};
 		searchOptions.location = searchingModules["location"].enabled;
-		searchOptions.diveguide = searchingModules["diveguide"].enabled;
+		searchOptions.divemaster = searchingModules["divemaster"].enabled;
 		searchOptions.buddy = searchingModules["buddy"].enabled;
 		searchOptions.notes = searchingModules["notes"].enabled;
 		searchOptions.tags = searchingModules["tags"].enabled;
@@ -568,8 +568,8 @@ function SearchModules(searchfor, searchOptions)
 		if (searchOptions.location === true)
 			keywordResult.Union(searchingModules["location"].search(keywords[i]));
 
-		if (searchOptions.diveguide === true)
-			keywordResult.Union(searchingModules["diveguide"].search(keywords[i]));
+		if (searchOptions.divemaster === true)
+			keywordResult.Union(searchingModules["divemaster"].search(keywords[i]));
 
 		if (searchOptions.buddy === true)
 			keywordResult.Union(searchingModules["buddy"].search(keywords[i]));
@@ -965,7 +965,7 @@ function get_dive_HTML(dive)
 {
 	var table1 = '<h2 class="det_hed">' + translate.Dive_information + '</h2><table><tr><td class="words">' + translate.Date + ': </td><td>' + dive.date +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Time + ': </td><td>' + dive.time +
-		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, diveguide:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
+		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Location + ': </td><td>' + '<a onclick=\"Search_list_Modules(\'' + dive.location + '\', {location:true, divemaster:false, buddy:false, notes:false, tags:false,})\">' + dive.location + '</a></td>' + getDiveCoor(dive) +
 		  '</tr></table>';
 	var table2 = '<table><tr><td class="words">' + translate.Rating + ':</td><td>' + putRating(dive.rating) + '</td>';
 	if (dive.wavesize > 0)
@@ -982,7 +982,7 @@ function get_dive_HTML(dive)
 	var table3 = '<table><tr><td class="words">' + translate.Air_Temp + ': </td><td>' + dive.temperature.air +
 		  '</td><td class="words">&nbsp;&nbsp;&nbsp;&nbsp;' + translate.Water_Temp + ': </td><td>' + dive.temperature.water +
 		  '</td></tr></table><table><tr><td class="words">' + translate.Max_Depth + ': </td><td>' + put_depth_unit(dive.maxdepth) + " " + depth_unit + '</td></tr><tr><td class="words">' + translate.Duration + ': </td><td>' + dive.dive_duration +
-		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.diveguide +
+		  '</td></tr><tr><td class="words">' + translate.DiveGuide + ': </td><td>' + dive.divemaster +
 		  '</td></tr><tr><td class="words"><p>' + translate.Buddy + ': </p></td><td>' + dive.buddy +
 		  '</td></tr><tr><td class="words">' + translate.Suit + ': </td><td>' + dive.suit +
 		  '</td></tr><tr><td class="words">' + translate.Tags + ': </td><td>' + putTags(dive.tags) +


### PR DESCRIPTION
In the HTML export, it's still `divemaster` in some places, but elsewhere the property is called `diveguide`. This broke search in the HTML export.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
I noticed that the search in the HTML export was broken, so I looked into it.
Turns out that the previous change to this file renamed the `divemaster` property in the dives to `diveguide` but didn't catch all the references to it. This PR fixes the remaining references and, thus, the search feature.

### Changes made:
1. renamed remaining `divemaster` property references to `diveguide`.
2. fixed search feature

### Related issues:

### Additional information:

### Release note:
Fixes search functionality in the HTML export

### Documentation change:

### Mentions:
