### PR TITLE
Desktop: Fix use of bluetooth address for remembered dive computer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 desktop: fix bug when printing a dive plan with multiple segments
+desktop: fix remembering of bluetooth address for remembered dive computers (not MacOS)
 desktop: fix bug in bailout gas selection for CCR dives
 desktop: fix crash on cylinder update of multiple dives
 desktop: use dynamic tank use drop down in equipment tab and planner

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -147,10 +147,13 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
-	ui.bluetoothMode->setChecked(isBluetoothAddress(qPrefDiveComputer::device##num())); \
-	if (ui.device->currentIndex() == -1) \
+	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
+	bool isMacOs = QSysInfo::kernelType() == "darwin"; \
+	ui.bluetoothMode->setChecked(isBluetoothDevice); \
+	if (ui.device->currentIndex() == -1 || (isBluetoothDevice && !isMacOs)) \
+		/* macOS seems to have a problem connecting to remembered bluetooth devices  if it hasn't already had a connection in the current session */ \
 		ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
-	if (QSysInfo::kernelType() == "darwin") { \
+	if (isMacOs) { \
 		/* it makes no sense that this would be needed on macOS but not Linux */ \
 		QCoreApplication::processEvents(); \
 		ui.vendor->update(); \


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a bug causing the bluetooth address not being used when downloading from a 'remembered' dive computer if the device selection is populated. This specifically excludes MacOS, as 'remembering' bluetooth connections does not seem to be working there as per
https://github.com/subsurface/subsurface/pull/2158#issuecomment-508933672. I am not super sure why we are _not_ trying to use the 'remembered' device if the device selection is populated (`ui.device->currentIndex() == -1`) - maybe this should be clarified in a comment?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) add condition to check about using the remembered device to do this if it is a bluetooth device and we're not on MacOS

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2158
Fixes #2139

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Tested on linux.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
desktop: fix remembering of bluetooth address for remembered dive computers (not MacOS)

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Signed-off-by: Michael Keller <github@ike.ch>