### PR TITLE
cleanup: remove unused roles in DiveTripModelBase

### DIFF
--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -389,10 +389,6 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		return d->rating;
 	case DIVE_ROLE:
 		return QVariant::fromValue(const_cast<dive *>(d));  // Not nice: casting away a const
-	case DIVE_IDX:
-		return get_divenr(d);
-	case SELECTED_ROLE:
-		return d->selected;
 	case CURRENT_ROLE:
 		return d == current_dive;
 	}

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -53,8 +53,6 @@ public:
 		IS_TRIP_ROLE,
 		DIVE_ROLE,
 		TRIP_ROLE,
-		DIVE_IDX,
-		SELECTED_ROLE,
 		CURRENT_ROLE,
 		TRIP_HAS_CURRENT_ROLE, // Returns true if this is a trip and it contains the current dive
 		LAST_ROLE


### PR DESCRIPTION
The roles DIVE_IDX and SELECTED_ROLE were used for the old selection system and removed in b8e7a600d2d2a30f7e0646fc164ab6e57fd4782f.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Opportunistic code cleanup while refactoring the dive list.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove unused roles in `DiveTripModelBase`.
