### PR TITLE
core: fix downloader builds

### DIFF
--- a/core/downloadfromdcthread.h
+++ b/core/downloadfromdcthread.h
@@ -95,9 +95,7 @@ struct mydescriptor {
 * stay like this for now.
 */
 void fill_computer_list();
-extern "C" {
 void show_computer_list();
-}
 extern QStringList vendorList;
 extern QHash<QString, QStringList> productList;
 extern QMap<QString, dc_descriptor_t *> descriptorLookup;


### PR DESCRIPTION
Downloder builds pull in show_computer_list() from downloadfromdcthread.cpp, but it's declared as extern "C". With 76c2069f having converted subsurfacestartup.c to .cpp, the extern must be updated accordingly.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Just a linkage fix to make the downloader build

### Changes made:
1) Update extern to "C"

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
