### PR TITLE
cleanup: redo event-name code [+small bugfix]

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -51,6 +51,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/divecomputer.c \
 	core/divefilter.cpp \
 	core/event.c \
+	core/eventname.cpp \
 	core/filterconstraint.cpp \
 	core/filterpreset.cpp \
 	core/divelist.c \
@@ -200,6 +201,7 @@ HEADERS += \
 	core/dive.h \
 	core/divecomputer.h \
 	core/event.h \
+	core/eventname.h \
 	core/extradata.h \
 	core/git-access.h \
 	core/globals.h \

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,6 +79,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	downloadfromdcthread.h
 	event.c
 	event.h
+	eventname.cpp
+	eventname.h
 	equipment.c
 	equipment.h
 	errorhelper.c

--- a/core/divecomputer.c
+++ b/core/divecomputer.c
@@ -2,6 +2,7 @@
 
 #include "divecomputer.h"
 #include "event.h"
+#include "eventname.h"
 #include "extradata.h"
 #include "pref.h"
 #include "sample.h"
@@ -442,7 +443,7 @@ struct event *add_event(struct divecomputer *dc, unsigned int time, int type, in
 
 	add_event_to_dc(dc, ev);
 
-	remember_event(name);
+	remember_event_name(name);
 	return ev;
 }
 

--- a/core/divecomputer.c
+++ b/core/divecomputer.c
@@ -2,7 +2,6 @@
 
 #include "divecomputer.h"
 #include "event.h"
-#include "eventname.h"
 #include "extradata.h"
 #include "pref.h"
 #include "sample.h"
@@ -443,7 +442,6 @@ struct event *add_event(struct divecomputer *dc, unsigned int time, int type, in
 
 	add_event_to_dc(dc, ev);
 
-	remember_event_name(name);
 	return ev;
 }
 

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -8,6 +8,7 @@
 #include "divesite.h"
 #include "dive.h"
 #include "event.h"
+#include "eventname.h"
 #include "filterpreset.h"
 #include "fulltext.h"
 #include "interpolate.h"
@@ -1375,7 +1376,7 @@ void clear_dive_file_data()
 
 	clear_dive(&displayed_dive);
 	clear_device_table(&device_table);
-	clear_events();
+	clear_event_names();
 	clear_filter_presets();
 
 	reset_min_datafile_version();

--- a/core/event.c
+++ b/core/event.c
@@ -99,38 +99,3 @@ bool same_event(const struct event *a, const struct event *b)
 		return 0;
 	return !strcmp(a->name, b->name);
 }
-
-/* collect all event names and whether we display them */
-struct ev_select *ev_namelist = NULL;
-int evn_used = 0;
-static int evn_allocated = 0;
-
-void clear_events(void)
-{
-	for (int i = 0; i < evn_used; i++)
-		free(ev_namelist[i].ev_name);
-	evn_used = 0;
-}
-
-void remember_event(const char *eventname)
-{
-	int i = 0, len;
-
-	if (!eventname || (len = strlen(eventname)) == 0)
-		return;
-	while (i < evn_used) {
-		if (!strncmp(eventname, ev_namelist[i].ev_name, len))
-			return;
-		i++;
-	}
-	if (evn_used == evn_allocated) {
-		evn_allocated += 10;
-		ev_namelist = realloc(ev_namelist, evn_allocated * sizeof(struct ev_select));
-		if (!ev_namelist)
-			/* we are screwed, but let's just bail out */
-			return;
-	}
-	ev_namelist[evn_used].ev_name = strdup(eventname);
-	ev_namelist[evn_used].plot_ev = true;
-	evn_used++;
-}

--- a/core/event.c
+++ b/core/event.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "event.h"
+#include "eventname.h"
 #include "subsurface-string.h"
 
 #include <string.h>
@@ -78,6 +79,8 @@ struct event *create_event(unsigned int time, int type, int flags, int value, co
 		ev->gas.index = gas_index;
 		break;
 	}
+
+	remember_event_name(name);
 
 	return ev;
 }

--- a/core/event.h
+++ b/core/event.h
@@ -39,15 +39,6 @@ struct event {
 	char name[];
 };
 
-struct ev_select {
-	char *ev_name;
-	bool plot_ev;
-};
-
-/* collect all event names and whether we display them */
-extern struct ev_select *ev_namelist;
-extern int evn_used;
-
 extern int event_is_gaschange(const struct event *ev);
 extern bool event_is_divemodechange(const struct event *ev);
 extern struct event *clone_event(const struct event *src_ev);
@@ -55,8 +46,6 @@ extern void free_events(struct event *ev);
 extern struct event *create_event(unsigned int time, int type, int flags, int value, const char *name);
 extern struct event *clone_event_rename(const struct event *ev, const char *name);
 extern bool same_event(const struct event *a, const struct event *b);
