### PR TITLE
Desktop: Fix planner for CCR dives with first segment on OC.

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -383,8 +383,6 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 				p.divemode = (enum divemode_t) value.toInt();
 				p.setpoint = p.divemode == CCR ? prefs.defaultsetpoint : 0;
 			}
-			if (index.row() == 0)
-				d->dc.divemode = (enum divemode_t) value.toInt();
 			break;
 		}
 		editStop(index.row(), p);


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a bug that results in dive plans outside of the configured risk profile being produced when planning a CCR dive with the first segment set to open circuit.
`d->dc.divemode` is already set in `setRebreatherMode`, which is sufficient, and congruent with the setting of other dive parameters, like `diveplan.gflow`.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1.) remove setting of `dc.divemode` from the divemode of the first segment.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Before:
![Screenshot from 2023-02-23 13-30-34](https://user-images.githubusercontent.com/4742747/221393369-23a9683d-c3aa-47ce-8ddb-78ccfc2a5c08.png)

After:
![image](https://user-images.githubusercontent.com/4742747/221392546-f126050c-cb9c-400a-93ab-5690c00e565c.png)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>
