### PR TITLE
NULL cylinders are never the same

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1165,16 +1165,20 @@ void AddCylinder::redo()
 	}
 }
 
-static bool same_cylinder_type(const cylinder_t &cyl1, const cylinder_t &cyl2)
+static bool same_cylinder_type(const cylinder_t *cyl1, const cylinder_t *cyl2)
 {
-	return same_string(cyl1.type.description, cyl2.type.description) &&
-	       cyl1.cylinder_use == cyl2.cylinder_use;
+	if (cyl1 == NULL || cyl2 == NULL)
+		return 0;
+	return same_string(cyl1->type.description, cyl2->type.description) &&
+	       cyl1->cylinder_use == cyl2->cylinder_use;
 }
 
-static bool same_cylinder_size(const cylinder_t &cyl1, const cylinder_t &cyl2)
+static bool same_cylinder_size(const cylinder_t *cyl1, const cylinder_t *cyl2)
 {
-	return cyl1.type.size.mliter == cyl2.type.size.mliter &&
-	       cyl1.type.workingpressure.mbar == cyl2.type.workingpressure.mbar;
+	if (cyl1 == NULL || cyl2 == NULL)
+		return 0;
+	return cyl1->type.size.mliter == cyl2->type.size.mliter &&
+	       cyl1->type.workingpressure.mbar == cyl2->type.workingpressure.mbar;
 }
 
 // Flags for comparing cylinders
@@ -1202,7 +1206,7 @@ EditCylinderBase::EditCylinderBase(int index, bool currentDiveOnly, bool nonProt
 		if (nonProtectedOnly && is_cylinder_prot(d, index))
 			continue;
 		if (d != current &&
-		    (!same_cylinder_size(orig, *get_cylinder(d, index)) || !same_cylinder_type(orig, *get_cylinder(d, index))))
+		    (!same_cylinder_size(&orig, get_cylinder(d, index)) || !same_cylinder_type(&orig, get_cylinder(d, index))))
 			// when editing cylinders, we assume that the user wanted to edit the 'n-th' cylinder
 			// and we only do edit that cylinder, if it was the same type as the one in the current dive
 			continue;


### PR DESCRIPTION
When editing many dives it can happen that a cylinder index is invalid which results in  a NULL cylinter pointer. Treat such a cylinder as different from any other cylinder rather than dereferencing the NULL pointer and crashing.

Fixes #3578 (at least as far as I can tell)

Signed-off-by: Robert C. Helling <helling@atdotde.de>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
