### PR TITLE
Fix building against upstream libdivecomputer and the v0.9.0 api changes

### DIFF
--- a/core/configuredivecomputerthreads.cpp
+++ b/core/configuredivecomputerthreads.cpp
@@ -2218,7 +2218,11 @@ void FirmwareUpdateThread::run()
 	}
 	switch (dc_device_get_type(m_data->device)) {
 	case DC_FAMILY_HW_OSTC3:
+#ifdef DC_FIELD_STRING
 		rc = hw_ostc3_device_fwupdate(m_data->device, qPrintable(m_fileName), m_forceUpdate);
+#else
+		rc = hw_ostc3_device_fwupdate(m_data->device, qPrintable(m_fileName));
+#endif
 		break;
 	case DC_FAMILY_HW_OSTC:
 		rc = hw_ostc_device_fwupdate(m_data->device, qPrintable(m_fileName));


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

With these changes, subsurface can be build against:
- Current subsurface fork of libdivecomputer
- Upstream libdivecomputer v0.8.0
- Upstream libdivecomputer v0.9.0

I use these changes for testing libdivecomputer fixes, but they might be useful for other developers too. When merging the v0.9.0 changes into the subsurface fork, some more changes might be necessary. Feel free to modify the changes in this PR as necessary.