### PR TITLE
mobile: show incorrect cloud password state

### DIFF
--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -270,6 +270,22 @@ Kirigami.ApplicationWindow {
 						visible: text.length > 0
 						level: 5
 						color: "white"
+						text: manager.passwordState
+						wrapMode: Text.NoWrap
+						elide: Text.ElideRight
+						font.weight: Font.Normal
+					}
+				}
+
+				RowLayout {
+					Layout.leftMargin: Kirigami.Units.smallSpacing
+					Layout.topMargin: 0
+					Kirigami.Heading {
+						Layout.fillWidth: true
+						Layout.topMargin: 0
+						visible: text.length > 0
+						level: 5
+						color: "white"
 						text: manager.syncState
 						wrapMode: Text.NoWrap
 						elide: Text.ElideRight

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -58,7 +58,7 @@ class QMLManager : public QObject {
 	Q_PROPERTY(bool diveListProcessing MEMBER m_diveListProcessing  WRITE setDiveListProcessing NOTIFY diveListProcessingChanged)
 	Q_PROPERTY(bool initialized MEMBER m_initialized NOTIFY initializedChanged)
 	Q_PROPERTY(QString syncState READ getSyncState NOTIFY syncStateChanged)
-
+	Q_PROPERTY(QString passwordState READ getPasswordState NOTIFY passwordStateChanged)
 public:
 	QMLManager();
 	~QMLManager();
@@ -162,6 +162,7 @@ public:
 	void rememberOldStatus();
 
 	QString getSyncState() const;
+	QString getPasswordState() const;
 
 public slots:
 	void appInitialized();
@@ -297,6 +298,7 @@ signals:
 	void redoTextChanged();
 	void restartDownloadSignal();
 	void syncStateChanged();
+	void passwordStateChanged();
 
 	// From upload process
 	void uploadFinish(bool success, const QString &text);


### PR DESCRIPTION
While the startup flow should make it obvious when a user is not correctly logged into the cloud, we still do see fairly frequent situations where a user has an incorrect password on a mobile device and is confused about why their data isn't syncing with their PC. Now this is clearly shown in the main menu.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature
