### PR TITLE
cleanup: fix memory leak (probably / untested)

### DIFF
--- a/core/git-access.c
+++ b/core/git-access.c
@@ -161,7 +161,9 @@ char *get_local_dir(const char *url, const char *branch)
 static char *move_local_cache(struct git_info *info)
 {
 	char *old_path = get_local_dir(info->url, info->branch);
-	return move_away(old_path);
+	char *new_path = move_away(old_path);
+	free(old_path);
+	return new_path;
 }
 
 static int check_clean(const char *path, unsigned int status, void *payload)


### PR DESCRIPTION
get_local_dir() returns the copy of a c-string. It therefore has to be free()d.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix a memory leak.

Note: C-memory management is just unmaintainable. If nobody objects I will start converting the C sourcefiles to C++ and then replace C strings by std::string or QString. My plan is the use the former (UTF-8 stored as C string) in the "core". However, the separation will not be completely clear.