### PR TITLE
planner: fix gas selection

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -130,6 +130,7 @@ QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 	currCombo.currRow = index.row();
 	currCombo.model = const_cast<QAbstractItemModel *>(index.model());
 	currCombo.activeText = currCombo.model->data(index).toString();
+	currCombo.ignoreSelection = false;
 
 	return comboDelegate;
 }

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -371,8 +371,8 @@ void AirTypesDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, 
 }
 
 AirTypesDelegate::AirTypesDelegate(const dive &d, QObject *parent) :
-	ComboBoxDelegate([d] (QWidget *parent) { return new GasSelectionModel(d, parent); },
-			      parent, false)
+	ComboBoxDelegate([&d] (QWidget *parent) { return new GasSelectionModel(d, parent); },
+			       parent, false)
 {
 }
 

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -614,9 +614,8 @@ void CylindersModel::updateNumRows()
 // Only invoked from planner.
 void CylindersModel::moveAtFirst(int cylid)
 {
-	if (!d)
+	if (!d || cylid <= 0 || cylid >= d->cylinders.nr)
 		return;
-
 	cylinder_t temp_cyl;
 
 	beginMoveRows(QModelIndex(), cylid, cylid, QModelIndex(), 0);

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -381,7 +381,7 @@ bool DivePlannerPointsModel::setData(const QModelIndex &index, const QVariant &v
 			if (value.toInt() >= 0)
 				p.cylinderid = value.toInt();
 			/* Did we change the start (dp 0) cylinder to another cylinderid than 0? */
-			if (value.toInt() != 0 && index.row() == 0)
+			if (value.toInt() > 0 && index.row() == 0)
 				cylinders.moveAtFirst(value.toInt());
 			cylinders.updateTrashIcon();
 			break;


### PR DESCRIPTION
The lambda that created the list of gases took a copy not a reference of the planned dive. Of course, that never had its gases updated. Ultimately this would crash, because this sent an index of "-1" on change.

Fix by
1) Using a reference to the dive, not the copy
2) Catch an invalid "-1" index (by Michael Keller <github@ike.ch>)

Fixes #4188

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix crash in planner, see commit description and discussion in #4188.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Use reference, not copy of dive
2) Check cylinder index for validity
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4188.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller @linuxcrash