### PR TITLE
CICD: Update the android Build Docker Image.

### DIFF
--- a/.github/workflows/android-dockerimage.yml
+++ b/.github/workflows/android-dockerimage.yml
@@ -1,24 +1,18 @@
 name: Android Docker Image CI
 
-# -- disabled for now, as the resulting image is HUGE and causes our
-#    Android builds to fail
-#on:
-#  push:
-#    paths:
-#    - scripts/docker/android-build-container/Dockerfile
-#    - .github/workflows/android-docker*
-
-# this is here to prevent errors about not having an on: clause
 on:
-  repository_dispatch:
-    types:
-    - unused
+  push:
+    paths:
+    - scripts/docker/android-build-container
+    - .github/workflows/android-docker*
+    - packaging/android/android-build-setup.sh
+    - packaging/android/variables.sh
 
 jobs:
   android-build-container:
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ '5.13.10' }} # the version numbers here is based on the Qt version, the third digit is the rev of the docker image
+      VERSION: ${{ '5.15.2' }} # the version numbers here is based on the Qt version, the third digit is the rev of the docker image
 
     steps:
     - uses: actions/checkout@v1
@@ -26,23 +20,22 @@ jobs:
     - name: Get our pre-reqs
       run: |
           cd scripts/docker/android-build-container
-          bash download.sh
-          sed -ie 's/^sudo/#sudo/' setup-docker.sh
-          bash setup-docker.sh
+          bash setup-docker.sh -no-docker-build
 
