### PR TITLE
Build script: Qt has tagged versions currently

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -293,16 +293,8 @@ if [ "$PLATFORM" = Linux ] && [[ $QT_VERSION == 5* ]] ; then
 		rm -rf "$INSTALL_ROOT"/include/QtLocation > /dev/null 2>&1
 		rm -rf "$INSTALL_ROOT"/include/QtPositioning > /dev/null 2>&1
 
-		# thanks for nothing, Qt company...
-		# the forced open source releases apparently don't even deserve a tag in their repos
-		# so the correct SHA is extracted by looking at the qtlocation change introduced by
-		# the -lts-lgpl tag in https://code.qt.io/cgit/qt/qt5.git
-		if [ "$QT_VERSION" = "5.15.3" ] ; then
-			git clone https://code.qt.io/qt/qtlocation.git $QTLOC_GIT
-			git -C $QTLOC_GIT checkout 1bf01b84e30aab2b87a19184ce42160e6c92d8b
-		else
-			git clone --branch "v$QT_VERSION" https://code.qt.io/qt/qtlocation.git --depth=1 $QTLOC_GIT
-		fi
+		git clone --branch "v$QT_VERSION" https://code.qt.io/qt/qtlocation.git --depth=1 $QTLOC_GIT ||
+			git clone --branch "v$QT_VERSION-lts-lgpl" https://code.qt.io/qt/qtlocation.git --depth=1 $QTLOC_GIT
 
 		mkdir -p "$QTLOC_PRIVATE"
 		cd $QTLOC_GIT/src/location


### PR DESCRIPTION
It looks like Qt company has LGPLed versions tagged wich simplifies things a bit while building, e.g. 5.15.3 current workaround matches "v5.15.3-lts-lgpl" tag.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I don't know if tags where in place when @dirkhh made the workaround and wrote the note on the script, but they are now, thus workaround for 5.15.3 is no more needed and the other 5.15.X versions are reachable via git tags.

Background: Debian Sid is currently at Qt 5.15.8 which is impossible to build from scratch with current script as only a few git versions are tagged in the format "v5.15.8" used in the script.

![flameshot_2023-04-15_18-58-22](https://user-images.githubusercontent.com/17911757/232245739-7237203b-449c-49a2-8887-4357c1ea153e.png)


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
