### PR TITLE
Correct paths, to allow libmtp to build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -498,9 +498,7 @@ if [[ $PLATFORM = Darwin && "$BUILD_DEPS" == "1" ]] ; then
 	pushd libmtp
 	patch -p1 < ../${SRC_DIR}/scripts/libmtp.patch || true
 	echo 'N' | NOCONFIGURE="1" bash ./autogen.sh
-	mkdir -p build
-	cd build
-	CFLAGS="$MAC_OPTS" ../configure --prefix="$INSTALL_ROOT"
+	CFLAGS="$MAC_OPTS" ./configure --prefix="$INSTALL_ROOT"
 	make -j4
 	make install
 	popd


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
As captured in [this ](https://github.com/subsurface/subsurface/issues/3577#issuecomment-1422828481)discussion - addresses the path issue for libmtp.

### Changes made:
Updates the paths, don't make (and enter) a build directory - so include files like `ptp.h` are available.

### Related issues:
As noted above (discussion / bug report).

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
