### PR TITLE
UI: hide first gas change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: add `hide first gas change` preference option.
 desktop: add divemode as a possible dive list column
 profile-widget: Now zomed in profiles can be panned with horizontal scroll.
 desktop: hide only events with the same severity when 'Hide similar events' is used

--- a/core/pref.c
+++ b/core/pref.c
@@ -96,6 +96,7 @@ struct preferences default_prefs = {
 	.extract_video_thumbnails = true,
 	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
 	.three_m_based_grid = false,
+	.map_short_names = false,
 	.graph_hide_first_gaschange = true,
 	.sync_dc_time = false,
 };

--- a/core/pref.c
+++ b/core/pref.c
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "pref.h"
 #include "subsurface-string.h"
+#include "units.h"
 #include "git-access.h" // for CLOUD_HOST
+
+#include <stdbool.h>
 
 struct preferences prefs, git_prefs;
 struct preferences default_prefs = {
@@ -93,6 +96,7 @@ struct preferences default_prefs = {
 	.extract_video_thumbnails = true,
 	.extract_video_thumbnails_position = 20,		// The first fifth seems like a reasonable place
 	.three_m_based_grid = false,
+	.graph_hide_first_gaschange = true,
 	.sync_dc_time = false,
 };
 

--- a/core/pref.h
+++ b/core/pref.h
@@ -106,6 +106,7 @@ struct preferences {
 	bool        show_developer;
 	bool        three_m_based_grid;
 	bool        map_short_names;
+	bool        graph_hide_first_gaschange;
 
 	// ********** Equipment tab *******
 	const char *default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -69,6 +69,7 @@ void qPrefDisplay::loadSync(bool doSync)
 	}
 	disk_three_m_based_grid(doSync);
 	disk_map_short_names(doSync);
+	disk_graph_hide_first_gaschange(doSync);
 }
 
 void qPrefDisplay::set_divelist_font(const QString &value)
@@ -153,6 +154,8 @@ HANDLE_PREFERENCE_BOOL(Display, "show_developer", show_developer);
 HANDLE_PREFERENCE_BOOL(Display, "three_m_based_grid", three_m_based_grid);
 
 HANDLE_PREFERENCE_BOOL(Display, "map_short_names", map_short_names);
