### PR TITLE
cleanup: fix enum in profile.c

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -1302,9 +1302,9 @@ void create_plot_info_new(const struct dive *dive, const struct divecomputer *dc
 	free_plot_info_data(pi);
 	calculate_max_limits_new(dive, dc, pi, in_planner);
 	get_dive_gas(dive, &o2, &he, &o2max);
-	if (dc->divemode == FREEDIVE){
-		pi->dive_type = FREEDIVE;
-	} else 	if (he > 0) {
+	if (dc->divemode == FREEDIVE) {
+		pi->dive_type = FREEDIVING;
+	} else if (he > 0) {
 		pi->dive_type = TRIMIX;
 	} else {
 		if (o2)


### PR DESCRIPTION
There are two enums related to the type of dive.
There is the global

enum divemode_t {OC, CCR, PSCR, FREEDIVE, NUM_DIVEMODE,
                 UNDEF_COMP_TYPE};

and the anonymous

enum {AIR, NITROX, TRIMIX, FREEDIVING} dive_type;

in struct plot_info.

In profile.c FREEDIVE (of divemode_t) is assigned to dive_type. This only works because by chance(?) FREEDIVE and FREEDIVING are the fourth element of each enum.

Fix this. C truly is a bad language when it comes to types (very weak) and namespaces (non existing).

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Not really a bug, since the code worked by chance, but still clearly wrong.

Note: detected when trying to compile profile.c with C++, because C string handling is so painful.