### PR TITLE
snap: refresh to base on Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux-snap.patch
+++ b/.github/workflows/linux-snap.patch
@@ -1,24 +1,24 @@
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 6b9542555..7f5ccabf2 100644
+index 9f34d0169..0d5a89fd9 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
 @@ -35,6 +35,7 @@ parts:
-   googlemaps:
      source: https://github.com/Subsurface/googlemaps.git
+     plugin: make
      build-packages:
 +    - ccache
+     - qtbase5-dev
      - wget
      override-pull: |
-       snapcraftctl pull
-@@ -78,6 +79,7 @@ parts:
-     plugin: qmake
-     qmake-parameters:
-     - INCLUDEPATH+=QtHeaders
-+    - CONFIG+=ccache
+@@ -79,6 +80,7 @@ parts:
+     override-build: |
+       qmake \
+         INCLUDEPATH+=${CRAFT_PART_SRC}/QtHeaders \
++        CONFIG+=ccache \
+         ${CRAFT_PART_SRC}
+       craftctl default
  
-   desktop-qt5:
-     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-@@ -108,7 +110,11 @@ parts:
+@@ -111,7 +113,11 @@ parts:
      source: .
      source-type: git
      source-subdir: libdivecomputer
@@ -30,7 +30,7 @@ index 6b9542555..7f5ccabf2 100644
      - libbluetooth-dev
      - libhidapi-dev
      - libusb-dev
-@@ -131,8 +137,11 @@ parts:
+@@ -134,8 +140,11 @@ parts:
      - -DFTDISUPPORT=ON
      - -DLIBDIVECOMPUTER_LIBRARIES=../../../stage/usr/local/lib/libdivecomputer.so
      - -DLIBDIVECOMPUTER_INCLUDE_DIR=../../../stage/usr/local/include

--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -1,6 +1,11 @@
 name: Linux Snap
 
 on:
+  push:
+    paths-ignore:
+    - scripts/docker/**
+    branches:
+    - master
   pull_request:
     paths-ignore:
     - scripts/docker/**

--- a/.github/workflows/linux-snap.yml
+++ b/.github/workflows/linux-snap.yml
@@ -1,4 +1,4 @@
-name: Linux Snap
+name: Snap
 
 on:
   push:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,13 +22,15 @@ apps:
     desktop: usr/local/share/applications/subsurface.desktop
     plugs:
     - bluez
+    - desktop
+    - desktop-legacy
     - home
     - network
     - opengl
     - raw-usb
     - removable-media
-    - unity7
     - wayland
+    - x11
 
 parts:
   googlemaps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,15 +8,14 @@ description: |
   equipment used and names of other divers, and lets users rate dives and
   provide additional notes.
 
-grade: stable
 confinement: strict
-base: core20
+base: core22
 adopt-info: subsurface
 
 apps:
   subsurface:
     environment:
-      LD_LIBRARY_PATH: ${SNAP}/usr/local/lib
+      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SNAP}/usr/local/lib
     command-chain:
     - bin/desktop-launch
     command: usr/local/bin/subsurface
@@ -34,10 +33,14 @@ apps:
 parts:
   googlemaps:
     source: https://github.com/Subsurface/googlemaps.git
+    plugin: make
+    make-parameters:
+    - INSTALL_ROOT=${CRAFT_PART_INSTALL}
     build-packages:
+    - qtbase5-dev
     - wget
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       export QT_SELECT=5
       export QT_VERSION=$( qmake -query QT_VERSION )
       mkdir -p QtHeaders/QtLocation/private QtHeaders/QtPositioning/private
@@ -62,7 +65,7 @@ parts:
           places/unsupportedreplies
       do
         wget --no-verbose --content-disposition \
-          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/location/${HEADER}_p.h?h=v${QT_VERSION}
+          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/location/${HEADER}_p.h?h=v${QT_VERSION}-lts-lgpl
       done
       cd -
       cd QtHeaders/QtPositioning/private
@@ -73,11 +76,13 @@ parts:
           qpositioningglobal
       do
         wget --no-verbose --content-disposition \
-          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/positioning/${HEADER}_p.h?h=v${QT_VERSION}
+          http://code.qt.io/cgit/qt/qtlocation.git/plain/src/positioning/${HEADER}_p.h?h=v${QT_VERSION}-lts-lgpl
       done
-    plugin: qmake
-    qmake-parameters:
-    - INCLUDEPATH+=QtHeaders
+    override-build: |
+      qmake \
+        INCLUDEPATH+=${CRAFT_PART_SRC}/QtHeaders \
+        ${CRAFT_PART_SRC}
+      craftctl default
 
   desktop-qt5:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
@@ -90,7 +95,7 @@ parts:
       - dpkg-dev
     stage-packages:
       - libxkbcommon0
-      - ttf-ubuntu-font-family
+      - fonts-ubuntu
       - dmz-cursor-theme
       - light-themes
       - adwaita-icon-theme
@@ -114,7 +119,7 @@ parts:
     - libusb-dev
     override-build: |
       sed -i 's/\[HIDAPI\], \[hidapi\]/[HIDAPI], [hidapi-libusb]/' libdivecomputer/configure.ac
-      snapcraftctl build
+      craftctl default
     stage-packages:
     - libbluetooth3
     - libftdi1-2
@@ -151,24 +156,27 @@ parts:
     - qtpositioning5-dev
     - qttools5-dev
     override-pull: |
-      snapcraftctl pull
+      craftctl default
+      craftctl set grade=devel
       if [ ! -f latest-subsurface-buildnumber ]; then
         git fetch --depth=1 https://github.com/subsurface/nightly-builds.git branch-for-$( git rev-parse HEAD )
         git checkout FETCH_HEAD latest-subsurface-buildnumber
+        # We succeeded getting the release version, allow publishing above `beta`
+        craftctl set grade=stable
       fi
-      snapcraftctl set-version $( scripts/get-version )
+      craftctl set version=$( scripts/get-version )
     override-build: |
       mkdir -p ../install-root
       ln -sf ../../../stage/usr/lib/*/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so \
         ../install-root/
       sed -i 's@^Icon=.*@Icon=${SNAP}/share/icons/hicolor/scalable/apps/subsurface-icon.svg@' ../src/subsurface.desktop
-      snapcraftctl build
+      craftctl default
     stage-packages:
     - libcap2
     - libcurl3-gnutls
     - libdb5.3
     - libftdi1-2
-    - libgit2-28
+    - libgit2-1.1
     - libqt5bluetooth5
     - libqt5charts5
     - libqt5concurrent5
@@ -186,11 +194,11 @@ parts:
     - libqt5widgets5
     - libsqlite3-0
     - libssh2-1
-    - libssl1.1
+    - libssl3
     - libusb-1.0-0
     - libxml2
     - libxslt1.1
-    - libzip5
+    - libzip4
     - qml-module-qtlocation
     - qml-module-qtpositioning
     - qml-module-qtquick2


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Refresh the snap to build on Ubuntu 22.04.

### Changes made:
1) bump the snap `base:` to `core22`
2) move away from the `qmake` plugin, no longer supported
3) refresh snap dependencies
4) refresh the CI snap patch
6) bring back builds on pushes to `master` - populating the ccache
7) refresh the snap interfaces

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
The next step will be to migrate to Qt 6.