-extern void remember_event(const char *eventname);
-extern void clear_events(void);
 
 /* Since C doesn't have parameter-based overloading, two versions of get_next_event. */
 extern const struct event *get_next_event(const struct event *event, const char *name);

--- a/core/eventname.cpp
+++ b/core/eventname.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "eventname.h"
+#include "subsurface-string.h"
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+struct event_name {
+	std::string name;
+	bool plot;
+};
+
+static std::vector<event_name> event_names;
+
+// Small helper so that we can compare events to C-strings
+static bool operator==(const event_name &en, const char *s)
+{
+	return en.name == s;
+}
+
+extern "C" void clear_event_names()
+{
+	event_names.clear();
+}
+
+extern "C" void remember_event_name(const char *eventname)
+{
+	if (empty_string(eventname))
+		return;
+	if (std::find(event_names.begin(), event_names.end(), eventname) != event_names.end())
+		return;
+	event_names.push_back({ eventname, true });
+}
+
+extern "C" bool is_event_hidden(const char *eventname)
+{
+	auto it = std::find(event_names.begin(), event_names.end(), eventname);
+	return it != event_names.end() && !it->plot;
+}
+
+extern "C" void hide_event(const char *eventname)
+{
+	auto it = std::find(event_names.begin(), event_names.end(), eventname);
+	if (it != event_names.end())
+		it->plot = false;
+}
+
+extern "C" void show_all_events()
+{
+	for (event_name &en: event_names)
+		en.plot = true;
+}
+
+extern "C" bool any_events_hidden()
+{
+	return std::any_of(event_names.begin(), event_names.end(),
+			   [] (const event_name &en) { return !en.plot; });
+}

--- a/core/eventname.h
+++ b/core/eventname.h
@@ -1,0 +1,21 @@
+// collect all event names and whether we display events of that type
+// SPDX-License-Identifier: GPL-2.0
+#ifndef EVENTNAME_H
+#define EVENTNAME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void clear_event_names(void);
+extern void remember_event_name(const char *eventname);
+extern bool is_event_hidden(const char *eventname);
+extern void hide_event(const char *eventname);
+extern void show_all_events();
+extern bool any_events_hidden();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -4,6 +4,7 @@
 #include "profile-widget/divepixmapcache.h"
 #include "profile-widget/animationfunctions.h"
 #include "core/event.h"
+#include "core/eventname.h"
 #include "core/format.h"
 #include "core/profile.h"
 #include "core/gettextfromc.h"
