### PR TITLE
Add delete dive computer buttons.

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -117,13 +117,15 @@ DownloadFromDCWidget::DownloadFromDCWidget(const QString &filename, QWidget *par
 #define SETUPDC(num) \
 	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
 		ui.DC##num->setVisible(true); \
-		ui.DDC##num->setVisible(true); \
+		ui.DCFrame##num->setVisible(true); \
+		ui.DeleteDC##num->setVisible(true); \
 		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
 		connect(ui.DC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DC##num##Clicked, Qt::UniqueConnection); \
-		connect(ui.DDC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DDC##num##Clicked, Qt::UniqueConnection); \
+		connect(ui.DeleteDC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DeleteDC##num##Clicked, Qt::UniqueConnection); \
 	} else { \
 		ui.DC##num->setVisible(false); \
-		ui.DDC##num->setVisible(false); \
+		ui.DCFrame##num->setVisible(false); \
+		ui.DeleteDC##num->setVisible(false); \
 	}
 
 void DownloadFromDCWidget::showRememberedDCs()
@@ -176,11 +178,11 @@ DCBUTTON(3)
 DCBUTTON(4)
 
 // Delete DC button slots
-#define DDCBUTTON(num) \
-void DownloadFromDCWidget::DDC##num##Clicked() \
+#define DELETEDCBUTTON(num) \
+void DownloadFromDCWidget::DeleteDC##num##Clicked() \
 { \
 	ui.DC##num->setVisible(false); \
-	ui.DDC##num->setVisible(false); \
+	ui.DeleteDC##num->setVisible(false); \
 	int dc = num; \
 	switch (dc) { \
 		case 1: \
@@ -203,13 +205,13 @@ void DownloadFromDCWidget::DDC##num##Clicked() \
 	qPrefDiveComputer::set_vendor(qPrefDiveComputer::vendor1()); \
 	qPrefDiveComputer::set_product(qPrefDiveComputer::product1()); \
 	qPrefDiveComputer::set_device(qPrefDiveComputer::device1()); \
-   DownloadFromDCWidget::showRememberedDCs(); \
+	DownloadFromDCWidget::showRememberedDCs(); \
 }
 
-DDCBUTTON(1)
-DDCBUTTON(2)
-DDCBUTTON(3)
-DDCBUTTON(4)
+DELETEDCBUTTON(1)
+DELETEDCBUTTON(2)
+DELETEDCBUTTON(3)
+DELETEDCBUTTON(4)
 
 void DownloadFromDCWidget::updateProgressBar()
 {

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -202,9 +202,6 @@ void DownloadFromDCWidget::DeleteDC##num##Clicked() \
 			qPrefDiveComputer::set_product4(QString()); \
 			qPrefDiveComputer::set_device4(QString()); \
 	} \
-	qPrefDiveComputer::set_vendor(qPrefDiveComputer::vendor1()); \
-	qPrefDiveComputer::set_product(qPrefDiveComputer::product1()); \
-	qPrefDiveComputer::set_device(qPrefDiveComputer::device1()); \
 	DownloadFromDCWidget::showRememberedDCs(); \
 }
 

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -117,10 +117,13 @@ DownloadFromDCWidget::DownloadFromDCWidget(const QString &filename, QWidget *par
 #define SETUPDC(num) \
 	if (!qPrefDiveComputer::vendor##num().isEmpty()) { \
 		ui.DC##num->setVisible(true); \
+		ui.DDC##num->setVisible(true); \
 		ui.DC##num->setText(qPrefDiveComputer::vendor##num() + " - " + qPrefDiveComputer::product##num()); \
 		connect(ui.DC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DC##num##Clicked, Qt::UniqueConnection); \
+		connect(ui.DDC##num, &QPushButton::clicked, this, &DownloadFromDCWidget::DDC##num##Clicked, Qt::UniqueConnection); \
 	} else { \
 		ui.DC##num->setVisible(false); \
+		ui.DDC##num->setVisible(false); \
 	}
 
 void DownloadFromDCWidget::showRememberedDCs()
@@ -141,6 +144,7 @@ int DownloadFromDCWidget::deviceIndex(QString deviceText)
 	}
 	return rv;
 }
+
 
 // DC button slots
 // we need two versions as one of the helper functions used is only available if
@@ -163,13 +167,6 @@ void DownloadFromDCWidget::DC##num##Clicked() \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	ui.device->setCurrentIndex(deviceIndex(qPrefDiveComputer::device##num())); \
-	if (QSysInfo::kernelType() == "darwin") { \
-		/* it makes no sense that this would be needed on macOS but not Linux */ \
-		QCoreApplication::processEvents(); \
-		ui.vendor->update(); \
-		ui.product->update(); \
-		ui.device->update(); \
-	} \
 }
 #endif
 
@@ -177,6 +174,42 @@ DCBUTTON(1)
 DCBUTTON(2)
 DCBUTTON(3)
 DCBUTTON(4)
+
+// Delete DC button slots
+#define DDCBUTTON(num) \
+void DownloadFromDCWidget::DDC##num##Clicked() \
+{ \
+	ui.DC##num->setVisible(false); \
+	ui.DDC##num->setVisible(false); \
+	int dc = num; \
+	switch (dc) { \
+		case 1: \
+			qPrefDiveComputer::set_vendor1(qPrefDiveComputer::vendor2()); \
+			qPrefDiveComputer::set_product1(qPrefDiveComputer::product2()); \
+			qPrefDiveComputer::set_device1(qPrefDiveComputer::device2()); \
+		case 2: \
+			qPrefDiveComputer::set_vendor2(qPrefDiveComputer::vendor3()); \
+			qPrefDiveComputer::set_product2(qPrefDiveComputer::product3()); \
+			qPrefDiveComputer::set_device2(qPrefDiveComputer::device3()); \
+		case 3: \
+			qPrefDiveComputer::set_vendor3(qPrefDiveComputer::vendor4()); \
+			qPrefDiveComputer::set_product3(qPrefDiveComputer::product4()); \
+			qPrefDiveComputer::set_device3(qPrefDiveComputer::device4()); \
+		case 4: \
+			qPrefDiveComputer::set_vendor4(QString()); \
+			qPrefDiveComputer::set_product4(QString()); \
+			qPrefDiveComputer::set_device4(QString()); \
+	} \
+	qPrefDiveComputer::set_vendor(qPrefDiveComputer::vendor1()); \
+	qPrefDiveComputer::set_product(qPrefDiveComputer::product1()); \
+	qPrefDiveComputer::set_device(qPrefDiveComputer::device1()); \
+   DownloadFromDCWidget::showRememberedDCs(); \
+}
+
+DDCBUTTON(1)
+DDCBUTTON(2)
+DDCBUTTON(3)
+DDCBUTTON(4)
 
 void DownloadFromDCWidget::updateProgressBar()
 {

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-// SPDX-License-Identifier: GPL-2.0
 #ifndef DOWNLOADFROMDIVECOMPUTER_H
 #define DOWNLOADFROMDIVECOMPUTER_H
 
@@ -57,10 +56,10 @@ slots:
 	void DC2Clicked();
 	void DC3Clicked();
 	void DC4Clicked();
-	void DDC1Clicked();
-	void DDC2Clicked();
-	void DDC3Clicked();
-	void DDC4Clicked();
+	void DeleteDC1Clicked();
+	void DeleteDC2Clicked();
+	void DeleteDC3Clicked();
+	void DeleteDC4Clicked();
 	int deviceIndex(QString deviceText);
 
 #if defined(BT_SUPPORT)

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: GPL-2.0
 #ifndef DOWNLOADFROMDIVECOMPUTER_H
 #define DOWNLOADFROMDIVECOMPUTER_H
 
@@ -56,6 +57,10 @@ slots:
 	void DC2Clicked();
 	void DC3Clicked();
 	void DC4Clicked();
+	void DDC1Clicked();
+	void DDC2Clicked();
+	void DDC3Clicked();
+	void DDC4Clicked();
 	int deviceIndex(QString deviceText);
 
 #if defined(BT_SUPPORT)

--- a/desktop-widgets/downloadfromdivecomputer.ui
+++ b/desktop-widgets/downloadfromdivecomputer.ui
@@ -155,105 +155,166 @@
          </item>
          <item row="6" column="0">
           <layout class="QGridLayout" name="DCGrid">
-           <property name="verticalSpacing">
-             <number>0</number>
-           </property>
            <item row="0" column="0">
-            <layout class="QGridLayout" name="DC1Grid">
-             <property name="horizontalSpacing">
-              <number>0</number>
+            <widget class="QFrame" name="DCFrame1">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
              </property>
-             <item row="0" column="0">
-              <widget class="QPushButton" name="DC1">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QPushButton" name="DDC1">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>X</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="DC1Grid">
+              <property name="horizontalSpacing">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="DC1">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="DeleteDC1">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+                <property name="icon">
+                 <iconset>
+                   <normaloff>:list-remove-icon</normaloff>:list-remove-icon</iconset>
+                 </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
+
            <item row="0" column="1">
-            <layout class="QGridLayout" name="DC2Grid">
-             <property name="horizontalSpacing">
-              <number>0</number>
+            <widget class="QFrame" name="DCFrame2">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
              </property>
-             <item row="0" column="0">
-              <widget class="QPushButton" name="DC2">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QPushButton" name="DDC2">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>X</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="DC2Grid">
+              <property name="horizontalSpacing">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="DC2">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="DeleteDC2">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+                <property name="icon">
+                 <iconset>
+                   <normaloff>:list-remove-icon</normaloff>:list-remove-icon</iconset>
+                 </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
+
            <item row="1" column="0">
-            <layout class="QGridLayout" name="DC3Grid">
-             <property name="horizontalSpacing">
-              <number>0</number>
+            <widget class="QFrame" name="DCFrame3">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
              </property>
-             <item row="0" column="0">
-              <widget class="QPushButton" name="DC3">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QPushButton" name="DDC3">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>X</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="DC3Grid">
+              <property name="horizontalSpacing">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="DC3">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="DeleteDC3">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+                <property name="icon">
+                 <iconset>
+                   <normaloff>:list-remove-icon</normaloff>:list-remove-icon</iconset>
+                 </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
+
            <item row="1" column="1">
-            <layout class="QGridLayout" name="DC4Grid">
-             <property name="horizontalSpacing">
-              <number>0</number>
+            <widget class="QFrame" name="DCFrame4">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
              </property>
-             <item row="0" column="0">
-              <widget class="QPushButton" name="DC4">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QPushButton" name="DDC4">
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>X</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="DC4Grid">
+              <property name="horizontalSpacing">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="DC4">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="DeleteDC4">
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+                <property name="icon">
+                 <iconset>
+                   <normaloff>:list-remove-icon</normaloff>:list-remove-icon</iconset>
+                 </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
+
           </layout>
          </item>
          <item row="13" column="0">

--- a/desktop-widgets/downloadfromdivecomputer.ui
+++ b/desktop-widgets/downloadfromdivecomputer.ui
@@ -155,33 +155,104 @@
          </item>
          <item row="6" column="0">
           <layout class="QGridLayout" name="DCGrid">
+           <property name="verticalSpacing">
+             <number>0</number>
+           </property>
            <item row="0" column="0">
-            <widget class="QPushButton" name="DC1">
-             <property name="autoDefault">
-              <bool>false</bool>
+            <layout class="QGridLayout" name="DC1Grid">
+             <property name="horizontalSpacing">
+              <number>0</number>
              </property>
-            </widget>
+             <item row="0" column="0">
+              <widget class="QPushButton" name="DC1">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="DDC1">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="0" column="1">
-            <widget class="QPushButton" name="DC2">
-             <property name="autoDefault">
-              <bool>false</bool>
+            <layout class="QGridLayout" name="DC2Grid">
+             <property name="horizontalSpacing">
+              <number>0</number>
              </property>
-            </widget>
+             <item row="0" column="0">
+              <widget class="QPushButton" name="DC2">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="DDC2">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="1" column="0">
-            <widget class="QPushButton" name="DC3">
-             <property name="autoDefault">
-              <bool>false</bool>
+            <layout class="QGridLayout" name="DC3Grid">
+             <property name="horizontalSpacing">
+              <number>0</number>
              </property>
-            </widget>
+             <item row="0" column="0">
+              <widget class="QPushButton" name="DC3">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="DDC3">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="1" column="1">
-            <widget class="QPushButton" name="DC4">
-             <property name="autoDefault">
-              <bool>false</bool>
+            <layout class="QGridLayout" name="DC4Grid">
+             <property name="horizontalSpacing">
+              <number>0</number>
              </property>
-            </widget>
+             <item row="0" column="0">
+              <widget class="QPushButton" name="DC4">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="DDC4">
+               <property name="autoDefault">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Added a button to delete individual dive computers from the import window.    If this change is accepted, a potential follow on would be removing the delete all dive computers from the preferences window.    

### Changes made:
1. Added 4 buttons to the UI to accompany the dive computer buttons.
2. Added code to downloaddivecomputer to delete dive computers.  The code isn't necessarily the way I would choose to implement, but I tried to be consistent with the existing code for the dive computer buttons.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
This change adds an X button beside each dive computer on the import window.

### Mentions:
@mikeller