### PR TITLE
Add BLE detection for the Aqualung i330R and Apeks DSX

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -35,7 +35,9 @@ static struct modelPattern model[] = {
 	{ 0x4654, "Oceanic", "Veo 4.0" },
 	{ 0x4655, "Sherwood", "Wisdom 4" },
 	{ 0x4656, "Oceanic", "Pro Plus 4" },
-	{ 0x4743, "Aqualung", "i470TC" }
+	{ 0x4741, "Apeks", "DSX" },
+	{ 0x4743, "Aqualung", "i470TC" },
+	{ 0x4744, "Aqualung", "i330R" },
 };
 
 struct namePattern {

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -141,6 +141,7 @@ static const struct uuid_match serial_service_uuids[] = {
 	{ "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic Semi UART" },
 	{ "98ae7120-e62e-11e3-badd-0002a5d5c51b", "Suunto (EON Steel/Core, G5)" },
 	{ "cb3c4555-d670-4670-bc20-b61dbc851e9a", "Pelagic (i770R, i200C, Pro Plus X, Geo 4.0)" },
+	{ "ca7b0001-f785-4c38-b599-c7c5fbadb034", "Pelagic (i330R, DSX)" },
 	{ "fdcdeaaa-295d-470e-bf15-04217b7aa0a0", "ScubaPro G2"},
 	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric/Peregrine)" },
 	{ NULL, }


### PR DESCRIPTION
Add the Aqualung i330R and Apeks DSX model numbers to the Pelagic pattern table. These two models also use a new BLE service UUID.

Note that this only adds the BLE detection. Actual support for the devices in libdivecomputer is still being worked on.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