-    - name: set env
+    - name: Build the name for the docker image
+      id: build_name
       run: |
         v=${{ env.VERSION }}
         b=${{ github.ref }} # -BRANCH suffix, unless the branch is master
         b=${b/refs\/heads\//}
         b=${b,,} # the name needs to be all lower case
         if [ $b = "master" ] ; then b="" ; else b="-$b" ; fi
-        echo "::set-env name=NAME::subsurface/android-build-container${b}:${v}"
+        echo "NAME=subsurface/android-build${b}:${v}" >> $GITHUB_OUTPUT
 
     - name: Build and Publish Linux Docker image to Dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
-        name:       ${{ env.NAME }}
+        name:       ${{ steps.build_name.outputs.NAME }}
         username:   ${{ secrets.DOCKER_USERNAME }}
         password:   ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: 'Dockerfile'

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ packaging/ios/Info.plist
 packaging/ios/Qt
 packaging/ios/asset_catalog_compiler.Info.plist
 appdata/subsurface.appdata.xml
+scripts/docker/android-build-container/android-build-setup.sh
+scripts/docker/android-build-container/variables.sh
+

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -1,43 +1,33 @@
-From ubuntu:18.04
+FROM subsurface/android-build-container:5.15.1 as base
+
+FROM ubuntu:22.04 as build
 
 RUN apt-get update  && \
     apt-get upgrade -y && \
     apt-get install -y \
-    autoconf \
-    automake \
-    cmake \
-    git \
-    libtool-bin \
-    make \
-    wget \
     unzip \
-    python \
-    python3-pip \
-    bzip2 \
-    pkg-config \
-    libx11-xcb1 \
-    libgl1-mesa-glx \
-    libglib2.0-0 \
+    git \
+    cmake \
+    autoconf \
+    libtool-bin \
     openjdk-8-jdk \
-    curl \
-    coreutils \
-    p7zip-full
+    wget
 
-# create our working directory and place the local copies of the Qt
+WORKDIR /android
+
+COPY --from=base /android/5.15.1 5.15.1
+
 # install, NDK and SDK there, plus the three files from the Subsurface
 # sources that we need to get the prep routines to run
-RUN mkdir -p /android
-ADD commandlinetools-linux-*.zip /android/
-RUN cd /android && unzip commandlinetools-linux-*.zip
-ADD android-build-setup.sh variables.sh /android/
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip && \
+    unzip commandlinetools-linux-*.zip
+ADD android-build-setup.sh variables.sh .
 
 # run the build setup
-RUN ls -l /android
-RUN cd /android && bash -x /android/android-build-setup.sh
+RUN bash -x android-build-setup.sh
 
 # clean up the files that we don't need to keep the container smaller
-RUN cd /android && \
-    rm -rf \
+RUN rm -rf \
 	   5*/android/lib/*x86* \
 	   5*/android/doc \
 	   5*/android/include/QtHelp \
@@ -48,6 +38,7 @@ RUN cd /android && \
 	   5*/android/include/QtTest \
 	   5*/android/include/QtXml \
 	   5*/android/plugins/geoservices/libqtgeoservices_mapboxgl.so \
+	   5*/android/lib/cmake/Qt5Test/Qt5TestConfig.cmake \
 	   commandlinetools-linux-*.zip \
 	   $( find platforms -name arch-mips -o -name arch-x86 ) \
 	   toolchains/x86-* android-ndk*/toolchains/llvm/prebuilt/x86-* \
@@ -69,10 +60,50 @@ RUN cd /android && \
 	   emulator \
 	   platform-tools-2 \
 	   variables.sh \
-	   android-build-setup.sh
-	   /usr/lib/gcc && \
-    ls -l && \
-    du -sh *
-RUN apt-get clean
-#RUN cd /android/android-ndk-r18b/toolchains && ln -s x86_64-4.9 x86-64-4.9
-RUN touch /android/finished-"`date`"
+	   android-build-setup.sh \
+	   /usr/lib/gcc
+
+FROM ubuntu:22.04
+
+# Repeat exactly the same step as in the 'build' image above, so it can be reused
+RUN apt-get update  && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    unzip \
+    git \
+    cmake \
+    autoconf \
+    libtool-bin \
+    openjdk-8-jdk \
+    wget
+
+RUN apt-get install -y \
+    autoconf \
+    automake \
+    cmake \
+    git \
+    make \
+    wget \
+    zip \
+    unzip \
+    python3 \
+    python3-pip \
+    bzip2 \
+    pkg-config \
+    libx11-xcb1 \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    openjdk-8-jdk \
+    curl \
+    coreutils \
+    p7zip-full && \
+    apt-get clean
+
+WORKDIR /android
+
+COPY --from=build /android/ .
+
+RUN git config --global --add safe.directory /android/subsurface && \
+    git config --global --add safe.directory /android/subsurface/libdivecomputer
+
+RUN touch finished-"`date`"

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update  && \
 
 WORKDIR /android
 
+# Scrape the manually curated Qt install from the previous build image
 COPY --from=base /android/5.15.1 5.15.1
 
 # install, NDK and SDK there, plus the three files from the Subsurface

--- a/scripts/docker/android-build-container/Dockerfile
+++ b/scripts/docker/android-build-container/Dockerfile
@@ -104,6 +104,7 @@ WORKDIR /android
 COPY --from=build /android/ .
 
 RUN git config --global --add safe.directory /android/subsurface && \
-    git config --global --add safe.directory /android/subsurface/libdivecomputer
+    git config --global --add safe.directory /android/subsurface/libdivecomputer && \
+    git config --global --add safe.directory /android/subsurface/nightly-builds
 
 RUN touch finished-"`date`"

--- a/scripts/docker/android-build-container/download.sh
+++ b/scripts/docker/android-build-container/download.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-wget https://download.qt.io/official_releases/qt/5.13/5.13.1/qt-opensource-linux-x64-5.13.1.run
-wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
-wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-wget https://ftp.osuosl.org/pub/blfs/conglomeration/cmake/cmake-3.13.2.tar.gz

--- a/scripts/docker/android-build-container/setup-docker.sh
+++ b/scripts/docker/android-build-container/setup-docker.sh
@@ -16,5 +16,9 @@
 cp ../../../packaging/android/android-build-setup.sh .
 cp ../../../packaging/android/variables.sh .
 
+if [ "$1X" == "-no-docker-buildX" ]; then
+    exit 0
+fi
+
 # create the container (this takes a while)
 docker build -t android-build .

--- a/scripts/docker/android-build-container/setup-docker.sh
+++ b/scripts/docker/android-build-container/setup-docker.sh
@@ -5,16 +5,16 @@
 # Google makes it intentionally very hard to download the command line tools
 # the URL is constantly changing and the website requires you to click through
 # a license.
+#
 # Today this URL works:
-if [ ! -f commandlinetools-linux-6858069_latest.zip ] ; then
-	wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip
-fi
-# if this fails, go to https://developer.android.com/studio#cmdline-tools and click through
-# for yourself...
+# https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip
+#
+# If this fails, go to https://developer.android.com/studio#cmdline-tools and
+# click through for yourself, and then update the URL in the Dockerfile
 
 # copy the dependency script into this folder
 cp ../../../packaging/android/android-build-setup.sh .
 cp ../../../packaging/android/variables.sh .
 
 # create the container (this takes a while)
-sudo docker build -t android-builder --squash .
+docker build -t android-build .


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Update the android build docker image:
- rebase on ubuntu 22.04;
- add tooling required to sign APKs;
- changes to make the container re-usable;
- change to a multi-stage build to keep the image size smaller;
- generic improvements to the Dockerfile

Also update the example script for how to use the container.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Since there is no offline installer available for Qt 5.15, the new docker container re-uses the Qt install from the existing 'subsurface/android-build-container:5.15.1' image, by using it as the first stage of the multi-stage build. In order to avoid overwriting this source image the new image is named 'android-build'.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
