### PR TITLE
core: fix memory leak in tables code

### DIFF
--- a/core/table.h
+++ b/core/table.h
@@ -96,6 +96,9 @@
 	{									\
 		for (int i = 0; i < table->nr; i++)				\
 			free_##item_name(table->array_name[i]);			\
+		free(table->array_name);					\
+		table->array_name = NULL;					\
+		table->allocated = 0;						\
 		table->nr = 0;							\
 	}
 


### PR DESCRIPTION
The function clear_*_table frees all elements of the table. However, persumably as a performance feature, it kept the memory of the table itselt (i.e. it only reset the number of elements but kept the capacity).

That is fine if the table is reused later. However, this function was also used when freeing the table and this would leak the table memory.

This commit frees the table memory. An alternative would be to have separate clear_*_table and free_*_table functions. But let's wait with that until we port the table code to C++. Then this will be "automatically" fixed.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a leak in the table code.

This again shows that we can't get C memory management right. In this case I am the culprit.