### PR TITLE
Desktop: Fix bug in diveplan for CCR dives with multiple segments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: fix bug when printing a dive plan with multiple segments
 desktop: fix bug in bailout gas selection for CCR dives
 desktop: fix crash on cylinder update of multiple dives
 desktop: use dynamic tank use drop down in equipment tab and planner

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -325,15 +325,15 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 				/* Normally a gas change is displayed on the stopping segment, so only display a gas change at the end of
 				 * an ascent segment if it is not followed by a stop
 				 */
-				if ((isascent || dp->entered) && gaschange_after && dp->next && nextdp && (dp->depth.mm != nextdp->depth.mm || nextdp->entered)) {
-					if (dp->setpoint) {
-						asprintf_loc(&temp, translate("gettextFromC", "(SP = %.1fbar CCR)"), dp->setpoint / 1000.0);
+				if (isascent && gaschange_after && dp->next && nextdp && nextdp->entered) {
+					if (nextdp->setpoint) {
+						asprintf_loc(&temp, translate("gettextFromC", "(SP = %.1fbar CCR)"), nextdp->setpoint / 1000.0);
 						put_format(&buf, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>",
 							gasname(newgasmix), temp);
 						free(temp);
 					} else {
 						put_format(&buf, "<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>",
-							gasname(newgasmix), lastdivemode == UNDEF_COMP_TYPE || lastdivemode == dp->divemode ? "" : translate("gettextFromC", divemode_text_ui[dp->divemode]));
+							gasname(newgasmix), dp->divemode == UNDEF_COMP_TYPE || dp->divemode == nextdp->divemode ? "" : translate("gettextFromC", divemode_text_ui[nextdp->divemode]));
 						if (isascent && (get_he(lastprintgasmix) > 0)) { // For a trimix gas change on ascent, save ICD info if previous cylinder had helium
 							if (isobaric_counterdiffusion(lastprintgasmix, newgasmix, &icdvalues)) // Do icd calulations
 								icdwarning = true;
@@ -343,9 +343,9 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 							}
 						}
 					}
-					lastprintsetpoint = dp->setpoint;
+					lastprintsetpoint = nextdp->setpoint;
 					lastprintgasmix = newgasmix;
-					lastdivemode = dp->divemode;
+					lastdivemode = nextdp->divemode;
 					gaschange_after = false;
 				} else if (gaschange_before || rebreatherchange_before) {
 					// If a new gas has been used for this segment, now is the time to show it


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug reported in
https://groups.google.com/g/subsurface-divelog/c/8N3cTz2Zv5E: When planning a CCR dive with multiple segments, the textual dive plan was showing a non-existent gas change with bogus data.  The first part of the fix is uncluttering of the message printed: Since this change is _after_ the current diveplanpoint the data needs to come from `nextdp` and not `dp`.  The second part is that the message is not printed any more if the current and the following segments have been manually added: According to comments in the code the change should only be printed on the segment _before_ the change if this segment is an ascent segment that is followed by a manually entered segment.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) fixed contents of change text when printed on segment before change
2) fixed conditions for printing changes on segment before change

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
https://groups.google.com/g/subsurface-divelog/c/8N3cTz2Zv5E

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://user-images.githubusercontent.com/4742747/219662905-76349f8f-5ef9-480e-9944-ae268d90aa59.png)


In general I am not fully clear on why we are printing changes in the segment _before_ they happen - all I could find on this was a comment stating that this is so without a reason:

https://github.com/subsurface/subsurface/blob/ab7b9329c0ce00297faba256c22ddcdb1f1e8912/core/plannernotes.c#L325-L327

What I can see is that this may result in an unsafe dive plan if the diver is to execute the change at the start of the segment it is listed in, as is required for most changes: In the example below, the diver is asked to change to EAN32 at the start of an ascent segment when they are at 80 meters, resulting in a ppO2 of ~ 2.9!
So this begs the question if the special case of listing changes in the segment before they are required should be removed, or at least checks added to avoid doing this in situations where it results in dangerous conditions.

![image](https://user-images.githubusercontent.com/4742747/219661712-eea5b87c-add3-43cf-85da-efd33acd3f22.png)


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: fix bug when printing a dive plan with multiple segments

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>