### PR TITLE
iOS: crash fix: don't try to deallocate IosShare

### DIFF
--- a/ios/ios-share.mm
+++ b/ios/ios-share.mm
@@ -30,7 +30,9 @@ IosShare::IosShare() : self(NULL) {
 }
 
 IosShare::~IosShare() {
-	[(id)self dealloc];
+//  this call below apparently caused a crash at exit.
+//  since at exit I really don't care much about a memory leak, this should be fine.
+//	[(id)self dealloc];
 }
 
 // simplified method that fills subject, recipient, and body for support emails


### PR DESCRIPTION
We have a strange crash on exit on iOS and this looks like the likely culprit. And since it happens at app exit, I'm not too worried about leaking memory...

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
