### PR TITLE
Mobile: improve GFLow/High settings UI

### DIFF
--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -536,11 +536,11 @@ TemplatePage {
 			GridLayout {
 				visible: sectionAdvanced.isExpanded
 				width: parent.width
-				columns: 2
+				columns: 3
 
 				TemplateLine {
 					visible: sectionAdvanced.isExpanded
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Bluetooth")
@@ -548,11 +548,12 @@ TemplatePage {
 					font.weight: Font.Light
 					Layout.topMargin: Kirigami.Units.largeSpacing
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Temporarily show all bluetooth devices \neven if not recognized as dive computers.\nPlease report DCs that need this setting")
 					Layout.fillWidth: true
+					Layout.columnSpan: 2
 				}
 				SsrfSwitch {
 					id: nonDCButton
@@ -564,7 +565,7 @@ TemplatePage {
 
 				TemplateLine {
 					visible: sectionAdvanced.isExpanded
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Display")
@@ -572,11 +573,12 @@ TemplatePage {
 					font.weight: Font.Light
 					Layout.topMargin: Kirigami.Units.largeSpacing
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Show only one column in Portrait mode")
 					Layout.fillWidth: true
+					Layout.columnSpan: 2
 				}
 				SsrfSwitch {
 					id: singleColumnButton
@@ -585,19 +587,20 @@ TemplatePage {
 						PrefDisplay.singleColumnPortrait = checked
 					}
 				}
-		TemplateLabel {
-		    text: qsTr("Depth line based on ×3 intervals")
-		}
-		SsrfSwitch {
-		    checked: PrefDisplay.three_m_based_grid
-		    onClicked: {
-			PrefDisplay.three_m_based_grid = checked
-			rootItem.settingsChanged()
-		    }
-		}
+				TemplateLabel {
+					text: qsTr("Depth line based on ×3 intervals")
+					Layout.columnSpan: 2
+				}
+				SsrfSwitch {
+					checked: PrefDisplay.three_m_based_grid
+					onClicked: {
+					PrefDisplay.three_m_based_grid = checked
+					rootItem.settingsChanged()
+					}
+				}
 				TemplateLine {
 					visible: sectionAdvanced.isExpanded
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Profile deco ceiling")
@@ -605,10 +608,11 @@ TemplatePage {
 					font.weight: Font.Light
 					Layout.topMargin: Kirigami.Units.largeSpacing
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Show DC reported ceiling")
+					Layout.columnSpan: 2
 				}
 				SsrfSwitch {
 					checked: PrefTechnicalDetails.dcceiling
@@ -619,6 +623,7 @@ TemplatePage {
 				}
 				TemplateLabel {
 					text: qsTr("Show calculated ceiling")
+					Layout.columnSpan: 2
 				}
 				SsrfSwitch {
 					checked: PrefTechnicalDetails.calcceiling
@@ -628,12 +633,14 @@ TemplatePage {
 					}
 				}
 				TemplateLabel {
-					enabled: PrefTechnicalDetails.calcceiling
+					visible: PrefTechnicalDetails.calcceiling
 					text: qsTr("GFLow")
 				}
 				TemplateSpinBox {
-					enabled: PrefTechnicalDetails.calcceiling
+					visible: PrefTechnicalDetails.calcceiling
 					id: gfLow
+					Layout.columnSpan: 2
+					Layout.alignment: Qt.AlignHCenter
 					from: 10
 					to: 150
 					stepSize: 1
@@ -647,12 +654,14 @@ TemplatePage {
 					}
 				}
 				TemplateLabel {
-					enabled: PrefTechnicalDetails.calcceiling
+					visible: PrefTechnicalDetails.calcceiling
 					text: qsTr("GFHigh")
 				}
 				TemplateSpinBox {
-					enabled: PrefTechnicalDetails.calcceiling
+					visible: PrefTechnicalDetails.calcceiling
 					id: gfHigh
+					Layout.columnSpan: 2
+					Layout.alignment: Qt.AlignHCenter
 					from: 10
 					to: 150
 					stepSize: 1
@@ -667,7 +676,7 @@ TemplatePage {
 				}
 				TemplateLine {
 					visible: sectionAdvanced.isExpanded
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Developer")
@@ -675,11 +684,12 @@ TemplatePage {
 					font.weight: Font.Light
 					Layout.topMargin: Kirigami.Units.largeSpacing
 					Layout.bottomMargin: Kirigami.Units.largeSpacing / 2
-					Layout.columnSpan: 2
+					Layout.columnSpan: 3
 				}
 				TemplateLabel {
 					text: qsTr("Display Developer menu")
 					Layout.fillWidth: true
+					Layout.columnSpan: 2
 				}
 				SsrfSwitch {
 					id: developerButton

--- a/mobile-widgets/qml/TemplateSpinBox.qml
+++ b/mobile-widgets/qml/TemplateSpinBox.qml
@@ -12,6 +12,7 @@ SpinBox {
 
 	contentItem: TextInput {
 		z: 2
+		width: Kirigami.Units.gridUnit * 3
 		text: control.textFromValue(control.value, control.locale)
 		font: control.font
 		color: control.enabled ? subsurfaceTheme.textColor : subsurfaceTheme.disabledTextColor
@@ -25,14 +26,14 @@ SpinBox {
 
 	up.indicator: Rectangle {
 		x: control.mirrored ? 0 : parent.width - width
-		height: Kirigami.Units.gridUnit * 2
-		implicitWidth: Kirigami.Units.gridUnit * 1.5
-		implicitHeight: Kirigami.Units.gridUnit * 1.5
+		height: Kirigami.Units.gridUnit * 1.5
+		implicitWidth: Kirigami.Units.gridUnit
+		implicitHeight: Kirigami.Units.gridUnit
 		color: control.enabled ? subsurfaceTheme.primaryColor : subsurfaceTheme.backgroundColor
 		border.color: control.enabled ? subsurfaceTheme.primaryColor : subsurfaceTheme.backgroundColor
 		Text {
 			text: "+"
-			font.pixelSize: control.font.pixelSize * 2
+			font.pixelSize: control.font.pixelSize * 1.5
 			color: control.enabled ? subsurfaceTheme.primaryTextColor : subsurfaceTheme.disabledTextColor
 			anchors.fill: parent
 			fontSizeMode: Text.Fit
@@ -43,14 +44,14 @@ SpinBox {
 
 	down.indicator: Rectangle {
 		x: control.mirrored ? parent.width - width : 0
-		height: Kirigami.Units.gridUnit * 2
-		implicitWidth: Kirigami.Units.gridUnit * 1.5
-		implicitHeight: Kirigami.Units.gridUnit * 1.5
+		height: Kirigami.Units.gridUnit * 1.5
+		implicitWidth: Kirigami.Units.gridUnit
+		implicitHeight: Kirigami.Units.gridUnit
 		color: control.enabled ? subsurfaceTheme.primaryColor : subsurfaceTheme.backgroundColor
 		border.color: control.enabled ? subsurfaceTheme.primaryColor : subsurfaceTheme.backgroundColor
 		Text {
 			text: "-"
-			font.pixelSize: control.font.pixelSize * 2
+			font.pixelSize: control.font.pixelSize * 1.5
 			color: control.enabled ? subsurfaceTheme.primaryTextColor : subsurfaceTheme.disabledTextColor
 			anchors.fill: parent
 			fontSizeMode: Text.Fit


### PR DESCRIPTION
- move the spinbox closer to the senter
- improve sizing and spacing of the spinbox
- hide it when we aren't showing the calculated ceiling

Also address an odd whitespace issue.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
it's been quite a while since I've played with the QML code. Kinda fun to try my hand at this again.
This is just a tiny improvement triggered by the discussions toward the end of #4052
With this the spinboxes should be much easier to see and use.
