### PR TITLE
CICD updates

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,14 +17,19 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
 
-    - name: create release name
-      id: tag
+    - name: atomically create or retrieve the build number
+      id: build_nr
       run: |
-        export tag=""
-        export is_latest=false
-        if [ "${{ github.ref_type }}" = "tag" ] ; then tag="${{ github.ref_name }}" ; else tag="latest"; is_latest=true ; fi
-        echo "tag=${tag}" >> $GITHUB_OUTPUT
-        echo "is_latest=${is_latest}" >> $GITHUB_OUTPUT
+        cd .. # check out parallel to subsurface sources
+        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
+        # the clone followed by the pointless push should verify that the password is stored in the config
+        # that way the script doesn't need the password
+        git clone -b main https://github.com/subsurface/nightly-builds
+        cd nightly-builds
+        git remote set-url origin "$url"
+        git push origin main
+        cd ..
+        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
 
     - name: run build
       id: build
@@ -51,16 +56,20 @@ jobs:
         git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         bash -x ./subsurface/packaging/android/qmake-build.sh
 
-    - name: Get current date
-      id: date
-      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+    - name: create version number
+      id: version_number
+      run: |
+        latest=$(cat ../nightly-builds/latest-subsurface-buildnumber)
+        today=$(date '+%Y-%m-%d')
+        version="$today.$latest"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries
       if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        tag_name: v${{ steps.version_number.outputs.version }}
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,7 +64,20 @@ jobs:
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false
-        body: CICD release artifact
         fail_on_unmatched_files: true
         files: |
           Subsurface-mobile*.apk
+        body: |
+          CICD release artifact
+
+          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
+          This build is based on http://github.com/subsurface/subsurface/commit/${{ github.sha }}
+
+          None of these artifacts are signed.
+          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
+          The Windows installer will ask you to confirm installation of an app from an unknown developer.
+          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
+
+          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
+
+          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,14 +51,20 @@ jobs:
         git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
         bash -x ./subsurface/packaging/android/qmake-build.sh
 
+    - name: Get current date
+      id: date
+      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries
       if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ steps.tag.outputs.tag }}
-        prerelease: ${{ steps.tag.outputs.is_latest }}
+        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        repository: subsurface/nightly-builds
+        token: ${{ secrets.NIGHTLY_BUILDS }}
+        prerelease: false
         body: CICD release artifact
-        fail_on_unmatched_files: false
+        fail_on_unmatched_files: true
         files: |
           Subsurface-mobile*.apk

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,6 +53,19 @@ jobs:
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false
-        body: CICD release artifact
         fail_on_unmatched_files: true
         files: ${{ steps.build.outputs.dmg }}
+        body: |
+          CICD release artifact
+
+          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
+          This build is based on http://github.com/subsurface/subsurface/commit/${{ github.sha }}
+
+          None of these artifacts are signed.
+          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
+          The Windows installer will ask you to confirm installation of an app from an unknown developer.
+          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
+
+          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
+
+          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,7 +14,7 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
     - name: setup Homebrew
-      run: brew install autoconf automake libtool xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libjpg libpng libmtp create-dmg
+      run: brew install autoconf automake libtool xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libjpg libpng libmtp create-dmg confuse
     - name: set our Qt build
       run: |
         curl --output ssrf-Qt-5.15.2-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/ssrf-Qt5.15.2.tar.xz

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -13,6 +13,20 @@ jobs:
     steps:
     - name: checkout sources
       uses: actions/checkout@v1
+    - name: atomically create or retrieve the build number
+      id: build_nr
+      run: |
+        cd .. # check out parallel to subsurface sources
+        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
+        # the clone followed by the pointless push should verify that the password is stored in the config
+        # that way the script doesn't need the password
+        git clone -b main https://github.com/subsurface/nightly-builds
+        cd nightly-builds
+        git remote set-url origin "$url"
+        git push origin main
+        cd ..
+        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
+
     - name: setup Homebrew
       run: brew install hidapi libxslt libjpg libmtp create-dmg confuse
     - name: set our Qt build
@@ -40,16 +54,20 @@ jobs:
         echo "Created $IMG"
         echo "dmg=$IMG" >> $GITHUB_OUTPUT
 
