### PR TITLE
Don't crash when we see too many O2 sensors

### DIFF
--- a/core/profile.c
+++ b/core/profile.c
@@ -6,7 +6,6 @@
 #include "gettext.h"
 #include <limits.h>
 #include <string.h>
-#include <assert.h>
 #include <stdlib.h>
 
 #include "dive.h"
@@ -1156,7 +1155,8 @@ static int calculate_ccr_po2(struct plot_data *entry, const struct divecomputer 
 				return sump / 3;
 		}
 	default: // This should not happen
-		assert(np <= 3);
+		// assert(np <= 3);
+		printf("calculate_ccr_po2: np > 3 -- that's a problem, but maybe not enough to crash the app\n");
 		return 0;
 	}
 }


### PR DESCRIPTION
I can think of very, very, VERY few circumstances where it makes sense to crash an end user application. This isn't one of them.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
I don't understand why anyone ever thought this made sense. And apparently we now see CCR dive logs with more than 3 PO2 sensors

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@atdotde 