### PR TITLE
Improve automated language handling

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -466,18 +466,22 @@ void initUiLanguage()
 	auto it = std::find_if(languages.begin(), languages.end(), [](const QString &s)
 				{ return s.count('-') == 1; });
 	uiLang = it == languages.end() ? languages[0] : *it;
+#ifdef SUBSURFACE_MOBILE
+	qDebug() << "uiLanguages was" << languages << ", picked" << uiLang;
+#endif
 
 	// there's a stupid Qt bug on MacOS where uiLanguages doesn't give us the country info
 	if (!uiLang.contains('-') && uiLang != loc.bcp47Name()) {
 		QLocale loc2(loc.bcp47Name());
 		loc = loc2;
 		QStringList languages = loc2.uiLanguages();
-		if (languages[0].contains('-'))
-			uiLang = languages[0];
-		else if (languages.count() > 1 && languages[1].contains('-'))
-			uiLang = languages[1];
-		else if (languages.count() > 2 && languages[2].contains('-'))
-			uiLang = languages[2];
+
+		it = std::find_if(languages.begin(), languages.end(), [](const QString &s)
+				{ return s.contains('-'); });
+		uiLang = it == languages.end() ? languages[0] : *it;
+#ifdef SUBSURFACE_MOBILE
+		qDebug() << "bcp47 based languages was" << languages << ", picked" << uiLang;
+#endif
 	}
 
 	free((void*)prefs.locale.lang_locale);

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -280,6 +280,7 @@ QMLManager::QMLManager() :
 	git_libgit2_version(&git_maj, &git_min, &git_rev);
 	appendTextToLog(QStringLiteral("built with libgit2 %1.%2.%3").arg(git_maj).arg(git_min).arg(git_rev));
 	appendTextToLog(QStringLiteral("Running on %1").arg(QSysInfo::prettyProductName()));
+	appendTextToLog(QStringLiteral("Locale Languages offered %1, picked %2").arg(QLocale().uiLanguages().join(", ")).arg(prefs.locale.lang_locale));
 #if defined(Q_OS_ANDROID)
 	extern QString getAndroidHWInfo();
 	appendTextToLog(getAndroidHWInfo());


### PR DESCRIPTION
This mimics the code added in commit cf990b0f39 ("preferences: choose language code with one '-'") and adds some debugging for the mobile case - some people are being presented with Subsurface-mobile in Korean for some reason.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix (?)

### Pull request long description:
<!-- Describe your pull request in detail. -->
Initially I just wanted to add some debug code to figure out while some users on iOS suddenly see Korean as default language - but in the process I noticed that there was essentially the same code block that Berthold had already replaced a second time just a few lines below. So I tried to update that as well - and added the debug output that I was looking for.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger - I think I adapted this correctly, but always appreciate your keen eye on this.