### PR TITLE
statistics: improve formatting of date axis in day-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+statistics: show proper dates in January
 desktop: add country to the fields indexed for full text search
 import: update libdivecomputer version, add support for the Scubapro G3 / Luna and Shearwater Tern
 desktop: add a button linking to the 'Contribute' page

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -630,9 +630,9 @@ static std::vector<HistogramAxisEntry> timeRangeToBins(double from, double to)
 		// histogram bins. The entries are the values *between* the histograms.
 		for (auto act = day_from; act <= day_to; inc(act)) {
 			double val = date_to_double(act[0], act[1], act[2]);
-			if (act[1] == 0) {
+			if (act[1] == 0 && act[2] == 1) {
 				res.push_back({ QString::number(act[0]), val, true });
-			} else if (act[2] == 0) {
+			} else if (act[2] == 1) {
 				res.push_back({ monthname(act[1]), val, true });
 			} else {
 				QString s = format.arg(QString::number(act[2]), sep, QString::number(act[1] + 1));


### PR DESCRIPTION
In January it would just show the year for every day. That's silly. Show the year only for Jan 1st.

Moreover, it would never show the month, because day-of-month is counted from 1 (whereas month-of-year is counted from 0).

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes an ugly formatting bug in the statistics widget for dives in January.
 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

Show year only on 1st of Jan, not every day in Jan.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.
