### PR TITLE
Core: extend last gas mix instead of defaulting to air.

### DIFF
--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -117,11 +117,11 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 		}
 	}
 	bool no_volume = true;
-	cylinder_t cyl = empty_cylinder;
 	struct gasmix last_mix = gasmix_air; /* default to air */
 
 	clear_cylinder_table(&dive->cylinders);
 	for (i = 0; i < MAX(ngases, ntanks); i++) {
+		cylinder_t cyl = empty_cylinder;
 		cyl = empty_cylinder;
 		if (i < ngases) {
 			dc_gasmix_t gasmix = { 0 };

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -113,14 +113,16 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 			report_error("Warning: different number of gases (%d) and cylinders (%d)", ngases, ntanks);
 		} else if (ntanks > ngases) {
 			shown_warning = true;
-			report_error("Warning: smaller number of gases (%d) than cylinders (%d). Assuming air.", ngases, ntanks);
+			report_error("Warning: smaller number of gases (%d) than cylinders (%d).", ngases, ntanks);
 		}
 	}
 	bool no_volume = true;
+	cylinder_t cyl = empty_cylinder;
+	struct gasmix last_mix = gasmix_air; /* default to air */
 
 	clear_cylinder_table(&dive->cylinders);
-	for (i = 0; i < ngases || i < ntanks; i++) {
-		cylinder_t cyl = empty_cylinder;
+	for (i = 0; i < MAX(ngases, ntanks); i++) {
+		cyl = empty_cylinder;
 		if (i < ngases) {
 			dc_gasmix_t gasmix = { 0 };
 			int o2, he;
@@ -147,9 +149,10 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 				}
 				he = 0;
 			}
-			cyl.gasmix.o2.permille = o2;
-			cyl.gasmix.he.permille = he;
+			last_mix.o2.permille = o2;
+			last_mix.he.permille = he;
 		}
+		cyl.gasmix = last_mix;
 
 		if (rc == DC_STATUS_UNSUPPORTED)
 			// Gasmix is inactive

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -123,7 +123,7 @@ static struct gasmix get_deeper_gasmix(struct gasmix a, struct gasmix b)
 	if (get_o2(a) < get_o2(b)) {
 		return a;
 	}
-	if (get_o2(a) > get_o2(b))
+	if (get_o2(a) > get_o2(b)) {
 		return b;
 	}
 	return get_he(a) < get_he(b) ? b : a;
@@ -161,7 +161,10 @@ static int parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_parser_t
 		}
 	}
 	bool no_volume = true;
-	struct gasmix bottom_gas = { {1000}, {0} }; /* Default to pure O2 */
+	struct gasmix bottom_gas = { {1000}, {0} }; /* Default to pure O2, or air if there are no mixes defined */
+	if (ngases == 0) {
+		bottom_gas = gasmix_air;
+	}
 
 	clear_cylinder_table(&dive->cylinders);
 	for (i = 0; i < MAX(ngases, ntanks); i++) {


### PR DESCRIPTION
Instead of defaulting to air when we run out of gas mixes to assign to cylinders, use the bottom gas mix provided by the dive computer. The bottom gas mix is the one with the deepest MOD.  Note that no actual MOD calculations are performed, the relative MOD between 2 gas mixes is a simple comparison between the amount of O2 in the mixes or, if equal, helium.

If no gas mixes are provided at all, then default to air.

This prevents Subsurface from "inventing" gas mixes which are not reported by the dive computer. It also works very nicely with a sidemount configuration where the dive computer typically reports two cylinders but only a single gas mix.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Added a new variable, `bottom_gas`, which tracks the bottom gas mix read from the dive computer. The contents of this variable are assigned to cylinders if there are no more gas mixes.

In the case where the dive computer does not report any gas mixes, the behaviour is identical to the original code - all cylinders are assigned 'air'. 

In the case there are the same (or more) gas mixes than cylinders, the behaviour is also identical to the original code.

In the case where there are less gas mixes than cylinders, the behaviour now differs. Whereas previously all additional cylinders were assigned 'air', these additional cylinders are now assigned the bottom gas mix read from the dive computer.

For example, 

1)
Mixes = [ 99%, 51%, 32%, 'air' ];
Cylinders = [ 1, 2 ];

1 - 99%
2 - 51%


2)
Mixes = [32%];
Cylinders = [ 1, 2, 3 ];

1 - 32%
2 - 32% (previously air)
3 - 32% (previously air)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) core/libdivecomputer.c : parse_gasmixes
Calculate the relative MOD between 2 gas mixes and save the one with the deeper MOD as the bottom gas. If there are no more gas mixes, but more tanks, assign this gas to the additional cylinders.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

[subsurface_perdixai_2.log](https://github.com/subsurface/subsurface/files/13345042/subsurface_perdixai_2.log)


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@jefdriesen 