### PR TITLE
Mobile: Fix Editing of Gradient Factors

### DIFF
--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -228,7 +228,7 @@ TemplatePage {
 				}
 				TemplateSpinBox {
 					from: 1
-					to: 99
+					to: 100
 					stepSize: 1
 					value: Backend.gflow
 					textFromValue: function (value, locale) {
@@ -245,7 +245,7 @@ TemplatePage {
 				}
 				TemplateSpinBox {
 					from: 1
-					to: 99
+					to: 100
 					stepSize: 1
 					value: Backend.gfhigh
 					textFromValue: function (value, locale) {

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -227,8 +227,8 @@ TemplatePage {
 					leftPadding: Kirigami.Units.smallSpacing * 2
 				}
 				TemplateSpinBox {
-					from: 1
-					to: 100
+					from: 10
+					to: 150
 					stepSize: 1
 					value: Backend.gflow
 					textFromValue: function (value, locale) {
@@ -244,8 +244,8 @@ TemplatePage {
 					leftPadding: Kirigami.Units.smallSpacing * 2
 				}
 				TemplateSpinBox {
-					from: 1
-					to: 100
+					from: 10
+					to: 150
 					stepSize: 1
 					value: Backend.gfhigh
 					textFromValue: function (value, locale) {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -632,8 +632,8 @@ TemplatePage {
 				}
 				TemplateSpinBox {
 					id: gfLow
-					from: 1
-					to: 100
+					from: 10
+					to: 150
 					stepSize: 1
 					value: PrefTechnicalDetails.gflow
 					textFromValue: function (value, locale) {
@@ -649,8 +649,8 @@ TemplatePage {
 				}
 				TemplateSpinBox {
 					id: gfHigh
-					from: 1
-					to: 100
+					from: 10
+					to: 150
 					stepSize: 1
 					value: PrefTechnicalDetails.gfhigh
 					textFromValue: function (value, locale) {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -585,16 +585,16 @@ TemplatePage {
 						PrefDisplay.singleColumnPortrait = checked
 					}
 				}
-                TemplateLabel {
-                    text: qsTr("Depth line based on ×3 intervals")
-                }
-                SsrfSwitch {
-                    checked: PrefDisplay.three_m_based_grid
-                    onClicked: {
-                        PrefDisplay.three_m_based_grid = checked
-                        rootItem.settingsChanged()
-                    }
-                }
+		TemplateLabel {
+		    text: qsTr("Depth line based on ×3 intervals")
+		}
+		SsrfSwitch {
+		    checked: PrefDisplay.three_m_based_grid
+		    onClicked: {
+			PrefDisplay.three_m_based_grid = checked
+			rootItem.settingsChanged()
+		    }
+		}
 				TemplateLine {
 					visible: sectionAdvanced.isExpanded
 					Layout.columnSpan: 2
@@ -630,12 +630,16 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("GFLow")
 				}
-				TemplateTextField {
+				TemplateSpinBox {
 					id: gfLow
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 2
-					text: PrefTechnicalDetails.gflow
-					inputMask: "99"
-					onEditingFinished: {
+					from: 1
+					to: 100
+					stepSize: 1
+					value: PrefTechnicalDetails.gflow
+					textFromValue: function (value, locale) {
+						return value + "%"
+					}
+					onValueModified: {
 						PrefTechnicalDetails.gflow = gfLow.text
 						rootItem.settingsChanged()
 					}
@@ -643,12 +647,16 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("GFHigh")
 				}
-				TemplateTextField {
+				TemplateSpinBox {
 					id: gfHigh
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 2
-					text: PrefTechnicalDetails.gfhigh
-					inputMask: "99"
-					onEditingFinished: {
+					from: 1
+					to: 100
+					stepSize: 1
+					value: PrefTechnicalDetails.gfhigh
+					textFromValue: function (value, locale) {
+						return value + "%"
+					}
+					onValueModified: {
 						PrefTechnicalDetails.gfhigh = gfHigh.text
 						rootItem.settingsChanged()
 					}


### PR DESCRIPTION



<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the issue that Gradient Factors cannot be set to 100 in the mobile version. This is done by changing the edits from a text box to a spin edit, which seems to be a better match for numerical values. As a side effect this also solves the issue that the keyboard for the text edit is not properly displayed when settings are opened when dive details are already on the page stack.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. change `TextField` to `SpinBox` with appropriate range for gradiend factors in mobile settings;
2. fix the range for planner gradient factors in mobile;
3. fix indentation in mobile settings QML file.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3911.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Look of the SpinBox based edits:

![Screenshot_2023-05-26-13-54-05-930_org subsurfacedivelog mobile](https://github.com/subsurface/subsurface/assets/4742747/a6974968-1789-4628-b44f-f6cae314fba3)

Reproduction for the 'keyboard not showing' problem:

![Screenshot_2023-05-26-10-02-44-754_org subsurfacedivelog mobile](https://github.com/subsurface/subsurface/assets/4742747/3de194af-3d74-47ca-bfa7-81c216c31446)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported-by: @gbetous
