### PR TITLE
build-system: create release notes only once

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,6 @@ on:
 env:
   BUILD_ROOT: ${{ github.workspace }}/..
   KEYSTORE_FILE: ${{ github.workspace }}/../subsurface.keystore
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   buildAndroid:
@@ -28,7 +27,6 @@ jobs:
       run: |
         version="$(bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")"
         echo "version=$version" >> $GITHUB_OUTPUT
-        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for non-push build runs
       if: github.event_name != 'push'
@@ -79,7 +77,6 @@ jobs:
         fail_on_unmatched_files: true
         files: |
           Subsurface-mobile*.apk
-        body_path: gh_release_notes
 
     - name: delete the keystore
       if: github.event_name == 'push'

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -7,9 +7,6 @@ on:
     branches:
     - master
 
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   buildAppImage:
     runs-on: ubuntu-latest
@@ -26,7 +23,6 @@ jobs:
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
-        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -74,4 +70,3 @@ jobs:
         fail_on_unmatched_files: true
         files: |
          ./Subsurface*.AppImage
-        body_path: gh_release_notes

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -7,9 +7,6 @@ on:
     branches:
     - master
 
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   buildMac:
     runs-on: macOS-11
@@ -23,7 +20,6 @@ jobs:
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
-        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -69,4 +65,3 @@ jobs:
         prerelease: false
         fail_on_unmatched_files: true
         files: ${{ steps.build.outputs.dmg }}
-        body_path: gh_release_notes

--- a/.github/workflows/post-releasenotes.yml
+++ b/.github/workflows/post-releasenotes.yml
@@ -1,0 +1,31 @@
+name: Post Release
+on:
+  push:
+    branches:
+    - master
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  postRelease:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout sources
+      uses: actions/checkout@v1
+
+    - name: atomically create or retrieve the build number and assemble release notes
+      id: version_number
+      run: |
+        version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
+        echo "version=$version" >> $GITHUB_OUTPUT
+        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
+
+    - name: publish release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ steps.version_number.outputs.version }}
+        repository: subsurface/nightly-builds
+        token: ${{ secrets.NIGHTLY_BUILDS }}
+        prerelease: false
+        body_path: gh_release_notes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,9 +7,6 @@ on:
     branches:
     - master
 
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   buildWindows:
     runs-on: ubuntu-latest
@@ -26,7 +23,6 @@ jobs:
       run: |
         version=$(bash ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release")
         echo "version=$version" >> $GITHUB_OUTPUT
-        bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
 
     - name: store dummy version and build number for pull request
       if: github.event_name == 'pull_request'
@@ -64,4 +60,3 @@ jobs:
         files: |
          ./subsurface*.exe*
          ./smtk2ssrf*.exe
-         body_path: gh_release_notes


### PR DESCRIPTION
Some experimentation showed what should have been obvious. The release information is additive. So it's enough if ONE of the actions creates release notes, all the others can simply add additional release artifacts.

To make this more obvious, this commit creates a new action that does nothing but create the release notes and publish the release. Since it really doesn't do anything else, it's likely to be the quickest to complete, but that doesn't matter - the last action that has a body or body_path in the gh-release action determines the release notes. And we now have exactly one action that does so.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup
- [x] Build system change
