### PR TITLE
Fix memory management in configure dive computer code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
-ForEachMacros: [ 'foreach', 'for_each_dc', 'for_each_relevant_dc', 'for_each_dive', 'for_each_line', 'Q_FOREACH' ]
+ForEachMacros: [ 'for_each_dc', 'for_each_relevant_dc', 'for_each_dive', 'for_each_line' ]
 IndentFunctionDeclarationAfterType: false #personal taste, good for long methods
 IndentWidth: 8
 MaxEmptyLinesToKeep: 2

--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -574,8 +574,8 @@ QString ConfigureDiveComputer::dc_open(device_data_t *data)
 	FILE *fp = NULL;
 	dc_status_t rc;
 
-	if (data->libdc_log)
-		fp = subsurface_fopen(logfile_name, "w");
+	if (data->libdc_log && !logfile_name.empty())
+		fp = subsurface_fopen(logfile_name.c_str(), "w");
 
 	data->libdc_logfile = fp;
 

--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -41,7 +41,7 @@ void ConfigureDiveComputer::readSettings(device_data_t *data)
 	readThread->start();
 }
 
-void ConfigureDiveComputer::saveDeviceDetails(DeviceDetails *details, device_data_t *data)
+void ConfigureDiveComputer::saveDeviceDetails(const DeviceDetails &details, device_data_t *data)
 {
 	setState(WRITING);
 
@@ -65,7 +65,7 @@ static QString writeGasDetails(gas g)
 		}).join(QLatin1Char(','));
 }
 
-bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, DeviceDetails *details, device_data_t *data)
+bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, const DeviceDetails &details, device_data_t *data)
 {
 	QString xml = "";
 	QString vendor = data->vendor;
@@ -80,37 +80,37 @@ bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, DeviceDetails
 	writer.writeTextElement("Product", product);
 	writer.writeEndElement();
 	writer.writeStartElement("Settings");
-	writer.writeTextElement("CustomText", details->customText);
+	writer.writeTextElement("CustomText", details.customText);
 	//Add gasses
-	writer.writeTextElement("Gas1", writeGasDetails(details->gas1));
-	writer.writeTextElement("Gas2", writeGasDetails(details->gas2));
-	writer.writeTextElement("Gas3", writeGasDetails(details->gas3));
-	writer.writeTextElement("Gas4", writeGasDetails(details->gas4));
-	writer.writeTextElement("Gas5", writeGasDetails(details->gas5));
+	writer.writeTextElement("Gas1", writeGasDetails(details.gas1));
+	writer.writeTextElement("Gas2", writeGasDetails(details.gas2));
+	writer.writeTextElement("Gas3", writeGasDetails(details.gas3));
+	writer.writeTextElement("Gas4", writeGasDetails(details.gas4));
+	writer.writeTextElement("Gas5", writeGasDetails(details.gas5));
 	//
 	//Add dil values
-	writer.writeTextElement("Dil1", writeGasDetails(details->dil1));
-	writer.writeTextElement("Dil2", writeGasDetails(details->dil2));
-	writer.writeTextElement("Dil3", writeGasDetails(details->dil3));
-	writer.writeTextElement("Dil4", writeGasDetails(details->dil4));
-	writer.writeTextElement("Dil5", writeGasDetails(details->dil5));
+	writer.writeTextElement("Dil1", writeGasDetails(details.dil1));
+	writer.writeTextElement("Dil2", writeGasDetails(details.dil2));
+	writer.writeTextElement("Dil3", writeGasDetails(details.dil3));
+	writer.writeTextElement("Dil4", writeGasDetails(details.dil4));
+	writer.writeTextElement("Dil5", writeGasDetails(details.dil5));
 
 	//Add setpoint values
 	QString sp1 = QString("%1,%2")
-			      .arg(QString::number(details->sp1.sp),
-				   QString::number(details->sp1.depth));
+			      .arg(QString::number(details.sp1.sp),
+				   QString::number(details.sp1.depth));
 	QString sp2 = QString("%1,%2")
-			      .arg(QString::number(details->sp2.sp),
-				   QString::number(details->sp2.depth));
+			      .arg(QString::number(details.sp2.sp),
+				   QString::number(details.sp2.depth));
 	QString sp3 = QString("%1,%2")
-			      .arg(QString::number(details->sp3.sp),
-				   QString::number(details->sp3.depth));
+			      .arg(QString::number(details.sp3.sp),
+				   QString::number(details.sp3.depth));
 	QString sp4 = QString("%1,%2")
-			      .arg(QString::number(details->sp4.sp),
-				   QString::number(details->sp4.depth));
+			      .arg(QString::number(details.sp4.sp),
+				   QString::number(details.sp4.depth));
 	QString sp5 = QString("%1,%2")
-			      .arg(QString::number(details->sp5.sp),
-				   QString::number(details->sp5.depth));
+			      .arg(QString::number(details.sp5.sp),
+				   QString::number(details.sp5.depth));
 	writer.writeTextElement("SetPoint1", sp1);
 	writer.writeTextElement("SetPoint2", sp2);
 	writer.writeTextElement("SetPoint3", sp3);
@@ -118,60 +118,60 @@ bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, DeviceDetails
 	writer.writeTextElement("SetPoint5", sp5);
 
 	//Other Settings
-	writer.writeTextElement("DiveMode", QString::number(details->diveMode));
-	writer.writeTextElement("Saturation", QString::number(details->saturation));
-	writer.writeTextElement("Desaturation", QString::number(details->desaturation));
-	writer.writeTextElement("LastDeco", QString::number(details->lastDeco));
-	writer.writeTextElement("Brightness", QString::number(details->brightness));
-	writer.writeTextElement("Units", QString::number(details->units));
-	writer.writeTextElement("SamplingRate", QString::number(details->samplingRate));
-	writer.writeTextElement("Salinity", QString::number(details->salinity));
-	writer.writeTextElement("DiveModeColor", QString::number(details->diveModeColor));
-	writer.writeTextElement("Language", QString::number(details->language));
-	writer.writeTextElement("DateFormat", QString::number(details->dateFormat));
-	writer.writeTextElement("CompassGain", QString::number(details->compassGain));
-	writer.writeTextElement("SafetyStop", QString::number(details->safetyStop));
-	writer.writeTextElement("GfHigh", QString::number(details->gfHigh));
-	writer.writeTextElement("GfLow", QString::number(details->gfLow));
-	writer.writeTextElement("PressureSensorOffset", QString::number(details->pressureSensorOffset));
-	writer.writeTextElement("PpO2Min", QString::number(details->ppO2Min));
-	writer.writeTextElement("PpO2Max", QString::number(details->ppO2Max));
-	writer.writeTextElement("FutureTTS", QString::number(details->futureTTS));
-	writer.writeTextElement("CcrMode", QString::number(details->ccrMode));
-	writer.writeTextElement("DecoType", QString::number(details->decoType));
-	writer.writeTextElement("AGFSelectable", QString::number(details->aGFSelectable));
-	writer.writeTextElement("AGFHigh", QString::number(details->aGFHigh));
-	writer.writeTextElement("AGFLow", QString::number(details->aGFLow));
-	writer.writeTextElement("CalibrationGas", QString::number(details->calibrationGas));
-	writer.writeTextElement("FlipScreen", QString::number(details->flipScreen));
-	writer.writeTextElement("SetPointFallback", QString::number(details->setPointFallback));
-	writer.writeTextElement("LeftButtonSensitivity", QString::number(details->leftButtonSensitivity));
-	writer.writeTextElement("RightButtonSensitivity", QString::number(details->rightButtonSensitivity));
-	writer.writeTextElement("BottomGasConsumption", QString::number(details->bottomGasConsumption));
-	writer.writeTextElement("DecoGasConsumption", QString::number(details->decoGasConsumption));
-	writer.writeTextElement("ModWarning", QString::number(details->modWarning));
-	writer.writeTextElement("DynamicAscendRate", QString::number(details->dynamicAscendRate));
-	writer.writeTextElement("GraphicalSpeedIndicator", QString::number(details->graphicalSpeedIndicator));
-	writer.writeTextElement("AlwaysShowppO2", QString::number(details->alwaysShowppO2));
+	writer.writeTextElement("DiveMode", QString::number(details.diveMode));
+	writer.writeTextElement("Saturation", QString::number(details.saturation));
+	writer.writeTextElement("Desaturation", QString::number(details.desaturation));
+	writer.writeTextElement("LastDeco", QString::number(details.lastDeco));
+	writer.writeTextElement("Brightness", QString::number(details.brightness));
+	writer.writeTextElement("Units", QString::number(details.units));
+	writer.writeTextElement("SamplingRate", QString::number(details.samplingRate));
+	writer.writeTextElement("Salinity", QString::number(details.salinity));
+	writer.writeTextElement("DiveModeColor", QString::number(details.diveModeColor));
+	writer.writeTextElement("Language", QString::number(details.language));
+	writer.writeTextElement("DateFormat", QString::number(details.dateFormat));
+	writer.writeTextElement("CompassGain", QString::number(details.compassGain));
+	writer.writeTextElement("SafetyStop", QString::number(details.safetyStop));
+	writer.writeTextElement("GfHigh", QString::number(details.gfHigh));
+	writer.writeTextElement("GfLow", QString::number(details.gfLow));
+	writer.writeTextElement("PressureSensorOffset", QString::number(details.pressureSensorOffset));
+	writer.writeTextElement("PpO2Min", QString::number(details.ppO2Min));
+	writer.writeTextElement("PpO2Max", QString::number(details.ppO2Max));
+	writer.writeTextElement("FutureTTS", QString::number(details.futureTTS));
+	writer.writeTextElement("CcrMode", QString::number(details.ccrMode));
+	writer.writeTextElement("DecoType", QString::number(details.decoType));
+	writer.writeTextElement("AGFSelectable", QString::number(details.aGFSelectable));
+	writer.writeTextElement("AGFHigh", QString::number(details.aGFHigh));
+	writer.writeTextElement("AGFLow", QString::number(details.aGFLow));
+	writer.writeTextElement("CalibrationGas", QString::number(details.calibrationGas));
+	writer.writeTextElement("FlipScreen", QString::number(details.flipScreen));
+	writer.writeTextElement("SetPointFallback", QString::number(details.setPointFallback));
+	writer.writeTextElement("LeftButtonSensitivity", QString::number(details.leftButtonSensitivity));
+	writer.writeTextElement("RightButtonSensitivity", QString::number(details.rightButtonSensitivity));
+	writer.writeTextElement("BottomGasConsumption", QString::number(details.bottomGasConsumption));
+	writer.writeTextElement("DecoGasConsumption", QString::number(details.decoGasConsumption));
+	writer.writeTextElement("ModWarning", QString::number(details.modWarning));
+	writer.writeTextElement("DynamicAscendRate", QString::number(details.dynamicAscendRate));
+	writer.writeTextElement("GraphicalSpeedIndicator", QString::number(details.graphicalSpeedIndicator));
+	writer.writeTextElement("AlwaysShowppO2", QString::number(details.alwaysShowppO2));
 
 	// Suunto vyper settings.
-	writer.writeTextElement("Altitude", QString::number(details->altitude));
-	writer.writeTextElement("PersonalSafety", QString::number(details->personalSafety));
-	writer.writeTextElement("TimeFormat", QString::number(details->timeFormat));
+	writer.writeTextElement("Altitude", QString::number(details.altitude));
+	writer.writeTextElement("PersonalSafety", QString::number(details.personalSafety));
+	writer.writeTextElement("TimeFormat", QString::number(details.timeFormat));
 
 	writer.writeStartElement("Light");
-	writer.writeAttribute("enabled", QString::number(details->lightEnabled));
-	writer.writeCharacters(QString::number(details->light));
+	writer.writeAttribute("enabled", QString::number(details.lightEnabled));
+	writer.writeCharacters(QString::number(details.light));
 	writer.writeEndElement();
 
 	writer.writeStartElement("AlarmTime");
-	writer.writeAttribute("enabled", QString::number(details->alarmTimeEnabled));
-	writer.writeCharacters(QString::number(details->alarmTime));
+	writer.writeAttribute("enabled", QString::number(details.alarmTimeEnabled));
+	writer.writeCharacters(QString::number(details.alarmTime));
 	writer.writeEndElement();
 
 	writer.writeStartElement("AlarmDepth");
-	writer.writeAttribute("enabled", QString::number(details->alarmDepthEnabled));
-	writer.writeCharacters(QString::number(details->alarmDepth));
+	writer.writeAttribute("enabled", QString::number(details.alarmDepthEnabled));
+	writer.writeCharacters(QString::number(details.alarmDepth));
 	writer.writeEndElement();
 
 	writer.writeEndElement();
@@ -192,7 +192,7 @@ bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, DeviceDetails
 	return true;
 }
 
-bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDetails *details)
+bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDetails &details)
 {
 	QFile file(fileName);
 	if (!file.open(QIODevice::ReadOnly)) {
@@ -211,7 +211,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 			QString keyString = reader.text().toString();
 
 			if (settingName == "CustomText")
-				details->customText = keyString;
+				details.customText = keyString;
 
 			if (settingName == "Gas1") {
 				QStringList gasData = keyString.split(",");
@@ -220,7 +220,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				gas1.helium = gasData.at(1).toInt();
 				gas1.type = gasData.at(2).toInt();
 				gas1.depth = gasData.at(3).toInt();
-				details->gas1 = gas1;
+				details.gas1 = gas1;
 			}
 
 			if (settingName == "Gas2") {
@@ -230,7 +230,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				gas2.helium = gasData.at(1).toInt();
 				gas2.type = gasData.at(2).toInt();
 				gas2.depth = gasData.at(3).toInt();
-				details->gas2 = gas2;
+				details.gas2 = gas2;
 			}
 
 			if (settingName == "Gas3") {
@@ -240,7 +240,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				gas3.helium = gasData.at(1).toInt();
 				gas3.type = gasData.at(2).toInt();
 				gas3.depth = gasData.at(3).toInt();
-				details->gas3 = gas3;
+				details.gas3 = gas3;
 			}
 
 			if (settingName == "Gas4") {
@@ -250,7 +250,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				gas4.helium = gasData.at(1).toInt();
 				gas4.type = gasData.at(2).toInt();
 				gas4.depth = gasData.at(3).toInt();
-				details->gas4 = gas4;
+				details.gas4 = gas4;
 			}
 
 			if (settingName == "Gas5") {
@@ -260,7 +260,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				gas5.helium = gasData.at(1).toInt();
 				gas5.type = gasData.at(2).toInt();
 				gas5.depth = gasData.at(3).toInt();
-				details->gas5 = gas5;
+				details.gas5 = gas5;
 			}
 
 			if (settingName == "Dil1") {
@@ -270,7 +270,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				dil1.helium = dilData.at(1).toInt();
 				dil1.type = dilData.at(2).toInt();
 				dil1.depth = dilData.at(3).toInt();
-				details->dil1 = dil1;
+				details.dil1 = dil1;
 			}
 
 			if (settingName == "Dil2") {
@@ -280,7 +280,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				dil2.helium = dilData.at(1).toInt();
 				dil2.type = dilData.at(2).toInt();
 				dil2.depth = dilData.at(3).toInt();
-				details->dil1 = dil2;
+				details.dil1 = dil2;
 			}
 
 			if (settingName == "Dil3") {
@@ -290,7 +290,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				dil3.helium = dilData.at(1).toInt();
 				dil3.type = dilData.at(2).toInt();
 				dil3.depth = dilData.at(3).toInt();
-				details->dil3 = dil3;
+				details.dil3 = dil3;
 			}
 
 			if (settingName == "Dil4") {
@@ -300,7 +300,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				dil4.helium = dilData.at(1).toInt();
 				dil4.type = dilData.at(2).toInt();
 				dil4.depth = dilData.at(3).toInt();
-				details->dil4 = dil4;
+				details.dil4 = dil4;
 			}
 
 			if (settingName == "Dil5") {
@@ -310,7 +310,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				dil5.helium = dilData.at(1).toInt();
 				dil5.type = dilData.at(2).toInt();
 				dil5.depth = dilData.at(3).toInt();
-				details->dil5 = dil5;
+				details.dil5 = dil5;
 			}
 
 			if (settingName == "SetPoint1") {
@@ -318,7 +318,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				setpoint sp1;
 				sp1.sp = spData.at(0).toInt();
 				sp1.depth = spData.at(1).toInt();
-				details->sp1 = sp1;
+				details.sp1 = sp1;
 			}
 
 			if (settingName == "SetPoint2") {
@@ -326,7 +326,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				setpoint sp2;
 				sp2.sp = spData.at(0).toInt();
 				sp2.depth = spData.at(1).toInt();
-				details->sp2 = sp2;
+				details.sp2 = sp2;
 			}
 
 			if (settingName == "SetPoint3") {
@@ -334,7 +334,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				setpoint sp3;
 				sp3.sp = spData.at(0).toInt();
 				sp3.depth = spData.at(1).toInt();
-				details->sp3 = sp3;
+				details.sp3 = sp3;
 			}
 
 			if (settingName == "SetPoint4") {
@@ -342,7 +342,7 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				setpoint sp4;
 				sp4.sp = spData.at(0).toInt();
 				sp4.depth = spData.at(1).toInt();
-				details->sp4 = sp4;
+				details.sp4 = sp4;
 			}
 
 			if (settingName == "SetPoint5") {
@@ -350,139 +350,139 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 				setpoint sp5;
 				sp5.sp = spData.at(0).toInt();
 				sp5.depth = spData.at(1).toInt();
-				details->sp5 = sp5;
+				details.sp5 = sp5;
 			}
 
 			if (settingName == "Saturation")
-				details->saturation = keyString.toInt();
+				details.saturation = keyString.toInt();
 
 			if (settingName == "Desaturation")
-				details->desaturation = keyString.toInt();
+				details.desaturation = keyString.toInt();
 
 			if (settingName == "DiveMode")
-				details->diveMode = keyString.toInt();
+				details.diveMode = keyString.toInt();
 
 			if (settingName == "LastDeco")
-				details->lastDeco = keyString.toInt();
+				details.lastDeco = keyString.toInt();
 
 			if (settingName == "Brightness")
-				details->brightness = keyString.toInt();
+				details.brightness = keyString.toInt();
 
 			if (settingName == "Units")
-				details->units = keyString.toInt();
+				details.units = keyString.toInt();
 
 			if (settingName == "SamplingRate")
-				details->samplingRate = keyString.toInt();
+				details.samplingRate = keyString.toInt();
 
 			if (settingName == "Salinity")
-				details->salinity = keyString.toInt();
+				details.salinity = keyString.toInt();
 
 			if (settingName == "DiveModeColour")
-				details->diveModeColor = keyString.toInt();
+				details.diveModeColor = keyString.toInt();
 
 			if (settingName == "Language")
-				details->language = keyString.toInt();
+				details.language = keyString.toInt();
 
 			if (settingName == "DateFormat")
-				details->dateFormat = keyString.toInt();
+				details.dateFormat = keyString.toInt();
 
 			if (settingName == "CompassGain")
-				details->compassGain = keyString.toInt();
+				details.compassGain = keyString.toInt();
 
 			if (settingName == "SafetyStop")
-				details->safetyStop = keyString.toInt();
+				details.safetyStop = keyString.toInt();
 
 			if (settingName == "GfHigh")
-				details->gfHigh = keyString.toInt();
+				details.gfHigh = keyString.toInt();
 
 			if (settingName == "GfLow")
-				details->gfLow = keyString.toInt();
+				details.gfLow = keyString.toInt();
 
 			if (settingName == "PressureSensorOffset")
-				details->pressureSensorOffset = keyString.toInt();
+				details.pressureSensorOffset = keyString.toInt();
 
 			if (settingName == "PpO2Min")
-				details->ppO2Min = keyString.toInt();
+				details.ppO2Min = keyString.toInt();
 
 			if (settingName == "PpO2Max")
-				details->ppO2Max = keyString.toInt();
+				details.ppO2Max = keyString.toInt();
 
 			if (settingName == "FutureTTS")
-				details->futureTTS = keyString.toInt();
+				details.futureTTS = keyString.toInt();
 
 			if (settingName == "CcrMode")
-				details->ccrMode = keyString.toInt();
+				details.ccrMode = keyString.toInt();
 
 			if (settingName == "DecoType")
-				details->decoType = keyString.toInt();
+				details.decoType = keyString.toInt();
 
 			if (settingName == "AGFSelectable")
-				details->aGFSelectable = keyString.toInt();
+				details.aGFSelectable = keyString.toInt();
 
 			if (settingName == "AGFHigh")
-				details->aGFHigh = keyString.toInt();
+				details.aGFHigh = keyString.toInt();
 
 			if (settingName == "AGFLow")
-				details->aGFLow = keyString.toInt();
+				details.aGFLow = keyString.toInt();
 
 			if (settingName == "CalibrationGas")
-				details->calibrationGas = keyString.toInt();
+				details.calibrationGas = keyString.toInt();
 
 			if (settingName == "FlipScreen")
-				details->flipScreen = keyString.toInt();
+				details.flipScreen = keyString.toInt();
 
 			if (settingName == "SetPointFallback")
-				details->setPointFallback = keyString.toInt();
+				details.setPointFallback = keyString.toInt();
 
 			if (settingName == "LeftButtonSensitivity")
-				details->leftButtonSensitivity = keyString.toInt();
+				details.leftButtonSensitivity = keyString.toInt();
 
 			if (settingName == "RightButtonSensitivity")
-				details->rightButtonSensitivity = keyString.toInt();
+				details.rightButtonSensitivity = keyString.toInt();
 
 			if (settingName == "BottomGasConsumption")
-				details->bottomGasConsumption = keyString.toInt();
+				details.bottomGasConsumption = keyString.toInt();
 
 			if (settingName == "DecoGasConsumption")
-				details->decoGasConsumption = keyString.toInt();
+				details.decoGasConsumption = keyString.toInt();
 
 			if (settingName == "ModWarning")
-				details->modWarning = keyString.toInt();
+				details.modWarning = keyString.toInt();
 
 			if (settingName == "DynamicAscendRate")
-				details->dynamicAscendRate = keyString.toInt();
+				details.dynamicAscendRate = keyString.toInt();
 
 			if (settingName == "GraphicalSpeedIndicator")
-				details->graphicalSpeedIndicator = keyString.toInt();
+				details.graphicalSpeedIndicator = keyString.toInt();
 
 			if (settingName == "AlwaysShowppO2")
-				details->alwaysShowppO2 = keyString.toInt();
+				details.alwaysShowppO2 = keyString.toInt();
 
 			if (settingName == "Altitude")
-				details->altitude = keyString.toInt();
+				details.altitude = keyString.toInt();
 
 			if (settingName == "PersonalSafety")
-				details->personalSafety = keyString.toInt();
+				details.personalSafety = keyString.toInt();
 
 			if (settingName == "TimeFormat")
-				details->timeFormat = keyString.toInt();
+				details.timeFormat = keyString.toInt();
 
 			if (settingName == "Light") {
 				if (attributes.hasAttribute("enabled"))
-					details->lightEnabled = attributes.value("enabled").toString().toInt();
-				details->light = keyString.toInt();
+					details.lightEnabled = attributes.value("enabled").toString().toInt();
+				details.light = keyString.toInt();
 			}
 
 			if (settingName == "AlarmDepth") {
 				if (attributes.hasAttribute("enabled"))
-					details->alarmDepthEnabled = attributes.value("enabled").toString().toInt();
-				details->alarmDepth = keyString.toInt();
+					details.alarmDepthEnabled = attributes.value("enabled").toString().toInt();
+				details.alarmDepth = keyString.toInt();
 			}
 
 			if (settingName == "AlarmTime") {
 				if (attributes.hasAttribute("enabled"))
-					details->alarmTimeEnabled = attributes.value("enabled").toString().toInt();
-				details->alarmTime = keyString.toInt();
+					details.alarmTimeEnabled = attributes.value("enabled").toString().toInt();
+				details.alarmTime = keyString.toInt();
 			}
 		}
 		reader.readNext();

--- a/core/configuredivecomputer.h
+++ b/core/configuredivecomputer.h
@@ -32,10 +32,10 @@ public:
 
 	QString lastError;
 	states currentState;
-	void saveDeviceDetails(DeviceDetails *details, device_data_t *data);
+	void saveDeviceDetails(const DeviceDetails &details, device_data_t *data);
 	void fetchDeviceDetails();
-	bool saveXMLBackup(const QString &fileName, DeviceDetails *details, device_data_t *data);
-	bool restoreXMLBackup(const QString &fileName, DeviceDetails *details);
+	bool saveXMLBackup(const QString &fileName, const DeviceDetails &details, device_data_t *data);
+	bool restoreXMLBackup(const QString &fileName, DeviceDetails &details);
 	void startFirmwareUpdate(const QString &fileName, device_data_t *data, bool forceUpdate);
 	void resetSettings(device_data_t *data);
 
@@ -48,7 +48,7 @@ signals:
 	void message(QString msg);
 	void error(QString err);
 	void stateChanged(states newState);
-	void deviceDetailsChanged(DeviceDetails *newDetails);
+	void deviceDetailsChanged(DeviceDetails newDetails);
 
 private:
 	ReadSettingsThread *readThread;

--- a/core/configuredivecomputerthreads.cpp
+++ b/core/configuredivecomputerthreads.cpp
@@ -148,7 +148,7 @@ static void write_ostc_cf(unsigned char data[], unsigned char cf, unsigned char 
 		progress_cb(device, DC_EVENT_PROGRESS, &progress, userdata); \
 	} while (0)
 
-static dc_status_t read_suunto_vyper_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t read_suunto_vyper_settings(dc_device_t *device, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	unsigned char data[SUUNTO_VYPER_CUSTOM_TEXT_LENGTH + 1];
 	dc_status_t rc;
@@ -163,7 +163,7 @@ static dc_status_t read_suunto_vyper_settings(dc_device_t *device, DeviceDetails
 		if (desc) {
 			// We found a supported device
 			// we can safely proceed with reading/writing to this device.
-			m_deviceDetails->model = dc_descriptor_get_product(desc);
+			deviceDetails.model = dc_descriptor_get_product(desc);
 			dc_descriptor_free(desc);
 		} else {
 			return DC_STATUS_UNSUPPORTED;
@@ -176,86 +176,86 @@ static dc_status_t read_suunto_vyper_settings(dc_device_t *device, DeviceDetails
 		return rc;
 	// in ft * 128.0
 	int depth = feet_to_mm(data[0] << 8 ^ data[1]) / 128;
-	m_deviceDetails->maxDepth = depth;
+	deviceDetails.maxDepth = depth;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_TOTAL_TIME, data, 2);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	int total_time = data[0] << 8 ^ data[1];
-	m_deviceDetails->totalTime = total_time;
+	deviceDetails.totalTime = total_time;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_NUMBEROFDIVES, data, 2);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	int number_of_dives = data[0] << 8 ^ data[1];
-	m_deviceDetails->numberOfDives = number_of_dives;
+	deviceDetails.numberOfDives = number_of_dives;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_FIRMWARE, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->firmwareVersion = QString::number(data[0]) + ".0.0";
+	deviceDetails.firmwareVersion = QString::number(data[0]) + ".0.0";
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_SERIALNUMBER, data, 4);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	int serial_number = data[0] * 1000000 + data[1] * 10000 + data[2] * 100 + data[3];
-	m_deviceDetails->serialNo = QString::number(serial_number);
+	deviceDetails.serialNo = QString::number(serial_number);
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_CUSTOM_TEXT, data, SUUNTO_VYPER_CUSTOM_TEXT_LENGTH);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	data[SUUNTO_VYPER_CUSTOM_TEXT_LENGTH] = 0;
-	m_deviceDetails->customText = (const char *)data;
+	deviceDetails.customText = (const char *)data;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_SAMPLING_RATE, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->samplingRate = (int)data[0];
+	deviceDetails.samplingRate = (int)data[0];
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_ALTITUDE_SAFETY, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->altitude = data[0] & 0x03;
-	m_deviceDetails->personalSafety = data[0] >> 2 & 0x03;
+	deviceDetails.altitude = data[0] & 0x03;
+	deviceDetails.personalSafety = data[0] >> 2 & 0x03;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_TIMEFORMAT, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->timeFormat = data[0] & 0x01;
+	deviceDetails.timeFormat = data[0] & 0x01;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_UNITS, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->units = data[0] & 0x01;
+	deviceDetails.units = data[0] & 0x01;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_MODEL, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->diveMode = data[0] & 0x03;
+	deviceDetails.diveMode = data[0] & 0x03;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_LIGHT, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->lightEnabled = data[0] >> 7;
-	m_deviceDetails->light = data[0] & 0x7F;
+	deviceDetails.lightEnabled = data[0] >> 7;
+	deviceDetails.light = data[0] & 0x7F;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_ALARM_DEPTH_TIME, data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
-	m_deviceDetails->alarmTimeEnabled = data[0] & 0x01;
-	m_deviceDetails->alarmDepthEnabled = data[0] >> 1 & 0x01;
+	deviceDetails.alarmTimeEnabled = data[0] & 0x01;
+	deviceDetails.alarmDepthEnabled = data[0] >> 1 & 0x01;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_ALARM_TIME, data, 2);
@@ -263,22 +263,22 @@ static dc_status_t read_suunto_vyper_settings(dc_device_t *device, DeviceDetails
 		return rc;
 	int time = data[0] << 8 ^ data[1];
 	// The stinger stores alarm time in seconds instead of minutes.
-	if (m_deviceDetails->model == "Stinger")
+	if (deviceDetails.model == "Stinger")
 		time /= 60;
-	m_deviceDetails->alarmTime = time;
+	deviceDetails.alarmTime = time;
 	EMIT_PROGRESS();
 
 	rc = dc_device_read(device, SUUNTO_VYPER_ALARM_DEPTH, data, 2);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	depth = feet_to_mm(data[0] << 8 ^ data[1]) / 128;
-	m_deviceDetails->alarmDepth = depth;
+	deviceDetails.alarmDepth = depth;
 	EMIT_PROGRESS();
 
 	return DC_STATUS_SUCCESS;
 }
 
