### PR TITLE
Desktop: Fix bug when synching to the cloud

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -426,7 +426,7 @@ void MainWindow::on_actionCloudstorageopen_triggered()
 // Return whether saving to cloud is OK. If it isn't, show an error return false.
 static bool saveToCloudOK()
 {
-	if (divelog.dives->nr) {
+	if (!divelog.dives->nr) {
 		report_error(qPrintable(gettextFromC::tr("Don't save an empty log to the cloud")));
 		return false;
 	}


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a bug introduced in 8cd451fc338da275f66b15181894e37621698109 causing an error to be thrown every time trying to do 'Save to cloud storage'.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix a bug introduced in 8cd451fc338da275f66b15181894e37621698109 causing an error to be thrown every time trying to do 'Save to cloud storage'.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Introduced in #3553.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