-    - name: Get current date
-      id: date
-      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+    - name: create version number
+      id: version_number
+      run: |
+        latest=$(cat ../nightly-builds/latest-subsurface-buildnumber)
+        today=$(date '+%Y-%m-%d')
+        version="$today.$latest"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries
       if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        tag_name: v${{ steps.version_number.outputs.version }}
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -28,34 +28,13 @@ jobs:
         export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
         DIR=$(pwd)
 
-        # now build Subsurface with WebKit, using the generic build script
-        bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -release -build-deps -ftdi
+        # now setup Subsurface with WebKit and build the dependencies, using the generic build script
+        bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -release -build-deps -ftdi -prep-only
 
-        echo "finished initial build of Subsurface"
-
-        # make sure we have FTDI enabled for the package
+        echo "finished initial cmake setup of Subsurface - next build the package"
         cd subsurface/build
-        FTDI=$(grep FTDISUPPORT:BOOL CMakeCache.txt | grep ON)
-        if [ "$FTDI" != "FTDISUPPORT:BOOL=ON" ] ; then
-          cmake -D FTDISUPPORT:BOOL=ON .
-        fi
         echo "run the packaging script"
-        bash -e -x ../packaging/macos/make-package.sh
-        IMG=$(grep ^created: ../trigger-daily.log | tail -1 | cut -b10-)
+        bash -e -x ../packaging/macosx/make-package.sh | tee mp.log 2>&1
+        IMG=$(grep ^created: mp.log | tail -1 | cut -b10-)
         echo "Created $IMG"
-
-    - name: test desktop build
-      run: |
-        # build export-html to make sure that didn't get broken
-        cd ${GITHUB_WORKSPACE}/build
-        cmake -DMAKE_TESTS=ON
-        make -j
-        make -j export-html
-        echo "------------------------------------"
-        echo "run tests for desktop build"
-        export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
-        export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
-        cd tests
-        # ./TestGitStorage -v2
-        make check
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -48,7 +48,9 @@ jobs:
       run: |
         # build export-html to make sure that didn't get broken
         cd ${GITHUB_WORKSPACE}/build
-        make export-html
+        cmake -DMAKE_TESTS=ON
+        make -j
+        make -j export-html
         echo "------------------------------------"
         echo "run tests for desktop build"
         export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -20,6 +20,7 @@ jobs:
         curl --output ssrf-Qt-5.15.2-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/ssrf-Qt5.15.2.tar.xz
         tar -xJf ssrf-Qt-5.15.2-mac.tar.xz
     - name: build Subsurface
+      id: build
       run: |
         cd ${GITHUB_WORKSPACE}/..
         export QT_ROOT=${GITHUB_WORKSPACE}/Qt5.15.2/5.15.2/clang_64
@@ -37,4 +38,21 @@ jobs:
         bash -e -x ../packaging/macosx/make-package.sh | tee mp.log 2>&1
         IMG=$(grep ^created: mp.log | tail -1 | cut -b10-)
         echo "Created $IMG"
+        echo "dmg=$IMG" >> $GITHUB_OUTPUT
 
