### PR TITLE
[TRIVIAL(?)] cleanup: remove ominous pointer calculation

### DIFF
--- a/core/import-csv.c
+++ b/core/import-csv.c
@@ -222,10 +222,8 @@ static int parse_dan_format(const char *filename, struct xml_params *params, str
 			continue;
 		}
 
-		if (ptr && ptr[4] == '}') {
-			end_ptr += ptr - (char *)mem_csv.buffer;
+		if (ptr && ptr[4] == '}')
 			return report_error(translate("gettextFromC", "No dive profile found from '%s'"), filename);
-		}
 
 		if (ptr)
 			ptr = parse_dan_new_line(ptr, NL);


### PR DESCRIPTION
Firstly, why calculate something when the next statement is a return anyway.

Secondly, the calculation subtracts two completely unrelated pointers.

This must be some code reshuffling artifact.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This code left me very confused until I realized that it has no effect, so can be removed.