### PR TITLE
Desktop: Fix incorrect use of 'free()'.

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -2341,16 +2341,16 @@ static xmlDoc *test_xslt_transforms(xmlDoc *doc, const struct xml_params *params
 	xmlDoc *transformed;
 	xsltStylesheetPtr xslt = NULL;
 	xmlNode *root_element = xmlDocGetRootElement(doc);
-	char *attribute;
+	xmlChar *attribute;
 
 	while (info->root) {
 		if ((strcasecmp((const char *)root_element->name, info->root) == 0)) {
 			if (info->attribute == NULL)
 				break;
 
-			void *prop = xmlGetProp(root_element, (const xmlChar *)info->attribute);
+			xmlChar *prop = xmlGetProp(root_element, (const xmlChar *)info->attribute);
 			if (prop != NULL) {
-				free(prop);
+				xmlFree(prop);
 
 				break;
 			}
@@ -2359,13 +2359,13 @@ static xmlDoc *test_xslt_transforms(xmlDoc *doc, const struct xml_params *params
 	}
 
 	if (info->root) {
-		attribute = (char *)xmlGetProp(xmlFirstElementChild(root_element), (const xmlChar *)"name");
+		attribute = xmlGetProp(xmlFirstElementChild(root_element), (const xmlChar *)"name");
 		if (attribute) {
-			if (strcasecmp(attribute, "subsurface") == 0) {
-				free((void *)attribute);
+			if (strcasecmp((char *)attribute, "subsurface") == 0) {
+				xmlFree(attribute);
 				return doc;
 			}
-			free((void *)attribute);
+			xmlFree(attribute);
 		}
 		xmlSubstituteEntitiesDefault(1);
 		xslt = get_stylesheet(info->file);


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use 'xmlFree()' to free memory returned by libxml.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. use 'xmlFree()' to free memory returned by libxml.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
 Follow-up to #3900.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger: Until you mentioned it I wasn't even aware that libxml came with its own implementation of `free()`.