### PR TITLE
Update comment on Qt6 destruction of StatsView

### DIFF
--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -91,6 +91,7 @@ static void print_help()
 	printf("\n --dc-product=product  Set the dive computer to download from");
 	printf("\n --device=device       Set the device to download from");
 #endif
+	printf("\n --no-opengl-sharing   Don't share OpenGL contexts between QQuickItems (for testing)");
 	printf("\n --cloud-timeout=<nr>  Set timeout for cloud connection (0 < timeout < 60)\n\n");
 }
 
@@ -147,6 +148,10 @@ void parse_argument(const char *arg)
 			}
 			if (strcmp(arg, "--allow_run_as_root") == 0) {
 				++force_root;
+				return;
+			}
+			if (strcmp(arg, "--no-opengl-sharing") == 0) {
+				// This was already checked in main()
 				return;
 			}
 #if SUBSURFACE_DOWNLOADER

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -39,7 +39,6 @@ int main(int argc, char **argv)
 	if (verbose) /* print the version if the Win32 console_init() code enabled verbose. */
 		print_version();
 
-	int i;
 	bool no_filenames = true;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
 
@@ -65,7 +64,7 @@ int main(int argc, char **argv)
 	const char *default_filename = system_default_filename();
 	subsurface_mkdir(default_directory);
 
-	for (i = 1; i < arguments.length(); i++) {
+	for (int i = 1; i < arguments.length(); i++) {
 		QString a = arguments.at(i);
 		if (a.isEmpty())
 			continue;

--- a/subsurface-desktop-main.cpp
+++ b/subsurface-desktop-main.cpp
@@ -13,6 +13,7 @@
 #include "core/qt-gui.h"
 #include "core/qthelper.h"
 #include "core/subsurfacestartup.h"
+#include "core/subsurface-string.h"
 #include "core/settings/qPref.h"
 #include "core/tag.h"
 #include "desktop-widgets/mainwindow.h"
@@ -41,6 +42,20 @@ int main(int argc, char **argv)
 	int i;
 	bool no_filenames = true;
 	QLoggingCategory::setFilterRules(QStringLiteral("qt.bluetooth* = true"));
+
+	// Allow OpenGL-based QtQuick backends to share OpenGL contexts.
+	// This avoids destruction of QQuickItems if their parent widgets are moved between widgets in Qt6.
+	// Sadly, this does not help when running on non-OpenGL backends.
+	// Allow for turning this off to test destruction of QQuickItems.
+	// The parameter is checked here because QCoreApplication::parameters() only
+	// works after instantiation of the QApplication class, but the flag has
+	// to be set bofore.
+	if (std::any_of(argv + 1, argv + argc,
+	    [](char *arg) { return same_string(arg, "--no-opengl-sharing"); })) {
+		fprintf(stderr, "Disabling sharing of OpenGL contexts\n");
+	} else {
+		QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+	}
 	std::unique_ptr<QApplication> app(new QApplication(argc, argv));
 	QStringList files;
 	QStringList importedFiles;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Explain why Qt6 destroys our StatsView. I hope this is not too aggressive, but it really annoys me. In particular, it stops progress on the profile-to-QtQuick project. For the stats it seems to work, but I am not sure the profile is happy when the view is constantly destroyed. There, the connection between widget and view is much more convoluted.

@dirkhh: please check.