+    - name: Get current date
+      id: date
+      run: echo "today=$(date '+%Y%m%d')" >> $GITHUB_OUTPUT
+
+    # only publish a 'release' on push events (those include merging a PR)
+    - name: upload binaries
+      if: github.event_name == 'push'
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        repository: subsurface/nightly-builds
+        token: ${{ secrets.NIGHTLY_BUILDS }}
+        prerelease: false
+        body: CICD release artifact
+        fail_on_unmatched_files: true
+        files: ${{ steps.build.outputs.dmg }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,7 +14,7 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
     - name: setup Homebrew
-      run: brew install autoconf automake libtool xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libjpg libpng libmtp create-dmg confuse
+      run: brew install hidapi libxslt libjpg libmtp create-dmg confuse
     - name: set our Qt build
       run: |
         curl --output ssrf-Qt-5.15.2-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/ssrf-Qt5.15.2.tar.xz

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "today=$(date '+%Y%m%d')" >> $GITHUB_OUTPUT
+      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,68 +9,51 @@ on:
 
 jobs:
   buildMac:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
     - name: checkout sources
       uses: actions/checkout@v1
     - name: setup Homebrew
-      run: brew install autoconf automake libtool xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libjpg libpng libmtp
+      run: brew install autoconf automake libtool xz hidapi libusb libxml2 libxslt libzip openssl pkg-config libgit2 libssh2 libjpg libpng libmtp create-dmg
     - name: set our Qt build
       run: |
-        mkdir -p Qt/5.13.0
-        curl --output Qt-5.13.0-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/Qt-5.13.0-mac.tar.xz
-        tar -xJ -C Qt/5.13.0 -f Qt-5.13.0-mac.tar.xz
-    - name: build Subsurface-mobile
-      env:
-         SUBSURFACE_REPO_PATH: ${{ github.workspace }}
-      run: |
-        cd ${GITHUB_WORKSPACE}/..
-        export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
-        export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
-        export PATH=$QT_ROOT/bin:$PATH
-        export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
-        DIR=$(pwd)
-        git config --global user.email "ci@subsurface-divelog.org"
-        git config --global user.name "Subsurface CI"
-        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}
-        git config --global --add safe.directory ${SUBSURFACE_REPO_PATH}/libdivecomputer
-        # first build Subsurface-mobile to ensure this didn't get broken
-        bash -e -x ./subsurface/scripts/build.sh -mobile
-
-    - name: test mobile build
-      run: |
-        echo "------------------------------------"
-        echo "run tests for mobile build"
-        export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
-        export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
-        cd ${GITHUB_WORKSPACE}/build-mobile/tests
-        # ./TestGitStorage -v2
-        make check
-
+        curl --output ssrf-Qt-5.15.2-mac.tar.xz https://f002.backblazeb2.com/file/Subsurface-Travis/ssrf-Qt5.15.2.tar.xz
+        tar -xJf ssrf-Qt-5.15.2-mac.tar.xz
     - name: build Subsurface
       run: |
         cd ${GITHUB_WORKSPACE}/..
-        export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
+        export QT_ROOT=${GITHUB_WORKSPACE}/Qt5.15.2/5.15.2/clang_64
         export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
         export PATH=$QT_ROOT/bin:$PATH
         export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
         DIR=$(pwd)
 
-        # now Subsurface with WebKit
-        bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -release
+        # now build Subsurface with WebKit, using the generic build script
+        bash -e -x ./subsurface/scripts/build.sh -desktop -build-with-webkit -release -build-deps -ftdi
 
-        cd ${GITHUB_WORKSPACE}/build
+        echo "finished initial build of Subsurface"
 
-        # build export-html to make sure that didn't get broken
-        make export-html
+        # make sure we have FTDI enabled for the package
+        cd subsurface/build
+        FTDI=$(grep FTDISUPPORT:BOOL CMakeCache.txt | grep ON)
+        if [ "$FTDI" != "FTDISUPPORT:BOOL=ON" ] ; then
+          cmake -D FTDISUPPORT:BOOL=ON .
+        fi
+        echo "run the packaging script"
+        bash -e -x ../packaging/macos/make-package.sh
+        IMG=$(grep ^created: ../trigger-daily.log | tail -1 | cut -b10-)
+        echo "Created $IMG"
 
     - name: test desktop build
       run: |
+        # build export-html to make sure that didn't get broken
+        cd ${GITHUB_WORKSPACE}/build
+        make export-html
         echo "------------------------------------"
         echo "run tests for desktop build"
         export QT_ROOT=${GITHUB_WORKSPACE}/Qt/5.13.0/clang_64
         export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_ROOT/plugins
-        cd ${GITHUB_WORKSPACE}/build/tests
+        cd tests
         # ./TestGitStorage -v2
         make check
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,15 +58,21 @@ jobs:
         bash -x subsurface/.github/workflows/scripts/windows-in-container-build.sh 2>&1 | tee build.log
         grep "Built target installer" build.log
 
+    - name: Get current date
+      id: date
+      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries
       if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ steps.tag.outputs.tag }}
-        prerelease: ${{ steps.tag.outputs.is_latest }}
+        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        repository: subsurface/nightly-builds
+        token: ${{ secrets.NIGHTLY_BUILDS }}
+        prerelease: false
         body: CICD release artifact
-        fail_on_unmatched_files: false
+        fail_on_unmatched_files: true
         files: |
          ./subsurface*.exe*
          ./smtk2ssrf*.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,29 +17,19 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
 
