### PR TITLE
ci: bring Snap USNs back

### DIFF
--- a/.github/workflows/scripts/check_usns.py
+++ b/.github/workflows/scripts/check_usns.py
@@ -34,6 +34,7 @@ STORE_URL = "https://api.snapcraft.io/api/v1/snaps" "/details/{snap}?channel={ch
 STORE_HEADERS = {"X-Ubuntu-Series": "16", "X-Ubuntu-Architecture": "{arch}"}
 
 CHECK_NOTICES_PATH = "/snap/bin/review-tools.check-notices"
+CHECK_NOTICES_ARGS = ["--ignore-pockets", "esm-apps"]
 
 
 def get_store_snap(processor, snap, channel):
@@ -76,7 +77,7 @@ def check_snap_notices(store_snaps):
         )
 
         try:
-            notices = subprocess.check_output([CHECK_NOTICES_PATH] + snaps, encoding="UTF-8")
+            notices = subprocess.check_output([CHECK_NOTICES_PATH] + CHECK_NOTICES_ARGS + snaps, encoding="UTF-8")
             logger.debug("Got check_notices output:\n%s", notices)
         except subprocess.CalledProcessError as e:
             logger.error("Failed to check notices:\n%s", e.output)

--- a/.github/workflows/snap_usns.yml
+++ b/.github/workflows/snap_usns.yml
@@ -1,9 +1,9 @@
 name: SnapUSNs
 
 on:
-  workflow_dispatch
-#  schedule:
-#  - cron: '0 5 * * *'
+  workflow_dispatch:
+  schedule:
+  - cron: '0 5 * * *'
 
 jobs:
   CheckUSNs:
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install Snap dependencies
       run: |
-        sudo snap install review-tools
+        sudo snap install review-tools --edge
 
     - name: Set up Launchpad credentials
       uses: DamianReeves/write-file-action@v1.0


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Ref. https://bugs.launchpad.net/snapstore-server/+bug/2004008

While that gets resolved, ignore the extra packages when checking for security notices.

### Changes made:
Use the `--ignore-pockets` from review-tools `edge` channel to skip security fixes unavailable to the build system.

### Mentions:
@dirkhh this brings back the security checks / rebuilds. I will drop the `--edge` when that becomes available on stable. Note that i386 isn't built since 5.0.8, I wonder if we should unlist it from the store?
