### PR TITLE
parser: fix end-of-string check in import-csv.c

### DIFF
--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -178,7 +178,7 @@ static int parse_dan_format(const char *filename, struct xml_params *params, str
 		memset(tmpbuf, 0, sizeof(tmpbuf));
 		iter = strchr(iter, '|');
 
-		if (iter && iter[1]) {
+		if (iter) {
 			iter = iter + 1;
 			iter_end = strchr(iter, '|');
 
@@ -203,7 +203,7 @@ static int parse_dan_format(const char *filename, struct xml_params *params, str
 			for (i = 0; i < 5 && iter; ++i)
 				iter = strchr(iter + 1, '|');
 
-			if (iter && iter + 1) {
+			if (iter) {
 				iter = iter + 1;
 				iter_end = strchr(iter, '|');
 
@@ -254,7 +254,7 @@ static int parse_dan_format(const char *filename, struct xml_params *params, str
 			for (i = 0; i < 5 && iter; ++i)
 				iter = strchr(iter + 1, '|');
 
-			if (iter && iter + 1) {
+			if (iter) {
 				iter = iter + 1;
 				iter_end = strchr(iter, '|');
 


### PR DESCRIPTION
For details, see 096de0efd01e12de6c4ce968eead90e95ff8157f.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

A rather trivial bug fix. The old code looks actively dangerous, as the NULL check did not work and a smart compiler would throw it away.