### PR TITLE
core: don't do C-style string initialization in core/device.cpp [Alternative to #4129]

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -296,10 +296,11 @@ std::string fp_get_data(struct fingerprint_table *table, unsigned int i)
 	if (!table || i >= table->fingerprints.size())
 		return std::string();
 	struct fingerprint_record *fpr = &table->fingerprints[i];
-	std::string res(' ', fpr->fsize * 2);
+	std::string res;
+	res.reserve(fpr->fsize * 2);
 	for (unsigned int i = 0; i < fpr->fsize; ++i) {
-		res[2 * i] = to_hex_digit((fpr->raw_data[i] >> 4) & 0xf);
-		res[2 * i + 1] = to_hex_digit(fpr->raw_data[i] & 0xf);
+		res += to_hex_digit((fpr->raw_data[i] >> 4) & 0xf);
+		res += to_hex_digit(fpr->raw_data[i] & 0xf);
 	}
 	return res;
 }


### PR DESCRIPTION
The std::string was wrongly initialized (character and length were exchanged) and then filled with C-style array accesses.

Instead, reserve the memory and use string concetanation. This will not break, even if we get the length wrong. In the worst case, it will cause reallocation.

Fixes #4127.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Alternative way of fixing: #4127. Probably should have converted right to the secure way. Unfortunately, I am also not  immune to "C"-style thinking. :(

You choose.