-static dc_status_t write_suunto_vyper_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t write_suunto_vyper_settings(dc_device_t *device, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	dc_status_t rc;
 	dc_event_progress_t progress;
@@ -290,62 +290,62 @@ static dc_status_t write_suunto_vyper_settings(dc_device_t *device, DeviceDetail
 
 	// Maybee we should read the model from the device to sanity check it here too..
 	// For now we just check that we actually read a device before writing to one.
-	if (m_deviceDetails->model == "")
+	if (deviceDetails.model == "")
 		return DC_STATUS_UNSUPPORTED;
 
 	rc = dc_device_write(device, SUUNTO_VYPER_CUSTOM_TEXT,
 			     // Convert the customText to a 30 char wide padded with " "
-			     (const unsigned char *)qPrintable(QString("%1").arg(m_deviceDetails->customText, -30, QChar(' '))),
+			     (const unsigned char *)qPrintable(QString("%1").arg(deviceDetails.customText, -30, QChar(' '))),
 			     SUUNTO_VYPER_CUSTOM_TEXT_LENGTH);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->samplingRate;
+	data = deviceDetails.samplingRate;
 	rc = dc_device_write(device, SUUNTO_VYPER_SAMPLING_RATE, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->personalSafety << 2 ^ m_deviceDetails->altitude;
+	data = deviceDetails.personalSafety << 2 ^ deviceDetails.altitude;
 	rc = dc_device_write(device, SUUNTO_VYPER_ALTITUDE_SAFETY, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->timeFormat;
+	data = deviceDetails.timeFormat;
 	rc = dc_device_write(device, SUUNTO_VYPER_TIMEFORMAT, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->units;
+	data = deviceDetails.units;
 	rc = dc_device_write(device, SUUNTO_VYPER_UNITS, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->diveMode;
+	data = deviceDetails.diveMode;
 	rc = dc_device_write(device, SUUNTO_VYPER_MODEL, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->lightEnabled << 7 ^ (m_deviceDetails->light & 0x7F);
+	data = deviceDetails.lightEnabled << 7 ^ (deviceDetails.light & 0x7F);
 	rc = dc_device_write(device, SUUNTO_VYPER_LIGHT, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
-	data = m_deviceDetails->alarmDepthEnabled << 1 ^ m_deviceDetails->alarmTimeEnabled;
+	data = deviceDetails.alarmDepthEnabled << 1 ^ deviceDetails.alarmTimeEnabled;
 	rc = dc_device_write(device, SUUNTO_VYPER_ALARM_DEPTH_TIME, &data, 1);
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
 	// The stinger stores alarm time in seconds instead of minutes.
-	time = m_deviceDetails->alarmTime;
-	if (m_deviceDetails->model == "Stinger")
+	time = deviceDetails.alarmTime;
+	if (deviceDetails.model == "Stinger")
 		time *= 60;
 	data2[0] = time >> 8;
 	data2[1] = time & 0xFF;
@@ -354,14 +354,14 @@ static dc_status_t write_suunto_vyper_settings(dc_device_t *device, DeviceDetail
 		return rc;
 	EMIT_PROGRESS();
 
-	data2[0] = (int)(mm_to_feet(m_deviceDetails->alarmDepth) * 128) >> 8;
-	data2[1] = (int)(mm_to_feet(m_deviceDetails->alarmDepth) * 128) & 0x0FF;
+	data2[0] = (int)(mm_to_feet(deviceDetails.alarmDepth) * 128) >> 8;
+	data2[1] = (int)(mm_to_feet(deviceDetails.alarmDepth) * 128) & 0x0FF;
 	rc = dc_device_write(device, SUUNTO_VYPER_ALARM_DEPTH, data2, 2);
 	EMIT_PROGRESS();
 	return rc;
 }
 
-static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	// This code is really similar to the OSTC3 code, but there are minor
 	// differences in what the data means, and how to communicate with the
@@ -426,11 +426,11 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 	gas5.depth = gasData[3];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->gas1 = gas1;
-	m_deviceDetails->gas2 = gas2;
-	m_deviceDetails->gas3 = gas3;
-	m_deviceDetails->gas4 = gas4;
-	m_deviceDetails->gas5 = gas5;
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
 	EMIT_PROGRESS();
 
 	//Read Dil Values
@@ -486,11 +486,11 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 	dil5.depth = dilData[3];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->dil1 = dil1;
-	m_deviceDetails->dil2 = dil2;
-	m_deviceDetails->dil3 = dil3;
-	m_deviceDetails->dil4 = dil4;
-	m_deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 
 	//Read setpoint Values
 	setpoint sp1;
@@ -535,11 +535,11 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 	sp5.depth = spData[1];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->sp1 = sp1;
-	m_deviceDetails->sp2 = sp2;
-	m_deviceDetails->sp3 = sp3;
-	m_deviceDetails->sp4 = sp4;
-	m_deviceDetails->sp5 = sp5;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
+	deviceDetails.sp4 = sp4;
+	deviceDetails.sp5 = sp5;
 
 	//Read other settings
 	unsigned char uData[4] = { 0 };
@@ -549,7 +549,7 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 		rc = hw_ostc3_device_config_read(device, _OSTC4_SETTING, uData, sizeof(uData)); \
 		if (rc != DC_STATUS_SUCCESS)                                                    \
 			return rc;                                                              \
-		m_deviceDetails->_DEVICE_DETAIL = uData[0];                                     \
+		deviceDetails._DEVICE_DETAIL = uData[0];                                        \
 		EMIT_PROGRESS();                                                                \
 	} while (0)
 
@@ -597,14 +597,14 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	// OSTC3 stores the pressureSensorOffset in two-complement
-	m_deviceDetails->pressureSensorOffset = (signed char)uData[0];
+	deviceDetails.pressureSensorOffset = (signed char)uData[0];
 	EMIT_PROGRESS();
 
 	rc = hw_ostc3_device_config_read(device, OSTC3_TEMP_SENSOR_OFFSET, uData, sizeof(uData));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	// OSTC3 stores the tempSensorOffset in two-complement
-	m_deviceDetails->tempSensorOffset = (signed char)uData[0];
+	deviceDetails.tempSensorOffset = (signed char)uData[0];
 	EMIT_PROGRESS();
 
 	//read firmware settings
@@ -613,22 +613,22 @@ static dc_status_t read_ostc4_settings(dc_device_t *device, DeviceDetails *m_dev
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	int serial = fData[0] + (fData[1] << 8);
-	m_deviceDetails->serialNo = QString::number(serial);
+	deviceDetails.serialNo = QString::number(serial);
 	unsigned char X, Y, Z, beta;
 	unsigned int firmwareOnDevice = (fData[3] << 8) + fData[2];
 	X = (firmwareOnDevice & 0xF800) >> 11;
 	Y = (firmwareOnDevice & 0x07C0) >> 6;
 	Z = (firmwareOnDevice & 0x003E) >> 1;
 	beta = firmwareOnDevice & 0x0001;
-	m_deviceDetails->firmwareVersion = QString("%1.%2.%3%4").arg(X).arg(Y).arg(Z).arg(beta?" beta":"");
+	deviceDetails.firmwareVersion = QString("%1.%2.%3%4").arg(X).arg(Y).arg(Z).arg(beta?" beta":"");
 	QByteArray ar((char *)fData + 4, 60);
-	m_deviceDetails->customText = ar.trimmed();
+	deviceDetails.customText = ar.trimmed();
 	EMIT_PROGRESS();
 
 	return rc;
 }
 
-static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t write_ostc4_settings(dc_device_t *device, const DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	// This code is really similar to the OSTC3 code, but there are minor
 	// differences in what the data means, and how to communicate with the
@@ -640,38 +640,38 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write gas values
 	unsigned char gas1Data[4] = {
-		m_deviceDetails->gas1.oxygen,
-		m_deviceDetails->gas1.helium,
-		m_deviceDetails->gas1.type,
-		m_deviceDetails->gas1.depth
+		deviceDetails.gas1.oxygen,
+		deviceDetails.gas1.helium,
+		deviceDetails.gas1.type,
+		deviceDetails.gas1.depth
 	};
 
 	unsigned char gas2Data[4] = {
-		m_deviceDetails->gas2.oxygen,
-		m_deviceDetails->gas2.helium,
-		m_deviceDetails->gas2.type,
-		m_deviceDetails->gas2.depth
+		deviceDetails.gas2.oxygen,
+		deviceDetails.gas2.helium,
+		deviceDetails.gas2.type,
+		deviceDetails.gas2.depth
 	};
 
 	unsigned char gas3Data[4] = {
-		m_deviceDetails->gas3.oxygen,
-		m_deviceDetails->gas3.helium,
-		m_deviceDetails->gas3.type,
-		m_deviceDetails->gas3.depth
+		deviceDetails.gas3.oxygen,
+		deviceDetails.gas3.helium,
+		deviceDetails.gas3.type,
+		deviceDetails.gas3.depth
 	};
 
 	unsigned char gas4Data[4] = {
-		m_deviceDetails->gas4.oxygen,
-		m_deviceDetails->gas4.helium,
-		m_deviceDetails->gas4.type,
-		m_deviceDetails->gas4.depth
+		deviceDetails.gas4.oxygen,
+		deviceDetails.gas4.helium,
+		deviceDetails.gas4.type,
+		deviceDetails.gas4.depth
 	};
 
 	unsigned char gas5Data[4] = {
-		m_deviceDetails->gas5.oxygen,
-		m_deviceDetails->gas5.helium,
-		m_deviceDetails->gas5.type,
-		m_deviceDetails->gas5.depth
+		deviceDetails.gas5.oxygen,
+		deviceDetails.gas5.helium,
+		deviceDetails.gas5.type,
+		deviceDetails.gas5.depth
 	};
 	//gas 1
 	rc = hw_ostc3_device_config_write(device, OSTC3_GAS1, gas1Data, sizeof(gas1Data));
@@ -701,28 +701,28 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write setpoint values
 	unsigned char sp1Data[4] = {
-		m_deviceDetails->sp1.sp,
-		m_deviceDetails->sp1.depth
+		deviceDetails.sp1.sp,
+		deviceDetails.sp1.depth
 	};
 
 	unsigned char sp2Data[4] = {
-		m_deviceDetails->sp2.sp,
-		m_deviceDetails->sp2.depth
+		deviceDetails.sp2.sp,
+		deviceDetails.sp2.depth
 	};
 
 	unsigned char sp3Data[4] = {
-		m_deviceDetails->sp3.sp,
-		m_deviceDetails->sp3.depth
+		deviceDetails.sp3.sp,
+		deviceDetails.sp3.depth
 	};
 
 	unsigned char sp4Data[4] = {
-		m_deviceDetails->sp4.sp,
-		m_deviceDetails->sp4.depth
+		deviceDetails.sp4.sp,
+		deviceDetails.sp4.depth
 	};
 
 	unsigned char sp5Data[4] = {
-		m_deviceDetails->sp5.sp,
-		m_deviceDetails->sp5.depth
+		deviceDetails.sp5.sp,
+		deviceDetails.sp5.depth
 	};
 
 	//sp 1
@@ -753,38 +753,38 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write dil values
 	unsigned char dil1Data[4] = {
-		m_deviceDetails->dil1.oxygen,
-		m_deviceDetails->dil1.helium,
-		m_deviceDetails->dil1.type,
-		m_deviceDetails->dil1.depth
+		deviceDetails.dil1.oxygen,
+		deviceDetails.dil1.helium,
+		deviceDetails.dil1.type,
+		deviceDetails.dil1.depth
 	};
 
 	unsigned char dil2Data[4] = {
-		m_deviceDetails->dil2.oxygen,
-		m_deviceDetails->dil2.helium,
-		m_deviceDetails->dil2.type,
-		m_deviceDetails->dil2.depth
+		deviceDetails.dil2.oxygen,
+		deviceDetails.dil2.helium,
+		deviceDetails.dil2.type,
+		deviceDetails.dil2.depth
 	};
 
 	unsigned char dil3Data[4] = {
-		m_deviceDetails->dil3.oxygen,
-		m_deviceDetails->dil3.helium,
-		m_deviceDetails->dil3.type,
-		m_deviceDetails->dil3.depth
+		deviceDetails.dil3.oxygen,
+		deviceDetails.dil3.helium,
+		deviceDetails.dil3.type,
+		deviceDetails.dil3.depth
 	};
 
 	unsigned char dil4Data[4] = {
-		m_deviceDetails->dil4.oxygen,
-		m_deviceDetails->dil4.helium,
-		m_deviceDetails->dil4.type,
-		m_deviceDetails->dil4.depth
+		deviceDetails.dil4.oxygen,
+		deviceDetails.dil4.helium,
+		deviceDetails.dil4.type,
+		deviceDetails.dil4.depth
 	};
 
 	unsigned char dil5Data[4] = {
-		m_deviceDetails->dil5.oxygen,
-		m_deviceDetails->dil5.helium,
-		m_deviceDetails->dil5.type,
-		m_deviceDetails->dil5.depth
+		deviceDetails.dil5.oxygen,
+		deviceDetails.dil5.helium,
+		deviceDetails.dil5.type,
+		deviceDetails.dil5.depth
 	};
 	//dil 1
 	rc = hw_ostc3_device_config_write(device, OSTC3_DIL1, dil1Data, sizeof(gas1Data));
@@ -814,7 +814,7 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write general settings
 	//custom text
-	rc = hw_ostc3_device_customtext(device, qPrintable(m_deviceDetails->customText));
+	rc = hw_ostc3_device_customtext(device, qPrintable(deviceDetails.customText));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
@@ -822,7 +822,7 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 	unsigned char data[4] = { 0 };
 #define WRITE_SETTING(_OSTC4_SETTING, _DEVICE_DETAIL)                                          \
 	do {                                                                                   \
-		data[0] = m_deviceDetails->_DEVICE_DETAIL;                                     \
+		data[0] = deviceDetails._DEVICE_DETAIL;                                        \
 		rc = hw_ostc3_device_config_write(device, _OSTC4_SETTING, data, sizeof(data)); \
 		if (rc != DC_STATUS_SUCCESS)                                                   \
 			return rc;                                                             \
@@ -870,14 +870,14 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 #undef WRITE_SETTING
 
 	// OSTC3 stores the pressureSensorOffset in two-complement
-	data[0] = (unsigned char)m_deviceDetails->pressureSensorOffset;
+	data[0] = (unsigned char)deviceDetails.pressureSensorOffset;
 	rc = hw_ostc3_device_config_write(device, OSTC3_PRESSURE_SENSOR_OFFSET, data, sizeof(data));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
 	// OSTC3 stores the tempSensorOffset in two-complement
-	data[0] = (unsigned char)m_deviceDetails->tempSensorOffset;
+	data[0] = (unsigned char)deviceDetails.tempSensorOffset;
 	rc = hw_ostc3_device_config_write(device, OSTC3_TEMP_SENSOR_OFFSET, data, sizeof(data));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
@@ -885,7 +885,7 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 
 
 	//sync date and time
-	if (m_deviceDetails->syncTime) {
+	if (deviceDetails.syncTime) {
 		dc_datetime_t now;
 		dc_datetime_localtime(&now, dc_datetime_now());
 
@@ -897,7 +897,7 @@ static dc_status_t write_ostc4_settings(dc_device_t *device, DeviceDetails *m_de
 	return rc;
 }
 
-static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	dc_status_t rc;
 	dc_event_progress_t progress;
@@ -912,14 +912,14 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 
 	dc_descriptor_t *desc = get_descriptor(DC_FAMILY_HW_OSTC3, hardware[0]);
 	if (desc) {
-		m_deviceDetails->model = dc_descriptor_get_product(desc);
+		deviceDetails.model = dc_descriptor_get_product(desc);
 		dc_descriptor_free(desc);
 	} else {
 		return DC_STATUS_UNSUPPORTED;
 	}
 
-	if (m_deviceDetails->model == "OSTC 4")
-		return read_ostc4_settings(device, m_deviceDetails, progress_cb, userdata);
+	if (deviceDetails.model == "OSTC 4")
+		return read_ostc4_settings(device, deviceDetails, progress_cb, userdata);
 
 	EMIT_PROGRESS();
 
@@ -976,11 +976,11 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	gas5.depth = gasData[3];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->gas1 = gas1;
-	m_deviceDetails->gas2 = gas2;
-	m_deviceDetails->gas3 = gas3;
-	m_deviceDetails->gas4 = gas4;
-	m_deviceDetails->gas5 = gas5;
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
 	EMIT_PROGRESS();
 
 	//Read Dil Values
@@ -1036,11 +1036,11 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	dil5.depth = dilData[3];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->dil1 = dil1;
-	m_deviceDetails->dil2 = dil2;
-	m_deviceDetails->dil3 = dil3;
-	m_deviceDetails->dil4 = dil4;
-	m_deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 
 	//Read setpoint Values
 	setpoint sp1;
@@ -1085,11 +1085,11 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	sp5.depth = spData[1];
 	EMIT_PROGRESS();
 
-	m_deviceDetails->sp1 = sp1;
-	m_deviceDetails->sp2 = sp2;
-	m_deviceDetails->sp3 = sp3;
-	m_deviceDetails->sp4 = sp4;
-	m_deviceDetails->sp5 = sp5;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
+	deviceDetails.sp4 = sp4;
+	deviceDetails.sp5 = sp5;
 
 	//Read other settings
 	unsigned char uData[1] = { 0 };
@@ -1099,7 +1099,7 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 		rc = hw_ostc3_device_config_read(device, _OSTC3_SETTING, uData, sizeof(uData)); \
 		if (rc != DC_STATUS_SUCCESS)                                                    \
 			return rc;                                                              \
-		m_deviceDetails->_DEVICE_DETAIL = uData[0];                                     \
+		deviceDetails._DEVICE_DETAIL = uData[0];                                        \
 		EMIT_PROGRESS();                                                                \
 	} while (0)
 
@@ -1147,14 +1147,14 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	// OSTC3 stores the pressureSensorOffset in two-complement
-	m_deviceDetails->pressureSensorOffset = (signed char)uData[0];
+	deviceDetails.pressureSensorOffset = (signed char)uData[0];
 	EMIT_PROGRESS();
 
 	rc = hw_ostc3_device_config_read(device, OSTC3_TEMP_SENSOR_OFFSET, uData, sizeof(uData));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	// OSTC3 stores the tempSensorOffset in two-complement
-	m_deviceDetails->tempSensorOffset = (signed char)uData[0];
+	deviceDetails.tempSensorOffset = (signed char)uData[0];
 	EMIT_PROGRESS();
 
 	//read firmware settings
@@ -1163,16 +1163,16 @@ static dc_status_t read_ostc3_settings(dc_device_t *device, DeviceDetails *m_dev
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	int serial = fData[0] + (fData[1] << 8);
-	m_deviceDetails->serialNo = QString::number(serial);
-	m_deviceDetails->firmwareVersion = QString::number(fData[2]) + "." + QString::number(fData[3]);
+	deviceDetails.serialNo = QString::number(serial);
+	deviceDetails.firmwareVersion = QString::number(fData[2]) + "." + QString::number(fData[3]);
 	QByteArray ar((char *)fData + 4, 60);
-	m_deviceDetails->customText = ar.trimmed();
+	deviceDetails.customText = ar.trimmed();
 	EMIT_PROGRESS();
 
 	return rc;
 }
 
-static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t write_ostc3_settings(dc_device_t *device, const DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	dc_status_t rc;
 	dc_event_progress_t progress;
@@ -1181,38 +1181,38 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write gas values
 	unsigned char gas1Data[4] = {
-		m_deviceDetails->gas1.oxygen,
-		m_deviceDetails->gas1.helium,
-		m_deviceDetails->gas1.type,
-		m_deviceDetails->gas1.depth
+		deviceDetails.gas1.oxygen,
+		deviceDetails.gas1.helium,
+		deviceDetails.gas1.type,
+		deviceDetails.gas1.depth
 	};
 
 	unsigned char gas2Data[4] = {
-		m_deviceDetails->gas2.oxygen,
-		m_deviceDetails->gas2.helium,
-		m_deviceDetails->gas2.type,
-		m_deviceDetails->gas2.depth
+		deviceDetails.gas2.oxygen,
+		deviceDetails.gas2.helium,
+		deviceDetails.gas2.type,
+		deviceDetails.gas2.depth
 	};
 
 	unsigned char gas3Data[4] = {
-		m_deviceDetails->gas3.oxygen,
-		m_deviceDetails->gas3.helium,
-		m_deviceDetails->gas3.type,
-		m_deviceDetails->gas3.depth
+		deviceDetails.gas3.oxygen,
+		deviceDetails.gas3.helium,
+		deviceDetails.gas3.type,
+		deviceDetails.gas3.depth
 	};
 
 	unsigned char gas4Data[4] = {
-		m_deviceDetails->gas4.oxygen,
-		m_deviceDetails->gas4.helium,
-		m_deviceDetails->gas4.type,
-		m_deviceDetails->gas4.depth
+		deviceDetails.gas4.oxygen,
+		deviceDetails.gas4.helium,
+		deviceDetails.gas4.type,
+		deviceDetails.gas4.depth
 	};
 
 	unsigned char gas5Data[4] = {
-		m_deviceDetails->gas5.oxygen,
-		m_deviceDetails->gas5.helium,
-		m_deviceDetails->gas5.type,
-		m_deviceDetails->gas5.depth
+		deviceDetails.gas5.oxygen,
+		deviceDetails.gas5.helium,
+		deviceDetails.gas5.type,
+		deviceDetails.gas5.depth
 	};
 	//gas 1
 	rc = hw_ostc3_device_config_write(device, OSTC3_GAS1, gas1Data, sizeof(gas1Data));
@@ -1242,28 +1242,28 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write setpoint values
 	unsigned char sp1Data[2] = {
-		m_deviceDetails->sp1.sp,
-		m_deviceDetails->sp1.depth
+		deviceDetails.sp1.sp,
+		deviceDetails.sp1.depth
 	};
 
 	unsigned char sp2Data[2] = {
-		m_deviceDetails->sp2.sp,
-		m_deviceDetails->sp2.depth
+		deviceDetails.sp2.sp,
+		deviceDetails.sp2.depth
 	};
 
 	unsigned char sp3Data[2] = {
-		m_deviceDetails->sp3.sp,
-		m_deviceDetails->sp3.depth
+		deviceDetails.sp3.sp,
+		deviceDetails.sp3.depth
 	};
 
 	unsigned char sp4Data[2] = {
-		m_deviceDetails->sp4.sp,
-		m_deviceDetails->sp4.depth
+		deviceDetails.sp4.sp,
+		deviceDetails.sp4.depth
 	};
 
 	unsigned char sp5Data[2] = {
-		m_deviceDetails->sp5.sp,
-		m_deviceDetails->sp5.depth
+		deviceDetails.sp5.sp,
+		deviceDetails.sp5.depth
 	};
 
 	//sp 1
@@ -1294,38 +1294,38 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write dil values
 	unsigned char dil1Data[4] = {
-		m_deviceDetails->dil1.oxygen,
-		m_deviceDetails->dil1.helium,
-		m_deviceDetails->dil1.type,
-		m_deviceDetails->dil1.depth
+		deviceDetails.dil1.oxygen,
+		deviceDetails.dil1.helium,
+		deviceDetails.dil1.type,
+		deviceDetails.dil1.depth
 	};
 
 	unsigned char dil2Data[4] = {
-		m_deviceDetails->dil2.oxygen,
-		m_deviceDetails->dil2.helium,
-		m_deviceDetails->dil2.type,
-		m_deviceDetails->dil2.depth
+		deviceDetails.dil2.oxygen,
+		deviceDetails.dil2.helium,
+		deviceDetails.dil2.type,
+		deviceDetails.dil2.depth
 	};
 
 	unsigned char dil3Data[4] = {
-		m_deviceDetails->dil3.oxygen,
-		m_deviceDetails->dil3.helium,
-		m_deviceDetails->dil3.type,
-		m_deviceDetails->dil3.depth
+		deviceDetails.dil3.oxygen,
+		deviceDetails.dil3.helium,
+		deviceDetails.dil3.type,
+		deviceDetails.dil3.depth
 	};
 
 	unsigned char dil4Data[4] = {
-		m_deviceDetails->dil4.oxygen,
-		m_deviceDetails->dil4.helium,
-		m_deviceDetails->dil4.type,
-		m_deviceDetails->dil4.depth
+		deviceDetails.dil4.oxygen,
+		deviceDetails.dil4.helium,
+		deviceDetails.dil4.type,
+		deviceDetails.dil4.depth
 	};
 
 	unsigned char dil5Data[4] = {
-		m_deviceDetails->dil5.oxygen,
-		m_deviceDetails->dil5.helium,
-		m_deviceDetails->dil5.type,
-		m_deviceDetails->dil5.depth
+		deviceDetails.dil5.oxygen,
+		deviceDetails.dil5.helium,
+		deviceDetails.dil5.type,
+		deviceDetails.dil5.depth
 	};
 	//dil 1
 	rc = hw_ostc3_device_config_write(device, OSTC3_DIL1, dil1Data, sizeof(gas1Data));
@@ -1355,14 +1355,14 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 
 	//write general settings
 	//custom text
-	rc = hw_ostc3_device_customtext(device, qPrintable(m_deviceDetails->customText));
+	rc = hw_ostc3_device_customtext(device, qPrintable(deviceDetails.customText));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 
 	unsigned char data[1] = { 0 };
 #define WRITE_SETTING(_OSTC3_SETTING, _DEVICE_DETAIL)                                          \
 	do {                                                                                   \
-		data[0] = m_deviceDetails->_DEVICE_DETAIL;                                     \
+		data[0] = deviceDetails._DEVICE_DETAIL;                                        \
 		rc = hw_ostc3_device_config_write(device, _OSTC3_SETTING, data, sizeof(data)); \
 		if (rc != DC_STATUS_SUCCESS)                                                   \
 			return rc;                                                             \
@@ -1410,21 +1410,21 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 #undef WRITE_SETTING
 
 	// OSTC3 stores the pressureSensorOffset in two-complement
-	data[0] = (unsigned char)m_deviceDetails->pressureSensorOffset;
+	data[0] = (unsigned char)deviceDetails.pressureSensorOffset;
 	rc = hw_ostc3_device_config_write(device, OSTC3_PRESSURE_SENSOR_OFFSET, data, sizeof(data));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
 	// OSTC3 stores the tempSensorOffset in two-complement
-	data[0] = (unsigned char)m_deviceDetails->tempSensorOffset;
+	data[0] = (unsigned char)deviceDetails.tempSensorOffset;
 	rc = hw_ostc3_device_config_write(device, OSTC3_TEMP_SENSOR_OFFSET, data, sizeof(data));
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
 
 	//sync date and time
-	if (m_deviceDetails->syncTime) {
+	if (deviceDetails.syncTime) {
 		dc_datetime_t now;
 		dc_datetime_localtime(&now, dc_datetime_now());
 
@@ -1435,7 +1435,7 @@ static dc_status_t write_ostc3_settings(dc_device_t *device, DeviceDetails *m_de
 	return rc;
 }
 
-static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	dc_status_t rc;
 	dc_event_progress_t progress;
@@ -1451,8 +1451,8 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	if (rc != DC_STATUS_SUCCESS)
 		return rc;
 	EMIT_PROGRESS();
-	m_deviceDetails->serialNo = QString::number(data[1] << 8 ^ data[0]);
-	m_deviceDetails->numberOfDives = data[3] << 8 ^ data[2];
+	deviceDetails.serialNo = QString::number(data[1] << 8 ^ data[0]);
+	deviceDetails.numberOfDives = data[3] << 8 ^ data[2];
 	//Byte5-6:
 	//Gas 1 default (%O2=21, %He=0)
 	gas gas1;
@@ -1480,7 +1480,7 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	gas5.helium = data[23];
 	//Byte25-26:
 	//Gas 6 current (%O2, %He)
-	m_deviceDetails->salinity = data[26];
+	deviceDetails.salinity = data[26];
 	// Active Gas Flag Register
 	gas1.type = data[27] & 0x01;
 	gas2.type = (data[27] & 0x02) >> 1;
@@ -1516,15 +1516,15 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 		break;
 	}
 	// Data filled up, set the gases.
-	m_deviceDetails->gas1 = gas1;
-	m_deviceDetails->gas2 = gas2;
-	m_deviceDetails->gas3 = gas3;
-	m_deviceDetails->gas4 = gas4;
-	m_deviceDetails->gas5 = gas5;
-	m_deviceDetails->decoType = data[34];
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
+	deviceDetails.decoType = data[34];
 	//Byte36:
 	//Use O2 Sensor Module in CC Modes (0= OFF, 1= ON) (Only available in old OSTC1 - unused for OSTC Mk.2/2N)
-	//m_deviceDetails->ccrMode = data[35];
+	//deviceDetails.ccrMode = data[35];
 	setpoint sp1;
 	sp1.sp = data[36];
 	sp1.depth = 0;
@@ -1534,9 +1534,9 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	setpoint sp3;
 	sp3.sp = data[38];
 	sp3.depth = 0;
-	m_deviceDetails->sp1 = sp1;
-	m_deviceDetails->sp2 = sp2;
-	m_deviceDetails->sp3 = sp3;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
 	// Byte41-42:
 	// Lowest Battery voltage seen (in mV)
 	// Byte43:
@@ -1586,7 +1586,7 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 		char *term = strchr((char *)data + 65, (int)'}');
 		if (term)
 			*term = 0;
-		m_deviceDetails->customText = (const char *)data + 65;
+		deviceDetails.customText = (const char *)data + 65;
 	}
 	// Byte91:
 	// Dim OLED in Divemode (>0), Normal mode (=0)
@@ -1595,7 +1595,7 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	// =0: MM/DD/YY
 	// =1: DD/MM/YY
 	// =2: YY/MM/DD
-	m_deviceDetails->dateFormat = data[91];
+	deviceDetails.dateFormat = data[91];
 // Byte93:
 // Total number of CF used in installed firmware
 #ifdef DEBUG_OSTC_CF
@@ -1652,11 +1652,11 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 		//Error?
 		break;
 	}
-	m_deviceDetails->dil1 = dil1;
-	m_deviceDetails->dil2 = dil2;
-	m_deviceDetails->dil3 = dil3;
-	m_deviceDetails->dil4 = dil4;
-	m_deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 	// Byte117-128:
 	// not used/reserved
 	// Byte129-256:
@@ -1664,17 +1664,17 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 
 	// Decode the relevant ones
 	// CF11: Factor for saturation processes
-	m_deviceDetails->saturation = read_ostc_cf(data, 11);
+	deviceDetails.saturation = read_ostc_cf(data, 11);
 	// CF12: Factor for desaturation processes
-	m_deviceDetails->desaturation = read_ostc_cf(data, 12);
+	deviceDetails.desaturation = read_ostc_cf(data, 12);
 	// CF17: Lower threshold for ppO2 warning
-	m_deviceDetails->ppO2Min = read_ostc_cf(data, 17);
+	deviceDetails.ppO2Min = read_ostc_cf(data, 17);
 	// CF18: Upper threshold for ppO2 warning
-	m_deviceDetails->ppO2Max = read_ostc_cf(data, 18);
+	deviceDetails.ppO2Max = read_ostc_cf(data, 18);
 	// CF20: Depth sampling rate for Profile storage
-	m_deviceDetails->samplingRate = read_ostc_cf(data, 20);
+	deviceDetails.samplingRate = read_ostc_cf(data, 20);
 	// CF29: Depth of last decompression stop
-	m_deviceDetails->lastDeco = read_ostc_cf(data, 29);
+	deviceDetails.lastDeco = read_ostc_cf(data, 29);
 
 #ifdef DEBUG_OSTC_CF
 	for (int cf = 0; cf <= 31 && cf <= max_CF; cf++)
@@ -1689,7 +1689,7 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	// Logbook version indicator (Not writable!)
 	// Byte2-3:
 	// Last Firmware installed, 1st Byte.2nd Byte (e.g. „1.90“) (Not writable!)
-	m_deviceDetails->firmwareVersion = QString::number(data[1]) + "." + QString::number(data[2]);
+	deviceDetails.firmwareVersion = QString::number(data[1]) + "." + QString::number(data[2]);
 	// Byte4:
 	// OLED brightness (=0: Eco, =1 High) (Not writable!)
 	// Byte5-11:
@@ -1701,15 +1701,15 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 
 	// Decode the relevant ones
 	// CF32: Gradient Factor low
-	m_deviceDetails->gfLow = read_ostc_cf(data, 32);
+	deviceDetails.gfLow = read_ostc_cf(data, 32);
 	// CF33: Gradient Factor high
-	m_deviceDetails->gfHigh = read_ostc_cf(data, 33);
+	deviceDetails.gfHigh = read_ostc_cf(data, 33);
 	// CF56: Bottom gas consumption
-	m_deviceDetails->bottomGasConsumption = read_ostc_cf(data, 56);
+	deviceDetails.bottomGasConsumption = read_ostc_cf(data, 56);
 	// CF57: Ascent gas consumption
-	m_deviceDetails->decoGasConsumption = read_ostc_cf(data, 57);
+	deviceDetails.decoGasConsumption = read_ostc_cf(data, 57);
 	// CF58: Future time to surface setFutureTTS
-	m_deviceDetails->futureTTS = read_ostc_cf(data, 58);
+	deviceDetails.futureTTS = read_ostc_cf(data, 58);
 
 #ifdef DEBUG_OSTC_CF
 	for (int cf = 32; cf <= 63 && cf <= max_CF; cf++)
@@ -1729,23 +1729,23 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 
 	// Decode the relevant ones
 	// CF60: Graphic velocity
-	m_deviceDetails->graphicalSpeedIndicator = read_ostc_cf(data, 60);
+	deviceDetails.graphicalSpeedIndicator = read_ostc_cf(data, 60);
 	// CF65: Show safety stop
-	m_deviceDetails->safetyStop = read_ostc_cf(data, 65);
+	deviceDetails.safetyStop = read_ostc_cf(data, 65);
 	// CF67: Alternaitve Gradient Factor low
-	m_deviceDetails->aGFLow = read_ostc_cf(data, 67);
+	deviceDetails.aGFLow = read_ostc_cf(data, 67);
 	// CF68: Alternative Gradient Factor high
-	m_deviceDetails->aGFHigh = read_ostc_cf(data, 68);
+	deviceDetails.aGFHigh = read_ostc_cf(data, 68);
 	// CF69: Allow Gradient Factor change
-	m_deviceDetails->aGFSelectable = read_ostc_cf(data, 69);
+	deviceDetails.aGFSelectable = read_ostc_cf(data, 69);
 	// CF70: Safety Stop Duration [s]
-	m_deviceDetails->safetyStopLength = read_ostc_cf(data, 70);
+	deviceDetails.safetyStopLength = read_ostc_cf(data, 70);
 	// CF71: Safety Stop Start Depth [m]
-	m_deviceDetails->safetyStopStartDepth = read_ostc_cf(data, 71);
+	deviceDetails.safetyStopStartDepth = read_ostc_cf(data, 71);
 	// CF72: Safety Stop End Depth [m]
-	m_deviceDetails->safetyStopEndDepth = read_ostc_cf(data, 72);
+	deviceDetails.safetyStopEndDepth = read_ostc_cf(data, 72);
 	// CF73: Safety Stop Reset Depth [m]
-	m_deviceDetails->safetyStopResetDepth = read_ostc_cf(data, 73);
+	deviceDetails.safetyStopResetDepth = read_ostc_cf(data, 73);
 	// CF74: Battery Timeout [min]
 
 #ifdef DEBUG_OSTC_CF
@@ -1756,7 +1756,7 @@ static dc_status_t read_ostc_settings(dc_device_t *device, DeviceDetails *m_devi
 	return rc;
 }
 
-static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_deviceDetails, dc_event_callback_t progress_cb, void *userdata)
+static dc_status_t write_ostc_settings(dc_device_t *device, const DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	dc_status_t rc;
 	dc_event_progress_t progress;
@@ -1773,32 +1773,32 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 	EMIT_PROGRESS();
 	//Byte5-6:
 	//Gas 1 default (%O2=21, %He=0)
-	gas gas1 = m_deviceDetails->gas1;
+	gas gas1 = deviceDetails.gas1;
 	data[6] = gas1.oxygen;
 	data[7] = gas1.helium;
 	//Byte9-10:
 	//Gas 2 default (%O2=21, %He=0)
-	gas gas2 = m_deviceDetails->gas2;
+	gas gas2 = deviceDetails.gas2;
 	data[10] = gas2.oxygen;
 	data[11] = gas2.helium;
 	//Byte13-14:
 	//Gas 3 default (%O2=21, %He=0)
-	gas gas3 = m_deviceDetails->gas3;
+	gas gas3 = deviceDetails.gas3;
 	data[14] = gas3.oxygen;
 	data[15] = gas3.helium;
 	//Byte17-18:
 	//Gas 4 default (%O2=21, %He=0)
-	gas gas4 = m_deviceDetails->gas4;
+	gas gas4 = deviceDetails.gas4;
 	data[18] = gas4.oxygen;
 	data[19] = gas4.helium;
 	//Byte21-22:
 	//Gas 5 default (%O2=21, %He=0)
-	gas gas5 = m_deviceDetails->gas5;
+	gas gas5 = deviceDetails.gas5;
 	data[22] = gas5.oxygen;
 	data[23] = gas5.helium;
 	//Byte25-26:
 	//Gas 6 current (%O2, %He)
-	data[26] = m_deviceDetails->salinity;
+	data[26] = deviceDetails.salinity;
 	// Gas types, 0=Disabled, 1=Active, 2=Fist
 	// Active Gas Flag Register
 	data[27] = 0;
@@ -1835,13 +1835,13 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 		// Set gas 1 to first
 		data[33] = 1;
 
-	data[34] = m_deviceDetails->decoType;
+	data[34] = deviceDetails.decoType;
 	//Byte36:
 	//Use O2 Sensor Module in CC Modes (0= OFF, 1= ON) (Only available in old OSTC1 - unused for OSTC Mk.2/2N)
-	//m_deviceDetails->ccrMode = data[35];
-	data[36] = m_deviceDetails->sp1.sp;
-	data[37] = m_deviceDetails->sp2.sp;
-	data[38] = m_deviceDetails->sp3.sp;
+	//deviceDetails.ccrMode = data[35];
+	data[36] = deviceDetails.sp1.sp;
+	data[37] = deviceDetails.sp2.sp;
+	data[38] = deviceDetails.sp3.sp;
 	// Byte41-42:
 	// Lowest Battery voltage seen (in mV)
 	// Byte43:
@@ -1883,15 +1883,15 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 	// Byte66-90:
 	// (25Bytes): Custom Text for Surfacemode (Real text must end with "}")
 	// Example: "OSTC Dive Computer}" (19 Characters incl. "}") Bytes 85-90 will be ignored.
-	if (m_deviceDetails->customText == "") {
+	if (deviceDetails.customText == "") {
 		data[64] = 0;
 	} else {
 		data[64] = 1;
 		// Copy the string to the right place in the memory, padded with 0x20 (" ")
-		strncpy((char *)data + 65, qPrintable(QString("%1").arg(m_deviceDetails->customText, -23, QChar(' '))), 23);
+		strncpy((char *)data + 65, qPrintable(QString("%1").arg(deviceDetails.customText, -23, QChar(' '))), 23);
 		// And terminate the string.
-		if (m_deviceDetails->customText.length() <= 23)
-			data[65 + m_deviceDetails->customText.length()] = '}';
+		if (deviceDetails.customText.length() <= 23)
+			data[65 + deviceDetails.customText.length()] = '}';
 		else
 			data[90] = '}';
 	}
@@ -1902,7 +1902,7 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 	// =0: MM/DD/YY
 	// =1: DD/MM/YY
 	// =2: YY/MM/DD
-	data[91] = m_deviceDetails->dateFormat;
+	data[91] = deviceDetails.dateFormat;
 	// Byte93:
 	// Total number of CF used in installed firmware
 	max_CF = data[92];
@@ -1914,35 +1914,35 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 	// Diluent 1 Default (%O2,%He)
 	// Byte98-99:
 	// Diluent 1 Current (%O2,%He)
-	gas dil1 = m_deviceDetails->dil1;
+	gas dil1 = deviceDetails.dil1;
 	data[97] = dil1.oxygen;
 	data[98] = dil1.helium;
 	// Byte100-101:
 	// Gasuent 2 Default (%O2,%He)
 	// Byte102-103:
 	// Gasuent 2 Current (%O2,%He)
-	gas dil2 = m_deviceDetails->dil2;
+	gas dil2 = deviceDetails.dil2;
 	data[101] = dil2.oxygen;
 	data[102] = dil2.helium;
 	// Byte104-105:
 	// Gasuent 3 Default (%O2,%He)
 	// Byte106-107:
 	// Gasuent 3 Current (%O2,%He)
-	gas dil3 = m_deviceDetails->dil3;
+	gas dil3 = deviceDetails.dil3;
 	data[105] = dil3.oxygen;
 	data[106] = dil3.helium;
 	// Byte108-109:
 	// Gasuent 4 Default (%O2,%He)
 	// Byte110-111:
 	// Gasuent 4 Current (%O2,%He)
-	gas dil4 = m_deviceDetails->dil4;
+	gas dil4 = deviceDetails.dil4;
 	data[109] = dil4.oxygen;
 	data[110] = dil4.helium;
 	// Byte112-113:
 	// Gasuent 5 Default (%O2,%He)
 	// Byte114-115:
 	// Gasuent 5 Current (%O2,%He)
-	gas dil5 = m_deviceDetails->dil5;
+	gas dil5 = deviceDetails.dil5;
 	data[113] = dil5.oxygen;
 	data[114] = dil5.helium;
 	// Byte116:
@@ -1969,17 +1969,17 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 
 	// Write the relevant ones
 	// CF11: Factor for saturation processes
-	write_ostc_cf(data, 11, max_CF, m_deviceDetails->saturation);
+	write_ostc_cf(data, 11, max_CF, deviceDetails.saturation);
 	// CF12: Factor for desaturation processes
-	write_ostc_cf(data, 12, max_CF, m_deviceDetails->desaturation);
+	write_ostc_cf(data, 12, max_CF, deviceDetails.desaturation);
 	// CF17: Lower threshold for ppO2 warning
-	write_ostc_cf(data, 17, max_CF, m_deviceDetails->ppO2Min);
+	write_ostc_cf(data, 17, max_CF, deviceDetails.ppO2Min);
 	// CF18: Upper threshold for ppO2 warning
-	write_ostc_cf(data, 18, max_CF, m_deviceDetails->ppO2Max);
+	write_ostc_cf(data, 18, max_CF, deviceDetails.ppO2Max);
 	// CF20: Depth sampling rate for Profile storage
-	write_ostc_cf(data, 20, max_CF, m_deviceDetails->samplingRate);
+	write_ostc_cf(data, 20, max_CF, deviceDetails.samplingRate);
 	// CF29: Depth of last decompression stop
-	write_ostc_cf(data, 29, max_CF, m_deviceDetails->lastDeco);
+	write_ostc_cf(data, 29, max_CF, deviceDetails.lastDeco);
 
 #ifdef DEBUG_OSTC_CF
 	for (int cf = 0; cf <= 31 && cf <= max_CF; cf++)
@@ -2009,15 +2009,15 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 
 	// Decode the relevant ones
 	// CF32: Gradient Factor low
-	write_ostc_cf(data, 32, max_CF, m_deviceDetails->gfLow);
+	write_ostc_cf(data, 32, max_CF, deviceDetails.gfLow);
 	// CF33: Gradient Factor high
-	write_ostc_cf(data, 33, max_CF, m_deviceDetails->gfHigh);
+	write_ostc_cf(data, 33, max_CF, deviceDetails.gfHigh);
 	// CF56: Bottom gas consumption
-	write_ostc_cf(data, 56, max_CF, m_deviceDetails->bottomGasConsumption);
+	write_ostc_cf(data, 56, max_CF, deviceDetails.bottomGasConsumption);
 	// CF57: Ascent gas consumption
-	write_ostc_cf(data, 57, max_CF, m_deviceDetails->decoGasConsumption);
+	write_ostc_cf(data, 57, max_CF, deviceDetails.decoGasConsumption);
 	// CF58: Future time to surface setFutureTTS
-	write_ostc_cf(data, 58, max_CF, m_deviceDetails->futureTTS);
+	write_ostc_cf(data, 58, max_CF, deviceDetails.futureTTS);
 #ifdef DEBUG_OSTC_CF
 	for (int cf = 32; cf <= 63 && cf <= max_CF; cf++)
 		printf("CF %d: %d\n", cf, read_ostc_cf(data, cf));
@@ -2040,23 +2040,23 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 
 	// Decode the relevant ones
 	// CF60: Graphic velocity
-	write_ostc_cf(data, 60, max_CF, m_deviceDetails->graphicalSpeedIndicator);
+	write_ostc_cf(data, 60, max_CF, deviceDetails.graphicalSpeedIndicator);
 	// CF65: Show safety stop
-	write_ostc_cf(data, 65, max_CF, m_deviceDetails->safetyStop);
+	write_ostc_cf(data, 65, max_CF, deviceDetails.safetyStop);
 	// CF67: Alternaitve Gradient Factor low
-	write_ostc_cf(data, 67, max_CF, m_deviceDetails->aGFLow);
+	write_ostc_cf(data, 67, max_CF, deviceDetails.aGFLow);
 	// CF68: Alternative Gradient Factor high
-	write_ostc_cf(data, 68, max_CF, m_deviceDetails->aGFHigh);
+	write_ostc_cf(data, 68, max_CF, deviceDetails.aGFHigh);
 	// CF69: Allow Gradient Factor change
-	write_ostc_cf(data, 69, max_CF, m_deviceDetails->aGFSelectable);
+	write_ostc_cf(data, 69, max_CF, deviceDetails.aGFSelectable);
 	// CF70: Safety Stop Duration [s]
-	write_ostc_cf(data, 70, max_CF, m_deviceDetails->safetyStopLength);
+	write_ostc_cf(data, 70, max_CF, deviceDetails.safetyStopLength);
 	// CF71: Safety Stop Start Depth [m]
-	write_ostc_cf(data, 71, max_CF, m_deviceDetails->safetyStopStartDepth);
+	write_ostc_cf(data, 71, max_CF, deviceDetails.safetyStopStartDepth);
 	// CF72: Safety Stop End Depth [m]
-	write_ostc_cf(data, 72, max_CF, m_deviceDetails->safetyStopEndDepth);
+	write_ostc_cf(data, 72, max_CF, deviceDetails.safetyStopEndDepth);
 	// CF73: Safety Stop Reset Depth [m]
-	write_ostc_cf(data, 73, max_CF, m_deviceDetails->safetyStopResetDepth);
+	write_ostc_cf(data, 73, max_CF, deviceDetails.safetyStopResetDepth);
 	// CF74: Battery Timeout [min]
 
 #ifdef DEBUG_OSTC_CF
@@ -2069,7 +2069,7 @@ static dc_status_t write_ostc_settings(dc_device_t *device, DeviceDetails *m_dev
 	EMIT_PROGRESS();
 
 	//sync date and time
-	if (m_deviceDetails->syncTime) {
+	if (deviceDetails.syncTime) {
 		QDateTime timeToSet = QDateTime::currentDateTime();
 		dc_datetime_t time = { 0 };
 		time.year = timeToSet.date().year();
@@ -2119,12 +2119,12 @@ void ReadSettingsThread::run()
 {
 	dc_status_t rc;
 
-	DeviceDetails *m_deviceDetails = new DeviceDetails(0);
+	DeviceDetails deviceDetails;
 	switch (dc_device_get_type(m_data->device)) {
 	case DC_FAMILY_SUUNTO_VYPER:
-		rc = read_suunto_vyper_settings(m_data->device, m_deviceDetails, DeviceThread::event_cb, this);
+		rc = read_suunto_vyper_settings(m_data->device, deviceDetails, DeviceThread::event_cb, this);
 		if (rc == DC_STATUS_SUCCESS) {
-			emit devicedetails(m_deviceDetails);
+			emit devicedetails(std::move(deviceDetails));
 		} else if (rc == DC_STATUS_UNSUPPORTED) {
 			emit error(tr("This feature is not yet available for the selected dive computer."));
 		} else {
@@ -2132,9 +2132,9 @@ void ReadSettingsThread::run()
 		}
 		break;
 	case DC_FAMILY_HW_OSTC3:
-		rc = read_ostc3_settings(m_data->device, m_deviceDetails, DeviceThread::event_cb, this);
+		rc = read_ostc3_settings(m_data->device, deviceDetails, DeviceThread::event_cb, this);
 		if (rc == DC_STATUS_SUCCESS)
-			emit devicedetails(m_deviceDetails);
+			emit devicedetails(std::move(deviceDetails));
 		else
 			emit error(tr("Failed!"));
 		break;
@@ -2143,9 +2143,9 @@ void ReadSettingsThread::run()
 	case DC_FAMILY_NULL:
 #endif
 	case DC_FAMILY_HW_OSTC:
-		rc = read_ostc_settings(m_data->device, m_deviceDetails, DeviceThread::event_cb, this);
+		rc = read_ostc_settings(m_data->device, deviceDetails, DeviceThread::event_cb, this);
 		if (rc == DC_STATUS_SUCCESS)
-			emit devicedetails(m_deviceDetails);
+			emit devicedetails(std::move(deviceDetails));
 		else
 			emit error(tr("Failed!"));
 		break;
@@ -2156,12 +2156,11 @@ void ReadSettingsThread::run()
 }
 
 WriteSettingsThread::WriteSettingsThread(QObject *parent, device_data_t *data) :
-	DeviceThread(parent, data),
-	m_deviceDetails(NULL)
+	DeviceThread(parent, data)
 {
 }
 
-void WriteSettingsThread::setDeviceDetails(DeviceDetails *details)
+void WriteSettingsThread::setDeviceDetails(const DeviceDetails &details)
 {
 	m_deviceDetails = details;
 }
@@ -2181,7 +2180,7 @@ void WriteSettingsThread::run()
 		break;
 	case DC_FAMILY_HW_OSTC3:
 		// Is this the best way?
-		if (m_deviceDetails->model == "OSTC 4")
+		if (m_deviceDetails.model == "OSTC 4")
 			rc = write_ostc4_settings(m_data->device, m_deviceDetails, DeviceThread::event_cb, this);
 		else
 			rc = write_ostc3_settings(m_data->device, m_deviceDetails, DeviceThread::event_cb, this);

--- a/core/configuredivecomputerthreads.h
+++ b/core/configuredivecomputerthreads.h
@@ -27,18 +27,18 @@ public:
 	ReadSettingsThread(QObject *parent, device_data_t *data);
 	void run();
 signals:
-	void devicedetails(DeviceDetails *newDeviceDetails);
+	void devicedetails(DeviceDetails newDeviceDetails);
 };
 
 class WriteSettingsThread : public DeviceThread {
 	Q_OBJECT
 public:
 	WriteSettingsThread(QObject *parent, device_data_t *data);
-	void setDeviceDetails(DeviceDetails *details);
+	void setDeviceDetails(const DeviceDetails &details);
 	void run();
 
 private:
-	DeviceDetails *m_deviceDetails;
+	DeviceDetails m_deviceDetails;
 };
 
 class FirmwareUpdateThread : public DeviceThread {

--- a/core/devicedetails.cpp
+++ b/core/devicedetails.cpp
@@ -11,8 +11,7 @@ setpoint::setpoint(unsigned char sp, unsigned char depth) :
 {
 }
 
-DeviceDetails::DeviceDetails(QObject *parent) :
-	QObject(parent),
+DeviceDetails::DeviceDetails() :
 	syncTime(false),
 	setPointFallback(0),
 	ccrMode(0),

--- a/core/devicedetails.h
+++ b/core/devicedetails.h
@@ -20,11 +20,10 @@ struct setpoint {
 	setpoint(unsigned char sp = 0, unsigned char depth = 0);
 };
 
-class DeviceDetails : public QObject
+class DeviceDetails
 {
-	Q_OBJECT
 public:
-	explicit DeviceDetails(QObject *parent = 0);
+	DeviceDetails();
 
 	QString serialNo;
 	QString firmwareVersion;
@@ -103,5 +102,6 @@ public:
 	unsigned safetyStopResetDepth;
 };
 
+Q_DECLARE_METATYPE(DeviceDetails);
 
 #endif // DEVICEDETAILS_H

--- a/core/dive.h
+++ b/core/dive.h
@@ -207,8 +207,6 @@ extern void invalidate_dive_cache(struct dive *dc);
 
 extern int total_weight(const struct dive *);
 
-extern const char *existing_filename;
-
 extern bool has_planned(const struct dive *dive, bool planned);
 
 /* Get gasmixes at increasing timestamps.
@@ -229,7 +227,10 @@ extern void update_setpoint_events(const struct dive *dive, struct divecomputer 
  * QVariants and through QML.
  */
 #include <QObject>
+#include <string>
 Q_DECLARE_METATYPE(struct dive *);
+
+extern std::string existing_filename;
 
 #endif
 

--- a/core/downloadfromdcthread.cpp
+++ b/core/downloadfromdcthread.cpp
@@ -156,7 +156,7 @@ void fill_computer_list()
 		descriptorLookup[QString(vendor).toLower() + QString(product).toLower()] = descriptor;
 	}
 	dc_iterator_free(iterator);
-	Q_FOREACH (QString vendor, vendorList) {
+	for (const QString &vendor: vendorList) {
 		auto &l = productList[vendor];
 		std::sort(l.begin(), l.end());
 	}
@@ -194,9 +194,9 @@ void show_computer_list()
 {
 	unsigned int transportMask = get_supported_transports(NULL);
 	qDebug() << "Supported dive computers:";
-	Q_FOREACH (QString vendor, vendorList) {
+	for (const QString &vendor: vendorList) {
 		QString msg = vendor + ": ";
-		Q_FOREACH (QString product, productList[vendor]) {
+		for (const QString &product: productList[vendor]) {
 			dc_descriptor_t *descriptor = descriptorLookup[vendor.toLower() + product.toLower()];
 			unsigned int transport = dc_descriptor_get_transports(descriptor) & transportMask;
 			QString transportString = getTransportString(transport);

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -38,11 +38,10 @@
 #include "core/version.h"
 #include "core/qthelper.h"
 #include "core/file.h"
-#include <QtGlobal>
 #include <array>
 
-char *dumpfile_name;
-char *logfile_name;
+std::string dumpfile_name;
+std::string logfile_name;
 const char *progress_bar_text = "";
 void (*progress_callback)(const char *text) = NULL;
 double progress_bar_fraction = 0.0;
@@ -1173,8 +1172,8 @@ static const char *do_device_import(device_data_t *data)
 		dc_buffer_t *buffer = dc_buffer_new(0);
 
 		rc = dc_device_dump(device, buffer);
-		if (rc == DC_STATUS_SUCCESS && dumpfile_name) {
-			FILE *fp = subsurface_fopen(dumpfile_name, "wb");
+		if (rc == DC_STATUS_SUCCESS && !dumpfile_name.empty()) {
+			FILE *fp = subsurface_fopen(dumpfile_name.c_str(), "wb");
 			if (fp != NULL) {
 				fwrite(dc_buffer_get_data(buffer), 1, dc_buffer_get_size(buffer), fp);
 				fclose(fp);
@@ -1479,8 +1478,8 @@ const char *do_libdivecomputer_import(device_data_t *data)
 	data->fingerprint = NULL;
 	data->fsize = 0;
 
-	if (data->libdc_log && logfile_name)
-		fp = subsurface_fopen(logfile_name, "w");
+	if (data->libdc_log && !logfile_name.empty())
+		fp = subsurface_fopen(logfile_name.c_str(), "w");
 
 	data->libdc_logfile = fp;
 

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -62,8 +62,6 @@ extern int import_thread_cancelled;
 extern const char *progress_bar_text;
 extern void (*progress_callback)(const char *text);
 extern double progress_bar_fraction;
-extern char *logfile_name;
-extern char *dumpfile_name;
 
 dc_status_t ble_packet_open(dc_iostream_t **iostream, dc_context_t *context, const char* devaddr, void *userdata);
 dc_status_t rfcomm_stream_open(dc_iostream_t **iostream, dc_context_t *context, const char* devaddr);
@@ -76,6 +74,11 @@ unsigned int get_supported_transports(device_data_t *data);
 
 #ifdef __cplusplus
 }
+
+#include <string>
+extern std::string logfile_name;
+extern std::string dumpfile_name;
+
 #endif
 
 #endif // LIBDIVECOMPUTER_H

--- a/core/parse-gpx.cpp
+++ b/core/parse-gpx.cpp
@@ -47,7 +47,7 @@ int getCoordsFromGPXFile(struct dive_coords *coords, const QString &fileName)
 			if (nameCmp(gpxReader, "trkpt") == 0) {
 				trkpt_found = true;
 				line++;
-				foreach (const QXmlStreamAttribute &attr, gpxReader.attributes()) {
+				for (const QXmlStreamAttribute &attr: gpxReader.attributes()) {
 					if (attr.name().toString() == QLatin1String("lat"))
 						lat = attr.value().toString().toDouble();
 					else if (attr.name().toString() == QLatin1String("lon"))

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -308,7 +308,7 @@ dc_status_t BLEObject::write(const void *data, size_t size, size_t *actual)
 		} while (!receivedPackets.isEmpty());
 	}
 
-	foreach (const QLowEnergyCharacteristic &c, preferredService()->characteristics()) {
+	for (const QLowEnergyCharacteristic &c: preferredService()->characteristics()) {
 		if (!is_write_characteristic(c))
 			continue;
 
@@ -398,7 +398,7 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 dc_status_t BLEObject::select_preferred_service(void)
 {
 	// Wait for each service to finish discovering
-	foreach (const QLowEnergyService *s, services) {
+	for (const QLowEnergyService *s: services) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		WAITFOR(s->state() != QLowEnergyService::RemoteServiceDiscovering, BLE_TIMEOUT);
 		if (s->state() == QLowEnergyService::RemoteServiceDiscovering)
@@ -410,19 +410,19 @@ dc_status_t BLEObject::select_preferred_service(void)
 	}
 
 	// Print out the services for debugging
-	foreach (const QLowEnergyService *s, services) {
+	for (const QLowEnergyService *s: services) {
 		qDebug() << "Found service" << s->serviceUuid() << s->serviceName();
 
-		foreach (const QLowEnergyCharacteristic &c, s->characteristics()) {
+		for (const QLowEnergyCharacteristic &c: s->characteristics()) {
 			qDebug() << "   c:" << c.uuid();
 
-			foreach (const QLowEnergyDescriptor &d, c.descriptors())
+			for (const QLowEnergyDescriptor &d: c.descriptors())
 				qDebug() << "        d:" << d.uuid();
 		}
 	}
 
 	// Pick the preferred one
-	foreach (QLowEnergyService *s, services) {
+	for (QLowEnergyService *s: services) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		if (s->state() != QLowEnergyService::RemoteServiceDiscovered)
 #else
@@ -434,7 +434,7 @@ dc_status_t BLEObject::select_preferred_service(void)
 		bool haswrite = false;
 		QBluetoothUuid uuid = s->serviceUuid();
 
-		foreach (const QLowEnergyCharacteristic &c, s->characteristics()) {
+		for (const QLowEnergyCharacteristic &c: s->characteristics()) {
 			hasread |= is_read_characteristic(c);
 			haswrite |= is_write_characteristic(c);
 		}
@@ -615,9 +615,8 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 	// Finish discovering the services, then add all those services and discover their characteristics.
 	ble->connect(controller, &QLowEnergyController::discoveryFinished, [=] {
 		qDebug() << "finished service discovery, start discovering characteristics";
-		foreach(QBluetoothUuid s, controller->services()) {
+		for (QBluetoothUuid s: controller->services())
 			ble->addService(s);
-		}
 	});
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	ble->connect(controller, &QLowEnergyController::errorOccurred, [=](QLowEnergyController::Error newError) {

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1176,7 +1176,7 @@ QStringList mediaExtensionFilters()
 QStringList imageExtensionFilters()
 {
 	QStringList filters;
-	foreach (const QString &format, QImageReader::supportedImageFormats())
+	for (QString format: QImageReader::supportedImageFormats())
 		filters.append("*." + format);
 	return filters;
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -44,7 +44,7 @@
 
 #include <libxslt/documents.h>
 
-const char *existing_filename;
+std::string existing_filename;
 static QLocale loc;
 
 static inline QString degreeSigns()
@@ -519,12 +519,6 @@ void initUiLanguage()
 QLocale getLocale()
 {
 	return loc;
-}
-
-void set_filename(const char *filename)
-{
-	free((void *)existing_filename);
-	existing_filename = copy_string(filename);
 }
 
 QString get_depth_string(int mm, bool showunit, bool showdecimal)

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -125,7 +125,6 @@ bool canReachCloudServer(struct git_info *);
 void updateWindowTitle();
 void subsurface_mkdir(const char *dir);
 char *get_file_name(const char *fileName);
-void set_filename(const char *filename);
 void copy_image_and_overwrite(const char *cfileName, const char *path, const char *cnewName);
 char *move_away(const char *path);
 const char *local_file_path(struct picture *picture);

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -1192,12 +1192,12 @@ static int create_new_commit(struct git_info *info, git_oid *tree_id, bool creat
 			return report_error("Unable to look up parent in branch '%s'", info->branch);
 
 		if (!saved_git_id.empty()) {
-			if (existing_filename && verbose)
-				report_info("existing filename %s\n", existing_filename);
+			if (!existing_filename.empty() && verbose)
+				report_info("existing filename %s\n", existing_filename.c_str());
 			const git_oid *id = git_commit_id((const git_commit *) parent);
 			/* if we are saving to the same git tree we got this from, let's make
 			 * sure there is no confusion */
-			if (same_string(existing_filename, info->url) && git_oid_strcmp(id, saved_git_id.c_str()))
+			if (existing_filename == info->url && git_oid_strcmp(id, saved_git_id.c_str()))
 				return report_error("The git branch does not match the git parent of the source");
 		}
 

--- a/core/subsurface-string.h
+++ b/core/subsurface-string.h
@@ -76,5 +76,11 @@ std::string format_string_std(const char *fmt, Args&&... args)
 	return res;
 }
 
+// Sadly, starts_with only with C++20!
+inline bool starts_with(const std::string &s, const char *s2)
+{
+	return s.rfind(s2, 0) == 0;
+}
+
 #endif
 #endif // SUBSURFACE_STRING_H

--- a/core/tag.c
+++ b/core/tag.c
@@ -181,25 +181,3 @@ void taglist_init_global()
 	for (i = 0; i < sizeof(default_tags) / sizeof(char *); i++)
 		taglist_add_tag(&g_tag_list, default_tags[i]);
 }
-
-bool taglist_contains(struct tag_entry *tag_list, const char *tag)
-{
-	while (tag_list) {
-		if (same_string(tag_list->tag->name, tag))
-			return true;
-		tag_list = tag_list->next;
-	}
-	return false;
-}
-
-struct tag_entry *taglist_added(struct tag_entry *original_list, struct tag_entry *new_list)
-{
-	struct tag_entry *added_list = NULL;
-	while (new_list) {
-		if (!taglist_contains(original_list, new_list->tag->name))
-			taglist_add_tag(&added_list, new_list->tag->name);
-		new_list = new_list->next;
-	}
-	return added_list;
-}
-

--- a/core/tag.h
+++ b/core/tag.h
@@ -35,7 +35,6 @@ struct tag_entry {
 extern struct tag_entry *g_tag_list;
 
 struct divetag *taglist_add_tag(struct tag_entry **tag_list, const char *tag);
-struct tag_entry *taglist_added(struct tag_entry *original_list, struct tag_entry *new_list);
 
 /*
  * Writes all divetags form tag_list into internally allocated buffer
@@ -52,7 +51,6 @@ void taglist_cleanup(struct tag_entry **tag_list);
 void taglist_init_global();
 void taglist_free(struct tag_entry *tag_list);
 struct tag_entry *taglist_copy(struct tag_entry *s);
-bool taglist_contains(struct tag_entry *tag_list, const char *tag);
 void taglist_merge(struct tag_entry **dst, struct tag_entry *src1, struct tag_entry *src2);
 
 #ifdef __cplusplus

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -120,15 +120,11 @@ static const DiveComputerEntry supportedDiveComputers[] = {
 ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDialog(parent),
 	config(0),
 #ifdef BT_SUPPORT
-	deviceDetails(0),
 	btDeviceSelectionDialog(0)
-#else
-	deviceDetails(0)
 #endif
 {
 	ui.setupUi(this);
 
-	deviceDetails = new DeviceDetails(this);
 	config = new ConfigureDiveComputer();
 	connect(config, &ConfigureDiveComputer::progress, ui.progressBar, &QProgressBar::setValue);
 	connect(config, &ConfigureDiveComputer::error, this, &ConfigureDiveComputerDialog::configError);
@@ -466,47 +462,47 @@ void ConfigureDiveComputerDialog::populateDeviceDetails()
 
 void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 {
-	deviceDetails->customText = ui.customTextLlineEdit->text();
-	deviceDetails->diveMode = ui.diveModeComboBox->currentIndex();
-	deviceDetails->saturation = ui.saturationSpinBox->value();
-	deviceDetails->desaturation = ui.desaturationSpinBox->value();
-	deviceDetails->lastDeco = ui.lastDecoSpinBox->value();
-	deviceDetails->brightness = ui.brightnessComboBox->currentIndex();
-	deviceDetails->units = ui.unitsComboBox->currentIndex();
-	deviceDetails->samplingRate = ui.samplingRateComboBox->currentIndex();
-	deviceDetails->salinity = ui.salinitySpinBox->value();
-	deviceDetails->diveModeColor = ui.diveModeColour->currentIndex();
-	deviceDetails->language = ui.languageComboBox->currentIndex();
-	deviceDetails->dateFormat = ui.dateFormatComboBox->currentIndex();
-	deviceDetails->compassGain = ui.compassGainComboBox->currentIndex();
-	deviceDetails->syncTime = ui.dateTimeSyncCheckBox->isChecked();
-	deviceDetails->safetyStop = ui.safetyStopCheckBox->isChecked();
-	deviceDetails->gfHigh = ui.gfHighSpinBox->value();
-	deviceDetails->gfLow = ui.gfLowSpinBox->value();
-	deviceDetails->pressureSensorOffset = ui.pressureSensorOffsetSpinBox->value();
-	deviceDetails->ppO2Min = ui.ppO2MinSpinBox->value();
-	deviceDetails->ppO2Max = ui.ppO2MaxSpinBox->value();
-	deviceDetails->futureTTS = ui.futureTTSSpinBox->value();
-	deviceDetails->ccrMode = ui.ccrModeComboBox->currentIndex();
-	deviceDetails->decoType = ui.decoTypeComboBox->currentIndex();
-	deviceDetails->aGFSelectable = ui.aGFSelectableCheckBox->isChecked();
-	deviceDetails->aGFHigh = ui.aGFHighSpinBox->value();
-	deviceDetails->aGFLow = ui.aGFLowSpinBox->value();
-	deviceDetails->calibrationGas = ui.calibrationGasSpinBox->value();
-	deviceDetails->flipScreen = ui.flipScreenCheckBox->isChecked();
-	deviceDetails->leftButtonSensitivity = ui.leftButtonSensitivity->value();
-	deviceDetails->rightButtonSensitivity = ui.rightButtonSensitivity->value();
-	deviceDetails->bottomGasConsumption = ui.bottomGasConsumption->value();
-	deviceDetails->decoGasConsumption = ui.decoGasConsumption->value();
-	deviceDetails->modWarning = ui.modWarning->isChecked();
-	deviceDetails->dynamicAscendRate = ui.dynamicAscendRate->isChecked();
-	deviceDetails->graphicalSpeedIndicator = ui.graphicalSpeedIndicator->isChecked();
-	deviceDetails->alwaysShowppO2 = ui.alwaysShowppO2->isChecked();
-	deviceDetails->tempSensorOffset = lrint(ui.tempSensorOffsetDoubleSpinBox->value() * 10);
-	deviceDetails->safetyStopLength = ui.safetyStopLengthSpinBox->value();
-	deviceDetails->safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox->value() * 10);
-	deviceDetails->safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox->value() * 10);
-	deviceDetails->safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox->value() * 10);
+	deviceDetails.customText = ui.customTextLlineEdit->text();
+	deviceDetails.diveMode = ui.diveModeComboBox->currentIndex();
+	deviceDetails.saturation = ui.saturationSpinBox->value();
+	deviceDetails.desaturation = ui.desaturationSpinBox->value();
+	deviceDetails.lastDeco = ui.lastDecoSpinBox->value();
+	deviceDetails.brightness = ui.brightnessComboBox->currentIndex();
+	deviceDetails.units = ui.unitsComboBox->currentIndex();
+	deviceDetails.samplingRate = ui.samplingRateComboBox->currentIndex();
+	deviceDetails.salinity = ui.salinitySpinBox->value();
+	deviceDetails.diveModeColor = ui.diveModeColour->currentIndex();
+	deviceDetails.language = ui.languageComboBox->currentIndex();
+	deviceDetails.dateFormat = ui.dateFormatComboBox->currentIndex();
+	deviceDetails.compassGain = ui.compassGainComboBox->currentIndex();
+	deviceDetails.syncTime = ui.dateTimeSyncCheckBox->isChecked();
+	deviceDetails.safetyStop = ui.safetyStopCheckBox->isChecked();
+	deviceDetails.gfHigh = ui.gfHighSpinBox->value();
+	deviceDetails.gfLow = ui.gfLowSpinBox->value();
+	deviceDetails.pressureSensorOffset = ui.pressureSensorOffsetSpinBox->value();
+	deviceDetails.ppO2Min = ui.ppO2MinSpinBox->value();
+	deviceDetails.ppO2Max = ui.ppO2MaxSpinBox->value();
+	deviceDetails.futureTTS = ui.futureTTSSpinBox->value();
+	deviceDetails.ccrMode = ui.ccrModeComboBox->currentIndex();
+	deviceDetails.decoType = ui.decoTypeComboBox->currentIndex();
+	deviceDetails.aGFSelectable = ui.aGFSelectableCheckBox->isChecked();
+	deviceDetails.aGFHigh = ui.aGFHighSpinBox->value();
+	deviceDetails.aGFLow = ui.aGFLowSpinBox->value();
+	deviceDetails.calibrationGas = ui.calibrationGasSpinBox->value();
+	deviceDetails.flipScreen = ui.flipScreenCheckBox->isChecked();
+	deviceDetails.leftButtonSensitivity = ui.leftButtonSensitivity->value();
+	deviceDetails.rightButtonSensitivity = ui.rightButtonSensitivity->value();
+	deviceDetails.bottomGasConsumption = ui.bottomGasConsumption->value();
+	deviceDetails.decoGasConsumption = ui.decoGasConsumption->value();
+	deviceDetails.modWarning = ui.modWarning->isChecked();
+	deviceDetails.dynamicAscendRate = ui.dynamicAscendRate->isChecked();
+	deviceDetails.graphicalSpeedIndicator = ui.graphicalSpeedIndicator->isChecked();
+	deviceDetails.alwaysShowppO2 = ui.alwaysShowppO2->isChecked();
+	deviceDetails.tempSensorOffset = lrint(ui.tempSensorOffsetDoubleSpinBox->value() * 10);
+	deviceDetails.safetyStopLength = ui.safetyStopLengthSpinBox->value();
+	deviceDetails.safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox->value() * 10);
+	deviceDetails.safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox->value() * 10);
+	deviceDetails.safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox->value() * 10);
 
 	//set gas values
 	gas gas1;
@@ -540,11 +536,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 	gas5.type = GET_INT_FROM(ui.ostc3GasTable->item(4, 3), 0);
 	gas5.depth = GET_INT_FROM(ui.ostc3GasTable->item(4, 4), 0);
 
-	deviceDetails->gas1 = gas1;
-	deviceDetails->gas2 = gas2;
-	deviceDetails->gas3 = gas3;
-	deviceDetails->gas4 = gas4;
-	deviceDetails->gas5 = gas5;
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
 
 	//set dil values
 	gas dil1;
@@ -578,11 +574,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 	dil5.type = GET_INT_FROM(ui.ostc3DilTable->item(4, 3), 0);
 	dil5.depth = GET_INT_FROM(ui.ostc3DilTable->item(4, 4), 0);
 
-	deviceDetails->dil1 = dil1;
-	deviceDetails->dil2 = dil2;
-	deviceDetails->dil3 = dil3;
-	deviceDetails->dil4 = dil4;
-	deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 
 	//set setpoint details
 	setpoint sp1;
@@ -606,40 +602,40 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC3()
 	sp5.sp = GET_INT_FROM(ui.ostc3SetPointTable->item(4, 1), 140);
 	sp5.depth = GET_INT_FROM(ui.ostc3SetPointTable->item(4, 2), 70);
 
-	deviceDetails->sp1 = sp1;
-	deviceDetails->sp2 = sp2;
-	deviceDetails->sp3 = sp3;
-	deviceDetails->sp4 = sp4;
-	deviceDetails->sp5 = sp5;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
+	deviceDetails.sp4 = sp4;
+	deviceDetails.sp5 = sp5;
 }
 
 void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 {
-	deviceDetails->customText = ui.customTextLlineEdit_3->text();
-	deviceDetails->saturation = ui.saturationSpinBox_3->value();
-	deviceDetails->desaturation = ui.desaturationSpinBox_3->value();
-	deviceDetails->lastDeco = ui.lastDecoSpinBox_3->value();
-	deviceDetails->samplingRate = ui.samplingRateSpinBox_3->value();
-	deviceDetails->salinity = lrint(ui.salinityDoubleSpinBox_3->value() * 100);
-	deviceDetails->dateFormat = ui.dateFormatComboBox_3->currentIndex();
-	deviceDetails->syncTime = ui.dateTimeSyncCheckBox_3->isChecked();
-	deviceDetails->safetyStop = ui.safetyStopCheckBox_3->isChecked();
-	deviceDetails->gfHigh = ui.gfHighSpinBox_3->value();
-	deviceDetails->gfLow = ui.gfLowSpinBox_3->value();
-	deviceDetails->ppO2Min = ui.ppO2MinSpinBox_3->value();
-	deviceDetails->ppO2Max = ui.ppO2MaxSpinBox_3->value();
-	deviceDetails->futureTTS = ui.futureTTSSpinBox_3->value();
-	deviceDetails->decoType = ui.decoTypeComboBox_3->currentIndex();
-	deviceDetails->aGFSelectable = ui.aGFSelectableCheckBox_3->isChecked();
-	deviceDetails->aGFHigh = ui.aGFHighSpinBox_3->value();
-	deviceDetails->aGFLow = ui.aGFLowSpinBox_3->value();
-	deviceDetails->bottomGasConsumption = ui.bottomGasConsumption_3->value();
-	deviceDetails->decoGasConsumption = ui.decoGasConsumption_3->value();
-	deviceDetails->graphicalSpeedIndicator = ui.graphicalSpeedIndicator_3->isChecked();
-	deviceDetails->safetyStopLength = ui.safetyStopLengthSpinBox_3->value();
-	deviceDetails->safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox_3->value() * 10);
-	deviceDetails->safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox_3->value() * 10);
-	deviceDetails->safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox_3->value() * 10);
+	deviceDetails.customText = ui.customTextLlineEdit_3->text();
+	deviceDetails.saturation = ui.saturationSpinBox_3->value();
+	deviceDetails.desaturation = ui.desaturationSpinBox_3->value();
+	deviceDetails.lastDeco = ui.lastDecoSpinBox_3->value();
+	deviceDetails.samplingRate = ui.samplingRateSpinBox_3->value();
+	deviceDetails.salinity = lrint(ui.salinityDoubleSpinBox_3->value() * 100);
+	deviceDetails.dateFormat = ui.dateFormatComboBox_3->currentIndex();
+	deviceDetails.syncTime = ui.dateTimeSyncCheckBox_3->isChecked();
+	deviceDetails.safetyStop = ui.safetyStopCheckBox_3->isChecked();
+	deviceDetails.gfHigh = ui.gfHighSpinBox_3->value();
+	deviceDetails.gfLow = ui.gfLowSpinBox_3->value();
+	deviceDetails.ppO2Min = ui.ppO2MinSpinBox_3->value();
+	deviceDetails.ppO2Max = ui.ppO2MaxSpinBox_3->value();
+	deviceDetails.futureTTS = ui.futureTTSSpinBox_3->value();
+	deviceDetails.decoType = ui.decoTypeComboBox_3->currentIndex();
+	deviceDetails.aGFSelectable = ui.aGFSelectableCheckBox_3->isChecked();
+	deviceDetails.aGFHigh = ui.aGFHighSpinBox_3->value();
+	deviceDetails.aGFLow = ui.aGFLowSpinBox_3->value();
+	deviceDetails.bottomGasConsumption = ui.bottomGasConsumption_3->value();
+	deviceDetails.decoGasConsumption = ui.decoGasConsumption_3->value();
+	deviceDetails.graphicalSpeedIndicator = ui.graphicalSpeedIndicator_3->isChecked();
+	deviceDetails.safetyStopLength = ui.safetyStopLengthSpinBox_3->value();
+	deviceDetails.safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox_3->value() * 10);
+	deviceDetails.safetyStopEndDepth = lrint(ui.safetyStopEndDepthDoubleSpinBox_3->value() * 10);
+	deviceDetails.safetyStopResetDepth = lrint(ui.safetyStopResetDepthDoubleSpinBox_3->value() * 10);
 
 	//set gas values
 	gas gas1;
@@ -673,11 +669,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 	gas5.type = GET_INT_FROM(ui.ostcGasTable->item(4, 3), 0);
 	gas5.depth = GET_INT_FROM(ui.ostcGasTable->item(4, 4), 0);
 
-	deviceDetails->gas1 = gas1;
-	deviceDetails->gas2 = gas2;
-	deviceDetails->gas3 = gas3;
-	deviceDetails->gas4 = gas4;
-	deviceDetails->gas5 = gas5;
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
 
 	//set dil values
 	gas dil1;
@@ -711,11 +707,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 	dil5.type = GET_INT_FROM(ui.ostcDilTable->item(4, 3), 0);
 	dil5.depth = GET_INT_FROM(ui.ostcDilTable->item(4, 4), 0);
 
-	deviceDetails->dil1 = dil1;
-	deviceDetails->dil2 = dil2;
-	deviceDetails->dil3 = dil3;
-	deviceDetails->dil4 = dil4;
-	deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 
 	//set setpoint details
 	setpoint sp1;
@@ -739,63 +735,63 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC()
 	sp5.sp = GET_INT_FROM(ui.ostcSetPointTable->item(4, 1), 140);
 	sp5.depth = GET_INT_FROM(ui.ostcSetPointTable->item(4, 2), 70);
 
-	deviceDetails->sp1 = sp1;
-	deviceDetails->sp2 = sp2;
-	deviceDetails->sp3 = sp3;
-	deviceDetails->sp4 = sp4;
-	deviceDetails->sp5 = sp5;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
+	deviceDetails.sp4 = sp4;
+	deviceDetails.sp5 = sp5;
 }
 
 void ConfigureDiveComputerDialog::populateDeviceDetailsSuuntoVyper()
 {
-	deviceDetails->customText = ui.customTextLlineEdit_1->text();
-	deviceDetails->samplingRate = ui.samplingRateComboBox_1->currentIndex() == 3 ? 60 : (ui.samplingRateComboBox_1->currentIndex() + 1) * 10;
-	deviceDetails->altitude = ui.altitudeRangeComboBox->currentIndex();
-	deviceDetails->personalSafety = ui.personalSafetyComboBox->currentIndex();
-	deviceDetails->timeFormat = ui.timeFormatComboBox->currentIndex();
-	deviceDetails->units = ui.unitsComboBox_1->currentIndex();
-	deviceDetails->diveMode = ui.diveModeComboBox_1->currentIndex();
-	deviceDetails->lightEnabled = ui.lightCheckBox->isChecked();
-	deviceDetails->light = ui.lightSpinBox->value();
-	deviceDetails->alarmDepthEnabled = ui.alarmDepthCheckBox->isChecked();
-	deviceDetails->alarmDepth = units_to_depth(ui.alarmDepthDoubleSpinBox->value()).mm;
-	deviceDetails->alarmTimeEnabled = ui.alarmTimeCheckBox->isChecked();
-	deviceDetails->alarmTime = ui.alarmTimeSpinBox->value();
+	deviceDetails.customText = ui.customTextLlineEdit_1->text();
+	deviceDetails.samplingRate = ui.samplingRateComboBox_1->currentIndex() == 3 ? 60 : (ui.samplingRateComboBox_1->currentIndex() + 1) * 10;
+	deviceDetails.altitude = ui.altitudeRangeComboBox->currentIndex();
+	deviceDetails.personalSafety = ui.personalSafetyComboBox->currentIndex();
+	deviceDetails.timeFormat = ui.timeFormatComboBox->currentIndex();
+	deviceDetails.units = ui.unitsComboBox_1->currentIndex();
+	deviceDetails.diveMode = ui.diveModeComboBox_1->currentIndex();
+	deviceDetails.lightEnabled = ui.lightCheckBox->isChecked();
+	deviceDetails.light = ui.lightSpinBox->value();
+	deviceDetails.alarmDepthEnabled = ui.alarmDepthCheckBox->isChecked();
+	deviceDetails.alarmDepth = units_to_depth(ui.alarmDepthDoubleSpinBox->value()).mm;
+	deviceDetails.alarmTimeEnabled = ui.alarmTimeCheckBox->isChecked();
+	deviceDetails.alarmTime = ui.alarmTimeSpinBox->value();
 }
 
 void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC4()
 {
-	deviceDetails->customText = ui.customTextLlineEdit_4->text();
-	deviceDetails->diveMode = ui.diveModeComboBox_4->currentIndex();
-	deviceDetails->lastDeco = ui.lastDecoSpinBox_4->value();
-	deviceDetails->brightness = ui.brightnessComboBox_4->currentIndex();
-	deviceDetails->units = ui.unitsComboBox_4->currentIndex();
-	deviceDetails->salinity = ui.salinitySpinBox_4->value();
-	deviceDetails->diveModeColor = ui.diveModeColour_4->currentIndex();
-	deviceDetails->language = ui.languageComboBox_4->currentIndex();
-	deviceDetails->dateFormat = ui.dateFormatComboBox_4->currentIndex();
-	deviceDetails->syncTime = ui.dateTimeSyncCheckBox_4->isChecked();
-	deviceDetails->safetyStop = ui.safetyStopCheckBox_4->isChecked();
-	deviceDetails->gfHigh = ui.gfHighSpinBox_4->value();
-	deviceDetails->gfLow = ui.gfLowSpinBox_4->value();
-	deviceDetails->pressureSensorOffset = ui.pressureSensorOffsetSpinBox_4->value();
-	deviceDetails->ppO2Min = ui.ppO2MinSpinBox_4->value();
-	deviceDetails->ppO2Max = ui.ppO2MaxSpinBox_4->value();
-	deviceDetails->futureTTS = ui.futureTTSSpinBox_4->value();
-	deviceDetails->ccrMode = ui.ccrModeComboBox_4->currentIndex();
-	deviceDetails->decoType = ui.decoTypeComboBox_4->currentIndex();
-	deviceDetails->aGFHigh = ui.aGFHighSpinBox_4->value();
-	deviceDetails->aGFLow = ui.aGFLowSpinBox_4->value();
-	deviceDetails->vpmConservatism = ui.vpmConservatismSpinBox->value();
-	deviceDetails->setPointFallback = ui.setPointFallbackCheckBox_4->isChecked();
-	deviceDetails->buttonSensitivity = ui.buttonSensitivity_4->value();
-	deviceDetails->bottomGasConsumption = ui.bottomGasConsumption_4->value();
-	deviceDetails->decoGasConsumption = ui.decoGasConsumption_4->value();
-	deviceDetails->travelGasConsumption = ui.travelGasConsumption_4->value();
-	deviceDetails->alwaysShowppO2 = ui.alwaysShowppO2_4->isChecked();
-	deviceDetails->tempSensorOffset = lrint(ui.tempSensorOffsetDoubleSpinBox_4->value() * 10);
-	deviceDetails->safetyStopLength = ui.safetyStopLengthSpinBox_4->value();
-	deviceDetails->safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox_4->value() * 10);
+	deviceDetails.customText = ui.customTextLlineEdit_4->text();
+	deviceDetails.diveMode = ui.diveModeComboBox_4->currentIndex();
+	deviceDetails.lastDeco = ui.lastDecoSpinBox_4->value();
+	deviceDetails.brightness = ui.brightnessComboBox_4->currentIndex();
+	deviceDetails.units = ui.unitsComboBox_4->currentIndex();
+	deviceDetails.salinity = ui.salinitySpinBox_4->value();
+	deviceDetails.diveModeColor = ui.diveModeColour_4->currentIndex();
+	deviceDetails.language = ui.languageComboBox_4->currentIndex();
+	deviceDetails.dateFormat = ui.dateFormatComboBox_4->currentIndex();
+	deviceDetails.syncTime = ui.dateTimeSyncCheckBox_4->isChecked();
+	deviceDetails.safetyStop = ui.safetyStopCheckBox_4->isChecked();
+	deviceDetails.gfHigh = ui.gfHighSpinBox_4->value();
+	deviceDetails.gfLow = ui.gfLowSpinBox_4->value();
+	deviceDetails.pressureSensorOffset = ui.pressureSensorOffsetSpinBox_4->value();
+	deviceDetails.ppO2Min = ui.ppO2MinSpinBox_4->value();
+	deviceDetails.ppO2Max = ui.ppO2MaxSpinBox_4->value();
+	deviceDetails.futureTTS = ui.futureTTSSpinBox_4->value();
+	deviceDetails.ccrMode = ui.ccrModeComboBox_4->currentIndex();
+	deviceDetails.decoType = ui.decoTypeComboBox_4->currentIndex();
+	deviceDetails.aGFHigh = ui.aGFHighSpinBox_4->value();
+	deviceDetails.aGFLow = ui.aGFLowSpinBox_4->value();
+	deviceDetails.vpmConservatism = ui.vpmConservatismSpinBox->value();
+	deviceDetails.setPointFallback = ui.setPointFallbackCheckBox_4->isChecked();
+	deviceDetails.buttonSensitivity = ui.buttonSensitivity_4->value();
+	deviceDetails.bottomGasConsumption = ui.bottomGasConsumption_4->value();
+	deviceDetails.decoGasConsumption = ui.decoGasConsumption_4->value();
+	deviceDetails.travelGasConsumption = ui.travelGasConsumption_4->value();
+	deviceDetails.alwaysShowppO2 = ui.alwaysShowppO2_4->isChecked();
+	deviceDetails.tempSensorOffset = lrint(ui.tempSensorOffsetDoubleSpinBox_4->value() * 10);
+	deviceDetails.safetyStopLength = ui.safetyStopLengthSpinBox_4->value();
+	deviceDetails.safetyStopStartDepth = lrint(ui.safetyStopStartDepthDoubleSpinBox_4->value() * 10);
 
 	//set gas values
 	gas gas1;
@@ -829,11 +825,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC4()
 	gas5.type = GET_INT_FROM(ui.ostc4GasTable->item(4, 3), 0);
 	gas5.depth = GET_INT_FROM(ui.ostc4GasTable->item(4, 4), 0);
 
-	deviceDetails->gas1 = gas1;
-	deviceDetails->gas2 = gas2;
-	deviceDetails->gas3 = gas3;
-	deviceDetails->gas4 = gas4;
-	deviceDetails->gas5 = gas5;
+	deviceDetails.gas1 = gas1;
+	deviceDetails.gas2 = gas2;
+	deviceDetails.gas3 = gas3;
+	deviceDetails.gas4 = gas4;
+	deviceDetails.gas5 = gas5;
 
 	//set dil values
 	gas dil1;
@@ -867,11 +863,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC4()
 	dil5.type = GET_INT_FROM(ui.ostc4DilTable->item(4, 3), 0);
 	dil5.depth = GET_INT_FROM(ui.ostc4DilTable->item(4, 4), 0);
 
-	deviceDetails->dil1 = dil1;
-	deviceDetails->dil2 = dil2;
-	deviceDetails->dil3 = dil3;
-	deviceDetails->dil4 = dil4;
-	deviceDetails->dil5 = dil5;
+	deviceDetails.dil1 = dil1;
+	deviceDetails.dil2 = dil2;
+	deviceDetails.dil3 = dil3;
+	deviceDetails.dil4 = dil4;
+	deviceDetails.dil5 = dil5;
 
 	//set setpoint details
 	setpoint sp1;
@@ -895,11 +891,11 @@ void ConfigureDiveComputerDialog::populateDeviceDetailsOSTC4()
 	sp5.sp = GET_INT_FROM(ui.ostc4SetPointTable->item(4, 1), 140);
 	sp5.depth = GET_INT_FROM(ui.ostc4SetPointTable->item(4, 2), 70);
 
-	deviceDetails->sp1 = sp1;
-	deviceDetails->sp2 = sp2;
-	deviceDetails->sp3 = sp3;
-	deviceDetails->sp4 = sp4;
-	deviceDetails->sp5 = sp5;
+	deviceDetails.sp1 = sp1;
+	deviceDetails.sp2 = sp2;
+	deviceDetails.sp3 = sp3;
+	deviceDetails.sp4 = sp4;
+	deviceDetails.sp5 = sp5;
 }
 
 void ConfigureDiveComputerDialog::readSettings()
@@ -976,9 +972,9 @@ void ConfigureDiveComputerDialog::on_saveSettingsPushButton_clicked()
 	config->saveDeviceDetails(deviceDetails, &device_data);
 }
 
-void ConfigureDiveComputerDialog::deviceDetailsReceived(DeviceDetails *newDeviceDetails)
+void ConfigureDiveComputerDialog::deviceDetailsReceived(DeviceDetails newDeviceDetails)
 {
-	deviceDetails = newDeviceDetails;
+	deviceDetails = std::move(newDeviceDetails);
 	reloadValues();
 }
 
@@ -1006,129 +1002,129 @@ void ConfigureDiveComputerDialog::reloadValues()
 
 void ConfigureDiveComputerDialog::reloadValuesOSTC3()
 {
-	ui.serialNoLineEdit->setText(deviceDetails->serialNo);
-	ui.firmwareVersionLineEdit->setText(deviceDetails->firmwareVersion);
-	ui.customTextLlineEdit->setText(deviceDetails->customText);
-	ui.modelLineEdit->setText(deviceDetails->model);
-	ui.diveModeComboBox->setCurrentIndex(deviceDetails->diveMode);
-	ui.saturationSpinBox->setValue(deviceDetails->saturation);
-	ui.desaturationSpinBox->setValue(deviceDetails->desaturation);
-	ui.lastDecoSpinBox->setValue(deviceDetails->lastDeco);
-	ui.brightnessComboBox->setCurrentIndex(deviceDetails->brightness);
-	ui.unitsComboBox->setCurrentIndex(deviceDetails->units);
-	ui.samplingRateComboBox->setCurrentIndex(deviceDetails->samplingRate);
-	ui.salinitySpinBox->setValue(deviceDetails->salinity);
-	ui.diveModeColour->setCurrentIndex(deviceDetails->diveModeColor);
-	ui.languageComboBox->setCurrentIndex(deviceDetails->language);
-	ui.dateFormatComboBox->setCurrentIndex(deviceDetails->dateFormat);
-	ui.compassGainComboBox->setCurrentIndex(deviceDetails->compassGain);
-	ui.safetyStopCheckBox->setChecked(deviceDetails->safetyStop);
-	ui.gfHighSpinBox->setValue(deviceDetails->gfHigh);
-	ui.gfLowSpinBox->setValue(deviceDetails->gfLow);
-	ui.pressureSensorOffsetSpinBox->setValue(deviceDetails->pressureSensorOffset);
-	ui.ppO2MinSpinBox->setValue(deviceDetails->ppO2Min);
-	ui.ppO2MaxSpinBox->setValue(deviceDetails->ppO2Max);
-	ui.futureTTSSpinBox->setValue(deviceDetails->futureTTS);
-	ui.ccrModeComboBox->setCurrentIndex(deviceDetails->ccrMode);
-	ui.decoTypeComboBox->setCurrentIndex(deviceDetails->decoType);
-	ui.aGFSelectableCheckBox->setChecked(deviceDetails->aGFSelectable);
-	ui.aGFHighSpinBox->setValue(deviceDetails->aGFHigh);
-	ui.aGFLowSpinBox->setValue(deviceDetails->aGFLow);
-	ui.calibrationGasSpinBox->setValue(deviceDetails->calibrationGas);
-	ui.flipScreenCheckBox->setChecked(deviceDetails->flipScreen);
-	ui.leftButtonSensitivity->setValue(deviceDetails->leftButtonSensitivity);
-	ui.rightButtonSensitivity->setValue(deviceDetails->rightButtonSensitivity);
-	ui.bottomGasConsumption->setValue(deviceDetails->bottomGasConsumption);
-	ui.decoGasConsumption->setValue(deviceDetails->decoGasConsumption);
-	ui.modWarning->setChecked(deviceDetails->modWarning);
-	ui.dynamicAscendRate->setChecked(deviceDetails->dynamicAscendRate);
-	ui.graphicalSpeedIndicator->setChecked(deviceDetails->graphicalSpeedIndicator);
-	ui.alwaysShowppO2->setChecked(deviceDetails->alwaysShowppO2);
-	ui.tempSensorOffsetDoubleSpinBox->setValue((double)deviceDetails->tempSensorOffset / 10.0);
-	ui.safetyStopLengthSpinBox->setValue(deviceDetails->safetyStopLength);
-	ui.safetyStopStartDepthDoubleSpinBox->setValue(deviceDetails->safetyStopStartDepth / 10.0);
-	ui.safetyStopEndDepthDoubleSpinBox->setValue(deviceDetails->safetyStopEndDepth / 10.0);
-	ui.safetyStopResetDepthDoubleSpinBox->setValue(deviceDetails->safetyStopResetDepth / 10.0);
+	ui.serialNoLineEdit->setText(deviceDetails.serialNo);
+	ui.firmwareVersionLineEdit->setText(deviceDetails.firmwareVersion);
+	ui.customTextLlineEdit->setText(deviceDetails.customText);
+	ui.modelLineEdit->setText(deviceDetails.model);
+	ui.diveModeComboBox->setCurrentIndex(deviceDetails.diveMode);
+	ui.saturationSpinBox->setValue(deviceDetails.saturation);
+	ui.desaturationSpinBox->setValue(deviceDetails.desaturation);
+	ui.lastDecoSpinBox->setValue(deviceDetails.lastDeco);
+	ui.brightnessComboBox->setCurrentIndex(deviceDetails.brightness);
+	ui.unitsComboBox->setCurrentIndex(deviceDetails.units);
+	ui.samplingRateComboBox->setCurrentIndex(deviceDetails.samplingRate);
+	ui.salinitySpinBox->setValue(deviceDetails.salinity);
+	ui.diveModeColour->setCurrentIndex(deviceDetails.diveModeColor);
+	ui.languageComboBox->setCurrentIndex(deviceDetails.language);
+	ui.dateFormatComboBox->setCurrentIndex(deviceDetails.dateFormat);
+	ui.compassGainComboBox->setCurrentIndex(deviceDetails.compassGain);
+	ui.safetyStopCheckBox->setChecked(deviceDetails.safetyStop);
+	ui.gfHighSpinBox->setValue(deviceDetails.gfHigh);
+	ui.gfLowSpinBox->setValue(deviceDetails.gfLow);
+	ui.pressureSensorOffsetSpinBox->setValue(deviceDetails.pressureSensorOffset);
+	ui.ppO2MinSpinBox->setValue(deviceDetails.ppO2Min);
+	ui.ppO2MaxSpinBox->setValue(deviceDetails.ppO2Max);
+	ui.futureTTSSpinBox->setValue(deviceDetails.futureTTS);
+	ui.ccrModeComboBox->setCurrentIndex(deviceDetails.ccrMode);
+	ui.decoTypeComboBox->setCurrentIndex(deviceDetails.decoType);
+	ui.aGFSelectableCheckBox->setChecked(deviceDetails.aGFSelectable);
+	ui.aGFHighSpinBox->setValue(deviceDetails.aGFHigh);
+	ui.aGFLowSpinBox->setValue(deviceDetails.aGFLow);
+	ui.calibrationGasSpinBox->setValue(deviceDetails.calibrationGas);
+	ui.flipScreenCheckBox->setChecked(deviceDetails.flipScreen);
+	ui.leftButtonSensitivity->setValue(deviceDetails.leftButtonSensitivity);
+	ui.rightButtonSensitivity->setValue(deviceDetails.rightButtonSensitivity);
+	ui.bottomGasConsumption->setValue(deviceDetails.bottomGasConsumption);
+	ui.decoGasConsumption->setValue(deviceDetails.decoGasConsumption);
+	ui.modWarning->setChecked(deviceDetails.modWarning);
+	ui.dynamicAscendRate->setChecked(deviceDetails.dynamicAscendRate);
+	ui.graphicalSpeedIndicator->setChecked(deviceDetails.graphicalSpeedIndicator);
+	ui.alwaysShowppO2->setChecked(deviceDetails.alwaysShowppO2);
+	ui.tempSensorOffsetDoubleSpinBox->setValue((double)deviceDetails.tempSensorOffset / 10.0);
+	ui.safetyStopLengthSpinBox->setValue(deviceDetails.safetyStopLength);
+	ui.safetyStopStartDepthDoubleSpinBox->setValue(deviceDetails.safetyStopStartDepth / 10.0);
+	ui.safetyStopEndDepthDoubleSpinBox->setValue(deviceDetails.safetyStopEndDepth / 10.0);
+	ui.safetyStopResetDepthDoubleSpinBox->setValue(deviceDetails.safetyStopResetDepth / 10.0);
 
 	//load gas 1 values
-	ui.ostc3GasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->gas1.oxygen)));
-	ui.ostc3GasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->gas1.helium)));
-	ui.ostc3GasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->gas1.type)));
-	ui.ostc3GasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->gas1.depth)));
+	ui.ostc3GasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.gas1.oxygen)));
+	ui.ostc3GasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.gas1.helium)));
+	ui.ostc3GasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.gas1.type)));
+	ui.ostc3GasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.gas1.depth)));
 
 	//load gas 2 values
-	ui.ostc3GasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->gas2.oxygen)));
-	ui.ostc3GasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->gas2.helium)));
-	ui.ostc3GasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->gas2.type)));
-	ui.ostc3GasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->gas2.depth)));
+	ui.ostc3GasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.gas2.oxygen)));
+	ui.ostc3GasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.gas2.helium)));
+	ui.ostc3GasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.gas2.type)));
+	ui.ostc3GasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.gas2.depth)));
 
 	//load gas 3 values
-	ui.ostc3GasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->gas3.oxygen)));
-	ui.ostc3GasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->gas3.helium)));
-	ui.ostc3GasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->gas3.type)));
-	ui.ostc3GasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->gas3.depth)));
+	ui.ostc3GasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.gas3.oxygen)));
+	ui.ostc3GasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.gas3.helium)));
+	ui.ostc3GasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.gas3.type)));
+	ui.ostc3GasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.gas3.depth)));
 
 	//load gas 4 values
-	ui.ostc3GasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->gas4.oxygen)));
-	ui.ostc3GasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->gas4.helium)));
-	ui.ostc3GasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->gas4.type)));
-	ui.ostc3GasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->gas4.depth)));
+	ui.ostc3GasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.gas4.oxygen)));
+	ui.ostc3GasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.gas4.helium)));
+	ui.ostc3GasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.gas4.type)));
+	ui.ostc3GasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.gas4.depth)));
 
 	//load gas 5 values
-	ui.ostc3GasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->gas5.oxygen)));
-	ui.ostc3GasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->gas5.helium)));
-	ui.ostc3GasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->gas5.type)));
-	ui.ostc3GasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->gas5.depth)));
+	ui.ostc3GasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.gas5.oxygen)));
+	ui.ostc3GasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.gas5.helium)));
+	ui.ostc3GasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.gas5.type)));
+	ui.ostc3GasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.gas5.depth)));
 
 	//load dil 1 values
-	ui.ostc3DilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->dil1.oxygen)));
-	ui.ostc3DilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->dil1.helium)));
-	ui.ostc3DilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->dil1.type)));
-	ui.ostc3DilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->dil1.depth)));
+	ui.ostc3DilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.dil1.oxygen)));
+	ui.ostc3DilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.dil1.helium)));
+	ui.ostc3DilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.dil1.type)));
+	ui.ostc3DilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.dil1.depth)));
 
 	//load dil 2 values
-	ui.ostc3DilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->dil2.oxygen)));
-	ui.ostc3DilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->dil2.helium)));
-	ui.ostc3DilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->dil2.type)));
-	ui.ostc3DilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->dil2.depth)));
+	ui.ostc3DilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.dil2.oxygen)));
+	ui.ostc3DilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.dil2.helium)));
+	ui.ostc3DilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.dil2.type)));
+	ui.ostc3DilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.dil2.depth)));
 
 	//load dil 3 values
-	ui.ostc3DilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->dil3.oxygen)));
-	ui.ostc3DilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->dil3.helium)));
-	ui.ostc3DilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->dil3.type)));
-	ui.ostc3DilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->dil3.depth)));
+	ui.ostc3DilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.dil3.oxygen)));
+	ui.ostc3DilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.dil3.helium)));
+	ui.ostc3DilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.dil3.type)));
+	ui.ostc3DilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.dil3.depth)));
 
 	//load dil 4 values
-	ui.ostc3DilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->dil4.oxygen)));
-	ui.ostc3DilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->dil4.helium)));
-	ui.ostc3DilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->dil4.type)));
-	ui.ostc3DilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->dil4.depth)));
+	ui.ostc3DilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.dil4.oxygen)));
+	ui.ostc3DilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.dil4.helium)));
+	ui.ostc3DilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.dil4.type)));
+	ui.ostc3DilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.dil4.depth)));
 
 	//load dil 5 values
-	ui.ostc3DilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->dil5.oxygen)));
-	ui.ostc3DilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->dil5.helium)));
-	ui.ostc3DilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->dil5.type)));
-	ui.ostc3DilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->dil5.depth)));
+	ui.ostc3DilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.dil5.oxygen)));
+	ui.ostc3DilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.dil5.helium)));
+	ui.ostc3DilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.dil5.type)));
+	ui.ostc3DilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.dil5.depth)));
 
 	//load setpoint 1 values
-	ui.ostc3SetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->sp1.sp)));
-	ui.ostc3SetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->sp1.depth)));
+	ui.ostc3SetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.sp1.sp)));
+	ui.ostc3SetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.sp1.depth)));
 
 	//load setpoint 2 values
-	ui.ostc3SetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->sp2.sp)));
-	ui.ostc3SetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->sp2.depth)));
+	ui.ostc3SetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.sp2.sp)));
+	ui.ostc3SetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.sp2.depth)));
 
 	//load setpoint 3 values
-	ui.ostc3SetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->sp3.sp)));
-	ui.ostc3SetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->sp3.depth)));
+	ui.ostc3SetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.sp3.sp)));
+	ui.ostc3SetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.sp3.depth)));
 
 	//load setpoint 4 values
-	ui.ostc3SetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->sp4.sp)));
-	ui.ostc3SetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->sp4.depth)));
+	ui.ostc3SetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.sp4.sp)));
+	ui.ostc3SetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.sp4.depth)));
 
 	//load setpoint 5 values
-	ui.ostc3SetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->sp5.sp)));
-	ui.ostc3SetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->sp5.depth)));
+	ui.ostc3SetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.sp5.sp)));
+	ui.ostc3SetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.sp5.depth)));
 }
 
 void ConfigureDiveComputerDialog::reloadValuesOSTC()
@@ -1149,256 +1145,256 @@ setCcrMode
 # Not in OSTC3
 setNumberOfDives
 */
-	ui.serialNoLineEdit_3->setText(deviceDetails->serialNo);
-	ui.firmwareVersionLineEdit_3->setText(deviceDetails->firmwareVersion);
-	ui.customTextLlineEdit_3->setText(deviceDetails->customText);
-	ui.saturationSpinBox_3->setValue(deviceDetails->saturation);
-	ui.desaturationSpinBox_3->setValue(deviceDetails->desaturation);
-	ui.lastDecoSpinBox_3->setValue(deviceDetails->lastDeco);
-	ui.samplingRateSpinBox_3->setValue(deviceDetails->samplingRate);
-	ui.salinityDoubleSpinBox_3->setValue((double)deviceDetails->salinity / 100.0);
-	ui.dateFormatComboBox_3->setCurrentIndex(deviceDetails->dateFormat);
-	ui.safetyStopCheckBox_3->setChecked(deviceDetails->safetyStop);
-	ui.gfHighSpinBox_3->setValue(deviceDetails->gfHigh);
-	ui.gfLowSpinBox_3->setValue(deviceDetails->gfLow);
-	ui.ppO2MinSpinBox_3->setValue(deviceDetails->ppO2Min);
-	ui.ppO2MaxSpinBox_3->setValue(deviceDetails->ppO2Max);
-	ui.futureTTSSpinBox_3->setValue(deviceDetails->futureTTS);
-	ui.decoTypeComboBox_3->setCurrentIndex(deviceDetails->decoType);
-	ui.aGFSelectableCheckBox_3->setChecked(deviceDetails->aGFSelectable);
-	ui.aGFHighSpinBox_3->setValue(deviceDetails->aGFHigh);
-	ui.aGFLowSpinBox_3->setValue(deviceDetails->aGFLow);
-	ui.numberOfDivesSpinBox_3->setValue(deviceDetails->numberOfDives);
-	ui.bottomGasConsumption_3->setValue(deviceDetails->bottomGasConsumption);
-	ui.decoGasConsumption_3->setValue(deviceDetails->decoGasConsumption);
-	ui.graphicalSpeedIndicator_3->setChecked(deviceDetails->graphicalSpeedIndicator);
-	ui.safetyStopLengthSpinBox_3->setValue(deviceDetails->safetyStopLength);
-	ui.safetyStopStartDepthDoubleSpinBox_3->setValue(deviceDetails->safetyStopStartDepth / 10.0);
-	ui.safetyStopEndDepthDoubleSpinBox_3->setValue(deviceDetails->safetyStopEndDepth / 10.0);
-	ui.safetyStopResetDepthDoubleSpinBox_3->setValue(deviceDetails->safetyStopResetDepth / 10.0);
+	ui.serialNoLineEdit_3->setText(deviceDetails.serialNo);
+	ui.firmwareVersionLineEdit_3->setText(deviceDetails.firmwareVersion);
+	ui.customTextLlineEdit_3->setText(deviceDetails.customText);
+	ui.saturationSpinBox_3->setValue(deviceDetails.saturation);
+	ui.desaturationSpinBox_3->setValue(deviceDetails.desaturation);
+	ui.lastDecoSpinBox_3->setValue(deviceDetails.lastDeco);
+	ui.samplingRateSpinBox_3->setValue(deviceDetails.samplingRate);
+	ui.salinityDoubleSpinBox_3->setValue((double)deviceDetails.salinity / 100.0);
+	ui.dateFormatComboBox_3->setCurrentIndex(deviceDetails.dateFormat);
+	ui.safetyStopCheckBox_3->setChecked(deviceDetails.safetyStop);
+	ui.gfHighSpinBox_3->setValue(deviceDetails.gfHigh);
+	ui.gfLowSpinBox_3->setValue(deviceDetails.gfLow);
+	ui.ppO2MinSpinBox_3->setValue(deviceDetails.ppO2Min);
+	ui.ppO2MaxSpinBox_3->setValue(deviceDetails.ppO2Max);
+	ui.futureTTSSpinBox_3->setValue(deviceDetails.futureTTS);
+	ui.decoTypeComboBox_3->setCurrentIndex(deviceDetails.decoType);
+	ui.aGFSelectableCheckBox_3->setChecked(deviceDetails.aGFSelectable);
+	ui.aGFHighSpinBox_3->setValue(deviceDetails.aGFHigh);
+	ui.aGFLowSpinBox_3->setValue(deviceDetails.aGFLow);
+	ui.numberOfDivesSpinBox_3->setValue(deviceDetails.numberOfDives);
+	ui.bottomGasConsumption_3->setValue(deviceDetails.bottomGasConsumption);
+	ui.decoGasConsumption_3->setValue(deviceDetails.decoGasConsumption);
+	ui.graphicalSpeedIndicator_3->setChecked(deviceDetails.graphicalSpeedIndicator);
+	ui.safetyStopLengthSpinBox_3->setValue(deviceDetails.safetyStopLength);
+	ui.safetyStopStartDepthDoubleSpinBox_3->setValue(deviceDetails.safetyStopStartDepth / 10.0);
+	ui.safetyStopEndDepthDoubleSpinBox_3->setValue(deviceDetails.safetyStopEndDepth / 10.0);
+	ui.safetyStopResetDepthDoubleSpinBox_3->setValue(deviceDetails.safetyStopResetDepth / 10.0);
 
 	//load gas 1 values
-	ui.ostcGasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->gas1.oxygen)));
-	ui.ostcGasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->gas1.helium)));
-	ui.ostcGasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->gas1.type)));
-	ui.ostcGasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->gas1.depth)));
+	ui.ostcGasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.gas1.oxygen)));
+	ui.ostcGasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.gas1.helium)));
+	ui.ostcGasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.gas1.type)));
+	ui.ostcGasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.gas1.depth)));
 
 	//load gas 2 values
-	ui.ostcGasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->gas2.oxygen)));
-	ui.ostcGasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->gas2.helium)));
-	ui.ostcGasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->gas2.type)));
-	ui.ostcGasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->gas2.depth)));
+	ui.ostcGasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.gas2.oxygen)));
+	ui.ostcGasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.gas2.helium)));
+	ui.ostcGasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.gas2.type)));
+	ui.ostcGasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.gas2.depth)));
 
 	//load gas 3 values
