### PR TITLE
snap: fix grade determination for local builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -159,8 +159,8 @@ parts:
     - qttools5-dev
     override-pull: |
       craftctl default
-      if [ ! -f latest-subsurface-buildnumber ]; then
-        git fetch --depth=1 https://github.com/subsurface/nightly-builds.git branch-for-$( git rev-parse HEAD )
+      if [ ! -f latest-subsurface-buildnumber ] \
+         && git fetch --depth=1 https://github.com/subsurface/nightly-builds.git branch-for-$( git rev-parse HEAD ); then
         git checkout FETCH_HEAD latest-subsurface-buildnumber
         # We succeeded getting the release version, allow publishing above `beta`
         craftctl set grade=stable


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Determine grade based on whether we actually managed to check out the buildnumber.

This assumes that the tree is clean for building a stable snap (one that can be published to candidate and stable channels).

### Changes made:
1) only set `grade=stable` when the tree is clean and `latest-subsurface-buildnumber` was found

### Mentions:
@dirkhh @mikeller this fixes locally modified snap builds.