### PR TITLE
[RFC] tests: make profile test work with non-C locales

### DIFF
--- a/tests/testprofile.cpp
+++ b/tests/testprofile.cpp
@@ -18,6 +18,8 @@
 
 void TestProfile::init()
 {
+	setlocale(LC_ALL, "C");
+
 	// Set UTF8 text codec as in real applications
 	QTextCodec::setCodecForLocale(QTextCodec::codecForMib(106));
 	// first, setup the preferences


### PR DESCRIPTION
For reasons unknown to me, the profile test is executed with a weird locale, resulting in wrong formatting.

By setting the locale manually to "C", the tests start to work.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This makes the profile-test work for me. I feel that this is the wrong way to do it, because we don't have a `setlocale()` call in the code base, yet it seems to work for the rest of the code.

My locale at the start of the test is:
` LC_CTYPE=en_US.UTF-8;LC_NUMERIC=de_AT.UTF-8;LC_TIME=de_AT.UTF-8;LC_COLLATE=en_US.UTF-8;LC_MONETARY=de_AT.UTF-8;LC_MESSAGES=en_US.UTF-8;LC_PAPER=de_AT.UTF-8;LC_NAME=de_AT.UTF-8;LC_ADDRESS=de_AT.UTF-8;LC_TELEPHONE=de_AT.UTF-8;LC_MEASUREMENT=de_AT.UTF-8;LC_IDENTIFICATION=de_AT.UTF-8`
and not `C` as it should be!?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Set locale to "C" in profile test.