-	ui.ostcGasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->gas3.oxygen)));
-	ui.ostcGasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->gas3.helium)));
-	ui.ostcGasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->gas3.type)));
-	ui.ostcGasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->gas3.depth)));
+	ui.ostcGasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.gas3.oxygen)));
+	ui.ostcGasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.gas3.helium)));
+	ui.ostcGasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.gas3.type)));
+	ui.ostcGasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.gas3.depth)));
 
 	//load gas 4 values
-	ui.ostcGasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->gas4.oxygen)));
-	ui.ostcGasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->gas4.helium)));
-	ui.ostcGasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->gas4.type)));
-	ui.ostcGasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->gas4.depth)));
+	ui.ostcGasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.gas4.oxygen)));
+	ui.ostcGasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.gas4.helium)));
+	ui.ostcGasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.gas4.type)));
+	ui.ostcGasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.gas4.depth)));
 
 	//load gas 5 values
-	ui.ostcGasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->gas5.oxygen)));
-	ui.ostcGasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->gas5.helium)));
-	ui.ostcGasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->gas5.type)));
-	ui.ostcGasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->gas5.depth)));
+	ui.ostcGasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.gas5.oxygen)));
+	ui.ostcGasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.gas5.helium)));
+	ui.ostcGasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.gas5.type)));
+	ui.ostcGasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.gas5.depth)));
 
 	//load dil 1 values
