### PR TITLE
Copr and Launchpad builds from GitHub

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - master
-    - github-action-test
   pull_request:
     branches:
     - master

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -1,0 +1,50 @@
+name: Fedora Copr Build
+on:
+  push:
+    branches:
+    - master
+    - github-action-test
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  setup-build:
+    name: Submit build to Fedora COPR
+    # this seems backwards, but we want to run under Fedora, but Github doesn' support that
+    container: fedora:latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out sources
+      uses: actions/checkout@v1
+
+    - name: Setup API token for copr-cli
+      env:
+        API_TOKEN: ${{ secrets.COPR_TOKEN }}
+        API_LOGIN: ${{ secrets.COPR_LOGIN }}
+      run: |
+        mkdir -p "$HOME/.config"
+        cp packaging/copr/config.copr "$HOME/.config/copr"
+        sed -i "s/API_TOKEN/$API_TOKEN/;s/API_LOGIN/$API_LOGIN/" "$HOME/.config/copr"
+
+    - name: Setup build dependencies in the Fedora container
+      run: |
+        dnf -y install @development-tools @rpm-development-tools
+        dnf -y install copr-cli make
+
+    - name: setup git
+      run: |
+        git config --global --add safe.directory /__w/subsurface/subsurface
+        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+
+    - name: Checkout googlemaps
+      run: |
+        cd ..
+        git clone https://github.com/subsurface/googlemaps
+
+    - name: run the copr build script
+      run: |
+        cd ..
+        bash -x subsurface/packaging/copr/make-package.sh post
+          

--- a/.github/workflows/ubuntu-launchpad-build.yml
+++ b/.github/workflows/ubuntu-launchpad-build.yml
@@ -1,0 +1,47 @@
+name: Ubuntu Launchpad Build
+on:
+  push:
+    branches:
+    - master
+    - github-action-test
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  push-to-ppa:
+
+    name: Submit build to Ubuntu Launchpad
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out sources
+      uses: actions/checkout@v1
+
+    - name: Setup build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y devscripts dput gpg debhelper qt5-qmake cmake
+
+    - name: Setup gpg key token for launchpad
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.PPA_SECRET_KEY }}
+      run: |
+        echo "$GPG_PRIVATE_KEY" > ~/.key
+        gpg --import ~/.key
+
+    - name: setup git
+      run: |
+        git config --global --add safe.directory /__w/subsurface/subsurface
+        git config --global --add safe.directory /__w/subsurface/subsurface/libdivecomputer
+
+    - name: Checkout googlemaps
+      run: |
+        cd ..
+        git clone https://github.com/subsurface/googlemaps
+
+    - name: run the launchpad make-package script
+      run: |
+        cd ..
+        bash -x subsurface/packaging/ubuntu/make-package.sh post
+

--- a/INSTALL
+++ b/INSTALL
@@ -159,7 +159,7 @@ sudo zypper install git gcc-c++ make autoconf automake libtool cmake libzip-deve
 	libqt5-qtconnectivity-devel libqt5-qtlocation-devel libcurl-devel \
 	bluez-devel libgit2-devel libmtp-devel
 
-On Debian Buster this seems to work
+On Debian Bookworm this seems to work
 
 sudo apt install \
 	autoconf automake cmake g++ git libbluetooth-dev libcrypto++-dev \
@@ -167,7 +167,7 @@ sudo apt install \
 	libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libtool \
 	libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make pkg-config \
 	qml-module-qtlocation qml-module-qtpositioning qml-module-qtquick2 \
-	qt5-default qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
+	qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
 	qtdeclarative5-private-dev qtlocation5-dev qtpositioning5-dev \
 	qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ We frequently make new test versions of Subsurface available at
 http://subsurface-divelog.org/downloads/test/ and there you can always get
 the latest builds for Mac, Windows, Linux AppImage and Android (with some
 caveats about installability). Additionally, those same versions are
-posted to the Subsurface-daily repos on Launchpad and OBS.
+posted to the Subsurface-daily repos on Ubuntu Launchpad, Fedora COPR, and
+OpenSUSE OBS.
 
 These tend to contain the latest bug fixes and features, but also
 occasionally the latest bugs and issues. Please understand when using them

--- a/core/deco.c
+++ b/core/deco.c
@@ -17,6 +17,7 @@
  * restore_deco_state()
  * dump_tissues()
  */
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <assert.h>

--- a/core/dive.h
+++ b/core/dive.h
@@ -10,6 +10,7 @@
 #include "picture.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/import-cobalt.c
