### PR TITLE
Improvement: Show gases as diluent by default for CCR dives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+equipment: Use 'diluent' as default gas use type if the dive mode is 'CCR'
 htmlexport: fix search in HTML export
 statistics: fix value axis for degenerate value ranges
 profile: Show correct gas density when in CCR mode

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -150,6 +150,11 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 			cyl.gasmix.he.permille = he;
 		}
 
+		if (dive->dc.divemode == CCR)
+			cyl.cylinder_use = DILUENT;
+		else
+			cyl.cylinder_use = OC_GAS;
+
 		if (i < ntanks) {
 			dc_tank_t tank = { 0 };
 			rc = dc_parser_get_field(parser, DC_FIELD_TANK, i, &tank);
@@ -157,11 +162,11 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 				cyl.type.size.mliter = lrint(tank.volume * 1000);
 				cyl.type.workingpressure.mbar = lrint(tank.workpressure * 1000);
 
-				cyl.cylinder_use = OC_GAS;
-				if (tank.type & DC_TANKINFO_CC_O2)
-					cyl.cylinder_use = OXYGEN;
+				// libdivecomputer treats these as independent, but a tank cannot be used for diluent and O2 at the same time
 				if (tank.type & DC_TANKINFO_CC_DILUENT)
 					cyl.cylinder_use = DILUENT;
+				else if (tank.type & DC_TANKINFO_CC_O2)
+					cyl.cylinder_use = OXYGEN;
 
 				if (tank.type & DC_TANKINFO_IMPERIAL) {
 					if (same_string(devdata->model, "Suunto EON Steel")) {


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Instead of adding all gases read from a dive computer as part of a dive log as 'OC-gas', add gases as 'diluent' if the dive has a dive mode of 'CCR'. This creates consistency with the ppO2 for CCR dives being tracked as sensor readings or a fixed setpoint, and not as the ppO2 of the current gas ad depth.
A follow up question from this is whether gas use in the cylinders list on the Equipment tab should be user editable. This seems to be inconsistent at the moment, with gas constituent percentages downloaded from the dive computer being editable, but gas use not.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) use 'diluent' as the default gas use if the dive mode is 'CCR'

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://user-images.githubusercontent.com/4742747/213627578-79437f54-e2b0-4c54-96f2-927358c7795c.png)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
equipment: Use 'diluent' as default gas use type if the dive mode is 'CCR'

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

Signed-off-by: Michael Keller <github@ike.ch>