### PR TITLE
Desktop: Add Multi-Tank Support for Profile Ruler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: add support for multiple tanks to the profile ruler
 export: change format produced by 'CSV summary dive details' from TSV (tab separated) to CSV
 desktop: add function to merge dive site into site selected in list
 import: add option to synchronise dive computer time when downloading dives


### PR DESCRIPTION



<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add support for tracking the gas usage across multiple tanks to the 'bar used' and SAC values shown for the profile ruler.
The following rules are implemented:
- a tank is considered 'used' if at least one bar has been consumed;
- only used tanks are taken into account for calculations;
- 'bar used' is only shown if all tanks used have the same (or unknown) volume;
- SAC is only shown if all tanks used have a known volume.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. add support for tracking the gas usage across multiple tanks to the 'bar used' and SAC values shown for the profile ruler;
2. removed unneeded `memcpy()`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3902.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![Screenshot from 2023-05-26 20-03-48](https://github.com/subsurface/subsurface/assets/4742747/36c87574-b36b-4b9a-9d9e-f875d344691d)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: add support for multiple tanks to the profile ruler

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported-by: @pabdakine
