### PR TITLE
enable creating current releases for Ubuntu and Fedora

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -5,6 +5,7 @@ on:
     - scripts/docker/**
     branches:
     - master
+    - current
 
 jobs:
   setup-build:
@@ -52,5 +53,5 @@ jobs:
     - name: run the copr build script
       run: |
         cd ..
-        bash -x subsurface/packaging/copr/make-package.sh post
+        bash -x subsurface/packaging/copr/make-package.sh ${{ github.refname }}
 

--- a/.github/workflows/ubuntu-launchpad-build.yml
+++ b/.github/workflows/ubuntu-launchpad-build.yml
@@ -5,6 +5,7 @@ on:
     - scripts/docker/**
     branches:
     - master
+    - current
 
 jobs:
   push-to-ppa:
@@ -47,5 +48,5 @@ jobs:
     - name: run the launchpad make-package script
       run: |
         cd ..
-        bash -x subsurface/packaging/ubuntu/make-package.sh post
+        bash -x subsurface/packaging/ubuntu/make-package.sh ${{ github.ref_name }}
 

--- a/packaging/copr/make-package.sh
+++ b/packaging/copr/make-package.sh
@@ -70,22 +70,18 @@ fi
 # file, this is hard coded to 1 - it's entirely possible that there will be use cases where we
 # need to push additional versions... but it seems impossible to predict what exactly would drive
 # those and how to automate them
-if [[ "$1" = "post" ]] ; then
-	# daily vs. release
-	if [[ "$GITREVISION" == "" ]] ; then
-		# this is a release
-		echo "RELEASE PROCESS IS NOT WELL TESTED"
-		REPO="Subsurface"
-		SUMMARY="official Fedora RPMs from the Subsurface project"
-		DESCRIPTION="This is the official Subsurface build, provided by the Subsurface team, including our own custom libdivecomputer."
-	else
-		REPO="Subsurface-test"
-		SUMMARY="rolling build of the latest development version of Subsurface"
-		DESCRIPTION="This is a 'daily' build of Subsurface, provided by the Subsurface team, based on the latest sources. The builds aren't always well tested."
-	fi
-	cd "$HOME"/rpmbuild
-	# shellcheck disable=SC2002
-	cat "$TOPDIR"/subsurface/packaging/copr/subsurface.spec | sed "s/%define latestVersion.*/%define latestVersion $GITVERSION/;s/DESCRIPTION/$DESCRIPTION/;s/SUMMARY/$SUMMARY/" > SPECS/subsurface.spec
-	rpmbuild --verbose -bs "$(pwd)/SPECS/subsurface.spec"
-	copr build --nowait $REPO "$(pwd)/SRPMS/subsurface-$GITVERSION"-1.fc*.src.rpm
+if [[ "$1" = "current" ]] ; then
+	# this is a release
+	REPO="Subsurface"
+	SUMMARY="official Fedora RPMs from the Subsurface project"
+	DESCRIPTION="This is the current (or roughly 'weekly') Subsurface release build, provided by the Subsurface team, including our own custom libdivecomputer."
+else
+	REPO="Subsurface-test"
+	SUMMARY="rolling build of the latest development version of Subsurface"
+	DESCRIPTION="This is a 'daily' build of Subsurface, provided by the Subsurface team, based on the latest sources. The builds aren't always well tested."
 fi
+cd "$HOME"/rpmbuild
+# shellcheck disable=SC2002
+cat "$TOPDIR"/subsurface/packaging/copr/subsurface.spec | sed "s/%define latestVersion.*/%define latestVersion $GITVERSION/;s/DESCRIPTION/$DESCRIPTION/;s/SUMMARY/$SUMMARY/" > SPECS/subsurface.spec
+rpmbuild --verbose -bs "$(pwd)/SPECS/subsurface.spec"
+copr build --nowait $REPO "$(pwd)/SRPMS/subsurface-$GITVERSION"-1.fc*.src.rpm

--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -118,12 +118,9 @@ fi
 
 cd ..
 
-if [[ "$1" = "post" ]] ; then
-	# daily vs. release
-	if [[ "$GITREVISION" == "" ]] ; then
-		# this is a release
-		dput ppa:subsurface/subsurface "$FOLDER-$rev"~*.changes
-	else
-		dput ppa:subsurface/subsurface-daily "$FOLDER-$rev"~*.changes
-	fi
+if [[ "$1" = "current" ]] ; then
+	# this is a current release
+	dput ppa:subsurface/subsurface "$FOLDER-$rev"~*.changes
+else
+	dput ppa:subsurface/subsurface-daily "$FOLDER-$rev"~*.changes
 fi


### PR DESCRIPTION
While for the other platforms we can simply copy our binaries (maybe after signing them), for Fedora and Ubuntu we have to trigger fresh builds.

The most logical way that I could think of to do this was to push the same commit corresponding with the intended current release into a branch named 'current' and have that trigger Copr and Launchpad builds that post into our release repos.

So 'master' keeps moving forward, keeps creating new build numbers. At some point we pick a build number that we want to be the next 'current' release. We then update the current branch to the commit that corresponds to that build number and push the current branch which triggers new builds in the correct repos on Copr and Launchpad.

This commit removes the silly 'push' argument from the make-package scripts (after all, they are used to push those packages to the respective build services) and instead use the branch name as argument to those scripts - allowing us to pick which repo to push into.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
unsurprisingly this is untested... and we can't really test it until we pick the next 'current' build that comes AFTER this gets merged. Oh well.