-	ui.ostcDilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->dil1.oxygen)));
-	ui.ostcDilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->dil1.helium)));
-	ui.ostcDilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->dil1.type)));
-	ui.ostcDilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->dil1.depth)));
+	ui.ostcDilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.dil1.oxygen)));
+	ui.ostcDilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.dil1.helium)));
+	ui.ostcDilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.dil1.type)));
+	ui.ostcDilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.dil1.depth)));
 
 	//load dil 2 values
-	ui.ostcDilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->dil2.oxygen)));
-	ui.ostcDilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->dil2.helium)));
-	ui.ostcDilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->dil2.type)));
-	ui.ostcDilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->dil2.depth)));
+	ui.ostcDilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.dil2.oxygen)));
+	ui.ostcDilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.dil2.helium)));
+	ui.ostcDilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.dil2.type)));
+	ui.ostcDilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.dil2.depth)));
 
 	//load dil 3 values
-	ui.ostcDilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->dil3.oxygen)));
-	ui.ostcDilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->dil3.helium)));
-	ui.ostcDilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->dil3.type)));
-	ui.ostcDilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->dil3.depth)));
+	ui.ostcDilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.dil3.oxygen)));
+	ui.ostcDilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.dil3.helium)));
+	ui.ostcDilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.dil3.type)));
+	ui.ostcDilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.dil3.depth)));
 
 	//load dil 4 values
