### PR TITLE
Mobile: Fix Cloud Synch Status Management.

### DIFF
--- a/mobile-widgets/qml/CloudCredentials.qml
+++ b/mobile-widgets/qml/CloudCredentials.qml
@@ -125,6 +125,7 @@ Item {
 				id: signin_register_normal
 				text: qsTr("Sign-in or Register")
 				onClicked: {
+					PrefCloudStorage.cloud_auto_sync = true
 					manager.saveCloudCredentials(login.text, password.text, "")
 				}
 			}

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -334,7 +334,7 @@ Kirigami.ApplicationWindow {
 						name: ":/icons/cloud_sync.svg"
 					}
 					text: qsTr("Manual sync with cloud")
-					enabled: Backend.cloud_verification_status === Enums.CS_VERIFIED
+					visible: Backend.cloud_verification_status !== Enums.CS_NOCLOUD
 					onTriggered: {
 						globalDrawer.close()
 						detailsWindow.endEditMode()
@@ -344,14 +344,14 @@ Kirigami.ApplicationWindow {
 					}
 				}
 				Kirigami.Action {
-				icon {
-					name: PrefCloudStorage.cloud_auto_sync ?  ":/icons/ic_cloud_off.svg" : ":/icons/ic_cloud_done.svg"
-				}
-text: (PrefCloudStorage.cloud_auto_sync ? "\u2610 " : "\u2611 ") + qsTr("Auto cloud sync")
+					icon {
+						name: PrefCloudStorage.cloud_auto_sync ?  ":/icons/ic_cloud_done.svg" : ":/icons/ic_cloud_off.svg"
+					}
+					text: (PrefCloudStorage.cloud_auto_sync ? "\u2611 " : "\u2610 ") + qsTr("Auto cloud sync")
 					visible: Backend.cloud_verification_status !== Enums.CS_NOCLOUD
 					onTriggered: {
 						PrefCloudStorage.cloud_auto_sync = !PrefCloudStorage.cloud_auto_sync
-						manager.setGitLocalOnly(PrefCloudStorage.cloud_auto_sync)
+						manager.setGitLocalOnly(!PrefCloudStorage.cloud_auto_sync)
 						if (!PrefCloudStorage.cloud_auto_sync) {
 							showPassiveNotification(qsTr("Turning off automatic sync to cloud causes all data to only be \
 stored locally. This can be very useful in situations with limited or no network access. Please choose 'Manual sync with cloud' \


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix how the cloud synch status is handled - currently the preference is used incorrectly, switching cloud synch off when it should be on. Also hide the 'Manual cloud synch' button when no cloud credentials are stored, and don't show the 'manual synch' popup when auto synch is enabled.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix how the cloud synch status is handled ;
2. hide the 'Manual cloud synch' button when no cloud credentials are stored;
3. don't show the 'manual synch' popup when auto synch is enabled.


### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
From https://groups.google.com/g/subsurface-divelog/c/ccHX2Zse3Qc/m/aNi3OHtwAQAJ

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
