### PR TITLE
core: fix INFO() and ERROR() macros in core/serial_ftdi.cpp

### DIFF
--- a/core/serial_ftdi.c
+++ b/core/serial_ftdi.c
@@ -38,8 +38,8 @@
 #endif
 
 #include "errorhelper.h"
-#define INFO(context, fmt, ...)	report_info(stderr, "INFO: " fmt, ##__VA_ARGS__)
-#define ERROR(context, fmt, ...)	report_info(stderr, "ERROR: " fmt, ##__VA_ARGS__)
+#define INFO(context, fmt, ...)	report_info("INFO: " fmt, ##__VA_ARGS__)
+#define ERROR(context, fmt, ...)	report_info("ERROR: " fmt, ##__VA_ARGS__)
 //#define SYSERROR(context, errcode)	ERROR(__FILE__ ":" __LINE__ ": %s", strerror(errcode))
 #define SYSERROR(context, errcode)	;
 
@@ -467,7 +467,7 @@ static dc_status_t serial_ftdi_purge (void *io, dc_direction_t queue)
 
 	size_t input;
 	serial_ftdi_get_available (io, &input);
-	INFO (device->context, "Flush: queue=%u, input=%lu, output=%i", queue, input,
+	INFO (device->context, "Flush: queue=%u, input=%lu, output=%i", queue, (unsigned long)input,
 	      serial_ftdi_get_transmitted (device));
 
 	switch (queue) {


### PR DESCRIPTION
Error introduced in da7ea17b66: the INDO() and ERROR() macros pass stdout instead of the format string as first parameter to report_error(). Ooooops. How did this ever pass the compile tests!?

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Stupid bug - how did this ever compile on Windows!?
