### PR TITLE
Desktop: Fix Gas Editing for Manually Added Dives.

### DIFF
--- a/commands/command.h
+++ b/commands/command.h
@@ -100,6 +100,7 @@ enum class EditProfileType {
 	ADD,
 	REMOVE,
 	MOVE,
+	EDIT,
 };
 void replanDive(dive *d); // dive computer(s) and cylinder(s) of first argument will be consumed!
 void editProfile(const dive *d, int dcNr, EditProfileType type, int count);

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -879,6 +879,7 @@ QString editProfileTypeToString(EditProfileType type, int count)
 		case EditProfileType::ADD: return Command::Base::tr("Add stop");
 		case EditProfileType::REMOVE: return Command::Base::tr("Remove %n stop(s)", "", count);
 		case EditProfileType::MOVE: return Command::Base::tr("Move %n stop(s)", "", count);
+		case EditProfileType::EDIT: return Command::Base::tr("Edit stop");
 	}
 }
 
@@ -904,7 +905,7 @@ EditProfile::EditProfile(const dive *source, int dcNr, EditProfileType type, int
 	copy_samples(sdc, &dc);
 	copy_events(sdc, &dc);
 
-	setText(editProfileTypeToString(type, count) + diveNumberOrDate(d));
+	setText(editProfileTypeToString(type, count) + " " + diveNumberOrDate(d));
 }
 
 EditProfile::~EditProfile()
@@ -925,6 +926,7 @@ void EditProfile::undo()
 	std::swap(sdc->samples, dc.samples);
 	std::swap(sdc->alloc_samples, dc.alloc_samples);
 	std::swap(sdc->sample, dc.sample);
+	std::swap(sdc->events, dc.events);
 	std::swap(sdc->maxdepth, dc.maxdepth);
 	std::swap(d->maxdepth, maxdepth);
 	std::swap(d->meandepth, meandepth);
@@ -1125,7 +1127,7 @@ AddCylinder::AddCylinder(bool currentDiveOnly) :
 		setText(Command::Base::tr("Add cylinder"));
 	else
 		setText(Command::Base::tr("Add cylinder (%n dive(s))", "", dives.size()));
-	cyl = create_new_cylinder(dives[0]);
+	cyl = create_new_manual_cylinder(dives[0]);
 	indexes.reserve(dives.size());
 }
 

--- a/core/equipment.c
+++ b/core/equipment.c
@@ -510,12 +510,38 @@ cylinder_t create_new_cylinder(const struct dive *d)
 	cylinder_t cyl = empty_cylinder;
 	fill_default_cylinder(d, &cyl);
 	cyl.start = cyl.type.workingpressure;
-	cyl.manually_added = true;
 	cyl.cylinder_use = OC_GAS;
 	return cyl;
 }
 
-static bool show_cylinder(const struct dive *d, int i) 
+cylinder_t create_new_manual_cylinder(const struct dive *d)
+{
+	cylinder_t cyl = create_new_cylinder(d);
+	cyl.manually_added = true;
+	return cyl;
+}
+
+void add_default_cylinder(struct dive *d)
+{
+	// Only add if there are no cylinders yet
+	if (d->cylinders.nr > 0)
+		return;
+
+	cylinder_t cyl;
+	if (!empty_string(prefs.default_cylinder)) {
+		cyl = create_new_cylinder(d);
+	} else {
+		cyl = empty_cylinder;
+		// roughly an AL80
+		cyl.type.description = strdup(translate("gettextFromC", "unknown"));
+		cyl.type.size.mliter = 11100;
+		cyl.type.workingpressure.mbar = 207000;
+	}
+	add_cylinder(&d->cylinders, 0, cyl);
+	reset_cylinders(d, false);
+}
+
+static bool show_cylinder(const struct dive *d, int i)
 {
 	if (is_cylinder_used(d, i))
 		return true;

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -93,7 +93,8 @@ extern void reset_cylinders(struct dive *dive, bool track_gas);
 extern int gas_volume(const cylinder_t *cyl, pressure_t p); /* Volume in mliter of a cylinder at pressure 'p' */
 extern int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table *cylinders);
 extern void fill_default_cylinder(const struct dive *dive, cylinder_t *cyl); /* dive is needed to fill out MOD, which depends on salinity. */
-extern cylinder_t create_new_cylinder(const struct dive *dive); /* dive is needed to fill out MOD, which depends on salinity. */
+extern cylinder_t create_new_manual_cylinder(const struct dive *dive); /* dive is needed to fill out MOD, which depends on salinity. */
+extern void add_default_cylinder(struct dive *dive);
 extern int first_hidden_cylinder(const struct dive *d);
 #ifdef DEBUG_CYL
 extern void dump_cylinders(struct dive *dive, bool verbose);

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -711,6 +711,7 @@ void MainWindow::on_actionAddDive_triggered()
 	d.dc.meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
 	make_manually_added_dive_dc(&d.dc);
 	fake_dc(&d.dc);
+	add_default_cylinder(&d);
 	fixup_dive(&d);
 
 	Command::addDive(&d, divelog.autogroup, true);

