### PR TITLE
desktop: unglobalize ComboBox-models

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1289,14 +1289,7 @@ EditCylinder::EditCylinder(int index, cylinder_t cylIn, EditCylinderType typeIn,
 	else
 		setText(Command::Base::tr("Edit cylinder (%n dive(s))", "", dives.size()));
 
-	// Try to untranslate the cylinder type
 	QString description = cylIn.type.description;
-	for (int i = 0; i < tank_info_table.nr; ++i) {
-		if (gettextFromC::tr(tank_info_table.infos[i].name) == description) {
-			description = tank_info_table.infos[i].name;
-			break;
-		}
-	}
 
 	// The base class copied the cylinders for us, let's edit them
 	for (int i = 0; i < (int)indexes.size(); ++i) {

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -125,12 +125,16 @@ extern void reset_tank_info_table(struct tank_info_table *table);
 extern void clear_tank_info_table(struct tank_info_table *table);
 extern void add_tank_info_metric(struct tank_info_table *table, const char *name, int ml, int bar);
 extern void add_tank_info_imperial(struct tank_info_table *table, const char *name, int cuft, int psi);
+extern void set_tank_info_size(struct tank_info_table *table, const char *name, volume_t size);
+extern void set_tank_info_workingpressure(struct tank_info_table *table, const char *name, pressure_t working_pressure);
+extern struct tank_info *get_tank_info(struct tank_info_table *table, const char *name);
 
 struct ws_info_t {
 	const char *name;
 	int grams;
 };
 extern struct ws_info_t ws_info[MAX_WS_INFO];
+extern struct ws_info_t *get_weightsystem_description(const char *name);
 
 #ifdef __cplusplus
 }

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -32,8 +32,8 @@ DivePlannerWidget::DivePlannerWidget(dive &planned_dive, PlannerWidgets *parent)
 	ui.tableWidget->setTitle(tr("Dive planner points"));
 	ui.tableWidget->setModel(plannerModel);
 	connect(ui.tableWidget, &TableView::itemClicked, plannerModel, &DivePlannerPointsModel::remove);
-	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::GAS, new AirTypesDelegate(parent->gasModel.get(), this));
-	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(parent->diveTypeModel.get(), this));
+	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::GAS, new AirTypesDelegate(planned_dive, this));
+	ui.tableWidget->view()->setItemDelegateForColumn(DivePlannerPointsModel::DIVEMODE, new DiveTypesDelegate(this));
 	ui.cylinderTableWidget->setTitle(tr("Available gases"));
 	ui.cylinderTableWidget->setBtnToolTip(tr("Add cylinder"));
 	ui.cylinderTableWidget->setModel(cylinders);
@@ -56,9 +56,6 @@ DivePlannerWidget::DivePlannerWidget(dive &planned_dive, PlannerWidgets *parent)
 	view->setItemDelegateForColumn(CylindersModel::USE, tankUseDelegate);
 	connect(ui.cylinderTableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addCylinder_clicked);
 	connect(ui.tableWidget, &TableView::addButtonClicked, plannerModel, &DivePlannerPointsModel::addDefaultStop);
-	connect(cylinders, &CylindersModel::dataChanged, parent, &PlannerWidgets::repopulateGasModel);
-	connect(cylinders, &CylindersModel::rowsInserted, parent, &PlannerWidgets::repopulateGasModel);
-	connect(cylinders, &CylindersModel::rowsRemoved, parent, &PlannerWidgets::repopulateGasModel);
 	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::emitDataChanged);
 	connect(cylinders, &CylindersModel::dataChanged, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
 	connect(cylinders, &CylindersModel::rowsInserted, plannerModel, &DivePlannerPointsModel::cylinderModelEdited);
@@ -542,8 +539,6 @@ void PlannerDetails::setPlanNotes(QString plan)
 
 PlannerWidgets::PlannerWidgets() :
 	planned_dive(alloc_dive()),
-	gasModel(std::make_unique<GasSelectionModel>()),
-	diveTypeModel(std::make_unique<DiveTypeSelectionModel>()),
 	plannerWidget(*planned_dive, this),
 	plannerSettingsWidget(this)
 {
@@ -587,7 +582,6 @@ void PlannerWidgets::planDive()
 {
 	DivePlannerPointsModel::instance()->setPlanMode(DivePlannerPointsModel::PLAN);
 
-	repopulateGasModel();
 	plannerWidget.setReplanButton(false);
 	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->when));	// This will reload the profile!
 }
@@ -610,11 +604,6 @@ void PlannerWidgets::replanDive(int currentDC)
 		plannerWidget.setSalinity(planned_dive->salinity);
 	reset_cylinders(planned_dive.get(), true);
 	DivePlannerPointsModel::instance()->cylindersModel()->updateDive(planned_dive.get(), currentDC);