-	ui.ostcDilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->dil4.oxygen)));
-	ui.ostcDilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->dil4.helium)));
-	ui.ostcDilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->dil4.type)));
-	ui.ostcDilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->dil4.depth)));
+	ui.ostcDilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.dil4.oxygen)));
+	ui.ostcDilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.dil4.helium)));
+	ui.ostcDilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.dil4.type)));
+	ui.ostcDilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.dil4.depth)));
 
 	//load dil 5 values
-	ui.ostcDilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->dil5.oxygen)));
-	ui.ostcDilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->dil5.helium)));
-	ui.ostcDilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->dil5.type)));
-	ui.ostcDilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->dil5.depth)));
+	ui.ostcDilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.dil5.oxygen)));
+	ui.ostcDilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.dil5.helium)));
+	ui.ostcDilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.dil5.type)));
+	ui.ostcDilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.dil5.depth)));
 
 	//load setpoint 1 values
-	ui.ostcSetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->sp1.sp)));
-	ui.ostcSetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->sp1.depth)));
+	ui.ostcSetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.sp1.sp)));
+	ui.ostcSetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.sp1.depth)));
 
 	//load setpoint 2 values
-	ui.ostcSetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->sp2.sp)));
-	ui.ostcSetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->sp2.depth)));
+	ui.ostcSetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.sp2.sp)));
+	ui.ostcSetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.sp2.depth)));
 
 	//load setpoint 3 values
