### PR TITLE
desktop: fix multi-dive editing of cylinders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: fix crash on cylinder update of multiple dives
 desktop: use dynamic tank use drop down in equipment tab and planner
 desktop: fix brightness configuration for OSTC4
 equipment: Use 'diluent' as default gas use type if the dive mode is 'CCR'

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1199,19 +1199,24 @@ EditCylinderBase::EditCylinderBase(int index, bool currentDiveOnly, bool nonProt
 	cyl.reserve(dives.size());
 
 	for (dive *d: dives) {
+		if (index >= d->cylinders.nr)
+			continue;
 		if (nonProtectedOnly && is_cylinder_prot(d, index))
 			continue;
+		// We checked that the cylinder exists above.
+		const cylinder_t &cylinder = *get_cylinder(d, index);
 		if (d != current &&
-		    (!same_cylinder_size(orig, *get_cylinder(d, index)) || !same_cylinder_type(orig, *get_cylinder(d, index))))
+		    (!same_cylinder_size(orig, cylinder) || !same_cylinder_type(orig, cylinder))) {
 			// when editing cylinders, we assume that the user wanted to edit the 'n-th' cylinder
 			// and we only do edit that cylinder, if it was the same type as the one in the current dive
 			continue;
+		}
 
 		divesNew.push_back(d);
 		// that's silly as it's always the same value - but we need this vector of indices in the case where we add
 		// a cylinder to several dives as the spot will potentially be different in different dives
 		indexes.push_back(index);
-		cyl.push_back(clone_cylinder(*get_cylinder(d, index)));
+		cyl.push_back(clone_cylinder(cylinder));
 	}
 	dives = std::move(divesNew);
 }


### PR DESCRIPTION
3629a87 changed the handling of cylinders in multi-dives edit. Not only should the cylinders be the "same", but also at the same position. The code did not check whether the edited dives even had that many cylinders, leading to a null-pointer dereference.

Check whether the cylinder exists before comparing it.

Fixes #3578.

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

See commit description and discussion in #3585.

This is only compile tested!

PS: This demonstrates that there should be tests for the undo-commands. But that would need a change of the API (no direct access of the selection and current_dive).

@mikeller 