### PR TITLE
Core: Fix default sea water salinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+core: fix bug when save sea water salinity given by DC
 desktop: add column for dive notes to the dive list table
 desktop: fix bug when printing a dive plan with multiple segments
 desktop: fix bug in bailout gas selection for CCR dives

--- a/core/save-git.c
+++ b/core/save-git.c
@@ -211,8 +211,7 @@ static void save_airpressure(struct membuffer *b, struct divecomputer *dc)
 
 static void save_salinity(struct membuffer *b, struct divecomputer *dc)
 {
-	/* only save if we have a value that isn't the default of sea water */
-	if (!dc->salinity || dc->salinity == SEAWATER_SALINITY)
+	if (!dc->salinity)
 		return;
 	put_salinity(b, dc->salinity, "salinity ", "g/l\n");
 }

--- a/core/save-xml.c
+++ b/core/save-xml.c
@@ -152,8 +152,7 @@ static void save_airpressure(struct membuffer *b, struct divecomputer *dc)
 
 static void save_salinity(struct membuffer *b, struct divecomputer *dc)
 {
-	/* only save if we have a value that isn't the default of sea water */
-	if (!dc->salinity || dc->salinity == SEAWATER_SALINITY)
+	if (!dc->salinity)
 		return;
 	put_string(b, "  <water");
 	put_salinity(b, dc->salinity, " salinity='", " g/l'");


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Some dive computers (like Mares Puck Pro) just given the type of water, without salinity levels. Subsurface correct this using default levels for fresh and salt water. However, Subsurface doesn't stores this information in logbook. So when user defines manually the salinity, the exclamation icon always showed. There isn't this bug when fresh water is reported by DC. Probabily this is a legacy code from older versions that doesn't have salinity configuration. This pull request correct this bug.

### Changes made:
1) Allows save default salt water salinity on cloud storage
2) Allows save default salt water salinity on SSRF

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