+++ b/core/import-cobalt.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include <stdlib.h>
 #include "ssrf.h"
 #include "dive.h"
 #include "divesite.h"

--- a/core/import-seac.c
+++ b/core/import-seac.c
@@ -4,6 +4,7 @@
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#include <stdlib.h>
 #include "qthelper.h"
 #include "ssrf.h"
 #include "dive.h"

--- a/core/libdivecomputer.c
+++ b/core/libdivecomputer.c
@@ -6,6 +6,7 @@
 
 #include "ssrf.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
 #include <string.h>

--- a/core/liquivision.c
+++ b/core/liquivision.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <string.h>
+#include <stdlib.h>
 
 #include "ssrf.h"
 #include "divesite.h"

--- a/core/planner.c
+++ b/core/planner.c
@@ -5,6 +5,7 @@
  *
  * (c) Dirk Hohndel 2013
  */
+#include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>
 #include <ctype.h>

--- a/core/plannernotes.c
+++ b/core/plannernotes.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdlib.h>
 #include "dive.h"
 #include "deco.h"
 #include "units.h"

--- a/core/profile.c
+++ b/core/profile.c
@@ -7,6 +7,7 @@
 #include <limits.h>
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #include "dive.h"
 #include "divelist.h"

--- a/core/subsurfacestartup.c
+++ b/core/subsurfacestartup.c
@@ -11,6 +11,7 @@
 
 #include <stdbool.h>
 #include <string.h>
+#include <stdlib.h>
 
 extern void show_computer_list();
 

--- a/core/uemis-downloader.c
+++ b/core/uemis-downloader.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include "gettext.h"
 #include "libdivecomputer.h"

--- a/core/uemis.c
+++ b/core/uemis.c
@@ -9,6 +9,7 @@
  */
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "gettext.h"
 

--- a/packaging/copr/config.copr
+++ b/packaging/copr/config.copr
@@ -1,0 +1,6 @@
+[copr-cli]
+login = API_LOGIN
+username = dirkhh
+token = API_TOKEN
+copr_url = https://copr.fedorainfracloud.org
+# expiration date: 2024-05-31

--- a/packaging/ubuntu/debian/control
+++ b/packaging/ubuntu/debian/control
@@ -1,13 +1,14 @@
 Source: subsurface
 Section: utils
 Priority: optional
-Maintainer: Dirk Hohndel <dirk@hohndel.org>
+Maintainer: Subsurface CI Bot <dirk@subsurface-divelog.org>
 Build-Depends: asciidoc,
                debhelper (>= 9),
                libgconf2-dev,
                libtool,
                libxml2-dev,
                libxslt-dev,
+               libgit2-dev,
                libsoup2.4-dev,
                pkg-config,
                txt2html,

--- a/packaging/ubuntu/debian/rules
+++ b/packaging/ubuntu/debian/rules
@@ -36,7 +36,6 @@ override_dh_auto_clean:
 	rm -f libdivecomputer/missing
 	rm -f libdivecomputer/src/Makefile.in
 	rm -rf install-root
-	rm -rf libgit2/build
 	rm -rf googlemaps/build
 	rm -rf subsurface-build
 
@@ -53,15 +52,10 @@ override_dh_auto_configure:
 		./configure --disable-examples --prefix=$(MY_INSTALL_ROOT) --disable-shared ; \
 		make -j8 ; \
 		make install)
