### PR TITLE
Desktop: Fix salinity combo/icon when DC doesnt have salinity info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ desktop: add support for multiple tanks to the profile ruler
 export: change format produced by 'CSV summary dive details' from TSV (tab separated) to CSV
 desktop: add function to merge dive site into site selected in list
 import: add option to synchronise dive computer time when downloading dives
+desktop: fix salinity combo/icon when DC doesnt have salinity info
 core: fix bug when save sea water salinity given by DC
 desktop: add option to force firmware update on OSTC4
 desktop: add column for dive notes to the dive list table

--- a/desktop-widgets/tab-widgets/TabDiveInformation.h
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.h
@@ -33,7 +33,6 @@ private slots:
 	void on_waterTypeCombo_activated(int index);
 private:
 	Ui::TabDiveInformation *ui;
-	bool manualDive;
 	void updateProfile();
 	int updateSalinityComboIndex(int salinity);
 	void checkDcSalinityOverWritten();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Today salinity combo is editable if one of these rules matches: The dive was manually entered or if salinity edition is allowed in preferences. However we can have cases that dives were downloaded but its doesn't have salinity info.

This fix considers if there's a DC salinity info to decides combo edition and if salinity change indicator will be showed or not.
If DC doesn't have salinity, the UI behavior is the same of a manual dive. Its important because after PR #3852 was accepted, too many existant download dives will be inconsitents.

### Changes made:
Basically just change TabDiveInformation and fix whole salinity references.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
To exemplify, get a downloaded dive and open it with and without tag `//dive/divecomputer/water`, like this:
`<water salinity='1030 g/L' />`

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
@mikeller 
