### PR TITLE
Planner: Improve Exit Warning.

### DIFF
--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -178,6 +178,7 @@ private:
 	QString filter_import_dive_sites();
 	static MainWindow *m_Instance;
 	QString displayedFilename(const std::string &fullFilename);
+	int saveChangesConfirmationBox(QString message);
 	bool askSaveChanges();
 	bool okToClose(QString message);
 	void closeCurrentFile();


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Improve the warning shown to the user when closing the application wile in the planner. We now allow the user to directly discard the planned dive, save it into the dive log, or cancel the operation altogether. If they save into the dive log, or if they modified the dive log before starting the planner, a second warning about the unsaved dive log changes will be shown.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://github.com/subsurface/subsurface/assets/4742747/01241e54-9fa8-4808-8c23-4ca70cbdc397)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
