### PR TITLE
Desktop: Use Persisted Device Information for Dive Computer Configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: use persisted device information for the dive computer configuration
 export: fix bug resulting in invalid CSV for '""' in 'CSV summary dive details'
 desktop: add support for multiple tanks to the profile ruler
 export: change format produced by 'CSV summary dive details' from TSV (tab separated) to CSV

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -72,7 +72,7 @@ slots:
 	void resetSettings();
 	void configMessage(QString msg);
 	void configError(QString err);
-	void on_cancel_clicked();
+	void on_close_clicked();
 	void on_saveSettingsPushButton_clicked();
 	void deviceDetailsReceived(DeviceDetails *newDeviceDetails);
 	void reloadValues();
@@ -114,10 +114,6 @@ private:
 	void reloadValuesOSTC();
 	void reloadValuesSuuntoVyper();
 	void reloadValuesOSTC4();
-
-	QString selected_vendor;
-	QString selected_product;
-	bool fw_upgrade_possible;
 
 #ifdef BT_SUPPORT
 	BtDeviceSelectionDialog *btDeviceSelectionDialog;

--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -42,9 +42,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="bluetoothMode">
+        <widget class="QPushButton" name="connectBluetoothButton">
          <property name="text">
-          <string>Connect via Bluetooth</string>
+          <string>Select Bluetooth Device</string>
          </property>
         </widget>
        </item>
@@ -182,9 +182,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cancel">
+      <widget class="QPushButton" name="close">
        <property name="text">
-        <string>Cancel</string>
+        <string>Close</string>
        </property>
       </widget>
      </item>
@@ -3972,7 +3972,7 @@
   <tabstop>saveSettingsPushButton</tabstop>
   <tabstop>backupButton</tabstop>
   <tabstop>restoreBackupButton</tabstop>
-  <tabstop>cancel</tabstop>
+  <tabstop>close</tabstop>
  </tabstops>
  <resources>
   <include location="../subsurface.qrc"/>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Use the dive computer / device information that was persisted when previously downloading dives or configuring the dive computer in the dive computer configuration dialog.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. change the list of supported devices to an `std::array`;
2. use the persisted device information to try and find the device when opening the configuration dialog;
3. disable bluetooth device selection for devices that do not support bluetooth;
4. preserve the entered device name when repopulating the device list;
5. made the use of bluetooth dependent on the format of the device being a bluetooth address;
6. move persisting of device information to after a successful connection attempt;
7. rename 'Connect with bluetooth' and 'Cancel' buttons in the dialog to make them more consistent with what they do.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: use persisted device information for the dive computer configuration

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
