### PR TITLE
Avoid unnecessary bluetooth device address scanning. 

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -642,7 +642,7 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 
 	if (state == Qt::Checked) {
 		if (ui.device->currentText().isEmpty()) 
-         		selectRemoteBluetoothDevice();
+			selectRemoteBluetoothDevice();
 	} else {
 		ui.device->setCurrentIndex(-1);
 	}

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -152,12 +152,10 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
-
 	/* If we have a Bluetooth device, set the ui.device->CurrentText to avoid starting \
    	a Bluetooth scan in enableBluetoothMode(). \
    	Note: enableBlueToothMode() will set ui.device.CurrentIndex to -1 unless \
     	ui.bluetoothMode is checked. */ \
-
 	if (isBluetoothDevice) \
 		ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	ui.bluetoothMode->setChecked(isBluetoothDevice); \

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -641,7 +641,7 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
 	if (state == Qt::Checked) {
-		if (ui.device->currentText().isEmpty()) 
+		if (!isBluetoothAddress(ui.device->currentText()))
 			selectRemoteBluetoothDevice();
 	} else {
 		ui.device->setCurrentIndex(-1);

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -152,24 +152,17 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
-	bool isMacOs = QSysInfo::kernelType() == "darwin"; \
-	/* If we have a Bluetooth address, use it instead of rescanning. For \
-	MacOs, save the mount point.  This may be the wrong thing to do, but for \
-	the Catalina 10.15.7 laptop and Oceanic Atom 3.1 I use, the mountpoint \
-	is /dev/tty.usbserial-20030001 and it doesn't change regardless of the \
-	USB port being used.   If it isn't saved, it must be reentered. */ \
-	if (isBluetoothDevice || isMacOs) \
+
+	/* If we have a Bluetooth device, set the ui.device->CurrentText to avoid starting \
+   	a Bluetooth scan in enableBluetoothMode(). \
+   	Note: enableBlueToothMode() will set ui.device.CurrentIndex to -1 unless \
+    	ui.bluetoothMode is checked. */ \
+
+	if (isBluetoothDevice) \
 		ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	ui.bluetoothMode->setChecked(isBluetoothDevice); \
 	if (ui.device->currentIndex() == -1 || isBluetoothDevice) \
 		ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
-	if (isMacOs) { \
-		/* it makes no sense that this would be needed on macOS but not Linux */ \
-		QCoreApplication::processEvents(); \
-		ui.vendor->update(); \
-		ui.product->update(); \
-		ui.device->update(); \
-	} \
 }
 #else
 #define DCBUTTON(num) \

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -641,11 +641,10 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
 	if (state == Qt::Checked) {
-      		if (ui.device->currentText().isEmpty()) {
+		if (ui.device->currentText().isEmpty()) 
          		selectRemoteBluetoothDevice();
-   		} else {
-      			ui.device->setCurrentIndex(-1);
-   		}
+	} else {
+		ui.device->setCurrentIndex(-1);
 	}
 }
 #endif

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -629,15 +629,14 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
 	/*	This is convoluted enough to warrant explanation:
- 		1. If we have a Bluetooth device, but no Bluetooth address then scan.
-		2. If we have a Bluetooth device and address, skip scan.
-		3. If it's not Bluetooth, clear the device address unless it's a Mac.
-		Mac USB addresses tend to be persistent and are better saved. */
+ 		1. If Bluetooth is enabled, but no Bluetooth address then scan.
+		2. If Bluetooth is enabled and we have a Bluetooth address, skip scan.
+		3. If Bluetooth is not enabled, but it's a Bluetooth address, clear it. */
 	if (state == Qt::Checked) {
 		if (!isBluetoothAddress(ui.device->currentText()))
 			selectRemoteBluetoothDevice();
 	} else
