### PR TITLE
profile: fix string formating in profile.cpp

### DIFF
--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1368,8 +1368,8 @@ static std::vector<std::string> plot_string(const struct dive *d, const struct p
 	std::vector<std::string> res;
 
 	depthvalue = get_depth_units(entry->depth, NULL, &depth_unit);
-	res.push_back(casprintf_loc(translate("gettextFromC", "@: %d:%02d"), FRACTION(entry->sec, 60), depthvalue));
-	res.push_back(casprintf_loc(translate("gettextFromC", "D: %.1f%s"), depth_unit));
+	res.push_back(casprintf_loc(translate("gettextFromC", "@: %d:%02d"), FRACTION(entry->sec, 60)));
+	res.push_back(casprintf_loc(translate("gettextFromC", "D: %.1f%s"), depthvalue, depth_unit));
 	for (cyl = 0; cyl < pi->nr_cylinders; cyl++) {
 		int mbar = get_plot_pressure(pi, idx, cyl);
 		if (!mbar)


### PR DESCRIPTION
ae299d5e663cd672d1114c3fe90cf026b9ab463e introduced a format- string bug by splitting a format-string in two and splitting the arguments at the wrong place.

The compiler doesn't warn in this case, because the format- string is passed through translate(...).

This should have crashed, but for some reason didn't, at least on Linux.

Fix the arguments.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix potential crash. See commit description and discussion in #4126.