### PR TITLE
Correctly initialize string in core/device.cpp

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -296,7 +296,7 @@ std::string fp_get_data(struct fingerprint_table *table, unsigned int i)
 	if (!table || i >= table->fingerprints.size())
 		return std::string();
 	struct fingerprint_record *fpr = &table->fingerprints[i];
-	std::string res(' ', fpr->fsize * 2);
+	std::string res(fpr->fsize * 2, ' ');
 	for (unsigned int i = 0; i < fpr->fsize; ++i) {
 		res[2 * i] = to_hex_digit((fpr->raw_data[i] >> 4) & 0xf);
 		res[2 * i + 1] = to_hex_digit(fpr->raw_data[i] & 0xf);


### PR DESCRIPTION
When initializing a string with multiple characters, first comes the length, then the size. Not the other way around.

Fixes #4127.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit description.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4127.