-		if (isBluetoothAddress(ui.device->currentText()) || QSysInfo::kernelType() != "darwin")
+		if (isBluetoothAddress(ui.device->currentText()))
 			ui.device->setCurrentIndex(-1);
 }
 #endif

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -151,16 +151,8 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
-	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
-	/* If we have a Bluetooth device, set the ui.device->CurrentText to avoid starting \
-   	a Bluetooth scan in enableBluetoothMode(). \
-   	Note: enableBlueToothMode() will set ui.device.CurrentIndex to -1 unless \
-    	ui.bluetoothMode is checked. */ \
-	if (isBluetoothDevice) \
-		ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
-	ui.bluetoothMode->setChecked(isBluetoothDevice); \
-	if (ui.device->currentIndex() == -1 || isBluetoothDevice) \
-		ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
+	ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
+	ui.bluetoothMode->setChecked(isBluetoothAddress(qPrefDiveComputer::device##num())); \
 }
 #else
 #define DCBUTTON(num) \
@@ -636,12 +628,17 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 {
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
+	/*	This is convoluted enough to warrant explanation:
+ 		1. If we have a Bluetooth device, but no Bluetooth address then scan.
+		2. If we have a Bluetooth device and address, skip scan.
+		3. If it's not Bluetooth, clear the device address unless it's a Mac.
+		Mac USB addresses tend to be persistent and are better saved. */
 	if (state == Qt::Checked) {
 		if (!isBluetoothAddress(ui.device->currentText()))
 			selectRemoteBluetoothDevice();
-	} else {
-		ui.device->setCurrentIndex(-1);
-	}
+	} else
+		if (isBluetoothAddress(ui.device->currentText()) || QSysInfo::kernelType() != "darwin")
+			ui.device->setCurrentIndex(-1);
 }
 #endif
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -149,6 +149,7 @@ int DownloadFromDCWidget::deviceIndex(QString deviceText)
 void DownloadFromDCWidget::DC##num##Clicked() \
 { \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
+	ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
@@ -639,10 +640,13 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 {
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
-	if (state == Qt::Checked)
-		selectRemoteBluetoothDevice();
-	else
-		ui.device->setCurrentIndex(-1);
+	if (state == Qt::Checked) {
+      		if (ui.device->currentText().isEmpty()) {
+         		selectRemoteBluetoothDevice();
+   		} else {
+      			ui.device->setCurrentIndex(-1);
+   		}
+	}
 }
 #endif
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -149,14 +149,19 @@ int DownloadFromDCWidget::deviceIndex(QString deviceText)
 void DownloadFromDCWidget::DC##num##Clicked() \
 { \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
-	ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
 	bool isMacOs = QSysInfo::kernelType() == "darwin"; \
+	/* If we have a Bluetooth address, use it instead of rescanning. For \
+	MacOs, save the mount point.  This may be the wrong thing to do, but for \
+	the Catalina 10.15.7 laptop and Oceanic Atom 3.1 I use, the mountpoint \
+	is /dev/tty.usbserial-20030001 and it doesn't change regardless of the \
+	USB port being used.   If it isn't saved, it must be reentered. */ \
+	if (isBluetoothDevice || isMacOs) \
+		ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	ui.bluetoothMode->setChecked(isBluetoothDevice); \
-	if (ui.device->currentIndex() == -1 || (isBluetoothDevice && !isMacOs)) \
-		/* macOS seems to have a problem connecting to remembered bluetooth devices  if it hasn't already had a connection in the current session */ \
+	if (ui.device->currentIndex() == -1 || isBluetoothDevice) \
 		ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
 	if (isMacOs) { \
 		/* it makes no sense that this would be needed on macOS but not Linux */ \


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When switching from a non-bluetooth computer to a bluetooh computer an unnecessary bluetooth scan may be forced.   This change will avoid the scan if the bluetooth device address is known.

I discovered this issue when sharing a laptop to upload dives. If I upload dives using a bluetooth computer I have to rescan the device address after a dive is uploaded with a different computer. This change uses the existing device address instead of scanning. A scan can be forces by clearing/rechecking the "Choose Bluetooth download mode" checkbox.

### Changes made:
There are two changes. First, set the device address using the prefs value when a dive computer is selected. Second, avoid scanning if the device address is already known.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
