### PR TITLE
cleanup: fix typo: verboseEnabebled -> verboseEnabled

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -253,7 +253,7 @@ Item {
 						// before realizing that this is actually a pinch/zoom. So let's reset this
 						// just in case
 						qmlProfile.opacity = 1.0
-						if (manager.verboseEnabebled)
+						if (manager.verboseEnabled)
 							manager.appendTextToLog("pinch started w/ previousScale " + qmlProfile.lastScale)
 					}
 					onPinchUpdated: {

--- a/mobile-widgets/qml/SsrfTextField.qml
+++ b/mobile-widgets/qml/SsrfTextField.qml
@@ -65,7 +65,7 @@ Controls.TextField {
 			// make sure there's enough space for the input field above the keyboard and action button (and that it's not too far up, either)
 			var positionInFlickable = stf.mapToItem(flickable.contentItem, 0, 0)
 			var stfY = positionInFlickable.y
-			if (manager.verboseEnabebled)
+			if (manager.verboseEnabled)
 				manager.appendTextToLog("position check: lower edge of view is " + (0 + flickable.contentY + flickable.height) + " and text field is at " + stfY)
 			if (stfY + stf.height > flickable.contentY + flickable.height - 3 * Kirigami.Units.gridUnit || stfY < flickable.contentY)
 				flickable.contentY = Math.max(0, 3 * Kirigami.Units.gridUnit + stfY + stf.height - flickable.height)


### PR DESCRIPTION
Not really relevant, because it only affects debugging output.

But shows why I dislike weakly typed, non-compiled languages.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

Trivial typo, see commit description.