### PR TITLE
fix memory leak in subsurface-downloader

### DIFF
--- a/subsurface-downloader-main.cpp
+++ b/subsurface-downloader-main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 	QStringList arguments = QCoreApplication::arguments();
 
 	// set a default logfile name for libdivecomputer so we always get a logfile
-	logfile_name = strdup("subsurface-downloader.log");
+	logfile_name = "subsurface-downloader.log";
 
 	const char *default_directory = system_default_directory();
 	subsurface_mkdir(default_directory);


### PR DESCRIPTION
logfile_name was converted to std::string. Assigning a strdup()ed string to it will leak memory.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A trivial leak fix.