### PR TITLE
Planner: Fix Editing of Plans in Multi-Divecomputer Dives.

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -339,28 +339,27 @@ extern "C" void selective_copy_dive(const struct dive *s, struct dive *d, struct
 }
 #undef CONDITIONAL_COPY_STRING
 
-/* copies all events from all dive computers before a given time
+/* copies all events from the given dive computer before a given time
    this is used when editing a dive in the planner to preserve the events
    of the old dive */
-extern "C" void copy_events_until(const struct dive *sd, struct dive *dd, int time)
+extern "C" void copy_events_until(const struct dive *sd, struct dive *dd, int dcNr, int time)
 {
 	if (!sd || !dd)
 		return;
 
 	const struct divecomputer *s = &sd->dc;
-	struct divecomputer *d = &dd->dc;
+	struct divecomputer *d = get_dive_dc(dd, dcNr);
 
-	while (s && d) {
-		const struct event *ev;
-		ev = s->events;
-		while (ev != NULL) {
-			// Don't add events the planner knows about
-			if (ev->time.seconds < time && !event_is_gaschange(ev) && !event_is_divemodechange(ev))
-				add_event(d, ev->time.seconds, ev->type, ev->flags, ev->value, ev->name);
-			ev = ev->next;
-		}
-		s = s->next;
-		d = d->next;
+	if (!s || !d)
+		return;
+
+	const struct event *ev;
+	ev = s->events;
+	while (ev != NULL) {
+		// Don't add events the planner knows about
+		if (ev->time.seconds < time && !event_is_gaschange(ev) && !event_is_divemodechange(ev))
+			add_event(d, ev->time.seconds, ev->type, ev->flags, ev->value, ev->name);
+		ev = ev->next;
 	}
 }
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -186,7 +186,7 @@ extern int split_dive(const struct dive *dive, struct dive **new1, struct dive *
 extern int split_dive_at_time(const struct dive *dive, duration_t time, struct dive **new1, struct dive **new2);
 extern struct dive *merge_dives(const struct dive *a, const struct dive *b, int offset, bool prefer_downloaded, struct dive_trip **trip, struct dive_site **site);
 extern struct dive *try_to_merge(struct dive *a, struct dive *b, bool prefer_downloaded);
-extern void copy_events_until(const struct dive *sd, struct dive *dd, int time);
+extern void copy_events_until(const struct dive *sd, struct dive *dd, int dcNr, int time);
 extern void copy_used_cylinders(const struct dive *s, struct dive *d, bool used_only);
 extern bool is_cylinder_used(const struct dive *dive, int idx);
 extern bool is_cylinder_prot(const struct dive *dive, int idx);

--- a/core/planner.h
+++ b/core/planner.h
@@ -60,6 +60,6 @@ struct decostop {
 
 #include <string>
 extern std::string get_planner_disclaimer_formatted();
-extern bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, int timestep, struct decostop *decostoptable, deco_state_cache &cache, bool is_planner, bool show_disclaimer);
+extern bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, int dcNr, int timestep, struct decostop *decostoptable, deco_state_cache &cache, bool is_planner, bool show_disclaimer);
 #endif
 #endif // PLANNER_H

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -18,7 +18,7 @@ struct dive;
 class DivePlannerWidget : public QWidget {
 	Q_OBJECT
 public:
-	explicit DivePlannerWidget(dive &planned_dive, PlannerWidgets *parent);
+	explicit DivePlannerWidget(dive &planned_dive, int dcNr, PlannerWidgets *parent);
 	~DivePlannerWidget();
 	void setReplanButton(bool replan);
 public
@@ -80,17 +80,20 @@ class PlannerWidgets : public QObject {
 public:
 	PlannerWidgets();
 	~PlannerWidgets();
-	void preparePlanDive(const dive *currentDive); // Create a new planned dive
+	void preparePlanDive(const dive *currentDive, int currentDc); // Create a new planned dive
 	void planDive();
-	void prepareReplanDive(const dive *d); // Make a copy of the dive to be replanned
-	void replanDive(int currentDC);
+	void prepareReplanDive(const dive *currentDive, int currentDc); // Make a copy of the dive to be replanned
+	void replanDive();
 	struct dive *getDive() const;
+	int getDcNr();
 	divemode_t getRebreatherMode() const;
 public
 slots:
 	void printDecoPlan();
-public:
+private:
 	OwningDivePtr planned_dive;
+	int dcNr;
+public:
 	DivePlannerWidget plannerWidget;
 	PlannerSettingsWidget plannerSettingsWidget;
 	PlannerDetails plannerDetails;

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -665,8 +665,8 @@ void MainWindow::on_actionReplanDive_triggered()
 {
 	if (!plannerStateClean() || !current_dive || !userMayChangeAppState())
 		return;
-	else if (!is_dc_planner(&current_dive->dc)) {
-		if (QMessageBox::warning(this, tr("Warning"), tr("Trying to replan a dive that's not a planned dive."),
+	else if (!is_dc_planner(get_dive_dc(current_dive, profile->dc))) {
+		if (QMessageBox::warning(this, tr("Warning"), tr("Trying to replan a dive dive profile that is not a dive plan."),
 					 QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel)
 					return;
 	}
@@ -675,9 +675,9 @@ void MainWindow::on_actionReplanDive_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	disableShortcuts(true);
-	plannerWidgets->prepareReplanDive(current_dive);
-	profile->setPlanState(plannerWidgets->getDive(), profile->dc);
-	plannerWidgets->replanDive(profile->dc);
+	plannerWidgets->prepareReplanDive(current_dive, profile->dc);
+	profile->setPlanState(plannerWidgets->getDive(), plannerWidgets->getDcNr());
+	plannerWidgets->replanDive();
 }
 
 void MainWindow::on_actionDivePlanner_triggered()
@@ -689,8 +689,8 @@ void MainWindow::on_actionDivePlanner_triggered()
 	setApplicationState(ApplicationState::PlanDive);
 
 	disableShortcuts(true);
-	plannerWidgets->preparePlanDive(current_dive);
-	profile->setPlanState(plannerWidgets->getDive(), 0);
+	plannerWidgets->preparePlanDive(current_dive, profile->dc);
+	profile->setPlanState(plannerWidgets->getDive(), plannerWidgets->getDcNr());
 	plannerWidgets->planDive();
 }
 

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -157,11 +157,11 @@ void ProfileWidget::setEnabledToolbar(bool enabled)
 		b->setEnabled(enabled);
 }
 
-void ProfileWidget::setDive(const struct dive *d)
+void ProfileWidget::setDive(const struct dive *d, int dcNr)
 {
 	stack->setCurrentIndex(1); // show profile
 
-	bool freeDiveMode = d->dc.divemode == FREEDIVE;
+	bool freeDiveMode = get_dive_dc_const(d, dcNr)->divemode == FREEDIVE;
 	ui.profCalcCeiling->setDisabled(freeDiveMode);
 	ui.profCalcCeiling->setDisabled(freeDiveMode);
 	ui.profCalcAllTissues ->setDisabled(freeDiveMode);
@@ -217,12 +217,12 @@ void ProfileWidget::plotDive(dive *dIn, int dcIn)
 	setEnabledToolbar(d != nullptr);
 	if (editedDive) {
 		view->plotDive(editedDive.get(), editedDc);
-		setDive(editedDive.get());
+		setDive(editedDive.get(), dc);
 	} else if (d) {
 		view->setProfileState(d, dc);
 		view->resetZoom(); // when switching dive, reset the zoomLevel
 		view->plotDive(d, dc);
-		setDive(d);
+		setDive(d, dc);
 	} else {
 		view->clear();
 		stack->setCurrentIndex(0);
@@ -274,11 +274,12 @@ void ProfileWidget::divesChanged(const QVector<dive *> &dives, DiveField field)
 	plotCurrentDive();
 }
 
-void ProfileWidget::setPlanState(const struct dive *d, int dc)
+void ProfileWidget::setPlanState(const struct dive *d, int dcNr)
 {
 	exitEditMode();
-	view->setPlanState(d, dc);
-	setDive(d);
+	dc = dcNr;
+	view->setPlanState(d, dcNr);
+	setDive(d, dcNr);
 }
 
 void ProfileWidget::unsetProfHR()

--- a/desktop-widgets/profilewidget.h
+++ b/desktop-widgets/profilewidget.h
@@ -44,7 +44,7 @@ private:
 	std::vector<QAction *> toolbarActions;
 	Ui::ProfileWidget ui;
 	QStackedWidget *stack;
-	void setDive(const struct dive *d);
+	void setDive(const struct dive *d, int dcNr);
 	void editDive();
 	void exitEditMode();
 	void rotateDC(int dir);

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -15,7 +15,7 @@
 static struct dive dive = { 0 };
 static struct decostop stoptable[60];
 static struct deco_state test_deco_state;
-extern bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, int timestep, struct decostop *decostoptable, deco_state_cache &cache, bool is_planner, bool show_disclaimer);
+extern bool plan(struct deco_state *ds, struct diveplan *diveplan, struct dive *dive, int dcNr, int timestep, struct decostop *decostoptable, deco_state_cache &cache, bool is_planner, bool show_disclaimer);
 void setupPrefs()
 {
 	copy_prefs(&default_prefs, &prefs);
@@ -453,7 +453,7 @@ void TestPlan::testMetric()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -494,7 +494,7 @@ void TestPlan::testImperial()
 	struct diveplan testPlan = {};
 	setupPlan(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -534,7 +534,7 @@ void TestPlan::testVpmbMetric45m30minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb45m30mTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -564,7 +564,7 @@ void TestPlan::testVpmbMetric60m10minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m10mTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -594,7 +594,7 @@ void TestPlan::testVpmbMetric60m30minAir()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minAir(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -624,7 +624,7 @@ void TestPlan::testVpmbMetric60m30minEan50()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minEan50(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -660,7 +660,7 @@ void TestPlan::testVpmbMetric60m30minTx()
 	struct diveplan testPlan = {};
 	setupPlanVpmb60m30minTx(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -696,7 +696,7 @@ void TestPlan::testVpmbMetric100m60min()
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m60min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -739,7 +739,7 @@ void TestPlan::testMultipleGases()
 
 	setupPlanSeveralGases(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -764,7 +764,7 @@ void TestPlan::testVpmbMetricMultiLevelAir()
 	struct diveplan testPlan = {};
 	setupPlanVpmbMultiLevelAir(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -794,7 +794,7 @@ void TestPlan::testVpmbMetric100m10min()
 	struct diveplan testPlan = {};
 	setupPlanVpmb100m10min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -840,7 +840,7 @@ void TestPlan::testVpmbMetricRepeat()
 	struct diveplan testPlan = {};
 	setupPlanVpmb30m20min(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -861,7 +861,7 @@ void TestPlan::testVpmbMetricRepeat()
 	int firstDiveRunTimeSeconds = dive.dc.duration.seconds;
 
 	setupPlanVpmb100mTo70m30min(&testPlan);
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -898,7 +898,7 @@ void TestPlan::testVpmbMetricRepeat()
 	QVERIFY(compareDecoTime(dive.dc.duration.seconds, 127u * 60u + 20u, 127u * 60u + 20u));
 
 	setupPlanVpmb30m20min(&testPlan);
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, 1, 0);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, 1, 0);
 
 #if DEBUG
 	free(dive.notes);
@@ -937,7 +937,7 @@ void TestPlan::testCcrBailoutGasSelection()
 	struct diveplan testPlan = {};
 	setupPlanCcr(&testPlan);
 
-	plan(&test_deco_state, &testPlan, &dive, 60, stoptable, cache, true, false);
+	plan(&test_deco_state, &testPlan, &dive, 0, 60, stoptable, cache, true, false);
 
 #if DEBUG
 	free(dive.notes);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Currently editing of planned dives that have been merged with actual (logged) dives only works if the 'Planned dive' divecomputer is the first divecomputer, and this divecomputer is selected when clicking 'Edit planned dive'. In other cases the profile of the first divecomputer is overlaid with the profile of the planned dive, and the first divecomputer's profile is overwritten when saving the dive plan. Fix this problem.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #1913 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Triggered by @SeppoTakalo's comment (https://github.com/subsurface/subsurface/issues/1913#issuecomment-2075562119): Users don't like that planned dives show up as their own entries in the dive list, so being able to merge them with the actual dive after it has been executed is a good feature - but this wasn't working well until now.

