### PR TITLE
build-system: avoid output that confuses the script

### DIFF
--- a/scripts/get-atomic-buildnr.sh
+++ b/scripts/get-atomic-buildnr.sh
@@ -15,7 +15,7 @@ cd nightly-builds
 git remote set-url origin "$url"
 git push origin main
 cd ..
-bash -x subsurface/scripts/get-or-create-build-nr.sh "$1"
+bash -x subsurface/scripts/get-or-create-build-nr.sh "$1" &> /dev/null
 cp nightly-builds/latest-subsurface-buildnumber subsurface
 [[ -n $3 ]] && echo "$3" > subsurface/latest-subsurface-buildnumber-extension
 bash subsurface/scripts/get-version


### PR DESCRIPTION
The `get-or-create-buildnr.sh` script writes a nice message to `stdout` which is useful when using it interactively - but it broke the scripting; so redirect that output.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Build system change

