### PR TITLE
Desktop: Load the Dive Computer List in 'Configure Dive Computer' Dynamically.

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -104,16 +104,17 @@ struct DiveComputerEntry {
 	QString product;
 	unsigned int transport;
 	bool fwUpgradePossible;
+	bool forcedFirmwareUpgradeSupported;
 };
 
 //WARNING: Do not edit this list or even just change its order without
 // making corresponding changes to the `DiveComputerList` element
 // in `configuredivecomputerdialog.ui` or this functionality will stop working.
 static const DiveComputerEntry supportedDiveComputers[] = {
-	{ "Heinrichs Weikamp", "OSTC 2N", DC_TRANSPORT_SERIAL, true },
-	{ "Heinrichs Weikamp", "OSTC Plus", DC_TRANSPORT_BLUETOOTH, true },
-	{ "Heinrichs Weikamp", "OSTC 4", DC_TRANSPORT_BLUETOOTH, true },
-	{ "Suunto", "Vyper", DC_TRANSPORT_SERIAL, false },
+	{ "Heinrichs Weikamp", "OSTC 2N", DC_TRANSPORT_SERIAL, true, false },
+	{ "Heinrichs Weikamp", "OSTC Plus", DC_TRANSPORT_BLUETOOTH, true, false },
+	{ "Heinrichs Weikamp", "OSTC 4", DC_TRANSPORT_BLUETOOTH, true, true },
+	{ "Suunto", "Vyper", DC_TRANSPORT_SERIAL, false, false },
 };
 
 ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDialog(parent),
@@ -1538,7 +1539,7 @@ void ConfigureDiveComputerDialog::dc_open()
 
 	const DiveComputerEntry selectedDiveComputer = supportedDiveComputers[ui.DiveComputerList->currentRow()];
 	ui.updateFirmwareButton->setEnabled(selectedDiveComputer.fwUpgradePossible);
-	ui.forceUpdateFirmware->setEnabled(supportedDiveComputers[selectedDiveComputerIndex].product == "OSTC 4");
+	ui.forceUpdateFirmware->setEnabled(selectedDiveComputer.forcedFirmwareUpgradeSupported);
 
 	ui.progressBar->setFormat(tr("Connected to device"));
 


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Load the dive computer list in the 'Change Settings on Dive Computer' dialog dynamically.
Also incorporate suggestions from
https://github.com/subsurface/subsurface/pull/3925#issuecomment-1595784076.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. use constant array for dive computer list;
2. load the dive computer list in the 'Change Settings on Dive Computer' dialog dynamically.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Suggested-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>