-}
-
-void PlannerWidgets::repopulateGasModel()
-{
-	gasModel->repopulate(planned_dive.get());
 }
 
 void PlannerWidgets::printDecoPlan()

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -10,8 +10,6 @@
 #include <QDateTime>
 
 class DivePlannerPointsModel;
-class GasSelectionModel;
-class DiveTypeSelectionModel;
 class PlannerWidgets;
 struct dive;
 
@@ -92,10 +90,7 @@ public
 slots:
 	void printDecoPlan();
 public:
-	void repopulateGasModel();
 	OwningDivePtr planned_dive;
-	std::unique_ptr<GasSelectionModel> gasModel;
-	std::unique_ptr<DiveTypeSelectionModel> diveTypeModel;
 	DivePlannerWidget plannerWidget;
 	PlannerSettingsWidget plannerSettingsWidget;
 	PlannerDetails plannerDetails;

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -6,8 +6,10 @@
 
 #include <QStyledItemDelegate>
 #include <QComboBox>
+#include <functional>
 
 class QPainter;
+struct dive;
 struct divecomputer;
 
 class DiveListDelegate : public QStyledItemDelegate {
@@ -32,7 +34,8 @@ private:
 class ComboBoxDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 public:
-	explicit ComboBoxDelegate(QAbstractItemModel *model, QObject *parent = 0, bool allowEdit = true);
+	// First parameter: function that creates a model and makes it a child of the passed-in widget.
+	explicit ComboBoxDelegate(std::function<QAbstractItemModel *(QWidget *)> create_model_func, QObject *parent = 0, bool allowEdit = true);
 private
 slots:
 	void testActivationString(const QString &currString);
@@ -43,13 +46,13 @@ protected
 slots:
 	virtual void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) = 0;
 private:
+	std::function<QAbstractItemModel *(QWidget *)> create_model_func;
 	bool editable;
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 	void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	bool eventFilter(QObject *object, QEvent *event) override;
 protected:
-	QAbstractItemModel *model;
 	mutable struct CurrSelected {
 		QComboBox *comboEditor;
 		int currRow;
@@ -103,7 +106,7 @@ private:
 class AirTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
-	explicit AirTypesDelegate(QAbstractItemModel *model, QObject *parent = 0);
+	explicit AirTypesDelegate(const dive &d, QObject *parent = 0);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
@@ -112,7 +115,7 @@ private:
 class DiveTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
-	explicit DiveTypesDelegate(QAbstractItemModel *model, QObject *parent = 0);
+	explicit DiveTypesDelegate(QObject *parent = 0);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;

--- a/desktop-widgets/preferences/preferences_equipment.cpp
+++ b/desktop-widgets/preferences/preferences_equipment.cpp
@@ -42,11 +42,8 @@ void PreferencesEquipment::syncSettings()
 	equipment->set_default_cylinder(ui->default_cylinder->currentText());
 
 	// In case the user changed the tank info settings,
-	// reset the tank_info_table and inform the TankInfoModel of
-	// the changed table. It is somewhat questionable to do this here.
-	// Moreover, it is a bit crude, as this will be called for *any*
-	// preferences change. Perhaps, the model should listen to the
-	// precise changed signal of the preferences system?
+	// reset the tank_info_table. It is somewhat questionable
+	// to do this here. Moreover, it is a bit crude, as this
+	// will be called for *any* preferences change.
 	reset_tank_info_table(&tank_info_table);
-	TankInfoModel::instance()->update();
 }

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "cylindermodel.h"
-#include "tankinfomodel.h"
 #include "models.h"
 #include "commands/command.h"
 #include "core/qthelper.h"
@@ -381,23 +380,12 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		cyl.type.description = newType.c_str();
 		type = Command::EditCylinderType::TYPE;
 		break;
-	case SIZE: {
-			TankInfoModel *tanks = TankInfoModel::instance();
-			QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, cyl.type.description);
-
-			cyl.type.size = string_to_volume(qPrintable(vString), cyl.type.workingpressure);
-			if (!matches.isEmpty())
-				tanks->setData(tanks->index(matches.first().row(), TankInfoModel::ML), cyl.type.size.mliter);
-		}
+	case SIZE:
+		cyl.type.size = string_to_volume(qPrintable(vString), cyl.type.workingpressure);
 		type = Command::EditCylinderType::TYPE;
 		break;
