### PR TITLE
 snap: use the rolling release version

### DIFF
--- a/.github/workflows/linux-snap.patch
+++ b/.github/workflows/linux-snap.patch
@@ -1,3 +1,5 @@
+diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
+index 6b9542555..7f5ccabf2 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
 @@ -35,6 +35,7 @@ parts:
@@ -28,13 +30,12 @@
      - libbluetooth-dev
      - libhidapi-dev
      - libusb-dev
-@@ -131,9 +137,12 @@ parts:
+@@ -131,8 +137,11 @@ parts:
      - -DFTDISUPPORT=ON
      - -DLIBDIVECOMPUTER_LIBRARIES=../../../stage/usr/local/lib/libdivecomputer.so
      - -DLIBDIVECOMPUTER_INCLUDE_DIR=../../../stage/usr/local/include
 +    - -DCMAKE_C_COMPILER_LAUNCHER=ccache
 +    - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-     source-type: git
      build-packages:
      - build-essential
 +    - ccache

--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -1,11 +1,6 @@
 name: Linux Snap
 
 on:
-  push:
-    paths-ignore:
-    - scripts/docker/**
-    branches:
-    - master
   pull_request:
     paths-ignore:
     - scripts/docker/**

--- a/.github/workflows/scripts/check_usns.py
+++ b/.github/workflows/scripts/check_usns.py
@@ -28,6 +28,7 @@ TEAM = "subsurface"
 SOURCE_NAME = "subsurface"
 SNAPS = {
     "subsurface": {"stable": {"recipe": "subsurface-stable"}},
+    "subsurface": {"candidate": {"recipe": "subsurface-candidate"}},
 }
 
 STORE_URL = "https://api.snapcraft.io/api/v1/snaps" "/details/{snap}?channel={channel}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,6 @@ parts:
     - -DFTDISUPPORT=ON
     - -DLIBDIVECOMPUTER_LIBRARIES=../../../stage/usr/local/lib/libdivecomputer.so
     - -DLIBDIVECOMPUTER_INCLUDE_DIR=../../../stage/usr/local/include
-    source-type: git
     build-packages:
     - build-essential
     - libcurl4-gnutls-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: subsurface
-version: git
 icon: icons/subsurface-icon.svg
 summary: Open source divelog program for recreational, tech, and free-divers
 description: |
@@ -12,6 +11,7 @@ description: |
 grade: stable
 confinement: strict
 base: core20
+adopt-info: subsurface
 
 apps:
   subsurface:
@@ -151,6 +151,13 @@ parts:
     - qtlocation5-dev
     - qtpositioning5-dev
     - qttools5-dev
+    override-pull: |
+      snapcraftctl pull
+      if [ ! -f latest-subsurface-buildnumber ]; then
+        git fetch --depth=1 https://github.com/subsurface/nightly-builds.git branch-for-$( git rev-parse HEAD )
+        git checkout FETCH_HEAD latest-subsurface-buildnumber
+      fi
+      snapcraftctl set-version $( scripts/get-version )
     override-build: |
       mkdir -p ../install-root
       ln -sf ../../../stage/usr/lib/*/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so \


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This makes the snap build process retrieve the buildnumber from nightly-builds, if not already populated (e.g. by the GitHub CI setup). I've disabled the `push` builds on `master` as this will build on the Launchpad / Snapcraft infrastructure, triggered by a push.

### Changes made:
1) pick up the rolling version number
2) skip building `master` on GitHub
3) check security notices on the `candidate` channel as well.

### Mentions:
@dirkhh hey, this should work for the new version numbers, I've set up the git `current` -> snap `candidate` builds [here](https://launchpad.net/~subsurface/+snap/subsurface-candidate). I'll work on refreshing the snap after we're happy with all this.