### PR TITLE
Properly handle the planner state

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -568,6 +568,7 @@ divemode_t PlannerWidgets::getRebreatherMode() const
 
 void PlannerWidgets::preparePlanDive(const dive *currentDive)
 {
+	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 	// create a simple starting dive, using the first gas from the just copied cylinders
 	DivePlannerPointsModel::instance()->createSimpleDive(planned_dive.get());
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -581,7 +581,7 @@ void MainWindow::enableShortcuts()
 void MainWindow::showProfile()
 {
 	enableShortcuts();
-	profile->plotCurrentDive();
+	profile->plotDive(current_dive, profile->dc);
 	setApplicationState(ApplicationState::Default);
 }
 

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -393,6 +393,7 @@ static void hideAll(const T &container)
 
 void ProfileWidget2::clear()
 {
+	currentState = INIT;
 #ifndef SUBSURFACE_MOBILE
 	clearPictures();
 #endif


### PR DESCRIPTION
This does two independent things:

It sets the planner state early enough so the appropriate default profile for the planner is created (without safety stop).

Upon cancelling the planner, it resets the profile widget to profile more (rather than planner) as otherwise upon the next change into the planner the planner model is not properly initialized.

Fixes #3955 

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@bstoeger could you please check this is done correctly? I am not 100% sure I do these mode changes in the appropriate places. But at least, this fixes the crash ;-)