### PR TITLE
Fix certificate_check_cb() return value

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -313,9 +313,9 @@ int certificate_check_cb(git_cert *cert, int valid, const char *host, void *payl
 		// if we are connecting to the cloud server we alrady called 'canReachCloudServer()'
 		// which will fail if the SSL certificate isn't valid, so let's simply always
 		// tell the caller that this certificate is valid
-		return 1;
+		return 0;
 	}
-	return valid;
+	return valid ? 0 : -1;
 }
 
 static int update_remote(struct git_info *info, git_remote *origin, git_reference *local, git_reference *remote)


### PR DESCRIPTION
libgit documents the return value of callbacks.certificate_check[0] as 0 for success and <0 as failure. Returning 1 for success (kind of) works because some parts of libgit[1] check for <0 return values and only treat those as errors, but the function actually calling the callback (check_certificate) treats anything non-zero as error[2] and ends up setting a spurious error message with a return value of 1.

[0] https://libgit2.org/libgit2/#HEAD/group/callback/git_transport_certificate_check_cb
[1] https://github.com/libgit2/libgit2/blob/maint/v1.5/src/libgit2/transports/httpclient.c#L1054
[2] https://github.com/libgit2/libgit2/blob/maint/v1.5/src/libgit2/transports/httpclient.c#L785

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
