### PR TITLE
Profile: Reinstate Hiding of Events by Type across Dives.

### DIFF
--- a/core/event.c
+++ b/core/event.c
@@ -80,7 +80,7 @@ struct event *create_event(unsigned int time, int type, int flags, int value, co
 		break;
 	}
 
-	remember_event_name(name);
+	remember_event_name(name, flags);
 
 	return ev;
 }

--- a/core/eventname.cpp
+++ b/core/eventname.cpp
@@ -8,15 +8,16 @@
 
 struct event_name {
 	std::string name;
+	int flags;
 	bool plot;
 };
 
 static std::vector<event_name> event_names;
 
 // Small helper so that we can compare events to C-strings
-static bool operator==(const event_name &en, const char *s)
+static bool operator==(const event_name &en1, const event_name &en2)
 {
-	return en.name == s;
+	return en1.name == en2.name && en1.flags == en2.flags;
 }
 
 extern "C" void clear_event_names()
@@ -24,19 +25,26 @@ extern "C" void clear_event_names()
 	event_names.clear();
 }
 
-extern "C" void remember_event_name(const char *eventname)
+extern "C" void remember_event_name(const char *eventname, const int flags)
 {
 	if (empty_string(eventname))
 		return;
-	if (std::find(event_names.begin(), event_names.end(), eventname) != event_names.end())
+	if (std::find(event_names.begin(), event_names.end(), event_name{ eventname, flags }) != event_names.end())
 		return;
-	event_names.push_back({ eventname, true });
+	event_names.push_back({ eventname, flags, true });
 }
 
-extern "C" bool is_event_hidden(const char *eventname)
+extern "C" bool is_event_hidden(const char *eventname, const int flags)
 {
-	auto it = std::find(event_names.begin(), event_names.end(), eventname);
+	auto it = std::find(event_names.begin(), event_names.end(), event_name{ eventname, flags });
 	return it != event_names.end() && !it->plot;
+}
+
+extern "C" void hide_similar_events(const char *eventname, const int flags)
+{
+	auto it = std::find(event_names.begin(), event_names.end(), event_name{ eventname, flags });
+	if (it != event_names.end())
+		it->plot = false;
 }
 
 extern "C" void show_all_events()

--- a/core/eventname.h
+++ b/core/eventname.h
@@ -8,8 +8,9 @@ extern "C" {
 #endif
 
 extern void clear_event_names(void);
-extern void remember_event_name(const char *eventname);
-extern bool is_event_hidden(const char *eventname);
+extern void remember_event_name(const char *eventname, const int flags);
+extern bool is_event_hidden(const char *eventname, const int flags);
+extern void hide_similar_events(const char *eventname, const int flags);
 extern void show_all_events();
 extern bool any_events_hidden();
 

--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -226,7 +226,7 @@ bool DiveEventItem::isInteresting(const struct dive *d, const struct divecompute
 
 bool DiveEventItem::shouldBeHidden()
 {
-	return is_event_hidden(ev->name);
+	return is_event_hidden(ev->name, ev->flags);
 }
 
 void DiveEventItem::recalculatePos()

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -656,7 +656,7 @@ void ProfileWidget2::contextMenuEvent(QContextMenuEvent *event)
 		}
 #endif
 	}
-	if (any_events_hidden())
+	if (any_events_hidden() || std::any_of(profileScene->eventItems.begin(), profileScene->eventItems.end(), [] (const DiveEventItem *item) { return !item->isVisible(); }))
 		m.addAction(tr("Unhide all events"), this, &ProfileWidget2::unhideEvents);
 	m.exec(event->globalPos());
 }
@@ -701,13 +701,10 @@ void ProfileWidget2::hideSimilarEvents(DiveEventItem *item)
 {
 	const struct event *event = item->getEvent();
 
-	hideEvent(item);
-
 	if (!empty_string(event->name)) {
-		for (DiveEventItem *evItem: profileScene->eventItems) {
-			if (same_string(evItem->getEvent()->name, event->name) && evItem->getEvent()->flags == event->flags)
-				evItem->hide();
-		}
+		hide_similar_events(event->name, event->flags);
+
+		replot();
 	}
 }
 


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Reinstate the hiding of events by event type across all dives in the log. This was unintentionally removed in #3948. Also change the event type to be specific to name and severity, and fix bug causing 'Unhide all events' to not show when only individual events were hidden.

This still leaves the inconsistency that hiding of similar events is persisted across the switch between dives, but hiding of individual events is lost when switching dives, which is mildly confusing.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. reinstate the hiding of events by event type across all dives in the log;
2. change the event type to be specific to name and severity
3. fix bug causing 'Unhide all events' to not show when only individual events were hidden.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Follow-up to #4092.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
