### PR TITLE
core: remove put_format_loc()

### DIFF
--- a/core/format.cpp
+++ b/core/format.cpp
@@ -343,17 +343,6 @@ QString vqasprintf_loc(const char *fmt, va_list ap_in)
 	return ret;
 }
 
-extern "C" void put_vformat_loc(struct membuffer *b, const char *fmt, va_list args)
-{
-	QByteArray utf8 = vqasprintf_loc(fmt, args).toUtf8();
-	const char *data = utf8.constData();
-	size_t utf8_size = utf8.size();
-
-	make_room(b, utf8_size);
-	memcpy(b->buffer + b->len, data, utf8_size);
-	b->len += utf8_size;
-}
-
 // TODO: Avoid back-and-forth conversion between UTF16 and UTF8.
 std::string casprintf_loc(const char *cformat, ...)
 {

--- a/core/membuffer.cpp
+++ b/core/membuffer.cpp
@@ -169,15 +169,6 @@ void put_format(struct membuffer *b, const char *fmt, ...)
 	va_end(args);
 }
 
-void put_format_loc(struct membuffer *b, const char *fmt, ...)
-{
-	va_list args;
-
-	va_start(args, fmt);
-	put_vformat_loc(b, fmt, args);
-	va_end(args);
-}
-
 void put_milli(struct membuffer *b, const char *pre, int value, const char *post)
 {
 	int i;

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -75,9 +75,7 @@ extern void strip_mb(struct membuffer *);
 /* The pointer obtained by mb_cstring is invalidated by any modifictation to the membuffer! */
 extern const char *mb_cstring(struct membuffer *);
 extern __printf(2, 0) void put_vformat(struct membuffer *, const char *, va_list);
-extern __printf(2, 0) void put_vformat_loc(struct membuffer *, const char *, va_list);
 extern __printf(2, 3) void put_format(struct membuffer *, const char *fmt, ...);
-extern __printf(2, 3) void put_format_loc(struct membuffer *, const char *fmt, ...);
 extern __printf(2, 0) char *add_to_string_va(char *old, const char *fmt, va_list args);
 extern __printf(2, 3) char *add_to_string(char *old, const char *fmt, ...);
 


### PR DESCRIPTION
This was replaced by C++ functions in ae299d5e663c.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

Another (trivial?) dead code removal.