### PR TITLE
Cylindermodel: Improve editing of tank use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: use dynamic tank use drop down in equipment tab and planner
 desktop: fix brightness configuration for OSTC4
 equipment: Use 'diluent' as default gas use type if the dive mode is 'CCR'
 htmlexport: fix search in HTML export

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -51,6 +51,7 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	view->setColumnHidden(CylindersModel::SIZE_INT, true);
 	view->setColumnHidden(CylindersModel::SENSORS, true);
 	view->setItemDelegateForColumn(CylindersModel::TYPE, new TankInfoDelegate(this));
+	view->setItemDelegateForColumn(CylindersModel::USE, new TankUseDelegate(this));
 	connect(ui.cylinderTableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addCylinder_clicked);
 	connect(ui.tableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addDefaultStop);
 	connect(cylinders, &CylindersModel::dataChanged, GasSelectionModel::instance(), &GasSelectionModel::repopulate);

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -142,11 +142,6 @@ void TabDiveEquipment::updateData()
 	cylindersModel->updateDive(current_dive);
 	weightModel->updateDive(current_dive);
 
-	bool is_ccr = current_dive && get_dive_dc(current_dive, dc_number)->divemode == CCR;
-	if (is_ccr)
-		ui.cylinders->view()->showColumn(CylindersModel::USE);
-	else
-		ui.cylinders->view()->hideColumn(CylindersModel::USE);
 	if (current_dive && current_dive->suit)
 		ui.suit->setText(QString(current_dive->suit));
 	else

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -537,7 +537,7 @@ void CylindersModel::updateDive(dive *dIn)
 
 Qt::ItemFlags CylindersModel::flags(const QModelIndex &index) const
 {
-	if (index.column() == REMOVE || index.column() == USE)
+	if (index.column() == REMOVE)
 		return Qt::ItemIsEnabled;
 	return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
 }
@@ -549,15 +549,6 @@ void CylindersModel::remove(QModelIndex index)
 {
 	if (!d)
 		return;
-	if (index.column() == USE) {
-		cylinder_t *cyl = cylinderAt(index);
-		if (cyl->cylinder_use == OC_GAS)
-			cyl->cylinder_use = NOT_USED;
-		else if (cyl->cylinder_use == NOT_USED)
-			cyl->cylinder_use = OC_GAS;
-		dataChanged(index, index);
-		return;
-	}
 
 	if (index.column() != REMOVE)
 		return;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1042,7 +1042,7 @@ void DivePlannerPointsModel::createTemporaryPlan()
 	struct divedatapoint *dp = NULL;
 	for (int i = 0; i < d->cylinders.nr; i++) {
 		cylinder_t *cyl = get_cylinder(d, i);
-		if (cyl->depth.mm && cyl->cylinder_use != NOT_USED) {
+		if (cyl->depth.mm && cyl->cylinder_use == OC_GAS) {
 			dp = create_dp(0, cyl->depth.mm, i, 0);
 			if (diveplan.dp) {
 				dp->next = diveplan.dp;


### PR DESCRIPTION


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use the drop down for editing the tank use in the gas list in both the equipment tab and the dive planner.
The tank use column is now available in the equipment tab for all dives and not just CCR dives, as 'not used' is a valid entry in both cases. However, if the current dive is an OC dive, only 'OC-gas' and 'not used' are shown.
There still seems to be a problem that in some cases, when opening the planner after selecting an existing CCR dive the drop down in the planner does not list CCR gas uses - for some reason `displayed_dive` does not seem to be updated correctly on opening of the planner. But I have not been able to reproduce this consistently, and changing 'Dive mode' fixes this.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) use the tank use drop down in the dive planner instead of the on / off toggle
2) always show the tank use column in the equipment tab
3) only populate the tank use combobox with 'OC-gas' and 'not used' if the current / planned dive is an OC dive

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://user-images.githubusercontent.com/4742747/216806026-19a94744-885b-4a6e-8a69-76e65ebd78c9.png)
![image](https://user-images.githubusercontent.com/4742747/216806056-1a3bbe98-bdce-4a4e-949d-eb747110497a.png)
![image](https://user-images.githubusercontent.com/4742747/216806073-dd5bfc56-4ad5-4ecc-925d-5ac4deecba7f.png)


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: use tank dynamic tank use drop down in equipment tab and planner

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>
