### PR TITLE
[TRIVIAL?] cleanup: remove unnecessary string duplication

### DIFF
--- a/core/unix.c
+++ b/core/unix.c
@@ -90,7 +90,6 @@ int enumerate_devices(device_callback_t callback, void *userdata, unsigned int t
 	size_t i;
 	FILE *file;
 	char *line = NULL;
-	char *fname;
 	size_t len;
 	if (transport & DC_TRANSPORT_SERIAL) {
 		const char *dirname = "/dev";
@@ -155,15 +154,13 @@ int enumerate_devices(device_callback_t callback, void *userdata, unsigned int t
 					end++;
 
 				*end = '\0';
-				fname = strdup(start);
 
-				callback(fname, userdata);
+				callback(start, userdata);
 
-				if (is_default_dive_computer_device(fname))
+				if (is_default_dive_computer_device(start))
 					index = entries;
 				entries++;
 				num_uemis++;
-				free((void *)fname);
 			}
 		}
 		free(line);


### PR DESCRIPTION
I don't understand why the functions must be called on a copy of the string.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove redundant `strdup()`.

@dirkhh: Am I missing something - that `strdup()` appears completely pointless to me...?