### PR TITLE
More cloud servers

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: subsurface
+ko_fi: dirkhh

--- a/core/checkcloudconnection.cpp
+++ b/core/checkcloudconnection.cpp
@@ -103,7 +103,9 @@ bool CheckCloudConnection::nextServer()
 	};
 	static struct serverTried cloudServers[] = {
 		{ CLOUD_HOST_EU, false },
-		{ CLOUD_HOST_US, false }
+		{ CLOUD_HOST_US, false },
+		{ CLOUD_HOST_E2, false },
+		{ CLOUD_HOST_U2, false }
 	};
 	const char *server = nullptr;
 	for (serverTried &item: cloudServers) {

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -306,7 +306,11 @@ int certificate_check_cb(git_cert *cert, int valid, const char *host, void *payl
 	UNUSED(payload);
 	if (verbose)
 		SSRF_INFO("git storage: certificate callback for host %s with validity %d\n", host, valid);
-	if ((same_string(host, CLOUD_HOST_GENERIC) || same_string(host, CLOUD_HOST_US) || same_string(host, CLOUD_HOST_EU)) &&
+	if ((same_string(host, CLOUD_HOST_GENERIC) ||
+	     same_string(host, CLOUD_HOST_US) ||
+	     same_string(host, CLOUD_HOST_U2) ||
+	     same_string(host, CLOUD_HOST_EU) ||
+	     same_string(host, CLOUD_HOST_E2)) &&
 			cert->cert_type == GIT_CERT_X509) {
 		// for some reason the LetsEncrypt certificate makes libgit2 throw up on some
 		// platforms but not on others

--- a/core/git-access.c
+++ b/core/git-access.c
@@ -887,6 +887,8 @@ static bool create_local_repo(struct git_info *info)
 		if (giterr_last()) {
 			 msg = giterr_last()->message;
 			 SSRF_INFO("git storage: error message was %s\n", msg);
+		} else {
+			 SSRF_INFO("git storage: giterr_last() is null\n");
 		}
 		char *pattern = format_string("reference 'refs/remotes/origin/%s' not found", info->branch);
 		// it seems that we sometimes get 'Reference' and sometimes 'reference'

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -14,7 +14,9 @@ extern "C" {
 #endif
 
 #define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"
+#define CLOUD_HOST_U2 "ssrf-cloud-u2.subsurface-divelog.org"
 #define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"
+#define CLOUD_HOST_E2 "ssrf-cloud-e2.subsurface-divelog.org"
 #define CLOUD_HOST_PATTERN "ssrf-cloud-..\\.subsurface-divelog\\.org"
 #define CLOUD_HOST_GENERIC "cloud.subsurface-divelog.org"
 

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -13,10 +13,10 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
-#define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"
-#define CLOUD_HOST_U2 "ssrf-cloud-u2.subsurface-divelog.org"
-#define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"
-#define CLOUD_HOST_E2 "ssrf-cloud-e2.subsurface-divelog.org"
+#define CLOUD_HOST_US "ssrf-cloud-us.subsurface-divelog.org"  // preferred (faster/bigger) server in the US
+#define CLOUD_HOST_U2 "ssrf-cloud-u2.subsurface-divelog.org"  // secondary (older) server in the US
+#define CLOUD_HOST_EU "ssrf-cloud-eu.subsurface-divelog.org"  // preferred (faster/bigger) server in Germany
+#define CLOUD_HOST_E2 "ssrf-cloud-e2.subsurface-divelog.org"  // secondary (older) server in Germany
 #define CLOUD_HOST_PATTERN "ssrf-cloud-..\\.subsurface-divelog\\.org"
 #define CLOUD_HOST_GENERIC "cloud.subsurface-divelog.org"
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This allows us to use four distinct servers instead of only two.
Right now they are still fairly close to each other (two in Germany, two in California), but they are in different data centers and from different hosting providers, hopefully making all of this a bit more resillient.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
This should be completely transparent to the user. People using older versions will only access the -us and -eu server, while people using this code will also try the -u2 and -e2 servers