+
+HANDLE_PREFERENCE_BOOL(Display, "graph_hide_first_gaschange", graph_hide_first_gaschange);
 
 void qPrefDisplay::setCorrectFont()
 {

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -27,6 +27,7 @@ class qPrefDisplay : public QObject {
 	Q_PROPERTY(bool singleColumnPortrait READ singleColumnPortrait WRITE set_singleColumnPortrait NOTIFY singleColumnPortraitChanged)
 	Q_PROPERTY(bool three_m_based_grid READ three_m_based_grid WRITE set_three_m_based_grid NOTIFY three_m_based_gridChanged)
 	Q_PROPERTY(bool map_short_names READ map_short_names WRITE set_map_short_names NOTIFY map_short_namesChanged)
+	Q_PROPERTY(bool graph_hide_first_gaschange READ graph_hide_first_gaschange WRITE set_graph_hide_first_gaschange NOTIFY graph_hide_first_gaschangeChanged)
 
 public:
 	static qPrefDisplay *instance();
@@ -56,6 +57,7 @@ public:
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 	static bool three_m_based_grid() { return prefs.three_m_based_grid; }
 	static bool map_short_names() { return prefs.map_short_names; }
+	static bool graph_hide_first_gaschange() { return prefs.graph_hide_first_gaschange; }
 
 public slots:
 	static void set_animation_speed(int value);
@@ -77,6 +79,7 @@ public slots:
 	static void set_singleColumnPortrait(bool value);
 	static void set_three_m_based_grid(bool value);
 	static void set_map_short_names(bool value);
+	static void set_graph_hide_first_gaschange(bool value);
 
 signals:
 	void animation_speedChanged(int value);
@@ -98,6 +101,7 @@ signals:
 	void singleColumnPortraitChanged(bool value);
 	void three_m_based_gridChanged(bool value);
 	void map_short_namesChanged(bool value);
+	void graph_hide_first_gaschangeChanged(bool value);
 
 private:
 	qPrefDisplay() {}
@@ -111,6 +115,7 @@ private:
 	static void disk_show_developer(bool doSync);
 	static void disk_three_m_based_grid(bool doSync);
 	static void disk_map_short_names(bool doSync);
+	static void disk_graph_hide_first_gaschange(bool doSync);
 
 	// functions to handle class variables
 	static void load_lastDir();

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -34,6 +34,7 @@ void PreferencesDefaults::refreshSettings()
 		ui->gridGeneric->setChecked(true);
 
 	ui->checkBox_map_short_names->setChecked(qPrefDisplay::map_short_names());
+	ui->checkBox_hide_first_gaschange->setChecked(qPrefDisplay::graph_hide_first_gaschange());
 }
 
 void PreferencesDefaults::syncSettings()
@@ -43,4 +44,5 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
 	qPrefDisplay::set_three_m_based_grid(ui->grid3MBased->isChecked());
 	qPrefDisplay::set_map_short_names(ui->checkBox_map_short_names->isChecked());
+	qPrefDisplay::set_graph_hide_first_gaschange(ui->checkBox_hide_first_gaschange->isChecked());
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -6,27 +6,34 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>561</width>
-    <height>558</height>
+    <width>610</width>
+    <height>438</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_fonts">
      <property name="title">
       <string>Font for lists and tables</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_1">
-      <property name="margin">
+      <property name="leftMargin">
        <number>5</number>
       </property>
-
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
       <item>
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="label_font">
         <property name="text">
          <string>Font</string>
         </property>
@@ -35,20 +42,18 @@
       <item>
        <widget class="QFontComboBox" name="font"/>
       </item>
-
       <item>
        <widget class="QLabel" name="label_default1">
+        <property name="text">
+         <string/>
+        </property>
         <property name="wordWrap">
          <bool>true</bool>
         </property>
-        <property name="text">
-         <string></string>
-        </property>
        </widget>
       </item>
-
       <item>
-       <widget class="QLabel" name="label_8">
+       <widget class="QLabel" name="label_fontsize">
         <property name="text">
          <string>Font size</string>
         </property>
@@ -57,35 +62,40 @@
       <item>
        <widget class="QDoubleSpinBox" name="fontsize"/>
       </item>
-
      </layout>
     </widget>
    </item>
-
    <item>
-    <widget class="QGroupBox" name="groupBox_7">
+    <widget class="QGroupBox" name="groupBox_animations">
      <property name="title">
       <string>Animations</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
-      <property name="margin">
+      <property name="leftMargin">
        <number>5</number>
       </property>
-
+      <property name="topMargin">
+       <number>5</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>5</number>
+      </property>
       <item>
        <widget class="QLabel" name="label_help4">
         <property name="toolTip">
          <string extracomment="Help info 1"/>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
         <property name="text">
          <string>In some actions, e.g. when zooming the dive profile, the changing axis values are animated. Select the speed with which this animation should occur (maximum = 500):</string>
         </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
-
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
@@ -114,49 +124,69 @@
         </item>
        </layout>
       </item>
-
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_gridDepth">
+    <widget class="QGroupBox" name="groupBox_diveProfile">
      <property name="title">
-      <string>Dive profile depth grid</string>
+      <string>Dive profile options</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Depth line intevals.</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_depthgrid">
+          <property name="text">
+           <string>Depth grid line intevals:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="gridGeneric">
+          <property name="text">
+           <string>generic ( 1, 2, 4, 5, 10 )</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="grid3MBased">
+          <property name="text">
+           <string>based on ×3 intervals ( 1, 3, 6, 15 )</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QRadioButton" name="gridGeneric">
-        <property name="text">
-         <string>generic ( 1, 2, 4, 5, 10 )</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="grid3MBased">
-        <property name="text">
-         <string>based on ×3 intervals ( 1, 3, 6, 15 )</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="label_hide_first_gaschange">
+          <property name="text">
+           <string>Hide first Gas Change:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_hide_first_gaschange">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
    </item>
-   
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_mapDisplay">
      <property name="title">
       <string>Map Display Options</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="label_short_names">
         <property name="text">
          <string>Short Names:</string>
         </property>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

Adds an option to hide the first gaschange event, defaulting to `true` to keep the current behaviour.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The first gaschange event is hidden if it occurs at the beginning of the dive log as it is considered unimportant.

However in certain scenarios Subsurface imports "phantom cylinders" which did not actually exist on a dive. If such a "phantom cylinder" is attached to the first gaschange event, there is no way for the user to delete such a cylinder, since there is no way to edit or delete the first gaschange event using the UI.

This change adds an option to show the first gaschange event. Or rather, to hide it, and it defaults to true. This means that by default, the program behaves as it always did, but now users have an option to toggle hiding this event. If it s shown, the user can edit or delete the event, and thus edit or delete the cylinder to which the event is attached.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Add a new preference option to hide the first gaschange event (defaulting to true). This was added in the `Display -> Dive profile depth grid` section, which has been renamed to `Dive profile options`. Both the existing `Depth line intervals` and the new `Hide first Gas Change` options affect the same part of the Subsurface UI, so it was natural to group them together.

2) Check the new preference option and only hide the first gas change events if this option is set to `true` (the default).

3) Unrelated, but during development of this feature it was discovered that the `map_short_names` preference setting was not being explicitly initialized to `false`. Fixed.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

While this change does not fix #3935, it does allow the user to mitigate it by editing the dive data of affected dives using the UI.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->



### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Yes.

"desktop: add `hide first gas change` preference option."


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

New option, `Hide first Gas Change` in the `Preferences -> Display` tab.
This option is checked by default, which means that the first gas change event is hidden from view. This reflects the behaviour of Subsurface prior to release XXX. For most users and most of the time this event is just clutter, however in certain circumstances it may be useful for the user to enable viewing these events in order to be able to edit them.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
