### PR TITLE
desktop: pass dive list to ShiftTimesDialog

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -845,7 +845,10 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 
 void DiveListView::shiftTimes()
 {
-	ShiftTimesDialog dialog(MainWindow::instance());
+	std::vector<dive *> dives = getDiveSelection();
+	if (dives.empty())
+		return;
+	ShiftTimesDialog dialog(std::move(dives), MainWindow::instance());
 	dialog.exec();
 }
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -87,7 +87,7 @@ void ShiftTimesDialog::buttonClicked(QAbstractButton *button)
 		if (ui.backwards->isChecked())
 			amount *= -1;
 		if (amount != 0)
-			Command::shiftTime(getDiveSelection(), amount);
+			Command::shiftTime(dives, amount);
 	}
 }
 
@@ -102,8 +102,8 @@ void ShiftTimesDialog::changeTime()
 	ui.shiftedTime->setText(get_dive_date_string(amount + when));
 }
 
-ShiftTimesDialog::ShiftTimesDialog(QWidget *parent) : QDialog(parent),
-	when(0)
+ShiftTimesDialog::ShiftTimesDialog(std::vector<dive *> dives_in, QWidget *parent) : QDialog(parent),
+	when(0), dives(std::move(dives_in))
 {
 	ui.setupUi(this);
 	connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
@@ -113,12 +113,9 @@ ShiftTimesDialog::ShiftTimesDialog(QWidget *parent) : QDialog(parent),
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
-	dive *d = first_selected_dive();
-	if (d) {
-		when = d->when;
-		ui.currentTime->setText(get_dive_date_string(when));
-		ui.shiftedTime->setText(get_dive_date_string(when));
-	}
+	when = dives[0]->when;
+	ui.currentTime->setText(get_dive_date_string(when));
+	ui.shiftedTime->setText(get_dive_date_string(when));
 }
 
 void ShiftImageTimesDialog::syncCameraClicked()

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -55,7 +55,8 @@ private:
 class ShiftTimesDialog : public QDialog {
 	Q_OBJECT
 public:
-	explicit ShiftTimesDialog(QWidget *parent);
+	// Must be called with non-empty dives vector!
+	explicit ShiftTimesDialog(std::vector<dive *> dives, QWidget *parent);
 private
 slots:
 	void buttonClicked(QAbstractButton *button);
@@ -63,6 +64,7 @@ slots:
 
 private:
 	int64_t when;
+	std::vector<dive *> dives;
 	Ui::ShiftTimesDialog ui;
 };
 


### PR DESCRIPTION
Users report that the ShiftTimesDialog does not work on Mac and Windows. Apparently, get_first_selected_dive returns NULL, which should not be possible because the dialog is only created when dives are selected. Very omninous.

Get the selected dives in the caller and pass them down. This bug at least should not happen anylonger. Perhaps now the dialog does not show at all, but that will narrow down the root cause of the problem.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Potential fix for the UI issue reported in #3560. At least it should give us a better idea of what is going on.
