### PR TITLE
Standardised how divedatapoints are created.

### DIFF
--- a/core/planner.c
+++ b/core/planner.c
@@ -339,7 +339,7 @@ void free_dps(struct diveplan *diveplan)
 	diveplan->dp = NULL;
 }
 
-struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po2)
+static struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po2)
 {
 	struct divedatapoint *dp;
 

--- a/core/planner.h
+++ b/core/planner.h
@@ -51,7 +51,6 @@ extern char *get_planner_disclaimer_formatted();
 extern void free_dps(struct diveplan *diveplan);
 
 struct divedatapoint *plan_add_segment(struct diveplan *diveplan, int duration, int depth, int cylinderid, int po2, bool entered, enum divemode_t divemode);
-struct divedatapoint *create_dp(int time_incr, int depth, int cylinderid, int po2);
 #if DEBUG_PLAN
 void dump_plan(struct diveplan *diveplan);
 #endif

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1025,6 +1025,14 @@ void DivePlannerPointsModel::createTemporaryPlan()
 {
 	// Get the user-input and calculate the dive info
 	free_dps(&diveplan);
+
+	for (int i = 0; i < d->cylinders.nr; i++) {
+		cylinder_t *cyl = get_cylinder(d, i);
+		if (cyl->depth.mm && cyl->cylinder_use == OC_GAS) {
+			plan_add_segment(&diveplan, 0, cyl->depth.mm, i, 0, false, OC);
+		}
+	}
+
 	int lastIndex = -1;
 	for (int i = 0; i < rowCount(); i++) {
 		divedatapoint p = at(i);
@@ -1039,20 +1047,6 @@ void DivePlannerPointsModel::createTemporaryPlan()
 			plan_add_segment(&diveplan, deltaT, p.depth.mm, p.cylinderid, p.setpoint, true, p.divemode);
 	}
 
-	struct divedatapoint *dp = NULL;
-	for (int i = 0; i < d->cylinders.nr; i++) {
-		cylinder_t *cyl = get_cylinder(d, i);
-		if (cyl->depth.mm && cyl->cylinder_use == OC_GAS) {
-			dp = create_dp(0, cyl->depth.mm, i, 0);
-			if (diveplan.dp) {
-				dp->next = diveplan.dp;
-				diveplan.dp = dp;
-			} else {
-				dp->next = NULL;
-				diveplan.dp = dp;
-			}
-		}
-	}
 #if DEBUG_PLAN
 	dump_plan(&diveplan);
 #endif


### PR DESCRIPTION


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Changed the way dive data points for OC cylinders to be added to the dive plan are created in `createTemporaryPlan()` in `diveplannermodel.cpp`. This now uses `plan_add_segment()` like all other places where dive data points are added, in particular the planner tests.
This also allowed for `create_dp()` to be made static.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Changed the way dive data points for OC cylinders to be added to the dive plan are created in `createTemporaryPlan()` in `diveplannermodel.cpp`.
2) Made `create_dp()` in `planner.c` static.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>
