### PR TITLE
profile: fix uninitialized variable in DivePercentageItem

### DIFF
--- a/profile-widget/divepercentageitem.cpp
+++ b/profile-widget/divepercentageitem.cpp
@@ -114,7 +114,7 @@ void DivePercentageItem::replot(const dive *d, const struct divecomputer *dc, co
 				continue;
 
 			double value = item.percentages[tissue];
-			struct gasmix gasmix = get_gasmix(d, dc, sec, &ev, gasmix);
+			struct gasmix gasmix = get_gasmix(d, dc, sec, &ev, gasmix_air);
 			int inert = get_n2(gasmix) + get_he(gasmix);
 			color = colorScale(value, inert);
 			if (nextX >= width)


### PR DESCRIPTION
Fix bug introduced in 505e4e47eb.

Nobody complained, so not clear if that was user visible.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix uninitialized variable. Not clear if this was user visible.