### PR TITLE
Desktop: Consider Severity when Hiding Events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: hide only events with the same severity when 'Hide similar events' is used
 equipment: mark gas mixes reported by the dive computer as 'inactive' as 'not used'
 equipment: include unused cylinders in merged dive if the preference is enabled
 equipment: fix bug showing the first diluent in the gas list as 'used' for CCR dives

--- a/core/eventname.cpp
+++ b/core/eventname.cpp
@@ -39,13 +39,6 @@ extern "C" bool is_event_hidden(const char *eventname)
 	return it != event_names.end() && !it->plot;
 }
 
-extern "C" void hide_event(const char *eventname)
-{
-	auto it = std::find(event_names.begin(), event_names.end(), eventname);
-	if (it != event_names.end())
-		it->plot = false;
-}
-
 extern "C" void show_all_events()
 {
 	for (event_name &en: event_names)

--- a/core/eventname.h
+++ b/core/eventname.h
@@ -10,7 +10,6 @@ extern "C" {
 extern void clear_event_names(void);
 extern void remember_event_name(const char *eventname);
 extern bool is_event_hidden(const char *eventname);
-extern void hide_event(const char *eventname);
 extern void show_all_events();
 extern bool any_events_hidden();
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -600,7 +600,8 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 
 	if (DiveEventItem *item = dynamic_cast<DiveEventItem *>(sceneItem)) {
 		m.addAction(tr("Remove event"), [this,item] { removeEvent(item); });
-		m.addAction(tr("Hide similar events"), [this, item] { hideEvents(item); });
+		m.addAction(tr("Hide event"), [this, item] { hideEvent(item); });
+		m.addAction(tr("Hide similar events"), [this, item] { hideSimilarEvents(item); });
 		const struct event *dcEvent = item->getEvent();
 		if (dcEvent->type == SAMPLE_EVENT_BOOKMARK)
 			m.addAction(tr("Edit name"), [this, item] { editName(item); });
@@ -682,21 +683,21 @@ void ProfileWidget2::renameCurrentDC()
 		Command::editDeviceNickname(currentdc, newName);
 }
 
-void ProfileWidget2::hideEvents(DiveEventItem *item)
+void ProfileWidget2::hideEvent(DiveEventItem *item)
+{
+	item->hide();
+}
+
+void ProfileWidget2::hideSimilarEvents(DiveEventItem *item)
 {
 	const struct event *event = item->getEvent();
 
-	if (QMessageBox::question(this,
-				  TITLE_OR_TEXT(tr("Hide events"), tr("Hide all %1 events?").arg(event->name)),
-				  QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
-		if (!empty_string(event->name)) {
-			hide_event(event->name);
-			for (DiveEventItem *evItem: profileScene->eventItems) {
-				if (same_string(evItem->getEvent()->name, event->name))
-					evItem->hide();
-			}
-		} else {
-			item->hide();
+	hideEvent(item);
+
+	if (!empty_string(event->name)) {
+		for (DiveEventItem *evItem: profileScene->eventItems) {
+			if (same_string(evItem->getEvent()->name, event->name) && evItem->getEvent()->flags == event->flags)
+				evItem->hide();
 		}
 	}
 }

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -125,7 +125,8 @@ private:
 	void splitDive(int seconds);
 	void addSetpointChange(int seconds);
 	void removeEvent(DiveEventItem *item);
-	void hideEvents(DiveEventItem *item);
+	void hideEvent(DiveEventItem *item);
+	void hideSimilarEvents(DiveEventItem *item);
 	void editName(DiveEventItem *item);
 	void unhideEvents();
 	void makeFirstDC();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When events are hidden in the profile, only hide events with the same name and the same severity (flags).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. when events are hidden in the profile, only hide events with the same name and the same severity (flags);
2. split out hiding of single events into its own menu item 'Hide event';
3. remove confirmation dialogue that is now inappropriate.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
From discussion in https://github.com/subsurface/libdc/pull/54.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
desktop: hide only events with the same severity when 'Hide similar events' is used

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
