### PR TITLE
cleanup: fix slot/signal code in preferences code

### DIFF
--- a/desktop-widgets/preferences/preferences_cloud.cpp
+++ b/desktop-widgets/preferences/preferences_cloud.cpp
@@ -96,7 +96,7 @@ void PreferencesCloud::syncSettings()
 				return;
 			}
 			CloudStorageAuthenticate *cloudAuth = new CloudStorageAuthenticate(this);
-			connect(cloudAuth, SIGNAL(finishedAuthenticate()), this, SLOT(updateCloudAuthenticationState()));
+			connect(cloudAuth, &CloudStorageAuthenticate::finishedAuthenticate, this, &PreferencesCloud::updateCloudAuthenticationState);
 			cloudAuth->backend(email, password, pin);
 		}
 	}

--- a/desktop-widgets/preferences/preferences_dc.cpp
+++ b/desktop-widgets/preferences/preferences_dc.cpp
@@ -37,4 +37,3 @@ void PreferencesDc::refreshSettings()
 void PreferencesDc::syncSettings()
 {
 }
-

--- a/desktop-widgets/preferences/preferences_graph.cpp
+++ b/desktop-widgets/preferences/preferences_graph.cpp
@@ -77,14 +77,19 @@ void PreferencesGraph::syncSettings()
 	qPrefTechnicalDetails::set_display_deco_mode(ui->vpmb->isChecked() ? VPMB : BUEHLMANN);
 }
 
-#define DANGER_GF (gf > 100) ? "* { color: red; }" : ""
+static const char *danger_gf(int gf)
+{
+	return (gf > 100) ? "* { color: red; }" : "";
+}
+
 void PreferencesGraph::on_gflow_valueChanged(int gf)
 {
-	ui->gflow->setStyleSheet(DANGER_GF);
+	ui->gflow->setStyleSheet(danger_gf(gf));
 }
+
 void PreferencesGraph::on_gfhigh_valueChanged(int gf)
 {
-	ui->gfhigh->setStyleSheet(DANGER_GF);
+	ui->gfhigh->setStyleSheet(danger_gf(gf));
 }
 
 void PreferencesGraph::on_buehlmann_toggled(bool buehlmann)
@@ -96,5 +101,3 @@ void PreferencesGraph::on_buehlmann_toggled(bool buehlmann)
 	ui->vpmb_conservatism->setEnabled(!buehlmann);
 	ui->label_VPMB->setEnabled(!buehlmann);
 }
-
-#undef DANGER_GF

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -30,8 +30,8 @@ PreferencesLanguage::PreferencesLanguage() : AbstractPreferencesWidget(tr("Langu
 	foreach (QString format, dateFormatShortMap.keys())
 		ui->dateFormatEntry->addItem(format);
 	ui->dateFormatEntry->completer()->setCaseSensitivity(Qt::CaseSensitive);
-	connect(ui->dateFormatEntry, SIGNAL(currentIndexChanged(const QString&)),
-		this, SLOT(dateFormatChanged(const QString&)));
+	connect(ui->dateFormatEntry, &QComboBox::currentTextChanged,
+		this, &PreferencesLanguage::dateFormatChanged);
 
 	ui->timeFormatEntry->addItem("hh:mm");
 	ui->timeFormatEntry->addItem("h:mm AP");

--- a/desktop-widgets/preferences/preferences_network.cpp
+++ b/desktop-widgets/preferences/preferences_network.cpp
@@ -17,7 +17,7 @@ PreferencesNetwork::PreferencesNetwork() : AbstractPreferencesWidget(tr("Network
 	ui->proxyType->addItem(tr("SOCKS proxy"), QNetworkProxy::Socks5Proxy);
 	ui->proxyType->setCurrentIndex(-1);
 
-	connect(ui->proxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(proxyType_changed(int)));
+	connect(ui->proxyType, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &PreferencesNetwork::proxyType_changed);
 }
 
 PreferencesNetwork::~PreferencesNetwork()
@@ -47,7 +47,6 @@ void PreferencesNetwork::syncSettings()
 	proxy->set_proxy_pass(ui->proxyPassword->text());
 }
 
-
 void PreferencesNetwork::proxyType_changed(int idx)
 {
 	if (idx == -1) {
@@ -63,4 +62,3 @@ void PreferencesNetwork::proxyType_changed(int idx)
 	ui->proxyPassword->setEnabled(hpEnabled & ui->proxyAuthRequired->isChecked());
 	ui->proxyAuthRequired->setChecked(ui->proxyAuthRequired->isChecked());
 }
-

--- a/desktop-widgets/preferences/preferences_reset.cpp
+++ b/desktop-widgets/preferences/preferences_reset.cpp
@@ -30,4 +30,3 @@ void PreferencesReset::refreshSettings()
 void PreferencesReset::syncSettings()
 {
 }
-


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Replace SIGNAL/SLOT macros by function pointers, which does compile-time checking. SIGNAL/SLOT should be removed/banned.

This fixes one signal, but it is unclear whether it also fixes a bug, since I didn't notice any change in the UI. At least it doesn't spam an "unknown signal" message to the console.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Fix a signal
2) Replace macro by local function
