### PR TITLE
Return the actual libdivecomputer error code

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -1343,7 +1343,7 @@ static dc_status_t bluetooth_device_open(dc_context_t *context, device_data_t *d
 
 dc_status_t divecomputer_device_open(device_data_t *data)
 {
-	dc_status_t rc;
+	dc_status_t rc = DC_STATUS_UNSUPPORTED;
 	dc_context_t *context = data->context;
 	unsigned int transports, supported;
 
@@ -1423,7 +1423,7 @@ dc_status_t divecomputer_device_open(device_data_t *data)
 			return rc;
 	}
 
-	return DC_STATUS_UNSUPPORTED;
+	return rc;
 }
 
 static dc_status_t sync_divecomputer_time(dc_device_t *device)


### PR DESCRIPTION
The divecomputer_device_open() function tries all supported transports one by one, and exits as soon as one is opened successfully. When the end of the function is reached, the DC_STATUS_UNSUPPORTED error code is returned.

The annoying side effect is that the actual error code returned by the transport is ignored and changed into DC_STATUS_UNSUPPORTED. This is very confusing while troubleshooting download problems.

Fixed by initializing the error code to DC_STATUS_UNSUPPORTED, in case no transport is available for trying, and returning the last reported error to caller.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