-	(mkdir libgit2/build ; cd libgit2/build ; \
-		cmake -DCMAKE_INSTALL_PREFIX=$(MY_INSTALL_ROOT) -DBUILD_SHARED_LIBS=OFF -DBUILD_CLAR=OFF -DREGEX_BACKEND=builtin .. ; \
-		make -j8 ; \
-		make install)
 	(mkdir subsurface-build ; cd subsurface-build ;  \
 		cmake -DCMAKE_BUILD_TYPE=Release \
 			-DCMAKE_INSTALL_PREFIX=/usr \
 			-DLIBGIT2_INCLUDE_DIR=$(MY_INSTALL_ROOT)/include \
-			-DLIBGIT2_LIBRARIES=$(MY_INSTALL_ROOT)/lib/libgit2.a \
 			-DLIBDIVECOMPUTER_INCLUDE_DIR=$(MY_INSTALL_ROOT)/include \
 			-DLIBDIVECOMPUTER_LIBRARIES=$(MY_INSTALL_ROOT)/lib/libdivecomputer.a \
 			-DFORCE_LIBSSH=1 \

--- a/packaging/ubuntu/debian/rules
+++ b/packaging/ubuntu/debian/rules
@@ -55,9 +55,9 @@ override_dh_auto_configure:
 	(mkdir subsurface-build ; cd subsurface-build ;  \
 		cmake -DCMAKE_BUILD_TYPE=Release \
 			-DCMAKE_INSTALL_PREFIX=/usr \
-			-DLIBGIT2_INCLUDE_DIR=$(MY_INSTALL_ROOT)/include \
 			-DLIBDIVECOMPUTER_INCLUDE_DIR=$(MY_INSTALL_ROOT)/include \
 			-DLIBDIVECOMPUTER_LIBRARIES=$(MY_INSTALL_ROOT)/lib/libdivecomputer.a \
+			-DLIBGIT2_DYNAMIC=ON -DLIBGIT2_FROM_PKGCONFIG=ON \
 			-DFORCE_LIBSSH=1 \
 			-DNO_PRINTING=OFF \
 			-DMAKE_TESTS=OFF \

--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -5,7 +5,7 @@
 # it is included in our source tar file
 #
 
-if [[ $(pwd | grep "subsurface$") || ! -d subsurface || ! -d subsurface/libdivecomputer ]] ; then
+if [[ ! -d subsurface || ! -d subsurface/libdivecomputer ]] ; then
 	echo "Please start this script from the folder ABOVE the subsurface source directory"
 	exit 1;
 fi
@@ -26,6 +26,9 @@ GITREVISION=$(echo $GITVERSION | sed -e 's/.*-// ; s/.*\..*//')
 VERSION=$(echo $GITVERSION | sed -e 's/-/./')
 GITDATE=$(cd subsurface ; git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d)
 LIBDCREVISION=$(cd subsurface/libdivecomputer ; git rev-parse --verify HEAD)
+
+export DEBSIGN_PROGRAM="gpg --passphrase-file passphrase_file.txt --batch --no-use-agent"
+export DEBSIGN_KEYID="F58109E3"
 
 if [[ "$GITVERSION" = "" ]] ; then
 	SUFFIX=".release"
@@ -65,7 +68,7 @@ echo "preparing the debian directory"
 
 # this uses my (Dirk's) email address by default... simply set that variable in your
 # environment prior to starting the script
-test -z $DEBEMAIL && export DEBEMAIL=dirk@hohndel.org
+test -z $DEBEMAIL && export DEBEMAIL=dirk@subsurface-divelog.org
 
 # copy over the debian files and allow maintaining a release and daily changelog files
 rm -rf debian

--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -15,12 +15,6 @@ if [[ ! -d googlemaps ]] ; then
 	exit 1;
 fi
 
-if [[ ! -d libgit2 ]] ; then
-	echo "Please make sure you have libgit2 1.0 from https://github.com/libgit2/libgit2"
-	echo "checked out in parallel to the Subsurface directory"
-	exit 1;
-fi
-
 # ensure that the libdivecomputer module is there and current
 cd subsurface
 git submodule init
@@ -52,14 +46,8 @@ if [[ ! -d subsurface_$VERSION ]]; then
 	(cd ../subsurface ; tar cf - . ) | (cd subsurface_$VERSION ; tar xf - )
 	cd subsurface_$VERSION;
 	cp -a ../../googlemaps .
-	cp -a ../../libgit2 .
 
-	# now make sure we have libgit2 1.0
-	cd libgit2
-	git fetch
-	git checkout v1.0.0
-	cd ..
-	rm -rf .git libdivecomputer/.git googlemaps/.git build build-mobile libdivecomputer/build googlemaps/build libgit2/.git libgit2/build
+	rm -rf .git libdivecomputer/.git googlemaps/.git build build-mobile libdivecomputer/build googlemaps/build
 	echo $GITVERSION > .gitversion
 	echo $GITDATE > .gitdate
 	echo $LIBDCREVISION > libdivecomputer/revision


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
The main part is a new GitHub action (combined with new secrets in the repo) that allows us to build Fedora RPMs directly from GitHub. The other two commits are a lame INSTALL file change that I stumbled across when setting up a new VM - and a few fixes caused by new compile flags enforced in Fedora Rawhide that made builds on copr fail

Additional commits to add Ubuntu / Launchpad to the GitHub Actions. There is an issue with missing dependencies (private headers) for the newer of these builds - but that's a Launchpad issue, not a GitHub issue - so the Action to trigger Launchpad builds seems to work already.
