### PR TITLE
Desktop: Add mergeing into the selected dive site.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 export: change format produced by 'CSV summary dive details' from TSV (tab separated) to CSV
+desktop: add function to merge dive site into site selected in list
 import: add option to synchronise dive computer time when downloading dives
 core: fix bug when save sea water salinity given by DC
 desktop: add option to force firmware update on OSTC4

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1650,6 +1650,8 @@ Select the dive site to be merged by right-clicking it. A confirmation
 message is presented (see image above). Clicking the confirmation message merges the selected dive with
 the dive named at the top of the panel and returns you to the dive sites management panel.
 
+Alternatively, if exactly one dive site is selected in the 'Near dive sites' list, there is an additional function 'Merge current site into this site' available in the context menu. This can be helpful if the name of the destination dive site is not known, e.g. when importing dive sites from a third party source.
+
 ==== Add a dive site
 
 At the top right of the dive sites management table is a round button with a "+". Clicking that button inserts a

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -64,6 +64,9 @@ bool LocationInformationWidget::eventFilter(QObject *, QEvent *ev)
 		QContextMenuEvent *ctx = (QContextMenuEvent *)ev;
 		QMenu contextMenu;
 		contextMenu.addAction(tr("Merge into current site"), this, &LocationInformationWidget::mergeSelectedDiveSites);
+		const QModelIndexList selection = ui.diveSiteListView->selectionModel()->selectedIndexes();
+		if (selection.count() == 1)
+			contextMenu.addAction(tr("Merge current site into this site"), this, &LocationInformationWidget::mergeIntoSelectedDiveSite);
 		contextMenu.exec(ctx->globalPos());
 		return true;
 	}
@@ -89,6 +92,24 @@ void LocationInformationWidget::mergeSelectedDiveSites()
 			selected_dive_sites.push_back(ds);
 	}
 	Command::mergeDiveSites(diveSite, selected_dive_sites);
+}
+
+void LocationInformationWidget::mergeIntoSelectedDiveSite()
+{
+	if (!diveSite)
+		return;
+
+	const QModelIndexList selection = ui.diveSiteListView->selectionModel()->selectedIndexes();
+	if (selection.count() != 1)
+		return;
+
+	dive_site *selected_dive_site = selection[0].data(LocationInformationModel::DIVESITE_ROLE).value<dive_site *>();
+	if (!selected_dive_site)
+		return;
+
+	QVector<dive_site *> dive_sites;
+	dive_sites.push_back(diveSite);
+	Command::mergeDiveSites(selected_dive_site, dive_sites);
 }
 
 // If we can't parse the coordinates, inform the user with a visual clue

--- a/desktop-widgets/locationinformation.h
+++ b/desktop-widgets/locationinformation.h
@@ -34,6 +34,7 @@ public slots:
 	void on_diveSiteDistance_textChanged(const QString &s);
 	void reverseGeocode();
 	void mergeSelectedDiveSites();
+	void mergeIntoSelectedDiveSite();
 	void on_GPSbutton_clicked();
 private slots:
 	void updateLabels();


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When editing a dive site in the 'Dive sites' view, add a context menu entry to allow mergeing of the displayed dive site into the dive site seleted in the 'Near dive sites' list.
This merge has the opposite direction of the existing 'Merge into current site' function, which can simplify the workflow when maintaining a large number of dive sites, as the facilities to sort dive sites in the 'Dive sites' view does not have a way to sort by location or proximity.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. add `mergeIntoSelectedDiveSite()` function;
2. add context menu entry for `mergeIntoSelectedDiveSite()` if exactly one dive site is selected.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://user-images.githubusercontent.com/4742747/233635937-0047f86b-bf97-450a-93e2-08b3f08fd88b.png)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: add function to merge dive site into site selected in list

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
- [x] done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
