### PR TITLE
[dummy] core: add "type safe" operators for unit types

### DIFF
--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -18,7 +18,7 @@
 
 struct lv_event {
 	uint32_t time;
-	struct pressure {
+	struct {
 		int sensor;
 		int mbar;
 	} pressure;

--- a/core/pref.h
+++ b/core/pref.h
@@ -2,14 +2,14 @@
 #ifndef PREF_H
 #define PREF_H
 
+#include "units.h"
+#include "taxonomy.h"
+
 #ifdef __cplusplus
 extern "C" {
 #else
 #include <stdbool.h>
 #endif
-
-#include "units.h"
-#include "taxonomy.h"
 
 typedef struct
 {

--- a/core/units.h
+++ b/core/units.h
@@ -2,15 +2,11 @@
 #ifndef UNITS_H
 #define UNITS_H
 
+#include "units_operators.h"
+
 #include <math.h>
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#else
-#include <stdbool.h>
 #endif
 
 #define FRACTION(n, x) ((unsigned)(n) / (x)), ((unsigned)(n) % (x))
@@ -77,64 +73,100 @@ extern "C" {
  */
 typedef int64_t timestamp_t;
 
-typedef struct
+typedef struct duration
+#ifdef __cplusplus
+	: public VectorType<duration>
+#endif
 {
 	int32_t seconds; // durations up to 34 yrs
 } duration_t;
 
 static const duration_t zero_duration = { 0 };
 
-typedef struct
+typedef struct offset
+#ifdef __cplusplus
+	: public VectorType<offset>
+#endif
 {
 	int32_t seconds; // offsets up to +/- 34 yrs
 } offset_t;
 
-typedef struct
+typedef struct depth
+#ifdef __cplusplus
+	: public VectorType<depth>
+#endif
 {
 	int32_t mm;
 } depth_t; // depth to 2000 km
 
-typedef struct
+typedef struct pressure
+#ifdef __cplusplus
+	: public VectorType<pressure>
+#endif
 {
 	int32_t mbar; // pressure up to 2000 bar
 } pressure_t;
 
-typedef struct
+typedef struct o2pressure
+#ifdef __cplusplus
+	: public VectorType<o2pressure>
+#endif
 {
 	uint16_t mbar;
 } o2pressure_t; // pressure up to 65 bar
 
-typedef struct
+typedef struct bearing
+#ifdef __cplusplus
+	: public VectorType<bearing>
+#endif
 {
 	int16_t degrees;
 } bearing_t; // compass bearing
 
-typedef struct
+typedef struct temperature
+#ifdef __cplusplus
+	: public VectorType<temperature>
+#endif
 {
 	uint32_t mkelvin; // up to 4 MK (temperatures in K are always positive)
 } temperature_t;
 
-typedef struct
+typedef struct temperature_sum
+#ifdef __cplusplus
+	: public VectorType<temperature_sum>
+#endif
 {
 	uint64_t mkelvin; // up to 18446744073 MK (temperatures in K are always positive)
 } temperature_sum_t;
 
-typedef struct
+typedef struct volume
+#ifdef __cplusplus
+	: public VectorType<volume>
+#endif
 {
 	int mliter;
 } volume_t;
 
-typedef struct
+typedef struct fraction
+#ifdef __cplusplus
+	: public VectorType<fraction>
+#endif
 {
 	int permille;
 } fraction_t;
 
-typedef struct
+typedef struct weight
+#ifdef __cplusplus
+	: public VectorType<weight>
+#endif
 {
 	int grams;
 } weight_t;
 
-typedef struct
+typedef struct degrees
+#ifdef __cplusplus
+	: public VectorType<degrees>
+#endif
 {
 	int udeg;
 } degrees_t;
@@ -144,6 +176,12 @@ typedef struct pos {
 } location_t;
 
 static const location_t zero_location = { { 0 }, { 0 }};
+
+#ifdef __cplusplus
+extern "C" {
+#else
+#include <stdbool.h>
+#endif
 
 extern void parse_location(const char *, location_t *);
 

--- a/core/units_operators.h
+++ b/core/units_operators.h
@@ -1,0 +1,41 @@
+#ifndef UNITS_OPERATORS_H
+#define UNITS_OPERATORS_H
+
+#ifdef __cplusplus
+
+#include <utility>
+
+template <typename T>
+struct VectorType {
+private:
+	T &downcast() { return static_cast<T&>(*this); }
+	const T &downcast() const { return static_cast<const T&>(*this); }
+	auto base() const { auto [y] = downcast(); return y; }
+	// Miscompiles on some clang versions!
+	//auto &base() { auto &[y] = downcast(); return y; }
+public:
+	VectorType() { auto &[y] = downcast(); y = 0; }
+	VectorType(int x) { auto &[y] = downcast(); y = x; }
+	T &operator+=(T v) { auto &[y] = downcast(); y += v.base(); return downcast(); }
+	T &operator-=(T v) { auto &[y] = downcast(); y  -= v.base(); return downcast(); }
+	T operator+(T v) const { T res = downcast(); res += v; return res; }
+	T operator-(T v) const { T res = downcast(); res -= v; return res; }
+	T operator-() const { T res = { -base() }; return res; }
+	T &operator*=(int x) { auto &[y] = downcast(); y *= x; return downcast(); }
+	T &operator/=(int x) { auto &[y] = downcast(); y /= x; return downcast(); }
+	T operator*(int x) const { T res = downcast(); res *= x; return res; }
+	T operator/(int x) const { T res = downcast(); res /= x; return res; }
+
+	// C++20 would be a single line here:
+	//auto operator<=>(const VectorType<T> &v) const { return base() <=> v.base(); }
+	bool operator==(T v) const { return base() == v.base(); }
+	bool operator!=(T v) const { return base() != v.base(); }
+	bool operator<(T v) const { return base() < v.base(); }
+	bool operator>(T v) const { return base() > v.base(); }
+	bool operator<=(T v) const { return base() <= v.base(); }
+	bool operator>=(T v) const { return base() >= v.base(); }
+};
+
+#endif
+
+#endif


### PR DESCRIPTION
Some ugly template trickery to allow vectorspace semantics for the unit types:
       //duration_t a = 5;     // Not OK
       //duration_t b = 6;     // Not OK
       duration_t a = {5};     // OK
       duration_t b = {6};     // OK
       duration_t c = a + b;   // OK
       duration_t d = c - a;   // OK
       c = d + b;              // OK
       c += d;                 // OK
       c -= b;                 // OK
       //c -= 5;               // Not OK
       //c += 5;               // Not OK
       //c *= d;               // Not OK
       c *= 5;                 // OK
       duration e = c * 5;     // OK

Notes:
 - Currently the scalar is always an int, even for broader types. The reason is that passing the proper type to the scalar multiplication function would either need a second template parameter or even more nasty trickery.
 - Scalar multiplication currently only supported from the right side, because left-side multiplication would need an external operator function.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] None of the above

### Pull request long description:
<!-- Describe your pull request in detail. -->
A dummy PR to show how one could endow the unit types with kind-of type safe operators without disrupting C code.
