### PR TITLE
cleanup: remove localized snprintf() functions

### DIFF
--- a/core/equipment.c
+++ b/core/equipment.c
@@ -207,13 +207,6 @@ void add_cloned_weightsystem(struct weightsystem_table *t, weightsystem_t ws)
 	add_to_weightsystem_table(t, t->nr, clone_weightsystem(ws));
 }
 
-/* Add a clone of a weightsystem to the end of a weightsystem table.
- * Cloned means that the description-string is copied. */
-void add_cloned_weightsystem_at(struct weightsystem_table *t, weightsystem_t ws)
-{
-	add_to_weightsystem_table(t, t->nr, clone_weightsystem(ws));
-}
-
 cylinder_t clone_cylinder(cylinder_t cyl)
 {
 	cylinder_t res = cyl;

--- a/core/format.h
+++ b/core/format.h
@@ -12,22 +12,7 @@
 __printf(1, 2) QString qasprintf_loc(const char *cformat, ...);
 __printf(1, 0) QString vqasprintf_loc(const char *cformat, va_list ap);
 __printf(1, 2) std::string casprintf_loc(const char *cformat, ...);
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-__printf(3, 4) int snprintf_loc(char *dst, size_t size, const char *cformat, ...);
-__printf(3, 0) int vsnprintf_loc(char *dst, size_t size, const char *cformat, va_list ap);
-__printf(2, 3) int asprintf_loc(char **dst, const char *cformat, ...);
-__printf(2, 0) int vasprintf_loc(char **dst, const char *cformat, va_list ap);
-
-#ifdef __cplusplus
-}
-
 __printf(1, 2) std::string format_string_std(const char *fmt, ...);
-
 #endif
 
 #endif


### PR DESCRIPTION
The last use of these functions was removed in ae299d5e663c.

And that's a good thing, because snprintf-style interfaces make zero sense in times of variable-length character encodings.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial dead code-removal. Nothing more to say.