### PR TITLE
remove Ubuntu Lunar as build target (EOL)

### DIFF
--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -105,7 +105,7 @@ debuild -S -d
 # create builds for the newer Ubuntu releases that Launchpad supports
 #
 rel=focal
-others="jammy lunar mantic"
+others="jammy mantic"
 for next in $others
 do
 	sed -i "s/${rel}/${next}/g" debian/changelog


### PR DESCRIPTION
more opportunities to test our GitHub tooling, I guess. EOL since Thursday 

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change