-	case WORKINGPRESS: {
-			TankInfoModel *tanks = TankInfoModel::instance();
-			QModelIndexList matches = tanks->match(tanks->index(0, 0), Qt::DisplayRole, cyl.type.description);
-			cyl.type.workingpressure = string_to_pressure(qPrintable(vString));
-			if (!matches.isEmpty())
-				tanks->setData(tanks->index(matches.first().row(), TankInfoModel::BAR), cyl.type.workingpressure.mbar / 1000.0);
-		}
+	case WORKINGPRESS:
+		cyl.type.workingpressure = string_to_pressure(qPrintable(vString));
 		type = Command::EditCylinderType::TYPE;
 		break;
 	case START:

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -18,9 +18,10 @@ Qt::ItemFlags GasSelectionModel::flags(const QModelIndex&) const
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-void GasSelectionModel::repopulate(const dive *d)
+GasSelectionModel::GasSelectionModel(const dive &d, QObject *parent)
+	: QStringListModel(parent)
 {
-	setStringList(get_dive_gas_list(d));
+	setStringList(get_dive_gas_list(&d));
 }
 
 QVariant GasSelectionModel::data(const QModelIndex &index, int role) const
@@ -37,7 +38,7 @@ Qt::ItemFlags DiveTypeSelectionModel::flags(const QModelIndex&) const
 	return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
-DiveTypeSelectionModel::DiveTypeSelectionModel()
+DiveTypeSelectionModel::DiveTypeSelectionModel(QObject *parent) : QStringListModel(parent)
 {
 	QStringList modes;
 	for (int i = 0; i < FREEDIVE; i++)

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -24,15 +24,15 @@ struct dive;
 class GasSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
+	GasSelectionModel(const dive &d, QObject *parent);
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
-	void repopulate(const dive *d);
 };
 
 class DiveTypeSelectionModel : public QStringListModel {
 	Q_OBJECT
 public:
-	DiveTypeSelectionModel();
+	DiveTypeSelectionModel(QObject *parent);
 	Qt::ItemFlags flags(const QModelIndex &index) const;
 	QVariant data(const QModelIndex &index, int role) const override;
 };

--- a/qt-models/tankinfomodel.h
+++ b/qt-models/tankinfomodel.h
@@ -9,22 +9,15 @@
 class TankInfoModel : public CleanerTableModel {
 	Q_OBJECT
 public:
-	static TankInfoModel *instance();
-
 	enum Column {
 		DESCRIPTION,
 		ML,
 		BAR
 	};
-	TankInfoModel();
+	TankInfoModel(QObject *parent);
 
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-public
-slots:
-	void update();
 };
 
 #endif

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -78,8 +78,10 @@ QVariant WeightModel::data(const QModelIndex &index, int role) const
 // Ownership of passed in weight system will be taken. Caller must not use it any longer.
 void WeightModel::setTempWS(int row, weightsystem_t ws)
 {
-	if (!d || row < 0 || row >= d->weightsystems.nr) // Sanity check: row must exist
+	if (!d || row < 0 || row >= d->weightsystems.nr) { // Sanity check: row must exist
+		free_weightsystem(ws);
 		return;
+	}
 
 	clearTempWS(); // Shouldn't be necessary, just in case: Reset old temporary row.
 

--- a/qt-models/weightsysteminfomodel.h
+++ b/qt-models/weightsysteminfomodel.h
@@ -8,24 +8,17 @@
 class WSInfoModel : public CleanerTableModel {
 	Q_OBJECT
 public:
-	static WSInfoModel *instance();
-
 	enum Column {
 		DESCRIPTION,
 		GR
 	};
-	WSInfoModel();
+	WSInfoModel(QObject *parent);
 
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
-	bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-	void clear();
-	void update();
 
 private:
 	int rows;
-	QString biggerEntry;
 };
 
 #endif


### PR DESCRIPTION
The combo-boxes (cylinder type, weightsystem, etc.) were controlled by global models. Keeping these models up-to-date was very combersome and buggy.

Create a new model everytime a combobox is opened. Ultimately it might even be better to create a copy of the strings and switch to simple QStringListModel. Set data in the core directly and don't do this via the models.

The result is much simpler and easier to handle.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The models are some of the most convoluted parts of the code base and have always been a thorn in my side. The fact that Qt's model/view API is comically broken doesn't help.

Let's try to simplify things by cutting out the model-craziness as far as possible. In particular I don't understand why we should keep in sync global models for the combo-boxes. That only would make sense if the combo-boxes are updated while they are active. I don't think so. So let's allocate the models on each invocation of a combo-box.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

This is only very lightly tested! Would need some good test run.

Please also check the second commit - probably I'm missing something. But the cylinder names are not in QT_TRANSLATE_NOOP or similar, so back-translation makes no sense...?