### PR TITLE
Update Build to use Qt 5.15.13 instead of Qt 5.15.12

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -320,7 +320,12 @@ brew install autoconf automake libtool pkg-config gettext
 
 download the macOS installer from https://download.qt.io/official_releases/online_installers
 and use it to install the desired Qt version. At this point the latest Qt5 version is still
-preferred over Qt6.
+preferred over Qt6.  
+
+If you plan to deploy your build to an Apple Silicon Mac, you may have better results
+results with Bluetooth connections if you install Qt5.15.13.  If Qt5.15.13 is not available
+via the installer, you can download from https://download.qt.io/official_releases/qt/5.15/5.15.13
+and build using the usual configure, make, and make install.
 
 3) now build Subsurface
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The current build using Qt 5.15.12 does not find some BLE devices when run on a Mac with Apple Silicon.   
An x86_64 MacOs binary built against Qt 5.15.13 will find and upload my G2 without any code changes.    I could not find a pre-built version of Qt 5.15.13 so I downloaded and built the source from https://download.qt.io/official_releases/qt/5.15/5.15.13.    After building on an Intel Mac and copying the entire app directory to an M2 Mac, I was able to connect and download 100 dives from a G2.

### Changes made:
No code or script changes - just a note in INSTALL about using Qt 5.15.13.
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
