### PR TITLE
Fix AppStream ID

### DIFF
--- a/appdata/subsurface.appdata.xml.in
+++ b/appdata/subsurface.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Pedro Neves <nevesdiver@gmail.com> -->
 <component type="desktop-application">
-  <id>subsurface</id>
+  <id>org.subsurface_divelog.subsurface</id>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
   <name>Subsurface</name>


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html\#tag-id-generic

### Changes made:
1. Fixed AppStream ID to be valid according to the specification.

### Related issues:
_None_

### Additional information:
_None_

### Release note:
Updated AppStream ID to `org.subsurface_divelog.subsurface`.

### Documentation change:
_None_

### Mentions:
_None_