-    - name: create release name
-      id: tag
+    - name: atomically create or retrieve the build number
+      id: build_nr
       run: |
-        export tag=""
-        export is_latest=false
-        if [ "${{ github.ref_type }}" = "tag" ]
-        then
-          tag="${{ github.ref_name }}"
-        else
-          tag="latest"
-          is_latest=true
-        fi
-        echo "tag=${tag}" >> $GITHUB_OUTPUT
-        echo "is_latest=${is_latest}" >> $GITHUB_OUTPUT
-
-    - name: tag current version as latest if we don't have a tag
-      if: ${{ steps.tag.outputs.is_latest == 'true' }}
-      uses: rickstaa/action-create-tag@v1
-      with:
-        tag: "latest"
-        tag_exists_error: false
-        force_push_tag: true
-        message: "latest commit to allow 'release' uploads"
+        cd .. # check out parallel to subsurface sources
+        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
+        # the clone followed by the pointless push should verify that the password is stored in the config
+        # that way the script doesn't need the password
+        git clone -b main https://github.com/subsurface/nightly-builds
+        cd nightly-builds
+        git remote set-url origin "$url"
+        git push origin main
+        cd ..
+        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
 
     - name: get other dependencies
       env:
@@ -58,16 +48,20 @@ jobs:
         bash -x subsurface/.github/workflows/scripts/windows-in-container-build.sh 2>&1 | tee build.log
         grep "Built target installer" build.log
 
-    - name: Get current date
-      id: date
-      run: echo "today=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+    - name: create version number
+      id: version_number
+      run: |
+        latest=$(cat ../nightly-builds/latest-subsurface-buildnumber)
+        today=$(date '+%Y-%m-%d')
+        version="$today.$latest"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     # only publish a 'release' on push events (those include merging a PR)
     - name: upload binaries
       if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
+        tag_name: v${{ steps.version_number.outputs.version }}
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,8 +71,21 @@ jobs:
         repository: subsurface/nightly-builds
         token: ${{ secrets.NIGHTLY_BUILDS }}
         prerelease: false
-        body: CICD release artifact
         fail_on_unmatched_files: true
         files: |
          ./subsurface*.exe*
          ./smtk2ssrf*.exe
+        body: |
+          CICD release artifact
+
+          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
+          This build is based on http://github.com/subsurface/subsurface/commit/${{ github.sha }}
+
+          None of these artifacts are signed.
+          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
+          The Windows installer will ask you to confirm installation of an app from an unknown developer.
+          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
+
+          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
+
+          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).

--- a/packaging/macosx/make-package.sh
+++ b/packaging/macosx/make-package.sh
@@ -7,17 +7,7 @@
 # find the directory above the sources - typically ~/src
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../../.. && pwd )
 
-# install location of create-dmg
-# by default we assume it's next to subsurface in ~/src/yoursway-create-dmg
-DMGCREATE=${DIR}/yoursway-create-dmg/create-dmg
-if [ ! -x $DMGCREATE ] ; then
-	# well, this app changed its github name, so it may be in a different directory now
-	DMGCREATE=${DIR}/create-dmg/create-dmg
-	if [ ! -x $DMGCREATE ] ; then
-		echo "Can't find working create-dmg, aborting"
-		exit 1
-	fi
-fi
+DMGCREATE=create-dmg
 
 # same git version magic as in the Makefile
 # for the naming of volume and dmg we want the 3 digits of the full version number
