### PR TITLE
mobile: fix undo/redo

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -321,10 +321,6 @@ QMLManager::QMLManager() :
 	if (verbose)
 		connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &QMLManager::divesChanged);
 
-	// get updates to the undo/redo texts
-	connect(Command::getUndoStack(), &QUndoStack::undoTextChanged, this, &QMLManager::undoTextChanged);
-	connect(Command::getUndoStack(), &QUndoStack::redoTextChanged, this, &QMLManager::redoTextChanged);
-
 	// now that everything is setup, connect the application changed signal
 	connect(qobject_cast<QApplication *>(QApplication::instance()), &QApplication::applicationStateChanged, this, &QMLManager::applicationStateChanged);
 
@@ -334,6 +330,10 @@ QMLManager::QMLManager() :
 	// setup Command infrastructure
 	Command::init();
 	undoAction = Command::undoAction(this);
+
+	// get updates to the undo/redo texts
+	connect(Command::getUndoStack(), &QUndoStack::undoTextChanged, this, &QMLManager::undoTextChanged);
+	connect(Command::getUndoStack(), &QUndoStack::redoTextChanged, this, &QMLManager::redoTextChanged);
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)


### PR DESCRIPTION
The signals of the undo-stack can only be connected after it was initialized. One of those cases where I would have preferred a crash over a warning message. The mobile version is extremely noisy!

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The undo/redo on mobile clearly hasn't worked for a *long* time. Nobody seems to use undo. :(