### PR TITLE
Desktop: Fix 'planned' and 'logged' Filters.

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -969,7 +969,7 @@ static void fixup_dc_depths(struct dive *dive, struct divecomputer *dc)
 	}
 
 	update_depth(&dc->maxdepth, maxdepth);
-	if (!has_planned(dive, false) || !is_dc_planner(dc))
+	if (!is_logged(dive) || !is_dc_planner(dc))
 		if (maxdepth > dive->maxdepth.mm)
 			dive->maxdepth.mm = maxdepth;
 }
@@ -2550,17 +2550,27 @@ static void join_dive_computers(struct dive *d, struct divecomputer *res,
 	remove_redundant_dc(res, prefer_downloaded);
 }
 
-// Does this dive have a dive computer for which is_dc_planner has value planned
-extern "C" bool has_planned(const struct dive *dive, bool planned)
+static bool has_dc_type(const struct dive *dive, bool dc_is_planner)
 {
 	const struct divecomputer *dc = &dive->dc;
 
 	while (dc) {
-		if (is_dc_planner(&dive->dc) == planned)
+		if (is_dc_planner(dc) == dc_is_planner)
 			return true;
 		dc = dc->next;
 	}
 	return false;
+}
+
+// Does this dive have a dive computer for which is_dc_planner has value planned
+extern "C" bool is_planned(const struct dive *dive)
+{
+	return has_dc_type(dive, true);
+}
+
+extern "C" bool is_logged(const struct dive *dive)
+{
+	return has_dc_type(dive, false);
 }
 
 /*

--- a/core/dive.h
+++ b/core/dive.h
@@ -141,8 +141,7 @@ void split_divecomputer(const struct dive *src, int num, struct dive **out1, str
 	for (_dc = &_dive->dc; _dc; _dc = _dc->next)
 
 #define for_each_relevant_dc(_dive, _dc) \
-	bool _all_planned = !has_planned(_dive, false); \
-	for (_dc = &_dive->dc; _dc; _dc = _dc->next) if (_all_planned || !is_dc_planner(_dc))
+	for (_dc = &_dive->dc; _dc; _dc = _dc->next) if (!is_logged(_dive) || !is_dc_planner(_dc))
 
 extern struct dive *get_dive_by_uniq_id(int id);
 extern int get_idx_by_uniq_id(int id);
@@ -207,7 +206,8 @@ extern void invalidate_dive_cache(struct dive *dc);
 
 extern int total_weight(const struct dive *);
 
-extern bool has_planned(const struct dive *dive, bool planned);
+extern bool is_planned(const struct dive *dive);
+extern bool is_logged(const struct dive *dive);
 
 /* Get gasmixes at increasing timestamps.
  * In "evp", pass a pointer to a "struct event *" which is NULL-initialized on first invocation.

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -1074,9 +1074,9 @@ bool filter_constraint_match_dive(const filter_constraint &c, const struct dive 
 	case FILTER_CONSTRAINT_SAC:
 		return check_numerical_range_non_zero(c, d->sac);
 	case FILTER_CONSTRAINT_LOGGED:
-		return has_planned(d, false) != c.negate;
+		return is_logged(d) != c.negate;
 	case FILTER_CONSTRAINT_PLANNED:
-		return has_planned(d, true) != c.negate;
+		return is_planned(d) != c.negate;
 	case FILTER_CONSTRAINT_DIVE_MODE:
 		return check_multiple_choice(c, (int)d->dc.divemode); // should we be smarter and check all DCs?
 	case FILTER_CONSTRAINT_TAGS:


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the filters for planned (i.e. has at least one dive plan attached) and logged (i.e. has at least one dive computer log attached) dives. Also refactor the respective functions for improved readability.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix the filters for planned (i.e. has at least one dive plan attached) and logged (i.e. has at least one dive computer log attached) dives;
2.  refactor the respective functions for improved readability.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Now we can filter for dives that are planned **and** logged:
![image](https://github.com/subsurface/subsurface/assets/4742747/3e6b8a9f-6709-45b1-9fd0-08f474dc01c0)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
