### PR TITLE
snap: fix grade-setting

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -159,12 +159,13 @@ parts:
     - qttools5-dev
     override-pull: |
       craftctl default
-      craftctl set grade=devel
       if [ ! -f latest-subsurface-buildnumber ]; then
         git fetch --depth=1 https://github.com/subsurface/nightly-builds.git branch-for-$( git rev-parse HEAD )
         git checkout FETCH_HEAD latest-subsurface-buildnumber
         # We succeeded getting the release version, allow publishing above `beta`
         craftctl set grade=stable
+      else
+        craftctl set grade=devel
       fi
       craftctl set version=$( scripts/get-version )
     override-build: |


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Snapcraft says: "variable 'grade' can be set only once."

### Changes made:
Only calling `craftctl set grade=` once.

### Mentions:
@dirkhh this is what caused the build failure on https://launchpad.net/~subsurface/+snap/subsurface-candidate - may want to cherry-pick that into `current`