-	ui.ostcSetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->sp3.sp)));
-	ui.ostcSetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->sp3.depth)));
+	ui.ostcSetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.sp3.sp)));
+	ui.ostcSetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.sp3.depth)));
 
 	//load setpoint 4 values
-	ui.ostcSetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->sp4.sp)));
-	ui.ostcSetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->sp4.depth)));
+	ui.ostcSetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.sp4.sp)));
+	ui.ostcSetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.sp4.depth)));
 
 	//load setpoint 5 values
-	ui.ostcSetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->sp5.sp)));
-	ui.ostcSetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->sp5.depth)));
+	ui.ostcSetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.sp5.sp)));
+	ui.ostcSetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.sp5.depth)));
 }
 
 void ConfigureDiveComputerDialog::reloadValuesSuuntoVyper()
 {
 	const char *depth_unit;
-	ui.maxDepthDoubleSpinBox->setValue(get_depth_units(deviceDetails->maxDepth, NULL, &depth_unit));
+	ui.maxDepthDoubleSpinBox->setValue(get_depth_units(deviceDetails.maxDepth, NULL, &depth_unit));
 	ui.maxDepthDoubleSpinBox->setSuffix(depth_unit);
-	ui.totalTimeSpinBox->setValue(deviceDetails->totalTime);
-	ui.numberOfDivesSpinBox->setValue(deviceDetails->numberOfDives);
-	ui.modelLineEdit_1->setText(deviceDetails->model);
-	ui.firmwareVersionLineEdit_1->setText(deviceDetails->firmwareVersion);
-	ui.serialNoLineEdit_1->setText(deviceDetails->serialNo);
-	ui.customTextLlineEdit_1->setText(deviceDetails->customText);
-	ui.samplingRateComboBox_1->setCurrentIndex(deviceDetails->samplingRate == 60 ? 3 : (deviceDetails->samplingRate / 10) - 1);
-	ui.altitudeRangeComboBox->setCurrentIndex(deviceDetails->altitude);
-	ui.personalSafetyComboBox->setCurrentIndex(deviceDetails->personalSafety);
-	ui.timeFormatComboBox->setCurrentIndex(deviceDetails->timeFormat);
-	ui.unitsComboBox_1->setCurrentIndex(deviceDetails->units);
-	ui.diveModeComboBox_1->setCurrentIndex(deviceDetails->diveMode);
-	ui.lightCheckBox->setChecked(deviceDetails->lightEnabled);
-	ui.lightSpinBox->setValue(deviceDetails->light);
-	ui.alarmDepthCheckBox->setChecked(deviceDetails->alarmDepthEnabled);
-	ui.alarmDepthDoubleSpinBox->setValue(get_depth_units(deviceDetails->alarmDepth, NULL, &depth_unit));
+	ui.totalTimeSpinBox->setValue(deviceDetails.totalTime);
+	ui.numberOfDivesSpinBox->setValue(deviceDetails.numberOfDives);
+	ui.modelLineEdit_1->setText(deviceDetails.model);
+	ui.firmwareVersionLineEdit_1->setText(deviceDetails.firmwareVersion);
+	ui.serialNoLineEdit_1->setText(deviceDetails.serialNo);
+	ui.customTextLlineEdit_1->setText(deviceDetails.customText);
+	ui.samplingRateComboBox_1->setCurrentIndex(deviceDetails.samplingRate == 60 ? 3 : (deviceDetails.samplingRate / 10) - 1);
+	ui.altitudeRangeComboBox->setCurrentIndex(deviceDetails.altitude);
+	ui.personalSafetyComboBox->setCurrentIndex(deviceDetails.personalSafety);
+	ui.timeFormatComboBox->setCurrentIndex(deviceDetails.timeFormat);
+	ui.unitsComboBox_1->setCurrentIndex(deviceDetails.units);
+	ui.diveModeComboBox_1->setCurrentIndex(deviceDetails.diveMode);
+	ui.lightCheckBox->setChecked(deviceDetails.lightEnabled);
+	ui.lightSpinBox->setValue(deviceDetails.light);
+	ui.alarmDepthCheckBox->setChecked(deviceDetails.alarmDepthEnabled);
+	ui.alarmDepthDoubleSpinBox->setValue(get_depth_units(deviceDetails.alarmDepth, NULL, &depth_unit));
 	ui.alarmDepthDoubleSpinBox->setSuffix(depth_unit);
-	ui.alarmTimeCheckBox->setChecked(deviceDetails->alarmTimeEnabled);
-	ui.alarmTimeSpinBox->setValue(deviceDetails->alarmTime);
+	ui.alarmTimeCheckBox->setChecked(deviceDetails.alarmTimeEnabled);
+	ui.alarmTimeSpinBox->setValue(deviceDetails.alarmTime);
 }
 
 void ConfigureDiveComputerDialog::reloadValuesOSTC4()
 {
-	ui.serialNoLineEdit_4->setText(deviceDetails->serialNo);
-	ui.firmwareVersionLineEdit_4->setText(deviceDetails->firmwareVersion);
-	ui.customTextLlineEdit_4->setText(deviceDetails->customText);
-	ui.modelLineEdit_4->setText(deviceDetails->model);
-	ui.diveModeComboBox_4->setCurrentIndex(deviceDetails->diveMode);
-	ui.lastDecoSpinBox_4->setValue(deviceDetails->lastDeco);
-	ui.brightnessComboBox_4->setCurrentIndex(deviceDetails->brightness);
-	ui.unitsComboBox_4->setCurrentIndex(deviceDetails->units);
-	ui.salinitySpinBox_4->setValue(deviceDetails->salinity);
-	ui.diveModeColour_4->setCurrentIndex(deviceDetails->diveModeColor);
-	ui.languageComboBox_4->setCurrentIndex(deviceDetails->language);
-	ui.dateFormatComboBox_4->setCurrentIndex(deviceDetails->dateFormat);
-	ui.safetyStopCheckBox_4->setChecked(deviceDetails->safetyStop);
-	ui.gfHighSpinBox_4->setValue(deviceDetails->gfHigh);
-	ui.gfLowSpinBox_4->setValue(deviceDetails->gfLow);
-	ui.pressureSensorOffsetSpinBox_4->setValue(deviceDetails->pressureSensorOffset);
-	ui.ppO2MinSpinBox_4->setValue(deviceDetails->ppO2Min);
-	ui.ppO2MaxSpinBox_4->setValue(deviceDetails->ppO2Max);
-	ui.futureTTSSpinBox_4->setValue(deviceDetails->futureTTS);
-	ui.ccrModeComboBox_4->setCurrentIndex(deviceDetails->ccrMode);
-	ui.decoTypeComboBox_4->setCurrentIndex(deviceDetails->decoType);
-	ui.aGFHighSpinBox_4->setValue(deviceDetails->aGFHigh);
-	ui.aGFLowSpinBox_4->setValue(deviceDetails->aGFLow);
-	ui.vpmConservatismSpinBox->setValue(deviceDetails->vpmConservatism);
-	ui.setPointFallbackCheckBox_4->setChecked(deviceDetails->setPointFallback);
-	ui.buttonSensitivity_4->setValue(deviceDetails->buttonSensitivity);
-	ui.bottomGasConsumption_4->setValue(deviceDetails->bottomGasConsumption);
-	ui.decoGasConsumption_4->setValue(deviceDetails->decoGasConsumption);
-	ui.travelGasConsumption_4->setValue(deviceDetails->travelGasConsumption);
-	ui.alwaysShowppO2_4->setChecked(deviceDetails->alwaysShowppO2);
-	ui.tempSensorOffsetDoubleSpinBox_4->setValue((double)deviceDetails->tempSensorOffset / 10.0);
-	ui.safetyStopLengthSpinBox_4->setValue(deviceDetails->safetyStopLength);
-	ui.safetyStopStartDepthDoubleSpinBox_4->setValue(deviceDetails->safetyStopStartDepth / 10.0);
+	ui.serialNoLineEdit_4->setText(deviceDetails.serialNo);
+	ui.firmwareVersionLineEdit_4->setText(deviceDetails.firmwareVersion);
+	ui.customTextLlineEdit_4->setText(deviceDetails.customText);
+	ui.modelLineEdit_4->setText(deviceDetails.model);
+	ui.diveModeComboBox_4->setCurrentIndex(deviceDetails.diveMode);
+	ui.lastDecoSpinBox_4->setValue(deviceDetails.lastDeco);
+	ui.brightnessComboBox_4->setCurrentIndex(deviceDetails.brightness);
+	ui.unitsComboBox_4->setCurrentIndex(deviceDetails.units);
+	ui.salinitySpinBox_4->setValue(deviceDetails.salinity);
+	ui.diveModeColour_4->setCurrentIndex(deviceDetails.diveModeColor);
+	ui.languageComboBox_4->setCurrentIndex(deviceDetails.language);
+	ui.dateFormatComboBox_4->setCurrentIndex(deviceDetails.dateFormat);
+	ui.safetyStopCheckBox_4->setChecked(deviceDetails.safetyStop);
+	ui.gfHighSpinBox_4->setValue(deviceDetails.gfHigh);
+	ui.gfLowSpinBox_4->setValue(deviceDetails.gfLow);
+	ui.pressureSensorOffsetSpinBox_4->setValue(deviceDetails.pressureSensorOffset);
+	ui.ppO2MinSpinBox_4->setValue(deviceDetails.ppO2Min);
+	ui.ppO2MaxSpinBox_4->setValue(deviceDetails.ppO2Max);
+	ui.futureTTSSpinBox_4->setValue(deviceDetails.futureTTS);
+	ui.ccrModeComboBox_4->setCurrentIndex(deviceDetails.ccrMode);
+	ui.decoTypeComboBox_4->setCurrentIndex(deviceDetails.decoType);
+	ui.aGFHighSpinBox_4->setValue(deviceDetails.aGFHigh);
+	ui.aGFLowSpinBox_4->setValue(deviceDetails.aGFLow);
+	ui.vpmConservatismSpinBox->setValue(deviceDetails.vpmConservatism);
+	ui.setPointFallbackCheckBox_4->setChecked(deviceDetails.setPointFallback);
+	ui.buttonSensitivity_4->setValue(deviceDetails.buttonSensitivity);
+	ui.bottomGasConsumption_4->setValue(deviceDetails.bottomGasConsumption);
+	ui.decoGasConsumption_4->setValue(deviceDetails.decoGasConsumption);
+	ui.travelGasConsumption_4->setValue(deviceDetails.travelGasConsumption);
+	ui.alwaysShowppO2_4->setChecked(deviceDetails.alwaysShowppO2);
+	ui.tempSensorOffsetDoubleSpinBox_4->setValue((double)deviceDetails.tempSensorOffset / 10.0);
+	ui.safetyStopLengthSpinBox_4->setValue(deviceDetails.safetyStopLength);
+	ui.safetyStopStartDepthDoubleSpinBox_4->setValue(deviceDetails.safetyStopStartDepth / 10.0);
 
 	//load gas 1 values
-	ui.ostc4GasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->gas1.oxygen)));
-	ui.ostc4GasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->gas1.helium)));
-	ui.ostc4GasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->gas1.type)));
-	ui.ostc4GasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->gas1.depth)));
+	ui.ostc4GasTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.gas1.oxygen)));
+	ui.ostc4GasTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.gas1.helium)));
+	ui.ostc4GasTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.gas1.type)));
+	ui.ostc4GasTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.gas1.depth)));
 
 	//load gas 2 values
