### PR TITLE
Profile: Add Gas Description to Disambiguate.

### DIFF
--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -600,7 +600,9 @@ void DiveGasPressureItem::replot(const dive *d, int fromIn, int toIn, bool in_pl
 		}
 	}
 
+	bool showDescriptions = false;
 	for (int cyl = 0; cyl < pInfo.nr_cylinders; cyl++) {
+		showDescriptions = showDescriptions || same_gasmix_cylinder(get_cylinder(d, cyl), cyl, d, true) != -1;
 		if (act_segments[cyl].polygon.empty())
 			continue;
 		act_segments[cyl].cyl = cyl;
@@ -618,45 +620,47 @@ void DiveGasPressureItem::replot(const dive *d, int fromIn, int toIn, bool in_pl
 	// Right now it's just strictly alternating when you have multiple gas
 	// pressures.
 
-	QFlags<Qt::AlignmentFlag> alignVar = Qt::AlignTop;
-	std::vector<QFlags<Qt::AlignmentFlag>> align(pInfo.nr_cylinders);
-
-	double labelHeight = DiveTextItem::fontHeight(dpr, 1.0);
+	QFlags<Qt::AlignmentFlag> startAlignVar = Qt::AlignTop;
 
 	for (const Segment &segment: segments) {
 		// Magic Y offset depending on whether we're aliging
 		// the top of the text or the bottom of the text to
 		// the pressure line.
-		double value_y_offset = -0.5 * dpr;
-		double label_y_offset = alignVar & Qt::AlignTop ? labelHeight : -labelHeight;
-		gasmix gas = get_cylinder(d, segment.cyl)->gasmix;
-		plotPressureValue(segment.first.pressure, segment.first.time, alignVar, value_y_offset);
-		plotGasValue(segment.first.pressure, segment.first.time, gas, alignVar, label_y_offset);
+		double y_offset = -0.5 * dpr;
+		plotPressureValue(segment.first.pressure, segment.first.time, startAlignVar, y_offset);
 
 		// For each cylinder, on right hand side of the curve, write cylinder pressure
-		plotPressureValue(segment.last.pressure, segment.last.time, alignVar | Qt::AlignLeft, value_y_offset);
+		double x_offset = plotPressureValue(segment.last.pressure, segment.last.time, Qt::AlignTop | Qt::AlignLeft, y_offset) + 2;
+		plotGasValue(segment.last.pressure, segment.last.time, get_cylinder(d, segment.cyl), Qt::AlignTop | Qt::AlignLeft, x_offset, y_offset, showDescriptions);
 
 		/* Alternate alignment as we see cylinder use.. */
-		alignVar ^= Qt::AlignTop | Qt::AlignBottom;
+		startAlignVar ^= Qt::AlignTop | Qt::AlignBottom;
 	}
 }
 
-void DiveGasPressureItem::plotPressureValue(double mbar, double sec, QFlags<Qt::AlignmentFlag> align, double pressure_offset)
+double DiveGasPressureItem::plotPressureValue(double mbar, double sec, QFlags<Qt::AlignmentFlag> align, double y_offset)
 {
 	const char *unit;
-	int pressure = get_pressure_units(lrint(mbar), &unit);
+	auto label = QString("%1%2").arg(get_pressure_units(lrint(mbar), &unit)).arg(unit);
 	auto text = std::make_unique<DiveTextItem>(dpr, 1.0, align, this);
-	text->set(QString("%1%2").arg(pressure).arg(unit), getColor(PRESSURE_TEXT));
-	text->setPos(hAxis.posAtValue(sec), vAxis.posAtValue(mbar) + pressure_offset);
+	text->set(label, getColor(PRESSURE_TEXT));
+	text->setPos(hAxis.posAtValue(sec), vAxis.posAtValue(mbar) + y_offset);
 	texts.push_back(std::move(text));
+
+	return DiveTextItem::getLabelSize(dpr, 1.0, label).first;
 }
 
-void DiveGasPressureItem::plotGasValue(double mbar, double sec, struct gasmix gasmix, QFlags<Qt::AlignmentFlag> align, double gasname_offset)
+void DiveGasPressureItem::plotGasValue(double mbar, double sec, const cylinder_t *cylinder, QFlags<Qt::AlignmentFlag> align, double x_offset, double y_offset, bool showDescription)
 {
-	QString gas = get_gas_string(gasmix);
+	QString gas = get_gas_string(cylinder->gasmix);
+	QString label;
+	if (showDescription)
+		label = QString("(%1) %2").arg(cylinder->type.description).arg(gas);
+	else
+		label = gas;
 	auto text = std::make_unique<DiveTextItem>(dpr, 1.0, align, this);
-	text->set(gas, getColor(PRESSURE_TEXT));
-	text->setPos(hAxis.posAtValue(sec), vAxis.posAtValue(mbar) + gasname_offset);
+	text->set(label, getColor(PRESSURE_TEXT));
+	text->setPos(hAxis.posAtValue(sec) - x_offset, vAxis.posAtValue(mbar) + y_offset);
 	texts.push_back(std::move(text));
 }
 

--- a/profile-widget/diveprofileitem.h
+++ b/profile-widget/diveprofileitem.h
@@ -7,6 +7,8 @@
 
 #include "divelineitem.h"
 
+#include "core/equipment.h"
+
 /* This is the Profile Item, it should be used for quite a lot of things
  on the profile view. The usage should be pretty simple:
 
@@ -105,8 +107,8 @@ public:
 	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
 
 private:
-	void plotPressureValue(double mbar, double sec, QFlags<Qt::AlignmentFlag> align, double offset);
-	void plotGasValue(double mbar, double sec, struct gasmix gasmix, QFlags<Qt::AlignmentFlag> align, double offset);
+	double plotPressureValue(double mbar, double sec, QFlags<Qt::AlignmentFlag> align, double y_offset);
+	void plotGasValue(double mbar, double sec, const cylinder_t *cylinder, QFlags<Qt::AlignmentFlag> align, double x_offset, double y_offset, bool showDescription);
 	struct PressureEntry {
 		double time = 0.0;
 		double pressure = 0.0;


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. add the gas description to the label on pressure graphs to disambiguate if multiple identical gasmixes are shown;
2. move the label to the right, where the end pressures will typically be more spread out than the starting pressures.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://github.com/subsurface/subsurface/assets/4742747/615b9ccc-22b4-44f4-82b5-5871c879a270)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
