### PR TITLE
Port some parts of string handling to C++ (part 1 of many)

### DIFF
--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -78,7 +78,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/worldmap-save.c \
 	core/libdivecomputer.c \
 	core/version.c \
-	core/save-git.c \
+	core/save-git.cpp \
 	core/datatrak.c \
 	core/ostctools.c \
 	core/planner.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -82,7 +82,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/datatrak.c \
 	core/ostctools.c \
 	core/planner.c \
-	core/save-xml.c \
+	core/save-xml.cpp \
 	core/cochran.c \
 	core/deco.c \
 	core/divesite.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -95,7 +95,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/strtod.c \
 	core/tag.c \
 	core/taxonomy.c \
-	core/time.c \
+	core/time.cpp \
 	core/trip.c \
 	core/units.c \
 	core/uemis.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -43,7 +43,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/windowtitleupdate.cpp \
 	core/file.c \
 	core/fulltext.cpp \
-	core/subsurfacestartup.c \
+	core/subsurfacestartup.cpp \
 	core/pref.c \
 	core/profile.c \
 	core/device.cpp \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -26,7 +26,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/downloadfromdcthread.cpp \
 	core/qtserialbluetooth.cpp \
 	core/plannernotes.c \
-	core/uemis-downloader.c \
+	core/uemis-downloader.cpp \
 	core/qthelper.cpp \
 	core/checkcloudconnection.cpp \
 	core/color.cpp \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -61,7 +61,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/git-access.cpp \
 	core/globals.cpp \
 	core/liquivision.c \
-	core/load-git.c \
+	core/load-git.cpp \
 	core/parse-xml.c \
 	core/parse.c \
 	core/picture.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -41,7 +41,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/qt-init.cpp \
 	core/subsurfacesysinfo.cpp \
 	core/windowtitleupdate.cpp \
-	core/file.c \
+	core/file.cpp \
 	core/fulltext.cpp \
 	core/subsurfacestartup.cpp \
 	core/pref.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -67,12 +67,12 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/picture.c \
 	core/pictureobj.cpp \
 	core/sample.cpp \
-	core/import-suunto.c \
-	core/import-shearwater.c \
-	core/import-seac.c \
-	core/import-cobalt.c \
-	core/import-divinglog.c \
-	core/import-csv.c \
+	core/import-suunto.cpp \
+	core/import-shearwater.cpp \
+	core/import-seac.cpp \
+	core/import-cobalt.cpp \
+	core/import-divinglog.cpp \
+	core/import-csv.cpp \
 	core/save-html.c \
 	core/statistics.c \
 	core/worldmap-save.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -47,7 +47,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/pref.c \
 	core/profile.c \
 	core/device.cpp \
-	core/dive.c \
+	core/dive.cpp \
 	core/divecomputer.c \
 	core/divefilter.cpp \
 	core/event.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -60,7 +60,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/gaspressures.c \
 	core/git-access.cpp \
 	core/globals.cpp \
-	core/liquivision.c \
+	core/liquivision.cpp \
 	core/load-git.cpp \
 	core/parse-xml.cpp \
 	core/parse.cpp \
@@ -76,14 +76,14 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/save-html.c \
 	core/statistics.c \
 	core/worldmap-save.c \
-	core/libdivecomputer.c \
+	core/libdivecomputer.cpp \
 	core/version.c \
 	core/save-git.cpp \
-	core/datatrak.c \
+	core/datatrak.cpp \
 	core/ostctools.c \
 	core/planner.c \
 	core/save-xml.cpp \
-	core/cochran.c \
+	core/cochran.cpp \
 	core/deco.c \
 	core/divesite.c \
 	core/equipment.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -62,8 +62,8 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/globals.cpp \
 	core/liquivision.c \
 	core/load-git.cpp \
-	core/parse-xml.c \
-	core/parse.c \
+	core/parse-xml.cpp \
+	core/parse.cpp \
 	core/picture.c \
 	core/pictureobj.cpp \
 	core/sample.cpp \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -58,7 +58,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/divelog.cpp \
 	core/gas-model.c \
 	core/gaspressures.c \
-	core/git-access.c \
+	core/git-access.cpp \
 	core/globals.cpp \
 	core/liquivision.c \
 	core/load-git.c \

--- a/Subsurface-mobile.pro
+++ b/Subsurface-mobile.pro
@@ -66,7 +66,7 @@ SOURCES += subsurface-mobile-main.cpp \
 	core/parse.c \
 	core/picture.c \
 	core/pictureobj.cpp \