-	ui.ostc4GasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->gas2.oxygen)));
-	ui.ostc4GasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->gas2.helium)));
-	ui.ostc4GasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->gas2.type)));
-	ui.ostc4GasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->gas2.depth)));
+	ui.ostc4GasTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.gas2.oxygen)));
+	ui.ostc4GasTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.gas2.helium)));
+	ui.ostc4GasTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.gas2.type)));
+	ui.ostc4GasTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.gas2.depth)));
 
 	//load gas 3 values
-	ui.ostc4GasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->gas3.oxygen)));
-	ui.ostc4GasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->gas3.helium)));
-	ui.ostc4GasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->gas3.type)));
-	ui.ostc4GasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->gas3.depth)));
+	ui.ostc4GasTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.gas3.oxygen)));
+	ui.ostc4GasTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.gas3.helium)));
+	ui.ostc4GasTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.gas3.type)));
+	ui.ostc4GasTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.gas3.depth)));
 
 	//load gas 4 values
-	ui.ostc4GasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->gas4.oxygen)));
-	ui.ostc4GasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->gas4.helium)));
-	ui.ostc4GasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->gas4.type)));
-	ui.ostc4GasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->gas4.depth)));
+	ui.ostc4GasTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.gas4.oxygen)));
+	ui.ostc4GasTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.gas4.helium)));
+	ui.ostc4GasTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.gas4.type)));
+	ui.ostc4GasTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.gas4.depth)));
 
 	//load gas 5 values
-	ui.ostc4GasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->gas5.oxygen)));
-	ui.ostc4GasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->gas5.helium)));
-	ui.ostc4GasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->gas5.type)));
-	ui.ostc4GasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->gas5.depth)));
+	ui.ostc4GasTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.gas5.oxygen)));
+	ui.ostc4GasTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.gas5.helium)));
+	ui.ostc4GasTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.gas5.type)));
+	ui.ostc4GasTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.gas5.depth)));
 
 	//load dil 1 values
-	ui.ostc4DilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->dil1.oxygen)));
-	ui.ostc4DilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->dil1.helium)));
-	ui.ostc4DilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails->dil1.type)));
-	ui.ostc4DilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails->dil1.depth)));
+	ui.ostc4DilTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.dil1.oxygen)));
+	ui.ostc4DilTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.dil1.helium)));
+	ui.ostc4DilTable->setItem(0, 3, new QTableWidgetItem(QString::number(deviceDetails.dil1.type)));
+	ui.ostc4DilTable->setItem(0, 4, new QTableWidgetItem(QString::number(deviceDetails.dil1.depth)));
 
 	//load dil 2 values
-	ui.ostc4DilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->dil2.oxygen)));
-	ui.ostc4DilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->dil2.helium)));
-	ui.ostc4DilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails->dil2.type)));
-	ui.ostc4DilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails->dil2.depth)));
+	ui.ostc4DilTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.dil2.oxygen)));
+	ui.ostc4DilTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.dil2.helium)));
+	ui.ostc4DilTable->setItem(1, 3, new QTableWidgetItem(QString::number(deviceDetails.dil2.type)));
+	ui.ostc4DilTable->setItem(1, 4, new QTableWidgetItem(QString::number(deviceDetails.dil2.depth)));
 
 	//load dil 3 values
-	ui.ostc4DilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->dil3.oxygen)));
-	ui.ostc4DilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->dil3.helium)));
-	ui.ostc4DilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails->dil3.type)));
-	ui.ostc4DilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails->dil3.depth)));
+	ui.ostc4DilTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.dil3.oxygen)));
+	ui.ostc4DilTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.dil3.helium)));
+	ui.ostc4DilTable->setItem(2, 3, new QTableWidgetItem(QString::number(deviceDetails.dil3.type)));
+	ui.ostc4DilTable->setItem(2, 4, new QTableWidgetItem(QString::number(deviceDetails.dil3.depth)));
 
 	//load dil 4 values
-	ui.ostc4DilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->dil4.oxygen)));
-	ui.ostc4DilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->dil4.helium)));
-	ui.ostc4DilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails->dil4.type)));
-	ui.ostc4DilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails->dil4.depth)));
+	ui.ostc4DilTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.dil4.oxygen)));
+	ui.ostc4DilTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.dil4.helium)));
+	ui.ostc4DilTable->setItem(3, 3, new QTableWidgetItem(QString::number(deviceDetails.dil4.type)));
+	ui.ostc4DilTable->setItem(3, 4, new QTableWidgetItem(QString::number(deviceDetails.dil4.depth)));
 
 	//load dil 5 values
-	ui.ostc4DilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->dil5.oxygen)));
-	ui.ostc4DilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->dil5.helium)));
-	ui.ostc4DilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails->dil5.type)));
-	ui.ostc4DilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails->dil5.depth)));
+	ui.ostc4DilTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.dil5.oxygen)));
+	ui.ostc4DilTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.dil5.helium)));
+	ui.ostc4DilTable->setItem(4, 3, new QTableWidgetItem(QString::number(deviceDetails.dil5.type)));
+	ui.ostc4DilTable->setItem(4, 4, new QTableWidgetItem(QString::number(deviceDetails.dil5.depth)));
 
 	//load setpoint 1 values
-	ui.ostc4SetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails->sp1.sp)));
-	ui.ostc4SetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails->sp1.depth)));
+	ui.ostc4SetPointTable->setItem(0, 1, new QTableWidgetItem(QString::number(deviceDetails.sp1.sp)));
+	ui.ostc4SetPointTable->setItem(0, 2, new QTableWidgetItem(QString::number(deviceDetails.sp1.depth)));
 
 	//load setpoint 2 values
-	ui.ostc4SetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails->sp2.sp)));
-	ui.ostc4SetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails->sp2.depth)));
+	ui.ostc4SetPointTable->setItem(1, 1, new QTableWidgetItem(QString::number(deviceDetails.sp2.sp)));
+	ui.ostc4SetPointTable->setItem(1, 2, new QTableWidgetItem(QString::number(deviceDetails.sp2.depth)));
 
 	//load setpoint 4 values
-	ui.ostc4SetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails->sp3.sp)));
-	ui.ostc4SetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails->sp3.depth)));
+	ui.ostc4SetPointTable->setItem(2, 1, new QTableWidgetItem(QString::number(deviceDetails.sp3.sp)));
+	ui.ostc4SetPointTable->setItem(2, 2, new QTableWidgetItem(QString::number(deviceDetails.sp3.depth)));
 
 	//load setpoint 4 values
-	ui.ostc4SetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails->sp4.sp)));
-	ui.ostc4SetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails->sp4.depth)));
+	ui.ostc4SetPointTable->setItem(3, 1, new QTableWidgetItem(QString::number(deviceDetails.sp4.sp)));
+	ui.ostc4SetPointTable->setItem(3, 2, new QTableWidgetItem(QString::number(deviceDetails.sp4.depth)));
 
 	//load setpoint 5 values
-	ui.ostc4SetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails->sp5.sp)));
-	ui.ostc4SetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails->sp5.depth)));
+	ui.ostc4SetPointTable->setItem(4, 1, new QTableWidgetItem(QString::number(deviceDetails.sp5.sp)));
+	ui.ostc4SetPointTable->setItem(4, 2, new QTableWidgetItem(QString::number(deviceDetails.sp5.depth)));
 }
 
 void ConfigureDiveComputerDialog::on_backupButton_clicked()

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -1481,10 +1481,8 @@ void ConfigureDiveComputerDialog::pickLogFile()
 	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
 					       filename, tr("Log files") + " (*.log)");
-	if (!logFile.isEmpty()) {
-		free(logfile_name);
-		logfile_name = copy_qstring(logFile);
-	}
+	if (!logFile.isEmpty())
+		logfile_name = logFile.toStdString();
 }
 
 #ifdef BT_SUPPORT

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -117,10 +117,11 @@ static const DiveComputerEntry supportedDiveComputers[] = {
 	{ "Suunto", "Vyper", DC_TRANSPORT_SERIAL, false, false },
 };
 
-ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(QWidget *parent) : QDialog(parent),
-	config(0),
+ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(const QString &filename, QWidget *parent) : QDialog(parent),
+	filename(filename),
+	config(0)
 #ifdef BT_SUPPORT
