### PR TITLE
build-system: assemble release notes using gh CLI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,10 +7,10 @@ on:
     branches:
     - master
 
-
 env:
   BUILD_ROOT: ${{ github.workspace }}/..
   KEYSTORE_FILE: ${{ github.workspace }}/../subsurface.keystore
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   buildAndroid:
@@ -22,25 +22,13 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v4
 
-    - name: get pull request information from corresponding merge
-      if: github.event_name == 'push'
-      id: get_pr
-      uses: pablogamboa/action-get-merged-pull-request@v1.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: atomically create or retrieve the build number
+    - name: atomically create or retrieve the build number and assemble release notes
       id: version_number
       if: github.event_name == 'push'
       run: |
         version="$(bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")"
         echo "version=$version" >> $GITHUB_OUTPUT
-        pr_num="${{ steps.get_pr.outputs.number }}"
-        pr_url="${{ steps.get_pr.outputs.html_url }}"
-        pr_title="${{ steps.get_pr.outputs.title }}"
-        commit_id="${{ github.event.head_commit.id }}"
-        commit_url="${{ github.event.head_commit.url }}"
-        bash scripts/create-releasenotes.sh "$pr_num" "$pr_url" "$pr_title" "$commit_id" "$commit_url"
+        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for non-push build runs
       if: github.event_name != 'push'

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - master
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   buildAppImage:
     runs-on: ubuntu-latest
@@ -17,12 +20,13 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
 
-    - name: atomically create or retrieve the build number
+    - name: atomically create or retrieve the build number and assemble release notes
       id: version_number
       if: github.event_name == 'push'
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
+        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -70,21 +74,4 @@ jobs:
         fail_on_unmatched_files: true
         files: |
          ./Subsurface*.AppImage
-        body: |
-          CICD release artifact
-
-          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
-
-          This build is based on changeset ${{ github.event.head_commit.id }} ([link](${{ github.event.head_commit.url }})):
-          ${{ github.event.head_commit.message }}
-
-          None of these artifacts are signed with an official key.
-          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
-          The Windows installer will ask you to confirm installation of an app from an unknown developer.
-          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
-
-          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
-
-          **Note:** Due to the asynchronous nature of our build process the artifacts for the individual platforms are added to the release one by one, whenever their build is finished. So if you can not find a particular artifact on a recent (less than 2 hours old) build, please come back later and check again.
-
-          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).
+        body_path: gh_release_notes

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - master
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   buildMac:
     runs-on: macOS-11
@@ -14,12 +17,13 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
 
-    - name: atomically create or retrieve the build number
+    - name: atomically create or retrieve the build number and assemble release notes
       id: version_number
       if: github.event_name == 'push'
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
+        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -65,21 +69,4 @@ jobs:
         prerelease: false
         fail_on_unmatched_files: true
         files: ${{ steps.build.outputs.dmg }}
-        body: |
-          CICD release artifact
-
-          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
-
-          This build is based on changeset ${{ github.event.head_commit.id }} ([link](${{ github.event.head_commit.url }})):
-          ${{ github.event.head_commit.message }}
-
-          None of these artifacts are signed with an official key.
-          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
-          The Windows installer will ask you to confirm installation of an app from an unknown developer.
-          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
-
-          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
-
-          **Note:** Due to the asynchronous nature of our build process the artifacts for the individual platforms are added to the release one by one, whenever their build is finished. So if you can not find a particular artifact on a recent (less than 2 hours old) build, please come back later and check again.
-
-          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).
+        body_path: gh_release_notes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - master
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   buildWindows:
     runs-on: ubuntu-latest
@@ -17,12 +20,13 @@ jobs:
     - name: checkout sources
       uses: actions/checkout@v1
 
-    - name: atomically create or retrieve the build number
+    - name: atomically create or retrieve the build number and assemble release notes
       id: version_number
       if: github.event_name == 'push'
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
+        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -60,21 +64,4 @@ jobs:
         files: |
          ./subsurface*.exe*
          ./smtk2ssrf*.exe
-        body: |
-          CICD release artifact
-
-          These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
-
-          This build is based on changeset ${{ github.event.head_commit.id }} ([link](${{ github.event.head_commit.url }})):
-          ${{ github.event.head_commit.message }}
-
-          None of these artifacts are signed with an official key.
-          The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.
-          The Windows installer will ask you to confirm installation of an app from an unknown developer.
-          The macOS DMG makes it even harder with a multi-step dance that requires opening the Privacy & Security settings in the System Preferences and explicitly confirming that you are willing to install this app.
-
-          You can find similar Subsurface-Daily builds for [Ubuntu](https://ppa.launchpadcontent.net/subsurface) and Subsurface-test for [Fedora](https://copr.fedorainfracloud.org/coprs/dirkhh/Subsurface-test).
-
-          **Note:** Due to the asynchronous nature of our build process the artifacts for the individual platforms are added to the release one by one, whenever their build is finished. So if you can not find a particular artifact on a recent (less than 2 hours old) build, please come back later and check again.
-
-          Please report any issues with these builds in the [Subsurface user forum](https://groups.google.com/g/subsurface-divelog).
+         body_path: gh_release_notes

--- a/gh_release_notes_bottom
+++ b/gh_release_notes_bottom
@@ -1,8 +1,3 @@
-CICD release artifact
-
-These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
-
-This build was created by [merging PR PRNUM ("PRTITLE")](PRURL) and is based on changeset COMMITID ([link](COMMITURL))
 
 None of these artifacts are signed with an official key.
 The Android APK can be side-loaded on most Android devices. If you had a previous Subsurface-mobile version installed from the Google Play store, you'll have to uninstall that first.

--- a/gh_release_notes_top
+++ b/gh_release_notes_top
@@ -1,0 +1,4 @@
+CICD release artifact
+
+These builds are created on every merge or push into the [Subsurface repo](http://github.com/subsurface/subsurface).
+

--- a/scripts/create-releasenotes.sh
+++ b/scripts/create-releasenotes.sh
@@ -2,7 +2,19 @@
 
 # use to assemble the details for our release notes and write them to a file
 #
-# Usage: create-releasenotes.sh pr_num pr_url pr_title commit_id commit_url
+# Usage: create-releasenotes.sh merge_sha
 
-sed "s/PRNUM/$1/;s/PRURL/$2/;s/PRTITLE/$3/;s/COMMITID/$4/;s/COMMITURL/$5/" < gh_release_notes.in > gh_release_notes
+json=$(gh pr list -s merged -S "$1" --json title,number,url)
 
+cp gh_release_notes_top gh_release_notes
+(
+	echo -n 'This build was created by [merging PR'
+	echo -n $json | jq -j '.[0]|{number}|join(" ")'
+	echo -n '('
+	echo -n $json | jq -j '.[0]|{title}|join(" ")'
+	echo -n ')]('
+	echo -n $json | jq -j '.[0]|{url}|join(" ")'
+	echo ' )'
+) >> gh_release_notes
+
+cat gh_release_notes_bottom >> gh_release_notes


### PR DESCRIPTION
Instead of using a thirdparty action and painfully passing things around, simply use the GitHub CLI (gh) and assemble the release notes on the fly.

This makes for much simpler and much easier to maintain code.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup
- [x] Build system change

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
See #4030 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This avoids the problems with the thirdparty action and the quoting issues for the arguments and a few other challenges. And it's much easier to read and maintain, IMHO.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller -- I know that code reviews for this stuff are hard, but I'd appreciate some careful eyeballs...