### PR TITLE
Use horizontal mouse wheel for zoomed panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 desktop: add divemode as a possible dive list column
+profile-widget: Now zomed in profiles can be panned with horizontal scroll.
 desktop: hide only events with the same severity when 'Hide similar events' is used
 equipment: mark gas mixes reported by the dive computer as 'inactive' as 'not used'
 equipment: include unused cylinders in merged dive if the preference is enabled

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -322,6 +322,14 @@ void ProfileWidget2::wheelEvent(QWheelEvent *event)
 {
 	if (!d)
 		return;
+	if (event->angleDelta().x() && zoomLevel > 0) {
+		double oldPos = zoomedPosition;
+		zoomedPosition = profileScene->calcZoomPosition(calcZoom(zoomLevel),
+								oldPos,
+								oldPos - event->angleDelta().x());
+		if (oldPos != zoomedPosition)
+			plotDive(d, dc, RenderFlags::Instant | RenderFlags::DontRecalculatePlotInfo);
+	}
 	if (panning)
 		return;	// No change in zoom level while panning.
 	if (event->buttons() == Qt::LeftButton)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Since a long time you have had the possibility to do vertical scroll on the profile to zome. This adds the possibility to do horizontal scroll in this zoomed in mode to pan the profile.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Added a case in the wheelEvent listener in the profile-widget for horizontal scroll.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Now zomed in profiles can be panned with horizontal scroll.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
