### PR TITLE
Desktop: Disable 'search' button if the vendor does not support it.

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -19,6 +19,11 @@
 #include <QTimer>
 #include <QUndoStack>
 
+static bool is_vendor_searchable(QString vendor)
+{
+	return vendor == "Uemis" || vendor == "Garmin";
+}
+
 DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent) : QDialog(parent, QFlag(0)),
 	downloading(false),
 	previousLast(0),
@@ -51,6 +56,7 @@ DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent) : QDialog(parent, QF
 	ui.selectAllButton->setEnabled(false);
 	ui.unselectAllButton->setEnabled(false);
 	ui.vendor->setModel(&vendorModel);
+	ui.search->setEnabled(is_vendor_searchable(ui.vendor->currentText()));
 	ui.product->setModel(&productModel);
 
 	progress_bar_text = "";
@@ -319,6 +325,7 @@ void DownloadFromDCWidget::on_vendor_currentTextChanged(const QString &vendor)
 	descriptor = descriptorLookup.value(ui.vendor->currentText().toLower() + ui.product->currentText().toLower());
 	transport = dc_descriptor_get_transports(descriptor);
 	fill_device_list(transport);
+	ui.search->setEnabled(is_vendor_searchable(vendor));
 }
 
 void DownloadFromDCWidget::on_product_currentTextChanged(const QString &)
@@ -342,7 +349,7 @@ void DownloadFromDCWidget::on_device_currentTextChanged(const QString &device)
 
 void DownloadFromDCWidget::on_search_clicked()
 {
-	if (ui.vendor->currentText() == "Uemis" || ui.vendor->currentText() == "Garmin") {
+	if (is_vendor_searchable(ui.vendor->currentText())) {
 		QString dialogTitle = ui.vendor->currentText() == "Uemis" ?
 					tr("Find Uemis dive computer") : tr("Find Garmin dive computer");
 		QString dirName = QFileDialog::getExistingDirectory(this,


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Disable the 'search dive computer' ([...]]) button in the 'Import from dive computer' window if searching is not supported by the currently selected vendor.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add function `is_vendor_searchable()`;
2) use `is_vendor_searchable()` to control 'search' button status in constructor
3) use `is_vendor_searchable()` to control 'search' button status on vendor change

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>