### PR TITLE
Mobile: Make Cloud Auto Synch Status Easier to Understand.

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -347,7 +347,7 @@ Kirigami.ApplicationWindow {
 				icon {
 					name: PrefCloudStorage.cloud_auto_sync ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
 				}
-				text: PrefCloudStorage.cloud_auto_sync ? qsTr("Disable auto cloud sync") : qsTr("Enable auto cloud sync")
+text: (PrefCloudStorage.cloud_auto_sync ? "\u2610 " : "\u2611 ") + qsTr("Auto cloud sync")
 					visible: Backend.cloud_verification_status !== Enums.CS_NOCLOUD
 					onTriggered: {
 						PrefCloudStorage.cloud_auto_sync = !PrefCloudStorage.cloud_auto_sync


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
- [x] UX Improvement

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add an explicit checkbox to the 'cloud auto synch' status toggle in the mobile 'Dive Management' menu in order to make it more intuitive to understand.
This isn't super pretty, but I think it will improve the usability. A prettier way to achieve this will be to redesign the `ic_cloud_off.svg` / `ic_cloud_done.svg` in order to make them intuitively recognisable as unchecked / checked checkboxes.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. add an explicit checkbox to the 'cloud auto synch' status toggle in the mobile 'Dive Management' menu in order to make it more intuitive to understand.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Example of a support request caused by confusion from the current implementation: https://groups.google.com/g/subsurface-divelog/c/9X-hTt9NFlE/m/ZcqtdOOhBQAJ

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![Screenshot_2023-06-16-15-06-06-678_org subsurfacedivelog mobile](https://github.com/subsurface/subsurface/assets/4742747/fe2dd495-cbd7-4ecc-aec6-7e602debc91d)

![Screenshot_2023-06-16-15-06-45-940_org subsurfacedivelog mobile](https://github.com/subsurface/subsurface/assets/4742747/6074ad2c-2415-40e6-af0d-b563a66a92c9)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
