### PR TITLE
More GitHub action changes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - master
 
+
 env:
   BUILD_ROOT: ${{ github.workspace }}/..
   KEYSTORE_FILE: ${{ github.workspace }}/../subsurface.keystore
@@ -21,12 +22,25 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v4
 
+    - name: get pull request information from corresponding merge
+      if: github.event_name == 'push'
+      id: get_pr
+      uses: pablogamboa/action-get-merged-pull-request@v1.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: atomically create or retrieve the build number
       id: version_number
       if: github.event_name == 'push'
       run: |
-        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
+        version=$(bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
+        pr_num = ${{ steps.get_pr.outputs.number }}
+        pr_url = ${{ steps.get_pr.outputs.html_url }}
+        pr_title = ${{ steps.get_pr.outputs.title }}
+        commit_id = ${{ github.event.head_commit.id }}
+        commit_url = ${{ github.event.head_commit.url }}
+        bash scripts/create-releasenotes.sh "$pr_num" "$pr_url" "$pr_title" "$commit_id" "$commit_url"
 
     - name: store dummy version and build number for non-push build runs
       if: github.event_name != 'push'
@@ -73,24 +87,7 @@ jobs:
         fail_on_unmatched_files: true
         files: |
           Subsurface-mobile*.apk
-        body: |
-          CICD release artifact
-
-          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
-
-          This build is based on changeset ${{ github.event.head_commit.id }} ([link](${{ github.event.head_commit.url }})):
-          ${{ github.event.head_commit.message }}
-
-          None of these artifacts are signed with an official key.
-          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
-          The Windows installer will ask you to confirm installation of an app from an unknown developer.
-          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
-
-          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
-
-          **Note:** Due to the asynchronous nature of our build process the artifacts for the individual platforms are added to the release one by one, whenever their build is finished. So if you can not find a particular artifact on a recent (less than 2 hours old) build, please come back later and check again.
-
-          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).
+        body_path: gh_release_notes
 
     - name: delete the keystore
       if: github.event_name == 'push'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,19 +25,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd $BUILD_ROOT # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for non-push build runs

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -29,19 +29,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Setup API token for copr-cli

--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -24,19 +24,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for pull request

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -21,19 +21,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for pull request

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -18,19 +18,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for pull request

--- a/.github/workflows/ubuntu-launchpad-build.yml
+++ b/.github/workflows/ubuntu-launchpad-build.yml
@@ -18,19 +18,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Setup build dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,19 +21,7 @@ jobs:
       id: version_number
       if: github.event_name == 'push'
       run: |
-        cd .. # check out parallel to subsurface sources
-        url="https://subsurface:${{ secrets.NIGHTLY_BUILDS }}@github.com/subsurface/nightly-builds"
-        # the clone followed by the pointless push should verify that the password is stored in the config
-        # that way the script doesn't need the password
-        git clone -b main https://github.com/subsurface/nightly-builds
-        cd nightly-builds
-        git remote set-url origin "$url"
-        git push origin main
-        cd ..
-        bash -x subsurface/scripts/get-or-create-build-nr.sh ${{ github.sha }}
-        cp nightly-builds/latest-subsurface-buildnumber subsurface
-        echo "CICD-release" > subsurface/latest-subsurface-buildnumber-extension
-        version=$(bash subsurface/scripts/get-version)
+        version=$(bash subsurface/scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for pull request

--- a/gh_release_notes.in
+++ b/gh_release_notes.in
@@ -1,0 +1,16 @@
+CICD release artifact
+
+These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
+
+This build was created by [merging PR PRNUM ("PRTITLE")](PRURL) and is based on changeset COMMITID ([link](COMMITURL))
+
+None of these artifacts are signed with an official key.
+The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
+The Windows installer will ask you to confirm installation of an app from an unknown developer.
+The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
+
+You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
+
+**Note:** Due to the asynchronous nature of our build process the artifacts for the individual platforms are added to the release one by one, whenever their build is finished. So if you can not find a particular artifact on a recent (less than 2 hours old) build, please come back later and check again.
+
+Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).

--- a/scripts/create-releasenotes.sh
+++ b/scripts/create-releasenotes.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# use to assemble the details for our release notes and write them to a file
+#
+# Usage: create-releasenotes.sh pr_num pr_url pr_title commit_id commit_url
+
+sed "s/PRNUM/$1/;s/PRURL/$2/;s/PRTITLE/$3/;s/COMMITID/$4/;s/COMMITURL/$5/" < gh_release_notes.in > gh_release_notes
+

--- a/scripts/get-atomic-buildnr.sh
+++ b/scripts/get-atomic-buildnr.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# this is intended to be used from within a GitHub action. Without the required
+# token this will not work when run from the command line
+# call it from the default position in the filesystem (which is inside the subsurface git tree)
+#
+# Usage: get-atimic-buildnr.sh SHA secrets.NIGHTLY_BUILDS [extra-name-component]
+# checkout the nightly-builds repo in parallel to the main repo
+# the clone followed by the pointless push should verify that the password is stored in the config
+# that way the script doesn't need the password
+cd ..
+url="https://subsurface:$2@github.com/subsurface/nightly-builds"
+git clone -b main https://github.com/subsurface/nightly-builds
+cd nightly-builds
+git remote set-url origin "$url"
+git push origin main
+cd ..
+bash -x subsurface/scripts/get-or-create-build-nr.sh "$1"
+cp nightly-builds/latest-subsurface-buildnumber subsurface
+[[ -n $3 ]] && echo "$3" > subsurface/latest-subsurface-buildnumber-extension
+bash subsurface/scripts/get-version


### PR DESCRIPTION
Move both the code to create atomic release numbers and the release note text into files that can be shared between multiple actions.
    
This should make the actions smaller and easier to read and since this is used in several actions it should make things much easier to maintain.

In order to test this without too much unnecessary noise, this commit only changes the android workflow - the others will be changed in a later commit once his has been tested and works (again, this can really only be tested by merging the PR into master).

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Code cleanup
- [x] Build system change