-	core/sample.c \
+	core/sample.cpp \
 	core/import-suunto.c \
 	core/import-shearwater.c \
 	core/import-seac.c \

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -514,7 +514,7 @@ ImportDives::ImportDives(struct divelog *log, int flags, const QString &source)
 	// When encountering filter presets with equal names, check whether they are
 	// the same. If they are, ignore them.
 	for (const filter_preset &preset: *log->filter_presets) {
-		QString name = preset.name;
+		std::string name = preset.name;
 		auto it = std::find_if(divelog.filter_presets->begin(), divelog.filter_presets->end(),
 				       [&name](const filter_preset &preset) { return preset.name == name; });
 		if (it != divelog.filter_presets->end() && it->data == preset.data)
@@ -580,7 +580,7 @@ void ImportDives::undoit()
 	// Remove filter presets. Do this in reverse order.
 	for (auto it = filterPresetsToRemove.rbegin(); it != filterPresetsToRemove.rend(); ++it) {
 		int index = *it;
-		QString oldName = filter_preset_name_qstring(index);
+		std::string oldName = filter_preset_name(index);
 		FilterData oldData = filter_preset_get(index);
 		filter_preset_delete(index);
 		emit diveListNotifier.filterPresetRemoved(index);

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -112,7 +112,7 @@ private:
 
 	// For redo
 	std::vector<OwningDiveSitePtr>	sitesToAdd;
-	std::vector<std::pair<QString,FilterData>>
+	std::vector<std::pair<std::string,FilterData>>
 					filterPresetsToAdd;
 
 	// For undo

--- a/commands/command_filter.cpp
+++ b/commands/command_filter.cpp
@@ -6,16 +6,16 @@
 
 namespace Command {
 
-static int createFilterPreset(const QString &name, const FilterData &data)
+static int createFilterPreset(const std::string &name, const FilterData &data)
 {
 	int index = filter_preset_add(name, data);
 	emit diveListNotifier.filterPresetAdded(index);
 	return index;
 }
 
-static std::pair<QString, FilterData> removeFilterPreset(int index)
+static std::pair<std::string, FilterData> removeFilterPreset(int index)
 {
-	QString oldName = filter_preset_name_qstring(index);
+	std::string oldName = filter_preset_name(index);
 	FilterData oldData = filter_preset_get(index);
 	filter_preset_delete(index);
 	emit diveListNotifier.filterPresetRemoved(index);
@@ -23,7 +23,7 @@ static std::pair<QString, FilterData> removeFilterPreset(int index)
 }
 
 CreateFilterPreset::CreateFilterPreset(const QString &nameIn, const FilterData &dataIn) :
-	name(nameIn), data(dataIn), index(0)
+	name(nameIn.toStdString()), data(dataIn), index(0)
 {
 	setText(Command::Base::tr("Create filter preset %1").arg(nameIn));
 }
@@ -46,7 +46,7 @@ void CreateFilterPreset::undo()
 
 RemoveFilterPreset::RemoveFilterPreset(int indexIn) : index(indexIn)
 {
-	setText(Command::Base::tr("Delete filter preset %1").arg(filter_preset_name_qstring(index)));
+	setText(Command::Base::tr("Delete filter preset %1").arg(QString(filter_preset_name(index).c_str())));
 }
 
 bool RemoveFilterPreset::workToBeDone()
@@ -68,7 +68,7 @@ void RemoveFilterPreset::undo()
 EditFilterPreset::EditFilterPreset(int indexIn, const FilterData &dataIn) :
 	index(indexIn), data(dataIn)
 {
-	setText(Command::Base::tr("Edit filter preset %1").arg(filter_preset_name_qstring(index)));
+	setText(Command::Base::tr("Edit filter preset %1").arg(QString(filter_preset_name(index).c_str())));
 }
 
 bool EditFilterPreset::workToBeDone()

--- a/commands/command_filter.h
+++ b/commands/command_filter.h
@@ -17,7 +17,7 @@ public:
 	CreateFilterPreset(const QString &name, const FilterData &data);
 private:
 	// for redo
-	QString name;
+	std::string name;
 	FilterData data;
 
 	// for undo
@@ -33,7 +33,7 @@ public:
 	RemoveFilterPreset(int index);
 private:
 	// for undo
-	QString name;
+	std::string name;
 	FilterData data;
 
 	// for redo

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -89,7 +89,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	exif.cpp
 	exif.h
 	extradata.h
-	file.c
+	file.cpp
 	file.h
 	filterconstraint.cpp
 	filterconstraint.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -155,7 +155,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	range.h
 	sample.cpp
 	sample.h
-	save-git.c
+	save-git.cpp
 	save-html.c
 	save-html.h
 	save-profiledata.c

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	device.h
 	devicedetails.cpp
 	devicedetails.h
-	dive.c
+	dive.cpp
 	dive.h
 	divecomputer.c
 	divecomputer.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -173,7 +173,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	strtod.c
 	subsurface-float.h
 	subsurface-string.h
-	subsurfacestartup.c
+	subsurfacestartup.cpp
 	subsurfacestartup.h
 	subsurfacesysinfo.cpp
 	subsurfacesysinfo.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -153,7 +153,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	qthelper.cpp
 	qthelper.h
 	range.h
-	sample.c
+	sample.cpp
 	sample.h
 	save-git.c
 	save-html.c

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -186,7 +186,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	timer.h
 	trip.c
 	trip.h
-	uemis-downloader.c
+	uemis-downloader.cpp
 	uemis.c
 	uemis.h
 	units.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -159,7 +159,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	save-html.c
 	save-html.h
 	save-profiledata.c
-	save-xml.c
+	save-xml.cpp
 	selection.cpp
 	selection.h
 	sha1.c

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -107,7 +107,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	gettext.h
 	gettextfromc.cpp
 	gettextfromc.h
-	git-access.c
+	git-access.cpp
 	git-access.h
 	globals.cpp
 	globals.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -134,8 +134,8 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	ostctools.c
 	owning_ptrs.h
 	parse-gpx.cpp
-	parse-xml.c
-	parse.c
+	parse-xml.cpp
+	parse.cpp
 	parse.h
 	picture.c
 	picture.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -124,7 +124,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	libdivecomputer.c
 	libdivecomputer.h
 	liquivision.c
-	load-git.c
+	load-git.cpp
 	membuffer.cpp
 	membuffer.h
 	metadata.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -113,13 +113,13 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	globals.h
 	imagedownloader.cpp
 	imagedownloader.h
-	import-cobalt.c
-	import-csv.c
+	import-cobalt.cpp
+	import-csv.cpp
 	import-csv.h
-	import-divinglog.c
-	import-shearwater.c
-	import-suunto.c
-	import-seac.c
+	import-divinglog.cpp
+	import-shearwater.cpp
+	import-suunto.cpp
+	import-seac.cpp
 	interpolate.h
 	libdivecomputer.c
 	libdivecomputer.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,7 +41,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	checkcloudconnection.h
 	cloudstorage.cpp
 	cloudstorage.h
-	cochran.c
+	cochran.cpp
 	cochran.h
 	color.cpp
 	color.h
@@ -51,7 +51,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	configuredivecomputerthreads.h
 	connectionlistmodel.cpp
 	connectionlistmodel.h
-	datatrak.c
+	datatrak.cpp
 	datatrak.h
 	deco.c
 	deco.h
@@ -121,9 +121,9 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	import-suunto.cpp
 	import-seac.cpp
 	interpolate.h
-	libdivecomputer.c
+	libdivecomputer.cpp
 	libdivecomputer.h
-	liquivision.c
+	liquivision.cpp
 	load-git.cpp
 	membuffer.cpp
 	membuffer.h

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -181,7 +181,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	tag.h
 	taxonomy.c
 	taxonomy.h
-	time.c
+	time.cpp
 	timer.c
 	timer.h
 	trip.c

--- a/core/datatrak.h
+++ b/core/datatrak.h
@@ -41,8 +41,8 @@ static const struct models_table_t g_models[] = {
 	{0xEE,	0x44,	"Uwatec Unknown model",		DC_FAMILY_UWATEC_ALADIN},
 };
 
-#define JUMP(_ptr, _n) if ((long) (_ptr += _n) > maxbuf) goto bail
-#define CHECK(_ptr, _n) if ((long) _ptr + _n > maxbuf) goto bail
+#define JUMP(_ptr, _n) if ((char *) (_ptr += _n) > (char *)maxbuf) goto bail
+#define CHECK(_ptr, _n) if ((char *) _ptr + _n > (char *)maxbuf) goto bail
 #define read_bytes(_n) \
 	switch (_n) { \
 		case 1: \
@@ -62,10 +62,12 @@ static const struct models_table_t g_models[] = {
 
 #define read_string(_property) \
 	CHECK(membuf, tmp_1byte); \
+	{ \
 	unsigned char *_property##tmp = (unsigned char *)calloc(tmp_1byte + 1, 1); \
-	_property##tmp = memcpy(_property##tmp, membuf, tmp_1byte);\
+	_property##tmp = (unsigned char*)memcpy(_property##tmp, membuf, tmp_1byte);\
 	_property = (unsigned char *)strcat(to_utf8(_property##tmp), ""); \
 	free(_property##tmp);\
-	JUMP(membuf, tmp_1byte);
+	JUMP(membuf, tmp_1byte); \
+	}
 
 #endif // DATATRAK_HEADER_H

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -286,12 +286,20 @@ extern "C" uint32_t fp_get_diveid(struct fingerprint_table *table, unsigned int 
 	return table->fingerprints[i].fdiveid;
 }
 
-extern "C" char *fp_get_data(struct fingerprint_table *table, unsigned int i)
+static char to_hex_digit(unsigned char d)
+{
+	return d <= 9 ? d + '0' : d - 10 + 'a';
+}
+
+std::string fp_get_data(struct fingerprint_table *table, unsigned int i)
 {
 	if (!table || i >= table->fingerprints.size())
-		return 0;
+		return std::string();
 	struct fingerprint_record *fpr = &table->fingerprints[i];
-	// fromRawData() avoids one copy of the raw_data
-	QByteArray hex = QByteArray::fromRawData((char *)fpr->raw_data, fpr->fsize).toHex();
-	return strdup(hex.constData());
+	std::string res(' ', fpr->fsize * 2);
+	for (unsigned int i = 0; i < fpr->fsize; ++i) {
+		res[2 * i] = to_hex_digit((fpr->raw_data[i] >> 4) & 0xf);
+		res[2 * i + 1] = to_hex_digit(fpr->raw_data[i] & 0xf);
+	}
+	return res;
 }

--- a/core/device.h
+++ b/core/device.h
@@ -54,7 +54,6 @@ extern uint32_t fp_get_model(struct fingerprint_table *table, unsigned int i);
 extern uint32_t fp_get_serial(struct fingerprint_table *table, unsigned int i);
 extern uint32_t fp_get_deviceid(struct fingerprint_table *table, unsigned int i);
 extern uint32_t fp_get_diveid(struct fingerprint_table *table, unsigned int i);
-extern char *fp_get_data(struct fingerprint_table *table, unsigned int i);
 
 extern int is_default_dive_computer_device(const char *);
 
@@ -99,6 +98,8 @@ struct fingerprint_table {
 	// Keep the fingerprint records in a vector sorted by (model, serial) - these are uint32_t here
 	std::vector<fingerprint_record> fingerprints;
 };
+
+std::string fp_get_data(struct fingerprint_table *table, unsigned int i);
 
 #endif
 

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1337,7 +1337,7 @@ static void merge_one_sample(const struct sample *sample, int time, struct divec
 		 * a minute apart, and shallower than 5m
 		 */
 		if (time > last_time + 60 && last_depth < 5000) {
-			struct sample surface = { 0 };
+			struct sample surface;
 
 			/* Init a few values from prev sample to avoid useless info in XML */
 			surface.bearing.degrees = prev->bearing.degrees;
@@ -1388,7 +1388,7 @@ static void merge_samples(struct divecomputer *res,
 	for (;;) {
 		int j;
 		int at, bt;
-		struct sample sample = { .ndl{ -1 } , .bearing{ -1 } };
+		struct sample sample;
 
 		if (!res)
 			return;

--- a/core/dive.h
+++ b/core/dive.h
@@ -220,7 +220,6 @@ extern struct gasmix get_gasmix(const struct dive *dive, const struct divecomput
 /* Get gasmix at a given time */
 extern struct gasmix get_gasmix_at_time(const struct dive *dive, const struct divecomputer *dc, duration_t time);
 
-extern char *get_dive_date_c_string(timestamp_t when);
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 
 #ifdef __cplusplus

--- a/core/divesite.c
+++ b/core/divesite.c
@@ -62,7 +62,7 @@ struct dive_site *get_dive_site_by_gps(const location_t *loc, struct dive_site_t
 /* to avoid a bug where we have two dive sites with different name and the same GPS coordinates
  * and first get the gps coordinates (reading a V2 file) and happen to get back "the other" name,
  * this function allows us to verify if a very specific name/GPS combination already exists */
-struct dive_site *get_dive_site_by_gps_and_name(char *name, const location_t *loc, struct dive_site_table *ds_table)
+struct dive_site *get_dive_site_by_gps_and_name(const char *name, const location_t *loc, struct dive_site_table *ds_table)
 {
 	int i;
 	struct dive_site *ds;

--- a/core/divesite.h
+++ b/core/divesite.h
@@ -62,7 +62,7 @@ struct dive_site *create_dive_site(const char *name, struct dive_site_table *ds_
 struct dive_site *create_dive_site_with_gps(const char *name, const location_t *, struct dive_site_table *ds_table);
 struct dive_site *get_dive_site_by_name(const char *name, struct dive_site_table *ds_table);
 struct dive_site *get_dive_site_by_gps(const location_t *, struct dive_site_table *ds_table);
-struct dive_site *get_dive_site_by_gps_and_name(char *name, const location_t *, struct dive_site_table *ds_table);
+struct dive_site *get_dive_site_by_gps_and_name(const char *name, const location_t *, struct dive_site_table *ds_table);
 struct dive_site *get_dive_site_by_gps_proximity(const location_t *, int distance, struct dive_site_table *ds_table);
 struct dive_site *get_same_dive_site(const struct dive_site *);
 bool dive_site_is_empty(struct dive_site *ds);

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -86,13 +86,13 @@ const char *cylinderuse_text[NUM_GAS_USE] = {
 	QT_TRANSLATE_NOOP("gettextFromC", "OC-gas"), QT_TRANSLATE_NOOP("gettextFromC", "diluent"), QT_TRANSLATE_NOOP("gettextFromC", "oxygen"), QT_TRANSLATE_NOOP("gettextFromC", "not used")
 };
 
-int cylinderuse_from_text(const char *text)
+enum cylinderuse cylinderuse_from_text(const char *text)
 {
 	for (enum cylinderuse i = 0; i < NUM_GAS_USE; i++) {
 		if (same_string(text, cylinderuse_text[i]) || same_string(text, translate("gettextFromC", cylinderuse_text[i])))
 			return i;
 	}
-	return -1;
+	return (enum cylinderuse)-1;
 }
 
 /* Add a metric or an imperial tank info structure. Copies the passed-in string. */

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -70,7 +70,7 @@ struct weightsystem_table {
 
 #define MAX_WS_INFO (100)
 
-extern int cylinderuse_from_text(const char *text);
+extern enum cylinderuse cylinderuse_from_text(const char *text);
 extern void copy_weights(const struct weightsystem_table *s, struct weightsystem_table *d);
 extern void copy_cylinders(const struct cylinder_table *s, struct cylinder_table *d);
 extern weightsystem_t clone_weightsystem(weightsystem_t ws);

--- a/core/file.cpp
+++ b/core/file.cpp
@@ -269,9 +269,9 @@ extern "C" bool remote_repo_uptodate(const char *filename, struct git_info *info
 	std::string current_sha = saved_git_id;
 
 	if (is_git_repository(filename, info) && open_git_repository(info)) {
-		const char *sha = get_sha(info->repo, info->branch);
+		std::string sha = get_sha(info->repo, info->branch);
 		if (!sha.empty() && current_sha == sha) {
-			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
+			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha.c_str());
 			return true;
 		}
 	}

--- a/core/file.cpp
+++ b/core/file.cpp
@@ -266,20 +266,18 @@ static int parse_file_buffer(const char *filename, struct memblock *mem, struct 
 
 extern "C" bool remote_repo_uptodate(const char *filename, struct git_info *info)
 {
-	char *current_sha = copy_string(saved_git_id);
+	std::string current_sha = saved_git_id;
 
 	if (is_git_repository(filename, info) && open_git_repository(info)) {
 		const char *sha = get_sha(info->repo, info->branch);
-		if (!empty_string(sha) && same_string(sha, current_sha)) {
+		if (!sha.empty() && current_sha == sha) {
 			fprintf(stderr, "already have loaded SHA %s - don't load again\n", sha);
-			free(current_sha);
 			return true;
 		}
 	}
 
 	// Either the repository couldn't be opened, or the SHA couldn't
 	// be found.
-	free(current_sha);
 	return false;
 }
 

--- a/core/file.h
+++ b/core/file.h
@@ -7,23 +7,14 @@
 #include <sys/stat.h>
 #include <stdio.h>
 
-struct memblock {
-	void *buffer;
-	size_t size;
-};
-
 struct divelog;
 struct zip;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int try_to_open_cochran(const char *filename, struct memblock *mem, struct divelog *log);
-extern int try_to_open_liquivision(const char *filename, struct memblock *mem, struct divelog *log);
-extern int datatrak_import(struct memblock *mem, struct memblock *wl_mem, struct divelog *log);
 extern void ostctools_import(const char *file, struct divelog *log);
 
-extern int readfile(const char *filename, struct memblock *mem);
 extern int parse_file(const char *filename, struct divelog *log);
 extern int try_to_open_zip(const char *filename, struct divelog *log);
 
@@ -39,7 +30,20 @@ extern struct zip *subsurface_zip_open_readonly(const char *path, int flags, int
 extern int subsurface_zip_close(struct zip *zip);
 
 #ifdef __cplusplus
+
 }
+
+// C++ only functions
+
+#include <vector>
+#include <utility>
+
+// return data, errorcode pair.
+extern std::pair<std::string, int> readfile(const char *filename);
+extern int try_to_open_cochran(const char *filename, std::string &mem, struct divelog *log);
+extern int try_to_open_liquivision(const char *filename, std::string &mem, struct divelog *log);
+extern int datatrak_import(std::string &mem, std::string &wl_mem, struct divelog *log);
+
 #endif
 
 #endif // FILE_H

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -622,27 +622,23 @@ filter_constraint::~filter_constraint()
 		delete data.string_list;
 }
 
-extern "C" char *filter_constraint_data_to_string(const filter_constraint *c)
+std::string filter_constraint_data_to_string(const filter_constraint *c)
 {
-	QString s;
 	if (filter_constraint_is_timestamp(c->type)) {
-		char *from_s = format_datetime(c->data.timestamp_range.from);
-		char *to_s = format_datetime(c->data.timestamp_range.to);
-		s = QString(from_s) + ',' + QString(to_s);
-		free(from_s);
-		free(to_s);
+		std::string from_s = format_datetime(c->data.timestamp_range.from);
+		std::string to_s = format_datetime(c->data.timestamp_range.to);
+		return from_s + ',' + to_s;
 	} else if (filter_constraint_is_string(c->type)) {
 		// TODO: this obviously breaks if the strings contain ",".
 		// That is currently not supported by the UI, but one day we might
 		// have to escape the strings.
-		s = c->data.string_list->join(",");
+		return c->data.string_list->join(",").toStdString();
 	} else if (filter_constraint_is_multiple_choice(c->type)) {
-		s = QString::number(c->data.multiple_choice);
+		return std::to_string(c->data.multiple_choice);
 	} else {
-		s = QString::number(c->data.numerical_range.from) + ',' +
-		    QString::number(c->data.numerical_range.to);
+		return std::to_string(c->data.numerical_range.from) + ',' +
+		       std::to_string(c->data.numerical_range.to);
 	}
-	return copy_qstring(s);
 }
 
 void filter_constraint_set_stringlist(filter_constraint &c, const QString &s)

--- a/core/filterconstraint.h
+++ b/core/filterconstraint.h
@@ -116,7 +116,6 @@ extern bool filter_constraint_has_date_widget(enum filter_constraint_type);
 extern bool filter_constraint_has_time_widget(enum filter_constraint_type);
 extern int filter_constraint_num_decimals(enum filter_constraint_type);
 extern bool filter_constraint_is_valid(const struct filter_constraint *constraint);
-extern char *filter_constraint_data_to_string(const struct filter_constraint *constraint); // caller takes ownership of returned string
 
 #ifdef __cplusplus
 }
@@ -152,6 +151,8 @@ void filter_constraint_set_timestamp_from(filter_constraint &c, timestamp_t from
 void filter_constraint_set_timestamp_to(filter_constraint &c, timestamp_t to); // convert according to current units (metric or imperial)
 void filter_constraint_set_multiple_choice(filter_constraint &c, uint64_t);
 bool filter_constraint_match_dive(const filter_constraint &c, const struct dive *d);
+std::string filter_constraint_data_to_string(const struct filter_constraint *constraint); // caller takes ownership of returned string
+
 #endif
 
 #endif

--- a/core/filterpreset.cpp
+++ b/core/filterpreset.cpp
@@ -53,16 +53,6 @@ extern "C" const filter_constraint *filter_preset_constraint(int preset, int con
 	return &global_table()[preset].data.constraints[constraint];
 }
 
-extern "C" struct filter_preset *alloc_filter_preset()
-{
-	return new filter_preset;
-}
-
-extern "C" void free_filter_preset(const struct filter_preset *preset)
-{
-	delete preset;
-}
-
 extern "C" void filter_preset_set_name(struct filter_preset *preset, const char *name)
 {
 	preset->name = name;

--- a/core/filterpreset.h
+++ b/core/filterpreset.h
@@ -18,9 +18,9 @@ struct filter_constraint;
 #ifdef __cplusplus
 #include "divefilter.h"
 #include <vector>
-#include <QStringList>
+#include <string>
 struct filter_preset {
-	QString name;
+	std::string name;
 	FilterData data;
 };
 
@@ -44,8 +44,6 @@ extern "C" {
 
 // The C IO code accesses the filter presets via integer indices.
 extern int filter_presets_count(void);
-extern char *filter_preset_name(int preset); // name of filter preset - caller must free the result.
-extern char *filter_preset_fulltext_query(int preset); // fulltext query of filter preset - caller must free the result.
 extern const char *filter_preset_fulltext_mode(int preset); // string mode of fulltext query. ownership is *not* passed to caller.
 extern int filter_preset_constraint_count(int preset); // number of constraints in the filter preset.
 extern const struct filter_constraint *filter_preset_constraint(int preset, int constraint); // get constraint. ownership is *not* passed to caller.
@@ -66,12 +64,13 @@ extern void filter_preset_add_constraint(struct filter_preset *preset, const cha
 
 struct FilterData;
 
-int filter_preset_id(const QString &s); // for now, we assume that names are unique. returns -1 if no preset with that name.
-QString filter_preset_name_qstring(int preset);
+int filter_preset_id(const std::string &s); // for now, we assume that names are unique. returns -1 if no preset with that name.
 void filter_preset_set(int preset, const FilterData &d); // this will override a preset if the name already exists.
 FilterData filter_preset_get(int preset);
-int filter_preset_add(const QString &name, const FilterData &d); // returns point of insertion
+int filter_preset_add(const std::string &name, const FilterData &d); // returns point of insertion
 void filter_preset_delete(int preset);
+std::string filter_preset_name(int preset); // name of filter preset - caller must free the result.
+std::string filter_preset_fulltext_query(int preset); // fulltext query of filter preset - caller must free the result.
 
 #endif
 

--- a/core/filterpreset.h
+++ b/core/filterpreset.h
@@ -47,8 +47,6 @@ extern int filter_presets_count(void);
 extern const char *filter_preset_fulltext_mode(int preset); // string mode of fulltext query. ownership is *not* passed to caller.
 extern int filter_preset_constraint_count(int preset); // number of constraints in the filter preset.
 extern const struct filter_constraint *filter_preset_constraint(int preset, int constraint); // get constraint. ownership is *not* passed to caller.
-extern struct filter_preset *alloc_filter_preset();
-extern void free_filter_preset(const struct filter_preset *preset);
 extern void filter_preset_set_name(struct filter_preset *preset, const char *name);
 extern void filter_preset_set_fulltext(struct filter_preset *preset, const char *fulltext, const char *fulltext_string_mode);
 extern void add_filter_preset_to_table(const struct filter_preset *preset, struct filter_preset_table *table);

--- a/core/gettext.h
+++ b/core/gettext.h
@@ -2,10 +2,22 @@
 #ifndef MYGETTEXT_H
 #define MYGETTEXT_H
 
+#ifdef __cplusplus
+
+extern "C" const char *trGettext(const char *);
+static inline const char *translate(const char *, const char *arg)
+{
+	return trGettext(arg);
+}
+
+#else
+
 /* this is for the Qt based translations */
 extern const char *trGettext(const char *);
 #define translate(_context, arg) trGettext(arg)
 #define QT_TRANSLATE_NOOP(_context, arg) arg
 #define QT_TRANSLATE_NOOP3(_context, arg, _comment) arg
+
+#endif
 
 #endif // MYGETTEXT_H

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -45,7 +45,6 @@ extern int git_load_dives(struct git_info *, struct divelog *log);
 extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(struct git_info *, bool select_only, bool create_empty);
 extern void cleanup_git_info(struct git_info *);
-extern const char *saved_git_id;
 extern bool git_local_only;
 extern bool git_remote_sync_successful;
 extern void clear_git_id(void);
@@ -58,6 +57,10 @@ int get_authorship(git_repository *repo, git_signature **authorp);
 
 #ifdef __cplusplus
 }
+
+#include <string>
+extern std::string saved_git_id;
+
 #endif
 #endif // GITACCESS_H
 

--- a/core/git-access.h
+++ b/core/git-access.h
@@ -42,7 +42,6 @@ extern bool remote_repo_uptodate(const char *filename, struct git_info *info);
 extern int sync_with_remote(struct git_info *);
 extern int git_save_dives(struct git_info *, bool select_only);
 extern int git_load_dives(struct git_info *, struct divelog *log);
-extern const char *get_sha(git_repository *repo, const char *branch);
 extern int do_git_save(struct git_info *, bool select_only, bool create_empty);
 extern void cleanup_git_info(struct git_info *);
 extern bool git_local_only;
@@ -60,6 +59,7 @@ int get_authorship(git_repository *repo, git_signature **authorp);
 
 #include <string>
 extern std::string saved_git_id;
+extern std::string get_sha(git_repository *repo, const char *branch);
 
 #endif
 #endif // GITACCESS_H

--- a/core/import-cobalt.cpp
+++ b/core/import-cobalt.cpp
@@ -18,10 +18,8 @@
 #include "membuffer.h"
 #include "gettext.h"
 
-static int cobalt_profile_sample(void *param, int columns, char **data, char **column)
+static int cobalt_profile_sample(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	sample_start(state);
@@ -37,10 +35,8 @@ static int cobalt_profile_sample(void *param, int columns, char **data, char **c
 }
 
 
-static int cobalt_cylinders(void *param, int columns, char **data, char **column)
+static int cobalt_cylinders(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	cylinder_t *cyl;
 
@@ -62,10 +58,8 @@ static int cobalt_cylinders(void *param, int columns, char **data, char **column
 	return 0;
 }
 
-static int cobalt_buddies(void *param, int columns, char **data, char **column)
+static int cobalt_buddies(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	if (data[0])
@@ -79,30 +73,21 @@ static int cobalt_buddies(void *param, int columns, char **data, char **column)
  * Subsurface star rating.
  */
 
-static int cobalt_visibility(void *param, int columns, char **data, char **column)
+static int cobalt_visibility(void *, int, char **, char **)
 {
-	UNUSED(param);
-	UNUSED(columns);
-	UNUSED(column);
-	UNUSED(data);
 	return 0;
 }
 
-static int cobalt_location(void *param, int columns, char **data, char **column)
+static int cobalt_location(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	char **location = (char **)param;
 	*location = data[0] ? strdup(data[0]) : NULL;
 	return 0;
 }
 
 
-static int cobalt_dive(void *param, int columns, char **data, char **column)
+static int cobalt_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
-
 	int retval = 0;
 	struct parser_state *state = (struct parser_state *)param;
 	sqlite3 *handle = state->sql_handle;
@@ -195,7 +180,7 @@ static int cobalt_dive(void *param, int columns, char **data, char **column)
 	}
 
 	if (location && location_site) {
-		char *tmp = malloc(strlen(location) + strlen(location_site) + 4);
+		char *tmp = (char *)malloc(strlen(location) + strlen(location_site) + 4);
 		if (!tmp) {
 			free(location);
 			free(location_site);
@@ -221,11 +206,8 @@ static int cobalt_dive(void *param, int columns, char **data, char **column)
 }
 
 
-int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	struct parser_state state;
 

--- a/core/import-cobalt.cpp
+++ b/core/import-cobalt.cpp
@@ -131,7 +131,7 @@ static int cobalt_dive(void *param, int, char **data, char **)
 	settings_start(state);
 	dc_settings_start(state);
 	if (data[9]) {
-		utf8_string(data[9], &state->cur_settings.dc.serial_nr);
+		utf8_string_std(data[9], &state->cur_settings.dc.serial_nr);
 		state->cur_settings.dc.deviceid = atoi(data[9]);
 		state->cur_settings.dc.model = strdup("Cobalt import");
 	}
@@ -211,14 +211,12 @@ extern "C" int parse_cobalt_buffer(sqlite3 *handle, const char *url, const char 
 	int retval;
 	struct parser_state state;
 
-	init_parser_state(&state);
 	state.log = log;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select Id,strftime('%s',DiveStartTime),LocationId,'buddy','notes',Units,(MaxDepthPressure*10000/SurfacePressure)-10000,DiveMinutes,SurfacePressure,SerialNumber,'model' from Dive where IsViewDeleted = 0";
 
 	retval = sqlite3_exec(handle, get_dives, &cobalt_dive, &state, NULL);
-	free_parser_state(&state);
 
 	if (retval != SQLITE_OK) {
 		fprintf(stderr, "Database query failed '%s'.\n", url);

--- a/core/import-csv.h
+++ b/core/import-csv.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 int parse_csv_file(const char *filename, struct xml_params *params, const char *csvtemplate, struct divelog *log);
-int try_to_open_csv(struct memblock *mem, enum csv_format type, struct divelog *log);
+int try_to_open_csv(std::string &mem, enum csv_format type, struct divelog *log);
 int parse_txt_file(const char *filename, const char *csv, struct divelog *log);
 
 int parse_seabear_log(const char *filename, struct divelog *log);

--- a/core/import-divinglog.cpp
+++ b/core/import-divinglog.cpp
@@ -16,10 +16,8 @@
 #include "membuffer.h"
 #include "gettext.h"
 
-static int divinglog_cylinder(void *param, int columns, char **data, char **column)
+static int divinglog_cylinder(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	cylinder_t *cyl;
 
@@ -55,10 +53,8 @@ static int divinglog_cylinder(void *param, int columns, char **data, char **colu
 	return 0;
 }
 
-static int divinglog_profile(void *param, int columns, char **data, char **column)
+static int divinglog_profile(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	int sinterval = 0;
@@ -193,8 +189,7 @@ static int divinglog_profile(void *param, int columns, char **data, char **colum
 			int ppo2_1 = atoi_n(ptr5 + 0, 3);
 			int ppo2_2 = atoi_n(ptr5 + 3, 3);
 			int ppo2_3 = atoi_n(ptr5 + 6, 3);
-			int otu = atoi_n(ptr5 + 9, 4);
-			UNUSED(otu); // we seem to not store this? Do we understand its format?
+			//int otu = atoi_n(ptr5 + 9, 4); // we seem to not store this? Do we understand its format?
 			int cns = atoi_n(ptr5 + 13, 4);
 			int setpoint = atoi_n(ptr5 + 17, 2);
 
@@ -262,11 +257,8 @@ static int divinglog_profile(void *param, int columns, char **data, char **colum
 	return 0;
 }
 
-static int divinglog_dive(void *param, int columns, char **data, char **column)
+static int divinglog_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
-
 	int retval = 0, diveid;
 	struct parser_state *state = (struct parser_state *)param;
 	sqlite3 *handle = state->sql_handle;
@@ -306,7 +298,7 @@ static int divinglog_dive(void *param, int columns, char **data, char **column)
 		state->cur_dive->watertemp.mkelvin = C_to_mkelvin(atol(data[9]));
 
 	if (data[10]) {
-		weightsystem_t ws = { { atol(data[10]) * 1000 }, translate("gettextFromC", "unknown"), false };
+		weightsystem_t ws = { { atoi(data[10]) * 1000 }, translate("gettextFromC", "unknown"), false };
 		add_cloned_weightsystem(&state->cur_dive->weightsystems, ws);
 	}
 
@@ -391,11 +383,8 @@ static int divinglog_dive(void *param, int columns, char **data, char **column)
 }
 
 
-int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	struct parser_state state;
 

--- a/core/import-divinglog.cpp
+++ b/core/import-divinglog.cpp
@@ -388,14 +388,12 @@ extern "C" int parse_divinglog_buffer(sqlite3 *handle, const char *url, const ch
 	int retval;
 	struct parser_state state;
 
-	init_parser_state(&state);
 	state.log = log;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select Number,strftime('%s',Divedate || ' ' || ifnull(Entrytime,'00:00')),Country || ' - ' || City || ' - ' || Place,Buddy,Comments,Depth,Divetime,Divemaster,Airtemp,Watertemp,Weight,Divesuit,Computer,ID,Visibility,SupplyType from Logbook where UUID not in (select UUID from DeletedRecords)";
 
 	retval = sqlite3_exec(handle, get_dives, &divinglog_dive, &state, NULL);
-	free_parser_state(&state);
 
 	if (retval != SQLITE_OK) {
 		fprintf(stderr, "Database query failed '%s'.\n", url);

--- a/core/import-seac.cpp
+++ b/core/import-seac.cpp
@@ -205,8 +205,10 @@ static int seac_dive(void *param, int, char **data, char **)
 	settings_start(state);
 	dc_settings_start(state);
 
-	utf8_string(data[1], &state->cur_dive->dc.serial);
-	utf8_string(data[12], &state->cur_dive->dc.fw_version);
+	// These dc values are const char *, therefore we have to cast.
+	// Will be fixed by converting to std::string
+	utf8_string(data[1], (char **)&state->cur_dive->dc.serial);
+	utf8_string(data[12], (char **)&state->cur_dive->dc.fw_version);
 	state->cur_dive->dc.model = strdup("Seac Action");
 
 	state->cur_dive->dc.deviceid = calculate_string_hash(data[1]);
@@ -268,7 +270,6 @@ extern "C" int parse_seac_buffer(sqlite3 *handle, const char *url, const char *,
 	char *err = NULL;
 	struct parser_state state;
 
-	init_parser_state(&state);
 	state.log = log;
 	state.sql_handle = handle;
 
@@ -290,7 +291,6 @@ extern "C" int parse_seac_buffer(sqlite3 *handle, const char *url, const char *,
 		 */
 
 	retval = sqlite3_exec(handle, get_dives, &seac_dive, &state, &err);
-	free_parser_state(&state);
 
 	if (retval != SQLITE_OK) {
 		fprintf(stderr, "Database query failed '%s'.\n", url);

--- a/core/import-seac.cpp
+++ b/core/import-seac.cpp
@@ -41,10 +41,8 @@ static int seac_gaschange(void *param, sqlite3_stmt *sqlstmt)
 /* Callback function to parse seac dives. Reads headers_dive table to read dive
  * information into divecomputer struct.
  */
-static int seac_dive(void *param, int columns, char **data, char **column)
+static int seac_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	int retval = 0, cylnum = 0;
 	int year, month, day, hour, min, sec, tz;
 	char isodatetime[30];
@@ -264,11 +262,8 @@ static int seac_dive(void *param, int columns, char **data, char **column)
  * The callback function performs another SQL query on the other
  * table, to read in the sample values.
  */
-int parse_seac_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_seac_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	char *err = NULL;
 	struct parser_state state;

--- a/core/import-shearwater.cpp
+++ b/core/import-shearwater.cpp
@@ -262,7 +262,7 @@ static int shearwater_dive(void *param, int, char **data, char **)
 	settings_start(state);
 	dc_settings_start(state);
 	if (data[9])
-		utf8_string(data[9], &state->cur_settings.dc.serial_nr);
+		utf8_string_std(data[9], &state->cur_settings.dc.serial_nr);
 	if (data[10]) {
 		switch (atoi(data[10])) {
 		case 2:
@@ -392,7 +392,7 @@ static int shearwater_cloud_dive(void *param, int, char **data, char **)
 	settings_start(state);
 	dc_settings_start(state);
 	if (data[9])
-		utf8_string(data[9], &state->cur_settings.dc.serial_nr);
+		utf8_string_std(data[9], &state->cur_settings.dc.serial_nr);
 	if (data[10]) {
 		switch (atoi(data[10])) {
 		case 2:
@@ -477,7 +477,6 @@ extern "C" int parse_shearwater_buffer(sqlite3 *handle, const char *url, const c
 	int retval;
 	struct parser_state state;
 
-	init_parser_state(&state);
 	state.log = log;
 	state.sql_handle = handle;
 
@@ -487,7 +486,6 @@ extern "C" int parse_shearwater_buffer(sqlite3 *handle, const char *url, const c
 	char get_dives[] = "select l.number,timestamp,location||' / '||site,buddy,notes,imperialUnits,maxDepth,maxTime,startSurfacePressure,computerSerial,computerModel,i.diveId FROM dive_info AS i JOIN dive_logs AS l ON i.diveId=l.diveId";
 
 	retval = sqlite3_exec(handle, get_dives, &shearwater_dive, &state, NULL);
-	free_parser_state(&state);
 
 	if (retval != SQLITE_OK) {
 		fprintf(stderr, "Database query failed '%s'.\n", url);
@@ -502,14 +500,12 @@ extern "C" int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, c
 	int retval;
 	struct parser_state state;
 
-	init_parser_state(&state);
 	state.log = log;
 	state.sql_handle = handle;
 
 	char get_dives[] = "select l.number,strftime('%s', DiveDate),location||' / '||site,buddy,notes,imperialUnits,maxDepth,DiveLengthTime,startSurfacePressure,computerSerial,computerModel,d.diveId,l.sampleRateMs / 1000 FROM dive_details AS d JOIN dive_logs AS l ON d.diveId=l.diveId";
 
 	retval = sqlite3_exec(handle, get_dives, &shearwater_cloud_dive, &state, NULL);
-	free_parser_state(&state);
 
 	if (retval != SQLITE_OK) {
 		fprintf(stderr, "Database query failed '%s'.\n", url);

--- a/core/import-shearwater.cpp
+++ b/core/import-shearwater.cpp
@@ -17,10 +17,8 @@
 
 #include <stdlib.h>
 
-static int shearwater_cylinders(void *param, int columns, char **data, char **column)
+static int shearwater_cylinders(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	cylinder_t *cyl;
 
@@ -40,10 +38,8 @@ static int shearwater_cylinders(void *param, int columns, char **data, char **co
 	return 0;
 }
 
-static int shearwater_changes(void *param, int columns, char **data, char **column)
+static int shearwater_changes(void *param, int columns, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	cylinder_t *cyl;
 
@@ -83,10 +79,8 @@ static int shearwater_changes(void *param, int columns, char **data, char **colu
 	return 0;
 }
 
-static int shearwater_profile_sample(void *param, int columns, char **data, char **column)
+static int shearwater_profile_sample(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	int d6, d7;
 
@@ -146,10 +140,8 @@ static int shearwater_profile_sample(void *param, int columns, char **data, char
 	return 0;
 }
 
-static int shearwater_ai_profile_sample(void *param, int columns, char **data, char **column)
+static int shearwater_ai_profile_sample(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	int d6, d9;
 
@@ -217,10 +209,8 @@ static int shearwater_ai_profile_sample(void *param, int columns, char **data, c
 	return 0;
 }
 
-static int shearwater_mode(void *param, int columns, char **data, char **column)
+static int shearwater_mode(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	if (data[0])
@@ -229,11 +219,8 @@ static int shearwater_mode(void *param, int columns, char **data, char **column)
 	return 0;
 }
 
-static int shearwater_dive(void *param, int columns, char **data, char **column)
+static int shearwater_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
-
 	int retval = 0;
 	struct parser_state *state = (struct parser_state *)param;
 	sqlite3 *handle = state->sql_handle;
@@ -348,11 +335,8 @@ static int shearwater_dive(void *param, int columns, char **data, char **column)
 	return SQLITE_OK;
 }
 
-static int shearwater_cloud_dive(void *param, int columns, char **data, char **column)
+static int shearwater_cloud_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
-
 	int retval = 0;
 	struct parser_state *state = (struct parser_state *)param;
 	sqlite3 *handle = state->sql_handle;
@@ -488,11 +472,8 @@ static int shearwater_cloud_dive(void *param, int columns, char **data, char **c
 	return SQLITE_OK;
 }
 
-int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	struct parser_state state;
 
@@ -516,11 +497,8 @@ int parse_shearwater_buffer(sqlite3 *handle, const char *url, const char *buffer
 	return 0;
 }
 
-int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_shearwater_cloud_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	struct parser_state state;
 

--- a/core/import-suunto.cpp
+++ b/core/import-suunto.cpp
@@ -18,10 +18,8 @@
 
 #include <stdlib.h>
 
-static int dm4_events(void *param, int columns, char **data, char **column)
+static int dm4_events(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	event_start(state);
@@ -151,10 +149,8 @@ static int dm4_events(void *param, int columns, char **data, char **column)
 	return 0;
 }
 
-static int dm4_tags(void *param, int columns, char **data, char **column)
+static int dm4_tags(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	if (data[0])
@@ -163,10 +159,8 @@ static int dm4_tags(void *param, int columns, char **data, char **column)
 	return 0;
 }
 
-static int dm4_dive(void *param, int columns, char **data, char **column)
+static int dm4_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	int i;
 	int interval, retval = 0;
 	struct parser_state *state = (struct parser_state *)param;
@@ -293,11 +287,8 @@ static int dm4_dive(void *param, int columns, char **data, char **column)
 	return SQLITE_OK;
 }
 
-int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	char *err = NULL;
 	struct parser_state state;
@@ -321,10 +312,8 @@ int parse_dm4_buffer(sqlite3 *handle, const char *url, const char *buffer, int s
 	return 0;
 }
 
-static int dm5_cylinders(void *param, int columns, char **data, char **column)
+static int dm5_cylinders(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 	cylinder_t *cyl;
 
@@ -350,10 +339,8 @@ static int dm5_cylinders(void *param, int columns, char **data, char **column)
 	return 0;
 }
 
-static int dm5_gaschange(void *param, int columns, char **data, char **column)
+static int dm5_gaschange(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	struct parser_state *state = (struct parser_state *)param;
 
 	event_start(state);
@@ -372,10 +359,8 @@ static int dm5_gaschange(void *param, int columns, char **data, char **column)
 	return 0;
 }
 
-static int dm5_dive(void *param, int columns, char **data, char **column)
+static int dm5_dive(void *param, int, char **data, char **)
 {
-	UNUSED(columns);
-	UNUSED(column);
 	int i;
 	int tempformat = 0;
 	int interval, retval = 0, block_size;
@@ -429,16 +414,15 @@ static int dm5_dive(void *param, int columns, char **data, char **column)
 		utf8_string(data[5], &state->cur_dive->dc.model);
 
 	if (data[25]) {
-		//enum divemode_t {OC, CCR, PSCR, FREEDIVE, NUM_DIVEMODE, UNDEF_COMP_TYPE};	// Flags (Open-circuit and Closed-circuit-rebreather) for setting dive computer type
 		switch(atoi(data[25])) {
 			case 1:
-				state->cur_dive->dc.divemode = 0;
+				state->cur_dive->dc.divemode = OC;
 				break;
 			case 5:
-				state->cur_dive->dc.divemode = 1;
+				state->cur_dive->dc.divemode = CCR;
 				break;
 			default:
-				state->cur_dive->dc.divemode = 0;
+				state->cur_dive->dc.divemode = OC;
 				break;
 		}
 	}
@@ -575,11 +559,8 @@ static int dm5_dive(void *param, int columns, char **data, char **column)
 	return SQLITE_OK;
 }
 
-int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *buffer, int size, struct divelog *log)
+extern "C" int parse_dm5_buffer(sqlite3 *handle, const char *url, const char *, int, struct divelog *log)
 {
-	UNUSED(buffer);
-	UNUSED(size);
-
 	int retval;
 	char *err = NULL;
 	struct parser_state state;

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -683,9 +683,8 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 	}
 
 	// Parse the divetime.
-	char *date_string = get_dive_date_c_string(dive->when);
-	dev_info(devdata, translate("gettextFromC", "Dive %d: %s"), import_dive_number, date_string);
-	free(date_string);
+	std::string date_string = get_dive_date_c_string(dive->when);
+	dev_info(devdata, translate("gettextFromC", "Dive %d: %s"), import_dive_number, date_string.c_str());
 
 	unsigned int divetime = 0;
 	rc = dc_parser_get_field(parser, DC_FIELD_DIVETIME, 0, &divetime);
@@ -882,9 +881,8 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 
 	/* If we already saw this dive, abort. */
 	if (!devdata->force_download && find_dive(&dive->dc)) {
-		char *date_string = get_dive_date_c_string(dive->when);
-		dev_info(devdata, translate("gettextFromC", "Already downloaded dive at %s"), date_string);
-		free(date_string);
+		std::string date_string = get_dive_date_c_string(dive->when);
+		dev_info(devdata, translate("gettextFromC", "Already downloaded dive at %s"), date_string.c_str());
 		free_dive(dive);
 		return false;
 	}

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <git2.h>
+#include <memory>
 #include <libdivecomputer/parser.h>
 
 #include "gettext.h"
@@ -32,7 +33,8 @@
 
 #define ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
 
-const char *saved_git_id = NULL;
+// TODO: Should probably be moved to struct divelog to allow for multi-document
+std::string saved_git_id;
 
 struct git_parser_state {
 	git_repository *repo;
@@ -1878,8 +1880,7 @@ static int load_dives_from_tree(git_repository *repo, git_tree *tree, struct git
 
 extern "C" void clear_git_id(void)
 {
-	free((void *)saved_git_id);
-	saved_git_id = NULL;
+	saved_git_id.clear();
 }
 
 extern "C" void set_git_id(const struct git_oid *id)
@@ -1887,8 +1888,7 @@ extern "C" void set_git_id(const struct git_oid *id)
 	char git_id_buffer[GIT_OID_HEXSZ + 1];
 
 	git_oid_tostr(git_id_buffer, sizeof(git_id_buffer), id);
-	free((void *)saved_git_id);
-	saved_git_id = strdup(git_id_buffer);
+	saved_git_id = git_id_buffer;
 }
 
 static int find_commit(git_repository *repo, const char *branch, git_commit **commit_p)

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -153,11 +153,11 @@ static duration_t get_duration(const char *line)
 
 static enum divemode_t get_dctype(const char *line)
 {
-	for (enum divemode_t i = 0; i < NUM_DIVEMODE; i++) {
+	for (int i = 0; i < NUM_DIVEMODE; i++) {
 		if (strcmp(line, divemode_text[i]) == 0)
-			return i;
+			return (divemode_t)i;
 	}
-	return 0;
+	return (divemode_t)0;
 }
 
 static int get_index(const char *line)
@@ -166,9 +166,8 @@ static int get_index(const char *line)
 static int get_hex(const char *line)
 { return strtoul(line, NULL, 16); }
 
-static void parse_dive_gps(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dive_gps(char *line, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
 	location_t location;
 	struct dive_site *ds = get_dive_site_for_dive(state->active_dive);
 
@@ -190,9 +189,8 @@ static void parse_dive_gps(char *line, struct membuffer *str, struct git_parser_
 
 }
 
-static void parse_dive_location(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dive_location(char *, struct membuffer *str, struct git_parser_state *state)
 {
-	UNUSED(line);
 	char *name = detach_cstring(str);
 	struct dive_site *ds = get_dive_site_for_dive(state->active_dive);
 	if (!ds) {
@@ -213,28 +211,27 @@ static void parse_dive_location(char *line, struct membuffer *str, struct git_pa
 	free(name);
 }
 
-static void parse_dive_diveguide(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dive->diveguide = detach_cstring(str); }
+static void parse_dive_diveguide(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_dive->diveguide = detach_cstring(str); }
 
-static void parse_dive_buddy(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dive->buddy = detach_cstring(str); }
+static void parse_dive_buddy(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_dive->buddy = detach_cstring(str); }
 
-static void parse_dive_suit(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dive->suit = detach_cstring(str); }
+static void parse_dive_suit(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_dive->suit = detach_cstring(str); }
 
-static void parse_dive_notes(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dive->notes = detach_cstring(str); }
+static void parse_dive_notes(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_dive->notes = detach_cstring(str); }
 
-static void parse_dive_divesiteid(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); add_dive_to_dive_site(state->active_dive, get_dive_site_by_uuid(get_hex(line), state->log->sites)); }
+static void parse_dive_divesiteid(char *line, struct membuffer *, struct git_parser_state *state)
+{ add_dive_to_dive_site(state->active_dive, get_dive_site_by_uuid(get_hex(line), state->log->sites)); }
 
 /*
  * We can have multiple tags in the membuffer. They are separated by
  * NUL bytes.
  */
-static void parse_dive_tags(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dive_tags(char *, struct membuffer *str, struct git_parser_state *state)
 {
-	UNUSED(line);
 	const char *tag;
 	int len = str->len;
 
@@ -255,65 +252,60 @@ static void parse_dive_tags(char *line, struct membuffer *str, struct git_parser
 	}
 }
 
-static void parse_dive_airtemp(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->airtemp = get_temperature(line); }
+static void parse_dive_airtemp(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->airtemp = get_temperature(line); }
 
-static void parse_dive_watertemp(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->watertemp = get_temperature(line); }
+static void parse_dive_watertemp(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->watertemp = get_temperature(line); }
 
-static void parse_dive_airpressure(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->surface_pressure = get_airpressure(line); }
+static void parse_dive_airpressure(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->surface_pressure = get_airpressure(line); }
 
-static void parse_dive_duration(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->duration = get_duration(line); }
+static void parse_dive_duration(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->duration = get_duration(line); }
 
-static void parse_dive_rating(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->rating = get_index(line); }
+static void parse_dive_rating(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->rating = get_index(line); }
 
-static void parse_dive_visibility(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->visibility = get_index(line); }
+static void parse_dive_visibility(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->visibility = get_index(line); }
 
-static void parse_dive_wavesize(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->wavesize = get_index(line); }
+static void parse_dive_wavesize(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->wavesize = get_index(line); }
 
-static void parse_dive_current(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->current = get_index(line); }
+static void parse_dive_current(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->current = get_index(line); }
 
-static void parse_dive_surge(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->surge = get_index(line); }
+static void parse_dive_surge(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->surge = get_index(line); }
 
-static void parse_dive_chill(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->chill = get_index(line); }
+static void parse_dive_chill(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->chill = get_index(line); }
 
-static void parse_dive_watersalinity(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dive->user_salinity = get_salinity(line); }
+static void parse_dive_watersalinity(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dive->user_salinity = get_salinity(line); }
 
-static void parse_dive_notrip(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dive_notrip(char *, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
-	UNUSED(line);
 	state->active_dive->notrip = true;
 }
 
-static void parse_dive_invalid(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dive_invalid(char *, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
-	UNUSED(line);
 	state->active_dive->invalid = true;
 }
 
-static void parse_site_description(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_site->description = detach_cstring(str); }
+static void parse_site_description(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_site->description = detach_cstring(str); }
 
-static void parse_site_name(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_site->name = detach_cstring(str); }
+static void parse_site_name(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_site->name = detach_cstring(str); }
 
-static void parse_site_notes(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_site->notes = detach_cstring(str); }
+static void parse_site_notes(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_site->notes = detach_cstring(str); }
 
-static void parse_site_gps(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_site_gps(char *line, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
 	parse_location(line, &state->active_site->location);
 }
 
@@ -322,18 +314,19 @@ static void parse_site_geo(char *line, struct membuffer *str, struct git_parser_
 	int origin;
 	int category;
 	sscanf(line, "cat %d origin %d \"", &category, &origin);
-	taxonomy_set_category(&state->active_site->taxonomy , category, mb_cstring(str), origin);
+	taxonomy_set_category(&state->active_site->taxonomy, (taxonomy_category)category,
+			      mb_cstring(str), (taxonomy_origin)origin);
 }
 
 static char *remove_from_front(struct membuffer *str, int len)
 {
 	char *prefix;
 
-	if (len >= str->len)
+	if ((unsigned int)len >= str->len)
 		return detach_cstring(str);
 
 	/* memdup() - oh well */
-	prefix = malloc(len);
+	prefix = (char *)malloc(len);
 	if (!prefix) {
 		report_error("git-load: out of memory");
 		return NULL;
@@ -390,7 +383,7 @@ static char *parse_keyvalue_entry(void (*fn)(void *, const char *, const char *)
 
 static void parse_cylinder_keyvalue(void *_cylinder, const char *key, const char *value)
 {
-	cylinder_t *cylinder = _cylinder;
+	cylinder_t *cylinder = (cylinder *)_cylinder;
 	if (!strcmp(key, "vol")) {
 		cylinder->type.size = get_volume(value);
 		return;
@@ -462,7 +455,7 @@ static void parse_dive_cylinder(char *line, struct membuffer *str, struct git_pa
 
 static void parse_weightsystem_keyvalue(void *_ws, const char *key, const char *value)
 {
-	weightsystem_t *ws = _ws;
+	weightsystem_t *ws = (wightsystem *)_ws;
 	if (!strcmp(key, "weight")) {
 		ws->weight = get_weight(value);
 		return;
@@ -518,9 +511,9 @@ static int match_action(char *line, struct membuffer *str, void *data,
 		struct keyword_action *a = action + mid;
 		int cmp = strcmp(line, a->keyword);
 		if (!cmp) {	// attribute found:
-			a->fn(p, str, data);	// Execute appropriate function,
-			return 0;		// .. passing 2n word from above
-		}				// (p) as a function argument.
+			a->fn(p, str, (git_parser_state *)data);	// Execute appropriate function,
+			return 0;					// .. passing 2n word from above
+		}							// (p) as a function argument.
 		if (cmp < 0)
 			high = mid;
 		else
@@ -533,7 +526,7 @@ report_error("Unmatched action '%s'", line);
 /* FIXME! We should do the array thing here too. */
 static void parse_sample_keyvalue(void *_sample, const char *key, const char *value)
 {
-	struct sample *sample = _sample;
+	struct sample *sample = (sample *)_sample;
 
 	if (!strcmp(key, "sensor")) {
 		sample->sensor[0] = atoi(value);
@@ -729,57 +722,55 @@ static void sample_parser(char *line, struct git_parser_state *state)
 	finish_sample(state->active_dc);
 }
 
-static void parse_dc_airtemp(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->airtemp = get_temperature(line); }
+static void parse_dc_airtemp(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->airtemp = get_temperature(line); }
 
-static void parse_dc_date(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); update_date(&state->active_dc->when, line); }
+static void parse_dc_date(char *line, struct membuffer *, struct git_parser_state *state)
+{ update_date(&state->active_dc->when, line); }
 
-static void parse_dc_deviceid(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_dc_deviceid(char *line, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
-	int id = get_hex(line);
-	UNUSED(id);	// legacy
+	get_hex(line); // legacy
 }
 
-static void parse_dc_diveid(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->diveid = get_hex(line); }
+static void parse_dc_diveid(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->diveid = get_hex(line); }
 
-static void parse_dc_duration(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->duration = get_duration(line); }
+static void parse_dc_duration(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->duration = get_duration(line); }
 
-static void parse_dc_dctype(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->divemode = get_dctype(line); }
+static void parse_dc_dctype(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->divemode = get_dctype(line); }
 
-static void parse_dc_lastmanualtime(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->last_manual_time = get_duration(line); }
+static void parse_dc_lastmanualtime(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->last_manual_time = get_duration(line); }
 
-static void parse_dc_maxdepth(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->maxdepth = get_depth(line); }
+static void parse_dc_maxdepth(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->maxdepth = get_depth(line); }
 
-static void parse_dc_meandepth(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->meandepth = get_depth(line); }
+static void parse_dc_meandepth(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->meandepth = get_depth(line); }
 
-static void parse_dc_model(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_dc->model = detach_cstring(str); }
+static void parse_dc_model(char *, struct membuffer *str, struct git_parser_state *state)
+{  state->active_dc->model = detach_cstring(str); }
 
-static void parse_dc_numberofoxygensensors(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->no_o2sensors = get_index(line); }
+static void parse_dc_numberofoxygensensors(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->no_o2sensors = get_index(line); }
 
-static void parse_dc_surfacepressure(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->surface_pressure = get_pressure(line); }
+static void parse_dc_surfacepressure(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->surface_pressure = get_pressure(line); }
 
-static void parse_dc_salinity(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->salinity = get_salinity(line); }
+static void parse_dc_salinity(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->salinity = get_salinity(line); }
 
-static void parse_dc_surfacetime(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->surfacetime = get_duration(line); }
+static void parse_dc_surfacetime(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->surfacetime = get_duration(line); }
 
-static void parse_dc_time(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); update_time(&state->active_dc->when, line); }
+static void parse_dc_time(char *line, struct membuffer *, struct git_parser_state *state)
+{ update_time(&state->active_dc->when, line); }
 
-static void parse_dc_watertemp(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(str); state->active_dc->watertemp = get_temperature(line); }
+static void parse_dc_watertemp(char *line, struct membuffer *, struct git_parser_state *state)
+{ state->active_dc->watertemp = get_temperature(line); }
 
 
 static int get_divemode(const char *divemodestring) {
@@ -806,7 +797,7 @@ struct parse_event {
 
 static void parse_event_keyvalue(void *_parse, const char *key, const char *value)
 {
-	struct parse_event *parse = _parse;
+	struct parse_event *parse = (parse_event *)_parse;
 	int val = atoi(value);
 
 	if (!strcmp(key, "type")) {
@@ -903,48 +894,39 @@ static void parse_dc_event(char *line, struct membuffer *str, struct git_parser_
 }
 
 /* Not needed anymore - trip date calculated implicitly from first dive */
-static void parse_trip_date(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); UNUSED(str); UNUSED(state); }
+static void parse_trip_date(char *, struct membuffer *, struct git_parser_state *)
+{ }
 
 /* Not needed anymore - trip date calculated implicitly from first dive */
-static void parse_trip_time(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); UNUSED(str); UNUSED(state); }
+static void parse_trip_time(char *, struct membuffer *, struct git_parser_state *)
+{ }
 
-static void parse_trip_location(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_trip->location = detach_cstring(str); }
+static void parse_trip_location(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_trip->location = detach_cstring(str); }
 
-static void parse_trip_notes(char *line, struct membuffer *str, struct git_parser_state *state)
-{ UNUSED(line); state->active_trip->notes = detach_cstring(str); }
+static void parse_trip_notes(char *, struct membuffer *str, struct git_parser_state *state)
+{ state->active_trip->notes = detach_cstring(str); }
 
-static void parse_settings_autogroup(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_settings_autogroup(char *, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(line);
-	UNUSED(str);
 	state->log->autogroup = true;
 }
 
-static void parse_settings_units(char *line, struct membuffer *str, struct git_parser_state *unused)
+static void parse_settings_units(char *line, struct membuffer *, struct git_parser_state *)
 {
-	UNUSED(str);
-	UNUSED(unused);
 	if (line)
 		set_informational_units(line);
 }
 
-static void parse_settings_userid(char *line, struct membuffer *str, struct git_parser_state *_unused)
+static void parse_settings_userid(char *, struct membuffer *, struct git_parser_state *)
 /* Keep this despite removal of the webservice as there are legacy logbook around
  * that still have this defined.
  */
 {
-	UNUSED(str);
-	UNUSED(_unused);
-	UNUSED(line);
 }
 
-static void parse_settings_prefs(char *line, struct membuffer *str, struct git_parser_state *unused)
+static void parse_settings_prefs(char *line, struct membuffer *, struct git_parser_state *)
 {
-	UNUSED(str);
-	UNUSED(unused);
 	if (line)
 		set_git_prefs(line);
 }
@@ -956,10 +938,8 @@ static void parse_settings_prefs(char *line, struct membuffer *str, struct git_p
  * We MUST keep this in sync with the XML version (so we can report a consistent
  * minimum datafile version)
  */
-static void parse_settings_version(char *line, struct membuffer *str, struct git_parser_state *_unused)
+static void parse_settings_version(char *line, struct membuffer *, struct git_parser_state *)
 {
-	UNUSED(str);
-	UNUSED(_unused);
 	int version = atoi(line);
 	report_datafile_version(version);
 	if (version > DATAFORMAT_VERSION)
@@ -967,11 +947,8 @@ static void parse_settings_version(char *line, struct membuffer *str, struct git
 }
 
 /* The string in the membuffer is the version string of subsurface that saved things, just FYI */
-static void parse_settings_subsurface(char *line, struct membuffer *str, struct git_parser_state *_unused)
+static void parse_settings_subsurface(char *, struct membuffer *, struct git_parser_state *)
 {
-	UNUSED(line);
-	UNUSED(str);
-	UNUSED(_unused);
 }
 
 struct divecomputerid {
@@ -984,7 +961,7 @@ struct divecomputerid {
 
 static void parse_divecomputerid_keyvalue(void *_cid, const char *key, const char *value)
 {
-	struct divecomputerid *cid = _cid;
+	struct divecomputerid *cid = (divecomputerid *)_cid;
 
 	// Ignored legacy fields
 	if (!strcmp(key, "firmware"))
@@ -1039,7 +1016,7 @@ struct fingerprint_helper {
 
 static void parse_fingerprint_keyvalue(void *_fph, const char *key, const char *value)
 {
-	struct fingerprint_helper *fph = _fph;
+	struct fingerprint_helper *fph = (fingerprint_helper *)_fph;
 
 	if (!strcmp(key, "model")) {
 		fph->model = get_hex(value);
@@ -1082,26 +1059,21 @@ static void parse_settings_fingerprint(char *line, struct membuffer *str, struct
 					 fph.hex_data, fph.fdeviceid, fph.fdiveid);
 }
 
-static void parse_picture_filename(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_picture_filename(char *, struct membuffer *str, struct git_parser_state *state)
 {
-	UNUSED(line);
 	state->active_pic.filename = detach_cstring(str);
 }
 
-static void parse_picture_gps(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_picture_gps(char *line, struct membuffer *, struct git_parser_state *state)
 {
-	UNUSED(str);
 	parse_location(line, &state->active_pic.location);
 }
 
-static void parse_picture_hash(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_picture_hash(char *, struct membuffer *, struct git_parser_state *)
 {
 	// we no longer use hashes to identify pictures, but we shouldn't
 	// remove this parser lest users get an ugly red warning when
 	// opening old git repos
-	UNUSED(line);
-	UNUSED(state);
-	UNUSED(str);
 }
 
 /* These need to be sorted! */
@@ -1187,7 +1159,7 @@ static void picture_parser(char *line, struct membuffer *str, struct git_parser_
 
 static void parse_filter_preset_constraint_keyvalue(void *_state, const char *key, const char *value)
 {
-	struct git_parser_state *state = _state;
+	struct git_parser_state *state = (git_parser_state *)_state;
 	if (!strcmp(key, "type")) {
 		free(state->filter_constraint_type);
 		state->filter_constraint_type = strdup(value);
@@ -1242,7 +1214,7 @@ static void parse_filter_preset_constraint(char *line, struct membuffer *str, st
 
 static void parse_filter_preset_fulltext_keyvalue(void *_state, const char *key, const char *value)
 {
-	struct git_parser_state *state = _state;
+	struct git_parser_state *state = (git_parser_state *)_state;
 	if (!strcmp(key, "mode")) {
 		free(state->fulltext_mode);
 		state->fulltext_mode = strdup(value);
@@ -1275,9 +1247,8 @@ static void parse_filter_preset_fulltext(char *line, struct membuffer *str, stru
 	state->fulltext_query = NULL;
 }
 
-static void parse_filter_preset_name(char *line, struct membuffer *str, struct git_parser_state *state)
+static void parse_filter_preset_name(char *, struct membuffer *str, struct git_parser_state *state)
 {
-	UNUSED(line);
 	filter_preset_set_name(state->active_filter, detach_cstring(str));
 }
 
@@ -1417,7 +1388,7 @@ static unsigned parse_one_line(const char *buf, unsigned size, line_fn_t *fn, st
  */
 static void for_each_line(git_blob *blob, line_fn_t *fn, struct git_parser_state *state)
 {
-	const char *content = git_blob_rawcontent(blob);
+	const char *content = (const char *)git_blob_rawcontent(blob);
 	unsigned int size = git_blob_rawsize(blob);
 	struct membuffer str = { 0 };
 
@@ -1587,10 +1558,8 @@ static int dive_directory(const char *root, const git_tree_entry *entry, const c
 	return GIT_WALK_OK;
 }
 
-static int picture_directory(const char *root, const char *name, struct git_parser_state *state)
+static int picture_directory(const char *, const char *, struct git_parser_state *state)
 {
-	UNUSED(root);
-	UNUSED(name);
 	if (!state->active_dive)
 		return GIT_WALK_SKIP;
 	return GIT_WALK_OK;
@@ -1711,7 +1680,7 @@ static struct divecomputer *create_new_dc(struct dive *dive)
 		dc = dc->next;
 	/* Did we already fill that in? */
 	if (dc->samples || dc->model || dc->when) {
-		struct divecomputer *newdc = calloc(1, sizeof(*newdc));
+		struct divecomputer *newdc = (divecomputer *)calloc(1, sizeof(*newdc));
 		if (!newdc)
 			return NULL;
 		dc->next = newdc;
@@ -1728,9 +1697,8 @@ static struct divecomputer *create_new_dc(struct dive *dive)
  * cheap, but the loading of the git blob into memory can be pretty
  * costly.
  */
-static int parse_divecomputer_entry(struct git_parser_state *state, const git_tree_entry *entry, const char *suffix)
+static int parse_divecomputer_entry(struct git_parser_state *state, const git_tree_entry *entry, const char *)
 {
-	UNUSED(suffix);
 	git_blob *blob = git_tree_entry_blob(state->repo, entry);
 
 	if (!blob)
@@ -1891,7 +1859,7 @@ static int walk_tree_file(const char *root, const git_tree_entry *entry, struct 
 
 static int walk_tree_cb(const char *root, const git_tree_entry *entry, void *payload)
 {
-	struct git_parser_state *state = payload;
+	struct git_parser_state *state = (git_parser_state *)payload;
 	git_filemode_t mode = git_tree_entry_filemode(entry);
 
 	if (mode == GIT_FILEMODE_TREE)
@@ -1908,13 +1876,13 @@ static int load_dives_from_tree(git_repository *repo, git_tree *tree, struct git
 	return 0;
 }
 
-void clear_git_id(void)
+extern "C" void clear_git_id(void)
 {
 	free((void *)saved_git_id);
 	saved_git_id = NULL;
 }
 
-void set_git_id(const struct git_oid *id)
+extern "C" void set_git_id(const struct git_oid *id)
 {
 	char git_id_buffer[GIT_OID_HEXSZ + 1];
 
@@ -1956,7 +1924,7 @@ static int do_git_load(git_repository *repo, const char *branch, struct git_pars
 	return ret;
 }
 
-const char *get_sha(git_repository *repo, const char *branch)
+extern "C" const char *get_sha(git_repository *repo, const char *branch)
 {
 	static char git_id_buffer[GIT_OID_HEXSZ + 1];
 	git_commit *commit;
@@ -1974,7 +1942,7 @@ const char *get_sha(git_repository *repo, const char *branch)
  * If it is a git repository, we return zero for success,
  * or report an error and return 1 if the load failed.
  */
-int git_load_dives(struct git_info *info, struct divelog *log)
+extern "C" int git_load_dives(struct git_info *info, struct divelog *log)
 {
 	int ret;
 	struct git_parser_state state = { 0 };

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -1906,14 +1906,14 @@ static int do_git_load(git_repository *repo, const char *branch, struct git_pars
 	return ret;
 }
 
-extern "C" const char *get_sha(git_repository *repo, const char *branch)
+std::string get_sha(git_repository *repo, const char *branch)
 {
-	static char git_id_buffer[GIT_OID_HEXSZ + 1];
+	char git_id_buffer[GIT_OID_HEXSZ + 1];
 	git_commit *commit;
 	if (find_commit(repo, branch, &commit))
-		return NULL;
+		return std::string();
 	git_oid_tostr(git_id_buffer, sizeof(git_id_buffer), (const git_oid *)commit);
-	return git_id_buffer;
+	return std::string(git_id_buffer);
 }
 
 /*

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -41,13 +41,13 @@ struct git_parser_state {
 	struct divecomputer *active_dc;
 	struct dive *active_dive;
 	dive_trip_t *active_trip;
-	char *fulltext_mode;
-	char *fulltext_query;
-	char *filter_constraint_type;
-	char *filter_constraint_string_mode;
-	char *filter_constraint_range_mode;
+	std::string fulltext_mode;
+	std::string fulltext_query;
+	std::string filter_constraint_type;
+	std::string filter_constraint_string_mode;
+	std::string filter_constraint_range_mode;
 	bool filter_constraint_negate;
-	char *filter_constraint_data;
+	std::string filter_constraint_data;
 	struct picture active_pic;
 	struct dive_site *active_site;
 	struct filter_preset *active_filter;
@@ -385,7 +385,7 @@ static char *parse_keyvalue_entry(void (*fn)(void *, const char *, const char *)
 
 static void parse_cylinder_keyvalue(void *_cylinder, const char *key, const char *value)
 {
-	cylinder_t *cylinder = (cylinder *)_cylinder;
+	cylinder_t *cylinder = (cylinder_t *)_cylinder;
 	if (!strcmp(key, "vol")) {
 		cylinder->type.size = get_volume(value);
 		return;
@@ -457,7 +457,7 @@ static void parse_dive_cylinder(char *line, struct membuffer *str, struct git_pa
 
 static void parse_weightsystem_keyvalue(void *_ws, const char *key, const char *value)
 {
-	weightsystem_t *ws = (wightsystem *)_ws;
+	weightsystem_t *ws = (weightsystem_t *)_ws;
 	if (!strcmp(key, "weight")) {
 		ws->weight = get_weight(value);
 		return;
@@ -528,7 +528,7 @@ report_error("Unmatched action '%s'", line);
 /* FIXME! We should do the array thing here too. */
 static void parse_sample_keyvalue(void *_sample, const char *key, const char *value)
 {
-	struct sample *sample = (sample *)_sample;
+	struct sample *sample = (struct sample *)_sample;
 
 	if (!strcmp(key, "sensor")) {
 		sample->sensor[0] = atoi(value);
@@ -1163,18 +1163,15 @@ static void parse_filter_preset_constraint_keyvalue(void *_state, const char *ke
 {
 	struct git_parser_state *state = (git_parser_state *)_state;
 	if (!strcmp(key, "type")) {
-		free(state->filter_constraint_type);
-		state->filter_constraint_type = strdup(value);
+		state->filter_constraint_type = value;
 		return;
 	}
 	if (!strcmp(key, "rangemode")) {
-		free(state->filter_constraint_range_mode);
-		state->filter_constraint_range_mode = strdup(value);
+		state->filter_constraint_range_mode = value;
 		return;
 	}
 	if (!strcmp(key, "stringmode")) {
-		free(state->filter_constraint_string_mode);
-		state->filter_constraint_string_mode = strdup(value);
+		state->filter_constraint_string_mode = value;
 		return;
 	}
 	if (!strcmp(key, "negate")) {
@@ -1182,8 +1179,7 @@ static void parse_filter_preset_constraint_keyvalue(void *_state, const char *ke
 		return;
 	}
 	if (!strcmp(key, "data")) {
-		free(state->filter_constraint_data);
-		state->filter_constraint_data = strdup(value);
+		state->filter_constraint_data = value;
 		return;
 	}
 
@@ -1201,30 +1197,26 @@ static void parse_filter_preset_constraint(char *line, struct membuffer *str, st
 		line = parse_keyvalue_entry(parse_filter_preset_constraint_keyvalue, state, line, str);
 	}
 
-	filter_preset_add_constraint(state->active_filter, state->filter_constraint_type, state->filter_constraint_string_mode,
-				     state->filter_constraint_range_mode, state->filter_constraint_negate, state->filter_constraint_data);
-	free(state->filter_constraint_type);
-	free(state->filter_constraint_string_mode);
-	free(state->filter_constraint_range_mode);
-	free(state->filter_constraint_data);
-	state->filter_constraint_type = NULL;
-	state->filter_constraint_string_mode = NULL;
-	state->filter_constraint_range_mode = NULL;
+	filter_preset_add_constraint(state->active_filter, state->filter_constraint_type.c_str(),
+				     state->filter_constraint_string_mode.c_str(),
+				     state->filter_constraint_range_mode.c_str(),
+				     state->filter_constraint_negate, state->filter_constraint_data.c_str());
+	state->filter_constraint_type.clear();
+	state->filter_constraint_string_mode.clear();
+	state->filter_constraint_range_mode.clear();
 	state->filter_constraint_negate = false;
-	state->filter_constraint_data = NULL;
+	state->filter_constraint_data.clear();
 }
 
 static void parse_filter_preset_fulltext_keyvalue(void *_state, const char *key, const char *value)
 {
 	struct git_parser_state *state = (git_parser_state *)_state;
 	if (!strcmp(key, "mode")) {
-		free(state->fulltext_mode);
-		state->fulltext_mode = strdup(value);
+		state->fulltext_mode = value;
 		return;
 	}
 	if (!strcmp(key, "query")) {
-		free(state->fulltext_query);
-		state->fulltext_query = strdup(value);
+		state->fulltext_query = value;
 		return;
 	}
 
@@ -1242,11 +1234,9 @@ static void parse_filter_preset_fulltext(char *line, struct membuffer *str, stru
 		line = parse_keyvalue_entry(parse_filter_preset_fulltext_keyvalue, state, line, str);
 	}
 
-	filter_preset_set_fulltext(state->active_filter, state->fulltext_query, state->fulltext_mode);
-	free(state->fulltext_mode);
-	free(state->fulltext_query);
-	state->fulltext_mode = NULL;
-	state->fulltext_query = NULL;
+	filter_preset_set_fulltext(state->active_filter, state->fulltext_query.c_str(), state->fulltext_mode.c_str());
+	state->fulltext_mode.clear();
+	state->fulltext_query.clear();
 }
 
 static void parse_filter_preset_name(char *, struct membuffer *str, struct git_parser_state *state)

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -181,10 +181,9 @@ static void parse_dive_gps(char *line, struct membuffer *, struct git_parser_sta
 		add_dive_to_dive_site(state->active_dive, ds);
 	} else {
 		if (dive_site_has_gps_location(ds) && !same_location(&ds->location, &location)) {
-			char *coords = printGPSCoordsC(&location);
+			std::string coords = printGPSCoordsC(&location);
 			// we have a dive site that already has GPS coordinates
-			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
-			free(coords);
+			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords.c_str());
 		}
 		ds->location = location;
 	}

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -1230,9 +1230,8 @@ static void gps_in_dive(const char *buffer, struct dive *dive, struct parser_sta
 			fprintf(stderr, "dive site uuid in dive, but gps location (%10.6f/%10.6f) different from dive location (%10.6f/%10.6f)\n",
 				ds->location.lat.udeg / 1000000.0, ds->location.lon.udeg / 1000000.0,
 				location.lat.udeg / 1000000.0, location.lon.udeg / 1000000.0);
-			char *coords = printGPSCoordsC(&location);
-			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords);
-			free(coords);
+			std::string coords = printGPSCoordsC(&location);
+			ds->notes = add_to_string(ds->notes, translate("gettextFromC", "multiple GPS locations for this dive site; also %s\n"), coords.c_str());
 		} else {
 			ds->location = location;
 		}

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -278,17 +278,15 @@ static void depth(const char *buffer, depth_t *depth, struct parser_state *state
 
 static void extra_data_start(struct parser_state *state)
 {
-	memset(&state->cur_extra_data, 0, sizeof(struct extra_data));
+	state->cur_extra_data.key.clear();
+	state->cur_extra_data.value.clear();
 }
 
 static void extra_data_end(struct parser_state *state)
 {
 	// don't save partial structures - we must have both key and value
-	if (state->cur_extra_data.key && state->cur_extra_data.value)
-		add_extra_data(get_dc(state), state->cur_extra_data.key, state->cur_extra_data.value);
-	free((void *)state->cur_extra_data.key);
-	free((void *)state->cur_extra_data.value);
-	state->cur_extra_data.key = state->cur_extra_data.value = NULL;
+	if (!state->cur_extra_data.key.empty() && !state->cur_extra_data.value.empty())
+		add_extra_data(get_dc(state), state->cur_extra_data.key.c_str(), state->cur_extra_data.value.c_str());
 }
 
 static void weight(const char *buffer, weight_t *weight, struct parser_state *state)
@@ -829,9 +827,9 @@ static int match_dc_data_fields(struct divecomputer *dc, const char *name, char 
 		return 1;
 	if (MATCH("salinity.water", salinity, &dc->salinity))
 		return 1;
-	if (MATCH("key.extradata", utf8_string, (char **)&state->cur_extra_data.key))
+	if (MATCH("key.extradata", utf8_string_std, &state->cur_extra_data.key))
 		return 1;
-	if (MATCH("value.extradata", utf8_string, (char **)&state->cur_extra_data.value))
+	if (MATCH("value.extradata", utf8_string_std, &state->cur_extra_data.value))
 		return 1;
 	if (MATCH("divemode", get_dc_type, &dc->divemode))
 		return 1;

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -1527,7 +1527,7 @@ static bool entry(const char *name, char *buf, struct parser_state *state)
 		return true;
 	}
 	if (state->cur_filter) {
-		try_to_fill_filter(state->cur_filter, name, buf);
+		try_to_fill_filter(state->cur_filter.get(), name, buf);
 		return true;
 	}
 	if (state->event_active) {

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -1244,7 +1244,6 @@ static void gps_picture_location(const char *buffer, struct picture *pic)
 /* We're in the top-level dive xml. Try to convert whatever value to a dive value */
 static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, struct parser_state *state)
 {
-	char *hash = NULL;
 	cylinder_t *cyl = dive->cylinders.nr > 0 ? get_cylinder(dive, dive->cylinders.nr - 1) : NULL;
 	weightsystem_t *ws = dive->weightsystems.nr > 0 ?
 		&dive->weightsystems.weightsystems[dive->weightsystems.nr - 1] : NULL;
@@ -1293,9 +1292,8 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH("gps.picture", gps_picture_location, &state->cur_picture))
 		return;
-	if (MATCH("hash.picture", utf8_string, &hash)) {
+	if (std::string hash; MATCH("hash.picture", utf8_string_std, &hash)) {
 		/* Legacy -> ignore. */
-		free(hash);
 		return;
 	}
 	if (MATCH_STATE("cylinderstartpressure", pressure, &p)) {

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -2256,42 +2256,20 @@ extern "C" int parse_dlf_buffer(unsigned char *buffer, size_t size, struct divel
 
 	/* Recording the starting battery status to extra data */
 	if (battery_start.volt1) {
-		size_t stringsize = snprintf(NULL, 0, "%dmV (%d%%)", battery_start.volt1, battery_start.percent1) + 1;
-		char *ptr = (char *)malloc(stringsize);
+		std::string str = format_string_std("%dmV (%d%%)", battery_start.volt1, battery_start.percent1);
+		add_extra_data(state.cur_dc, "Battery 1 (start)", str.c_str());
 
-		if (ptr) {
-			snprintf(ptr, stringsize, "%dmV (%d%%)", battery_start.volt1, battery_start.percent1);
-			add_extra_data(state.cur_dc, "Battery 1 (start)", ptr);
-			free(ptr);
-		}
-
-		stringsize = snprintf(NULL, 0, "%dmV (%d%%)", battery_start.volt2, battery_start.percent2) + 1;
-		ptr = (char *)malloc(stringsize);
-		if (ptr) {
-			snprintf(ptr, stringsize, "%dmV (%d%%)", battery_start.volt2, battery_start.percent2);
-			add_extra_data(state.cur_dc, "Battery 2 (start)", ptr);
-			free(ptr);
-		}
+		str = format_string_std("%dmV (%d%%)", battery_start.volt2, battery_start.percent2);
+		add_extra_data(state.cur_dc, "Battery 2 (start)", str.c_str());
 	}
 
 	/* Recording the ending battery status to extra data */
 	if (battery_end.volt1) {
-		size_t stringsize = snprintf(NULL, 0, "%dmV (%d%%)", battery_end.volt1, battery_end.percent1) + 1;
-		char *ptr = (char *)malloc(stringsize);
+		std::string str = format_string_std("%dmV (%d%%)", battery_end.volt1, battery_end.percent1);
+		add_extra_data(state.cur_dc, "Battery 1 (end)", str.c_str());
 
-		if (ptr) {
-			snprintf(ptr, stringsize, "%dmV (%d%%)", battery_end.volt1, battery_end.percent1);
-			add_extra_data(state.cur_dc, "Battery 1 (end)", ptr);
-			free(ptr);
-		}
-
-		stringsize = snprintf(NULL, 0, "%dmV (%d%%)", battery_end.volt2, battery_end.percent2) + 1;
-		ptr = (char *)malloc(stringsize);
-		if (ptr) {
-			snprintf(ptr, stringsize, "%dmV (%d%%)", battery_end.volt2, battery_end.percent2);
-			add_extra_data(state.cur_dc, "Battery 2 (end)", ptr);
-			free(ptr);
-		}
+		str = format_string_std("%dmV (%d%%)", battery_end.volt2, battery_end.percent2);
+		add_extra_data(state.cur_dc, "Battery 2 (end)", str.c_str());
 	}
 
 	divecomputer_end(&state);

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -24,7 +24,6 @@ parser_state::~parser_state()
 	free_dive(cur_dive);
 	free_trip(cur_trip);
 	free_dive_site(cur_dive_site);
-	free_filter_preset(cur_filter);
 	free((void *)cur_extra_data.key);
 	free((void *)cur_extra_data.value);
 }
@@ -213,14 +212,13 @@ void filter_preset_start(struct parser_state *state)
 {
 	if (state->cur_filter)
 		return;
-	state->cur_filter = alloc_filter_preset();
+	state->cur_filter = std::make_unique<filter_preset>();
 }
 
 void filter_preset_end(struct parser_state *state)
 {
-	add_filter_preset_to_table(state->cur_filter, state->log->filter_presets);
-	free_filter_preset(state->cur_filter);
-	state->cur_filter = NULL;
+	add_filter_preset_to_table(state->cur_filter.get(), state->log->filter_presets);
+	state->cur_filter.reset();
 }
 
 void fulltext_start(struct parser_state *state)
@@ -234,7 +232,7 @@ void fulltext_end(struct parser_state *state)
 {
 	if (!state->in_fulltext)
 		return;
-	filter_preset_set_fulltext(state->cur_filter, state->fulltext.c_str(), state->fulltext_string_mode.c_str());
+	filter_preset_set_fulltext(state->cur_filter.get(), state->fulltext.c_str(), state->fulltext_string_mode.c_str());
 	state->fulltext.clear();
 	state->fulltext_string_mode.clear();
 	state->in_fulltext = false;
@@ -251,7 +249,7 @@ void filter_constraint_end(struct parser_state *state)
 {
 	if (!state->in_filter_constraint)
 		return;
-	filter_preset_add_constraint(state->cur_filter, state->filter_constraint_type.c_str(), state->filter_constraint_string_mode.c_str(),
+	filter_preset_add_constraint(state->cur_filter.get(), state->filter_constraint_type.c_str(), state->filter_constraint_string_mode.c_str(),
 				     state->filter_constraint_range_mode.c_str(), state->filter_constraint_negate, state->filter_constraint.c_str());
 
 	state->filter_constraint_type.clear();

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -24,8 +24,6 @@ parser_state::~parser_state()
 	free_dive(cur_dive);
 	free_trip(cur_trip);
 	free_dive_site(cur_dive_site);
-	free((void *)cur_extra_data.key);
-	free((void *)cur_extra_data.value);
 }
 
 /*

--- a/core/parse.h
+++ b/core/parse.h
@@ -88,7 +88,7 @@ struct parser_state {
 	int lastcylinderindex = 0, next_o2_sensor = 0;
 	int o2pressure_sensor = 0;
 	int sample_rate = 0;
-	struct extra_data cur_extra_data{ 0 };
+	struct { std::string key; std::string value; } cur_extra_data;
 	struct units xml_parsing_units;
 	struct divelog *log = nullptr;				/* non-owning */
 	struct fingerprint_table *fingerprints = nullptr;	/* non-owning */

--- a/core/parse.h
+++ b/core/parse.h
@@ -10,6 +10,7 @@
 #include "filterpreset.h"
 #include "picture.h"
 
+#include <memory>
 #include <sqlite3.h>
 #include <time.h>
 
@@ -68,7 +69,7 @@ struct parser_state {
 	struct dive_trip *cur_trip = nullptr;			/* owning */
 	struct sample *cur_sample = nullptr;			/* non-owning */
 	struct picture cur_picture { 0 };			/* owning */
-	struct filter_preset *cur_filter = nullptr;		/* owning */
+	std::unique_ptr<filter_preset> cur_filter;		/* owning */
 	std::string fulltext;					/* owning */
 	std::string fulltext_string_mode;			/* owning */
 	std::string filter_constraint_type;			/* owning */

--- a/core/parse.h
+++ b/core/parse.h
@@ -102,7 +102,6 @@ extern "C" {
 void init_parser_state(struct parser_state *state);
 void free_parser_state(struct parser_state *state);
 
-int trimspace(char *buffer);
 void start_match(const char *type, const char *name, char *buffer);
 void nonmatch(const char *type, const char *name, char *buffer);
 void event_start(struct parser_state *state);
@@ -143,9 +142,9 @@ void divecomputer_start(struct parser_state *state);
 void divecomputer_end(struct parser_state *state);
 void userid_start(struct parser_state *state);
 void userid_stop(struct parser_state *state);
-void utf8_string(char *buffer, void *_res);
+void utf8_string(const char *buffer, void *_res);
 
-void add_dive_site(char *ds_name, struct dive *dive, struct parser_state *state);
+void add_dive_site(const char *ds_name, struct dive *dive, struct parser_state *state);
 int atoi_n(char *ptr, unsigned int len);
 
 void parse_xml_init(void);
@@ -161,6 +160,8 @@ int parse_divinglog_buffer(sqlite3 *handle, const char *url, const char *buf, in
 int parse_dlf_buffer(unsigned char *buffer, size_t size, struct divelog *log);
 #ifdef __cplusplus
 }
+#include <string>
+std::string trimspace(const char *buffer);
 #endif
 
 #endif

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1007,10 +1007,9 @@ QString get_short_dive_date_string(timestamp_t when)
 	return loc.toString(ts.toUTC(), QString(prefs.date_format_short) + " " + prefs.time_format);
 }
 
-char *get_dive_date_c_string(timestamp_t when)
+std::string get_dive_date_c_string(timestamp_t when)
 {
-	QString text = get_short_dive_date_string(when);
-	return copy_qstring(text);
+	return get_short_dive_date_string(when).toStdString();
 }
 
 static QString get_dive_only_date_string(timestamp_t when)

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -115,9 +115,9 @@ QString printGPSCoords(const location_t *location)
 	return result;
 }
 
-extern "C" char *printGPSCoordsC(const location_t *location)
+std::string printGPSCoordsC(const location_t *location)
 {
-	return copy_qstring(printGPSCoords(location));
+	return printGPSCoords(location).toStdString();
 }
 
 /**

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -434,11 +434,9 @@ QString getUserAgent()
 
 }
 
-extern "C" const char *subsurface_user_agent()
+std::string subsurface_user_agent()
 {
-	static QString uA = getUserAgent();
-
-	return copy_qstring(uA);
+	return getUserAgent().toStdString();
 }
 
 QString getUiLanguage()
@@ -1396,13 +1394,13 @@ extern "C" char *cloud_url()
 	return copy_qstring(filename);
 }
 
-extern "C" const char *normalize_cloud_name(const char *remote_in)
+std::string normalize_cloud_name(const char *remote_in)
 {
 	// replace ssrf-cloud-XX.subsurface... names with cloud.subsurface... names
 	// that trailing '/' is to match old code
 	QString ri(remote_in);
 	ri.replace(QRegularExpression(CLOUD_HOST_PATTERN), CLOUD_HOST_GENERIC "/");
-	return strdup(ri.toUtf8().constData());
+	return ri.toStdString();
 }
 
 extern "C" bool getProxyString(char **buffer)
@@ -1627,12 +1625,10 @@ void uiNotification(const QString &msg)
 // function to call to get changes for a git commit
 QString (*changesCallback)() = nullptr;
 
-extern "C" char *get_changes_made()
+std::string get_changes_made()
 {
-	if (changesCallback != nullptr)
-		return copy_qstring(changesCallback());
-	else
-		return nullptr;
+	return changesCallback != nullptr ? changesCallback().toStdString()
+					  : std::string();
 }
 
 // Generate a cylinder-renumber map for use when the n-th cylinder

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -98,6 +98,9 @@ std::vector<int> get_cylinder_map_for_add(int count, int n);
 
 extern QString (*changesCallback)();
 void uiNotification(const QString &msg);
+std::string get_changes_made();
+std::string subsurface_user_agent();
+std::string normalize_cloud_name(const char *remote_in);
 
 #if defined __APPLE__
 #define TITLE_OR_TEXT(_t, _m) "", _t + "\n" + _m
@@ -126,10 +129,8 @@ void copy_image_and_overwrite(const char *cfileName, const char *path, const cha
 char *move_away(const char *path);
 const char *local_file_path(struct picture *picture);
 char *cloud_url();
-const char *normalize_cloud_name(const char *remote_in);
 char *hashfile_name_string();
 char *picturedir_string();
-const char *subsurface_user_agent();
 enum deco_mode decoMode(bool in_planner);
 void parse_seabear_header(const char *filename, struct xml_params *params);
 char *get_current_date();
@@ -143,7 +144,6 @@ depth_t string_to_depth(const char *str);
 pressure_t string_to_pressure(const char *str);
 volume_t string_to_volume(const char *str, pressure_t workp);
 fraction_t string_to_fraction(const char *str);
-char *get_changes_made();
 void emit_reset_signal();
 
 extern void report_info(const char *fmt, ...);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -84,6 +84,7 @@ QString render_seconds_to_string(int seconds);
 QString get_dive_duration_string(timestamp_t when, QString hoursText, QString minutesText, QString secondsText = gettextFromC::tr("sec"), QString separator = ":", bool isFreeDive = false);
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);
+std::string get_dive_date_c_string(timestamp_t when);
 QString get_first_dive_date_string();
 QString get_last_dive_date_string();
 QString get_short_dive_date_string(timestamp_t when);

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -93,6 +93,7 @@ QLocale getLocale();
 QVector<QPair<QString, int>> selectedDivesGasUsed();
 QString getUserAgent();
 QString printGPSCoords(const location_t *loc);
+std::string printGPSCoordsC(const location_t *loc);
 std::vector<int> get_cylinder_map_for_remove(int count, int n);
 std::vector<int> get_cylinder_map_for_add(int count, int n);
 
@@ -118,7 +119,6 @@ extern "C" {
 
 struct git_info;
 
-char *printGPSCoordsC(const location_t *loc);
 bool getProxyString(char **buffer);
 bool canReachCloudServer(struct git_info *);
 void updateWindowTitle();

--- a/core/sample.cpp
+++ b/core/sample.cpp
@@ -2,6 +2,28 @@
 
 #include "sample.h"
 
+sample::sample() :
+	time({ 0 }),
+	stoptime({ 0 }),
+	ndl({ -1 }),
+	tts({ 0 }),
+	rbt({ 0 }),
+	depth({ 0 }),
+	stopdepth({ 0 }),
+	temperature({ 0 }),
+	pressure { { 0 }, { 0 } },
+	setpoint({ 0 }),
+	o2sensor { { 0 }, { 0 }, { 0 }, { 0 }, { 0 }, { 0 } },
+	bearing({ -1 }),
+	sensor { 0, 0 },
+	cns(0),
+	heartbeat(0),
+	sac({ 0 }),
+	in_deco(false),
+	manually_entered(false)
+{
+}
+
 /*
  * Adding a cylinder pressure sample field is not quite as trivial as it
  * perhaps should be.
@@ -15,7 +37,7 @@
  * from the previous sample, so the indices are pre-populated (but the
  * pressures obviously are not)
  */
-void add_sample_pressure(struct sample *sample, int sensor, int mbar)
+extern "C" void add_sample_pressure(struct sample *sample, int sensor, int mbar)
 {
 	int idx;
 
@@ -42,4 +64,3 @@ void add_sample_pressure(struct sample *sample, int sensor, int mbar)
 	/* We do not have enough slots for the pressure samples. */
 	/* Should we warn the user about dropping pressure data? */
 }
-

--- a/core/sample.h
+++ b/core/sample.h
@@ -33,6 +33,9 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	bool in_deco;                     // bool       1    y/n      y/n                  this sample is part of deco
 	bool manually_entered;            // bool       1    y/n      y/n                  this sample was entered by the user,
 					  //                                               not calculated when planning a dive
+#ifdef __cplusplus
+	sample();			  // Default constructor
+#endif
 };	                                  // Total size of structure: 63 bytes, excluding padding at end
 
 extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -957,7 +957,6 @@ static void format_one_filter_constraint(int preset_id, int constraint_id, struc
 {
 	const struct filter_constraint *constraint = filter_preset_constraint(preset_id, constraint_id);
 	const char *type = filter_constraint_type_to_string(constraint->type);
-	char *data;
 
 	show_utf8(b, "constraint type=", type, "");
 	if (filter_constraint_has_string_mode(constraint->type)) {
@@ -970,9 +969,8 @@ static void format_one_filter_constraint(int preset_id, int constraint_id, struc
 	}
 	if (constraint->negate)
 		put_format(b, " negate");
-	data = filter_constraint_data_to_string(constraint);
-	show_utf8(b, " data=", data, "\n");
-	free(data);
+	std::string data = filter_constraint_data_to_string(constraint);
+	show_utf8(b, " data=", data.c_str(), "\n");
 }
 
 /*

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -984,18 +984,14 @@ static void format_one_filter_constraint(int preset_id, int constraint_id, struc
  */
 static void format_one_filter_preset(int preset_id, struct membuffer *b)
 {
-	char *name, *fulltext;
+	std::string name = filter_preset_name(preset_id);
+	show_utf8(b, "name ", name.c_str(), "\n");
 
-	name = filter_preset_name(preset_id);
-	show_utf8(b, "name ", name, "\n");
-	free(name);
-
-	fulltext = filter_preset_fulltext_query(preset_id);
-	if (!empty_string(fulltext)) {
+	std::string fulltext = filter_preset_fulltext_query(preset_id);
+	if (!fulltext.empty()) {
 		show_utf8(b, "fulltext mode=", filter_preset_fulltext_mode(preset_id), "");
-		show_utf8(b, " query=", fulltext, "\n");
+		show_utf8(b, " query=", fulltext.c_str(), "\n");
 	}
-	free(fulltext);
 
 	for (int i = 0; i < filter_preset_constraint_count(preset_id); i++)
 		format_one_filter_constraint(preset_id, i, b);

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -881,14 +881,12 @@ static void save_one_device(struct membuffer *b, const struct device *d)
 
 static void save_one_fingerprint(struct membuffer *b, int i)
 {
-	char *fp_data = fp_get_data(&fingerprint_table, i);
 	put_format(b, "fingerprint model=%08x serial=%08x deviceid=%08x diveid=%08x data=\"%s\"\n",
 		   fp_get_model(&fingerprint_table, i),
 		   fp_get_serial(&fingerprint_table, i),
 		   fp_get_deviceid(&fingerprint_table, i),
 		   fp_get_diveid(&fingerprint_table, i),
-		   fp_data);
-	free(fp_data);
+		   fp_get_data(&fingerprint_table, i).c_str());
 }
 
 static void save_settings(git_repository *repo, struct dir *tree)

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -1143,12 +1143,12 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 {
 	int nr = divelog.dives->nr;
 	struct dive *dive = get_dive(nr-1);
-	char* changes_made = get_changes_made();
+	std::string changes_made = get_changes_made();
 
 	if (create_empty) {
 		put_string(msg, "Initial commit to create empty repo.\n\n");
-	} else if (!empty_string(changes_made)) {
-		put_format(msg, "Changes made: \n\n%s\n", changes_made);
+	} else if (!changes_made.empty()) {
+		put_format(msg, "Changes made: \n\n%s\n", changes_made.c_str());
 	} else if (dive) {
 		dive_trip_t *trip = dive->divetrip;
 		const char *location = get_dive_location(dive) ? : "no location";
@@ -1170,10 +1170,7 @@ static void create_commit_message(struct membuffer *msg, bool create_empty)
 		} while ((dc = dc->next) != NULL);
 		put_format(msg, "\n");
 	}
-	const char *user_agent = subsurface_user_agent();
-	put_format(msg, "Created by %s\n", user_agent);
-	free((void *)user_agent);
-	free(changes_made);
+	put_format(msg, "Created by %s\n", subsurface_user_agent().c_str());
 	if (verbose)
 		SSRF_INFO("Commit message:\n\n%s\n", mb_cstring(msg));
 }

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -1193,19 +1193,19 @@ static int create_new_commit(struct git_info *info, git_oid *tree_id, bool creat
 		return report_error("Invalid branch name '%s'", info->branch);
 	case GIT_ENOTFOUND: /* We'll happily create it */
 		ref = NULL;
-		parent = try_to_find_parent(saved_git_id, info->repo);
+		parent = try_to_find_parent(saved_git_id.c_str(), info->repo);
 		break;
 	case 0:
 		if (git_reference_peel(&parent, ref, GIT_OBJ_COMMIT))
 			return report_error("Unable to look up parent in branch '%s'", info->branch);
 
-		if (saved_git_id) {
+		if (!saved_git_id.empty()) {
 			if (existing_filename && verbose)
 				SSRF_INFO("existing filename %s\n", existing_filename);
 			const git_oid *id = git_commit_id((const git_commit *) parent);
 			/* if we are saving to the same git tree we got this from, let's make
 			 * sure there is no confusion */
-			if (same_string(existing_filename, info->url) && git_oid_strcmp(id, saved_git_id))
+			if (same_string(existing_filename, info->url) && git_oid_strcmp(id, saved_git_id.c_str()))
 				return report_error("The git branch does not match the git parent of the source");
 		}
 
@@ -1321,7 +1321,7 @@ extern "C" int do_git_save(struct git_info *info, bool select_only, bool create_
 	 * Check if we can do the cached writes - we need to
 	 * have the original git commit we loaded in the repo
 	 */
-	cached_ok = try_to_find_parent(saved_git_id, info->repo);
+	cached_ok = try_to_find_parent(saved_git_id.c_str(), info->repo);
 
 	/* Start with an empty tree: no subdirectories, no files */
 	if (git_treebuilder_new(&tree.files, info->repo, NULL))

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -620,14 +620,12 @@ static void save_one_device(struct membuffer *b, const struct device *d)
 
 static void save_one_fingerprint(struct membuffer *b, int i)
 {
-	char *data = fp_get_data(&fingerprint_table, i);
 	put_format(b, "<fingerprint model='%08x' serial='%08x' deviceid='%08x' diveid='%08x' data='%s'/>\n",
 		   fp_get_model(&fingerprint_table, i),
 		   fp_get_serial(&fingerprint_table, i),
 		   fp_get_deviceid(&fingerprint_table, i),
 		   fp_get_diveid(&fingerprint_table, i),
-		   data);
-	free(data);
+		   fp_get_data(&fingerprint_table, i).c_str());
 }
 
 extern "C" int save_dives(const char *filename)

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -641,20 +641,17 @@ static void save_filter_presets(struct membuffer *b)
 		return;
 	put_format(b, "<filterpresets>\n");
 	for (i = 0; i < filter_presets_count(); i++) {
-		char *name, *fulltext;
-		name = filter_preset_name(i);
+		std::string name = filter_preset_name(i);
 		put_format(b, " <filterpreset");
-		show_utf8(b, name, " name='", "'", 1);
+		show_utf8(b, name.c_str(), " name='", "'", 1);
 		put_format(b, ">\n");
-		free(name);
 
-		fulltext = filter_preset_fulltext_query(i);
-		if (!empty_string(fulltext)) {
+		std::string fulltext = filter_preset_fulltext_query(i);
+		if (!fulltext.empty()) {
 			const char *fulltext_mode = filter_preset_fulltext_mode(i);
 			show_utf8(b, fulltext_mode, "  <fulltext mode='", "'>", 1);
-			show_utf8(b, fulltext, "", "</fulltext>\n", 0);
+			show_utf8(b, fulltext.c_str(), "", "</fulltext>\n", 0);
 		}
-		free(fulltext);
 
 		for (int j = 0; j < filter_preset_constraint_count(i); j++) {
 			const struct filter_constraint *constraint = filter_preset_constraint(i, j);

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -657,7 +657,6 @@ static void save_filter_presets(struct membuffer *b)
 		free(fulltext);
 
 		for (int j = 0; j < filter_preset_constraint_count(i); j++) {
-			char *data;
 			const struct filter_constraint *constraint = filter_preset_constraint(i, j);
 			const char *type = filter_constraint_type_to_string(constraint->type);
 			put_format(b, "  <constraint");
@@ -673,9 +672,8 @@ static void save_filter_presets(struct membuffer *b)
 			if (constraint->negate)
 				put_format(b, " negate='1'");
 			put_format(b, ">");
-			data = filter_constraint_data_to_string(constraint);
-			show_utf8(b, data, "", "", 0);
-			free(data);
+			std::string data = filter_constraint_data_to_string(constraint);
+			show_utf8(b, data.c_str(), "", "", 0);
 			put_format(b, "</constraint>\n");
 		}
 		put_format(b, " </filterpreset>\n");

--- a/core/sha1.h
+++ b/core/sha1.h
@@ -8,6 +8,10 @@
 #ifndef SHA1_H
 #define SHA1_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct
 {
 	unsigned long long size;
@@ -34,5 +38,9 @@ static inline void SHA1(const void *dataIn, unsigned long len, unsigned char has
 	SHA1_Update(&ctx, dataIn, len);
 	SHA1_Final(hashout, &ctx);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // SHA1_H

--- a/core/strndup.h
+++ b/core/strndup.h
@@ -8,7 +8,7 @@ static char *strndup (const char *s, size_t n)
 	size_t len = strlen(s);
 	if (n < len)
 		len = n;
-	if ((cpy = malloc(len + 1)) !=
+	if ((cpy = (char *)malloc(len + 1)) !=
 	    NULL) {
 		cpy[len] =
 				'\0';

--- a/core/structured_list.h
+++ b/core/structured_list.h
@@ -13,17 +13,17 @@
 		}                                  \
 	}
 
-#define STRUCTURED_LIST_COPY(_type, _first, _dest, _cpy) \
-	{                                                \
-		_type *_sptr = _first;                   \
-		_type **_dptr = &_dest;                  \
-		while (_sptr) {                          \
-			*_dptr = malloc(sizeof(_type));  \
-			_cpy(_sptr, *_dptr);             \
-			_sptr = _sptr->next;             \
-			_dptr = &(*_dptr)->next;         \
-		}                                        \
-		*_dptr = 0;                              \
+#define STRUCTURED_LIST_COPY(_type, _first, _dest, _cpy)          \
+	{                                                         \
+		_type *_sptr = _first;                            \
+		_type **_dptr = &_dest;                           \
+		while (_sptr) {                                   \
+			*_dptr = (_type *)malloc(sizeof(_type));  \
+			_cpy(_sptr, *_dptr);                      \
+			_sptr = _sptr->next;                      \
+			_dptr = &(*_dptr)->next;                  \
+		}                                                 \
+		*_dptr = 0;                                       \
 	}
 
 #endif

--- a/core/subsurface-string.h
+++ b/core/subsurface-string.h
@@ -60,5 +60,21 @@ extern double strtod_flags(const char *str, const char **ptr, unsigned int flags
 
 #ifdef __cplusplus
 }
+
+#include <string>
+template <class... Args>
+std::string format_string_std(const char *fmt, Args&&... args)
+{
+	size_t stringsize = snprintf(NULL, 0, fmt, std::forward<Args>(args)...);
+	if (stringsize == 0)
+		return std::string();
+	std::string res;
+	res.resize(stringsize); // Pointless clearing, oh my.
+	// This overwrites the terminal null-byte of std::string.
+	// That's probably "undefined behavior". Oh my.
+	snprintf(res.data(), stringsize + 1, fmt, std::forward<Args>(args)...);
+	return res;
+}
+
 #endif
 #endif // SUBSURFACE_STRING_H

--- a/core/subsurface-time.h
+++ b/core/subsurface-time.h
@@ -16,12 +16,15 @@ extern int utc_weekday(timestamp_t timestamp);
 
 /* parse and format date times of the form YYYY-MM-DD hh:mm:ss */
 extern timestamp_t parse_datetime(const char *s); /* returns 0 on error */
-extern char *format_datetime(timestamp_t timestamp); /* ownership of string passed to caller */
 
 extern const char *monthname(int mon);
 
 #ifdef __cplusplus
 }
+
+#include <string>
+std::string format_datetime(timestamp_t timestamp); /* ownership of string passed to caller */
+
 #endif
 
 #endif

--- a/core/subsurfacestartup.cpp
+++ b/core/subsurfacestartup.cpp
@@ -17,7 +17,7 @@ extern void show_computer_list();
 
 int quit, force_root, ignore_bt;
 #ifdef SUBSURFACE_MOBILE_DESKTOP
-char *testqml = NULL;
+std::string testqml;
 #endif
 
 /*
@@ -169,8 +169,7 @@ extern "C" void parse_argument(const char *arg)
 			}
 #elif SUBSURFACE_MOBILE_DESKTOP
 			if (strncmp(arg, "--testqml=", sizeof("--testqml=") - 1) == 0) {
-				testqml = (char *)malloc(strlen(arg) - sizeof("--testqml=") + 1);
-				strcpy(testqml, arg + sizeof("--testqml=") - 1);
+				testqml = arg + sizeof("--testqml=") - 1;
 				return;
 			}
 #endif

--- a/core/subsurfacestartup.cpp
+++ b/core/subsurfacestartup.cpp
@@ -25,7 +25,7 @@ char *testqml = NULL;
  */
 bool imported = false;
 
-void print_version()
+extern "C" void print_version()
 {
 	static bool version_printed = false;
 	if (version_printed)
@@ -43,7 +43,7 @@ void print_version()
 	version_printed = true;
 }
 
-void print_files()
+extern "C" void print_files()
 {
 	struct git_info info = { };
 	const char *filename;
@@ -95,7 +95,7 @@ static void print_help()
 	printf("\n --cloud-timeout=<nr>  Set timeout for cloud connection (0 < timeout < 60)\n\n");
 }
 
-void parse_argument(const char *arg)
+extern "C" void parse_argument(const char *arg)
 {
 	const char *p = arg + 1;
 
@@ -169,7 +169,7 @@ void parse_argument(const char *arg)
 			}
 #elif SUBSURFACE_MOBILE_DESKTOP
 			if (strncmp(arg, "--testqml=", sizeof("--testqml=") - 1) == 0) {
-				testqml = malloc(strlen(arg) - sizeof("--testqml=") + 1);
+				testqml = (char *)malloc(strlen(arg) - sizeof("--testqml=") + 1);
 				strcpy(testqml, arg + sizeof("--testqml=") - 1);
 				return;
 			}
@@ -198,7 +198,7 @@ void parse_argument(const char *arg)
  * I guess Burma and Liberia should trigger this too. I'm too
  * lazy to look up the territory names, though.
  */
-void setup_system_prefs(void)
+extern "C" void setup_system_prefs(void)
 {
 	const char *env;
 

--- a/core/subsurfacestartup.h
+++ b/core/subsurfacestartup.h
@@ -10,9 +10,6 @@ extern "C" {
 
 extern bool imported;
 extern int quit, force_root, ignore_bt;
-#ifdef SUBSURFACE_MOBILE_DESKTOP
-extern char *testqml;
-#endif
 
 void setup_system_prefs(void);
 void parse_argument(const char *arg);
@@ -24,6 +21,12 @@ extern char *settings_suffix;
 
 #ifdef __cplusplus
 }
+
+#ifdef SUBSURFACE_MOBILE_DESKTOP
+#include <string>
+extern std::string testqml;
+#endif
+
 #endif
 
 #endif // SUBSURFACESTARTUP_H

--- a/core/time.cpp
+++ b/core/time.cpp
@@ -2,6 +2,7 @@
 #include "subsurface-time.h"
 #include "subsurface-string.h"
 #include "gettext.h"
+#include <QtCore> // for QT_TRANSLATE_NOOP
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,7 +33,7 @@
  * are unnecessary once you're counting minutes (32-bit minutes:
  * 8000+ years).
  */
-void utc_mkdate(timestamp_t timestamp, struct tm *tm)
+extern "C" void utc_mkdate(timestamp_t timestamp, struct tm *tm)
 {
 	static const unsigned int mdays[] = {
 		31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
@@ -99,7 +100,7 @@ void utc_mkdate(timestamp_t timestamp, struct tm *tm)
 	tm->tm_mon = m;
 }
 
-timestamp_t utc_mktime(const struct tm *tm)
+extern "C" timestamp_t utc_mktime(const struct tm *tm)
 {
 	static const int mdays[] = {
 		0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
@@ -146,7 +147,7 @@ timestamp_t utc_mktime(const struct tm *tm)
  * out unused calculations. If it turns out to be a bottle neck
  * we will have to cache a struct tm per dive.
  */
-int utc_year(timestamp_t timestamp)
+extern "C" int utc_year(timestamp_t timestamp)
 {
 	struct tm tm;
 	utc_mkdate(timestamp, &tm);
@@ -161,7 +162,7 @@ int utc_year(timestamp_t timestamp)
  * at throwing out unused calculations, so this is more efficient
  * than it looks.
  */
-int utc_weekday(timestamp_t timestamp)
+extern "C" int utc_weekday(timestamp_t timestamp)
 {
 	struct tm tm;
 	utc_mkdate(timestamp, &tm);
@@ -173,7 +174,7 @@ int utc_weekday(timestamp_t timestamp)
  * an 64-bit decimal and return 64-bit timestamp. On failure or
  * if passed an empty string, return 0.
  */
-extern timestamp_t parse_datetime(const char *s)
+extern "C" timestamp_t parse_datetime(const char *s)
 {
 	int y, m, d;
 	int hr, min, sec;
@@ -200,19 +201,19 @@ extern timestamp_t parse_datetime(const char *s)
  * Format 64-bit timestamp in the form "YYYY-MM-DD hh:mm:ss".
  * Returns the empty string for timestamp = 0
  */
-extern char *format_datetime(timestamp_t timestamp)
+std::string format_datetime(timestamp_t timestamp)
 {
 	char buf[32];
 	struct tm tm;
 
 	if (!timestamp)
-		return strdup("");
+		return std::string();
 
 	utc_mkdate(timestamp, &tm);
 	snprintf(buf, sizeof(buf), "%04u-%02u-%02u %02u:%02u:%02u",
 		 tm.tm_year, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
 
-	return strdup(buf);
+	return std::string(buf);
 }
 
 /* Turn month (0-12) into three-character short name */

--- a/core/units.c
+++ b/core/units.c
@@ -3,6 +3,15 @@
 #include "gettext.h"
 #include "pref.h"
 
+#define IMPERIAL_UNITS                                                                                     \
+        {                                                                                                  \
+	        .length = FEET, .volume = CUFT, .pressure = PSI, .temperature = FAHRENHEIT, .weight = LBS, \
+		.vertical_speed_time = MINUTES, .duration_units = MIXED, .show_units_table = false         \
+        }
+
+const struct units SI_units = SI_UNITS;
+const struct units IMPERIAL_units = IMPERIAL_UNITS;
+
 int get_pressure_units(int mb, const char **units)
 {
 	int pressure;

--- a/core/units.h
+++ b/core/units.h
@@ -333,12 +333,6 @@ struct units {
 		.vertical_speed_time = MINUTES, .duration_units = MIXED, .show_units_table = false         \
         }
 
-#define IMPERIAL_UNITS                                                                                     \
-        {                                                                                                  \
-	        .length = FEET, .volume = CUFT, .pressure = PSI, .temperature = FAHRENHEIT, .weight = LBS, \
-		.vertical_speed_time = MINUTES, .duration_units = MIXED, .show_units_table = false         \
-        }
-
 extern const struct units SI_units, IMPERIAL_units;
 
 extern const struct units *get_units(void);

--- a/desktop-widgets/filterwidget.cpp
+++ b/desktop-widgets/filterwidget.cpp
@@ -227,7 +227,7 @@ void FilterWidget::updatePresetLabel()
 	int presetId = selectedPreset();
 	QString text;
 	if (presetId >= 0) {
-		text = filter_preset_name_qstring(presetId);
+		text = QString(filter_preset_name(presetId).c_str());
 		if (presetModified)
 			text += " (" + tr("modified") + ")";
 	}
@@ -240,13 +240,13 @@ void FilterWidget::on_addSetButton_clicked()
 	// Thus, if the user selects an item and modify the filter,
 	// they can simply overwrite the preset.
 	int presetId = selectedPreset();
-	QString selectedPreset = presetId >= 0 ? filter_preset_name_qstring(presetId) : QString();
+	QString selectedPreset = presetId >= 0 ? QString(filter_preset_name(presetId).c_str()) : QString();
 
 	AddFilterPresetDialog dialog(selectedPreset, this);
 	QString name = dialog.doit();
 	if (name.isEmpty())
 		return;
-	int idx = filter_preset_id(name);
+	int idx = filter_preset_id(name.toStdString());
 	if (idx >= 0)
 		Command::editFilterPreset(idx, createFilterData());
 	else

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -385,7 +385,7 @@ AddFilterPresetDialog::AddFilterPresetDialog(const QString &defaultName, QWidget
 	int count = filter_presets_count();
 	presets.reserve(count);
 	for (int i = 0; i < count; ++i)
-		presets.push_back(filter_preset_name_qstring(i));
+		presets.push_back(QString(filter_preset_name(i).c_str()));
 	QCompleter *completer = new QCompleter(presets, this);
 	completer->setCaseSensitivity(Qt::CaseInsensitive);
 	ui.name->setCompleter(completer);
@@ -395,7 +395,7 @@ void AddFilterPresetDialog::nameChanged(const QString &text)
 {
 	QString trimmed = text.trimmed();
 	bool isEmpty = trimmed.isEmpty();
-	bool exists = !isEmpty && filter_preset_id(trimmed) >= 0;
+	bool exists = !isEmpty && filter_preset_id(trimmed.toStdString()) >= 0;
 	ui.duplicateWarning->setVisible(exists);
 	ui.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!isEmpty);
 }

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -287,13 +287,13 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 										      formatDiveDuration(d));
 	case MobileListModel::RatingRole: return d->rating;
 	case MobileListModel::VizRole: return d->visibility;
-	case MobileListModel::SuitRole: return d->suit;
+	case MobileListModel::SuitRole: return QString(d->suit);
 	case MobileListModel::AirTempRole: return get_temperature_string(d->airtemp, true);
 	case MobileListModel::WaterTempRole: return get_temperature_string(d->watertemp, true);
 	case MobileListModel::SacRole: return formatSac(d);
 	case MobileListModel::SumWeightRole: return formatSumWeight(d);
-	case MobileListModel::DiveGuideRole: return d->diveguide;
-	case MobileListModel::BuddyRole: return d->buddy;
+	case MobileListModel::DiveGuideRole: return QString(d->diveguide);
+	case MobileListModel::BuddyRole: return QString(d->buddy);
 	case MobileListModel::TagsRole: return get_taglist_string(d->tag_list);
 	case MobileListModel::NotesRole: return formatNotes(d);
 	case MobileListModel::GpsRole: return formatDiveGPS(d);

--- a/qt-models/filterpresetmodel.cpp
+++ b/qt-models/filterpresetmodel.cpp
@@ -32,7 +32,7 @@ QVariant FilterPresetModel::data(const QModelIndex &index, int role) const
 	switch (role) {
 	case Qt::DisplayRole:
 		if (index.column() == NAME)
-			return filter_preset_name_qstring(index.row());
+			return QString(filter_preset_name(index.row()).c_str());
 		break;
 	case Qt::DecorationRole:
 		if (index.column() == REMOVE)

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -133,8 +133,8 @@ void run_mobile_ui(double initial_font_size)
 	qmlRegisterUncreatableType<QMLManager>("org.subsurfacedivelog.mobile",1,0,"ExportType","Enum is not a type");
 
 #ifdef SUBSURFACE_MOBILE_DESKTOP
-	if (testqml) {
-		QString fileLoad(testqml);
+	if (!testqml.empty()) {
+		QString fileLoad(testqml.c_str());
 		fileLoad += "/main.qml";
 		engine.load(QUrl(fileLoad));
 	} else {

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -237,10 +237,10 @@ void TestParse::testParseNewFormat()
 
 void TestParse::testParseDLD()
 {
-	struct memblock mem;
 	QString filename = SUBSURFACE_TEST_DATA "/dives/TestDiveDivelogsDE.DLD";
 
-	QVERIFY(readfile(filename.toLatin1().data(), &mem) > 0);
+	auto [mem, err] = readfile(filename.toLatin1().data());
+	QVERIFY(err > 0);
 	QVERIFY(try_to_open_zip(filename.toLatin1().data(), &divelog) > 0);
 
 	fprintf(stderr, "number of dives from DLD: %d \n", divelog.dives->nr);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I am convinced that we should port core structures to C++, notably strings and collections. Experience shows that again and again, we are unable to produce proper C code that doesn't leak left and right and can be reasoned about. Yes, some galaxy brains with infinite time can do this, but that's just not a luxury we have.

The end goal is to convert the core structures such as `struct dive`, etc. But since these are accessed everywhere, we first have to convert everything to at least compile in C++. This PR is a humble start, concerning mostly string handling of the parser. It is a very long way to go.

I want to do this in "smallish" packages and let them stabilize, otherwise things will get unmanageable for me.

Just by this mostly trivial replacement of C-strings by C++-strings, the memory leaked by `TestParser` got cut nearly in half:
```
==704562== LEAK SUMMARY:
==704562==    definitely lost: 4,010 bytes in 21 blocks
==704562==    indirectly lost: 13,657 bytes in 35 blocks
==704562==      possibly lost: 480 bytes in 1 blocks
==704562==    still reachable: 54,603 bytes in 371 blocks
==704562==         suppressed: 0 bytes in 0 blocks
```
vs
```
==705012== LEAK SUMMARY:
==705012==    definitely lost: 2,221 bytes in 18 blocks
==705012==    indirectly lost: 13,657 bytes in 35 blocks
==705012==      possibly lost: 0 bytes in 0 blocks
==705012==    still reachable: 20,581 bytes in 96 blocks
```

Comments:

- This is a pretty much automatic conversion and yes, there will be new bugs introduced.
- Yes, this introduces an intermediate state, which is quite ugly.
- This uses std::string, which has a performance regression: It clears the data when allocating. So when reading a file, the memory is cleared just to be overwritten. If someone shows me that this has a noticeable effect, I will solve this problem with a custom class, but not before. The reason for using std::string instead of vector<char>: std::string guarantees to have a trailing 0-byte *after* the actual data. The parser actually expects this behavior.

More to come...