### PR TITLE
Report an error if enabling notifications fails

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -673,6 +673,12 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 
 			ble->preferredService()->writeDescriptor(d, QByteArray::fromHex("0100"));
 			WAITFOR(ble->descriptorWritten(), 1000);
+			if (!ble->descriptorWritten()) {
+				qDebug() << "Bluetooth: Failed to enable notifications for characteristic" << c.uuid();
+				report_error("Bluetooth: Failed to enable notifications.");
+				delete ble;
+				return DC_STATUS_TIMEOUT;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
The last few months I debugged some issues with the BLE connection, and a few of them show the same problem:

Deepsix Excursion:

```
Found service "{f000ffe0-ab12-45ec-84c8-46483f4626e9}" "Unknown Service"
      c: "{f000ffe1-ab12-45ec-84c8-46483f4626e9}"
           d: "{00002902-0000-1000-8000-00805f9b34fb}"
           d: "{00002901-0000-1000-8000-00805f9b34fb}"
      c: "{f000ffe2-ab12-45ec-84c8-46483f4626e9}"
           d: "{00002902-0000-1000-8000-00805f9b34fb}"
           d: "{00002901-0000-1000-8000-00805f9b34fb}"
      c: "{f000ffe3-ab12-45ec-84c8-46483f4626e9}"
           d: "{00002902-0000-1000-8000-00805f9b34fb}"
           d: "{00002901-0000-1000-8000-00805f9b34fb}"
Using service "{f000ffe0-ab12-45ec-84c8-46483f4626e9}" as preferred service
    .. enabling notifications
Using read characteristic "{f000ffe1-ab12-45ec-84c8-46483f4626e9}"
now writing "0x0100" to the descriptor "{00002902-0000-1000-8000-00805f9b34fb}"
error discovering service details QLowEnergyService::DescriptorWriteError
QTime("11:29:52.689") packet SEND "b028000027"
QTime("11:29:52.689") packet WAIT
error discovering service details QLowEnergyService::CharacteristicWriteError
```

https://scubaboard.com/community/threads/subsurface-and-the-new-deep6-excursion-firmware.628656/

Scubapro Aladin H Matrix:

```
Found service "{fdcdeaaa-295d-470e-bf15-04217b7aa0a0}" "Unknown Service"
       c: "{a188b7dd-debb-449a-852d-c243d46b4b1a}"
       c: "{aa0c68f0-ea9c-493d-8112-62879e72af68}"
            d: "{00002902-0000-1000-8000-00805f9b34fb}"
Using service "{fdcdeaaa-295d-470e-bf15-04217b7aa0a0}" as preferred service
     .. enabling notifications
Using read characteristic "{aa0c68f0-ea9c-493d-8112-62879e72af68}"
now writing "0x0100" to the descriptor
"{00002902-0000-1000-8000-00805f9b34fb}"
error discovering service details
QLowEnergyService::DescriptorWriteError
QTime("20:15:04.885") packet SEND "0110"
QTime("20:15:04.885") packet WAIT
error discovering service details
QLowEnergyService::CharacteristicWriteError
```

https://github.com/libdivecomputer/libdivecomputer/issues/27

Shearwater:

```
Found service "{fe25c237-0ece-443c-b0aa-e02033e7029d}" "Unknown Service"
      c: "{27b7570b-359e-45a3-91bb-cf7e70049bd2}"
           d: "{00002902-0000-1000-8000-00805f9b34fb}"
           d: "{00002901-0000-1000-8000-00805f9b34fb}"
Using service "{fe25c237-0ece-443c-b0aa-e02033e7029d}" as preferred service
    .. enabling notifications
Using read characteristic "{27b7570b-359e-45a3-91bb-cf7e70049bd2}"
now writing "0x0100" to the descriptor "{00002902-0000-1000-8000-00805f9b34fb}"
error discovering service details QLowEnergyService::DescriptorWriteError
QTime("21:02:21.768") packet SEND "0100ff0105002e902000c0"
```

https://groups.google.com/g/subsurface-divelog/c/fK1E8j7IsVM/m/Vh93IOYOBQAJ

Mares Sirius:

```
Found service "{544e326b-5b72-c6b0-1c46-41c1bc448118}" "Unknown Service"
     c: "{99a91ebd-b21f-1689-bb43-681f1f55e966}"
     c: "{1d1aae28-d2a8-91a1-1242-9d2973fbe571}"
          d: "{00002902-0000-1000-8000-00805f9b34fb}"
     c: "{d8b3ab7c-4101-ec80-c441-9b0914f6ebc3}"
Found service "{1d14d6ee-fd63-4fa1-bfa4-8f47b42119f0}" "Unknown Service"
     c: "{f7bf3564-fb6d-4e53-88a4-5e37e0326063}"
     c: "{984227f3-34fc-4045-a5d0-2c581f81a153}"
Using service "{544e326b-5b72-c6b0-1c46-41c1bc448118}" as preferred service
   .. enabling notifications
Using read characteristic "{1d1aae28-d2a8-91a1-1242-9d2973fbe571}"
now writing "0x0100" to the descriptor "{00002902-0000-1000-8000-00805f9b34fb}"
QTime("07:52:28.227") packet SEND "c267"
QTime("07:52:28.227") packet WAIT
error discovering service details QLowEnergyService::DescriptorWriteError
error discovering service details QLowEnergyService::CharacteristicWriteError
```

In all these cases, the BLE device and service discovery works fine. But trying to enable the notifications on the service fails for some unknown reason. Since those notifications are needed for receiving data packets, the download will fail with a timeout because we end up with a connection where we can only send but not receive. This problem is difficult to spot at first sight, because enabling the notifications is implemented with an async call. Errors are only logged and are not reported back to the caller.

Note that this PR does not fix the underlying problem, it just makes it more visible.