### PR TITLE
Ubuntu: remove obsolete dependency

### DIFF
--- a/packaging/ubuntu/debian/control
+++ b/packaging/ubuntu/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Subsurface CI Bot <dirk@subsurface-divelog.org>
 Build-Depends: asciidoc,
                debhelper (>= 9),
-               libgconf2-dev,
                libtool,
                libxml2-dev,
                libxslt-dev,


### PR DESCRIPTION
It appears that this dependency is no longer provided (as of Mantis), but also no longer needed (as a build without it appears to completed). Let's see if that fixes our Mantis build issue.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Build system change
