### PR TITLE
import: fix memory leak when importing dives

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -521,6 +521,11 @@ ImportDives::ImportDives(struct divelog *log, int flags, const QString &source)
 			continue;
 		filterPresetsToAdd.emplace_back(preset.name, preset.data);
 	}
+
+	free(dives_to_add.dives);
+	free(dives_to_remove.dives);
+	free(trips_to_add.trips);
+	free(sites_to_add.dive_sites);
 }
 
 bool ImportDives::workToBeDone()

--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1007,6 +1007,10 @@ void add_imported_dives(struct divelog *import_log, int flags)
 	current_dive = divelog.dives->nr > 0 ? divelog.dives->dives[divelog.dives->nr - 1] : NULL;
 
 	free_device_table(devices_to_add);
+	free(dives_to_add.dives);
+	free(dives_to_remove.dives);
+	free(trips_to_add.trips);
+	free(dive_sites_to_add.dive_sites);
 
 	/* Inform frontend of reset data. This should reset all the models. */
 	emit_reset_signal();


### PR DESCRIPTION
A long standing issue: the dives_to_add, etc. tables need to be manually freed. This kind of problem wouldn't arise with proper C++ data structures.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes another memory leak due to unmanaged C-code. I stopped doing these, because they will disappear anyway when converting to C++ structures. However, in this case it was my fault, so I should fix it, and it just highlights the issue.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Properly free table structures.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
All the more reason to continue with #4198.
