### PR TITLE
CICD: attempt to read file content in GH yaml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
       if: github.event_name == 'push'
       run: |
         bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release"
-        version=$(<release-version)
+        version=$(cat release-version)
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for non-push build runs

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -30,7 +30,7 @@ jobs:
       if: github.event_name == 'push'
       run: |
         bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release"
-        version=$(<release-version)
+        version=$(cat release-version)
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Setup API token for copr-cli

--- a/.github/workflows/linux-trusty-5.12.yml
+++ b/.github/workflows/linux-trusty-5.12.yml
@@ -25,7 +25,8 @@ jobs:
         echo "in yml we have PWD $(pwd)"
         ls -l release-version
         cat release-version
-        version=$(<release-version)
+        echo
+        version=$(cat release-version)
         echo "version=$version"
         echo "version=$version" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,7 +19,7 @@ jobs:
       if: github.event_name == 'push'
       run: |
         bash scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release"
-        version=$(<release-version)
+        version=$(cat release-version)
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: store dummy version and build number for pull request

--- a/.github/workflows/post-releasenotes.yml
+++ b/.github/workflows/post-releasenotes.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         bash -x ./scripts/get-atomic-buildnr.sh ${{ github.sha }} ${{ secrets.NIGHTLY_BUILDS }} "CICD-release"
         bash scripts/create-releasenotes.sh ${{ github.event.head_commit.id }}
-        version=$(<release-version)
+        version=$(cat release-version)
         echo "version=$version" >> $GITHUB_OUTPUT
 
     # ironically, we have to upload a file, otherwise this won't create a release with just the release notes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,8 @@ jobs:
         echo "in yml we have PWD $(pwd)"
         ls -l release-version
         cat release-version
-        version=$(<release-version)
+        echo
+        version=$(cat release-version)
         echo "version=$version"
         echo "version=$version" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
It is very strange that in some yaml files the $(<release-version) construct works just fine, but in others it evaluates to an empty string, even though the file is there an has the correct content.

Attempting to get more debugging info and also use a different expression to extract the information.

I'm not claiming that I'm confident this will fix the issue - but the extended logging in the last attempt appears to imply that this might be the issue here.