### PR TITLE
Planner: create mirrored return profile

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -4078,6 +4078,10 @@ The waypoints listed in the _Dive Planner Points_ dialog can be edited by hand i
 order to get a precise presentation of the dive plan. In fact, it is sometimes more easy to create the
 whole dive profile by editing the _Dive Planner Points_ dialog.
 
+For planning a dive which has an exit profile which is a mirror image of the entry
+(e.g. cave diving), there is a shortcut to mirror the first half of the dive. Once the intial half of
+the dive is planned, press CTRL+M to create a mirrored exit profile.
+
 Show any changes in gas cylinder used by indicating gas changes as explained
 in the section <<S_CreateProfile,hand-creating a dive profile>>. These changes should
 reflect the cylinders and gas compositions defined in the table with _Available Gases_.

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -78,6 +78,9 @@ DivePlannerWidget::DivePlannerWidget(QWidget *parent) : QWidget(parent, QFlag(0)
 	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::Key_Escape), this);
 	connect(closeKey, &QShortcut::activated, plannerModel, &DivePlannerPointsModel::cancelPlan);
 
+	QShortcut *mirrorProfileShortcut = new QShortcut(QKeySequence(Qt::Key_M + Qt::CTRL), this);
+	connect(mirrorProfileShortcut, &QShortcut::activated, plannerModel, &DivePlannerPointsModel::addReverseProfile);
+
 	// This makes shure the spinbox gets a setMinimum(0) on it so we can't have negative time or depth.
 	// Limit segments to a depth of 1000 m/3300 ft and a duration of 100 h. Setting the limit for
 	// the depth will be done in settingChanged() since this depends on the chosen units.

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -47,7 +47,6 @@ void DivePlannerPointsModel::removeSelectedPoints(const std::vector<int> &rows)
 {
 	removePoints(rows);
 
-	updateDiveProfile();
 	emitDataChanged();
 	cylinders.updateTrashIcon();
 }
@@ -179,7 +178,6 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn)
 	DiveTypeSelectionModel::instance()->repopulate();
 	preserved_until = d->duration;
 
-	updateDiveProfile();
 	emitDataChanged();
 }
 
@@ -921,7 +919,6 @@ void DivePlannerPointsModel::removeControlPressed(const QModelIndex &index)
 	if (divepoints[0].cylinderid != old_first_cylid)
 		cylinders.moveAtFirst(divepoints[0].cylinderid);
 
-	updateDiveProfile();
 	emitDataChanged();
 }
 
@@ -958,7 +955,6 @@ void DivePlannerPointsModel::remove(const QModelIndex &index)
 	if (divepoints[0].cylinderid != old_first_cylid)
 		cylinders.moveAtFirst(divepoints[0].cylinderid);
 
-	updateDiveProfile();
 	emitDataChanged();
 }
 

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -5,6 +5,7 @@
 #include <QAbstractTableModel>
 #include <QDateTime>
 #include <vector>
+#include <deque>
 
 #include "core/deco.h"
 #include "core/planner.h"
@@ -104,6 +105,7 @@ slots:
 	void setAscratestopsDisplay(int rate);
 	void setAscratelast6mDisplay(int rate);
 	void setDescrateDisplay(int rate);
+	void addReverseProfile();
 
 signals:
 	void planCreated();
@@ -131,6 +133,8 @@ private:
 	void computeVariations(struct diveplan *diveplan, const struct deco_state *ds);
 	void computeVariationsFreeDeco(struct diveplan *diveplan, struct deco_state *ds);
 	int analyzeVariations(struct decostop *min, struct decostop *mid, struct decostop *max, const char *unit);
+	std::deque<int> getTimeDeltas();
+
 	struct dive *d;
 	CylindersModel cylinders;
 	Mode mode;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
2 commits: 1 to remove unnecessary method calls within planner, and another to implement a feature request from mailing list 2023 MAR 4

Add a shortcut (CTRL + M) to append a reversed dive profile in cases where a diver must exit the same way they entered. 

The reversing method does not check for decompression obligations. The user must manually extend dive segments where decompression is required. 

All properties of the point, except runtime, are copied when reversed. Runtime is updated as needed to make a mirror image. 

Sorting the vector of points on runtime is maintained, because the mirror points are appended in increasing runtime order.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1) Add new shortcut (CTRL + M) to dive planner
2) Add method to get time deltas between planner points to planner model
3) Add method to create and append a reversed profile to planner model

<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Added comment about the shortcut in the technical dive planning section of the user manual.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