--- a/desktop-widgets/profilewidget.h
+++ b/desktop-widgets/profilewidget.h
@@ -34,11 +34,13 @@ public:
 private
 slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void cylindersChanged(struct dive *changed, int pos);
 	void unsetProfHR();
 	void unsetProfTissues();
 	void stopAdded();
 	void stopRemoved(int count);
 	void stopMoved(int count);
+	void stopEdited();
 private:
 	std::unique_ptr<EmptyView> emptyView;
 	std::vector<QAction *> toolbarActions;
@@ -49,8 +51,6 @@ private:
 	void exitEditMode();
 	void rotateDC(int dir);
 	OwningDivePtr editedDive;
-	int editedDc;
-	dive *originalDive;
 	bool placingCommand;
 };
 

--- a/profile-widget/divehandler.cpp
+++ b/profile-widget/divehandler.cpp
@@ -62,10 +62,10 @@ void DiveHandler::selfRemove()
 
 void DiveHandler::changeGas()
 {
+	ProfileWidget2 *view = qobject_cast<ProfileWidget2 *>(scene()->views().first());
 	QAction *action = qobject_cast<QAction *>(sender());
-	DivePlannerPointsModel *plannerModel = DivePlannerPointsModel::instance();
-	QModelIndex index = plannerModel->index(parentIndex(), DivePlannerPointsModel::GAS);
-	plannerModel->gasChange(index.sibling(index.row() + 1, index.column()), action->data().toInt());
+
+	view->changeGas(parentIndex(), action->data().toInt());
 }
 
 void DiveHandler::mouseMoveEvent(QGraphicsSceneMouseEvent *event)

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -68,6 +68,7 @@ signals:
 	void stopAdded(); // only emitted in edit mode
 	void stopRemoved(int count); // only emitted in edit mode
 	void stopMoved(int count); // only emitted in edit mode
+	void stopEdited(); // only emitted in edit mode
 
 public
 slots: // Necessary to call from QAction's signals.
@@ -111,7 +112,8 @@ private:
 
 	void replot();
 	void setZoom(int level);
-	void changeGas(int tank, int seconds);
+	void addGasSwitch(int tank, int seconds);
+	void changeGas(int index, int newCylinderId);
 	void setupSceneAndFlags();
 	void addItemsToScene();
 	void setupItemOnScene();

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -499,7 +499,7 @@ void CylindersModel::add()
 	if (!d)
 		return;
 	int row = d->cylinders.nr;
-	cylinder_t cyl = create_new_cylinder(d);
+	cylinder_t cyl = create_new_manual_cylinder(d);
 	beginInsertRows(QModelIndex(), row, row);
 	add_cylinder(&d->cylinders, row, cyl);
 	++numRows;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -206,20 +206,8 @@ void DivePlannerPointsModel::setupCylinders()
 			return;		// We have at least one cylinder
 		}
 	}
-	if (!empty_string(prefs.default_cylinder)) {
-		cylinder_t cyl = empty_cylinder;
-		fill_default_cylinder(d, &cyl);
-		cyl.start = cyl.type.workingpressure;
-		add_cylinder(&d->cylinders, 0, cyl);
-	} else {
-		cylinder_t cyl = empty_cylinder;
-		// roughly an AL80
-		cyl.type.description = copy_qstring(tr("unknown"));
-		cyl.type.size.mliter = 11100;
-		cyl.type.workingpressure.mbar = 207000;
-		add_cylinder(&d->cylinders, 0, cyl);
-	}
-	reset_cylinders(d, false);
+
+	add_default_cylinder(d);
 	cylinders.updateDive(d, dcNr);
 }
 
@@ -1288,7 +1276,7 @@ void DivePlannerPointsModel::computeVariationsDone(QString variations)
 	emit calculatedPlanNotes(QString(d->notes));
 }
 
-void DivePlannerPointsModel::createPlan(bool replanCopy)
+void DivePlannerPointsModel::createPlan(bool saveAsNew)
 {
 	// Ok, so, here the diveplan creates a dive
 	deco_state_cache cache;
@@ -1350,7 +1338,7 @@ void DivePlannerPointsModel::createPlan(bool replanCopy)
 #endif // !SUBSURFACE_TESTING
 	} else {
 		copy_events_until(current_dive, d, dcNr, preserved_until.seconds);
-		if (replanCopy) {
+		if (saveAsNew) {
 			// we were planning an old dive and save as a new dive
 			d->id = dive_getUniqID(); // Things will break horribly if we create dives with the same id.
 #if !defined(SUBSURFACE_TESTING)

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -23,12 +23,12 @@ public:
 		GAS,
 		CCSETPOINT,
 		DIVEMODE,
-		COLUMNS
+		COLUMNS,
 	};
 	enum Mode {
 		NOTHING,
 		PLAN,
-		ADD
+		EDIT,
 	};
 	int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. show the correct gasmix in the profile;
2. make gases available for gas switches in the profile after they have been added;
3. persist gas changes;
4. add air as a default gas when adding a dive.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3966.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This still has problems when undoing a gas switch - instead of completely removing the gas switch it is just moved to the next point in the profile.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
