### PR TITLE
snap: fix and refresh the snap job

### DIFF
--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -12,27 +12,22 @@ jobs:
   Snap:
     runs-on: ubuntu-latest
 
-    env:
-      SNAPCRAFT_BUILD_INFO: 1
-
     timeout-minutes: 60
     steps:
-    - name: Install Snapcraft
-      uses: samuelmeuli/action-snapcraft@v1
-
-    - name: Setup LXD
-      uses: whywaita/setup-lxd@v1
-
     - name: Check out code
       uses: actions/checkout@v2
       with:
         # Needed for version determination to work
         fetch-depth: 0
 
+    - name: Set up LXD
+      uses: canonical/setup-lxd@main
+
     - name: Set up CCache
       id: setup-ccache
       run: |
         sudo apt-get install ccache
+        mkdir -p ${HOME}/.ccache
         ccache --max-size=2G
         /snap/bin/lxc profile device add default ccache disk source=${HOME}/.ccache/ path=/root/.ccache
 
@@ -51,30 +46,18 @@ jobs:
           ccache-${{ runner.os }}-
         path: ~/.ccache/**
 
-    - name: Build
-      run: |
-        # Build the `subsurface` part.
-        /snap/bin/snapcraft build --use-lxd subsurface
+    - name: Build and verify the snap
+      uses: canonical/actions/build-snap@release
+      id: build-snap
+      with:
+        setup-lxd: false
 
     - name: Clear CCache stats
       run: ccache --show-stats --zero-stats
 
-    - name: Build and verify the snap
-      id: build-snap
-      env:
-        SNAP_ENFORCE_RESQUASHFS: 0
-      run: |
-        # Actually build the snap.
-        /snap/bin/snapcraft --use-lxd
-
-        sudo snap install review-tools
-        /snap/bin/review-tools.snap-review *.snap
-
-        echo "::set-output name=snap-file::$( ls *.snap )"
-
     - name: Upload the snap
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ steps.build-snap.outputs.snap-file }}
-        path: ${{ steps.build-snap.outputs.snap-file }}
+        name: ${{ steps.build-snap.outputs.snap-name }}
+        path: ${{ steps.build-snap.outputs.snap-path }}
         if-no-files-found: error

--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Needed for version determination to work
         fetch-depth: 0
@@ -36,10 +36,10 @@ jobs:
 
         # Find common base between master and HEAD to use as cache key.
         git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules origin master
-        echo "::set-output name=key::$( git merge-base origin/master ${{ github.sha }} )"
+        echo "key=$( git merge-base origin/master ${{ github.sha }} )" >> $GITHUB_OUTPUT
 
     - name: CCache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ccache-${{ runner.os }}-${{ steps.setup-ccache.outputs.key }}
         restore-keys: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: subsurface
-adopt-info: subsurface
+version: git
 icon: icons/subsurface-icon.svg
 summary: Open source divelog program for recreational, tech, and free-divers
 description: |
@@ -151,9 +151,6 @@ parts:
     - qtlocation5-dev
     - qtpositioning5-dev
     - qttools5-dev
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $( git describe )
     override-build: |
       mkdir -p ../install-root
       ln -sf ../../../stage/usr/lib/*/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so \


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This fixes the Linux-Snap CI job by using the Canonical `build-snap` action I maintain, rather than spelling out all the steps. The `ubuntu-latest` move to 22.04 broke some things.

While there, I also cleared up some warnings related to deprecated GitHub Actions usage (e.g. `set-output=`).

### Changes made:
1) use [`canonical/actions/build-snap`](https://github.com/canonical/actions/tree/main/build-snap) action
2) make the `.ccache` folder now that `ccache --max-size` doesn't
2) refresh `checkout` and `cache` actions for [GitHub deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
3) use simpler `version: git` stanza

### More information
A move to `base: core22` will be the next step I'll work on.

### Mentions:
@dirkhh this will fix Snap CI