@@ -225,11 +226,7 @@ bool DiveEventItem::isInteresting(const struct dive *d, const struct divecompute
 
 bool DiveEventItem::shouldBeHidden()
 {
-	for (int i = 0; i < evn_used; i++) {
-		if (!strcmp(ev->name, ev_namelist[i].ev_name) && ev_namelist[i].plot_ev == false)
-			return true;
-	}
-	return false;
+	return is_event_hidden(ev->name);
 }
 
 void DiveEventItem::recalculatePos()

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -826,7 +826,7 @@ void PartialPressureGasItem::paint(QPainter *painter, const QStyleOptionGraphics
 
 	QPolygonF poly;
 	painter->setPen(QPen(alertColor, pWidth));
-	Q_FOREACH (const QPolygonF &poly, alertPolygons)
+	for (const QPolygonF &poly: alertPolygons)
 		painter->drawPolyline(poly);
 	painter->restore();
 }

--- a/profile-widget/divetooltipitem.cpp
+++ b/profile-widget/divetooltipitem.cpp
@@ -14,12 +14,10 @@ void ToolTipItem::addToolTip(const QString &toolTip, const QPixmap &pixmap)
 
 	QGraphicsPixmapItem *iconItem = 0;
 	double yValue = title->boundingRect().height() + iconMetrics.spacing;
-	Q_FOREACH (ToolTip t, toolTips) {
+	for (ToolTip t: toolTips)
 		yValue += t.second->boundingRect().height();
-	}
-	if (entryToolTip.second) {
+	if (entryToolTip.second)
 		yValue += entryToolTip.second->boundingRect().height();
-	}
 	iconItem = new QGraphicsPixmapItem(this);
 	if (!pixmap.isNull())
 		iconItem->setPixmap(pixmap);
@@ -36,7 +34,7 @@ void ToolTipItem::addToolTip(const QString &toolTip, const QPixmap &pixmap)
 
 void ToolTipItem::clear()
 {
-	Q_FOREACH (ToolTip t, toolTips) {
+	for (ToolTip t: toolTips) {
 		delete t.first;
 		delete t.second;
 	}
@@ -78,7 +76,7 @@ void ToolTipItem::expand()
 	const IconMetrics &iconMetrics = defaultIconMetrics();
 
 	double width = 0, height = title->boundingRect().height() + iconMetrics.spacing;
-	Q_FOREACH (const ToolTip &t, toolTips) {
+	for (const ToolTip &t: toolTips) {
 		QRectF sRect = t.second->boundingRect();
 		if (sRect.width() > width)
 			width = sRect.width();
@@ -186,9 +184,8 @@ void ToolTipItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
 	persistPos();
 	QGraphicsRectItem::mouseReleaseEvent(event);
-	Q_FOREACH (QGraphicsItem *item, oldSelection) {
+	for (QGraphicsItem *item: oldSelection)
 		item->setSelected(true);
-	}
 }
 
 void ToolTipItem::persistPos() const

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -689,7 +689,7 @@ void ProfileWidget2::hideEvents(DiveEventItem *item)
 				  QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
 		if (!empty_string(event->name)) {
 			hide_event(event->name);
-			Q_FOREACH (DiveEventItem *evItem, profileScene->eventItems) {
+			for (DiveEventItem *evItem: profileScene->eventItems) {
 				if (same_string(evItem->getEvent()->name, event->name))
 					evItem->hide();
 			}
@@ -702,7 +702,7 @@ void ProfileWidget2::hideEvents(DiveEventItem *item)
 void ProfileWidget2::unhideEvents()
 {
 	show_all_events();
-	Q_FOREACH (DiveEventItem *item, profileScene->eventItems)
+	for (DiveEventItem *item: profileScene->eventItems)
 		item->show();
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -3,6 +3,7 @@
 #include "profile-widget/profilescene.h"
 #include "core/device.h"
 #include "core/event.h"
+#include "core/eventname.h"
 #include "core/subsurface-string.h"
 #include "core/qthelper.h"
 #include "core/range.h"
@@ -643,14 +644,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 		}
 #endif
 	}
-	bool some_hidden = false;
-	for (int i = 0; i < evn_used; i++) {
-		if (ev_namelist[i].plot_ev == false) {
-			some_hidden = true;
-			break;
-		}
-	}
-	if (some_hidden)
+	if (any_events_hidden())
 		m.addAction(tr("Unhide all events"), this, &ProfileWidget2::unhideEvents);
 	m.exec(event->globalPos());
 }
@@ -694,12 +688,7 @@ void ProfileWidget2::hideEvents(DiveEventItem *item)
 				  TITLE_OR_TEXT(tr("Hide events"), tr("Hide all %1 events?").arg(event->name)),
 				  QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
 		if (!empty_string(event->name)) {
-			for (int i = 0; i < evn_used; i++) {
-				if (same_string(event->name, ev_namelist[i].ev_name)) {
-					ev_namelist[i].plot_ev = false;
-					break;
-				}
-			}
+			hide_event(event->name);
 			Q_FOREACH (DiveEventItem *evItem, profileScene->eventItems) {
 				if (same_string(evItem->getEvent()->name, event->name))
 					evItem->hide();
@@ -712,9 +701,7 @@ void ProfileWidget2::hideEvents(DiveEventItem *item)
 
 void ProfileWidget2::unhideEvents()
 {
-	for (int i = 0; i < evn_used; i++) {
-		ev_namelist[i].plot_ev = true;
-	}
+	show_all_events();
 	Q_FOREACH (DiveEventItem *item, profileScene->eventItems)
 		item->show();
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
While polishing the profile code, the event-name code always annoyed me. It was splattered all over the place, accessed global variables, leaked on exit, etc. This collects all the code in one place, rewrites it in C++ and provides a C-only interface.

To see why C++ is preferable here, compare
```
void remember_event(const char *eventname)		
{		
	int i = 0, len;		

	if (!eventname || (len = strlen(eventname)) == 0)		
		return;		
	while (i < evn_used) {		
		if (!strncmp(eventname, ev_namelist[i].ev_name, len))		
			return;		
		i++;		
	}		
	if (evn_used == evn_allocated) {		
		evn_allocated += 10;		
		ev_namelist = realloc(ev_namelist, evn_allocated * sizeof(struct ev_select));		
		if (!ev_namelist)		
			/* we are screwed, but let's just bail out */		
			return;		
	}		
	ev_namelist[evn_used].ev_name = strdup(eventname);		
	ev_namelist[evn_used].plot_ev = true;		
	evn_used++;		
}
```
to
```
extern "C" void remember_event_name(const char *eventname)
{
	if (empty_string(eventname))
		return;
	if (std::find(event_names.begin(), event_names.end(), eventname) != event_names.end())
		return;
	event_names.push_back({ eventname, true });
}
```

The second commit fixes a bug, which was introduced during undoification of the event system.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Probably not necessary, bug is too obscure.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@dirkhh: this is a short one and should be easy to review.