@@ -42,7 +32,7 @@ OLDER_MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_SYSROOT=${
 export PKG_CONFIG_PATH=${DIR}/install-root/lib/pkgconfig:$PKG_CONFIG_PATH
 
 cmake $OLDER_MAC_CMAKE .
-LIBRARY_PATH=${DIR}/install-root/lib make -j8
+LIBRARY_PATH=${DIR}/install-root/lib make -j
 LIBRARY_PATH=${DIR}/install-root/lib make install
 
 # now adjust a few references that macdeployqt appears to miss
@@ -93,6 +83,10 @@ done
 
 if [ "$1" = "-nodmg" ] ; then
 	exit 0
+elif [ "$1" = "-sign" ] ; then
+	SIGN=1
+else
+	SIGN=0
 fi
 
 # copy things into staging so we can create a nice DMG
@@ -100,7 +94,9 @@ rm -rf ./staging
 mkdir ./staging
 cp -a ./Subsurface.app ./staging
 
-sh ${DIR}/subsurface/packaging/macosx/sign
+if [ "$SIGN" = "1" ] ; then
+	sh ${DIR}/subsurface/packaging/macosx/sign
+fi
 
 if [ -f ./Subsurface-$VERSION.dmg ]; then
 	rm ./Subsurface-$VERSION.dmg.bak

--- a/packaging/macosx/make-package.sh
+++ b/packaging/macosx/make-package.sh
@@ -31,7 +31,13 @@ BASESDK=$(ls $SDKROOT | grep "MacOSX1.*\.sdk" | head -1 | sed -e "s/MacOSX//;s/\
 OLDER_MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_SYSROOT=${SDKROOT}/MacOSX${BASESDK}.sdk/"
 export PKG_CONFIG_PATH=${DIR}/install-root/lib/pkgconfig:$PKG_CONFIG_PATH
 
-cmake $OLDER_MAC_CMAKE .
+cmake $OLDER_MAC_CMAKE \
+	-DLIBGIT2_FROM_PKGCONFIG=ON \
+	-DLIBGIT2_DYNAMIC=ON \
+	-DFTDISUPPORT=ON \
+	-DMAKE_TESTS=Off \
+	.
+
 LIBRARY_PATH=${DIR}/install-root/lib make -j
 LIBRARY_PATH=${DIR}/install-root/lib make install
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -77,6 +77,11 @@ while [[ $# -gt 0 ]] ; do
 			# call this script with -build-deps
 			BUILD_DEPS="1"
 			;;
+		-prep-only)
+			# use this script to build dependencies and set things up with default values, but don't actually run
+			# the build
+			PREP_ONLY="1"
+			;;
 		-fat-build)
 			# build a fat binary for macOS
 			# ignored on other platforms
@@ -151,7 +156,7 @@ while [[ $# -gt 0 ]] ; do
 			;;
 		*)
 			echo "Unknown command line argument $arg"
-			echo "Usage: build.sh [-no-bt] [-quick] [-build-deps] [-fat-build] [-src-dir <SUBSURFACE directory>] [-build-prefix <PREFIX>] [-build-with-webkit] [-build-with-map] [-mobile] [-desktop] [-downloader] [-both] [-all] [-ftdi] [-create-appdir] [-release]"
+			echo "Usage: build.sh [-no-bt] [-quick] [-build-deps] [-prep-only] [-fat-build] [-src-dir <SUBSURFACE directory>] [-build-prefix <PREFIX>] [-build-with-webkit] [-build-with-map] [-mobile] [-desktop] [-downloader] [-both] [-all] [-ftdi] [-create-appdir] [-release]"
 			exit 1
 			;;
 	esac
@@ -645,17 +650,19 @@ for (( i=0 ; i < ${#BUILDS[@]} ; i++ )) ; do
 		rm -rf Subsurface-mobile.app
 	fi
 
-	LIBRARY_PATH=$INSTALL_ROOT/lib make -j4
-	LIBRARY_PATH=$INSTALL_ROOT/lib make install
+	if [ ! "$PREP_ONLY" = "1" ] ; then
+		LIBRARY_PATH=$INSTALL_ROOT/lib make -j4
+		LIBRARY_PATH=$INSTALL_ROOT/lib make install
 
-	if [ "$CREATE_APPDIR" = "1" ] ; then
-		# if we create an AppImage this makes gives us a sane starting point
-		cd "$SRC"
-		mkdir -p ./appdir
-		mkdir -p appdir/usr/share/metainfo
-		mkdir -p appdir/usr/share/icons/hicolor/256x256/apps
-		cp -r ./install-root/* ./appdir/usr
-		cp ${SRC_DIR}/appdata/subsurface.appdata.xml appdir/usr/share/metainfo/
-		cp ${SRC_DIR}/icons/subsurface-icon.png appdir/usr/share/icons/hicolor/256x256/apps/
+		if [ "$CREATE_APPDIR" = "1" ] ; then
+			# if we create an AppImage this makes gives us a sane starting point
+			cd "$SRC"
+			mkdir -p ./appdir
+			mkdir -p appdir/usr/share/metainfo
+			mkdir -p appdir/usr/share/icons/hicolor/256x256/apps
+			cp -r ./install-root/* ./appdir/usr
+			cp ${SRC_DIR}/appdata/subsurface.appdata.xml appdir/usr/share/metainfo/
+			cp ${SRC_DIR}/icons/subsurface-icon.png appdir/usr/share/icons/hicolor/256x256/apps/
+		fi
 	fi
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -610,7 +610,7 @@ for (( i=0 ; i < ${#BUILDS[@]} ; i++ )) ; do
 		EXTRA_OPTS="-DNO_USERMANUAL=ON -DNO_PRINTING=ON"
 	fi
 	if [ "$FTDI" = "1" ] ; then
-		EXTRA_OPTSi="$EXTRA_OPTS -DFTDISUPPORT"
+		EXTRA_OPTSi="$EXTRA_OPTS -DFTDISUPPORT=ON"
 	fi
 	if [ "$BUILD_WITH_QT6" = "1" ] ; then
 		EXTRA_OPTS="$EXTRA_OPTS -DBUILD_WITH_QT6=ON"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -137,6 +137,10 @@ while [[ $# -gt 0 ]] ; do
 			BUILD_DESKTOP="1"
 			BUILD_DOWNLOADER="1"
 			;;
+		-ftdi)
+			# make sure we include the user space FTDI drivers
+			FTDI="1"
+			;;
 		-create-appdir)
 			# we are building an AppImage as by product
 			CREATE_APPDIR="1"
@@ -147,7 +151,7 @@ while [[ $# -gt 0 ]] ; do
 			;;
 		*)
 			echo "Unknown command line argument $arg"
-			echo "Usage: build.sh [-no-bt] [-quick] [-build-deps] [-fat-build] [-src-dir <SUBSURFACE directory>] [-build-prefix <PREFIX>] [-build-with-webkit] [-build-with-map] [-mobile] [-desktop] [-downloader] [-both] [-all] [-create-appdir] [-release]"
+			echo "Usage: build.sh [-no-bt] [-quick] [-build-deps] [-fat-build] [-src-dir <SUBSURFACE directory>] [-build-prefix <PREFIX>] [-build-with-webkit] [-build-with-map] [-mobile] [-desktop] [-downloader] [-both] [-all] [-ftdi] [-create-appdir] [-release]"
 			exit 1
 			;;
 	esac
@@ -572,13 +576,6 @@ if [ "$QUICK" != "1" ] && [ "$BUILD_DESKTOP$BUILD_MOBILE" != "" ] && ( [[ $QT_VE
 	else
 		$QMAKE "INCLUDEPATH=$INSTALL_ROOT/include" ../googlemaps.pro
 	fi
-	# on Travis the compiler doesn't support c++1z, yet qmake adds that flag;
-	# since things compile fine with c++11, let's just hack that away
-	# similarly, don't use -Wdata-time
-	if [ "$TRAVIS" = "true" ] ; then
-		mv Makefile Makefile.bak
-		cat Makefile.bak | sed -e 's/std=c++1z/std=c++11/g ; s/-Wdate-time//' > Makefile
-	fi
 	make -j4
 	if [ "$PLATFORM" = Darwin ]  && [[ $QT_VERSION == 6* ]] && [[ $ARCHS == *" "* ]] ; then
 		# we can't build fat binaries directly here, so let's do it in two steps
@@ -611,6 +608,9 @@ for (( i=0 ; i < ${#BUILDS[@]} ; i++ )) ; do
 		EXTRA_OPTS="-DNO_USERMANUAL=OFF -DNO_PRINTING=OFF"
 	else
 		EXTRA_OPTS="-DNO_USERMANUAL=ON -DNO_PRINTING=ON"
+	fi
+	if [ "$FTDI" = "1" ] ; then
+		EXTRA_OPTSi="$EXTRA_OPTS -DFTDISUPPORT"
 	fi
 	if [ "$BUILD_WITH_QT6" = "1" ] ; then
 		EXTRA_OPTS="$EXTRA_OPTS -DBUILD_WITH_QT6=ON"

--- a/scripts/get-dep-lib.sh
+++ b/scripts/get-dep-lib.sh
@@ -12,7 +12,7 @@ CURRENT_LIBSSH2="libssh2-1.8.0"
 CURRENT_XSLT="v1.1.34"
 CURRENT_SQLITE="3190200"
 CURRENT_LIBXML2="v2.9.4"
-CURRENT_LIBFTDI="1.3"
+CURRENT_LIBFTDI="abd19b721f7e9b4d514ed319ece173ebc7b1ea72"
 CURRENT_KIRIGAMI="v5.76.0"
 CURRENT_BREEZE_ICONS="4daac191fb33c8c03bba8356db9767816cb8ee02"
 CURRENT_MDBTOOLS="master"
@@ -190,7 +190,7 @@ for package in "${PACKAGES[@]}" ; do
 			git_checkout_library libzip $CURRENT_LIBZIP https://github.com/nih-at/libzip.git
 			;;
 		libftdi1)
-			curl_download_library libftdi1 https://www.intra2net.com/en/developer/libftdi/download/ libftdi1-${CURRENT_LIBFTDI}.tar.bz2
+			git_checkout_library libftdi1 $CURRENT_LIBFTDI git://developer.intra2net.com/libftdi
 			;;
 		sqlite)
 			curl_download_library sqlite https://www.sqlite.org/2017/ sqlite-autoconf-${CURRENT_SQLITE}.tar.gz

--- a/scripts/get-or-create-build-nr.sh
+++ b/scripts/get-or-create-build-nr.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# this is comically complicated - why does GitHub not have a monotonic number
+# that tracks how many times any action was kicked off? Or an atomic way to update a variable?
+# So we use the fact that git itself does a great job of preventing us from overwriting an
+# existing branch and abuse that to create atomicity
+
+SHA_BRANCH="branch-for-$1"
+
+# first - make sure git is configured so we can do stuff
+git config --global user.email "ci@subsurface-divelog.org"
+git config --global user.name "Subsurface CI"
+
+# next, clone the release repo
+[ -d nightly-builds ] || git clone https://github.com/subsurface/nightly-builds
+cd nightly-builds
+
+# this is from the main branch, so this should be the PREVIOUS build number
+latest=$(<latest-subsurface-buildnumber)
+
+# now let's see if a branch for the current SHA exists
+if git checkout $SHA_BRANCH
+then
+  # one of the other workflows created a release number already
+  latest=$(<latest-subsurface-buildnumber)
+else
+  # this is almost certainly a race between the different workflow files
+  # the main branch should have held the previous release number
+  # increment by one and write as new build number into the named branch
+  latest=$((latest+1))
+  git checkout -b $SHA_BRANCH
+  echo $latest > latest-subsurface-buildnumber
+  git commit -a -m "record build number for this SHA"
+
+  # now comes the moment of truth - are we the first one?
+  # the push will succeed for exactly one of the workflows
+  if git push https://github.com/subsurface/nightly-builds $SHA_BRANCH
+  then
+    # yay - we win! now let's make sure that we remember this number for next time
+    git checkout main
+    echo $latest > latest-subsurface-buildnumber
+    git commit -a -m "record latest build number in main branch"
+    if ! git push https://github.com/subsurface/nightly-builds main
+    then
+      echo "push to main failed - we'll lose monotonic property"
+      exit -1
+    fi
+  else
+    # someone else was faster - get the number they wrote
+    git checkout main
+    git branch -D $SHA_BRANCH
+    if ! git checkout -b $SHA_BRANCH
+    then
+      echo "push to $SHA_BRANCH failed, but switching to it failed as well"
+      exit -2
+    fi
+    latest=$(<latest-subsurface-buildnumber)
+  fi
+fi
+# if we get here, we have the next build number - wow that was weird.
+echo "Build number is $latest"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a fairly significant overhaul of the CICD system that creates working (but unsigned) packages for Windows, macOS, and Android, These are now posted in a parallel repo https://github.com/subsurface/nightly-builds as releases - each with a tag that includes the date and a built number.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) get the macOS builds to work with the current versions of the dependencies
2) create a convoluted and stupid system to atomically create monotonic build numbers that are identical across the different workflows
3) set things up so that the build artifacts are posted as releases in the nightly-builds repo

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
We'll need to test these to make sure there are no surprises - and then we need to update our documentation to reflect how things are set up

