### PR TITLE
preferences: fix language selector on recent Qt

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -462,16 +462,12 @@ void initUiLanguage()
 		loc = QLocale(QLocale().uiLanguages().first());
 	}
 
+	// Find language code with one '-', or use the first entry.
 	QStringList languages = loc.uiLanguages();
 	QString uiLang;
-	if (languages[0].contains('-'))
-		uiLang = languages[0];
-	else if (languages.count() > 1 && languages[1].contains('-'))
-		uiLang = languages[1];
-	else if (languages.count() > 2 && languages[2].contains('-'))
-		uiLang = languages[2];
-	else
-		uiLang = languages[0];
+	auto it = std::find_if(languages.begin(), languages.end(), [](const QString &s)
+				{ return s.count('-') == 1; });
+	uiLang = it == languages.end() ? languages[0] : *it;
 
 	// there's a stupid Qt bug on MacOS where uiLanguages doesn't give us the country info
 	if (!uiLang.contains('-') && uiLang != loc.bcp47Name()) {


### PR DESCRIPTION
On initialization, the old code searched for the first language code containing a '-'. However, my Qt version gives de-Latn-DE as the first entry. That messed up the preferences code: it didn't recognize that entry. Thus, simply opening and closing the preferences switched the language to Bulgarian.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit description: The language selection was messed up for me. Saving the preferences would switch the language to Bulgarian. Not a nice behavior.

The language selection code is very obscure to me. Not sure if this is the "right" fix, but it works for me.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Select the first language code with a single '-' from the list provided by Qt.