### PR TITLE
Add basic support to handle sub-second values

### DIFF
--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -396,6 +396,7 @@ sample_cb(dc_sample_type_t type, const dc_sample_value_t *pvalue, void *userdata
 		// Mark depth as negative
 		sample = prepare_sample(dc);
 		sample->time.seconds = value.time / 1000;
+		sample->time.ms = value.time % 1000;
 		sample->depth.mm = -1;
 		// The current sample gets some sticky values
 		// that may have been around from before, these

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -693,13 +693,16 @@ static struct sample *new_sample(struct git_parser_state *state)
 
 static void sample_parser(char *line, struct git_parser_state *state)
 {
-	int m, s = 0;
+	int m, s = 0, ms = 0;
 	struct sample *sample = new_sample(state);
 
 	m = strtol(line, &line, 10);
 	if (*line == ':')
 		s = strtol(line + 1, &line, 10);
 	sample->time.seconds = m * 60 + s;
+	if (*line == '.')
+		ms = strtol(line + 1, &line, 10);
+	sample->time.ms = ms;
 
 	for (;;) {
 		char c;

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -693,16 +693,9 @@ static struct sample *new_sample(struct git_parser_state *state)
 
 static void sample_parser(char *line, struct git_parser_state *state)
 {
-	int m, s = 0, ms = 0;
 	struct sample *sample = new_sample(state);
 
-	m = strtol(line, &line, 10);
-	if (*line == ':')
-		s = strtol(line + 1, &line, 10);
-	sample->time.seconds = m * 60 + s;
-	if (*line == '.')
-		ms = strtol(line + 1, &line, 10);
-	sample->time.ms = ms;
+	line += parse_duration(line, &sample->time, false);
 
 	for (;;) {
 		char c;

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -340,9 +340,15 @@ static void temperature(const char *buffer, temperature_t *temperature, struct p
 static void sampletime(const char *buffer, duration_t *time)
 {
 	int i;
-	int hr, min, sec;
+	int hr, min, sec, ms;
 
-	i = sscanf(buffer, "%d:%d:%d", &hr, &min, &sec);
+	i = sscanf(buffer, "%d:%d.%d", &min, &sec, &ms);
+	if (i != 3) {
+		i = sscanf(buffer, "%d:%d:%d", &hr, &min, &sec);
+	} else {
+		hr = 0;
+		i = 4;
+	}
 	switch (i) {
 	case 1:
 		min = hr;
@@ -354,7 +360,11 @@ static void sampletime(const char *buffer, duration_t *time)
 		hr = 0;
 	/* fallthrough */
 	case 3:
+		ms = 0;
+	/* fallthrough */
+	case 4:
 		time->seconds = (hr * 60 + min) * 60 + sec;
+		time->ms = ms;
 		break;
 	default:
 		time->seconds = 0;

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -339,37 +339,7 @@ static void temperature(const char *buffer, temperature_t *temperature, struct p
 
 static void sampletime(const char *buffer, duration_t *time)
 {
-	int i;
-	int hr, min, sec, ms;
-
-	i = sscanf(buffer, "%d:%d.%d", &min, &sec, &ms);
-	if (i != 3) {
-		i = sscanf(buffer, "%d:%d:%d", &hr, &min, &sec);
-	} else {
-		hr = 0;
-		i = 4;
-	}
-	switch (i) {
-	case 1:
-		min = hr;
-		hr = 0;
-	/* fallthrough */
-	case 2:
-		sec = min;
-		min = hr;
-		hr = 0;
-	/* fallthrough */
-	case 3:
-		ms = 0;
-	/* fallthrough */
-	case 4:
-		time->seconds = (hr * 60 + min) * 60 + sec;
-		time->ms = ms;
-		break;
-	default:
-		time->seconds = 0;
-		report_info("Strange sample time reading %s", buffer);
-	}
+	parse_duration(buffer, time, false);
 }
 
 static void offsettime(const char *buffer, offset_t *time)
@@ -388,17 +358,7 @@ static void offsettime(const char *buffer, offset_t *time)
 
 static void duration(const char *buffer, duration_t *time)
 {
-	/* DivingLog 5.08 (and maybe other versions) appear to sometimes
-	 * store the dive time as 44.00 instead of 44:00;
-	 * This attempts to parse this in a fairly robust way */
-	if (!strchr(buffer, ':') && strchr(buffer, '.')) {
-		std::string mybuffer(buffer);
-		char *dot = strchr(mybuffer.data(), '.');
-		*dot = ':';
-		sampletime(mybuffer.data(), time);
-	} else {
-		sampletime(buffer, time);
-	}
+	parse_duration(buffer, time, true);
 }
 
 static void percent(const char *buffer, fraction_t *fraction)

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -251,7 +251,10 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 {
 	int idx;
 
-	put_format(b, "%3u:%02u", FRACTION_TUPLE(sample->time.seconds, 60));
+	if (sample->time.ms)
+		put_format(b, "%3u:%02u.%03u", FRACTION_TUPLE(sample->time.seconds, 60), sample->time.ms);
+	else
+		put_format(b, "%3u:%02u", FRACTION_TUPLE(sample->time.seconds, 60));
 	put_milli(b, " ", sample->depth.mm, "m");
 	put_temperature(b, sample->temperature, " ", "°C");
 

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -236,7 +236,10 @@ static void save_sample(struct membuffer *b, struct sample *sample, struct sampl
 {
 	int idx;
 
-	put_format(b, "  <sample time='%u:%02u min'", FRACTION_TUPLE(sample->time.seconds, 60));
+	if (sample->time.ms == 0)
+		put_format(b, "  <sample time='%u:%02u min'", FRACTION_TUPLE(sample->time.seconds, 60));
+	else
+		put_format(b, "  <sample time='%u:%02u.%03u min'", FRACTION_TUPLE(sample->time.seconds, 60), sample->time.ms);
 	put_milli(b, " depth='", sample->depth.mm, " m'");
 	if (sample->temperature.mkelvin && sample->temperature.mkelvin != old->temperature.mkelvin) {
 		put_temperature(b, sample->temperature, " temp='", " C'");

--- a/core/units.h
+++ b/core/units.h
@@ -80,6 +80,7 @@ typedef int64_t timestamp_t;
 typedef struct
 {
 	int32_t seconds; // durations up to 34 yrs
+	int32_t ms; // milliseconds
 } duration_t;
 
 static const duration_t zero_duration = { 0 };

--- a/core/units.h
+++ b/core/units.h
@@ -347,6 +347,7 @@ extern double get_vertical_speed_units(unsigned int mms, int *frac, const char *
 
 extern depth_t units_to_depth(double depth);
 extern int units_to_sac(double volume);
+extern int parse_duration(const char *buffer, duration_t *time, bool dot_as_seperator);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
libdivecomputer reports sub-second values, where the sub-second accuracy is lost when imported into Subsurface.

Fix this by saving those values on import and storing them in the xml.

Also read those values back when parsing the xml.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
