### PR TITLE
divelog: fix erroneous use of std::move()

### DIFF
--- a/core/divelog.cpp
+++ b/core/divelog.cpp
@@ -40,8 +40,8 @@ divelog::divelog(divelog &&log) :
 	dives(new dive_table),
 	trips(new trip_table),
 	sites(new dive_site_table),
-	devices(std::move(log.devices)),
-	filter_presets(std::move(log.filter_presets))
+	devices(new device_table),
+	filter_presets(new filter_preset_table)
 {
 	*dives = empty_dive_table;
 	*trips = empty_trip_table;
@@ -49,6 +49,8 @@ divelog::divelog(divelog &&log) :
 	move_dive_table(log.dives, dives);
 	move_trip_table(log.trips, trips);
 	move_dive_site_table(log.sites, sites);
+	*devices = std::move(*log.devices);
+	*filter_presets = std::move(*log.filter_presets);
 }
 
 struct divelog &divelog::operator=(divelog &&log)
@@ -56,8 +58,8 @@ struct divelog &divelog::operator=(divelog &&log)
 	move_dive_table(log.dives, dives);
 	move_trip_table(log.trips, trips);
 	move_dive_site_table(log.sites, sites);
-	devices = std::move(log.devices);
-	filter_presets = std::move(log.filter_presets);
+	*devices = std::move(*log.devices);
+	*filter_presets = std::move(*log.filter_presets);
 	return *this;
 }
 


### PR DESCRIPTION
This has to be applied to the object, not the pointer to the object. Fixes a double-free crash introduced in 8cd451f.

Alternatively, we could use std::swap() for C++98 charm and perhaps better readability for people unfamiliar with C++11. Nowadays, std::move() is more idiomatic though. Shrug.

Reported-by: Michael Keller <github@ike.ch>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes bug introduced by #3512.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No, bug not in release.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller 