### PR TITLE
Add support for the Divesoft BLE service

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -143,6 +143,7 @@ static const struct uuid_match serial_service_uuids[] = {
 	{ "cb3c4555-d670-4670-bc20-b61dbc851e9a", "Pelagic (i770R, i200C, Pro Plus X, Geo 4.0)" },
 	{ "fdcdeaaa-295d-470e-bf15-04217b7aa0a0", "ScubaPro G2"},
 	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric/Peregrine)" },
+	{ "0000fcef-0000-1000-8000-00805f9b34fb", "Divesoft" },
 	{ NULL, }
 };
 


### PR DESCRIPTION
The UUID of the Divesoft BLE service needs to be added to the list of known services. It's a 16-bit UUID that gets detected as a standard service and is ignored otherwise.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
