### PR TITLE
cleanup: remove unused macros in qmlmanager.cpp

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -618,9 +618,6 @@ QMLManager *QMLManager::instance()
 	return m_instance;
 }
 
-#define CLOUDURL QString(prefs.cloud_base_url)
-#define CLOUDREDIRECTURL CLOUDURL + "/cgi-bin/redirect.pl"
-
 void QMLManager::saveCloudCredentials(const QString &newEmail, const QString &newPassword, const QString &pin)
 {
 	bool cloudCredentialsChanged = false;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Removes two unused macros. Similar macros are found in `cloudstorage.cpp` and of dubious value. But OK.

Posting for CI, will commit later.