### PR TITLE
cleanup: use proper size when allocating string

### DIFF
--- a/core/parse-xml.c
+++ b/core/parse-xml.c
@@ -2261,7 +2261,7 @@ int parse_dlf_buffer(unsigned char *buffer, size_t size, struct divelog *log)
 	/* Recording the starting battery status to extra data */
 	if (battery_start.volt1) {
 		size_t stringsize = snprintf(NULL, 0, "%dmV (%d%%)", battery_start.volt1, battery_start.percent1) + 1;
-		char *ptr = malloc(size);
+		char *ptr = malloc(stringsize);
 
 		if (ptr) {
 			snprintf(ptr, stringsize, "%dmV (%d%%)", battery_start.volt1, battery_start.percent1);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

Probably not a bug, but still...