### PR TITLE
Fix invalid bailout gas choice when planning a CCR dive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: fix bug in bailout gas selection for CCR dives
 desktop: fix crash on cylinder update of multiple dives
 desktop: use dynamic tank use drop down in equipment tab and planner
 desktop: fix brightness configuration for OSTC4

--- a/tests/testplan.h
+++ b/tests/testplan.h
@@ -19,6 +19,7 @@ private slots:
 	void testVpmbMetric100m10min();
 	void testVpmbMetricRepeat();
 	void testMultipleGases();
+	void testCcrBailoutGasSelection();
 };
 
 #endif // TESTPLAN_H


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug reported in https://groups.google.com/g/subsurface-divelog/c/8N3cTz2Zv5E:
When planning a CCR dive with OC bailout, the diluent gas may be chosen as the first OC bailout gas, despite being set up with a use type of 'diluent', and likely not being available for open circuit breathing.
`best_first_ascend_cylinder` is now initialised to an invalid value (instead of the first cylinder, which may or may not be a diluent cylinder), and its subsequent use is guarded by a validity check.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) initialise `best_first_ascend_cylinder` to -1 (invalid index value)
2) guard access to `best_first_ascend_cylinder` with a check for a valid value
3) added a test case for a CCR dive that includes a regression test for the bug

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
https://groups.google.com/g/subsurface-divelog/c/8N3cTz2Zv5E

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://user-images.githubusercontent.com/4742747/219287307-c54f1c5b-76a1-4510-8439-86a9baeb79ed.png)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: fix bug in bailout gas selection for CCR dives

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>