-	btDeviceSelectionDialog(0)
+	, btDeviceSelectionDialog(0)
 #endif
 {
 	ui.setupUi(this);
@@ -1399,7 +1400,6 @@ void ConfigureDiveComputerDialog::reloadValuesOSTC4()
 
 void ConfigureDiveComputerDialog::on_backupButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
 	QString backupPath = QFileDialog::getSaveFileName(this, tr("Backup dive computer settings"),
@@ -1420,7 +1420,6 @@ void ConfigureDiveComputerDialog::on_backupButton_clicked()
 
 void ConfigureDiveComputerDialog::on_restoreBackupButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("Backup.xml");
 	QString restorePath = QFileDialog::getOpenFileName(this, tr("Restore dive computer settings"),
@@ -1443,7 +1442,6 @@ void ConfigureDiveComputerDialog::on_restoreBackupButton_clicked()
 
 void ConfigureDiveComputerDialog::on_updateFirmwareButton_clicked()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
 	filename = fi.absolutePath();
 	QString firmwarePath = QFileDialog::getOpenFileName(this, tr("Select firmware file"),
@@ -1480,7 +1478,6 @@ void ConfigureDiveComputerDialog::checkLogFile(int state)
 
 void ConfigureDiveComputerDialog::pickLogFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
 	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -294,7 +294,7 @@ void OstcFirmwareCheck::parseOstcFwVersion(QNetworkReply *reply)
 	disconnect(&manager, &QNetworkAccessManager::finished, this, &OstcFirmwareCheck::parseOstcFwVersion);
 }
 
-void OstcFirmwareCheck::checkLatest(QWidget *_parent, device_data_t *data)
+void OstcFirmwareCheck::checkLatest(QWidget *_parent, device_data_t *data, const QString &filename)
 {
 	devData = *data;
 	parent = _parent;
@@ -339,21 +339,20 @@ void OstcFirmwareCheck::checkLatest(QWidget *_parent, device_data_t *data)
 		response.setWindowModality(Qt::WindowModal);
 		int ret = response.exec();
 		if (ret == QMessageBox::Accepted)
-			upgradeFirmware();
+			upgradeFirmware(filename);
 	}
 }
 
-void OstcFirmwareCheck::upgradeFirmware()
+void OstcFirmwareCheck::upgradeFirmware(const QString &filename)
 {
 	// start download of latestFirmwareHexFile
 	QString saveFileName = latestFirmwareHexFile;
 	saveFileName.replace("http://www.heinrichsweikamp.net/autofirmware/", "");
 	saveFileName.replace("firmware", latestFirmwareAvailable);
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append(saveFileName);
+	saveFileName = fi.absolutePath().append(QDir::separator()).append(saveFileName);
 	storeFirmware = QFileDialog::getSaveFileName(parent, tr("Save the downloaded firmware as"),
-						     filename, tr("Firmware files") + " (*.hex *.bin)");
+						     saveFileName, tr("Firmware files") + " (*.hex *.bin)");
 	if (storeFirmware.isEmpty())
 		return;
 

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -74,7 +74,7 @@ slots:
 	void configError(QString err);
 	void on_close_clicked();
 	void on_saveSettingsPushButton_clicked();
-	void deviceDetailsReceived(DeviceDetails *newDeviceDetails);
+	void deviceDetailsReceived(DeviceDetails newDeviceDetails);
 	void reloadValues();
 	void on_backupButton_clicked();
 
@@ -104,7 +104,7 @@ private:
 
 	void fill_device_list(unsigned int transport);
 
-	DeviceDetails *deviceDetails;
+	DeviceDetails deviceDetails;
 	void populateDeviceDetails();
 	void populateDeviceDetailsOSTC3();
 	void populateDeviceDetailsOSTC();

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -61,9 +61,6 @@ public:
 	explicit ConfigureDiveComputerDialog(QWidget *parent = 0);
 	~ConfigureDiveComputerDialog();
 
-protected:
-	void closeEvent(QCloseEvent *event);
-
 private
 slots:
 	void checkLogFile(int state);
@@ -97,6 +94,8 @@ private:
 	Ui::ConfigureDiveComputerDialog ui;
 
 	QString logFile;
+
+	void closeEvent(QCloseEvent *event);
 
 	ConfigureDiveComputer *config;
 	device_data_t device_data;

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -123,14 +123,14 @@ class OstcFirmwareCheck : public QObject {
 	Q_OBJECT
 public:
 	explicit OstcFirmwareCheck(const QString &product);
-	void checkLatest(QWidget *parent, device_data_t *data);
+	void checkLatest(QWidget *parent, device_data_t *data, const QString &filename);
 public
 slots:
 	void parseOstcFwVersion(QNetworkReply *reply);
 	void saveOstcFirmware(QNetworkReply *reply);
 
 private:
-	void upgradeFirmware();
+	void upgradeFirmware(const QString &filename);
 	device_data_t devData;
 	QString latestFirmwareAvailable;
 	QString latestFirmwareHexFile;

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -58,7 +58,7 @@ class ConfigureDiveComputerDialog : public QDialog {
 	Q_OBJECT
 
 public:
-	explicit ConfigureDiveComputerDialog(QWidget *parent = 0);
+	explicit ConfigureDiveComputerDialog(const QString &filename, QWidget *parent = 0);
 	~ConfigureDiveComputerDialog();
 
 private
@@ -77,7 +77,6 @@ slots:
 
 	void on_restoreBackupButton_clicked();
 
-
 	void on_updateFirmwareButton_clicked();
 
 	void on_DiveComputerList_currentRowChanged(int currentRow);
@@ -94,6 +93,7 @@ private:
 	Ui::ConfigureDiveComputerDialog ui;
 
 	QString logFile;
+	QString filename;
 
 	void closeEvent(QCloseEvent *event);
 

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -486,7 +486,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 	QItemSelection newSelected = selected.size() ? selected : selectionModel()->selection();
 
 	std::vector<dive *> addToSelection, removeFromSelection;
-	Q_FOREACH (const QModelIndex &index, newDeselected.indexes()) {
+	for (const QModelIndex &index: newDeselected.indexes()) {
 		if (index.column() != 0)
 			continue;
 		const QAbstractItemModel *model = index.model();
@@ -499,7 +499,7 @@ void DiveListView::selectionChanged(const QItemSelection &selected, const QItemS
 				removeFromSelection.push_back(trip->dives.dives[i]);
 		}
 	}
-	Q_FOREACH (const QModelIndex &index, newSelected.indexes()) {
+	for (const QModelIndex &index: newSelected.indexes()) {
 		if (index.column() != 0)
 			continue;
 

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -495,7 +495,7 @@ void DiveLogImportDialog::loadFileContents(int value, whatChanged triggeredBy)
 		firstLine = f.readLine().trimmed();
 
 		currColumns = firstLine.split(';');
-		Q_FOREACH (QString columnText, currColumns) {
+		for (const QString &columnText: currColumns) {
 			if (columnText == "Time") {
 				headers.append("Sample time");
 			} else if (columnText == "Depth") {
@@ -613,7 +613,7 @@ void DiveLogImportDialog::loadFileContents(int value, whatChanged triggeredBy)
 		if (line.length() > 0)
 			columns = line.split(separator);
 		// now try and guess the columns
-		Q_FOREACH (QString columnText, currColumns) {
+		for (QString columnText: currColumns) {
 			count++;
 			/*
 			 * We have to skip the conversion of 2 to ₂ for APD Log

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -466,10 +466,8 @@ void DownloadFromDCWidget::pickLogFile()
 	QString logfilename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	QString logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
 						       logfilename, tr("Log files") + " (*.log)");
-	if (!logFile.isEmpty()) {
-		free(logfile_name);
-		logfile_name = copy_qstring(logFile);
-	}
+	if (!logFile.isEmpty())
+		logfile_name = logFile.toStdString();
 }
 
 void DownloadFromDCWidget::checkDumpFile(int state)
@@ -491,10 +489,8 @@ void DownloadFromDCWidget::pickDumpFile()
 	QString dumpfilename = fi.absolutePath().append(QDir::separator()).append("subsurface.bin");
 	QString dumpFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer binary dump file"),
 							dumpfilename, tr("Dump files") + " (*.bin)");
-	if (!dumpFile.isEmpty()) {
-		free(dumpfile_name);
-		dumpfile_name = copy_qstring(dumpFile);
-	}
+	if (!dumpFile.isEmpty())
+		dumpfile_name = dumpFile.toStdString();
 }
 
 void DownloadFromDCWidget::reject()

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -26,7 +26,8 @@ static bool is_vendor_searchable(QString vendor)
 	return vendor == "Uemis" || vendor == "Garmin";
 }
 
-DownloadFromDCWidget::DownloadFromDCWidget(QWidget *parent) : QDialog(parent, QFlag(0)),
+DownloadFromDCWidget::DownloadFromDCWidget(const QString &filename, QWidget *parent) : QDialog(parent, QFlag(0)),
+	filename(filename),
 	downloading(false),
 	previousLast(0),
 	timer(new QTimer(this)),
@@ -461,11 +462,10 @@ void DownloadFromDCWidget::checkLogFile(int state)
 
 void DownloadFromDCWidget::pickLogFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
+	QString logfilename = fi.absolutePath().append(QDir::separator()).append("subsurface.log");
 	QString logFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer download logfile"),
-						       filename, tr("Log files") + " (*.log)");
+						       logfilename, tr("Log files") + " (*.log)");
 	if (!logFile.isEmpty()) {
 		free(logfile_name);
 		logfile_name = copy_qstring(logFile);
@@ -487,11 +487,10 @@ void DownloadFromDCWidget::checkDumpFile(int state)
 
 void DownloadFromDCWidget::pickDumpFile()
 {
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append("subsurface.bin");
+	QString dumpfilename = fi.absolutePath().append(QDir::separator()).append("subsurface.bin");
 	QString dumpFile = QFileDialog::getSaveFileName(this, tr("Choose file for dive computer binary dump file"),
-							filename, tr("Dump files") + " (*.bin)");
+							dumpfilename, tr("Dump files") + " (*.bin)");
 	if (!dumpFile.isEmpty()) {
 		free(dumpfile_name);
 		dumpfile_name = copy_qstring(dumpFile);
@@ -547,7 +546,7 @@ void DownloadFromDCWidget::on_ok_clicked()
 	diveImportedModel->recordDives(flags);
 
 	if (ostcFirmwareCheck && currentState == DONE)
-		ostcFirmwareCheck->checkLatest(this, diveImportedModel->thread.data()->internalData());
+		ostcFirmwareCheck->checkLatest(this, diveImportedModel->thread.data()->internalData(), filename);
 	accept();
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -25,7 +25,7 @@ class BTDiscovery;
 class DownloadFromDCWidget : public QDialog {
 	Q_OBJECT
 public:
-	explicit DownloadFromDCWidget(QWidget *parent = 0);
+	explicit DownloadFromDCWidget(const QString &filename, QWidget *parent = 0);
 	void reject();
 
 	enum states {
@@ -72,6 +72,7 @@ private:
 	QStringListModel vendorModel;
 	QStringListModel productModel;
 	Ui::DownloadFromDiveComputer ui;
+	QString filename;
 	bool downloading;
 
 	int previousLast;

--- a/desktop-widgets/groupedlineedit.cpp
+++ b/desktop-widgets/groupedlineedit.cpp
@@ -99,7 +99,7 @@ void GroupedLineEdit::addColor(QColor color)
 QStringList GroupedLineEdit::getBlockStringList()
 {
 	QStringList retList;
-	foreach (const Private::Block &block, d->blocks)
+	for (const Private::Block &block: d->blocks)
 		retList.append(block.text);
 	return retList;
 }
@@ -179,7 +179,7 @@ void GroupedLineEdit::paintEvent(QPaintEvent *e)
 
 	QVectorIterator<QColor> i(d->colors);
 	i.toFront();
-	foreach (const Private::Block &block, d->blocks) {
+	for (const Private::Block &block: d->blocks) {
 		qreal start_x = line.cursorToX(block.start, QTextLine::Leading);
 		qreal end_x = line.cursorToX(block.end-1, QTextLine::Trailing);
 

--- a/desktop-widgets/kmessagewidget.cpp
+++ b/desktop-widgets/kmessagewidget.cpp
@@ -111,7 +111,7 @@ void KMessageWidgetPrivate::createLayout()
     qDeleteAll(buttons);
     buttons.clear();
 
-    Q_FOREACH (QAction *action, q->actions()) {
+    for (QAction *action: q->actions()) {
         QToolButton *button = new QToolButton(content);
         button->setDefaultAction(action);
         button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
@@ -131,7 +131,7 @@ void KMessageWidgetPrivate::createLayout()
 
         QHBoxLayout *buttonLayout = new QHBoxLayout;
         buttonLayout->addStretch();
-        Q_FOREACH (QToolButton *button, buttons) {
+        for (QToolButton *button: buttons) {
             // For some reason, calling show() is necessary if wordwrap is true,
             // otherwise the buttons do not show up. It is not needed if
             // wordwrap is false.
@@ -145,9 +145,8 @@ void KMessageWidgetPrivate::createLayout()
         layout->addWidget(iconLabel);
         layout->addWidget(textLabel);
 
-        Q_FOREACH (QToolButton *button, buttons) {
+        for (QToolButton *button: buttons)
             layout->addWidget(button);
-        }
 
         layout->addWidget(closeButton);
     };

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -607,7 +607,8 @@ void MainWindow::on_actionQuit_triggered()
 
 void MainWindow::on_actionDownloadDC_triggered()
 {
-	DownloadFromDCWidget dlg(this);
+	QString filename = existing_filename ?: prefs.default_filename;
+	DownloadFromDCWidget dlg(filename, this);
 	dlg.exec();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1395,7 +1395,8 @@ void MainWindow::on_actionExport_triggered()
 
 void MainWindow::on_actionConfigure_Dive_Computer_triggered()
 {
-	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(this);
+	QString filename = existing_filename ?: prefs.default_filename;
+	ConfigureDiveComputerDialog *dcConfig = new ConfigureDiveComputerDialog(filename, this);
 	dcConfig->show();
 }
 

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -379,7 +379,7 @@ void MainWindow::on_actionOpen_triggered()
 	QStringList cleanFilenames;
 	QRegularExpression reg(".*\\[[^]]+]\\.ssrf", QRegularExpression::CaseInsensitiveOption);
 
-	Q_FOREACH (QString filename, filenames) {
+	for (QString filename: filenames) {
 		if (reg.match(filename).hasMatch())
 			filename.remove(QRegularExpression("\\.ssrf$", QRegularExpression::CaseInsensitiveOption));
 		cleanFilenames << filename;
@@ -1071,7 +1071,7 @@ void MainWindow::loadRecentFiles()
 	recentFiles.clear();
 	QSettings s;
 	s.beginGroup("Recent_Files");
-	foreach (const QString &key, s.childKeys()) {
+	for (const QString &key: s.childKeys()) {
 		// TODO Sorting only correct up to 9 entries. Currently, only 4 used, so no problem.
 		if (!key.startsWith("File_"))
 			continue;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -551,7 +551,8 @@ void MainWindow::on_actionPrint_triggered()
 	// When in planner, only print the planned dive.
 	dive *singleDive = appState == ApplicationState::PlanDive ? plannerWidgets->getDive()
 								  : nullptr;
-	PrintDialog dlg(singleDive, this);
+	QString filename = existing_filename ?: prefs.default_filename;
+	PrintDialog dlg(singleDive, filename, this);
 
 	dlg.exec();
 #endif

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -177,7 +177,7 @@ private:
 	QString filter_import();
 	QString filter_import_dive_sites();
 	static MainWindow *m_Instance;
-	QString displayedFilename(QString fullFilename);
+	QString displayedFilename(const std::string &fullFilename);
 	bool askSaveChanges();
 	bool okToClose(QString message);
 	void closeCurrentFile();

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -27,7 +27,7 @@ PreferencesLanguage::PreferencesLanguage() : AbstractPreferencesWidget(tr("Langu
 	dateFormatShortMap.insert("MM/dd/yyyy", "M/d/yy");
 	dateFormatShortMap.insert("dd.MM.yyyy", "d.M.yy");
 	dateFormatShortMap.insert("yyyy-MM-dd", "yy-M-d");
-	foreach (QString format, dateFormatShortMap.keys())
+	for (const QString &format: dateFormatShortMap.keys())
 		ui->dateFormatEntry->addItem(format);
 	ui->dateFormatEntry->completer()->setCaseSensitivity(Qt::CaseSensitive);
 	connect(ui->dateFormatEntry, &QComboBox::currentTextChanged,

--- a/desktop-widgets/printdialog.cpp
+++ b/desktop-widgets/printdialog.cpp
@@ -19,9 +19,10 @@
 
 template_options::color_palette_struct ssrf_colors, almond_colors, blueshades_colors, custom_colors;
 
-PrintDialog::PrintDialog(dive *singleDive, QWidget *parent) :
+PrintDialog::PrintDialog(dive *singleDive, const QString &filename, QWidget *parent) :
 	QDialog(parent, QFlag(0)),
 	singleDive(singleDive),
+	filename(filename),
 	printer(NULL),
 	qprinter(NULL)
 {
@@ -197,11 +198,10 @@ void PrintDialog::exportHtmlClicked(void)
 {
 	createPrinterObj();
 	QString saveFileName = printOptions.p_template;
-	QString filename = existing_filename ?: prefs.default_filename;
 	QFileInfo fi(filename);
-	filename = fi.absolutePath().append(QDir::separator()).append(saveFileName);
+	QString printfilename = fi.absolutePath().append(QDir::separator()).append(saveFileName);
 	QString htmlExportFilename = QFileDialog::getSaveFileName(this, tr("Filename to export html to"),
-							  filename, tr("Html file") + " (*.html)");
+							  printfilename, tr("Html file") + " (*.html)");
 	if (!htmlExportFilename.isEmpty()) {
 		QFile file(htmlExportFilename);
 		file.open(QIODevice::WriteOnly);

--- a/desktop-widgets/printdialog.h
+++ b/desktop-widgets/printdialog.h
@@ -20,11 +20,12 @@ class PrintDialog : public QDialog {
 
 public:
 	// If singleDive is non-null, print only that single dive
-	explicit PrintDialog(dive *singleDive, QWidget *parent = 0);
+	explicit PrintDialog(dive *singleDive, const QString &filename, QWidget *parent = 0);
 	~PrintDialog();
 
 private:
 	dive *singleDive;
+	QString filename;
 	PrintOptions *optionsWidget;
 	QProgressBar *progressBar;
 	Printer *printer;

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -55,7 +55,7 @@ void set_bundled_templates_as_read_only()
 		listStats[i] = stats + QDir::separator() + listStats.at(i);
 	list += listStats;
 
-	foreach (const QString& f, list)
+	for (const QString &f: list)
 		QFile::setPermissions(pathUser + QDir::separator() + f, QFileDevice::ReadOwner | QFileDevice::ReadUser);
 }
 

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2365,13 +2365,13 @@ QStringList QMLManager::cloudCacheList() const
 	QDir localCacheDir(QString("%1/cloudstorage/").arg(system_default_directory()));
 	QStringList dirs = localCacheDir.entryList();
 	QStringList result;
-	foreach(QString dir, dirs) {
+	for (const QString &dir: dirs) {
 		QString originsDir = QString("%1/cloudstorage/%2/.git/refs/remotes/origin/").arg(system_default_directory()).arg(dir);
 		QDir remote(originsDir);
 		if (dir == "localrepo") {
 			result << QString("localrepo[master]");
 		} else {
-			foreach(QString branch, remote.entryList().filter(QRegularExpression("...+")))
+			for (const QString &branch: remote.entryList().filter(QRegularExpression("...+")))
 				result << QString("%1[%2]").arg(dir).arg(branch);
 		}
 	}

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -266,7 +266,7 @@ QMLManager::QMLManager() :
 		// remove the existing libdivecomputer logfile so we don't copy an old one by mistake
 		QFile libdcLog(libdcLogFileName);
 		libdcLog.remove();
-		logfile_name = copy_qstring(libdcLogFileName);
+		logfile_name = libdcLogFileName.toStdString();
 	} else {
 		appendTextToLog("No writeable location found, in-memory log only and no libdivecomputer log");
 	}
@@ -497,7 +497,7 @@ bool QMLManager::createSupportEmail()
 	QAndroidJniObject activity = QtAndroid::androidActivity();
 	if (activity.isValid()) {
 		QAndroidJniObject applogfilepath = QAndroidJniObject::fromString(appLogFileName);
-		QAndroidJniObject libdcfilepath = QAndroidJniObject::fromString(logfile_name);
+		QAndroidJniObject libdcfilepath = QAndroidJniObject::fromString(QString::fromStdString(logfile_name));
 		bool success = activity.callMethod<jboolean>("supportEmail",
 					"(Ljava/lang/String;Ljava/lang/String;)Z", // two string arguments, return bool
 					applogfilepath.object<jstring>(), libdcfilepath.object<jstring>());
@@ -508,7 +508,7 @@ bool QMLManager::createSupportEmail()
 	qDebug() << __FUNCTION__ << "failed to share the logFiles via intent, use the fall-back mail body method";
 #elif defined(Q_OS_IOS)
 	// call into objC++ code to share on iOS
-	QString libdcLogFileName(logfile_name);
+	QString libdcLogFileName = QString::fromStdString(logfile_name);
 	iosshare.supportEmail(appLogFileName, libdcLogFileName);
 	// Unfortunately I haven't been able to figure out how to wait until the mail was sent
 	// so that this could tell us whether this was successful or not
@@ -536,7 +536,7 @@ QString QMLManager::getCombinedLogs()
 	copyString += MessageHandlerModel::self()->logAsString();
 
 	// Add heading and append libdivecomputer.log
-	QFile f(logfile_name);
+	QFile f(logfile_name.c_str());
 	if (f.open(QFile::ReadOnly | QFile::Text)) {
 		copyString += "\n\n\n---------- libdivecomputer.log ----------\n";
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -216,8 +216,7 @@ void MapLocationModel::setSelected(const QVector<dive_site *> &divesites)
 
 MapLocation *MapLocationModel::getMapLocation(const struct dive_site *ds)
 {
-	MapLocation *location;
-	foreach(location, m_mapLocations) {
+	for (MapLocation *location: m_mapLocations) {
 		if (ds == location->divesite)
 			return location;
 	}

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -64,7 +64,7 @@ LanguageModel *LanguageModel::instance()
 LanguageModel::LanguageModel(QObject *parent) : QAbstractListModel(parent)
 {
 	QDir d(getSubsurfaceDataPath("translations"));
-	Q_FOREACH (const QString &s, d.entryList()) {
+	for (const QString &s: d.entryList()) {
 		if (s.startsWith("subsurface_") && s.endsWith(".qm")) {
 			languages.push_back((s == "subsurface_source.qm") ? "English" : s);
 		}

--- a/scripts/whitespace.pl
+++ b/scripts/whitespace.pl
@@ -3,7 +3,7 @@
 my $input = $ARGV[0];
 my $source = `clang-format $input`;
 
-# for_each_dive (...) and Q_FOREACH and friends...
+# for_each_dive (...) and friends...
 $source =~ s/(?:\G|^)(.*each.*\(.*) \* (\S.*\))$/$1 *$2/img; # if a variable is declared in the argument, '*' is an indicator for a pointer, not arithmatic
 $source =~ s/(?:\G|^)(.*each.*\(.*) \& (\S.*\))$/$1 &$2/img; # if a variable is declared in the argument, '&' is an indicator for a reference, not bit logic
 $source =~ s/(?:\G|^)(.*each[^\s(]*)\s*(\(.*)$/$1 $2/img;    # we want exactly one space between keyword and opening parenthesis '('

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -67,7 +67,6 @@ void init_ui()
 void exit_ui()
 {
 	free_globals();
-	free((void *)existing_filename);
 }
 
 #ifdef SUBSURFACE_MOBILE

--- a/subsurface-helper.cpp
+++ b/subsurface-helper.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "stats/statsview.h"
+#include "core/devicedetails.h"
 #include "core/globals.h"
 #include "core/qt-gui.h"
 #include "core/settings/qPref.h"
@@ -201,6 +202,7 @@ Q_DECLARE_METATYPE(duration_t)
 static void register_meta_types()
 {
 	qRegisterMetaType<duration_t>();
+	qRegisterMetaType<DeviceDetails>();
 }
 
 template <typename T>

--- a/subsurface-mobile-main.cpp
+++ b/subsurface-mobile-main.cpp
@@ -79,9 +79,9 @@ int main(int argc, char **argv)
 	}
 	init_ui();
 	if (prefs.default_file_behavior == LOCAL_DEFAULT_FILE)
-		set_filename(prefs.default_filename);
+		existing_filename = prefs.default_filename;
 	else
-		set_filename(NULL);
+		existing_filename.clear();
 
 	// some hard coded settings
 	qPrefCloudStorage::set_save_password_local(true);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The configure dive computer code is very ominous. This is a drop in the ocean, but as a start: use value semantics for `DeviceDetails` (though pass it as references through functions).

Contains more cleanups:
- Conversion of some variables to std::string
- Less global variable accesses
- Removal of archaic `Q_FOREACH` and foreach.

Note: I don't have a divecomputer that can be configured, so this is 100% untested!
Note: The `device_data_t` is still shared among threads, which is pretty sketchy. Since libdivecomputer is a C-API, it is unclear what the semantics of this struct are with respect to copying. Will have to investigate at one point.