### PR TITLE
Downloader: fix segfault

### DIFF
--- a/subsurface-downloader-main.cpp
+++ b/subsurface-downloader-main.cpp
@@ -102,7 +102,14 @@ int main(int argc, char **argv)
 			cliDownloader(prefs.dive_computer.vendor, prefs.dive_computer.product, prefs.dive_computer.device);
 		}
 	}
-	save_dives(qPrintable(files.first()));
+	if (!files.isEmpty()) {
+		qDebug() << "saving dive data to" << files;
+		save_dives(qPrintable(files.first()));
+	}
+	else {
+		printf("No log files given, not saving dive data.\n");
+		printf("Give a log file name as argument, or configure a cloud URL.\n");
+	}
 	clear_divelog(&divelog);
 	taglist_free(g_tag_list);
 	parse_xml_exit();


### PR DESCRIPTION
With no files given and no config present, the downloader segfaults due to empty `files`. Print a message instead.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fixes segfault in downloader due to null pointer when no config present

### Changes made:
Check for emptiness of `files` list and print message if empty instead of accessing the first non existent element

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
Before change:
```
rainbow:~$ subsurface-downloader
Subsurface-downloader v,
built with libdivecomputer v0.8.0-devel-Subsurface-NG ()
built with Qt Version 5.15.10, runtime from Qt Version 5.15.10
built with libgit2 1.7.1

File locations:

Cloud email:(null)
Unable to get local git directory
Cloud URL: No valid cloud credentials set.

Image filename table: /home/dfx/.subsurface/hashes
Local picture directory: /home/dfx/.subsurface/picturedata/

Segmentation fault
rainbow:~$ 
```
After change:
```
rainbow:~/src/subsurface/downloader-build(master)*$ ./subsurface-downloader
Subsurface-downloader v6.0.5069-1-local,
built with libdivecomputer v0.8.0-devel-Subsurface-NG (78710ab2f1bf5843ab61d2ab2177ef2e3f8b90b3)
built with Qt Version 5.15.10, runtime from Qt Version 5.15.10
built with libgit2 1.7.1

File locations:

Cloud email:(null)
Unable to get local git directory
Cloud URL: No valid cloud credentials set.

Image filename table: /home/dfx/.subsurface/hashes
Local picture directory: /home/dfx/.subsurface/picturedata/

No log files given, not saving dive data.
Give a log file name as argument, or configure a cloud URL.
rainbow:~/src/subsurface/downloader-build(master)*$ 
```

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
